### PR TITLE
refactor: ProfilePageのAPI呼び出しをRepository化

### DIFF
--- a/frontend/src/repositories/ProfileRepository.ts
+++ b/frontend/src/repositories/ProfileRepository.ts
@@ -1,0 +1,27 @@
+import apiClient from '../lib/axios';
+
+/**
+ * プロフィールリポジトリ
+ *
+ * プロフィール関連のAPI呼び出しを抽象化し、
+ * axiosインターセプターによる自動トークンリフレッシュを活用する。
+ */
+
+interface ProfileData {
+  name: string;
+  bio: string;
+}
+
+const ProfileRepository = {
+  async fetchProfile(): Promise<ProfileData> {
+    const res = await apiClient.get('/api/profile/me');
+    return res.data;
+  },
+
+  async updateProfile(data: ProfileData): Promise<{ success: string }> {
+    const res = await apiClient.put('/api/profile/me/update', data);
+    return res.data;
+  },
+};
+
+export default ProfileRepository;

--- a/frontend/src/repositories/__tests__/ProfileRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ProfileRepository.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ProfileRepository from '../ProfileRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('ProfileRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchProfile: プロフィールを取得できる', async () => {
+    const mockData = { name: 'テスト', bio: '自己紹介' };
+    mockedApiClient.get.mockResolvedValue({ data: mockData });
+
+    const result = await ProfileRepository.fetchProfile();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/profile/me');
+    expect(result).toEqual(mockData);
+  });
+
+  it('updateProfile: プロフィールを更新できる', async () => {
+    const mockData = { success: 'プロフィールを更新しました。' };
+    mockedApiClient.put.mockResolvedValue({ data: mockData });
+
+    const result = await ProfileRepository.updateProfile({ name: 'テスト', bio: '更新' });
+
+    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/profile/me/update', { name: 'テスト', bio: '更新' });
+    expect(result).toEqual(mockData);
+  });
+});


### PR DESCRIPTION
## 概要
ProfilePageでfetch()を直接呼び出していた箇所をProfileRepository経由に変更。

## 変更内容
- `ProfileRepository`を新規作成（fetchProfile, updateProfile）
- ProfilePageから手動401トークンリフレッシュ処理を排除
- `useDispatch`/`clearAuth`のimportを削除

## 効果
- ProfilePage: 174行 → 105行（-40%）
- 手動トークンリフレッシュ2箇所を排除

## テスト
- ProfileRepository: 2テスト追加
- 既存テスト135件全パス

Closes #178