### PR TITLE
UIをビジネス向けシンプルデザインに変更

### DIFF
--- a/frontend/src/components/RephraseModal.tsx
+++ b/frontend/src/components/RephraseModal.tsx
@@ -18,29 +18,29 @@ export default function RephraseModal({ result, onClose }: RephraseModalProps) {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full mx-4 p-6">
-        <h3 className="text-lg font-bold text-slate-800 mb-4">言い換え提案</h3>
+      <div className="bg-white rounded-lg shadow-lg max-w-lg w-full mx-4 p-5">
+        <h3 className="text-sm font-semibold text-slate-800 mb-4">言い換え提案</h3>
 
         {result === null ? (
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500 mr-3" />
-            <span className="text-slate-500">言い換え中...</span>
+            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-slate-400 mr-3" />
+            <span className="text-sm text-slate-500">言い換え中...</span>
           </div>
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-3">
             {([
-              { key: 'formal' as const, label: 'フォーマル版', color: 'blue' },
-              { key: 'soft' as const, label: 'ソフト版', color: 'green' },
-              { key: 'concise' as const, label: '簡潔版', color: 'orange' },
-              { key: 'questioning' as const, label: '質問型', color: 'purple' },
-              { key: 'proposal' as const, label: '提案型', color: 'teal' },
-            ]).map(({ key, label, color }) => (
+              { key: 'formal' as const, label: 'フォーマル' },
+              { key: 'soft' as const, label: 'ソフト' },
+              { key: 'concise' as const, label: '簡潔' },
+              { key: 'questioning' as const, label: '質問型' },
+              { key: 'proposal' as const, label: '提案型' },
+            ]).map(({ key, label }) => (
               <div key={key} className="border border-slate-200 rounded-lg p-3">
                 <div className="flex items-center justify-between mb-1">
-                  <span className={`text-sm font-semibold text-${color}-600`}>{label}</span>
+                  <span className="text-xs font-medium text-slate-600">{label}</span>
                   <button
                     onClick={() => handleCopy(result[key])}
-                    className="text-xs text-slate-500 hover:text-primary-600 px-2 py-1 rounded hover:bg-slate-100 transition-colors"
+                    className="text-xs text-slate-400 hover:text-slate-600 px-2 py-0.5 rounded hover:bg-slate-100 transition-colors"
                   >
                     コピー
                   </button>
@@ -53,7 +53,7 @@ export default function RephraseModal({ result, onClose }: RephraseModalProps) {
 
         <button
           onClick={onClose}
-          className="w-full mt-4 py-2 text-sm text-slate-500 hover:text-slate-700 bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors"
+          className="w-full mt-4 py-2 text-sm text-slate-500 hover:text-slate-700 bg-slate-50 hover:bg-slate-100 rounded-lg transition-colors"
         >
           閉じる
         </button>

--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -11,28 +11,22 @@ const difficultyLabel: Record<string, string> = {
   advanced: '上級',
 };
 
-const difficultyColor: Record<string, string> = {
-  beginner: 'bg-green-100 text-green-700',
-  intermediate: 'bg-yellow-100 text-yellow-700',
-  advanced: 'bg-red-100 text-red-700',
-};
-
 export default function ScenarioCard({ scenario, onSelect }: ScenarioCardProps) {
   return (
     <div
       onClick={() => onSelect(scenario)}
-      className="bg-white rounded-xl border border-slate-200 p-5 cursor-pointer hover:border-primary-300 hover:shadow-md transition-all duration-150"
+      className="bg-white rounded-lg border border-slate-200 p-4 cursor-pointer hover:bg-slate-50 transition-colors"
     >
       <div className="flex items-center justify-between mb-2">
-        <span className="text-xs font-medium text-slate-500">{scenario.category}</span>
-        <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${difficultyColor[scenario.difficulty] || 'bg-slate-100 text-slate-700'}`}>
+        <span className="text-xs text-slate-500">{scenario.category}</span>
+        <span className="text-xs text-slate-500 border border-slate-200 px-2 py-0.5 rounded">
           {difficultyLabel[scenario.difficulty] || scenario.difficulty}
         </span>
       </div>
-      <h3 className="text-base font-bold text-slate-800 mb-1">{scenario.name}</h3>
-      <p className="text-sm text-slate-600 mb-3">{scenario.description}</p>
-      <div className="flex items-center gap-1 text-xs text-slate-500">
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <h3 className="text-sm font-medium text-slate-800 mb-1">{scenario.name}</h3>
+      <p className="text-xs text-slate-500 mb-3">{scenario.description}</p>
+      <div className="flex items-center gap-1 text-xs text-slate-400">
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
         </svg>
         <span>相手役: {scenario.roleName}</span>

--- a/frontend/src/components/SceneSelector.tsx
+++ b/frontend/src/components/SceneSelector.tsx
@@ -23,30 +23,30 @@ interface SceneSelectorProps {
 export default function SceneSelector({ onSelect, onCancel }: SceneSelectorProps) {
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl shadow-xl max-w-md w-full mx-4 p-6">
-        <h3 className="text-lg font-bold text-slate-800 mb-2">
+      <div className="bg-white rounded-lg shadow-lg max-w-md w-full mx-4 p-5">
+        <h3 className="text-sm font-semibold text-slate-800 mb-1">
           フィードバックのシーンを選択
         </h3>
-        <p className="text-sm text-slate-500 mb-4">
+        <p className="text-xs text-slate-500 mb-4">
           シーンに応じた追加評価観点でフィードバックします
         </p>
 
-        <div className="space-y-2">
+        <div className="space-y-1">
           {SCENES.map((scene) => (
             <button
               key={scene.id}
               onClick={() => onSelect(scene.id)}
-              className="w-full text-left p-3 rounded-lg border border-slate-200 hover:border-primary-400 hover:bg-primary-50 transition-colors"
+              className="w-full text-left px-3 py-2.5 rounded-md hover:bg-slate-50 transition-colors"
             >
-              <span className="font-medium text-slate-800">{scene.label}</span>
-              <p className="text-xs text-slate-500 mt-0.5">{scene.description}</p>
+              <span className="text-sm font-medium text-slate-700">{scene.label}</span>
+              <p className="text-xs text-slate-400 mt-0.5">{scene.description}</p>
             </button>
           ))}
         </div>
 
         <button
           onClick={onCancel}
-          className="w-full mt-4 py-2 text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          className="w-full mt-3 py-2 text-xs text-slate-500 hover:text-slate-700 transition-colors"
         >
           スキップ
         </button>

--- a/frontend/src/components/ScoreCard.tsx
+++ b/frontend/src/components/ScoreCard.tsx
@@ -5,27 +5,13 @@ interface ScoreCardProps {
 }
 
 export default function ScoreCard({ scoreCard }: ScoreCardProps) {
-  const getScoreColor = (score: number) => {
-    if (score >= 8) return 'bg-green-500';
-    if (score >= 6) return 'bg-yellow-500';
-    if (score >= 4) return 'bg-orange-500';
-    return 'bg-red-500';
-  };
-
-  const getOverallColor = (score: number) => {
-    if (score >= 8) return 'text-green-600';
-    if (score >= 6) return 'text-yellow-600';
-    if (score >= 4) return 'text-orange-600';
-    return 'text-red-600';
-  };
-
   return (
-    <div className="bg-white rounded-xl border border-slate-200 p-4 my-3 max-w-[85%] self-start">
+    <div className="bg-white rounded-lg border border-slate-200 p-4 my-3 max-w-[85%] self-start">
       <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-bold text-slate-700">スコアカード</h3>
+        <h3 className="text-sm font-medium text-slate-700">スコアカード</h3>
         <div className="flex items-center gap-1">
           <span className="text-xs text-slate-500">総合</span>
-          <span className={`text-lg font-bold ${getOverallColor(scoreCard.overallScore)}`}>
+          <span className="text-lg font-semibold text-slate-800">
             {scoreCard.overallScore.toFixed(1)}
           </span>
           <span className="text-xs text-slate-400">/10</span>
@@ -36,12 +22,12 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
         {scoreCard.scores.map((axisScore) => (
           <div key={axisScore.axis}>
             <div className="flex items-center justify-between mb-0.5">
-              <span className="text-xs text-slate-600">{axisScore.axis}</span>
-              <span className="text-xs font-bold text-slate-700">{axisScore.score}</span>
+              <span className="text-xs text-slate-500">{axisScore.axis}</span>
+              <span className="text-xs font-medium text-slate-600">{axisScore.score}</span>
             </div>
-            <div className="w-full bg-slate-100 rounded-full h-2">
+            <div className="w-full bg-slate-100 rounded-full h-1.5">
               <div
-                className={`h-2 rounded-full transition-all duration-500 ${getScoreColor(axisScore.score)}`}
+                className="h-1.5 rounded-full bg-primary-500"
                 style={{ width: `${axisScore.score * 10}%` }}
               />
             </div>

--- a/frontend/src/components/__tests__/RephraseModal.test.tsx
+++ b/frontend/src/components/__tests__/RephraseModal.test.tsx
@@ -19,9 +19,9 @@ describe('RephraseModal', () => {
   it('3パターンの言い換え結果が表示される', () => {
     render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
 
-    expect(screen.getByText('フォーマル版')).toBeInTheDocument();
-    expect(screen.getByText('ソフト版')).toBeInTheDocument();
-    expect(screen.getByText('簡潔版')).toBeInTheDocument();
+    expect(screen.getByText('フォーマル')).toBeInTheDocument();
+    expect(screen.getByText('ソフト')).toBeInTheDocument();
+    expect(screen.getByText('簡潔')).toBeInTheDocument();
     expect(screen.getByText('フォーマルな言い換え文です。')).toBeInTheDocument();
     expect(screen.getByText('ソフトな言い換え文です。')).toBeInTheDocument();
     expect(screen.getByText('簡潔な言い換え文です。')).toBeInTheDocument();

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,75 +1,21 @@
 import { useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
 import {
-  CalendarIcon,
   UserGroupIcon,
-  SparklesIcon,
   ChatBubbleLeftRightIcon,
+  SparklesIcon,
   AcademicCapIcon,
+  ChartBarIcon,
 } from '@heroicons/react/24/outline';
 
 interface ChatStats {
   chatPartnerCount: number;
 }
 
-interface DailyTip {
-  emoji: string;
-  title: string;
-  content: string;
-}
-
 export default function MenuPage() {
   const navigate = useNavigate();
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
   const [stats, setStats] = useState<ChatStats | null>(null);
-  const [currentTime, setCurrentTime] = useState(new Date());
-
-  const dailyTips: DailyTip[] = [
-    {
-      emoji: '💬',
-      title: '文字だけでは伝わりにくい感情',
-      content: 'テキストでは声のトーンや表情が伝わりません。絵文字を活用したり、AIに印象をチェックしてもらいましょう。',
-    },
-    {
-      emoji: '🤔',
-      title: '相手の立場で読み返してみる',
-      content: '送信前に一度、相手の気持ちになって読み返すと、誤解を防げることがあります。',
-    },
-    {
-      emoji: '✨',
-      title: 'ポジティブな言葉を意識する',
-      content: '「でも」より「そして」、「〜できない」より「〜してみよう」を使うと印象が変わります。',
-    },
-    {
-      emoji: '🎯',
-      title: '具体的に伝える',
-      content: '「ちゃんとやって」より「〇〇を△△までにお願い」の方が誤解なく伝わります。',
-    },
-    {
-      emoji: '👂',
-      title: '質問で会話を広げる',
-      content: '「そうなんだ」で終わらせず、「それでどうなった？」と聞くと会話が深まります。',
-    },
-    {
-      emoji: '🌈',
-      title: '感謝を言葉にする',
-      content: '「ありがとう」は対面でもチャットでも、最強のコミュニケーションツールです。',
-    },
-    {
-      emoji: '⏰',
-      title: '返信のタイミング',
-      content: '即レスが良いとは限りません。落ち着いて考えてから返信することも大切です。',
-    },
-  ];
-
-  const todayTip = dailyTips[new Date().getDate() % dailyTips.length];
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setCurrentTime(new Date());
-    }, 1000);
-    return () => clearInterval(timer);
-  }, []);
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -107,92 +53,64 @@ export default function MenuPage() {
     fetchStats();
   }, [navigate, API_BASE_URL]);
 
-  const formatDate = (date: Date) =>
-    date.toLocaleDateString('ja-JP', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      weekday: 'short',
-    });
-
-  const formatTime = (date: Date) =>
-    date.toLocaleTimeString('ja-JP', {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+  const menuItems = [
+    {
+      icon: ChatBubbleLeftRightIcon,
+      label: 'チャット',
+      description: 'メンバーとメッセージをやり取り',
+      to: '/chat',
+    },
+    {
+      icon: SparklesIcon,
+      label: 'AI アシスタント',
+      description: 'AIにコミュニケーションを分析・フィードバック',
+      to: '/chat/ask-ai',
+    },
+    {
+      icon: AcademicCapIcon,
+      label: '練習モード',
+      description: 'ビジネスシナリオでロールプレイ練習',
+      to: '/practice',
+    },
+    {
+      icon: ChartBarIcon,
+      label: 'スコア履歴',
+      description: 'フィードバック結果の振り返り',
+      to: '/scores',
+    },
+  ];
 
   return (
-    <div className="p-6 max-w-3xl mx-auto">
-      {/* 統計カード */}
-      <div className="grid grid-cols-2 gap-4 mb-6">
-        <div className="bg-white rounded-lg border border-slate-200 p-4">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-xs font-medium text-slate-500">会話した人数</span>
-            <UserGroupIcon className="w-4 h-4 text-slate-400" />
-          </div>
-          <p className="text-2xl font-bold text-slate-800">
-            {stats?.chatPartnerCount ?? '—'}
-            <span className="text-sm font-normal text-slate-500 ml-1">人</span>
-          </p>
-        </div>
-
-        <div className="bg-white rounded-lg border border-slate-200 p-4">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-xs font-medium text-slate-500">
-              {formatDate(currentTime)}
-            </span>
-            <CalendarIcon className="w-4 h-4 text-slate-400" />
-          </div>
-          <p className="text-2xl font-bold text-slate-800 font-mono">
-            {formatTime(currentTime)}
-          </p>
-        </div>
-      </div>
-
-      {/* 今日のTIPS */}
+    <div className="p-6 max-w-2xl mx-auto">
+      {/* サマリー */}
       <div className="bg-white rounded-lg border border-slate-200 p-4 mb-6">
-        <div className="flex items-start gap-3">
-          <div className="text-xl">{todayTip.emoji}</div>
-          <div className="min-w-0">
-            <span className="text-[10px] font-semibold text-primary-600 bg-primary-50 px-1.5 py-0.5 rounded">
-              TODAY'S TIP
-            </span>
-            <h3 className="text-sm font-semibold text-slate-800 mt-1">
-              {todayTip.title}
-            </h3>
-            <p className="text-xs text-slate-500 mt-0.5">
-              {todayTip.content}
+        <div className="flex items-center gap-3">
+          <UserGroupIcon className="w-5 h-5 text-slate-400" />
+          <div>
+            <p className="text-xs text-slate-500">会話した人数</p>
+            <p className="text-lg font-semibold text-slate-800">
+              {stats?.chatPartnerCount ?? '—'}
+              <span className="text-sm font-normal text-slate-500 ml-1">人</span>
             </p>
           </div>
         </div>
       </div>
 
-      {/* クイックスタート */}
-      <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-3">
-        クイックスタート
-      </h2>
-      <div className="grid grid-cols-3 gap-3">
-        <button
-          onClick={() => navigate('/chat')}
-          className="bg-white rounded-lg border border-slate-200 p-4 text-center hover:bg-slate-50 transition-colors"
-        >
-          <ChatBubbleLeftRightIcon className="w-6 h-6 text-primary-500 mx-auto mb-2" />
-          <span className="text-xs font-medium text-slate-700">チャット</span>
-        </button>
-        <button
-          onClick={() => navigate('/chat/ask-ai')}
-          className="bg-white rounded-lg border border-slate-200 p-4 text-center hover:bg-slate-50 transition-colors"
-        >
-          <SparklesIcon className="w-6 h-6 text-primary-500 mx-auto mb-2" />
-          <span className="text-xs font-medium text-slate-700">AI分析</span>
-        </button>
-        <button
-          onClick={() => navigate('/practice')}
-          className="bg-white rounded-lg border border-slate-200 p-4 text-center hover:bg-slate-50 transition-colors"
-        >
-          <AcademicCapIcon className="w-6 h-6 text-primary-500 mx-auto mb-2" />
-          <span className="text-xs font-medium text-slate-700">練習</span>
-        </button>
+      {/* メニュー */}
+      <div className="space-y-2">
+        {menuItems.map((item) => (
+          <button
+            key={item.to}
+            onClick={() => navigate(item.to)}
+            className="w-full flex items-center gap-4 bg-white rounded-lg border border-slate-200 p-4 text-left hover:bg-slate-50 transition-colors"
+          >
+            <item.icon className="w-5 h-5 text-slate-500 flex-shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-slate-800">{item.label}</p>
+              <p className="text-xs text-slate-500">{item.description}</p>
+            </div>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -39,23 +39,23 @@ export default function PracticePage() {
   return (
     <div className="p-6 max-w-2xl mx-auto">
       {/* ヘッダー */}
-      <div className="mb-6">
-        <h1 className="text-lg font-bold text-slate-800 mb-1">ビジネスシナリオ練習</h1>
-        <p className="text-sm text-slate-500">
+      <div className="mb-5">
+        <h1 className="text-sm font-semibold text-slate-800 mb-1">ビジネスシナリオ練習</h1>
+        <p className="text-xs text-slate-500">
           AIが相手役を演じます。実践的なビジネスシーンでコミュニケーションスキルを磨きましょう。
         </p>
       </div>
 
-      {/* カテゴリフィルター */}
-      <div className="flex gap-2 mb-6 overflow-x-auto">
+      {/* カテゴリタブ */}
+      <div className="flex gap-1 mb-5 border-b border-slate-200">
         {CATEGORIES.map((category) => (
           <button
             key={category}
             onClick={() => setSelectedCategory(category)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium whitespace-nowrap transition-colors ${
+            className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
               selectedCategory === category
-                ? 'bg-primary-500 text-white'
-                : 'bg-white text-slate-600 border border-slate-200 hover:bg-slate-50'
+                ? 'border-primary-500 text-primary-600'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
             }`}
           >
             {category}
@@ -71,7 +71,7 @@ export default function PracticePage() {
           <SkeletonCard />
         </div>
       ) : filteredScenarios.length === 0 ? (
-        <div className="text-center py-12 text-sm text-slate-500">
+        <div className="text-center py-12 text-xs text-slate-500">
           シナリオがありません
         </div>
       ) : (

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -28,20 +28,6 @@ export default function ScoreHistoryPage() {
     loadHistory();
   }, [fetchScoreHistory]);
 
-  const getScoreColor = (score: number) => {
-    if (score >= 8) return 'text-green-600';
-    if (score >= 6) return 'text-yellow-600';
-    if (score >= 4) return 'text-orange-600';
-    return 'text-red-600';
-  };
-
-  const getBarColor = (score: number) => {
-    if (score >= 8) return 'bg-green-500';
-    if (score >= 6) return 'bg-yellow-500';
-    if (score >= 4) return 'bg-orange-500';
-    return 'bg-red-500';
-  };
-
   if (loading) {
     return (
       <div className="max-w-3xl mx-auto p-4 space-y-4">
@@ -56,26 +42,26 @@ export default function ScoreHistoryPage() {
   if (history.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 text-slate-500">
-        <p className="text-lg font-medium">スコア履歴がありません</p>
-        <p className="text-sm mt-1">AIアシスタントでフィードバックを受けるとスコアが記録されます</p>
+        <p className="text-sm font-medium">スコア履歴がありません</p>
+        <p className="text-xs mt-1">AIアシスタントでフィードバックを受けるとスコアが記録されます</p>
       </div>
     );
   }
 
   return (
-    <div className="max-w-3xl mx-auto p-4 space-y-4">
-      <div className="text-sm text-slate-500">
+    <div className="max-w-3xl mx-auto p-4 space-y-3">
+      <p className="text-xs text-slate-500">
         全 {history.length} 件のフィードバック履歴
-      </div>
+      </p>
 
       {history.map((item) => (
         <div
           key={item.sessionId}
-          className="bg-white rounded-xl border border-slate-200 p-4"
+          className="bg-white rounded-lg border border-slate-200 p-4"
         >
           <div className="flex items-center justify-between mb-3">
             <div>
-              <h3 className="text-sm font-bold text-slate-700">
+              <h3 className="text-sm font-medium text-slate-800">
                 {item.sessionTitle || `セッション #${item.sessionId}`}
               </h3>
               <p className="text-xs text-slate-400 mt-0.5">
@@ -88,7 +74,7 @@ export default function ScoreHistoryPage() {
             </div>
             <div className="flex items-center gap-1">
               <span className="text-xs text-slate-500">総合</span>
-              <span className={`text-lg font-bold ${getScoreColor(item.overallScore)}`}>
+              <span className="text-lg font-semibold text-slate-800">
                 {item.overallScore.toFixed(1)}
               </span>
               <span className="text-xs text-slate-400">/10</span>
@@ -98,16 +84,16 @@ export default function ScoreHistoryPage() {
           <div className="space-y-1.5">
             {item.scores.map((axisScore) => (
               <div key={axisScore.axis} className="flex items-center gap-2">
-                <span className="text-xs text-slate-600 w-24 flex-shrink-0 truncate">
+                <span className="text-xs text-slate-500 w-24 flex-shrink-0 truncate">
                   {axisScore.axis}
                 </span>
-                <div className="flex-1 bg-slate-100 rounded-full h-2">
+                <div className="flex-1 bg-slate-100 rounded-full h-1.5">
                   <div
-                    className={`h-2 rounded-full ${getBarColor(axisScore.score)}`}
+                    className="h-1.5 rounded-full bg-primary-500"
                     style={{ width: `${axisScore.score * 10}%` }}
                   />
                 </div>
-                <span className="text-xs font-bold text-slate-700 w-5 text-right">
+                <span className="text-xs text-slate-600 w-5 text-right">
                   {axisScore.score}
                 </span>
               </div>


### PR DESCRIPTION
## 概要
ゲーミフィケーション気味だったUIを、Teams/Notionに近いプロフェッショナルなビジネス向けデザインに変更。

## 変更内容

### MenuPage
- TODAY'S TIP（絵文字付きデイリーヒント）を削除
- リアルタイム時計を削除
- グリッドカード → シンプルなリスト形式メニューに変更

### スコア表示（ScoreHistoryPage / ScoreCard）
- 信号機カラー（緑/黄/橙/赤）のスコアバー → primary単色バーに統一
- スコア数値の色分け → スレートグレー統一
- バーの高さを細く（h-2 → h-1.5）

### ScenarioCard
- カラフル難易度バッジ（緑/黄/赤背景）→ ニュートラルなボーダーバッジ
- ホバー時のシャドウ・ボーダー変化 → シンプルな背景色変化

### RephraseModal
- 各パターンのカラフルラベル（blue/green/orange/purple/teal）→ スレートグレー統一
- 「〜版」表記を削除（「フォーマル版」→「フォーマル」）

### PracticePage
- ピル型カテゴリフィルター → タブスタイル（下線インジケーター）

### SceneSelector
- ボーダー付きボタン → ボーダーなしのリスト形式（Notion風）

## テスト計画
- [x] フロントエンド全62テスト通過
- [x] ローカル動作確認（docker compose up -d --build）