### PR TITLE
feat: 練習ストリーク・達成バッジの実装

### DIFF
--- a/frontend/src/components/PracticeStreakBadge.tsx
+++ b/frontend/src/components/PracticeStreakBadge.tsx
@@ -1,0 +1,47 @@
+interface PracticeStreakBadgeProps {
+  streakDays: number;
+  totalSessions: number;
+}
+
+const BADGES = [
+  { label: '初回練習', condition: (streak: number, total: number) => total >= 1 },
+  { label: '3日連続', condition: (streak: number) => streak >= 3 },
+  { label: '7日連続', condition: (streak: number) => streak >= 7 },
+  { label: '10回達成', condition: (_streak: number, total: number) => total >= 10 },
+] as const;
+
+export default function PracticeStreakBadge({ streakDays, totalSessions }: PracticeStreakBadgeProps) {
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center gap-4 mb-3">
+        <div className="text-center">
+          <p className="text-2xl font-bold text-primary-600">{streakDays}</p>
+          <p className="text-[10px] text-slate-500">日連続</p>
+        </div>
+        <div className="h-8 w-px bg-slate-200" />
+        <div className="text-center">
+          <p className="text-sm font-semibold text-slate-700">累計 {totalSessions}回</p>
+          <p className="text-[10px] text-slate-400">練習セッション</p>
+        </div>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        {BADGES.map(({ label, condition }) => {
+          const achieved = condition(streakDays, totalSessions);
+          return (
+            <div
+              key={label}
+              className={`text-[10px] font-medium px-2 py-1 rounded-full border ${
+                achieved
+                  ? 'bg-primary-50 text-primary-700 border-primary-200'
+                  : 'bg-slate-50 text-slate-400 border-slate-200 opacity-40'
+              }`}
+            >
+              {label}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeStreakBadge.test.tsx
+++ b/frontend/src/components/__tests__/PracticeStreakBadge.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PracticeStreakBadge from '../PracticeStreakBadge';
+
+describe('PracticeStreakBadge', () => {
+  it('ストリーク日数が表示される', () => {
+    render(<PracticeStreakBadge streakDays={5} totalSessions={10} />);
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    // ストリークラベルのテキストを確認
+    const allText = document.body.textContent;
+    expect(allText).toContain('日連続');
+  });
+
+  it('累計練習回数が表示される', () => {
+    render(<PracticeStreakBadge streakDays={3} totalSessions={12} />);
+
+    expect(screen.getByText(/累計 12回/)).toBeInTheDocument();
+  });
+
+  it('初回練習バッジが達成済みで表示される', () => {
+    render(<PracticeStreakBadge streakDays={1} totalSessions={1} />);
+
+    expect(screen.getByText('初回練習')).toBeInTheDocument();
+  });
+
+  it('3日連続バッジが未達成の場合グレーで表示される', () => {
+    render(<PracticeStreakBadge streakDays={1} totalSessions={1} />);
+
+    const badge = screen.getByText('3日連続');
+    expect(badge.closest('div')?.className).toContain('opacity-40');
+  });
+
+  it('3日連続バッジが達成済みの場合通常表示される', () => {
+    render(<PracticeStreakBadge streakDays={3} totalSessions={5} />);
+
+    const badge = screen.getByText('3日連続');
+    expect(badge.closest('div')?.className).not.toContain('opacity-40');
+  });
+
+  it('ストリーク0日でも表示される', () => {
+    render(<PracticeStreakBadge streakDays={0} totalSessions={0} />);
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
練習の継続を促すストリークカウンターと達成バッジを表示するコンポーネントを追加。

## 変更内容
- `PracticeStreakBadge`コンポーネントを新規作成
- 連続練習日数の大きな数値表示
- 累計練習回数の表示
- 4種類の達成バッジ（初回練習、3日連続、7日連続、10回達成）
- 未達成バッジはopacity-40でグレーアウト

## テスト
- PracticeStreakBadge: 6テスト追加（ストリーク表示、累計回数、達成バッジ、未達成バッジ、達成済みバッジ、ゼロ日表示）

Closes #172