### PR TITLE
refactor: ChatListPageのAPI呼び出しをRepository化

### DIFF
--- a/frontend/src/hooks/__tests__/useChatList.test.ts
+++ b/frontend/src/hooks/__tests__/useChatList.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useChatList } from '../useChatList';
+import ChatRepository from '../../repositories/ChatRepository';
+
+vi.mock('../../repositories/ChatRepository');
+
+const mockedRepo = vi.mocked(ChatRepository);
+
+describe('useChatList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchChatUsers.mockResolvedValue([]);
+    mockedRepo.fetchCurrentUser.mockResolvedValue({ id: 1, name: 'テスト' });
+  });
+
+  it('初期ロード時にチャットユーザーを取得する', async () => {
+    const mockUsers = [{ roomId: 1, userId: 1, name: 'ユーザー1', unreadCount: 0 }];
+    mockedRepo.fetchChatUsers.mockResolvedValue(mockUsers as any);
+
+    const { result } = renderHook(() => useChatList());
+
+    await waitFor(() => {
+      expect(result.current.chatUsers).toEqual(mockUsers);
+    });
+  });
+
+  it('ユーザーIDを取得する', async () => {
+    const { result } = renderHook(() => useChatList());
+
+    await waitFor(() => {
+      expect(result.current.userId).toBe(1);
+    });
+  });
+
+  it('ローディング状態を管理する', async () => {
+    const { result } = renderHook(() => useChatList());
+
+    // 最終的にloadingはfalseになる
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+  });
+});

--- a/frontend/src/hooks/useChatList.ts
+++ b/frontend/src/hooks/useChatList.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect, useCallback } from 'react';
+import ChatRepository from '../repositories/ChatRepository';
+import { ChatUser } from '../types';
+
+/**
+ * チャットリスト管理フック
+ *
+ * ChatListPageからビジネスロジックを分離し、
+ * Repository経由でAPI呼び出しを行う。
+ */
+export function useChatList() {
+  const [chatUsers, setChatUsers] = useState<ChatUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [userId, setUserId] = useState<number | null>(null);
+
+  const fetchChatUsers = useCallback(async (query?: string) => {
+    try {
+      setLoading(true);
+      const users = await ChatRepository.fetchChatUsers(query);
+      setChatUsers(users);
+    } catch (e) {
+      console.error('チャットユーザー取得失敗', e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchUserId = useCallback(async () => {
+    try {
+      const user = await ChatRepository.fetchCurrentUser();
+      setUserId(user.id);
+    } catch (e) {
+      console.error('ユーザー情報取得エラー:', e);
+    }
+  }, []);
+
+  const updateUnreadCount = useCallback((roomId: number, increment: number) => {
+    setChatUsers((prev) =>
+      prev.map((u) =>
+        u.roomId === roomId
+          ? { ...u, unreadCount: (u.unreadCount || 0) + increment }
+          : u
+      )
+    );
+  }, []);
+
+  useEffect(() => {
+    fetchUserId();
+    fetchChatUsers();
+  }, [fetchUserId, fetchChatUsers]);
+
+  return {
+    chatUsers,
+    loading,
+    userId,
+    fetchChatUsers,
+    updateUnreadCount,
+  };
+}

--- a/frontend/src/repositories/ChatRepository.ts
+++ b/frontend/src/repositories/ChatRepository.ts
@@ -1,0 +1,25 @@
+import apiClient from '../lib/axios';
+import { ChatUser } from '../types';
+
+/**
+ * Chatリポジトリ
+ *
+ * チャット関連のAPI呼び出しを抽象化し、
+ * fetch()直接呼び出しを排除してaxiosインターセプターによる
+ * 自動トークンリフレッシュを活用する。
+ */
+const ChatRepository = {
+  async fetchChatUsers(query?: string): Promise<ChatUser[]> {
+    const params: Record<string, string> = {};
+    if (query) params.query = query;
+    const res = await apiClient.get('/api/chat/rooms', { params });
+    return res.data.chatUsers || [];
+  },
+
+  async fetchCurrentUser(): Promise<{ id: number; name: string }> {
+    const res = await apiClient.get('/api/auth/cognito/me');
+    return res.data;
+  },
+};
+
+export default ChatRepository;

--- a/frontend/src/repositories/__tests__/ChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ChatRepository.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatRepository from '../ChatRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('ChatRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchChatUsers: チャットユーザー一覧を取得できる', async () => {
+    const mockData = {
+      chatUsers: [
+        { roomId: 1, userId: 1, name: 'テスト', unreadCount: 0 },
+      ],
+    };
+    mockedApiClient.get.mockResolvedValue({ data: mockData });
+
+    const result = await ChatRepository.fetchChatUsers();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/rooms', { params: {} });
+    expect(result).toEqual(mockData.chatUsers);
+  });
+
+  it('fetchChatUsers: 検索クエリ付きで取得できる', async () => {
+    const mockData = { chatUsers: [] };
+    mockedApiClient.get.mockResolvedValue({ data: mockData });
+
+    await ChatRepository.fetchChatUsers('テスト');
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/rooms', { params: { query: 'テスト' } });
+  });
+
+  it('fetchCurrentUser: 現在のユーザー情報を取得できる', async () => {
+    const mockUser = { id: 1, name: 'テスト' };
+    mockedApiClient.get.mockResolvedValue({ data: mockUser });
+
+    const result = await ChatRepository.fetchCurrentUser();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/auth/cognito/me');
+    expect(result).toEqual(mockUser);
+  });
+});


### PR DESCRIPTION
## 概要
ChatListPageでfetch()を直接呼び出していた箇所をRepository+Hook経由に変更。

## 変更内容
- `ChatRepository`を新規作成（apiClient経由で401自動処理）
- `useChatList`フックを作成してビジネスロジックを分離
- ChatListPageからfetch()直接呼び出しとトークンリフレッシュ処理を排除
- `useDispatch`/`clearAuth`のimportを削除（axiosインターセプターが自動処理）

## 効果
- ChatListPage: 235行 → 157行（-33%）
- 手動401トークンリフレッシュ処理を排除

## テスト
- ChatRepository: 3テスト追加
- useChatList: 3テスト追加
- 既存テスト133件全パス

Closes #176