### PR TITLE
feat: シーン選択画面の説明強化

### DIFF
--- a/frontend/src/components/SceneSelector.tsx
+++ b/frontend/src/components/SceneSelector.tsx
@@ -2,17 +2,20 @@ interface Scene {
   id: string;
   label: string;
   description: string;
+  example: string;
+  recommended?: boolean;
+  category: string;
 }
 
 const SCENES: Scene[] = [
-  { id: 'meeting', label: '会議', description: '発言のタイミング・議論の建設性・ファシリテーション' },
-  { id: 'one_on_one', label: '1on1', description: '心理的安全性・フィードバックの具体性・傾聴の深さ' },
-  { id: 'email', label: 'メール', description: '件名の明確さ・構成の読みやすさ・アクション明示' },
-  { id: 'presentation', label: 'プレゼン', description: 'ストーリー構成・聞き手への配慮・質疑応答力' },
-  { id: 'negotiation', label: '商談', description: 'ニーズヒアリング・価値提案・クロージング' },
-  { id: 'code_review', label: 'コードレビュー', description: '指摘の具体性・代替案の提示・相手への配慮' },
-  { id: 'incident', label: '障害対応', description: '状況報告の正確さ・エスカレーション判断・事後報告の構成' },
-  { id: 'daily_report', label: '日報・週報', description: '成果の定量化・課題の明確化・ネクストアクション' },
+  { id: 'meeting', label: '会議', description: '発言のタイミング・議論の建設性・ファシリテーション', example: '朝会やスプリントレビューで', recommended: true, category: '日常業務' },
+  { id: 'code_review', label: 'コードレビュー', description: '指摘の具体性・代替案の提示・相手への配慮', example: 'PRへのコメントで', recommended: true, category: '日常業務' },
+  { id: 'daily_report', label: '日報・週報', description: '成果の定量化・課題の明確化・ネクストアクション', example: '日次・週次の報告で', recommended: true, category: '日常業務' },
+  { id: 'one_on_one', label: '1on1', description: '心理的安全性・フィードバックの具体性・傾聴の深さ', example: '上司との定期面談で', category: '対面コミュニケーション' },
+  { id: 'presentation', label: 'プレゼン', description: 'ストーリー構成・聞き手への配慮・質疑応答力', example: '技術共有会や提案で', category: '対面コミュニケーション' },
+  { id: 'negotiation', label: '商談', description: 'ニーズヒアリング・価値提案・クロージング', example: '顧客ミーティングで', category: '対面コミュニケーション' },
+  { id: 'email', label: 'メール', description: '件名の明確さ・構成の読みやすさ・アクション明示', example: '社内外への連絡で', category: '文書・報告' },
+  { id: 'incident', label: '障害対応', description: '状況報告の正確さ・エスカレーション判断・事後報告の構成', example: '本番障害発生時に', category: '文書・報告' },
 ];
 
 interface SceneSelectorProps {
@@ -21,9 +24,11 @@ interface SceneSelectorProps {
 }
 
 export default function SceneSelector({ onSelect, onCancel }: SceneSelectorProps) {
+  const categories = [...new Set(SCENES.map((s) => s.category))];
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg shadow-lg max-w-md w-full mx-4 p-5">
+      <div className="bg-white rounded-lg shadow-lg max-w-md w-full mx-4 p-5 max-h-[80vh] overflow-y-auto">
         <h3 className="text-sm font-semibold text-slate-800 mb-1">
           フィードバックのシーンを選択
         </h3>
@@ -31,16 +36,33 @@ export default function SceneSelector({ onSelect, onCancel }: SceneSelectorProps
           シーンに応じた追加評価観点でフィードバックします
         </p>
 
-        <div className="space-y-1">
-          {SCENES.map((scene) => (
-            <button
-              key={scene.id}
-              onClick={() => onSelect(scene.id)}
-              className="w-full text-left px-3 py-2.5 rounded-md hover:bg-primary-50 transition-colors"
-            >
-              <span className="text-sm font-medium text-slate-700">{scene.label}</span>
-              <p className="text-xs text-slate-400 mt-0.5">{scene.description}</p>
-            </button>
+        <div className="space-y-4">
+          {categories.map((category) => (
+            <div key={category}>
+              <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1 px-1">
+                {category}
+              </p>
+              <div className="space-y-1">
+                {SCENES.filter((s) => s.category === category).map((scene) => (
+                  <button
+                    key={scene.id}
+                    onClick={() => onSelect(scene.id)}
+                    className="w-full text-left px-3 py-2.5 rounded-md hover:bg-primary-50 transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-slate-700">{scene.label}</span>
+                      {scene.recommended && (
+                        <span className="text-[10px] font-medium bg-primary-50 text-primary-600 px-1.5 py-0.5 rounded">
+                          おすすめ
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-slate-400 mt-0.5">{scene.description}</p>
+                    <p className="text-[10px] text-slate-300 mt-0.5">{scene.example}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
           ))}
         </div>
 

--- a/frontend/src/components/__tests__/SceneSelector.test.tsx
+++ b/frontend/src/components/__tests__/SceneSelector.test.tsx
@@ -83,4 +83,26 @@ describe('SceneSelector', () => {
     // 8 scene buttons + 1 skip button = 9
     expect(buttons).toHaveLength(9);
   });
+
+  it('おすすめシーンに「おすすめ」ラベルが表示される', () => {
+    render(<SceneSelector onSelect={mockOnSelect} onCancel={mockOnCancel} />);
+
+    // 新卒におすすめの会議・コードレビュー・日報にラベルがつく
+    const badges = screen.getAllByText('おすすめ');
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('具体的な利用例が表示される', () => {
+    render(<SceneSelector onSelect={mockOnSelect} onCancel={mockOnCancel} />);
+
+    expect(screen.getByText(/朝会やスプリントレビューで/)).toBeInTheDocument();
+    expect(screen.getByText(/PRへのコメントで/)).toBeInTheDocument();
+  });
+
+  it('カテゴリヘッダーが表示される', () => {
+    render(<SceneSelector onSelect={mockOnSelect} onCancel={mockOnCancel} />);
+
+    expect(screen.getByText('日常業務')).toBeInTheDocument();
+    expect(screen.getByText('対面コミュニケーション')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- シーンをカテゴリ別に分類（日常業務/対面コミュニケーション/文書・報告）
- 新卒エンジニア向けの「おすすめ」ラベル表示（会議/コードレビュー/日報）
- 各シーンに具体的な利用例を追加（例：「朝会やスプリントレビューで」）

## テスト
- SceneSelector.test.tsx: 12テスト全てパス（新規3テスト追加）
- 全93テストパス

Closes #159