### PR TITLE
UI簡素化: チャットUI (MessageBubble, ChatPage, AskAiPage)

### DIFF
--- a/frontend/src/components/MessageBubble.jsx
+++ b/frontend/src/components/MessageBubble.jsx
@@ -14,15 +14,15 @@ export default function MessageBubble({
   const [showDelete, setShowDelete] = useState(false);
 
   const baseStyle =
-    'max-w-[95%] px-4 py-3 rounded-2xl text-sm whitespace-pre-wrap break-words shadow-md relative';
+    'max-w-[85%] px-4 py-2.5 rounded-2xl text-sm whitespace-pre-wrap break-words relative';
 
   const alignment = isSender
-    ? 'self-end bg-gradient-primary text-white rounded-br-none'
-    : 'self-start bg-gray-100 text-gray-800 rounded-bl-none border-l-4 border-primary-400';
+    ? 'self-end bg-primary-500 text-white rounded-br-sm'
+    : 'self-start bg-gray-100 text-gray-900 rounded-bl-sm';
 
   const deletedAlignment = isSender
-    ? 'self-end bg-gray-200 text-gray-500 italic rounded-br-none'
-    : 'self-start bg-gray-200 text-gray-500 italic rounded-bl-none border-l-4 border-gray-300';
+    ? 'self-end bg-gray-200 text-gray-500 italic rounded-br-sm'
+    : 'self-start bg-gray-200 text-gray-500 italic rounded-bl-sm';
 
   const formatTime = (dateString) => {
     if (!dateString) return '';
@@ -37,7 +37,7 @@ export default function MessageBubble({
     <div
       className={`flex ${
         isSender ? 'justify-end' : 'justify-start'
-      } my-3 animate-fade-in group`}
+      } my-3 group`}
       onMouseEnter={() => isSender && !isDeleted && setShowDelete(true)}
       onMouseLeave={() => setShowDelete(false)}
     >
@@ -66,7 +66,7 @@ export default function MessageBubble({
           {isSender && showDelete && onDelete && !isDeleted && (
             <button
               onClick={() => onDelete(id)}
-              className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-700 text-white rounded-full p-1 shadow-md transition-all"
+              className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 transition-colors duration-150"
               title="削除"
             >
               <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/components/MessageBubbleAi.jsx
+++ b/frontend/src/components/MessageBubbleAi.jsx
@@ -14,11 +14,11 @@ export default function MessageBubbleAi({
   const [showDelete, setShowDelete] = useState(false);
 
   const baseStyle =
-    'max-w-[95%] px-4 py-3 rounded-2xl text-sm whitespace-pre-wrap break-words shadow-md relative';
+    'max-w-[85%] px-4 py-2.5 rounded-2xl text-sm whitespace-pre-wrap break-words relative';
 
   const alignment = isSender
-    ? 'self-end bg-gradient-primary text-white rounded-br-none'
-    : 'self-start bg-gray-100 text-gray-800 rounded-bl-none border-l-4 border-primary-400';
+    ? 'self-end bg-primary-500 text-white rounded-br-sm'
+    : 'self-start bg-gray-100 text-gray-900 rounded-bl-sm';
 
   // 削除済みメッセージ用のスタイル
   const deletedStyle = 'bg-gray-200 text-gray-500 italic';
@@ -27,7 +27,7 @@ export default function MessageBubbleAi({
     <div
       className={`flex ${
         isSender ? 'justify-end' : 'justify-start'
-      } my-3 animate-fade-in group`}
+      } my-3 group`}
       onMouseEnter={() => isSender && !isDeleted && setShowDelete(true)}
       onMouseLeave={() => setShowDelete(false)}
     >
@@ -52,7 +52,7 @@ export default function MessageBubbleAi({
         {isSender && showDelete && onDelete && !isDeleted && (
           <button
             onClick={() => onDelete(id)}
-            className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-700 text-white rounded-full p-1 shadow-md transition-all"
+            className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 transition-colors duration-150"
             title="削除"
           >
             <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">

--- a/frontend/src/pages/AskAiPage.jsx
+++ b/frontend/src/pages/AskAiPage.jsx
@@ -408,14 +408,14 @@ export default function AskAiPage() {
       <HamburgerMenu title="AIに聞く" />
 
       {/* 全体レイアウト */}
-      <div className="flex h-screen bg-gradient-to-br from-gray-50 to-pink-50 text-black pt-16">
+      <div className="flex h-screen bg-gray-50 text-black pt-16">
         
         {/* サイドバー（セッション一覧） */}
-        <div className={`${sidebarOpen ? 'w-64' : 'w-0'} transition-all duration-300 bg-white border-r border-gray-200 flex flex-col overflow-hidden`}>
+        <div className={`${sidebarOpen ? 'w-64' : 'w-0'} bg-white border-r border-gray-200 flex flex-col overflow-hidden`}>
           <div className="p-4 border-b border-gray-200">
             <button
               onClick={handleNewSession}
-              className="w-full bg-gradient-to-r from-pink-500 to-orange-400 text-white py-2 px-4 rounded-lg font-medium hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+              className="w-full bg-primary-500 text-white py-2 px-4 rounded-lg font-medium hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
@@ -431,7 +431,7 @@ export default function AskAiPage() {
                   key={session.id}
                   className={`group flex items-center justify-between p-3 rounded-lg cursor-pointer transition-colors ${
                     currentSessionId === session.id
-                      ? 'bg-pink-100 text-pink-700'
+                      ? 'bg-primary-50 text-primary-700'
                       : 'hover:bg-gray-100'
                   }`}
                   onClick={() => editingSessionId !== session.id && handleSelectSession(session.id)}
@@ -447,7 +447,7 @@ export default function AskAiPage() {
                             if (e.key === 'Enter') handleSaveTitle(session.id);
                             if (e.key === 'Escape') handleCancelEditTitle();
                           }}
-                          className="flex-1 text-sm px-2 py-1 border border-pink-300 rounded focus:outline-none focus:ring-1 focus:ring-pink-400"
+                          className="flex-1 text-sm px-2 py-1 border border-primary-300 rounded focus:outline-none focus:ring-1 focus:ring-primary-400"
                           autoFocus
                         />
                         <button
@@ -510,7 +510,7 @@ export default function AskAiPage() {
         {/* サイドバートグルボタン */}
         <button
           onClick={() => setSidebarOpen(!sidebarOpen)}
-          className="absolute left-0 top-1/2 transform -translate-y-1/2 bg-white border border-gray-200 rounded-r-lg p-2 shadow-md z-20 ml-64 transition-all duration-300"
+          className="absolute left-0 top-1/2 transform -translate-y-1/2 bg-white border border-gray-200 rounded-r-lg p-2 shadow-sm z-20"
           style={{ marginLeft: sidebarOpen ? '256px' : '0' }}
         >
           <svg
@@ -528,7 +528,7 @@ export default function AskAiPage() {
           {/* ヘッダー情報 */}
           <div className="bg-white border-b border-gray-200 px-4 py-4 shadow-sm">
             <div className="max-w-4xl mx-auto flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-to-br from-pink-400 to-orange-400 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-primary-500 rounded-full flex items-center justify-center">
                 <svg
                   className="w-6 h-6 text-white"
                   fill="currentColor"
@@ -548,9 +548,9 @@ export default function AskAiPage() {
           <div className="flex-1 overflow-y-auto px-4 py-6 space-y-3 max-w-4xl mx-auto w-full mb-[100px]">
             {messages.length === 0 && (
               <div className="flex flex-col items-center justify-center h-full text-center">
-                <div className="w-16 h-16 bg-gradient-to-br from-pink-200 to-orange-200 rounded-full flex items-center justify-center mb-4">
+                <div className="w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center mb-4">
                   <svg
-                    className="w-8 h-8 text-pink-600"
+                    className="w-8 h-8 text-primary-600"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -579,7 +579,7 @@ export default function AskAiPage() {
           </div>
 
           {/* 入力欄固定 */}
-          <div className="fixed bottom-0 right-0 bg-white border-t border-gray-200 shadow-2xl p-4 z-10"
+          <div className="fixed bottom-0 right-0 bg-white border-t border-gray-200 shadow-sm p-4 z-10"
                style={{ left: sidebarOpen ? '256px' : '0', transition: 'left 0.3s' }}>
             <div className="max-w-4xl mx-auto w-full">
               <MessageInput onSend={handleSend} />

--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -466,10 +466,10 @@ export default function ChatPage() {
       <HamburgerMenu title="個人チャット" />
 
       {/* 全体レイアウト - サイドバー付き */}
-      <div className="flex h-screen bg-gradient-to-br from-gray-50 to-pink-50 text-black pt-16">
+      <div className="flex h-screen bg-gray-50 text-black pt-16">
         
         {/* サイドバー */}
-        <div className={`${sidebarOpen ? 'w-80' : 'w-0'} transition-all duration-300 bg-white border-r border-gray-200 flex flex-col overflow-hidden`}>
+        <div className={`${sidebarOpen ? 'w-80' : 'w-0'} bg-white border-r border-gray-200 flex flex-col overflow-hidden`}>
           {/* サイドバーヘッダー */}
           <div className="p-4 border-b border-gray-100">
             <h3 className="font-bold text-gray-800 mb-3">チャット履歴</h3>
@@ -496,7 +496,7 @@ export default function ChatPage() {
                   }`}
                 >
                   {/* アバター */}
-                  <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-purple-400 rounded-full flex-shrink-0 flex items-center justify-center">
+                  <div className="w-12 h-12 bg-primary-500 rounded-full flex-shrink-0 flex items-center justify-center">
                     <span className="text-white font-bold text-lg">
                       {user.name?.charAt(0)?.toUpperCase() || 'U'}
                     </span>
@@ -528,7 +528,7 @@ export default function ChatPage() {
         {/* サイドバートグルボタン */}
         <button
           onClick={() => setSidebarOpen(!sidebarOpen)}
-          className="absolute left-0 top-1/2 -translate-y-1/2 z-20 bg-white border border-gray-200 rounded-r-lg p-2 shadow-md hover:bg-gray-50 transition-colors"
+          className="absolute left-0 top-1/2 -translate-y-1/2 z-20 bg-white border border-gray-200 rounded-r-lg p-2 shadow-sm hover:bg-gray-50 transition-colors"
           style={{ left: sidebarOpen ? '320px' : '0' }}
         >
           <svg
@@ -546,7 +546,7 @@ export default function ChatPage() {
           {/* ヘッダー情報 */}
           <div className="bg-white border-b border-gray-200 px-4 py-4 shadow-sm">
             <div className="max-w-4xl mx-auto flex items-center space-x-3">
-              <div className="w-10 h-10 bg-gradient-to-br from-blue-400 to-purple-400 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-primary-500 rounded-full flex items-center justify-center">
                 <svg
                   className="w-6 h-6 text-white"
                   fill="currentColor"
@@ -566,7 +566,7 @@ export default function ChatPage() {
           <div className="flex-1 overflow-y-auto px-4 py-6 space-y-3 max-w-4xl mx-auto w-full mb-[160px]">
             {messages.length === 0 && (
               <div className="flex flex-col items-center justify-center h-full text-center">
-                <div className="w-16 h-16 bg-gradient-to-br from-blue-200 to-purple-200 rounded-full flex items-center justify-center mb-4">
+                <div className="w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center mb-4">
                   <svg
                     className="w-8 h-8 text-blue-600"
                     fill="currentColor"
@@ -631,7 +631,7 @@ export default function ChatPage() {
           </div>
 
           {/* 入力欄固定 */}
-          <div className="fixed bottom-0 right-0 bg-white border-t border-gray-200 shadow-2xl p-4 z-10" style={{ left: sidebarOpen ? '320px' : '0' }}>
+          <div className="fixed bottom-0 right-0 bg-white border-t border-gray-200 shadow-sm p-4 z-10" style={{ left: sidebarOpen ? '320px' : '0' }}>
             <div className="max-w-4xl mx-auto w-full space-y-3">
               {selectionMode ? (
                 /* 選択モードUI */
@@ -687,16 +687,16 @@ export default function ChatPage() {
                   <div className="flex gap-2">
                     <button
                       onClick={handleCancelSelection}
-                      className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold py-3 px-4 rounded-lg transition-all duration-150"
+                      className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold py-3 px-4 rounded-lg transition-colors duration-150"
                     >
                       キャンセル
                     </button>
                     <button
                       onClick={handleSendToAi}
                       disabled={selectedMessages.size === 0}
-                      className={`flex-1 font-semibold py-3 px-4 rounded-lg transition-all duration-150 ${
+                      className={`flex-1 font-semibold py-3 px-4 rounded-lg transition-colors duration-150 ${
                         selectedMessages.size > 0
-                          ? 'bg-gradient-to-r from-blue-500 to-purple-500 hover:shadow-lg text-white'
+                          ? 'bg-primary-500 hover:bg-primary-600 text-white'
                           : 'bg-gray-300 text-gray-500 cursor-not-allowed'
                       }`}
                     >
@@ -713,7 +713,7 @@ export default function ChatPage() {
                   {messages.length > 0 && (
                     <button
                       onClick={handleAiFeedback}
-                      className="w-full bg-gradient-to-r from-blue-500 to-purple-500 hover:shadow-lg text-white font-semibold py-3 px-4 rounded-lg transition-all duration-150"
+                      className="w-full bg-primary-500 hover:bg-primary-600 text-white font-semibold py-3 px-4 rounded-lg transition-colors duration-150"
                     >
                       AIにフィードバックしてもらう
                     </button>


### PR DESCRIPTION
## Summary
- MessageBubble/Ai: グラデーション→単色bg-primary-500、shadow/animate削除
- ChatPage: 背景フラット化、アバター単色化、ボタングラデーション削除
- AskAiPage: ピンク/オレンジ→ブルー統一

## Test plan
- [ ] チャットメッセージの送受信表示が正常
- [ ] AI チャットのセッション操作が正常
- [ ] サイドバーの開閉が正常

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)