### PR TITLE
UI簡素化: デザインシステムリセット

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,35 +12,6 @@ body {
   font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
-/* アニメーション */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes slideIn {
-  from {
-    transform: translateY(10px);
-    opacity: 0;
-  }
-  to {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-.fade-in {
-  animation: fadeIn 0.3s ease-in;
-}
-
-.slide-in {
-  animation: slideIn 0.3s ease-out;
-}
-
 /* スクロールバーのカスタマイズ */
 ::-webkit-scrollbar {
   width: 8px;
@@ -57,3 +28,4 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #b0bfd9;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,28 +3,24 @@
 @tailwind utilities;
 @layer base {
   body {
-    @apply bg-gradient-to-br from-gray-50 to-primary-50;
-  }
-
-  * {
-    @apply transition-colors duration-200;
+    @apply bg-gray-50;
   }
 }
 
 @layer components {
   .btn-primary {
-    @apply bg-gradient-primary text-white font-semibold py-3 rounded-lg hover:shadow-lg transition-all duration-200 transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-primary-500 text-white font-medium py-2.5 rounded-lg hover:bg-primary-600 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
   .btn-secondary {
-    @apply border-2 border-primary-300 text-primary-600 font-semibold py-3 rounded-lg hover:bg-primary-50 transition-all duration-200;
+    @apply border border-gray-300 text-gray-700 font-medium py-2.5 rounded-lg hover:bg-gray-50 transition-colors duration-150;
   }
 
   .card {
-    @apply bg-white rounded-xl shadow-lg p-6 border border-gray-100;
+    @apply bg-white rounded-xl shadow-sm p-6 border border-gray-200;
   }
 
   .input-primary {
-    @apply w-full border-2 border-gray-200 rounded-lg px-4 py-3 focus:border-primary-500 focus:ring-2 focus:ring-primary-100 transition-all duration-200;
+    @apply w-full border border-gray-300 rounded-lg px-4 py-2.5 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 focus:outline-none transition-colors duration-150;
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,62 +5,29 @@ export default {
     extend: {
       colors: {
         primary: {
-          50: '#f0f7ff',
-          100: '#e0effe',
-          200: '#bde9fe',
-          300: '#7dd3fc',
-          400: '#38bdf8',
-          500: '#0ea5e9',
-          600: '#0284c7',
-          700: '#0369a1',
-          800: '#075985',
-          900: '#0c3d66',
+          50: '#eff6ff',
+          100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
+          400: '#60a5fa',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          800: '#1e40af',
+          900: '#1e3a8a',
         },
-        secondary: {
-          50: '#f5f3ff',
-          100: '#ede9fe',
-          200: '#ddd6fe',
-          300: '#c4b5fd',
-          400: '#a78bfa',
-          500: '#8b5cf6',
-          600: '#7c3aed',
-          700: '#6d28d9',
-          800: '#5b21b6',
-          900: '#4c1d95',
-        },
-      },
-      backgroundImage: {
-        'gradient-primary': 'linear-gradient(135deg, #0ea5e9 0%, #6d28d9 100%)',
-        'gradient-secondary':
-          'linear-gradient(135deg, #6d28d9 0%, #ec4899 100%)',
-      },
-      boxShadow: {
-        'sm-soft': '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
-        'md-soft': '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
-        'lg-soft': '0 10px 15px -3px rgba(0, 0, 0, 0.1)',
-        'xl-soft': '0 20px 25px -5px rgba(0, 0, 0, 0.1)',
       },
       borderRadius: {
         xl: '1rem',
         '2xl': '1.5rem',
       },
       animation: {
-        'fade-in': 'fadeIn 0.3s ease-in',
-        'slide-in': 'slideIn 0.3s ease-out',
-        'scale-in': 'scaleIn 0.2s ease-out',
+        'fade-in': 'fadeIn 0.15s ease-in',
       },
       keyframes: {
         fadeIn: {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },
-        },
-        slideIn: {
-          '0%': { transform: 'translateY(10px)', opacity: '0' },
-          '100%': { transform: 'translateY(0)', opacity: '1' },
-        },
-        scaleIn: {
-          '0%': { transform: 'scale(0.9)', opacity: '0' },
-          '100%': { transform: 'scale(1)', opacity: '1' },
         },
       },
     },


### PR DESCRIPTION
## Summary
- tailwind.config.jsからsecondaryカラーパレット、グラデーション定義、カスタムシャドウ、slide-in/scale-inアニメーションを削除
- primaryカラーをBlue系 (#3b82f6) に統一
- index.cssからグローバル `* { transition-colors }` を削除し、body背景をフラットに
- App.cssから重複アニメーション定義を削除

## Test plan
- [ ] `npm run build` が成功すること
- [ ] アプリ全体のベースカラーがブルー系に統一されていること

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)