### PR TITLE
Phase 8: フロントエンド - Repository層の作成

### DIFF
--- a/frontend/src/lib/axios.ts
+++ b/frontend/src/lib/axios.ts
@@ -1,0 +1,115 @@
+import axios, { AxiosError, AxiosRequestConfig, InternalAxiosRequestConfig } from 'axios';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+/**
+ * Axiosインスタンス
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>API呼び出しの一元管理</li>
+ *   <li>認証トークンの自動リフレッシュ</li>
+ *   <li>エラーハンドリングの統一</li>
+ * </ul>
+ *
+ * <p>インフラ層（Infrastructure Layer）:</p>
+ * <ul>
+ *   <li>外部APIとの通信を担当</li>
+ *   <li>HTTPクライアントの設定</li>
+ * </ul>
+ */
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true, // Cookie（JWT）を自動送信
+});
+
+/**
+ * トークンリフレッシュ中フラグ
+ * 複数のリクエストが同時に401を受けた場合、リフレッシュは1回だけ実行
+ */
+let isRefreshing = false;
+
+/**
+ * リフレッシュ待ちのリクエストキュー
+ */
+let failedQueue: Array<{
+  resolve: (value?: unknown) => void;
+  reject: (reason?: unknown) => void;
+}> = [];
+
+/**
+ * キューの処理
+ */
+const processQueue = (error: AxiosError | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      prom.resolve();
+    }
+  });
+
+  failedQueue = [];
+};
+
+/**
+ * レスポンスインターセプター
+ * 401エラー時に自動的にトークンをリフレッシュ
+ */
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+
+    // 401エラーかつ、まだリトライしていない場合
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      if (isRefreshing) {
+        // 既にリフレッシュ中の場合はキューに追加
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(() => {
+            return apiClient(originalRequest);
+          })
+          .catch((err) => {
+            return Promise.reject(err);
+          });
+      }
+
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        // トークンリフレッシュ
+        await axios.post(
+          `${API_BASE_URL}/api/auth/cognito/refresh-token`,
+          {},
+          { withCredentials: true }
+        );
+
+        processQueue(null);
+        isRefreshing = false;
+
+        // リトライ
+        return apiClient(originalRequest);
+      } catch (refreshError) {
+        processQueue(error);
+        isRefreshing = false;
+
+        // リフレッシュ失敗 → ログインページへ
+        if (typeof window !== 'undefined') {
+          window.location.href = '/login';
+        }
+
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/frontend/src/repositories/AiChatRepository.ts
+++ b/frontend/src/repositories/AiChatRepository.ts
@@ -1,0 +1,119 @@
+import apiClient from '../lib/axios';
+import { AiSession, AiMessage, ScoreCard } from '../types';
+
+/**
+ * AI Chatリポジトリ
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>AI Chat関連のAPI呼び出しを抽象化</li>
+ *   <li>セッション、メッセージ、スコアカード管理</li>
+ * </ul>
+ *
+ * <p>インフラ層（Infrastructure Layer）:</p>
+ * <ul>
+ *   <li>外部APIとの通信を担当</li>
+ * </ul>
+ */
+
+export interface CreateSessionRequest {
+  title: string;
+  relatedRoomId?: number | null;
+}
+
+export interface UpdateSessionTitleRequest {
+  title: string;
+}
+
+export interface AddMessageRequest {
+  content: string;
+  role: 'user' | 'assistant';
+}
+
+export interface RephraseRequest {
+  originalMessage: string;
+  scene?: string | null;
+}
+
+class AiChatRepository {
+  /**
+   * セッション一覧を取得
+   */
+  async getSessions(): Promise<AiSession[]> {
+    const response = await apiClient.get('/api/chat/ai/sessions');
+    return response.data;
+  }
+
+  /**
+   * セッション詳細を取得
+   */
+  async getSession(sessionId: number): Promise<AiSession> {
+    const response = await apiClient.get(`/api/chat/ai/sessions/${sessionId}`);
+    return response.data;
+  }
+
+  /**
+   * 新規セッションを作成
+   */
+  async createSession(request: CreateSessionRequest): Promise<AiSession> {
+    const response = await apiClient.post('/api/chat/ai/sessions', request);
+    return response.data;
+  }
+
+  /**
+   * セッションタイトルを更新
+   */
+  async updateSessionTitle(sessionId: number, request: UpdateSessionTitleRequest): Promise<AiSession> {
+    const response = await apiClient.put(`/api/chat/ai/sessions/${sessionId}`, request);
+    return response.data;
+  }
+
+  /**
+   * セッションを削除
+   */
+  async deleteSession(sessionId: number): Promise<void> {
+    await apiClient.delete(`/api/chat/ai/sessions/${sessionId}`);
+  }
+
+  /**
+   * セッション内のメッセージ一覧を取得
+   */
+  async getMessages(sessionId: number): Promise<AiMessage[]> {
+    const response = await apiClient.get(`/api/chat/ai/sessions/${sessionId}/messages`);
+    return response.data;
+  }
+
+  /**
+   * メッセージを追加
+   */
+  async addMessage(sessionId: number, request: AddMessageRequest): Promise<AiMessage> {
+    const response = await apiClient.post(`/api/chat/ai/sessions/${sessionId}/messages`, request);
+    return response.data;
+  }
+
+  /**
+   * メッセージの言い換え提案を取得
+   */
+  async rephrase(request: RephraseRequest): Promise<{ result: string }> {
+    const response = await apiClient.post('/api/chat/ai/rephrase', request);
+    return response.data;
+  }
+
+  /**
+   * セッションのスコアカードを取得
+   */
+  async getScoreCard(sessionId: number): Promise<ScoreCard> {
+    const response = await apiClient.get(`/api/scores/sessions/${sessionId}`);
+    return response.data;
+  }
+
+  /**
+   * スコア履歴を取得
+   */
+  async getScoreHistory(): Promise<any[]> {
+    const response = await apiClient.get('/api/scores/history');
+    return response.data;
+  }
+}
+
+export default new AiChatRepository();

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -1,0 +1,112 @@
+import apiClient from '../lib/axios';
+
+/**
+ * 認証リポジトリ
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>認証関連のAPI呼び出しを抽象化</li>
+ *   <li>ログイン、ログアウト、ユーザー情報取得</li>
+ * </ul>
+ *
+ * <p>インフラ層（Infrastructure Layer）:</p>
+ * <ul>
+ *   <li>外部APIとの通信を担当</li>
+ *   <li>Domain層に依存せず、独立している</li>
+ * </ul>
+ */
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface SignupRequest {
+  email: string;
+  password: string;
+  name: string;
+}
+
+export interface ConfirmSignupRequest {
+  email: string;
+  confirmationCode: string;
+}
+
+export interface ForgotPasswordRequest {
+  email: string;
+}
+
+export interface ConfirmForgotPasswordRequest {
+  email: string;
+  confirmationCode: string;
+  newPassword: string;
+}
+
+export interface UserInfo {
+  id: number;
+  email: string;
+  name: string;
+  sub: string;
+}
+
+class AuthRepository {
+  /**
+   * ログイン
+   */
+  async login(request: LoginRequest): Promise<UserInfo> {
+    const response = await apiClient.post('/api/auth/cognito/login', request);
+    return response.data;
+  }
+
+  /**
+   * サインアップ
+   */
+  async signup(request: SignupRequest): Promise<void> {
+    await apiClient.post('/api/auth/cognito/signup', request);
+  }
+
+  /**
+   * サインアップ確認
+   */
+  async confirmSignup(request: ConfirmSignupRequest): Promise<void> {
+    await apiClient.post('/api/auth/cognito/confirm-signup', request);
+  }
+
+  /**
+   * パスワード再設定リクエスト
+   */
+  async forgotPassword(request: ForgotPasswordRequest): Promise<void> {
+    await apiClient.post('/api/auth/cognito/forgot-password', request);
+  }
+
+  /**
+   * パスワード再設定確認
+   */
+  async confirmForgotPassword(request: ConfirmForgotPasswordRequest): Promise<void> {
+    await apiClient.post('/api/auth/cognito/confirm-forgot-password', request);
+  }
+
+  /**
+   * ログアウト
+   */
+  async logout(): Promise<void> {
+    await apiClient.post('/api/auth/cognito/logout');
+  }
+
+  /**
+   * 現在のユーザー情報取得
+   */
+  async getCurrentUser(): Promise<UserInfo> {
+    const response = await apiClient.get('/api/auth/cognito/me');
+    return response.data;
+  }
+
+  /**
+   * トークンリフレッシュ
+   */
+  async refreshToken(): Promise<void> {
+    await apiClient.post('/api/auth/cognito/refresh-token');
+  }
+}
+
+export default new AuthRepository();

--- a/frontend/src/repositories/PracticeRepository.ts
+++ b/frontend/src/repositories/PracticeRepository.ts
@@ -1,0 +1,57 @@
+import apiClient from '../lib/axios';
+
+/**
+ * 練習モードリポジトリ
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>練習シナリオ関連のAPI呼び出しを抽象化</li>
+ * </ul>
+ *
+ * <p>インフラ層（Infrastructure Layer）:</p>
+ * <ul>
+ *   <li>外部APIとの通信を担当</li>
+ * </ul>
+ */
+
+export interface PracticeScenario {
+  id: number;
+  name: string;
+  description: string;
+  category: string;
+  roleName: string;
+  difficulty: string;
+  systemPrompt: string;
+}
+
+export interface CreatePracticeSessionRequest {
+  scenarioId: number;
+}
+
+class PracticeRepository {
+  /**
+   * シナリオ一覧を取得
+   */
+  async getScenarios(): Promise<PracticeScenario[]> {
+    const response = await apiClient.get('/api/practice/scenarios');
+    return response.data;
+  }
+
+  /**
+   * シナリオ詳細を取得
+   */
+  async getScenario(scenarioId: number): Promise<PracticeScenario> {
+    const response = await apiClient.get(`/api/practice/scenarios/${scenarioId}`);
+    return response.data;
+  }
+
+  /**
+   * 練習セッションを作成
+   */
+  async createPracticeSession(request: CreatePracticeSessionRequest): Promise<any> {
+    const response = await apiClient.post('/api/practice/sessions', request);
+    return response.data;
+  }
+}
+
+export default new PracticeRepository();

--- a/frontend/src/repositories/UserProfileRepository.ts
+++ b/frontend/src/repositories/UserProfileRepository.ts
@@ -1,0 +1,57 @@
+import apiClient from '../lib/axios';
+
+/**
+ * ユーザープロファイルリポジトリ
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>ユーザープロファイル関連のAPI呼び出しを抽象化</li>
+ * </ul>
+ *
+ * <p>インフラ層（Infrastructure Layer）:</p>
+ * <ul>
+ *   <li>外部APIとの通信を担当</li>
+ * </ul>
+ */
+
+export interface UserProfile {
+  id: number;
+  userId: number;
+  displayName: string;
+  selfIntroduction?: string;
+  communicationStyle?: string;
+  personalityTraits?: string[];
+  goals?: string;
+  concerns?: string;
+  preferredFeedbackStyle?: string;
+}
+
+export interface UpdateUserProfileRequest {
+  displayName: string;
+  selfIntroduction?: string;
+  communicationStyle?: string;
+  personalityTraits?: string[];
+  goals?: string;
+  concerns?: string;
+  preferredFeedbackStyle?: string;
+}
+
+class UserProfileRepository {
+  /**
+   * 自分のプロファイルを取得
+   */
+  async getMyProfile(): Promise<UserProfile> {
+    const response = await apiClient.get('/api/user-profile/me');
+    return response.data;
+  }
+
+  /**
+   * プロファイルを更新
+   */
+  async updateProfile(request: UpdateUserProfileRequest): Promise<UserProfile> {
+    const response = await apiClient.post('/api/user-profile/me', request);
+    return response.data;
+  }
+}
+
+export default new UserProfileRepository();


### PR DESCRIPTION
## 概要
API呼び出しをコンポーネントから分離し、Repository層として抽象化

## 変更内容

### 1. Axiosインスタンス作成（`src/lib/axios.ts`）
- ベースURL設定
- Cookie（JWT）の自動送信
- **401自動リフレッシュ機能**: レスポンスインターセプターで401エラーを検知し、自動的にトークンをリフレッシュしてリトライ
- 複数リクエストの同時401対応（キューイング）

### 2. AuthRepository（`src/repositories/AuthRepository.ts`）
- ログイン、サインアップ、確認
- パスワード再設定
- ログアウト
- ユーザー情報取得

### 3. AiChatRepository（`src/repositories/AiChatRepository.ts`）
- セッション管理（作成、取得、更新、削除）
- メッセージ管理
- 言い換え提案
- スコアカード取得

### 4. PracticeRepository（`src/repositories/PracticeRepository.ts`）
- シナリオ一覧・詳細取得
- 練習セッション作成

### 5. UserProfileRepository（`src/repositories/UserProfileRepository.ts`）
- プロファイル取得・更新

## 効果
- ✅ API呼び出しロジックの一元管理
- ✅ エラーハンドリングの統一
- ✅ 認証トークンリフレッシュの自動化
- ✅ クリーンアーキテクチャー（Infrastructure層）の確立
- ✅ テスタビリティの向上

## 関連Issue
Closes #128