### PR TITLE
test: Hooks層の全テスト追加

### DIFF
--- a/frontend/src/hooks/__tests__/useAiChat.test.ts
+++ b/frontend/src/hooks/__tests__/useAiChat.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useAiChat } from '../useAiChat';
+import AiChatRepository from '../../repositories/AiChatRepository';
+
+vi.mock('../../repositories/AiChatRepository');
+
+const mockedRepo = vi.mocked(AiChatRepository);
+
+describe('useAiChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchSessions: セッション一覧を取得してstateに保存する', async () => {
+    const mockSessions = [{ id: 1, title: 'テスト' }];
+    mockedRepo.getSessions.mockResolvedValue(mockSessions as any);
+
+    const { result } = renderHook(() => useAiChat());
+
+    await act(async () => {
+      await result.current.fetchSessions();
+    });
+
+    expect(result.current.sessions).toEqual(mockSessions);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetchSessions: エラー時にerrorを設定する', async () => {
+    mockedRepo.getSessions.mockRejectedValue(new Error('取得失敗'));
+
+    const { result } = renderHook(() => useAiChat());
+
+    await act(async () => {
+      await result.current.fetchSessions();
+    });
+
+    expect(result.current.error).toBe('取得失敗');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('createSession: セッションを作成してsessionsに追加する', async () => {
+    const mockSession = { id: 2, title: '新セッション' };
+    mockedRepo.createSession.mockResolvedValue(mockSession as any);
+
+    const { result } = renderHook(() => useAiChat());
+
+    let created: any;
+    await act(async () => {
+      created = await result.current.createSession({ title: '新セッション' });
+    });
+
+    expect(created).toEqual(mockSession);
+    expect(result.current.sessions).toContainEqual(mockSession);
+    expect(result.current.currentSession).toEqual(mockSession);
+  });
+
+  it('deleteSession: セッションを削除してsessionsから除外する', async () => {
+    const mockSessions = [{ id: 1, title: 'A' }, { id: 2, title: 'B' }];
+    mockedRepo.getSessions.mockResolvedValue(mockSessions as any);
+    mockedRepo.deleteSession.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useAiChat());
+
+    await act(async () => {
+      await result.current.fetchSessions();
+    });
+
+    await act(async () => {
+      await result.current.deleteSession(1);
+    });
+
+    expect(result.current.sessions).toHaveLength(1);
+    expect(result.current.sessions[0]).toEqual({ id: 2, title: 'B' });
+  });
+
+  it('fetchMessages: メッセージ一覧を取得する', async () => {
+    const mockMessages = [{ id: 1, content: 'テスト', role: 'user' }];
+    mockedRepo.getMessages.mockResolvedValue(mockMessages as any);
+
+    const { result } = renderHook(() => useAiChat());
+
+    await act(async () => {
+      await result.current.fetchMessages(1);
+    });
+
+    expect(result.current.messages).toEqual(mockMessages);
+  });
+
+  it('addMessage: メッセージを追加してmessagesに追記する', async () => {
+    const mockMessage = { id: 2, content: '新メッセージ', role: 'user' };
+    mockedRepo.addMessage.mockResolvedValue(mockMessage as any);
+
+    const { result } = renderHook(() => useAiChat());
+
+    await act(async () => {
+      await result.current.addMessage(1, { content: '新メッセージ', role: 'user' });
+    });
+
+    expect(result.current.messages).toContainEqual(mockMessage);
+  });
+
+  it('rephrase: 言い換え結果を返す', async () => {
+    mockedRepo.rephrase.mockResolvedValue({ result: '言い換え文' });
+
+    const { result } = renderHook(() => useAiChat());
+
+    let rephrased: string | null = null;
+    await act(async () => {
+      rephrased = await result.current.rephrase({ originalMessage: '元の文' });
+    });
+
+    expect(rephrased).toBe('言い換え文');
+  });
+
+  it('fetchScoreCard: スコアカードを取得する', async () => {
+    const mockScoreCard = { overallScore: 7.5, scores: [] };
+    mockedRepo.getScoreCard.mockResolvedValue(mockScoreCard as any);
+
+    const { result } = renderHook(() => useAiChat());
+
+    await act(async () => {
+      await result.current.fetchScoreCard(1);
+    });
+
+    expect(result.current.scoreCard).toEqual(mockScoreCard);
+  });
+});

--- a/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import { createElement } from 'react';
+import { useAuth } from '../useAuth';
+import AuthRepository from '../../repositories/AuthRepository';
+import authReducer from '../../store/authSlice';
+
+vi.mock('../../repositories/AuthRepository');
+
+const mockedRepo = vi.mocked(AuthRepository);
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function createWrapper() {
+  const store = configureStore({ reducer: { auth: authReducer } });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(Provider, { store },
+      createElement(MemoryRouter, null, children)
+    );
+}
+
+describe('useAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('login: ログイン成功時にtrueを返す', async () => {
+    const mockUser = { id: 1, email: 'test@example.com', name: 'テスト', sub: 'sub-123' };
+    mockedRepo.login.mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let success: boolean = false;
+    await act(async () => {
+      success = await result.current.login({ email: 'test@example.com', password: 'password' });
+    });
+
+    expect(success).toBe(true);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('login: ログイン失敗時にfalseとerrorを返す', async () => {
+    mockedRepo.login.mockRejectedValue(new Error('認証失敗'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let success: boolean = true;
+    await act(async () => {
+      success = await result.current.login({ email: 'test@example.com', password: 'wrong' });
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('認証失敗');
+  });
+
+  it('signup: サインアップ成功時にtrueを返す', async () => {
+    mockedRepo.signup.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let success: boolean = false;
+    await act(async () => {
+      success = await result.current.signup({ email: 'test@example.com', password: 'password', name: 'テスト' });
+    });
+
+    expect(success).toBe(true);
+  });
+
+  it('logout: ログアウト成功時にログインページに遷移する', async () => {
+    mockedRepo.logout.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('getCurrentUser: ユーザー情報取得成功時に認証状態を設定する', async () => {
+    const mockUser = { id: 1, email: 'test@example.com', name: 'テスト', sub: 'sub-123' };
+    mockedRepo.getCurrentUser.mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let user: any;
+    await act(async () => {
+      user = await result.current.getCurrentUser();
+    });
+
+    expect(user).toEqual(mockUser);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('refreshToken: リフレッシュ失敗時にログインページに遷移する', async () => {
+    mockedRepo.refreshToken.mockRejectedValue(new Error('トークン期限切れ'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let success: boolean = true;
+    await act(async () => {
+      success = await result.current.refreshToken();
+    });
+
+    expect(success).toBe(false);
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+});

--- a/frontend/src/hooks/__tests__/usePractice.test.ts
+++ b/frontend/src/hooks/__tests__/usePractice.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePractice } from '../usePractice';
+import PracticeRepository from '../../repositories/PracticeRepository';
+
+vi.mock('../../repositories/PracticeRepository');
+
+const mockedRepo = vi.mocked(PracticeRepository);
+
+describe('usePractice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchScenarios: シナリオ一覧を取得する', async () => {
+    const mockScenarios = [{ id: 1, name: 'テストシナリオ', description: '説明', category: 'customer', roleName: '顧客', difficulty: 'easy', systemPrompt: 'prompt' }];
+    mockedRepo.getScenarios.mockResolvedValue(mockScenarios as any);
+
+    const { result } = renderHook(() => usePractice());
+
+    await act(async () => {
+      await result.current.fetchScenarios();
+    });
+
+    expect(result.current.scenarios).toEqual(mockScenarios);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetchScenarios: エラー時にerrorを設定する', async () => {
+    mockedRepo.getScenarios.mockRejectedValue(new Error('取得失敗'));
+
+    const { result } = renderHook(() => usePractice());
+
+    await act(async () => {
+      await result.current.fetchScenarios();
+    });
+
+    expect(result.current.error).toBe('取得失敗');
+  });
+
+  it('fetchScenario: シナリオ詳細を取得する', async () => {
+    const mockScenario = { id: 1, name: 'テスト', description: '説明', category: 'customer', roleName: '顧客', difficulty: 'easy', systemPrompt: 'prompt' };
+    mockedRepo.getScenario.mockResolvedValue(mockScenario as any);
+
+    const { result } = renderHook(() => usePractice());
+
+    let fetched: any;
+    await act(async () => {
+      fetched = await result.current.fetchScenario(1);
+    });
+
+    expect(fetched).toEqual(mockScenario);
+    expect(result.current.currentScenario).toEqual(mockScenario);
+  });
+
+  it('createPracticeSession: 練習セッションを作成する', async () => {
+    const mockSession = { id: 1, scenarioId: 1 };
+    mockedRepo.createPracticeSession.mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => usePractice());
+
+    let created: any;
+    await act(async () => {
+      created = await result.current.createPracticeSession({ scenarioId: 1 });
+    });
+
+    expect(created).toEqual(mockSession);
+  });
+
+  it('createPracticeSession: エラー時にnullを返す', async () => {
+    mockedRepo.createPracticeSession.mockRejectedValue(new Error('作成失敗'));
+
+    const { result } = renderHook(() => usePractice());
+
+    let created: any;
+    await act(async () => {
+      created = await result.current.createPracticeSession({ scenarioId: 1 });
+    });
+
+    expect(created).toBeNull();
+    expect(result.current.error).toBe('作成失敗');
+  });
+});

--- a/frontend/src/hooks/__tests__/useUserProfile.test.ts
+++ b/frontend/src/hooks/__tests__/useUserProfile.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUserProfile } from '../useUserProfile';
+import UserProfileRepository from '../../repositories/UserProfileRepository';
+
+vi.mock('../../repositories/UserProfileRepository');
+
+const mockedRepo = vi.mocked(UserProfileRepository);
+
+describe('useUserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchMyProfile: プロファイルを取得する', async () => {
+    const mockProfile = { id: 1, userId: 1, displayName: 'テスト' };
+    mockedRepo.getMyProfile.mockResolvedValue(mockProfile as any);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await act(async () => {
+      await result.current.fetchMyProfile();
+    });
+
+    expect(result.current.profile).toEqual(mockProfile);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetchMyProfile: エラー時にerrorを設定する', async () => {
+    mockedRepo.getMyProfile.mockRejectedValue(new Error('取得失敗'));
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await act(async () => {
+      await result.current.fetchMyProfile();
+    });
+
+    expect(result.current.error).toBe('取得失敗');
+  });
+
+  it('updateProfile: プロファイルを更新する', async () => {
+    const mockUpdated = { id: 1, userId: 1, displayName: '更新済み' };
+    mockedRepo.updateProfile.mockResolvedValue(mockUpdated as any);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    let success: boolean = false;
+    await act(async () => {
+      success = await result.current.updateProfile({ displayName: '更新済み' });
+    });
+
+    expect(success).toBe(true);
+    expect(result.current.profile).toEqual(mockUpdated);
+  });
+
+  it('updateProfile: エラー時にfalseを返す', async () => {
+    mockedRepo.updateProfile.mockRejectedValue(new Error('更新失敗'));
+
+    const { result } = renderHook(() => useUserProfile());
+
+    let success: boolean = true;
+    await act(async () => {
+      success = await result.current.updateProfile({ displayName: '更新済み' });
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('更新失敗');
+  });
+});


### PR DESCRIPTION
## 概要
Closes #184

未テストだった4つのHooks層にテストを追加しました。

## 追加テスト
- **useAiChat**: 8テスト（fetchSessions, createSession, deleteSession, fetchMessages, addMessage, rephrase, fetchScoreCard, エラー処理）
- **useAuth**: 6テスト（login成功/失敗, signup, logout遷移, getCurrentUser, refreshToken失敗時遷移）
- **usePractice**: 5テスト（fetchScenarios成功/失敗, fetchScenario, createPracticeSession成功/失敗）
- **useUserProfile**: 4テスト（fetchMyProfile成功/失敗, updateProfile成功/失敗）

## テスト結果
- 追加テスト: +23件
- 全テスト: 182件 全て合格