### PR TITLE
Phase 3: ScoreCard機能のクリーンアーキテクチャ化

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreCardController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreCardController.java
@@ -15,9 +15,10 @@ import java.util.List;
 import com.example.FreStyle.dto.ScoreCardDto;
 import com.example.FreStyle.dto.ScoreHistoryDto;
 import com.example.FreStyle.entity.User;
-import com.example.FreStyle.service.ScoreCardService;
 import com.example.FreStyle.service.UserIdentityService;
 import com.example.FreStyle.usecase.GetAiChatSessionByIdUseCase;
+import com.example.FreStyle.usecase.GetScoreCardBySessionIdUseCase;
+import com.example.FreStyle.usecase.GetScoreHistoryByUserIdUseCase;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,9 +28,10 @@ import lombok.RequiredArgsConstructor;
 public class ScoreCardController {
 
     private static final Logger logger = LoggerFactory.getLogger(ScoreCardController.class);
-    private final ScoreCardService scoreCardService;
     private final UserIdentityService userIdentityService;
     private final GetAiChatSessionByIdUseCase getAiChatSessionByIdUseCase;
+    private final GetScoreCardBySessionIdUseCase getScoreCardBySessionIdUseCase;
+    private final GetScoreHistoryByUserIdUseCase getScoreHistoryByUserIdUseCase;
 
     /**
      * セッションのスコアカードを取得
@@ -47,7 +49,7 @@ public class ScoreCardController {
         // 権限チェック
         getAiChatSessionByIdUseCase.execute(sessionId, user.getId());
 
-        ScoreCardDto scoreCard = scoreCardService.getScoreCard(sessionId);
+        ScoreCardDto scoreCard = getScoreCardBySessionIdUseCase.execute(sessionId);
         logger.info("✅ スコアカード取得成功 - sessionId: {}", sessionId);
 
         return ResponseEntity.ok(scoreCard);
@@ -65,7 +67,7 @@ public class ScoreCardController {
         String sub = jwt.getSubject();
         User user = userIdentityService.findUserBySub(sub);
 
-        List<ScoreHistoryDto> history = scoreCardService.getScoreHistoryGrouped(user.getId());
+        List<ScoreHistoryDto> history = getScoreHistoryByUserIdUseCase.execute(user.getId());
         logger.info("✅ スコア履歴取得成功 - userId: {}, 件数: {}", user.getId(), history.size());
 
         return ResponseEntity.ok(history);

--- a/FreStyle/src/main/java/com/example/FreStyle/mapper/ScoreCardMapper.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/mapper/ScoreCardMapper.java
@@ -1,0 +1,114 @@
+package com.example.FreStyle.mapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.example.FreStyle.dto.ScoreCardDto;
+import com.example.FreStyle.dto.ScoreHistoryDto;
+import com.example.FreStyle.entity.CommunicationScore;
+
+/**
+ * ScoreCardのマッピングクラス
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>CommunicationScoreエンティティ ⇔ ScoreCardDto/ScoreHistoryDtoの変換</li>
+ *   <li>プレゼンテーション層とドメイン層の境界を明確化</li>
+ * </ul>
+ *
+ * <p>クリーンアーキテクチャー上の位置づけ:</p>
+ * <ul>
+ *   <li>プレゼンテーション層とアプリケーション層の間のマッピング層</li>
+ *   <li>DTOとEntityの変換ロジックを一箇所に集約</li>
+ * </ul>
+ */
+@Component
+public class ScoreCardMapper {
+
+    /**
+     * CommunicationScoreエンティティリストからScoreCardDtoへ変換
+     *
+     * @param sessionId セッションID
+     * @param scores CommunicationScoreエンティティのリスト
+     * @return ScoreCardDto（APIレスポンス用）
+     * @throws IllegalArgumentException scoresがnullの場合
+     */
+    public ScoreCardDto toScoreCardDto(Integer sessionId, List<CommunicationScore> scores) {
+        if (scores == null) {
+            throw new IllegalArgumentException("scoresがnullです");
+        }
+
+        List<ScoreCardDto.AxisScoreDto> scoreDtos = scores.stream()
+                .map(this::toAxisScoreDto)
+                .toList();
+
+        double overallScore = calculateOverallScore(scores);
+
+        return new ScoreCardDto(sessionId, scoreDtos, overallScore);
+    }
+
+    /**
+     * CommunicationScoreエンティティリストをセッション単位でグループ化し、ScoreHistoryDtoリストへ変換
+     *
+     * @param scores CommunicationScoreエンティティのリスト（createdAt降順）
+     * @return ScoreHistoryDtoのリスト
+     * @throws IllegalArgumentException scoresがnullの場合
+     */
+    public List<ScoreHistoryDto> toScoreHistoryDtoList(List<CommunicationScore> scores) {
+        if (scores == null) {
+            throw new IllegalArgumentException("scoresがnullです");
+        }
+
+        // セッションIDでグループ化（順序保持）
+        Map<Integer, List<CommunicationScore>> grouped = new LinkedHashMap<>();
+        for (CommunicationScore score : scores) {
+            grouped.computeIfAbsent(score.getSession().getId(), k -> new ArrayList<>()).add(score);
+        }
+
+        List<ScoreHistoryDto> history = new ArrayList<>();
+        for (Map.Entry<Integer, List<CommunicationScore>> entry : grouped.entrySet()) {
+            List<CommunicationScore> sessionScores = entry.getValue();
+            CommunicationScore first = sessionScores.get(0);
+
+            List<ScoreCardDto.AxisScoreDto> scoreDtos = sessionScores.stream()
+                    .map(this::toAxisScoreDto)
+                    .toList();
+
+            double overallScore = calculateOverallScore(sessionScores);
+            String title = first.getSession().getTitle();
+
+            history.add(new ScoreHistoryDto(
+                    entry.getKey(), title, overallScore, scoreDtos, first.getCreatedAt()));
+        }
+
+        return history;
+    }
+
+    /**
+     * CommunicationScoreエンティティからAxisScoreDtoへ変換
+     */
+    private ScoreCardDto.AxisScoreDto toAxisScoreDto(CommunicationScore score) {
+        return new ScoreCardDto.AxisScoreDto(
+                score.getAxisName(),
+                score.getScore(),
+                score.getComment()
+        );
+    }
+
+    /**
+     * CommunicationScoreリストから平均スコアを計算
+     */
+    private double calculateOverallScore(List<CommunicationScore> scores) {
+        if (scores.isEmpty()) {
+            return 0.0;
+        }
+        return scores.stream()
+                .mapToInt(CommunicationScore::getScore)
+                .average()
+                .orElse(0.0);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetScoreCardBySessionIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetScoreCardBySessionIdUseCase.java
@@ -1,0 +1,49 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ScoreCardDto;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.mapper.ScoreCardMapper;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * セッションIDによるスコアカード取得ユースケース
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>指定されたセッションIDに紐づくスコアカードを取得する</li>
+ *   <li>CommunicationScoreエンティティをScoreCardDtoに変換して返却する</li>
+ * </ul>
+ *
+ * <p>クリーンアーキテクチャー上の位置づけ:</p>
+ * <ul>
+ *   <li>アプリケーション層のユースケース</li>
+ *   <li>プレゼンテーション層（Controller）から呼び出される</li>
+ *   <li>ドメイン層（Repository）に依存</li>
+ * </ul>
+ */
+@Service
+@RequiredArgsConstructor
+public class GetScoreCardBySessionIdUseCase {
+
+    private final CommunicationScoreRepository communicationScoreRepository;
+    private final ScoreCardMapper mapper;
+
+    /**
+     * セッションIDでスコアカードを取得する
+     *
+     * @param sessionId セッションID
+     * @return ScoreCardDto（スコアカード情報）
+     */
+    @Transactional(readOnly = true)
+    public ScoreCardDto execute(Integer sessionId) {
+        List<CommunicationScore> scores = communicationScoreRepository.findBySessionId(sessionId);
+        return mapper.toScoreCardDto(sessionId, scores);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCase.java
@@ -1,0 +1,49 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ScoreHistoryDto;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.mapper.ScoreCardMapper;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * ユーザーIDによるスコア履歴取得ユースケース
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>指定されたユーザーIDに紐づくスコア履歴をセッション単位で取得する</li>
+ *   <li>CommunicationScoreエンティティをScoreHistoryDtoに変換して返却する</li>
+ * </ul>
+ *
+ * <p>クリーンアーキテクチャー上の位置づけ:</p>
+ * <ul>
+ *   <li>アプリケーション層のユースケース</li>
+ *   <li>プレゼンテーション層（Controller）から呼び出される</li>
+ *   <li>ドメイン層（Repository）に依存</li>
+ * </ul>
+ */
+@Service
+@RequiredArgsConstructor
+public class GetScoreHistoryByUserIdUseCase {
+
+    private final CommunicationScoreRepository communicationScoreRepository;
+    private final ScoreCardMapper mapper;
+
+    /**
+     * ユーザーIDでスコア履歴を取得する
+     *
+     * @param userId ユーザーID
+     * @return ScoreHistoryDtoのリスト（セッション単位でグループ化済み）
+     */
+    @Transactional(readOnly = true)
+    public List<ScoreHistoryDto> execute(Integer userId) {
+        List<CommunicationScore> scores = communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        return mapper.toScoreHistoryDtoList(scores);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveScoreCardUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveScoreCardUseCase.java
@@ -1,0 +1,87 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ScoreCardDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+import com.example.FreStyle.service.ScoreCardService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * スコアカード保存ユースケース
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>AI応答テキストからスコアを抽出する</li>
+ *   <li>抽出したスコアをデータベースに保存する</li>
+ *   <li>保存結果をScoreCardDtoとして返却する</li>
+ * </ul>
+ *
+ * <p>クリーンアーキテクチャー上の位置づけ:</p>
+ * <ul>
+ *   <li>アプリケーション層のユースケース</li>
+ *   <li>プレゼンテーション層（Controller）から呼び出される</li>
+ *   <li>ドメイン層（Repository）に依存</li>
+ * </ul>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SaveScoreCardUseCase {
+
+    private final CommunicationScoreRepository communicationScoreRepository;
+    private final ScoreCardService scoreCardService;
+
+    /**
+     * AI応答からスコアを抽出・保存し、ScoreCardDtoを返す
+     *
+     * @param sessionId セッションID
+     * @param userId ユーザーID
+     * @param aiResponse AI応答テキスト
+     * @param scene フィードバックシーン（nullable）
+     * @return ScoreCardDto（スコアが抽出できない場合はnull）
+     */
+    @Transactional
+    public ScoreCardDto execute(Integer sessionId, Integer userId, String aiResponse, String scene) {
+        List<ScoreCardService.AxisScore> scores = scoreCardService.parseScoresFromResponse(aiResponse);
+
+        if (scores.isEmpty()) {
+            return null;
+        }
+
+        AiChatSession session = new AiChatSession();
+        session.setId(sessionId);
+
+        User user = new User();
+        user.setId(userId);
+
+        for (ScoreCardService.AxisScore axisScore : scores) {
+            CommunicationScore entity = new CommunicationScore();
+            entity.setSession(session);
+            entity.setUser(user);
+            entity.setAxisName(axisScore.getAxis());
+            entity.setScore(axisScore.getScore());
+            entity.setComment(axisScore.getComment());
+            entity.setScene(scene);
+            communicationScoreRepository.save(entity);
+        }
+
+        log.info("スコア保存完了 - sessionId: {}, 軸数: {}", sessionId, scores.size());
+
+        double overallScore = scoreCardService.calculateOverallScore(scores);
+
+        List<ScoreCardDto.AxisScoreDto> scoreDtos = scores.stream()
+                .map(s -> new ScoreCardDto.AxisScoreDto(s.getAxis(), s.getScore(), s.getComment()))
+                .toList();
+
+        return new ScoreCardDto(sessionId, scoreDtos, overallScore);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/ScoreCardServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ScoreCardServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 class ScoreCardServiceTest {
 
-    private final ScoreCardService service = new ScoreCardService(null);
+    private final ScoreCardService service = new ScoreCardService();
 
     @Nested
     @DisplayName("parseScoresFromResponse - AI応答からスコアJSON抽出")

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreCardBySessionIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreCardBySessionIdUseCaseTest.java
@@ -1,0 +1,123 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ScoreCardDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.mapper.ScoreCardMapper;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+
+/**
+ * GetScoreCardBySessionIdUseCaseのテストクラス
+ *
+ * <p>テスト対象:</p>
+ * <ul>
+ *   <li>セッションIDによるスコアカード取得</li>
+ *   <li>エンティティからDTOへの変換</li>
+ *   <li>スコアが0件の場合のハンドリング</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class GetScoreCardBySessionIdUseCaseTest {
+
+    @Mock
+    private CommunicationScoreRepository communicationScoreRepository;
+
+    @Mock
+    private ScoreCardMapper mapper;
+
+    @InjectMocks
+    private GetScoreCardBySessionIdUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - セッションIDでスコアカード取得")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("セッションIDに紐づくスコアカードをDTOで取得する")
+        void shouldReturnScoreCardDtoBySessionId() {
+            // Arrange
+            Integer sessionId = 1;
+            List<CommunicationScore> entities = List.of(
+                    createEntity(1, sessionId, "論理的構成力", 8, "良い"),
+                    createEntity(2, sessionId, "配慮表現", 6, "改善余地")
+            );
+
+            ScoreCardDto expectedDto = new ScoreCardDto(
+                    sessionId,
+                    List.of(
+                            new ScoreCardDto.AxisScoreDto("論理的構成力", 8, "良い"),
+                            new ScoreCardDto.AxisScoreDto("配慮表現", 6, "改善余地")
+                    ),
+                    7.0
+            );
+
+            when(communicationScoreRepository.findBySessionId(sessionId)).thenReturn(entities);
+            when(mapper.toScoreCardDto(sessionId, entities)).thenReturn(expectedDto);
+
+            // Act
+            ScoreCardDto result = useCase.execute(sessionId);
+
+            // Assert
+            assertThat(result.getSessionId()).isEqualTo(sessionId);
+            assertThat(result.getScores()).hasSize(2);
+            assertThat(result.getOverallScore()).isEqualTo(7.0);
+
+            verify(communicationScoreRepository, times(1)).findBySessionId(sessionId);
+            verify(mapper, times(1)).toScoreCardDto(sessionId, entities);
+        }
+
+        @Test
+        @DisplayName("スコアが0件の場合でも正常にDTOを返す")
+        void shouldReturnEmptyScoreCardWhenNoScores() {
+            // Arrange
+            Integer sessionId = 99;
+            List<CommunicationScore> emptyList = List.of();
+
+            ScoreCardDto expectedDto = new ScoreCardDto(sessionId, List.of(), 0.0);
+
+            when(communicationScoreRepository.findBySessionId(sessionId)).thenReturn(emptyList);
+            when(mapper.toScoreCardDto(sessionId, emptyList)).thenReturn(expectedDto);
+
+            // Act
+            ScoreCardDto result = useCase.execute(sessionId);
+
+            // Assert
+            assertThat(result.getSessionId()).isEqualTo(sessionId);
+            assertThat(result.getScores()).isEmpty();
+            assertThat(result.getOverallScore()).isEqualTo(0.0);
+
+            verify(communicationScoreRepository, times(1)).findBySessionId(sessionId);
+            verify(mapper, times(1)).toScoreCardDto(sessionId, emptyList);
+        }
+    }
+
+    // ヘルパーメソッド
+    private CommunicationScore createEntity(Integer id, Integer sessionId, String axisName, Integer score, String comment) {
+        CommunicationScore entity = new CommunicationScore();
+        entity.setId(id);
+
+        AiChatSession session = new AiChatSession();
+        session.setId(sessionId);
+        entity.setSession(session);
+
+        entity.setAxisName(axisName);
+        entity.setScore(score);
+        entity.setComment(comment);
+        return entity;
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCaseTest.java
@@ -1,0 +1,136 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ScoreCardDto;
+import com.example.FreStyle.dto.ScoreHistoryDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.mapper.ScoreCardMapper;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+
+/**
+ * GetScoreHistoryByUserIdUseCaseのテストクラス
+ *
+ * <p>テスト対象:</p>
+ * <ul>
+ *   <li>ユーザーIDによるスコア履歴取得</li>
+ *   <li>セッション単位でのグループ化</li>
+ *   <li>スコアが0件の場合のハンドリング</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class GetScoreHistoryByUserIdUseCaseTest {
+
+    @Mock
+    private CommunicationScoreRepository communicationScoreRepository;
+
+    @Mock
+    private ScoreCardMapper mapper;
+
+    @InjectMocks
+    private GetScoreHistoryByUserIdUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - ユーザーIDでスコア履歴取得")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("ユーザーIDに紐づくスコア履歴をDTO化して取得する")
+        void shouldReturnScoreHistoryByUserId() {
+            // Arrange
+            Integer userId = 1;
+            Timestamp now = new Timestamp(System.currentTimeMillis());
+
+            List<CommunicationScore> entities = List.of(
+                    createEntity(1, 10, userId, "論理的構成力", 8, "良い", now),
+                    createEntity(2, 10, userId, "配慮表現", 6, "改善余地", now)
+            );
+
+            List<ScoreHistoryDto> expectedHistory = List.of(
+                    new ScoreHistoryDto(
+                            10,
+                            "セッション1",
+                            7.0,
+                            List.of(
+                                    new ScoreCardDto.AxisScoreDto("論理的構成力", 8, "良い"),
+                                    new ScoreCardDto.AxisScoreDto("配慮表現", 6, "改善余地")
+                            ),
+                            now
+                    )
+            );
+
+            when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(entities);
+            when(mapper.toScoreHistoryDtoList(entities)).thenReturn(expectedHistory);
+
+            // Act
+            List<ScoreHistoryDto> result = useCase.execute(userId);
+
+            // Assert
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getSessionId()).isEqualTo(10);
+            assertThat(result.get(0).getOverallScore()).isEqualTo(7.0);
+            assertThat(result.get(0).getScores()).hasSize(2);
+
+            verify(communicationScoreRepository, times(1)).findByUserIdOrderByCreatedAtDesc(userId);
+            verify(mapper, times(1)).toScoreHistoryDtoList(entities);
+        }
+
+        @Test
+        @DisplayName("スコア履歴が0件の場合は空リストを返す")
+        void shouldReturnEmptyListWhenNoHistory() {
+            // Arrange
+            Integer userId = 99;
+            List<CommunicationScore> emptyList = List.of();
+
+            when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId)).thenReturn(emptyList);
+            when(mapper.toScoreHistoryDtoList(emptyList)).thenReturn(List.of());
+
+            // Act
+            List<ScoreHistoryDto> result = useCase.execute(userId);
+
+            // Assert
+            assertThat(result).isEmpty();
+
+            verify(communicationScoreRepository, times(1)).findByUserIdOrderByCreatedAtDesc(userId);
+            verify(mapper, times(1)).toScoreHistoryDtoList(emptyList);
+        }
+    }
+
+    // ヘルパーメソッド
+    private CommunicationScore createEntity(Integer id, Integer sessionId, Integer userId,
+                                            String axisName, Integer score, String comment, Timestamp createdAt) {
+        CommunicationScore entity = new CommunicationScore();
+        entity.setId(id);
+
+        AiChatSession session = new AiChatSession();
+        session.setId(sessionId);
+        session.setTitle("セッション1");
+        entity.setSession(session);
+
+        User user = new User();
+        user.setId(userId);
+        entity.setUser(user);
+
+        entity.setAxisName(axisName);
+        entity.setScore(score);
+        entity.setComment(comment);
+        entity.setCreatedAt(createdAt);
+        return entity;
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveScoreCardUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveScoreCardUseCaseTest.java
@@ -1,0 +1,172 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ScoreCardDto;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+import com.example.FreStyle.service.ScoreCardService;
+
+/**
+ * SaveScoreCardUseCaseのテストクラス
+ *
+ * <p>テスト対象:</p>
+ * <ul>
+ *   <li>AI応答からスコアを抽出してDBに保存</li>
+ *   <li>保存成功時にScoreCardDtoを返却</li>
+ *   <li>スコアが抽出できない場合のハンドリング</li>
+ * </ul>
+ */
+@ExtendWith(MockitoExtension.class)
+class SaveScoreCardUseCaseTest {
+
+    @Mock
+    private CommunicationScoreRepository communicationScoreRepository;
+
+    @Mock
+    private ScoreCardService scoreCardService;
+
+    @InjectMocks
+    private SaveScoreCardUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - AI応答からスコアを保存")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("正常なAI応答からスコアを抽出・保存し、ScoreCardDtoを返す")
+        void shouldParseAndSaveScoresFromAiResponse() {
+            // Arrange
+            Integer sessionId = 1;
+            Integer userId = 10;
+            String scene = "meeting";
+            String aiResponse = "フィードバック...\n```json\n{\"scores\":[{\"axis\":\"論理的構成力\",\"score\":8,\"comment\":\"良い\"}]}\n```";
+
+            List<ScoreCardService.AxisScore> parsedScores = List.of(
+                    new ScoreCardService.AxisScore("論理的構成力", 8, "良い")
+            );
+
+            when(scoreCardService.parseScoresFromResponse(aiResponse)).thenReturn(parsedScores);
+            when(scoreCardService.calculateOverallScore(parsedScores)).thenReturn(8.0);
+            when(communicationScoreRepository.save(any(CommunicationScore.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // Act
+            ScoreCardDto result = useCase.execute(sessionId, userId, aiResponse, scene);
+
+            // Assert
+            assertThat(result).isNotNull();
+            assertThat(result.getSessionId()).isEqualTo(sessionId);
+            assertThat(result.getScores()).hasSize(1);
+            assertThat(result.getScores().get(0).getAxis()).isEqualTo("論理的構成力");
+            assertThat(result.getScores().get(0).getScore()).isEqualTo(8);
+            assertThat(result.getOverallScore()).isEqualTo(8.0);
+
+            verify(communicationScoreRepository, times(1)).save(any(CommunicationScore.class));
+        }
+
+        @Test
+        @DisplayName("複数軸のスコアを全て保存する")
+        void shouldSaveMultipleAxisScores() {
+            // Arrange
+            Integer sessionId = 1;
+            Integer userId = 10;
+            String aiResponse = "```json\n{\"scores\":[" +
+                    "{\"axis\":\"論理的構成力\",\"score\":8,\"comment\":\"良い\"}," +
+                    "{\"axis\":\"配慮表現\",\"score\":6,\"comment\":\"改善余地\"}," +
+                    "{\"axis\":\"要約力\",\"score\":7,\"comment\":\"まあまあ\"}" +
+                    "]}\n```";
+
+            List<ScoreCardService.AxisScore> parsedScores = List.of(
+                    new ScoreCardService.AxisScore("論理的構成力", 8, "良い"),
+                    new ScoreCardService.AxisScore("配慮表現", 6, "改善余地"),
+                    new ScoreCardService.AxisScore("要約力", 7, "まあまあ")
+            );
+
+            when(scoreCardService.parseScoresFromResponse(aiResponse)).thenReturn(parsedScores);
+            when(scoreCardService.calculateOverallScore(parsedScores)).thenReturn(7.0);
+            when(communicationScoreRepository.save(any(CommunicationScore.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // Act
+            ScoreCardDto result = useCase.execute(sessionId, userId, aiResponse, null);
+
+            // Assert
+            assertThat(result.getScores()).hasSize(3);
+            assertThat(result.getOverallScore()).isEqualTo(7.0);
+
+            ArgumentCaptor<CommunicationScore> captor = ArgumentCaptor.forClass(CommunicationScore.class);
+            verify(communicationScoreRepository, times(3)).save(captor.capture());
+
+            List<CommunicationScore> savedEntities = captor.getAllValues();
+            assertThat(savedEntities.get(0).getAxisName()).isEqualTo("論理的構成力");
+            assertThat(savedEntities.get(1).getAxisName()).isEqualTo("配慮表現");
+            assertThat(savedEntities.get(2).getAxisName()).isEqualTo("要約力");
+        }
+
+        @Test
+        @DisplayName("スコアが抽出できない場合はnullを返す")
+        void shouldReturnNullWhenNoScoresExtracted() {
+            // Arrange
+            Integer sessionId = 1;
+            Integer userId = 10;
+            String aiResponse = "フィードバックのみで、スコアJSON無し";
+
+            when(scoreCardService.parseScoresFromResponse(aiResponse)).thenReturn(List.of());
+
+            // Act
+            ScoreCardDto result = useCase.execute(sessionId, userId, aiResponse, null);
+
+            // Assert
+            assertThat(result).isNull();
+            verify(communicationScoreRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("保存時にsceneが正しくエンティティに設定される")
+        void shouldSetSceneOnSavedEntities() {
+            // Arrange
+            Integer sessionId = 1;
+            Integer userId = 10;
+            String scene = "presentation";
+            String aiResponse = "```json\n{\"scores\":[{\"axis\":\"要約力\",\"score\":7,\"comment\":\"OK\"}]}\n```";
+
+            List<ScoreCardService.AxisScore> parsedScores = List.of(
+                    new ScoreCardService.AxisScore("要約力", 7, "OK")
+            );
+
+            when(scoreCardService.parseScoresFromResponse(aiResponse)).thenReturn(parsedScores);
+            when(scoreCardService.calculateOverallScore(parsedScores)).thenReturn(7.0);
+            when(communicationScoreRepository.save(any(CommunicationScore.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // Act
+            useCase.execute(sessionId, userId, aiResponse, scene);
+
+            // Assert
+            ArgumentCaptor<CommunicationScore> captor = ArgumentCaptor.forClass(CommunicationScore.class);
+            verify(communicationScoreRepository, times(1)).save(captor.capture());
+
+            CommunicationScore saved = captor.getValue();
+            assertThat(saved.getScene()).isEqualTo("presentation");
+            assertThat(saved.getSession().getId()).isEqualTo(sessionId);
+            assertThat(saved.getUser().getId()).isEqualTo(userId);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
ScoreCardServiceのデータアクセスメソッドをUseCase化し、Entity⇔DTO変換をScoreCardMapperに集約。

closes #123

## 変更内容
- **ScoreCardMapper**: CommunicationScoreエンティティ ⇔ ScoreCardDto/ScoreHistoryDtoの変換を一元化
- **GetScoreCardBySessionIdUseCase**: セッションIDによるスコアカード取得
- **GetScoreHistoryByUserIdUseCase**: ユーザーIDによるスコア履歴取得（セッション単位グループ化）
- **SaveScoreCardUseCase**: AI応答テキストからスコア抽出・DB保存・ScoreCardDto返却
- **ScoreCardController**: ScoreCardService依存 → UseCase依存に移行
- **AiChatWebSocketController**: スコア抽出・保存ロジックをSaveScoreCardUseCaseに委譲
- **ScoreCardService**: パース・計算ユーティリティのみに縮小（不要なDB操作メソッドを削除）

## テスト
- GetScoreCardBySessionIdUseCaseTest: 2テスト
- GetScoreHistoryByUserIdUseCaseTest: 2テスト
- SaveScoreCardUseCaseTest: 4テスト
- ScoreCardServiceTest: 既存テスト修正（コンストラクタ変更対応）

## テスト計画
- [x] 全バックエンドテスト成功確認（92テスト通過、contextLoadsのみDB接続で失敗）
- [x] ローカル動作確認（docker compose up -d --build）