### PR TITLE
feat: グローバルエラーバウンダリーの実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,10 +18,12 @@ import ConfirmForgotPasswordPage from './pages/ConfirmForgotPasswordPage';
 import AuthInitializer from './utils/AuthInitializer';
 import Protected from './utils/Protected';
 import AppShell from './components/layout/AppShell';
+import ErrorBoundary from './components/ErrorBoundary';
 
 
 export default function App() {
   return (
+    <ErrorBoundary>
     <Routes>
       {/* 誰でもアクセス可能 */}
       <Route path="/login" element={<LoginPage />} />
@@ -58,5 +60,6 @@ export default function App() {
         <Route path="/chat/ask-ai/:sessionId" element={<AskAiPage />} />
       </Route>
     </Routes>
+    </ErrorBoundary>
   );
 }

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center h-full min-h-[300px] text-center px-4">
+          <div className="bg-rose-50 rounded-full p-4 mb-4">
+            <svg className="w-8 h-8 text-rose-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+            </svg>
+          </div>
+          <h2 className="text-base font-semibold text-slate-800 mb-1">エラーが発生しました</h2>
+          <p className="text-sm text-slate-500 mb-4 max-w-sm">
+            予期せぬエラーが発生しました。再試行するか、問題が解決しない場合はページを再読み込みしてください。
+          </p>
+          <button
+            onClick={this.handleRetry}
+            className="bg-primary-500 text-white text-sm px-4 py-2 rounded-lg hover:bg-primary-600 transition-colors"
+          >
+            再試行
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorBoundary from '../ErrorBoundary';
+
+function ThrowError({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('テストエラー');
+  }
+  return <div>正常なコンテンツ</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('エラーがない場合は子コンポーネントを表示する', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={false} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('正常なコンテンツ')).toBeInTheDocument();
+  });
+
+  it('エラー発生時にフレンドリーなメッセージを表示する', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('エラー発生時に再試行ボタンが表示される', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('再試行')).toBeInTheDocument();
+  });
+
+  it('エラー発生時に説明テキストが表示される', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText(/予期せぬエラーが発生しました/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
アプリ全体でキャッチされないエラーを捕捉するErrorBoundaryを追加。

## 変更内容
- `ErrorBoundary`クラスコンポーネントを新規作成
- `getDerivedStateFromError`でエラーをキャッチ
- フレンドリーなエラー画面（アイコン、メッセージ、再試行ボタン）
- `App.tsx`のRoutes全体をErrorBoundaryでラップ

## テスト
- ErrorBoundary: 4テスト追加（正常表示、エラー時メッセージ、再試行ボタン、説明テキスト）

Closes #174