### PR TITLE
fix: サイドバーのロゴアイコン拡大とFreStyleテキスト追加

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -102,8 +102,9 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   return (
     <aside className="flex flex-col w-56 h-full bg-white border-r border-slate-200 flex-shrink-0">
       {/* ロゴ */}
-      <div className="h-12 flex items-center px-4 border-b border-slate-200">
-        <img src="/image.png" alt="FreStyle" className="w-9 h-9 rounded-xl object-contain" />
+      <div className="h-14 flex items-center px-4 border-b border-slate-200 gap-2.5">
+        <img src="/image.png" alt="FreStyle" className="w-11 h-11 rounded-xl object-contain" />
+        <span className="text-base font-bold text-slate-800 tracking-tight">FreStyle</span>
       </div>
 
       {/* メインナビ */}

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -60,6 +60,11 @@ describe('Sidebar', () => {
     expect(logo.className).toContain('rounded-xl');
   });
 
+  it('FreStyleテキストがロゴ横に表示される', () => {
+    renderSidebar();
+    expect(screen.getByText('FreStyle')).toBeInTheDocument();
+  });
+
   it('ホームルートでホームがアクティブになる', () => {
     renderSidebar('/');
     const homeLink = screen.getByText('ホーム').closest('a');


### PR DESCRIPTION
## 概要
サイドバーのロゴアイコンを大きくし、横に「FreStyle」テキストを追加。

## 変更内容
- ロゴアイコンサイズをw-9 h-9からw-11 h-11に拡大
- ロゴ横に「FreStyle」の太字テキストを追加
- ヘッダー高さをh-12からh-14に調整してバランスを改善

## テスト
- FreStyleテキスト表示テストを1件追加