### PR TITLE
feat: スコアカードの解説強化（レベルラベル・色分け・改善ヒント）

### DIFF
--- a/frontend/src/components/ScoreCard.tsx
+++ b/frontend/src/components/ScoreCard.tsx
@@ -4,17 +4,36 @@ interface ScoreCardProps {
   scoreCard: ScoreCardType;
 }
 
+function getOverallLevel(score: number): { label: string; color: string } {
+  if (score >= 8) return { label: '優秀レベル', color: 'bg-emerald-50 text-emerald-700 border-emerald-200' };
+  if (score >= 5) return { label: '実務レベル', color: 'bg-amber-50 text-amber-700 border-amber-200' };
+  return { label: '基礎レベル', color: 'bg-rose-50 text-rose-700 border-rose-200' };
+}
+
+function getBarColor(score: number): string {
+  if (score >= 8) return 'bg-emerald-500';
+  if (score >= 6) return 'bg-amber-500';
+  return 'bg-rose-500';
+}
+
 export default function ScoreCard({ scoreCard }: ScoreCardProps) {
+  const level = getOverallLevel(scoreCard.overallScore);
+
   return (
     <div className="bg-white rounded-lg border border-slate-200 p-4 my-3 max-w-[85%] self-start">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-medium text-slate-700">スコアカード</h3>
-        <div className="flex items-center gap-1">
-          <span className="text-xs text-slate-500">総合</span>
-          <span className="text-lg font-semibold text-slate-800">
-            {scoreCard.overallScore.toFixed(1)}
+        <div className="flex items-center gap-2">
+          <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded border ${level.color}`}>
+            {level.label}
           </span>
-          <span className="text-xs text-slate-400">/10</span>
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-slate-500">総合</span>
+            <span className="text-lg font-semibold text-slate-800">
+              {scoreCard.overallScore.toFixed(1)}
+            </span>
+            <span className="text-xs text-slate-400">/10</span>
+          </div>
         </div>
       </div>
 
@@ -27,11 +46,16 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
             </div>
             <div className="w-full bg-slate-100 rounded-full h-1.5">
               <div
-                className="h-1.5 rounded-full bg-primary-500"
+                className={`h-1.5 rounded-full ${getBarColor(axisScore.score)}`}
                 style={{ width: `${axisScore.score * 10}%` }}
               />
             </div>
             <p className="text-[10px] text-slate-400 mt-0.5">{axisScore.comment}</p>
+            {axisScore.score <= 5 && (
+              <p className="text-[10px] text-amber-600 mt-0.5">
+                💡 この項目を重点的に練習しましょう
+              </p>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/components/__tests__/ScoreCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreCard.test.tsx
@@ -48,4 +48,67 @@ describe('ScoreCard', () => {
     expect(screen.getByText('改善余地あり')).toBeInTheDocument();
     expect(screen.getByText('優秀')).toBeInTheDocument();
   });
+
+  it('総合スコアのレベルラベルが表示される（実務レベル）', () => {
+    render(<ScoreCard scoreCard={scoreCard} />);
+
+    expect(screen.getByText('実務レベル')).toBeInTheDocument();
+  });
+
+  it('総合スコア8以上で「優秀」レベルが表示される', () => {
+    const excellentCard: ScoreCardType = {
+      ...scoreCard,
+      overallScore: 8.5,
+    };
+    render(<ScoreCard scoreCard={excellentCard} />);
+
+    expect(screen.getByText('優秀レベル')).toBeInTheDocument();
+  });
+
+  it('総合スコア5未満で「基礎レベル」が表示される', () => {
+    const basicCard: ScoreCardType = {
+      ...scoreCard,
+      overallScore: 4.0,
+    };
+    render(<ScoreCard scoreCard={basicCard} />);
+
+    expect(screen.getByText('基礎レベル')).toBeInTheDocument();
+  });
+
+  it('低スコアの軸に改善ヒントが表示される', () => {
+    render(<ScoreCard scoreCard={scoreCard} />);
+
+    // スコア5の「提案力」に改善ヒントが表示される
+    expect(screen.getByText(/この項目を重点的に練習しましょう/)).toBeInTheDocument();
+  });
+
+  it('高スコアの軸には改善ヒントが表示されない', () => {
+    const allHighCard: ScoreCardType = {
+      sessionId: 1,
+      scores: [
+        { axis: '論理的構成力', score: 9, comment: '素晴らしい' },
+      ],
+      overallScore: 9.0,
+    };
+    render(<ScoreCard scoreCard={allHighCard} />);
+
+    expect(screen.queryByText(/この項目を重点的に練習しましょう/)).not.toBeInTheDocument();
+  });
+
+  it('スコアに応じたプログレスバーの色分けがされる', () => {
+    render(<ScoreCard scoreCard={scoreCard} />);
+
+    // スコア9の軸 → emerald（高スコア）
+    const bars = document.querySelectorAll('[class*="rounded-full"][style]');
+    const highScoreBar = Array.from(bars).find(
+      (bar) => (bar as HTMLElement).style.width === '90%'
+    );
+    expect(highScoreBar?.className).toContain('bg-emerald');
+
+    // スコア5の軸 → rose（低スコア）
+    const lowScoreBar = Array.from(bars).find(
+      (bar) => (bar as HTMLElement).style.width === '50%'
+    );
+    expect(lowScoreBar?.className).toContain('bg-rose');
+  });
 });


### PR DESCRIPTION
## 概要
- 総合スコアに応じたレベルラベル表示（優秀レベル/実務レベル/基礎レベル）
- 各軸のプログレスバーをスコアに応じて色分け（8以上: emerald, 6-7: amber, 5以下: rose）
- 低スコア（5以下）の軸に「この項目を重点的に練習しましょう」ヒント表示

## テスト
- ScoreCard.test.tsx: 10テスト全てパス（新規5テスト追加）
- 全83テストパス

Closes #153