### PR TITLE
チャット機能の修正

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
@@ -11,7 +11,6 @@ import com.example.FreStyle.dto.ChatMessageDto;
 import com.example.FreStyle.entity.ChatRoom;
 import com.example.FreStyle.service.ChatMessageService;
 import com.example.FreStyle.service.ChatRoomService;
-import com.example.FreStyle.service.UserIdentityService;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,33 +22,100 @@ public class ChatWebSocketController {
 
     private final ChatRoomService chatRoomService;
     private final ChatMessageService chatMessageService;
-    private final UserIdentityService userIdentityService;
     private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/chat/send")
     public void sendMessage(
             @Payload Map<String, Object> payload
     ) {
+        System.out.println("\n========== WebSocket /chat/send リクエスト受信 ==========");
+        System.out.println("📨 ペイロード全体: " + payload);
+        
         try {
-            log.info("📨 Received message: {}", payload);
+            // パラメータの取得と検証
+            System.out.println("🔍 パラメータを抽出中...");
+            Object senderIdObj = payload.get("senderId");
+            Object roomIdObj = payload.get("roomId");
+            Object contentObj = payload.get("content");
             
+            System.out.println("   - senderId タイプ: " + (senderIdObj != null ? senderIdObj.getClass().getSimpleName() : "null"));
+            System.out.println("   - senderId 値: " + senderIdObj);
+            System.out.println("   - roomId タイプ: " + (roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null"));
+            System.out.println("   - roomId 値: " + roomIdObj);
+            System.out.println("   - content タイプ: " + (contentObj != null ? contentObj.getClass().getSimpleName() : "null"));
+            System.out.println("   - content 値: " + contentObj);
             
-            String senderId = (String) payload.get("senderId");
-            Integer roomId = Integer.parseInt((String) payload.get("roomId"));
+            // senderId は String または Integer で来る可能性がある
+            // Integer に変換して扱う
+            Integer senderId;
+            if (senderIdObj instanceof Integer) {
+                // Object型をIntegerに変換をしてから格納をする
+                senderId = (Integer) senderIdObj;
+                System.out.println("   💡 senderId を Integer から String に変換");
+            } else {
+                senderId = (Integer) senderIdObj;
+            }
+            
+            // roomId は String または Integer で来る可能性がある
+            Integer roomId;
+            if (roomIdObj instanceof Integer) {
+                roomId = (Integer) roomIdObj;
+                System.out.println("   💡 roomId を Integer として取得");
+            } else {
+                roomId = Integer.parseInt((String) roomIdObj);
+                System.out.println("   💡 roomId を String から Integer に変換");
+            }
+            
             String content = (String) payload.get("content");
             
+            System.out.println("✅ パラメータ抽出成功");
+            System.out.println("   - senderId (最終): " + senderId + " (タイプ: String)");
+            System.out.println("   - roomId (最終): " + roomId + " (タイプ: Integer)");
+            System.out.println("   - content: " + content);
+            
+            // ChatRoom 取得
+            System.out.println("🔍 ChatRoom を roomId=" + roomId + " で取得中...");
             ChatRoom room = chatRoomService.findChatRoomById(roomId);
+            System.out.println("✅ ChatRoom 取得成功: " + room.getId());
+            
+            // メッセージ保存
+            System.out.println("💾 メッセージをデータベースに保存中...");
             ChatMessageDto saved = chatMessageService.addMessage(room, senderId, content);
+            System.out.println("✅ メッセージ保存成功");
+            System.out.println("   - messageId: " + saved.getId());
+            System.out.println("   - roomId: " + saved.getRoomId());
+            System.out.println("   - senderId: " + saved.getSenderId());
+            System.out.println("   - content: " + saved.getContent());
+            System.out.println("   - createdAt: " + saved.getCreatedAt());
 
-            log.info("Message saved: {}", saved.getId());
-
+            // WebSocket トピックへ送信
+            System.out.println("📤 WebSocket トピック /topic/chat/" + room.getId() + " へメッセージを送信中...");
             messagingTemplate.convertAndSend(
                     "/topic/chat/" + room.getId(),
                     saved
             );
-            log.info("✅ Message sent to topic");
+            System.out.println("✅ WebSocket 送信完了");
+            System.out.println("========== /chat/send 処理完了 ==========\n");
+            
+        } catch (NumberFormatException e) {
+            System.out.println("❌ 型変換エラー発生");
+            System.out.println("   エラーメッセージ: " + e.getMessage());
+            System.out.println("   roomId を Integer に変換できませんでした");
+            e.printStackTrace();
+            System.out.println("========== /chat/send 処理失敗 ==========\n");
+        } catch (NullPointerException e) {
+            System.out.println("❌ NullPointerException 発生");
+            System.out.println("   ペイロードに必須パラメータが不足しています");
+            System.out.println("   必須: senderId, roomId, content");
+            System.out.println("   エラーメッセージ: " + e.getMessage());
+            e.printStackTrace();
+            System.out.println("========== /chat/send 処理失敗 ==========\n");
         } catch (Exception e) {
-            log.error("Error in sendMessage", e);
+            System.out.println("❌ 予期しないエラー発生");
+            System.out.println("   エラータイプ: " + e.getClass().getName());
+            System.out.println("   エラーメッセージ: " + e.getMessage());
+            e.printStackTrace();
+            System.out.println("========== /chat/send 処理失敗 ==========\n");
         }
     }
 
@@ -57,14 +123,34 @@ public class ChatWebSocketController {
     public void deleteMessage(
             @Payload Map<String, Object> payload
     ) {
+        System.out.println("\n========== WebSocket /chat/delete リクエスト受信 ==========");
+        System.out.println("🗑️ ペイロード全体: " + payload);
+        
         try {
-            log.info("🗑️ Delete request: {}", payload);
+            // パラメータの取得と検証
+            System.out.println("🔍 パラメータを抽出中...");
+            Object messageIdObj = payload.get("messageId");
+            Object roomIdObj = payload.get("roomId");
+            
+            System.out.println("   - messageId タイプ: " + (messageIdObj != null ? messageIdObj.getClass().getSimpleName() : "null"));
+            System.out.println("   - messageId 値: " + messageIdObj);
+            System.out.println("   - roomId タイプ: " + (roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null"));
+            System.out.println("   - roomId 値: " + roomIdObj);
             
             Integer messageId = ((Number) payload.get("messageId")).intValue();
             Integer roomId = ((Number) payload.get("roomId")).intValue();
             
-            chatMessageService.deleteMessage(messageId);
+            System.out.println("✅ パラメータ抽出成功");
+            System.out.println("   - messageId (最終): " + messageId);
+            System.out.println("   - roomId (最終): " + roomId);
             
+            // メッセージ削除
+            System.out.println("🔍 messageId=" + messageId + " を削除中...");
+            chatMessageService.deleteMessage(messageId);
+            System.out.println("✅ メッセージ削除成功");
+            
+            // WebSocket トピックへ削除通知を送信
+            System.out.println("📤 WebSocket トピック /topic/chat/" + roomId + " へ削除通知を送信中...");
             messagingTemplate.convertAndSend(
                     "/topic/chat/" + roomId,
                     Map.of(
@@ -72,9 +158,28 @@ public class ChatWebSocketController {
                         "messageId", messageId
                     )
             );
-            log.info("✅ Delete message sent to topic");
+            System.out.println("✅ WebSocket 送信完了");
+            System.out.println("========== /chat/delete 処理完了 ==========\n");
+            
+        } catch (NumberFormatException e) {
+            System.out.println("❌ 型変換エラー発生");
+            System.out.println("   エラーメッセージ: " + e.getMessage());
+            System.out.println("   messageId または roomId を Integer に変換できませんでした");
+            e.printStackTrace();
+            System.out.println("========== /chat/delete 処理失敗 ==========\n");
+        } catch (NullPointerException e) {
+            System.out.println("❌ NullPointerException 発生");
+            System.out.println("   ペイロードに必須パラメータが不足しています");
+            System.out.println("   必須: messageId, roomId");
+            System.out.println("   エラーメッセージ: " + e.getMessage());
+            e.printStackTrace();
+            System.out.println("========== /chat/delete 処理失敗 ==========\n");
         } catch (Exception e) {
-            log.error("Error in deleteMessage", e);
+            System.out.println("❌ 予期しないエラー発生");
+            System.out.println("   エラータイプ: " + e.getClass().getName());
+            System.out.println("   エラーメッセージ: " + e.getMessage());
+            e.printStackTrace();
+            System.out.println("========== /chat/delete 処理失敗 ==========\n");
         }
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ChatMessageDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ChatMessageDto.java
@@ -18,5 +18,4 @@ public class ChatMessageDto {
     private String content;
     private Timestamp createdAt;
     private Timestamp updatedAt;
-    private Boolean isSender;  // 新しく追加：自分が送ったメッセージかどうか
 }

--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -14,7 +14,7 @@ export default function MessageBubble({
   const [showDelete, setShowDelete] = useState(false);
 
   const baseStyle =
-    'max-w-[70%] px-4 py-3 rounded-2xl text-sm whitespace-pre-wrap break-words shadow-md relative';
+    'max-w-[85%] px-4 py-3 rounded-2xl text-sm whitespace-pre-wrap break-words shadow-md relative';
 
   const alignment = isSender
     ? 'self-end bg-gradient-primary text-white rounded-br-none'
@@ -39,7 +39,7 @@ export default function MessageBubble({
       onMouseEnter={() => isSender && !isDeleted && setShowDelete(true)}
       onMouseLeave={() => setShowDelete(false)}
     >
-      <div className="flex flex-col max-w-[70%]">
+      <div className="flex flex-col max-w-[85%]">
         {!isSender && senderName && (
           <span className="text-xs text-gray-500 mb-1 ml-1">{senderName}</span>
         )}

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -36,6 +36,7 @@ export default function ChatPage() {
         const data = await res.json();
         // このdata.idはリアルタイムで相手から送信してきた。それとも自分で送信をしたの判断をつけるためのフラグ
         setSenderId(data.id);
+        console.log('[ChatPage] Fetched user info, senderId:', data.id);
       } catch (error) {
         console.error('ユーザー情報取得エラー:', error);
         navigate('/login');
@@ -101,7 +102,7 @@ export default function ChatPage() {
         senderName: msg.senderName,
         content: msg.content,
         createdAt: msg.createdAt,
-        isSender: msg.isSender, // バックエンドから直接取得
+        isSender: msg.senderId === senderId,
       }));
 
       setMessages(formatted);
@@ -137,6 +138,8 @@ export default function ChatPage() {
           const data = JSON.parse(message.body);
           console.log('📩 Received message from topic:', data);
 
+          // バックエンドから返却された ChatMessageDto をそのまま使用
+          // data.isSender は既にバックエンドで計算されている
           setMessages((prev) => [
             ...prev,
             {
@@ -185,19 +188,9 @@ export default function ChatPage() {
       }),
     });
 
-    // ローカルでも先に追加（楽観的 UI 更新）
-    setMessages((prev) => [
-      ...prev,
-      {
-        id: Date.now(), // 仮のID
-        roomId,
-        senderId,
-        senderName: '自分',
-        content: text,
-        createdAt: new Date().toISOString(),
-        isSender: true,
-      },
-    ]);
+    // 💡 楽観的UI更新を削除：バックエンドからの返却を待つ
+    // WebSocket経由でバックエンドが /topic/chat/{roomId} にメッセージをブロードキャストするので
+    // 自動的にメッセージが画面に追加される
   };
 
   // --- メッセージ削除（拡張用） ---
@@ -236,7 +229,7 @@ export default function ChatPage() {
       <HamburgerMenu title="個人チャット" />
 
       <div className="flex flex-col h-screen bg-gradient-to-br from-gray-50 to-primary-50 text-black pt-16">
-        <div className="flex-1 overflow-y-auto px-4 py-6 space-y-2 max-w-4xl mx-auto w-full pb-[120px]">
+        <div className="flex-1 overflow-y-auto px-2 py-6 space-y-2 max-w-full mx-auto w-full pb-[120px]">
           {messages.length === 0 && (
             <div className="flex items-center justify-center h-full">
               <p className="text-gray-400 text-lg">メッセージがありません</p>
@@ -255,7 +248,7 @@ export default function ChatPage() {
         </div>
 
         <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-100 shadow-2xl p-4 z-10">
-          <div className="max-w-4xl mx-auto w-full space-y-3">
+          <div className="max-w-full mx-auto px-2 w-full space-y-3">
             {messages.length > 0 && (
               <button
                 onClick={handleAiFeedback}


### PR DESCRIPTION
### 修正点

1. フロントエンド側で当初はsubject値でユーザー識別をしていたが認可コードグラントの制約上idトークンを含め露出はしない方がいい
2. バックエンド側で相手ユーザーのメッセージか自分が送信したメッセージかを判定をしていたが、それでは単一サーバー側での条件分岐になってかくクライアント側にブロードキャストをしてしまうのでフロントエンドがわでuser_idを判定していた
3. フロントエンド側には現在ログ出力をしているが、これからは本番環境ベースでの開発になると思うのでログの内容も考えながらコーディングをしていく