### PR TITLE
UI簡素化: 共通コンポーネントの簡素化

### DIFF
--- a/frontend/src/components/ConfirmModal.jsx
+++ b/frontend/src/components/ConfirmModal.jsx
@@ -27,12 +27,12 @@ export default function ConfirmModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* オーバーレイ */}
       <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
+        className="absolute inset-0 bg-black/50 animate-fade-in"
         onClick={onCancel}
       />
 
       {/* モーダル */}
-      <div className="relative bg-white rounded-2xl shadow-2xl p-6 mx-4 max-w-sm w-full animate-scale-in">
+      <div className="relative bg-white rounded-2xl shadow-md p-6 mx-4 max-w-sm w-full animate-fade-in">
         {/* アイコン */}
         <div className="flex justify-center mb-4">
           <div
@@ -84,13 +84,13 @@ export default function ConfirmModal({
         <div className="flex gap-3">
           <button
             onClick={onCancel}
-            className="flex-1 px-4 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 font-semibold rounded-xl transition-colors"
+            className="flex-1 px-4 py-2.5 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-xl transition-colors duration-150"
           >
             {cancelText}
           </button>
           <button
             onClick={onConfirm}
-            className={`flex-1 px-4 py-3 font-semibold rounded-xl transition-colors ${
+            className={`flex-1 px-4 py-2.5 font-medium rounded-xl transition-colors duration-150 ${
               isDanger
                 ? 'bg-red-500 hover:bg-red-600 text-white'
                 : 'bg-primary-500 hover:bg-primary-600 text-white'

--- a/frontend/src/components/InputField.jsx
+++ b/frontend/src/components/InputField.jsx
@@ -18,7 +18,7 @@ export default function InputField({
   return (
     <div className="mb-6">
       <label
-        className="block text-sm font-semibold text-gray-700 mb-2"
+        className="block text-sm font-medium text-gray-700 mb-2"
         htmlFor={name}
       >
         {label}
@@ -33,7 +33,7 @@ export default function InputField({
             setInputValue(e.target.value);
             onChange(e);
           }}
-          className="w-full border-2 border-gray-200 rounded-lg px-4 py-3 pr-10 focus:outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100 transition-all duration-200"
+          className="w-full border border-gray-300 rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors duration-150"
         />
         {inputValue && (
           <button

--- a/frontend/src/components/LinkText.jsx
+++ b/frontend/src/components/LinkText.jsx
@@ -4,7 +4,7 @@ export default function LinkText({ to, children }) {
   return (
     <Link
       to={to}
-      className="text-sm text-primary-600 hover:text-primary-700 font-semibold transition-colors duration-200 hover:underline"
+      className="text-sm text-primary-500 hover:text-primary-600 font-medium transition-colors duration-150 hover:underline"
     >
       {children}
     </Link>

--- a/frontend/src/components/MessageInput.jsx
+++ b/frontend/src/components/MessageInput.jsx
@@ -59,10 +59,10 @@ export default function MessageInput({ onSend }) {
   };
 
   return (
-    <div className="w-full bg-white flex items-end p-3 border-t-2 border-gray-100 shadow-2xl transition-all duration-300">
+    <div className="w-full bg-white flex items-end p-3 border-t border-gray-200">
       {/* ＋アイコンボタン（左端） */}
       <button
-        className="text-primary-400 hover:text-primary-600 p-2.5 rounded-full transition-all duration-150 flex-shrink-0 mb-1 hover:bg-primary-50"
+        className="text-gray-500 hover:text-gray-700 p-2.5 rounded-full transition-colors duration-150 flex-shrink-0 mb-1"
         aria-label="添付ファイル"
       >
         <PlusIcon className="h-6 w-6" />
@@ -73,7 +73,7 @@ export default function MessageInput({ onSend }) {
         <textarea
           ref={textareaRef}
           rows={minRows}
-          className="w-full bg-transparent text-gray-800 outline-none resize-none px-3 py-2 placeholder-gray-400 leading-6 font-medium"
+          className="w-full bg-transparent text-gray-800 outline-none resize-none px-3 py-2 placeholder-gray-400 leading-6"
           placeholder="メッセージを入力..."
           value={text}
           onChange={(e) => setText(e.target.value)}
@@ -86,7 +86,7 @@ export default function MessageInput({ onSend }) {
       {/* 送信ボタン（右端） */}
       <button
         onClick={handleSend}
-        className="text-white bg-gradient-primary p-2.5 rounded-full hover:shadow-lg transition-all duration-150 flex-shrink-0 disabled:bg-gray-300 disabled:shadow-none mb-1 ml-2 transform hover:scale-110"
+        className="text-white bg-primary-500 p-2.5 rounded-full hover:bg-primary-600 transition-colors duration-150 flex-shrink-0 disabled:bg-gray-300 mb-1 ml-2"
         disabled={!text.trim()}
         aria-label="送信"
       >

--- a/frontend/src/components/PrimaryButton.jsx
+++ b/frontend/src/components/PrimaryButton.jsx
@@ -9,7 +9,7 @@ export default function PrimaryButton({
       type={type}
       onClick={onClick}
       disabled={disabled}
-      className="w-full bg-gradient-primary text-white font-semibold py-3 rounded-lg hover:shadow-lg transition-all duration-200 transform hover:scale-105 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+      className="w-full bg-primary-500 text-white font-medium py-2.5 rounded-lg hover:bg-primary-600 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {children}
     </button>

--- a/frontend/src/components/SNSSignInButton.jsx
+++ b/frontend/src/components/SNSSignInButton.jsx
@@ -17,10 +17,10 @@ export default function SNSSignInButton({ provider, onClick }) {
   return (
     <button
       onClick={onClick}
-      className="w-full border-2 border-gray-200 rounded-lg py-3 px-4 flex items-center justify-center space-x-3 hover:bg-gradient-to-r hover:from-primary-50 hover:to-secondary-50 hover:border-primary-300 transition-all duration-200 transform hover:scale-105 shadow-sm hover:shadow-md mb-3"
+      className="w-full border border-gray-300 rounded-lg py-2.5 px-4 flex items-center justify-center space-x-3 hover:bg-gray-50 transition-colors duration-150 mb-3"
     >
       <img src={providerIcons[provider]} alt={provider} className="w-5 h-5" />
-      <span className="text-sm font-semibold text-gray-700">
+      <span className="text-sm font-medium text-gray-700">
         {providerLabels[provider]}
       </span>
     </button>

--- a/frontend/src/components/SearchBox.jsx
+++ b/frontend/src/components/SearchBox.jsx
@@ -9,7 +9,7 @@ export default function SearchBox({ value, onChange, placeholder = '検索' }) {
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full rounded-lg border-2 border-gray-200 py-3 pl-12 pr-4 focus:border-primary-500 focus:ring-2 focus:ring-primary-100 focus:outline-none transition-all duration-200 shadow-sm placeholder-gray-400 font-medium"
+        className="w-full rounded-lg border border-gray-300 py-2.5 pl-12 pr-4 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 focus:outline-none transition-colors duration-150 placeholder-gray-400"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- PrimaryButton: グラデーション→単色blue、hover:scale削除
- InputField: border-2→border、focus:ring簡素化
- SearchBox: シャドウ・太字フォント削除
- ConfirmModal: backdrop-blur削除、shadow→shadow-md
- MessageInput: shadow-2xl削除、送信ボタン単色化
- SNSSignInButton: ホバーグラデーション・スケール削除
- LinkText: トランジション統一

## Test plan
- [ ] `npm run build` 成功
- [ ] ログインページのボタン・入力欄が正常表示
- [ ] チャット画面のメッセージ入力欄が正常動作

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)