### PR TITLE
feat: メッセージ送信状態の表示

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -3,9 +3,10 @@ import { PaperAirplaneIcon, PlusIcon } from '@heroicons/react/24/solid';
 
 interface MessageInputProps {
   onSend: (text: string) => void;
+  isSending?: boolean;
 }
 
-export default function MessageInput({ onSend }: MessageInputProps) {
+export default function MessageInput({ onSend, isSending = false }: MessageInputProps) {
   const [text, setText] = useState('');
   const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -40,7 +41,7 @@ export default function MessageInput({ onSend }: MessageInputProps) {
   }, [text]);
 
   const handleSend = () => {
-    if (!text.trim()) return;
+    if (!text.trim() || isSending) return;
     onSend(text);
     setText('');
   };
@@ -72,17 +73,22 @@ export default function MessageInput({ onSend }: MessageInputProps) {
           onKeyDown={handleKeyDown}
           onCompositionStart={() => setIsComposing(true)}
           onCompositionEnd={() => setIsComposing(false)}
+          disabled={isSending}
         />
       </div>
 
       <button
         onClick={handleSend}
         className="text-white bg-primary-500 p-2.5 rounded-full hover:bg-primary-600 transition-colors duration-150 flex-shrink-0 disabled:bg-slate-300 mb-1 ml-2"
-        disabled={!text.trim()}
+        disabled={!text.trim() || isSending}
         aria-label="送信"
       >
         <PaperAirplaneIcon className="h-6 w-6 rotate-90" />
       </button>
+
+      {isSending && (
+        <span className="text-xs text-slate-400 ml-2 mb-2 flex-shrink-0">送信中...</span>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/MessageInput.test.tsx
+++ b/frontend/src/components/__tests__/MessageInput.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MessageInput from '../MessageInput';
+
+describe('MessageInput', () => {
+  const mockOnSend = vi.fn();
+
+  beforeEach(() => {
+    mockOnSend.mockClear();
+  });
+
+  it('テキスト入力と送信ボタンが表示される', () => {
+    render(<MessageInput onSend={mockOnSend} />);
+
+    expect(screen.getByPlaceholderText('メッセージを入力...')).toBeInTheDocument();
+    expect(screen.getByLabelText('送信')).toBeInTheDocument();
+  });
+
+  it('空テキストでは送信ボタンが無効', () => {
+    render(<MessageInput onSend={mockOnSend} />);
+
+    expect(screen.getByLabelText('送信')).toBeDisabled();
+  });
+
+  it('テキスト入力後に送信ボタンが有効になる', () => {
+    render(<MessageInput onSend={mockOnSend} />);
+
+    fireEvent.change(screen.getByPlaceholderText('メッセージを入力...'), {
+      target: { value: 'テスト' },
+    });
+    expect(screen.getByLabelText('送信')).not.toBeDisabled();
+  });
+
+  it('送信中はインジケーターが表示される', () => {
+    render(<MessageInput onSend={mockOnSend} isSending={true} />);
+
+    expect(screen.getByText('送信中...')).toBeInTheDocument();
+  });
+
+  it('送信中は入力欄が無効化される', () => {
+    render(<MessageInput onSend={mockOnSend} isSending={true} />);
+
+    expect(screen.getByPlaceholderText('メッセージを入力...')).toBeDisabled();
+  });
+
+  it('送信中は送信ボタンが無効化される', () => {
+    render(<MessageInput onSend={mockOnSend} isSending={true} />);
+
+    expect(screen.getByLabelText('送信')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## 概要
AIチャットのMessageInputコンポーネントに送信中状態の表示機能を追加。

## 変更内容
- `isSending`プロパティを追加（オプション、デフォルトfalse）
- 送信中にテキストエリアと送信ボタンを無効化
- 「送信中...」テキストインジケーターを表示

## テスト
- MessageInput: 6テスト新規追加（表示、空テキスト無効化、テキスト入力有効化、送信中表示、送信中入力無効、送信中ボタン無効）

Closes #167