### PR TITLE
練習モード開始時にAIが自動的にシナリオ導入メッセージを送信

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
@@ -145,7 +145,16 @@ public class AiChatWebSocketController {
                 String practicePrompt = systemPromptBuilder.buildPracticePrompt(
                         scenario.getName(), scenario.getRoleName(),
                         scenario.getDifficulty(), scenario.getSystemPrompt());
-                aiReply = bedrockService.chatInPracticeMode(content, practicePrompt);
+
+                // 「練習開始」の場合は、AIにシナリオの導入メッセージを生成させる
+                if ("練習開始".equals(content)) {
+                    String startPrompt = practicePrompt +
+                        "\n\nこれから練習が始まります。あなたは相手役として、シナリオに基づいた最初の発言をしてください。" +
+                        "ユーザーに対して、シナリオの状況を反映した自然な会話で話しかけてください。";
+                    aiReply = bedrockService.chatInPracticeMode("", startPrompt);
+                } else {
+                    aiReply = bedrockService.chatInPracticeMode(content, practicePrompt);
+                }
             } else if (fromChatFeedback) {
                 // チャットフィードバックモード: バックエンドでUserProfileを取得
                 System.out.println("🤖 フィードバックモード: UserProfileをバックエンドで取得中... scene=" + scene);

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -91,6 +91,7 @@ export default function PracticePage() {
           sessionType: 'practice',
           scenarioId: scenario.id,
           scenarioName: scenario.name,
+          initialPrompt: '練習開始',
         },
       });
     } catch (err) {

--- a/frontend/src/pages/__tests__/PracticePage.test.tsx
+++ b/frontend/src/pages/__tests__/PracticePage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PracticePage from '../PracticePage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+global.fetch = vi.fn();
+
+describe('PracticePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ([
+        {
+          id: 1,
+          name: '本番障害の緊急報告',
+          description: '本番環境で重大な障害が発生',
+          category: 'customer',
+          roleName: '怒っている顧客（SIer企業のPM）',
+          difficulty: 'intermediate',
+        },
+      ]),
+    } as Response);
+  });
+
+  describe('シナリオカードクリック時の動作', () => {
+    it('シナリオカードクリック時にinitialPromptを含むstateでnavigateする', async () => {
+      render(
+        <BrowserRouter>
+          <PracticePage />
+        </BrowserRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('本番障害の緊急報告')).toBeInTheDocument();
+      });
+
+      // セッション作成APIのモック
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 123, title: '練習: 本番障害の緊急報告' }),
+      } as Response);
+
+      const scenarioCard = screen.getByText('本番障害の緊急報告').closest('div[class*="cursor-pointer"]');
+      if (scenarioCard) {
+        fireEvent.click(scenarioCard);
+      }
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          '/chat/ask-ai/123',
+          expect.objectContaining({
+            state: expect.objectContaining({
+              sessionType: 'practice',
+              scenarioId: 1,
+              scenarioName: '本番障害の緊急報告',
+              initialPrompt: '練習開始',
+            }),
+          })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 概要
練習モードでシナリオカードをクリックすると、AIが自動的にシナリオの導入メッセージを送信するようになりました。

## 変更内容

### フロントエンド
- **PracticePage.tsx**: navigate時に `initialPrompt: '練習開始'` を追加
- **PracticePage.test.tsx**: initialPrompt設定のテストを追加

### バックエンド
- **AiChatWebSocketController.java**: 「練習開始」メッセージを受信時、AIがシナリオの導入メッセージを生成

## 動作例

### 修正前
1. ユーザーがシナリオカード「本番障害の緊急報告」をクリック
2. AIページに遷移するが、AIは何も言わない
3. ユーザーが自分でメッセージを送る必要がある

### 修正後✨
1. ユーザーがシナリオカード「本番障害の緊急報告」をクリック
2. AIページに遷移
3. **AIが自動的に導入メッセージを送信**
   - 例: 「おい！さっきからシステムが30分以上止まってるぞ！一体どうなってるんだ！今すぐ状況を説明してくれ！」
4. ユーザーがすぐにロールプレイを開始できる

## テスト
- ✅ `PracticePage.test.tsx`: initialPromptを含むstateでnavigateすることを検証
- ✅ フロントエンドテスト: 1 passed

Closes #117