### PR TITLE
バックエンドデプロイのpathsフィルター削除

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -3,8 +3,6 @@ name: Deploy Spring Boot on ECS
 on:
   push:
     branches: ["main"]
-    paths:
-      - "FreStyle/**"
     
 env:
   AWS_REGION: ap-northeast-1


### PR DESCRIPTION
## 概要
`back-deploy.yml` の `paths: FreStyle/**` フィルターを削除し、mainへのマージ時に常にバックエンドデプロイが実行されるようにする。

## 背景
pathsフィルターにより、`FreStyle/` 配下以外のファイル変更（docker-compose.yml、README等）のみのマージ時にバックエンドデプロイがスキップされていた。