### PR TITLE
バックエンド: チャットユーザー一覧に未読数を反映（TDD）

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/service/ChatService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ChatService.java
@@ -27,6 +27,7 @@ public class ChatService {
     private final RoomMemberRepository roomMemberRepository;
     private final UserRepository userRepository;
     private final ChatMessageRepository chatMessageRepository;
+    private final UnreadCountService unreadCountService;
 
     
     // チャットルームの作成かすでに存在をしていた場合はそのままチャット画面のページへ移動をする
@@ -98,7 +99,10 @@ public class ChatService {
         Map<Integer, ChatMessage> roomToLatestMessage = latestMessages.stream()
                 .collect(Collectors.toMap(msg -> msg.getRoom().getId(), msg -> msg));
         
-        // 5. DTOを構築
+        // 5. 未読数を一括取得
+        Map<Integer, Integer> unreadCounts = unreadCountService.getUnreadCountsByUserAndRooms(myUserId, roomIds);
+
+        // 6. DTOを構築
         List<ChatUserDto> result = new ArrayList<>();
         
         for (Integer partnerId : partnerUserIds) {
@@ -125,7 +129,7 @@ public class ChatService {
             dto.setEmail(partner.getEmail());
             dto.setName(partner.getName());
             dto.setRoomId(roomId);
-            dto.setUnreadCount(0); // TODO: 未読数の実装
+            dto.setUnreadCount(unreadCounts.getOrDefault(roomId, 0));
             
             if (latestMsg != null) {
                 dto.setLastMessage(latestMsg.getContent());

--- a/FreStyle/src/test/java/com/example/FreStyle/service/ChatServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ChatServiceTest.java
@@ -20,7 +20,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -107,9 +106,10 @@ class ChatServiceTest {
     @DisplayName("findChatUsers: 未読レコードなしのルームはカウント0")
     void findChatUsers_noUnreadRecord_defaultsToZero() {
         // Arrange
-        Object[] partnerData = new Object[]{2, 10};
+        List<Object[]> partnerDataList = new ArrayList<>();
+        partnerDataList.add(new Object[]{2, 10});
         when(roomMemberRepository.findPartnerUserIdAndRoomIdByUserId(1))
-                .thenReturn(List.of(partnerData));
+                .thenReturn(partnerDataList);
         when(userRepository.findAllById(List.of(2)))
                 .thenReturn(List.of(partnerUser));
         when(chatMessageRepository.findLatestMessagesByRoomIds(List.of(10)))


### PR DESCRIPTION
## 概要
ChatService.findChatUsers()のTODOを実装し、チャットユーザー一覧APIに実際の未読数を含める。

## 変更内容
- `ChatService`: UnreadCountServiceを注入、未読数を一括取得してDTOに設定
- `ChatServiceTest`: 未読数の正常設定・デフォルト0のユニットテスト2件

## テスト結果
全テストパス

Closes #44