### PR TITLE
feat: スコア履歴ページのトレンド表示

### DIFF
--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -16,8 +16,15 @@ interface ScoreHistoryItem {
   createdAt: string;
 }
 
+const FILTERS = ['すべて', '練習', 'フリー'] as const;
+
+function isPracticeSession(title: string): boolean {
+  return title.startsWith('練習:') || title.startsWith('練習：');
+}
+
 export default function ScoreHistoryPage() {
   const [history, setHistory] = useState<ScoreHistoryItem[]>([]);
+  const [filter, setFilter] = useState<string>('すべて');
   const { fetchScoreHistory, loading } = useAiChat();
 
   useEffect(() => {
@@ -48,59 +55,114 @@ export default function ScoreHistoryPage() {
     );
   }
 
+  const filteredHistory = history.filter((item) => {
+    if (filter === '練習') return isPracticeSession(item.sessionTitle);
+    if (filter === 'フリー') return !isPracticeSession(item.sessionTitle);
+    return true;
+  });
+
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
+      {/* スコア推移グラフ */}
+      <div className="bg-white rounded-lg border border-slate-200 p-4">
+        <p className="text-xs font-medium text-slate-700 mb-3">スコア推移</p>
+        <div className="flex items-end gap-1 h-16">
+          {history.map((item) => (
+            <div
+              key={item.sessionId}
+              data-testid="trend-bar"
+              className="flex-1 bg-primary-500 rounded-t"
+              style={{ height: `${item.overallScore * 10}%` }}
+              title={`${item.sessionTitle}: ${item.overallScore}`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* フィルタタブ */}
+      <div className="flex gap-1 border-b border-slate-200">
+        {FILTERS.map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
+              filter === f
+                ? 'border-primary-500 text-primary-600'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
+            }`}
+          >
+            {f}
+          </button>
+        ))}
+      </div>
+
       <p className="text-xs text-slate-500">
-        全 {history.length} 件のフィードバック履歴
+        全 {filteredHistory.length} 件のフィードバック履歴
       </p>
 
-      {history.map((item) => (
-        <div
-          key={item.sessionId}
-          className="bg-white rounded-lg border border-slate-200 p-4"
-        >
-          <div className="flex items-center justify-between mb-3">
-            <div>
-              <h3 className="text-sm font-medium text-slate-800">
-                {item.sessionTitle || `セッション #${item.sessionId}`}
-              </h3>
-              <p className="text-xs text-slate-400 mt-0.5">
-                {new Date(item.createdAt).toLocaleDateString('ja-JP', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
-              </p>
-            </div>
-            <div className="flex items-center gap-1">
-              <span className="text-xs text-slate-500">総合</span>
-              <span className="text-lg font-semibold text-slate-800">
-                {item.overallScore.toFixed(1)}
-              </span>
-              <span className="text-xs text-slate-400">/10</span>
-            </div>
-          </div>
+      {filteredHistory.map((item, index) => {
+        // 元のhistory配列でのindexを使ってスコア変動を計算
+        const originalIndex = history.indexOf(item);
+        const prevItem = originalIndex > 0 ? history[originalIndex - 1] : null;
+        const delta = prevItem
+          ? Math.round((item.overallScore - prevItem.overallScore) * 10) / 10
+          : null;
 
-          <div className="space-y-1.5">
-            {item.scores.map((axisScore) => (
-              <div key={axisScore.axis} className="flex items-center gap-2">
-                <span className="text-xs text-slate-500 w-24 flex-shrink-0 truncate">
-                  {axisScore.axis}
-                </span>
-                <div className="flex-1 bg-slate-100 rounded-full h-1.5">
-                  <div
-                    className="h-1.5 rounded-full bg-primary-500"
-                    style={{ width: `${axisScore.score * 10}%` }}
-                  />
-                </div>
-                <span className="text-xs text-slate-600 w-5 text-right">
-                  {axisScore.score}
-                </span>
+        return (
+          <div
+            key={item.sessionId}
+            className="bg-white rounded-lg border border-slate-200 p-4"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <div>
+                <h3 className="text-sm font-medium text-slate-800">
+                  {item.sessionTitle || `セッション #${item.sessionId}`}
+                </h3>
+                <p className="text-xs text-slate-400 mt-0.5">
+                  {new Date(item.createdAt).toLocaleDateString('ja-JP', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </p>
               </div>
-            ))}
+              <div className="flex items-center gap-2">
+                {delta !== null && delta !== 0 && (
+                  <span className={`text-xs font-medium ${delta > 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+                    {delta > 0 ? `+${delta.toFixed(1)}` : `\u2212${Math.abs(delta).toFixed(1)}`}
+                  </span>
+                )}
+                <div className="flex items-center gap-1">
+                  <span className="text-xs text-slate-500">総合</span>
+                  <span className="text-lg font-semibold text-slate-800">
+                    {item.overallScore.toFixed(1)}
+                  </span>
+                  <span className="text-xs text-slate-400">/10</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              {item.scores.map((axisScore) => (
+                <div key={axisScore.axis} className="flex items-center gap-2">
+                  <span className="text-xs text-slate-500 w-24 flex-shrink-0 truncate">
+                    {axisScore.axis}
+                  </span>
+                  <div className="flex-1 bg-slate-100 rounded-full h-1.5">
+                    <div
+                      className="h-1.5 rounded-full bg-primary-500"
+                      style={{ width: `${axisScore.score * 10}%` }}
+                    />
+                  </div>
+                  <span className="text-xs text-slate-600 w-5 text-right">
+                    {axisScore.score}
+                  </span>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
 const mockHistory = [
@@ -15,12 +15,21 @@ const mockHistory = [
   },
   {
     sessionId: 2,
-    sessionTitle: 'コードレビューフィードバック',
+    sessionTitle: '練習: 本番障害の緊急報告',
     overallScore: 6.0,
     scores: [
       { axis: '論理的構成力', score: 6, comment: '改善の余地あり' },
     ],
     createdAt: '2026-01-16T10:00:00Z',
+  },
+  {
+    sessionId: 3,
+    sessionTitle: '練習: 設計方針の意見対立',
+    overallScore: 8.2,
+    scores: [
+      { axis: '論理的構成力', score: 9, comment: '素晴らしい' },
+    ],
+    createdAt: '2026-01-17T10:00:00Z',
   },
 ];
 
@@ -53,7 +62,7 @@ describe('ScoreHistoryPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('会議フィードバック')).toBeInTheDocument();
-      expect(screen.getByText('コードレビューフィードバック')).toBeInTheDocument();
+      expect(screen.getByText('練習: 本番障害の緊急報告')).toBeInTheDocument();
     }, { timeout: 3000 });
   });
 
@@ -86,5 +95,62 @@ describe('ScoreHistoryPage', () => {
     render(<ScoreHistoryPage />);
 
     expect(screen.getByText('スコア履歴を読み込み中...')).toBeInTheDocument();
+  });
+
+  it('スコア推移の棒グラフが表示される', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('スコア推移')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    const bars = document.querySelectorAll('[data-testid="trend-bar"]');
+    expect(bars.length).toBe(3);
+  });
+
+  it('スコア変動の矢印が表示される', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      // セッション2（6.0）はセッション1（7.4）より低いので↓
+      expect(screen.getByText('−1.4')).toBeInTheDocument();
+      // セッション3（8.2）はセッション2（6.0）より高いので↑
+      expect(screen.getByText('+2.2')).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it('「練習」フィルタで練習セッションのみ表示される', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('会議フィードバック')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: '練習' }));
+
+    expect(screen.queryByText('会議フィードバック')).not.toBeInTheDocument();
+    expect(screen.getByText('練習: 本番障害の緊急報告')).toBeInTheDocument();
+    expect(screen.getByText('練習: 設計方針の意見対立')).toBeInTheDocument();
+  });
+
+  it('「フリー」フィルタでフリーセッションのみ表示される', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('会議フィードバック')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'フリー' }));
+
+    expect(screen.getByText('会議フィードバック')).toBeInTheDocument();
+    expect(screen.queryByText('練習: 本番障害の緊急報告')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
- CSSベース棒グラフでスコア推移を可視化
- 前回比スコア変動値（+/-）を各エントリに表示
- セッション種別フィルタ（すべて/練習/フリー）

## テスト
- ScoreHistoryPage.test.tsx: 8テスト全てパス（新規4テスト追加）
- 全87テストパス

Closes #155