### PR TITLE
feat: 弱点ベースのおすすめ練習シナリオ提示

### DIFF
--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAiChat } from '../hooks/useAiChat';
 import { SkeletonCard } from '../components/Skeleton';
 
@@ -22,10 +23,19 @@ function isPracticeSession(title: string): boolean {
   return title.startsWith('練習:') || title.startsWith('練習：');
 }
 
+const AXIS_ADVICE: Record<string, string> = {
+  '論理的構成力': '論理的構成力を伸ばすシナリオで練習しましょう',
+  '配慮表現': '配慮表現を伸ばすシナリオで練習しましょう',
+  '要約力': '要約力を伸ばすシナリオで練習しましょう',
+  '提案力': '提案力を伸ばすシナリオで練習しましょう',
+  '質問・傾聴力': '質問・傾聴力を伸ばすシナリオで練習しましょう',
+};
+
 export default function ScoreHistoryPage() {
   const [history, setHistory] = useState<ScoreHistoryItem[]>([]);
   const [filter, setFilter] = useState<string>('すべて');
   const { fetchScoreHistory, loading } = useAiChat();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadHistory = async () => {
@@ -61,8 +71,29 @@ export default function ScoreHistoryPage() {
     return true;
   });
 
+  const latestSession = history[history.length - 1];
+  const weakestAxis = latestSession
+    ? [...latestSession.scores].sort((a, b) => a.score - b.score)[0]
+    : null;
+
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
+      {/* 弱点ベースのおすすめ練習 */}
+      {weakestAxis && (
+        <div className="bg-primary-50 rounded-lg border border-primary-100 p-4">
+          <p className="text-xs font-semibold text-primary-700 mb-1">おすすめ練習</p>
+          <p className="text-xs text-primary-600 mb-2">
+            {AXIS_ADVICE[weakestAxis.axis] || `${weakestAxis.axis}を伸ばすシナリオで練習しましょう`}
+          </p>
+          <button
+            onClick={() => navigate('/practice')}
+            className="text-xs font-medium text-primary-700 bg-white px-3 py-1.5 rounded-lg border border-primary-200 hover:bg-primary-100 transition-colors"
+          >
+            練習一覧を見る
+          </button>
+        </div>
+      )}
+
       {/* スコア推移グラフ */}
       <div className="bg-white rounded-lg border border-slate-200 p-4">
         <p className="text-xs font-medium text-slate-700 mb-3">スコア推移</p>

--- a/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
 const mockHistory = [
   {
     sessionId: 1,
@@ -10,6 +15,9 @@ const mockHistory = [
     scores: [
       { axis: '論理的構成力', score: 8, comment: '良い' },
       { axis: '配慮表現', score: 7, comment: '普通' },
+      { axis: '要約力', score: 7, comment: '普通' },
+      { axis: '提案力', score: 4, comment: '改善必要' },
+      { axis: '質問・傾聴力', score: 6, comment: '普通' },
     ],
     createdAt: '2026-01-15T10:00:00Z',
   },
@@ -19,6 +27,10 @@ const mockHistory = [
     overallScore: 6.0,
     scores: [
       { axis: '論理的構成力', score: 6, comment: '改善の余地あり' },
+      { axis: '配慮表現', score: 5, comment: '改善必要' },
+      { axis: '要約力', score: 7, comment: '良い' },
+      { axis: '提案力', score: 5, comment: '改善必要' },
+      { axis: '質問・傾聴力', score: 7, comment: '良い' },
     ],
     createdAt: '2026-01-16T10:00:00Z',
   },
@@ -28,6 +40,10 @@ const mockHistory = [
     overallScore: 8.2,
     scores: [
       { axis: '論理的構成力', score: 9, comment: '素晴らしい' },
+      { axis: '配慮表現', score: 8, comment: '良い' },
+      { axis: '要約力', score: 8, comment: '良い' },
+      { axis: '提案力', score: 7, comment: '改善の余地あり' },
+      { axis: '質問・傾聴力', score: 9, comment: '素晴らしい' },
     ],
     createdAt: '2026-01-17T10:00:00Z',
   },
@@ -152,5 +168,39 @@ describe('ScoreHistoryPage', () => {
 
     expect(screen.getByText('会議フィードバック')).toBeInTheDocument();
     expect(screen.queryByText('練習: 本番障害の緊急報告')).not.toBeInTheDocument();
+  });
+
+  it('弱点ベースのおすすめ練習セクションが表示される', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('おすすめ練習')).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it('最新スコアの弱点軸名が表示される', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      // 最新セッション(sessionId:3)の最低スコアは「提案力」(7)
+      expect(screen.getByText(/提案力.*を伸ばす/)).toBeInTheDocument();
+    }, { timeout: 3000 });
+  });
+
+  it('おすすめ練習ボタンクリックで練習ページに遷移する', async () => {
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('おすすめ練習')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.click(screen.getByText('練習一覧を見る'));
+    expect(mockNavigate).toHaveBeenCalledWith('/practice');
   });
 });


### PR DESCRIPTION
## 概要
スコア履歴ページに弱点ベースのおすすめ練習セクションを追加。

## 変更内容
- 最新セッションの最低スコア軸を弱点として特定し表示
- 5軸それぞれに対応したアドバイステキストを用意
- 「練習一覧を見る」ボタンで練習ページへの導線を提供
- テストデータを5軸完全対応に拡充

## テスト
- 3テスト追加（おすすめ練習セクション表示、弱点軸名表示、ナビゲーション）

Closes #165