### PR TITLE
Phase 11: ScoreHistoryPageをHooksに移行

### DIFF
--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useAiChat } from '../hooks/useAiChat';
 
 interface AxisScore {
   axis: string;
@@ -16,27 +17,15 @@ interface ScoreHistoryItem {
 
 export default function ScoreHistoryPage() {
   const [history, setHistory] = useState<ScoreHistoryItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { fetchScoreHistory, loading } = useAiChat();
 
   useEffect(() => {
-    const fetchHistory = async () => {
-      try {
-        const res = await fetch(
-          `${import.meta.env.VITE_API_BASE_URL}/api/scores/history`,
-          { credentials: 'include' }
-        );
-        if (res.ok) {
-          const data = await res.json();
-          setHistory(data);
-        }
-      } catch (err) {
-        console.error('スコア履歴取得エラー:', err);
-      } finally {
-        setLoading(false);
-      }
+    const loadHistory = async () => {
+      const data = await fetchScoreHistory();
+      setHistory(data);
     };
-    fetchHistory();
-  }, []);
+    loadHistory();
+  }, [fetchScoreHistory]);
 
   const getScoreColor = (score: number) => {
     if (score >= 8) return 'text-green-600';


### PR DESCRIPTION
## 概要
Phase 9で作成したHooks層を使用して、ScoreHistoryPageをリファクタリングし、ビジネスロジックをコンポーネントから分離しました。

## 実装内容

### ScoreHistoryPage
- useAiChatフックを使用してスコア履歴取得
- 直接fetch APIを削除（AiChatRepositoryに委譲）
- loading状態をフックから取得
- エラーハンドリングをフックに委譲

## 変更行数
- 削除: 18行
- 追加: 7行
- **合計: 11行削減**

## 期待効果
- コンポーネントがプレゼンテーション層として純粋化
- ビジネスロジックの再利用性向上
- コードの可読性・保守性向上

## 次のステップ
別PRで以下のページをリファクタリング予定：
- AskAiPage（useAiChat, useWebSocket使用）
- PracticePage（usePractice, useWebSocket使用）

Closes #134