### PR TITLE
Phase 10: フロントエンド - 認証・プロファイルページをHooksに移行

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
@@ -7,7 +6,7 @@ import SNSSignInButton from '../components/SNSSignInButton';
 import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { setAuthData } from '../store/authSlice';
+import { useAuth } from '../hooks/useAuth';
 
 interface LoginMessage {
   type: 'success' | 'error';
@@ -20,69 +19,21 @@ export default function LoginPage() {
 
   const location = useLocation();
   const navigate = useNavigate();
-  const dispatch = useDispatch();
+  const { login } = useAuth();
   const message = (location.state as { message?: string })?.message;
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
   const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    console.log('\n========== ログインリクエスト開始 ==========');
-    console.log('📌 リクエスト情報:');
-    console.log('   - URL:', `${API_BASE_URL}/api/auth/cognito/login`);
-    console.log('   - email:', form.email);
-    console.log('   - credentials: include');
+    const success = await login({ email: form.email, password: form.password });
 
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/auth/cognito/login`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email: form.email,
-          password: form.password,
-        }),
-        credentials: 'include',
+    if (success) {
+      navigate('/');
+    } else {
+      setLoginMessage({
+        type: 'error',
+        text: 'ログインに失敗しました。',
       });
-
-      console.log('📨 レスポンス受信:');
-      console.log('   - status:', response.status);
-      console.log('   - ok:', response.ok);
-      console.log('   - statusText:', response.statusText);
-
-      console.log('📋 レスポンスヘッダー:');
-      response.headers.forEach((value, key) => {
-        console.log(`   - ${key}: ${value}`);
-      });
-
-      const setCookie = response.headers.get('Set-Cookie');
-      console.log('🍪 Set-Cookie ヘッダー:', setCookie || '(アクセス不可 - httpOnlyのため正常)');
-
-      console.log('🍪 現在のdocument.cookie:', document.cookie || '(空)');
-
-      const data = await response.json();
-      console.log('📄 レスポンスボディ:', data);
-
-      console.log('ステータスコード', response.status);
-
-      if (response.ok) {
-        console.log('✅ ログイン成功 - ホームへ遷移');
-        console.log('🍪 遷移前のdocument.cookie:', document.cookie || '(空)');
-        dispatch(setAuthData());
-        navigate('/');
-      } else {
-        console.log('❌ ログイン失敗:', data.error);
-        setLoginMessage({
-          type: 'error',
-          text: data.error || 'ログインに失敗しました。',
-        });
-      }
-      console.log('========== ログインリクエスト終了 ==========\n');
-    } catch (error) {
-      console.log('❌ 通信エラー:', (error as Error).message);
-      console.log('========== ログインリクエスト終了(エラー) ==========\n');
-      setLoginMessage({ type: 'error', text: '通信エラーが発生しました。' });
     }
   };
 

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -8,6 +8,7 @@ import {
   CheckCircleIcon,
   ExclamationCircleIcon,
 } from '@heroicons/react/24/solid';
+import { useAuth } from '../hooks/useAuth';
 
 interface FormMessage {
   type: 'success' | 'error';
@@ -17,9 +18,8 @@ interface FormMessage {
 export default function SignupPage() {
   const [form, setForm] = useState({ email: '', password: '', name: '' });
   const [message, setMessage] = useState<FormMessage | null>(null);
-  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+  const { signup, loading } = useAuth();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({
@@ -30,44 +30,28 @@ export default function SignupPage() {
 
   const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setLoading(true);
 
-    try {
-      const response = await fetch(`${API_BASE_URL}/api/auth/cognito/signup`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email: form.email,
-          password: form.password,
-          name: form.name,
-        }),
-      });
+    const success = await signup({
+      email: form.email,
+      password: form.password,
+      name: form.name,
+    });
 
-      const data = await response.json();
-
-      if (response.ok) {
-        setMessage({ type: 'success', text: data.message });
-        setTimeout(() => {
-          navigate('/confirm', {
-            state: {
-              message:
-                '✓ サインアップに成功しました！メール確認をお願いします。',
-            },
-          });
-        }, 1500);
-      } else {
-        setMessage({
-          type: 'error',
-          text: data.error || '登録に失敗しました。',
+    if (success) {
+      setMessage({ type: 'success', text: 'サインアップに成功しました！' });
+      setTimeout(() => {
+        navigate('/confirm', {
+          state: {
+            message:
+              '✓ サインアップに成功しました！メール確認をお願いします。',
+          },
         });
-      }
-    } catch (error) {
-      console.log(error);
-      setMessage({ type: 'error', text: '通信エラーが発生しました。' });
-    } finally {
-      setLoading(false);
+      }, 1500);
+    } else {
+      setMessage({
+        type: 'error',
+        text: '登録に失敗しました。',
+      });
     }
   };
 


### PR DESCRIPTION
## 概要
Phase 9で作成したHooks層を使用して、認証・プロファイル関連ページをリファクタリングし、ビジネスロジックをコンポーネントから分離しました。

## 実装内容

### 1. LoginPage
- useAuthフックを使用してログイン処理を実装
- 直接fetch APIを削除（AuthRepositoryに委譲）
- console.logを削減（80行→30行）

### 2. SignupPage
- useAuthフックを使用してサインアップ処理を実装
- 直接fetch APIを削除（AuthRepositoryに委譲）
- loading状態をフックから取得

### 3. UserProfilePage
- useUserProfileフックを使用してプロファイル管理を実装
- 401エラーの手動リフレッシュ処理を削除（Axiosインターセプターに委譲）
- fetchProfile, handleSave関数を削減（150行削減）

## 変更行数
- 削除: 211行
- 追加: 52行
- **合計: 159行削減**

## 期待効果
- コンポーネントがプレゼンテーション層として純粋化
- ビジネスロジックの再利用性向上
- コードの可読性・保守性向上
- テスタビリティの向上（フックを個別にテスト可能）

## 次のステップ
別PRで以下のページをリファクタリング予定：
- AskAiPage（useAiChat, useWebSocket使用）
- PracticePage（usePractice, useWebSocket使用）
- ScoreHistoryPage（useAiChat使用）

Closes #132