### PR TITLE
リストビューUI簡素化

### DIFF
--- a/frontend/src/components/MemberItem.jsx
+++ b/frontend/src/components/MemberItem.jsx
@@ -90,17 +90,17 @@ export default function MemberItem({ id, name, roomId, email }) {
   return (
     <div
       onClick={handleClick}
-      className="bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 cursor-pointer overflow-hidden group border border-gray-100 hover:border-primary-200 mb-3"
+      className="bg-white rounded-2xl cursor-pointer overflow-hidden group border border-gray-200 hover:bg-gray-50 transition-colors duration-150 mb-3"
     >
       <div className="flex items-center p-4">
         {/* アバター */}
-        <div className="w-14 h-14 bg-gradient-to-br from-primary-400 via-secondary-400 to-pink-400 rounded-full flex items-center justify-center text-white font-bold text-xl flex-shrink-0 shadow-md group-hover:shadow-lg transform group-hover:scale-105 transition-all duration-300">
+        <div className="w-14 h-14 bg-primary-500 rounded-full flex items-center justify-center text-white font-bold text-xl flex-shrink-0">
           {name?.charAt(0)?.toUpperCase() || '?'}
         </div>
         
         {/* ユーザー情報 */}
         <div className="flex-1 ml-4 min-w-0">
-          <p className="text-base font-bold text-gray-800 truncate group-hover:text-primary-600 transition-colors">
+          <p className="text-base font-bold text-gray-800 truncate">
             {name || 'Unknown'}
           </p>
           <p className="text-sm text-gray-500 truncate">

--- a/frontend/src/components/RoomListItem.jsx
+++ b/frontend/src/components/RoomListItem.jsx
@@ -1,12 +1,12 @@
 export default function RoomListItem({ name, lastMessage, unreadCount }) {
   return (
-    <div className="p-4 rounded-xl hover:bg-gradient-to-r hover:from-primary-50 hover:to-secondary-50 cursor-pointer flex justify-between items-center transition-all duration-200 border border-gray-100 hover:border-primary-200 shadow-sm hover:shadow-md">
+    <div className="p-4 rounded-xl hover:bg-gray-50 cursor-pointer flex justify-between items-center transition-colors duration-150 border border-gray-200">
       <div className="flex-1 min-w-0">
         <p className="font-semibold text-gray-800">{name}</p>
         <p className="text-sm text-gray-500 truncate">{lastMessage}</p>
       </div>
       {unreadCount > 0 && (
-        <span className="bg-gradient-primary text-white text-xs px-3 py-1.5 rounded-full font-bold ml-3 flex-shrink-0">
+        <span className="bg-primary-500 text-white text-xs px-3 py-1.5 rounded-full font-medium ml-3 flex-shrink-0">
           {unreadCount}
         </span>
       )}

--- a/frontend/src/pages/AddUserPage.jsx
+++ b/frontend/src/pages/AddUserPage.jsx
@@ -8,7 +8,6 @@ import {
   MagnifyingGlassIcon,
   UserPlusIcon,
   SparklesIcon,
-  ChatBubbleLeftRightIcon,
 } from '@heroicons/react/24/solid';
 
 export default function AddUserPage() {
@@ -90,14 +89,11 @@ useEffect(() => {
     <>
       <HamburgerMenu title="ユーザー検索" />
 
-      <div className="min-h-screen bg-gradient-to-br from-gray-50 to-primary-50 pt-16 pb-24">
+      <div className="min-h-screen bg-gray-50 pt-16 pb-24">
         {/* ヘッダーセクション */}
-        <div className="bg-gradient-to-r from-primary-500 via-secondary-500 to-pink-500 px-4 py-8 mb-6">
+        <div className="bg-primary-500 px-4 py-6 mb-6">
           <div className="max-w-2xl mx-auto text-center">
-            <div className="bg-white/20 backdrop-blur-sm rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
-              <UserPlusIcon className="w-8 h-8 text-white" />
-            </div>
-            <h2 className="text-2xl font-bold text-white mb-2">
+            <h2 className="text-xl font-bold text-white mb-1">
               友達を探す
             </h2>
             <p className="text-white/80 text-sm">
@@ -107,7 +103,7 @@ useEffect(() => {
         </div>
 
         {/* 検索セクション */}
-        <div className="sticky top-16 z-10 bg-white/80 backdrop-blur-md border-b border-gray-100 px-4 py-4">
+        <div className="sticky top-16 z-10 bg-white border-b border-gray-200 px-4 py-4">
           <div className="max-w-2xl mx-auto">
             <div className="relative">
               <MagnifyingGlassIcon className="absolute left-4 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
@@ -119,7 +115,7 @@ useEffect(() => {
                   debounceSearch(e.target.value);
                 }}
                 placeholder="ユーザー名またはメールアドレスで検索..."
-                className="w-full pl-12 pr-4 py-4 bg-gray-100 rounded-xl border-none focus:outline-none focus:ring-2 focus:ring-primary-400 transition-all text-base"
+                className="w-full pl-12 pr-4 py-3 bg-gray-100 rounded-xl border-none focus:outline-none focus:ring-1 focus:ring-primary-500 transition-colors duration-150 text-base"
               />
             </div>
           </div>
@@ -129,8 +125,8 @@ useEffect(() => {
         <div className="max-w-2xl mx-auto px-4 pt-4">
           {/* エラー表示 */}
           {error && (
-            <div className="mb-6 p-4 bg-red-50 border-l-4 border-red-500 rounded-lg animate-fade-in">
-              <p className="text-red-700 font-semibold">
+            <div className="mb-6 p-4 bg-red-50 border-l-4 border-red-500 rounded-lg">
+              <p className="text-red-700 font-medium">
                 ⚠️ エラーが発生しました
               </p>
               <p className="text-red-600 text-sm mt-1">{error}</p>
@@ -140,7 +136,7 @@ useEffect(() => {
           {/* 検索前の状態 */}
           {users.length === 0 && !debounceQuery && (
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <div className="bg-gradient-to-br from-gray-100 to-gray-200 rounded-full p-8 mb-6">
+              <div className="bg-gray-100 rounded-full p-8 mb-6">
                 <MagnifyingGlassIcon className="w-12 h-12 text-gray-400" />
               </div>
               <h3 className="text-lg font-semibold text-gray-700 mb-2">
@@ -168,7 +164,7 @@ useEffect(() => {
           {/* 検索結果なし */}
           {users.length === 0 && debounceQuery && (
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <div className="bg-gradient-to-br from-gray-100 to-gray-200 rounded-full p-8 mb-6">
+              <div className="bg-gray-100 rounded-full p-8 mb-6">
                 <svg className="w-12 h-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
@@ -199,17 +195,17 @@ useEffect(() => {
           <div className="mt-8">
             <div
               onClick={() => navigate('/chat/ask-ai')}
-              className="bg-gradient-to-r from-pink-50 to-orange-50 rounded-xl p-4 border border-pink-200 cursor-pointer hover:shadow-md transition-all group"
+              className="bg-white rounded-xl p-4 border border-gray-200 cursor-pointer hover:bg-gray-50 transition-colors duration-150"
             >
               <div className="flex items-center gap-3">
-                <div className="bg-gradient-to-br from-pink-400 to-orange-400 rounded-lg p-2">
-                  <SparklesIcon className="w-5 h-5 text-white" />
+                <div className="bg-primary-100 rounded-lg p-2">
+                  <SparklesIcon className="w-5 h-5 text-primary-500" />
                 </div>
                 <div className="flex-1">
-                  <p className="font-semibold text-gray-800 group-hover:text-pink-600 transition-colors">AIでチャットを分析</p>
+                  <p className="font-medium text-gray-800">AIでチャットを分析</p>
                   <p className="text-xs text-gray-500">印象のギャップを発見しよう</p>
                 </div>
-                <svg className="w-5 h-5 text-gray-400 group-hover:text-pink-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
               </div>

--- a/frontend/src/pages/ChatListPage.jsx
+++ b/frontend/src/pages/ChatListPage.jsx
@@ -7,7 +7,6 @@ import {
   MagnifyingGlassIcon,
   ChatBubbleLeftRightIcon,
   SparklesIcon,
-  UserCircleIcon,
 } from '@heroicons/react/24/solid';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 
@@ -113,9 +112,9 @@ export default function ChatListPage() {
   return (
     <>
       <HamburgerMenu title="チャット" />
-      <div className="min-h-screen bg-gradient-to-br from-gray-50 to-primary-50 pt-16 pb-24">
+      <div className="min-h-screen bg-gray-50 pt-16 pb-24">
         {/* ヘッダーセクション */}
-        <div className="sticky top-16 z-10 bg-white/80 backdrop-blur-md border-b border-gray-100 px-4 py-4">
+        <div className="sticky top-16 z-10 bg-white border-b border-gray-200 px-4 py-4">
           <div className="max-w-2xl mx-auto">
             {/* 検索ボックス */}
             <div className="relative">
@@ -125,7 +124,7 @@ export default function ChatListPage() {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="名前やメールで検索..."
-                className="w-full pl-10 pr-4 py-3 bg-gray-100 rounded-xl border-none focus:outline-none focus:ring-2 focus:ring-primary-400 transition-all"
+                className="w-full pl-10 pr-4 py-3 bg-gray-100 rounded-xl border-none focus:outline-none focus:ring-1 focus:ring-primary-500 transition-colors duration-150"
               />
             </div>
           </div>
@@ -141,7 +140,7 @@ export default function ChatListPage() {
             </div>
           ) : chatUsers.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
-              <div className="bg-gradient-to-br from-primary-100 to-secondary-100 rounded-full p-6 mb-6">
+              <div className="bg-primary-100 rounded-full p-6 mb-6">
                 <ChatBubbleLeftRightIcon className="w-16 h-16 text-primary-400" />
               </div>
               <h2 className="text-xl font-bold text-gray-700 mb-2">
@@ -152,7 +151,7 @@ export default function ChatListPage() {
               </p>
               <button
                 onClick={() => navigate('/chat/users')}
-                className="bg-gradient-to-r from-primary-500 to-secondary-500 text-white font-semibold px-6 py-3 rounded-xl shadow-lg hover:shadow-xl transition-all transform hover:scale-105"
+                className="bg-primary-500 text-white font-medium px-6 py-3 rounded-xl hover:bg-primary-600 transition-colors duration-150"
               >
                 友達を追加する
               </button>
@@ -165,7 +164,7 @@ export default function ChatListPage() {
                   <div
                     key={user.roomId}
                     onClick={() => navigate(`/chat/users/${user.roomId}`)}
-                    className="bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 cursor-pointer overflow-hidden group border border-gray-100 hover:border-primary-200"
+                    className="bg-white rounded-2xl cursor-pointer overflow-hidden group border border-gray-200 hover:bg-gray-50 transition-colors duration-150"
                   >
                     <div className="flex items-center p-4">
                       {/* アバター */}
@@ -174,10 +173,10 @@ export default function ChatListPage() {
                           <img
                             src={user.profileImage}
                             alt={user.name}
-                            className="w-14 h-14 rounded-full object-cover border-2 border-gray-100 group-hover:border-primary-300 transition-colors"
+                            className="w-14 h-14 rounded-full object-cover border border-gray-200"
                           />
                         ) : (
-                          <div className="w-14 h-14 rounded-full bg-gradient-to-br from-primary-400 to-secondary-400 flex items-center justify-center border-2 border-gray-100 group-hover:border-primary-300 transition-colors">
+                          <div className="w-14 h-14 rounded-full bg-primary-500 flex items-center justify-center">
                             <span className="text-white text-xl font-bold">
                               {user.name?.charAt(0)?.toUpperCase() || '?'}
                             </span>
@@ -190,7 +189,7 @@ export default function ChatListPage() {
                       {/* ユーザー情報 */}
                       <div className="flex-1 ml-4 min-w-0">
                         <div className="flex items-center justify-between mb-1">
-                          <h3 className="text-base font-bold text-gray-800 truncate group-hover:text-primary-600 transition-colors">
+                          <h3 className="text-base font-bold text-gray-800 truncate">
                             {user.name || 'Unknown User'}
                           </h3>
                           <span className="text-xs text-gray-400 flex-shrink-0 ml-2">
@@ -213,7 +212,7 @@ export default function ChatListPage() {
                       </div>
 
                       {/* 矢印 */}
-                      <ChevronRightIcon className="w-5 h-5 text-gray-300 group-hover:text-primary-400 transition-colors ml-2 flex-shrink-0" />
+                      <ChevronRightIcon className="w-5 h-5 text-gray-300 ml-2 flex-shrink-0" />
                     </div>
                   </div>
                 ))}
@@ -223,26 +222,21 @@ export default function ChatListPage() {
               <div className="mt-8 mb-4">
                 <div
                   onClick={() => navigate('/chat/ask-ai')}
-                  className="relative bg-gradient-to-r from-pink-500 via-orange-400 to-yellow-400 rounded-2xl shadow-lg p-5 cursor-pointer hover:shadow-xl transition-all transform hover:scale-[1.02] overflow-hidden"
+                  className="bg-white rounded-2xl p-5 cursor-pointer border border-gray-200 hover:bg-gray-50 transition-colors duration-150"
                 >
-                  {/* 背景装飾 */}
-                  <div className="absolute top-0 left-0 w-full h-full opacity-20">
-                    <div className="absolute top-2 left-6 text-xl">✨</div>
-                    <div className="absolute bottom-2 right-8 text-lg">💬</div>
-                  </div>
-                  <div className="relative flex items-center">
-                    <div className="bg-white/30 backdrop-blur-sm rounded-xl p-3 mr-4">
-                      <SparklesIcon className="w-6 h-6 text-white" />
+                  <div className="flex items-center">
+                    <div className="bg-primary-100 rounded-xl p-3 mr-4">
+                      <SparklesIcon className="w-6 h-6 text-primary-500" />
                     </div>
                     <div className="flex-1">
-                      <h3 className="text-white font-bold text-lg">
+                      <h3 className="text-gray-800 font-bold text-lg">
                         AIにチャットを分析してもらう
                       </h3>
-                      <p className="text-white/80 text-sm">
+                      <p className="text-gray-500 text-sm">
                         印象のギャップを発見しよう
                       </p>
                     </div>
-                    <ChevronRightIcon className="w-5 h-5 text-white/70" />
+                    <ChevronRightIcon className="w-5 h-5 text-gray-400" />
                   </div>
                 </div>
               </div>
@@ -254,7 +248,7 @@ export default function ChatListPage() {
         <div className="fixed bottom-6 right-6 z-20">
           <button
             onClick={() => navigate('/chat/users')}
-            className="bg-gradient-to-r from-primary-500 to-secondary-500 text-white p-4 rounded-full shadow-lg hover:shadow-xl transition-all transform hover:scale-110"
+            className="bg-primary-500 text-white p-4 rounded-full shadow-md hover:bg-primary-600 transition-colors duration-150"
             title="新しいチャット"
           >
             <svg

--- a/frontend/src/pages/MemberPage.jsx
+++ b/frontend/src/pages/MemberPage.jsx
@@ -76,7 +76,7 @@ export default function MemberPage() {
   return (
     <>
       <HamburgerMenu title="チャットメンバー" />
-      <div className="min-h-screen bg-gradient-to-br from-gray-50 to-primary-50 p-4 pt-20 pb-8">
+      <div className="min-h-screen bg-gray-50 p-4 pt-20 pb-8">
         <div className="max-w-2xl mx-auto">
           {/* ヘッダー */}
           <div className="mb-8">


### PR DESCRIPTION
## Summary
- ChatListPage, AddUserPage, MemberPage の背景グラデーション→フラット `bg-gray-50` に統一
- RoomListItem, MemberItem のホバーエフェクト・シャドウ・アバターグラデーション簡素化
- AI分析カード: 派手な3色グラデーション→シンプルな白カード+ブルーアクセント
- FABボタン: グラデーション+スケールアニメーション→単色+カラー遷移のみ

## Test plan
- [ ] チャット一覧ページでグラデーションなし・フラットな背景を確認
- [ ] ユーザー検索ページのヒーローセクションが簡素化されていることを確認
- [ ] 各リストアイテムのホバー時に `bg-gray-50` のみ適用されることを確認
- [ ] AI分析カードが白背景+ブルーアイコンで表示されることを確認

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)