### PR TITLE
feat: 練習結果サマリーモーダルの実装

### DIFF
--- a/frontend/src/components/PracticeResultSummary.tsx
+++ b/frontend/src/components/PracticeResultSummary.tsx
@@ -1,0 +1,62 @@
+import { useNavigate } from 'react-router-dom';
+import type { ScoreCard } from '../types';
+
+interface PracticeResultSummaryProps {
+  scoreCard: ScoreCard;
+  scenarioName: string;
+}
+
+const IMPROVEMENT_ADVICE: Record<string, string> = {
+  '論理的構成力': '論理的構成力を伸ばすために、結論→理由→具体例の構成を意識して練習しましょう。',
+  '配慮表現': '配慮表現を伸ばすために、クッション言葉や敬語のバリエーションを増やしましょう。',
+  '要約力': '要約力を伸ばすために、要点を3つに絞って伝える練習をしましょう。',
+  '提案力': '提案力を伸ばすために、代替案を複数用意してから発言する習慣をつけましょう。',
+  '質問・傾聴力': '質問・傾聴力を伸ばすために、相手の発言を復唱してから質問する練習をしましょう。',
+};
+
+export default function PracticeResultSummary({ scoreCard, scenarioName }: PracticeResultSummaryProps) {
+  const navigate = useNavigate();
+
+  const sorted = [...scoreCard.scores].sort((a, b) => b.score - a.score);
+  const strongest = sorted[0];
+  const weakest = sorted[sorted.length - 1];
+
+  const advice = IMPROVEMENT_ADVICE[weakest.axis] || `${weakest.axis}を伸ばすために、繰り返し練習しましょう。`;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4 my-3 max-w-[85%] self-start">
+      <h3 className="text-sm font-semibold text-slate-800 mb-1">練習結果サマリー</h3>
+      <p className="text-xs text-slate-500 mb-3">「{scenarioName}」の練習結果</p>
+
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        {/* 強み */}
+        <div className="bg-emerald-50 rounded-lg p-3 border border-emerald-100">
+          <p className="text-[10px] font-semibold text-emerald-600 mb-1">強み</p>
+          <p className="text-sm font-medium text-emerald-800">{strongest.axis}</p>
+          <p className="text-xs text-emerald-600 mt-0.5">スコア: {strongest.score}/10</p>
+        </div>
+
+        {/* 課題 */}
+        <div className="bg-rose-50 rounded-lg p-3 border border-rose-100">
+          <p className="text-[10px] font-semibold text-rose-600 mb-1">課題</p>
+          <p className="text-sm font-medium text-rose-800">{weakest.axis}</p>
+          <p className="text-xs text-rose-600 mt-0.5">スコア: {weakest.score}/10</p>
+        </div>
+      </div>
+
+      {/* 改善アドバイス */}
+      <div className="bg-amber-50 rounded-lg p-3 border border-amber-100 mb-3">
+        <p className="text-[10px] font-semibold text-amber-700 mb-1">改善アドバイス</p>
+        <p className="text-xs text-amber-800">{advice}</p>
+      </div>
+
+      {/* 次の練習へ */}
+      <button
+        onClick={() => navigate('/practice')}
+        className="w-full py-2 text-sm font-medium text-primary-600 bg-primary-50 hover:bg-primary-100 rounded-lg transition-colors"
+      >
+        次の練習へ
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
+++ b/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PracticeResultSummary from '../PracticeResultSummary';
+import type { ScoreCard } from '../../types';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('PracticeResultSummary', () => {
+  const scoreCard: ScoreCard = {
+    sessionId: 1,
+    overallScore: 7.2,
+    scores: [
+      { axis: '論理的構成力', score: 9, comment: '非常に論理的です' },
+      { axis: '配慮表現', score: 8, comment: '丁寧な表現です' },
+      { axis: '要約力', score: 7, comment: '概ね良い要約です' },
+      { axis: '提案力', score: 4, comment: '提案が不足しています' },
+      { axis: '質問・傾聴力', score: 6, comment: '質問は適切です' },
+    ],
+  };
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('練習結果サマリーのタイトルが表示される', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    expect(screen.getByText('練習結果サマリー')).toBeInTheDocument();
+  });
+
+  it('最も高い評価軸が強みとして表示される', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    expect(screen.getByText('強み')).toBeInTheDocument();
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+  });
+
+  it('最も低い評価軸が課題として表示される', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    expect(screen.getByText('課題')).toBeInTheDocument();
+    expect(screen.getByText('提案力')).toBeInTheDocument();
+  });
+
+  it('改善アドバイスが表示される', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    expect(screen.getByText(/提案力を伸ばすために/)).toBeInTheDocument();
+  });
+
+  it('次の練習へボタンをクリックすると練習ページに遷移する', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    fireEvent.click(screen.getByText('次の練習へ'));
+    expect(mockNavigate).toHaveBeenCalledWith('/practice');
+  });
+
+  it('シナリオ名が表示される', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    expect(screen.getByText(/障害報告/)).toBeInTheDocument();
+  });
+
+  it('全軸のスコアが同じ場合でも正しく表示される', () => {
+    const equalScores: ScoreCard = {
+      sessionId: 2,
+      overallScore: 7.0,
+      scores: [
+        { axis: '論理的構成力', score: 7, comment: 'コメント' },
+        { axis: '配慮表現', score: 7, comment: 'コメント' },
+        { axis: '要約力', score: 7, comment: 'コメント' },
+        { axis: '提案力', score: 7, comment: 'コメント' },
+        { axis: '質問・傾聴力', score: 7, comment: 'コメント' },
+      ],
+    };
+
+    render(<PracticeResultSummary scoreCard={equalScores} scenarioName="テスト" />);
+
+    expect(screen.getByText('強み')).toBeInTheDocument();
+    expect(screen.getByText('課題')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -3,6 +3,7 @@ import MessageBubbleAi from '../components/MessageBubbleAi';
 import MessageInput from '../components/MessageInput';
 import ConfirmModal from '../components/ConfirmModal';
 import ScoreCardComponent from '../components/ScoreCard';
+import PracticeResultSummary from '../components/PracticeResultSummary';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { AiMessage, AiSession, ScoreCard } from '../types';
@@ -374,6 +375,9 @@ export default function AskAiPage() {
           {scoreCard && (
             <div className="max-w-3xl mx-auto w-full">
               <ScoreCardComponent scoreCard={scoreCard} />
+              {isPracticeMode && (
+                <PracticeResultSummary scoreCard={scoreCard} scenarioName={scenarioName || '練習'} />
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## 概要
練習モード終了後にスコアカードの下に結果サマリーを表示する機能を追加。

## 変更内容
- `PracticeResultSummary`コンポーネントを新規作成
- 最も高い評価軸を「強み」、最も低い評価軸を「課題」としてハイライト
- 弱点に基づく改善アドバイスを表示（5軸対応）
- 「次の練習へ」ボタンで練習ページへの導線を提供
- `AskAiPage`に練習モード時のサマリー表示を組み込み

## テスト
- PracticeResultSummary: 7テスト追加（タイトル表示、強み・課題表示、改善アドバイス、ナビゲーション、シナリオ名表示、同スコア対応）

Closes #163