### PR TITLE
refactor: MemberItemのビジネスロジックをRepository経由に分離

### DIFF
--- a/frontend/src/components/MemberItem.tsx
+++ b/frontend/src/components/MemberItem.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { clearAuth } from '../store/authSlice';
 import { ChatBubbleLeftIcon, UserPlusIcon } from '@heroicons/react/24/solid';
+import ChatRepository from '../repositories/ChatRepository';
 
 interface MemberItemProps {
   id: number;
@@ -12,77 +11,20 @@ interface MemberItemProps {
 
 export default function MemberItem({ id, name, roomId, email }: MemberItemProps) {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-
-  const displayErrorAndRedirect = (message: string) => {
-    console.error('❌ エラー発生:', message);
-  };
 
   const handleClick = async () => {
     try {
       if (roomId) {
-        console.log(`✅ 既存ルームあり: roomId = ${roomId}`);
         navigate(`/chat/users/${roomId}`);
         return;
       }
 
-      console.log(`🆕 新規ルーム作成リクエスト送信: userId = ${id}`);
-
-      let res = await fetch(`${API_BASE_URL}/api/chat/users/${id}/create`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-
-      if (res.status === 401) {
-        console.warn('⚠️ アクセストークン期限切れ。リフレッシュ試行中...');
-
-        const refreshRes = await fetch(
-          `${API_BASE_URL}/api/auth/cognito/refresh-token`,
-          {
-            method: 'POST',
-            credentials: 'include',
-          }
-        );
-
-        if (!refreshRes.ok) {
-          console.error('❌ リフレッシュ失敗。ログインへリダイレクト。');
-          dispatch(clearAuth());
-          navigate('/login');
-          return;
-        }
-
-        const refreshData = await refreshRes.json();
-        console.log('✅ 新アクセストークン取得成功。リクエスト再試行。');
-
-        res = await fetch(`${API_BASE_URL}/api/chat/users/${id}/create`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-        });
-      }
-
-      if (!res.ok) {
-        const errText = await res.text();
-        throw new Error(`ルーム作成に失敗しました: ${errText}`);
-      }
-
-      const data = await res.json();
-      console.log('🆗 ルーム作成成功:', data);
-
+      const data = await ChatRepository.createRoom(id);
       if (data.roomId) {
-        console.log(`➡️ チャット画面へ遷移: /chat/users/${data.roomId}`);
         navigate(`/chat/users/${data.roomId}`);
-      } else {
-        displayErrorAndRedirect('APIレスポンスに roomId が含まれていません');
       }
-    } catch (err) {
-      displayErrorAndRedirect(`ルーム作成中にエラー発生: ${(err as Error).message}`);
+    } catch {
+      // エラーはaxiosインターセプターが処理
     }
   };
 
@@ -95,7 +37,7 @@ export default function MemberItem({ id, name, roomId, email }: MemberItemProps)
         <div className="w-14 h-14 bg-primary-500 rounded-full flex items-center justify-center text-white font-bold text-xl flex-shrink-0">
           {name?.charAt(0)?.toUpperCase() || '?'}
         </div>
-        
+
         <div className="flex-1 ml-4 min-w-0">
           <p className="text-base font-bold text-slate-800 truncate">
             {name || 'Unknown'}
@@ -104,7 +46,7 @@ export default function MemberItem({ id, name, roomId, email }: MemberItemProps)
             {email}
           </p>
         </div>
-        
+
         <div className="flex-shrink-0 ml-3">
           {roomId ? (
             <div className="bg-primary-50 text-primary-600 px-3 py-1.5 rounded-full flex items-center gap-1.5 group-hover:bg-primary-100 transition-colors">

--- a/frontend/src/repositories/ChatRepository.ts
+++ b/frontend/src/repositories/ChatRepository.ts
@@ -20,6 +20,11 @@ const ChatRepository = {
     const res = await apiClient.get('/api/auth/cognito/me');
     return res.data;
   },
+
+  async createRoom(userId: number): Promise<{ roomId: number }> {
+    const res = await apiClient.post(`/api/chat/users/${userId}/create`);
+    return res.data;
+  },
 };
 
 export default ChatRepository;

--- a/frontend/src/repositories/__tests__/ChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ChatRepository.test.ts
@@ -43,4 +43,14 @@ describe('ChatRepository', () => {
     expect(mockedApiClient.get).toHaveBeenCalledWith('/api/auth/cognito/me');
     expect(result).toEqual(mockUser);
   });
+
+  it('createRoom: チャットルームを作成できる', async () => {
+    const mockData = { roomId: 42 };
+    mockedApiClient.post.mockResolvedValue({ data: mockData });
+
+    const result = await ChatRepository.createRoom(5);
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/users/5/create');
+    expect(result).toEqual(mockData);
+  });
 });


### PR DESCRIPTION
## 概要
MemberItemコンポーネント内のビジネスロジックをChatRepository経由に変更。

## 変更内容
- `ChatRepository`に`createRoom`メソッドを追加
- MemberItemからfetch()直接呼び出しと手動トークンリフレッシュを排除
- console.logデバッグ文7箇所を削除
- `useDispatch`/`clearAuth`のimportを削除

## 効果
- MemberItem: 124行 → 66行（-47%）
- デバッグログ完全除去
- ビジネスロジックとUIの明確な分離

## テスト
- ChatRepository.createRoom: 1テスト追加
- 既存テスト136件全パス

Closes #180