### PR TITLE
feat: チャット内メッセージ検索機能の実装

### DIFF
--- a/frontend/src/components/MessageSearchBar.tsx
+++ b/frontend/src/components/MessageSearchBar.tsx
@@ -1,0 +1,30 @@
+interface MessageSearchBarProps {
+  onSearch: (query: string) => void;
+  onClear: () => void;
+  matchCount: number;
+}
+
+export default function MessageSearchBar({ onSearch, onClear, matchCount }: MessageSearchBarProps) {
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 bg-slate-50 border-b border-slate-200">
+      <input
+        type="text"
+        placeholder="メッセージを検索..."
+        onChange={(e) => onSearch(e.target.value)}
+        className="flex-1 text-sm bg-white border border-slate-200 rounded-lg px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"
+      />
+      {matchCount > 0 && (
+        <span className="text-xs text-slate-500 flex-shrink-0">{matchCount}件</span>
+      )}
+      <button
+        onClick={onClear}
+        aria-label="検索をクリア"
+        className="text-xs text-slate-400 hover:text-slate-600 p-1 rounded hover:bg-slate-200 transition-colors"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/MessageSearchBar.test.tsx
+++ b/frontend/src/components/__tests__/MessageSearchBar.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MessageSearchBar from '../MessageSearchBar';
+
+describe('MessageSearchBar', () => {
+  const mockOnSearch = vi.fn();
+  const mockOnClear = vi.fn();
+
+  beforeEach(() => {
+    mockOnSearch.mockClear();
+    mockOnClear.mockClear();
+  });
+
+  it('検索入力フィールドが表示される', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+
+    expect(screen.getByPlaceholderText('メッセージを検索...')).toBeInTheDocument();
+  });
+
+  it('テキスト入力でonSearchが呼ばれる', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+
+    fireEvent.change(screen.getByPlaceholderText('メッセージを検索...'), {
+      target: { value: 'テスト' },
+    });
+    expect(mockOnSearch).toHaveBeenCalledWith('テスト');
+  });
+
+  it('マッチ件数が表示される', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={3} />);
+
+    expect(screen.getByText('3件')).toBeInTheDocument();
+  });
+
+  it('クリアボタンクリックでonClearが呼ばれる', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+
+    fireEvent.click(screen.getByLabelText('検索をクリア'));
+    expect(mockOnClear).toHaveBeenCalled();
+  });
+
+  it('マッチ件数が0のときは件数を表示しない', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+
+    expect(screen.queryByText('0件')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
チャット画面でメッセージ内のキーワード検索を行うコンポーネントを追加。

## 変更内容
- `MessageSearchBar`コンポーネントを新規作成
- キーワード入力でリアルタイムにonSearchコールバック発火
- マッチ件数の表示（0件の場合は非表示）
- クリアボタンで検索状態をリセット

## テスト
- MessageSearchBar: 5テスト追加（表示、検索入力、マッチ件数表示、クリア、0件非表示）

Closes #170