### PR TITLE
UI簡素化: ナビゲーション (HamburgerMenu) の簡素化

### DIFF
--- a/frontend/src/components/HamburgerMenu.jsx
+++ b/frontend/src/components/HamburgerMenu.jsx
@@ -49,57 +49,57 @@ export default function HamburgerMenu({ title }) {
       label: 'ホーム',
       icon: HomeIcon,
       onClick: () => navigate('/'),
-      color: 'text-primary-600',
+      color: 'text-gray-600',
     },
     {
       label: 'チャット一覧',
       icon: ChatBubbleLeftRightIcon,
       onClick: () => navigate('/chat'),
-      color: 'text-blue-600',
+      color: 'text-gray-600',
     },
     {
       label: 'プロフィール',
       icon: UserCircleIcon,
       onClick: () => navigate('/profile/me'),
-      color: 'text-secondary-600',
+      color: 'text-gray-600',
     },
     {
       label: 'パーソナリティ設定',
       icon: LightBulbIcon,
       onClick: () => navigate('/profile/personality'),
-      color: 'text-purple-600',
+      color: 'text-gray-600',
     },
     {
       label: 'ユーザー検索',
       icon: MagnifyingGlassIcon,
       onClick: () => navigate('/chat/users'),
-      color: 'text-teal-600',
+      color: 'text-gray-600',
     },
     {
       label: 'AI',
       icon: SparklesIcon,
       onClick: () => navigate('/chat/ask-ai'),
-      color: 'text-pink-600',
+      color: 'text-gray-600',
     },
     {
       label: 'ログアウト',
       icon: ArrowLeftOnRectangleIcon,
       onClick: handleLogout,
-      color: 'text-red-600',
+      color: 'text-red-500',
     },
   ];
 
   return (
-    <header className="w-full bg-gradient-to-r from-white to-gray-50 shadow-md fixed top-0 left-0 z-50 border-b border-gray-100">
+    <header className="w-full bg-white shadow-sm fixed top-0 left-0 z-50 border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
         <button
           onClick={() => navigate('/')}
           className="flex items-center space-x-2"
         >
-          <div className="bg-gradient-primary w-10 h-10 rounded-lg flex items-center justify-center">
+          <div className="bg-primary-500 w-10 h-10 rounded-lg flex items-center justify-center">
             <span className="text-white font-bold text-lg">F</span>
           </div>
-          <h1 className="text-xl bg-gradient-to-r from-primary-600 to-secondary-600 bg-clip-text text-transparent hidden sm:block">
+          <h1 className="text-xl font-bold text-gray-900 hidden sm:block">
             {title}
           </h1>
         </button>
@@ -112,9 +112,9 @@ export default function HamburgerMenu({ title }) {
               <button
                 key={index}
                 onClick={item.onClick}
-                className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-all duration-200 hover:bg-gray-100 ${item.color} font-medium group`}
+                className={`flex items-center space-x-2 px-4 py-2 rounded-lg transition-colors duration-150 hover:bg-gray-100 ${item.color} font-medium`}
               >
-                <Icon className="w-5 h-5 group-hover:scale-110 transition-transform" />
+                <Icon className="w-5 h-5" />
                 <span className="text-gray-700">{item.label}</span>
               </button>
             );
@@ -136,7 +136,7 @@ export default function HamburgerMenu({ title }) {
 
       {/* モバイルメニュー */}
       {isOpen && (
-        <div className="md:hidden bg-white border-t border-gray-200 shadow-lg animate-fade-in">
+        <div className="md:hidden bg-white border-t border-gray-200">
           {menuItems.map((item, index) => {
             const Icon = item.icon;
             return (
@@ -149,7 +149,7 @@ export default function HamburgerMenu({ title }) {
                 className={`flex items-center w-full px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors ${item.color}`}
               >
                 <Icon className="w-5 h-5 mr-3" />
-                <span className="font-semibold text-gray-800">
+                <span className="font-medium text-gray-800">
                   {item.label}
                 </span>
               </button>


### PR DESCRIPTION
## Summary
- メニューアイコン色をtext-gray-600に統一（ログアウトのみtext-red-500）
- ヘッダー背景をフラットなwhiteに変更
- ロゴ・タイトルのグラデーション削除
- hover:scale-110アイコンアニメーション削除

## Test plan
- [ ] 全ページでヘッダーが正常表示
- [ ] モバイルメニューの開閉が正常動作
- [ ] 各メニュー項目のナビゲーションが正常

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)