### PR TITLE
test: Repository層の全テスト追加

### DIFF
--- a/frontend/src/repositories/__tests__/AiChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AiChatRepository.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import aiChatRepository from '../AiChatRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('AiChatRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getSessions: セッション一覧を取得できる', async () => {
+    const mockSessions = [{ id: 1, title: 'テストセッション' }];
+    mockedApiClient.get.mockResolvedValue({ data: mockSessions });
+
+    const result = await aiChatRepository.getSessions();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/ai/sessions');
+    expect(result).toEqual(mockSessions);
+  });
+
+  it('getSession: セッション詳細を取得できる', async () => {
+    const mockSession = { id: 1, title: 'テストセッション' };
+    mockedApiClient.get.mockResolvedValue({ data: mockSession });
+
+    const result = await aiChatRepository.getSession(1);
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/ai/sessions/1');
+    expect(result).toEqual(mockSession);
+  });
+
+  it('createSession: 新規セッションを作成できる', async () => {
+    const mockSession = { id: 2, title: '新しいセッション' };
+    mockedApiClient.post.mockResolvedValue({ data: mockSession });
+
+    const result = await aiChatRepository.createSession({ title: '新しいセッション' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/sessions', { title: '新しいセッション' });
+    expect(result).toEqual(mockSession);
+  });
+
+  it('updateSessionTitle: セッションタイトルを更新できる', async () => {
+    const mockSession = { id: 1, title: '更新タイトル' };
+    mockedApiClient.put.mockResolvedValue({ data: mockSession });
+
+    const result = await aiChatRepository.updateSessionTitle(1, { title: '更新タイトル' });
+
+    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/chat/ai/sessions/1', { title: '更新タイトル' });
+    expect(result).toEqual(mockSession);
+  });
+
+  it('deleteSession: セッションを削除できる', async () => {
+    mockedApiClient.delete.mockResolvedValue({});
+
+    await aiChatRepository.deleteSession(1);
+
+    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/chat/ai/sessions/1');
+  });
+
+  it('getMessages: メッセージ一覧を取得できる', async () => {
+    const mockMessages = [{ id: 1, content: 'テストメッセージ', role: 'user' }];
+    mockedApiClient.get.mockResolvedValue({ data: mockMessages });
+
+    const result = await aiChatRepository.getMessages(1);
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/ai/sessions/1/messages');
+    expect(result).toEqual(mockMessages);
+  });
+
+  it('addMessage: メッセージを追加できる', async () => {
+    const mockMessage = { id: 2, content: '新しいメッセージ', role: 'user' };
+    mockedApiClient.post.mockResolvedValue({ data: mockMessage });
+
+    const result = await aiChatRepository.addMessage(1, { content: '新しいメッセージ', role: 'user' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/sessions/1/messages', { content: '新しいメッセージ', role: 'user' });
+    expect(result).toEqual(mockMessage);
+  });
+
+  it('rephrase: 言い換え提案を取得できる', async () => {
+    const mockResult = { result: '言い換え結果' };
+    mockedApiClient.post.mockResolvedValue({ data: mockResult });
+
+    const result = await aiChatRepository.rephrase({ originalMessage: '元のメッセージ', scene: 'meeting' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/rephrase', { originalMessage: '元のメッセージ', scene: 'meeting' });
+    expect(result).toEqual(mockResult);
+  });
+
+  it('getScoreCard: スコアカードを取得できる', async () => {
+    const mockScoreCard = { overallScore: 7.5, scores: [] };
+    mockedApiClient.get.mockResolvedValue({ data: mockScoreCard });
+
+    const result = await aiChatRepository.getScoreCard(1);
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/scores/sessions/1');
+    expect(result).toEqual(mockScoreCard);
+  });
+
+  it('getScoreHistory: スコア履歴を取得できる', async () => {
+    const mockHistory = [{ sessionId: 1, overallScore: 7.5 }];
+    mockedApiClient.get.mockResolvedValue({ data: mockHistory });
+
+    const result = await aiChatRepository.getScoreHistory();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/scores/history');
+    expect(result).toEqual(mockHistory);
+  });
+});

--- a/frontend/src/repositories/__tests__/AuthRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AuthRepository.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import authRepository from '../AuthRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('AuthRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('login: ログインできる', async () => {
+    const mockUser = { id: 1, email: 'test@example.com', name: 'テスト', sub: 'sub-123' };
+    mockedApiClient.post.mockResolvedValue({ data: mockUser });
+
+    const result = await authRepository.login({ email: 'test@example.com', password: 'password123' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/login', { email: 'test@example.com', password: 'password123' });
+    expect(result).toEqual(mockUser);
+  });
+
+  it('signup: サインアップできる', async () => {
+    mockedApiClient.post.mockResolvedValue({});
+
+    await authRepository.signup({ email: 'test@example.com', password: 'password123', name: 'テスト' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/signup', { email: 'test@example.com', password: 'password123', name: 'テスト' });
+  });
+
+  it('confirmSignup: サインアップ確認ができる', async () => {
+    mockedApiClient.post.mockResolvedValue({});
+
+    await authRepository.confirmSignup({ email: 'test@example.com', confirmationCode: '123456' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/confirm-signup', { email: 'test@example.com', confirmationCode: '123456' });
+  });
+
+  it('forgotPassword: パスワード再設定リクエストを送信できる', async () => {
+    mockedApiClient.post.mockResolvedValue({});
+
+    await authRepository.forgotPassword({ email: 'test@example.com' });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/forgot-password', { email: 'test@example.com' });
+  });
+
+  it('confirmForgotPassword: パスワード再設定確認ができる', async () => {
+    mockedApiClient.post.mockResolvedValue({});
+
+    await authRepository.confirmForgotPassword({
+      email: 'test@example.com',
+      confirmationCode: '123456',
+      newPassword: 'newPassword123',
+    });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/confirm-forgot-password', {
+      email: 'test@example.com',
+      confirmationCode: '123456',
+      newPassword: 'newPassword123',
+    });
+  });
+
+  it('logout: ログアウトできる', async () => {
+    mockedApiClient.post.mockResolvedValue({});
+
+    await authRepository.logout();
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/logout');
+  });
+
+  it('getCurrentUser: 現在のユーザー情報を取得できる', async () => {
+    const mockUser = { id: 1, email: 'test@example.com', name: 'テスト', sub: 'sub-123' };
+    mockedApiClient.get.mockResolvedValue({ data: mockUser });
+
+    const result = await authRepository.getCurrentUser();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/auth/cognito/me');
+    expect(result).toEqual(mockUser);
+  });
+
+  it('refreshToken: トークンリフレッシュできる', async () => {
+    mockedApiClient.post.mockResolvedValue({});
+
+    await authRepository.refreshToken();
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/refresh-token');
+  });
+});

--- a/frontend/src/repositories/__tests__/PracticeRepository.test.ts
+++ b/frontend/src/repositories/__tests__/PracticeRepository.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import practiceRepository from '../PracticeRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('PracticeRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getScenarios: シナリオ一覧を取得できる', async () => {
+    const mockScenarios = [
+      { id: 1, name: 'テストシナリオ', description: '説明', category: 'customer', roleName: '顧客', difficulty: 'easy', systemPrompt: 'prompt' },
+    ];
+    mockedApiClient.get.mockResolvedValue({ data: mockScenarios });
+
+    const result = await practiceRepository.getScenarios();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/practice/scenarios');
+    expect(result).toEqual(mockScenarios);
+  });
+
+  it('getScenario: シナリオ詳細を取得できる', async () => {
+    const mockScenario = { id: 1, name: 'テストシナリオ', description: '説明', category: 'customer', roleName: '顧客', difficulty: 'easy', systemPrompt: 'prompt' };
+    mockedApiClient.get.mockResolvedValue({ data: mockScenario });
+
+    const result = await practiceRepository.getScenario(1);
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/practice/scenarios/1');
+    expect(result).toEqual(mockScenario);
+  });
+
+  it('createPracticeSession: 練習セッションを作成できる', async () => {
+    const mockSession = { id: 1, scenarioId: 1 };
+    mockedApiClient.post.mockResolvedValue({ data: mockSession });
+
+    const result = await practiceRepository.createPracticeSession({ scenarioId: 1 });
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/practice/sessions', { scenarioId: 1 });
+    expect(result).toEqual(mockSession);
+  });
+});

--- a/frontend/src/repositories/__tests__/UserProfileRepository.test.ts
+++ b/frontend/src/repositories/__tests__/UserProfileRepository.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userProfileRepository from '../UserProfileRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('UserProfileRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getMyProfile: 自分のプロファイルを取得できる', async () => {
+    const mockProfile = {
+      id: 1,
+      userId: 1,
+      displayName: 'テストユーザー',
+      selfIntroduction: '自己紹介',
+      communicationStyle: 'assertive',
+    };
+    mockedApiClient.get.mockResolvedValue({ data: mockProfile });
+
+    const result = await userProfileRepository.getMyProfile();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/user-profile/me');
+    expect(result).toEqual(mockProfile);
+  });
+
+  it('updateProfile: プロファイルを更新できる', async () => {
+    const updateRequest = {
+      displayName: '更新ユーザー',
+      selfIntroduction: '更新された自己紹介',
+    };
+    const mockProfile = { id: 1, userId: 1, ...updateRequest };
+    mockedApiClient.post.mockResolvedValue({ data: mockProfile });
+
+    const result = await userProfileRepository.updateProfile(updateRequest);
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/user-profile/me', updateRequest);
+    expect(result).toEqual(mockProfile);
+  });
+});


### PR DESCRIPTION
## 概要
Closes #182

未テストだった4つのRepository層に対してテストを追加しました。

## 追加テスト
- **AiChatRepository**: 10テスト（getSessions, getSession, createSession, updateSessionTitle, deleteSession, getMessages, addMessage, rephrase, getScoreCard, getScoreHistory）
- **AuthRepository**: 8テスト（login, signup, confirmSignup, forgotPassword, confirmForgotPassword, logout, getCurrentUser, refreshToken）
- **PracticeRepository**: 3テスト（getScenarios, getScenario, createPracticeSession）
- **UserProfileRepository**: 2テスト（getMyProfile, updateProfile）

## テスト結果
- 追加テスト: +23件
- 全テスト: 159件 全て合格