### PR TITLE
バックエンド: 既読リセットAPIエンドポイント（TDD）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ChatControllerTest.java
@@ -51,27 +51,30 @@ class ChatControllerTest {
     @InjectMocks
     private ChatController chatController;
 
-    private Jwt mockJwt;
     private User testUser;
 
     @BeforeEach
     void setUp() {
-        mockJwt = mock(Jwt.class);
-        when(mockJwt.getSubject()).thenReturn("cognito-sub-123");
-
         testUser = new User();
         testUser.setId(1);
         testUser.setName("テストユーザー");
+    }
+
+    private Jwt createMockJwt() {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("cognito-sub-123");
+        return jwt;
     }
 
     @Test
     @DisplayName("markAsRead: 正常リクエスト → 200 OKとsuccessを返す")
     void markAsRead_validRequest_returnsOk() {
         // Arrange
+        Jwt jwt = createMockJwt();
         when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
 
         // Act
-        ResponseEntity<?> response = chatController.markAsRead(mockJwt, 10);
+        ResponseEntity<?> response = chatController.markAsRead(jwt, 10);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -96,10 +99,11 @@ class ChatControllerTest {
     @DisplayName("markAsRead: resetUnreadCountが正しいパラメータで呼ばれる")
     void markAsRead_callsResetWithCorrectParams() {
         // Arrange
+        Jwt jwt = createMockJwt();
         when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
 
         // Act
-        chatController.markAsRead(mockJwt, 25);
+        chatController.markAsRead(jwt, 25);
 
         // Assert
         verify(unreadCountService).resetUnreadCount(1, 25);


### PR DESCRIPTION
## 概要
チャットルーム開封時に未読カウントをリセットするREST APIエンドポイントを追加。

## 変更内容
- `ChatController`: `POST /api/chat/rooms/{roomId}/read` エンドポイント追加
- `ChatControllerTest`: ユニットテスト3件（正常/401/パラメータ検証）

## テスト結果
全テストパス

Closes #45