### PR TITLE
feat: 練習ページのUX向上（難易度説明・所要時間・色分けバッジ）

### DIFF
--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -17,6 +17,18 @@ const categoryLabel: Record<string, string> = {
   team: 'チーム内',
 };
 
+const difficultyDescription: Record<string, string> = {
+  beginner: '基本的な報連相',
+  intermediate: '利害関係の調整',
+  advanced: '複雑な交渉・説得',
+};
+
+const difficultyColor: Record<string, string> = {
+  beginner: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  intermediate: 'bg-amber-50 text-amber-700 border-amber-200',
+  advanced: 'bg-rose-50 text-rose-700 border-rose-200',
+};
+
 export default function ScenarioCard({ scenario, onSelect }: ScenarioCardProps) {
   return (
     <div
@@ -25,12 +37,15 @@ export default function ScenarioCard({ scenario, onSelect }: ScenarioCardProps) 
     >
       <div className="flex items-center justify-between mb-2">
         <span className="text-xs text-slate-500">{categoryLabel[scenario.category] || scenario.category}</span>
-        <span className="text-xs text-slate-500 border border-slate-200 px-2 py-0.5 rounded">
+        <span className={`text-xs px-2 py-0.5 rounded border ${difficultyColor[scenario.difficulty] || 'bg-slate-50 text-slate-500 border-slate-200'}`}>
           {difficultyLabel[scenario.difficulty] || scenario.difficulty}
         </span>
       </div>
       <h3 className="text-sm font-medium text-slate-800 mb-1">{scenario.name}</h3>
-      <p className="text-xs text-slate-500 mb-3">{scenario.description}</p>
+      <p className="text-xs text-slate-500 mb-2">{scenario.description}</p>
+      <p className="text-[11px] text-slate-400 mb-3">
+        {difficultyDescription[scenario.difficulty] || ''} ・ 約5〜10分
+      </p>
       <div className="flex items-center gap-1 text-xs text-slate-400">
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />

--- a/frontend/src/components/__tests__/ScenarioCard.test.tsx
+++ b/frontend/src/components/__tests__/ScenarioCard.test.tsx
@@ -62,6 +62,22 @@ describe('ScenarioCard', () => {
     expect(screen.getByText('チーム内')).toBeDefined();
   });
 
+  it('所要時間の目安を表示する', () => {
+    render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} />);
+    expect(screen.getByText(/約5〜10分/)).toBeDefined();
+  });
+
+  it('難易度の説明テキストを表示する', () => {
+    render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} />);
+    expect(screen.getByText(/利害関係の調整/)).toBeDefined();
+  });
+
+  it('初級の難易度説明を表示する', () => {
+    const beginnerScenario = { ...mockScenario, difficulty: 'beginner' };
+    render(<ScenarioCard scenario={beginnerScenario} onSelect={vi.fn()} />);
+    expect(screen.getByText(/基本的な報連相/)).toBeDefined();
+  });
+
   it('クリック時にonSelectが呼ばれる', async () => {
     const onSelect = vi.fn();
     render(<ScenarioCard scenario={mockScenario} onSelect={onSelect} />);


### PR DESCRIPTION
## 概要
Closes #151

練習ページのシナリオカードを新卒向けに改善。

### 変更内容
- 難易度に**説明テキスト**追加（初級: 基本的な報連相、中級: 利害関係の調整、上級: 複雑な交渉・説得）
- シナリオカードに**所要時間の目安**（約5〜10分）を表示
- 難易度バッジを**色分け**（初級: 緑、中級: 黄、上級: 赤）

## テスト（TDD）
- ScenarioCard.test.tsx にテスト3件追加
- 全77テスト合格