### PR TITLE
test: UIコンポーネントのテスト追加（9コンポーネント）

### DIFF
--- a/frontend/src/components/__tests__/ConfirmModal.test.tsx
+++ b/frontend/src/components/__tests__/ConfirmModal.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConfirmModal from '../ConfirmModal';
+
+describe('ConfirmModal', () => {
+  const mockOnConfirm = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('isOpen=trueでモーダルが表示される', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+
+    expect(screen.getByText('確認')).toBeInTheDocument();
+    expect(screen.getByText('削除しますか？')).toBeInTheDocument();
+  });
+
+  it('isOpen=falseでモーダルが非表示になる', () => {
+    render(
+      <ConfirmModal isOpen={false} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+
+    expect(screen.queryByText('削除しますか？')).not.toBeInTheDocument();
+  });
+
+  it('確認ボタンクリックでonConfirmが呼ばれる', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+
+    fireEvent.click(screen.getByText('削除'));
+    expect(mockOnConfirm).toHaveBeenCalled();
+  });
+
+  it('キャンセルボタンクリックでonCancelが呼ばれる', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+
+  it('カスタムタイトルとボタンテキストが表示される', () => {
+    render(
+      <ConfirmModal
+        isOpen={true}
+        title="注意"
+        message="本当に実行しますか？"
+        confirmText="実行"
+        cancelText="戻る"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByText('注意')).toBeInTheDocument();
+    expect(screen.getByText('実行')).toBeInTheDocument();
+    expect(screen.getByText('戻る')).toBeInTheDocument();
+  });
+
+  it('ESCキーでonCancelが呼ばれる', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(mockOnCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/InputField.test.tsx
+++ b/frontend/src/components/__tests__/InputField.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InputField from '../InputField';
+
+describe('InputField', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+
+    expect(screen.getByLabelText('メール')).toBeInTheDocument();
+  });
+
+  it('入力値が変更されるとonChangeが呼ばれる', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+
+    fireEvent.change(screen.getByLabelText('メール'), { target: { value: 'test@example.com' } });
+    expect(mockOnChange).toHaveBeenCalled();
+  });
+
+  it('値があるときクリアボタンが表示される', () => {
+    render(<InputField label="メール" name="email" value="test" onChange={mockOnChange} />);
+
+    const clearButton = screen.getByRole('button');
+    expect(clearButton).toBeInTheDocument();
+  });
+
+  it('クリアボタンで入力値がリセットされる', () => {
+    render(<InputField label="メール" name="email" value="test" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(mockOnChange).toHaveBeenCalledWith({ target: { name: 'email', value: '' } });
+  });
+});

--- a/frontend/src/components/__tests__/LinkText.test.tsx
+++ b/frontend/src/components/__tests__/LinkText.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LinkText from '../LinkText';
+
+describe('LinkText', () => {
+  it('リンクテキストが表示される', () => {
+    render(
+      <MemoryRouter>
+        <LinkText to="/signup">新規登録</LinkText>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('新規登録')).toBeInTheDocument();
+  });
+
+  it('正しいリンク先が設定される', () => {
+    render(
+      <MemoryRouter>
+        <LinkText to="/signup">新規登録</LinkText>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('新規登録').closest('a')).toHaveAttribute('href', '/signup');
+  });
+});

--- a/frontend/src/components/__tests__/Loading.test.tsx
+++ b/frontend/src/components/__tests__/Loading.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Loading from '../Loading';
+
+describe('Loading', () => {
+  it('スピナーが表示される', () => {
+    render(<Loading />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('メッセージが表示される', () => {
+    render(<Loading message="読み込み中..." />);
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('フルスクリーンモードで表示される', () => {
+    render(<Loading fullscreen message="処理中..." />);
+
+    expect(screen.getByText('処理中...')).toBeInTheDocument();
+  });
+
+  it('メッセージなしの場合テキストが表示されない', () => {
+    const { container } = render(<Loading />);
+
+    expect(container.querySelector('p')).toBeNull();
+  });
+});

--- a/frontend/src/components/__tests__/MemberItem.test.tsx
+++ b/frontend/src/components/__tests__/MemberItem.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MemberItem from '../MemberItem';
+import ChatRepository from '../../repositories/ChatRepository';
+
+vi.mock('../../repositories/ChatRepository');
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('MemberItem', () => {
+  it('名前とメールが表示される', () => {
+    render(
+      <MemoryRouter>
+        <MemberItem id={1} name="テストユーザー" email="test@example.com" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('名前の頭文字がアバターに表示される', () => {
+    render(
+      <MemoryRouter>
+        <MemberItem id={1} name="Test" email="test@example.com" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('T')).toBeInTheDocument();
+  });
+
+  it('roomIdがある場合「チャット」ボタンが表示される', () => {
+    render(
+      <MemoryRouter>
+        <MemberItem id={1} name="テスト" email="test@example.com" roomId={10} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('チャット')).toBeInTheDocument();
+  });
+
+  it('roomIdがない場合「追加」ボタンが表示される', () => {
+    render(
+      <MemoryRouter>
+        <MemberItem id={1} name="テスト" email="test@example.com" />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('追加')).toBeInTheDocument();
+  });
+
+  it('roomIdがある場合クリックで既存ルームに遷移する', async () => {
+    render(
+      <MemoryRouter>
+        <MemberItem id={1} name="テスト" email="test@example.com" roomId={10} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText('テスト'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/users/10');
+  });
+});

--- a/frontend/src/components/__tests__/PrimaryButton.test.tsx
+++ b/frontend/src/components/__tests__/PrimaryButton.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PrimaryButton from '../PrimaryButton';
+
+describe('PrimaryButton', () => {
+  it('子要素が表示される', () => {
+    render(<PrimaryButton>ログイン</PrimaryButton>);
+
+    expect(screen.getByText('ログイン')).toBeInTheDocument();
+  });
+
+  it('クリックでonClickが呼ばれる', () => {
+    const mockOnClick = vi.fn();
+    render(<PrimaryButton onClick={mockOnClick}>送信</PrimaryButton>);
+
+    fireEvent.click(screen.getByText('送信'));
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('disabled時にクリックが無効になる', () => {
+    const mockOnClick = vi.fn();
+    render(<PrimaryButton onClick={mockOnClick} disabled>送信</PrimaryButton>);
+
+    const button = screen.getByText('送信');
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/components/__tests__/RoomListItem.test.tsx
+++ b/frontend/src/components/__tests__/RoomListItem.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import RoomListItem from '../RoomListItem';
+
+describe('RoomListItem', () => {
+  it('名前と最新メッセージが表示される', () => {
+    render(<RoomListItem name="テストユーザー" lastMessage="こんにちは" unreadCount={0} />);
+
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument();
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+  });
+
+  it('未読数が0のときバッジが表示されない', () => {
+    const { container } = render(<RoomListItem name="テスト" lastMessage="メッセージ" unreadCount={0} />);
+
+    expect(container.querySelector('span')).toBeNull();
+  });
+
+  it('未読数が1以上のときバッジが表示される', () => {
+    render(<RoomListItem name="テスト" lastMessage="メッセージ" unreadCount={5} />);
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/SearchBox.test.tsx
+++ b/frontend/src/components/__tests__/SearchBox.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchBox from '../SearchBox';
+
+describe('SearchBox', () => {
+  it('プレースホルダーが表示される', () => {
+    render(<SearchBox value="" onChange={vi.fn()} placeholder="ユーザーを検索" />);
+
+    expect(screen.getByPlaceholderText('ユーザーを検索')).toBeInTheDocument();
+  });
+
+  it('デフォルトプレースホルダーが表示される', () => {
+    render(<SearchBox value="" onChange={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText('検索')).toBeInTheDocument();
+  });
+
+  it('入力時にonChangeが呼ばれる', () => {
+    const mockOnChange = vi.fn();
+    render(<SearchBox value="" onChange={mockOnChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('検索'), { target: { value: 'テスト' } });
+    expect(mockOnChange).toHaveBeenCalledWith('テスト');
+  });
+});

--- a/frontend/src/components/__tests__/Skeleton.test.tsx
+++ b/frontend/src/components/__tests__/Skeleton.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Skeleton, { SkeletonCard, SkeletonList } from '../Skeleton';
+
+describe('Skeleton', () => {
+  it('スケルトン要素が表示される', () => {
+    render(<Skeleton />);
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('count指定で複数のスケルトンが表示される', () => {
+    render(<Skeleton count={3} />);
+
+    const elements = screen.getAllByRole('status');
+    expect(elements).toHaveLength(3);
+  });
+});
+
+describe('SkeletonCard', () => {
+  it('カード型スケルトンが表示される', () => {
+    render(<SkeletonCard />);
+
+    const elements = screen.getAllByRole('status');
+    expect(elements.length).toBeGreaterThan(0);
+  });
+});
+
+describe('SkeletonList', () => {
+  it('リスト型スケルトンがデフォルト3件表示される', () => {
+    render(<SkeletonList />);
+
+    const elements = screen.getAllByRole('status');
+    expect(elements.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 概要
Closes #186

未テストだった9つのUIコンポーネントにテストを追加しました。

## 追加テスト
- **ConfirmModal**: 6テスト（表示/非表示、確認/キャンセル、カスタムテキスト、ESCキー）
- **InputField**: 4テスト（ラベル表示、入力変更、クリアボタン表示/動作）
- **PrimaryButton**: 3テスト（子要素表示、クリック、disabled状態）
- **SearchBox**: 3テスト（プレースホルダー、デフォルト値、入力変更）
- **Loading**: 4テスト（スピナー、メッセージ、フルスクリーン、メッセージなし）
- **Skeleton**: 4テスト（基本表示、count指定、SkeletonCard、SkeletonList）
- **LinkText**: 2テスト（テキスト表示、リンク先設定）
- **RoomListItem**: 3テスト（名前/メッセージ表示、未読バッジ表示/非表示）
- **MemberItem**: 5テスト（名前表示、アバター、チャット/追加ボタン、遷移）

## テスト結果
- 追加テスト: +34件
- 全テスト: 216件 全て合格