### PR TITLE
test: ページコンポーネントのテスト追加（4ページ）

### DIFF
--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import LoginPage from '../LoginPage';
+import authReducer from '../../store/authSlice';
+
+const mockLogin = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    login: mockLogin,
+    loading: false,
+    error: null,
+    isAuthenticated: false,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderLoginPage() {
+  const store = configureStore({ reducer: { auth: authReducer } });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ログインフォームが表示される', () => {
+    renderLoginPage();
+
+    expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+  });
+
+  it('リンクテキストが表示される', () => {
+    renderLoginPage();
+
+    expect(screen.getByText('パスワードをお忘れですか？')).toBeInTheDocument();
+    expect(screen.getByText('アカウント作成')).toBeInTheDocument();
+  });
+
+  it('ログイン成功時にホームに遷移する', async () => {
+    mockLogin.mockResolvedValue(true);
+    renderLoginPage();
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), { target: { value: 'test@example.com', name: 'email' } });
+    fireEvent.change(screen.getByLabelText('パスワード'), { target: { value: 'password123', name: 'password' } });
+
+    const loginButtons = screen.getAllByText('ログイン');
+    const submitButton = loginButtons.find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit');
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password123' });
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('ログイン失敗時にエラーメッセージが表示される', async () => {
+    mockLogin.mockResolvedValue(false);
+    renderLoginPage();
+
+    const loginButtons = screen.getAllByText('ログイン');
+    const submitButton = loginButtons.find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit');
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/ログインに失敗しました/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import ProfilePage from '../ProfilePage';
+import ProfileRepository from '../../repositories/ProfileRepository';
+
+vi.mock('../../repositories/ProfileRepository');
+
+const mockedRepo = vi.mocked(ProfileRepository);
+
+describe('ProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ローディング中はスピナーが表示される', () => {
+    mockedRepo.fetchProfile.mockReturnValue(new Promise(() => {}));
+    render(<ProfilePage />);
+
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('プロファイル取得後にフォームが表示される', async () => {
+    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テストユーザー', bio: '自己紹介文' });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('プロフィールを編集')).toBeInTheDocument();
+      expect(screen.getByText('プロフィールを更新')).toBeInTheDocument();
+    });
+  });
+
+  it('プロファイル取得失敗時にエラーが表示される', async () => {
+    mockedRepo.fetchProfile.mockRejectedValue(new Error('取得失敗'));
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('プロフィール取得に失敗しました。')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/SignupPage.test.tsx
+++ b/frontend/src/pages/__tests__/SignupPage.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import SignupPage from '../SignupPage';
+import authReducer from '../../store/authSlice';
+
+const mockSignup = vi.fn();
+
+vi.mock('../../hooks/useAuth', () => ({
+  useAuth: () => ({
+    signup: mockSignup,
+    loading: false,
+    error: null,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+function renderSignupPage() {
+  const store = configureStore({ reducer: { auth: authReducer } });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <SignupPage />
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+describe('SignupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('サインアップフォームが表示される', () => {
+    renderSignupPage();
+
+    expect(screen.getByRole('heading', { name: 'アカウント作成' })).toBeInTheDocument();
+    expect(screen.getByLabelText('ニックネーム')).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+  });
+
+  it('ログインリンクが表示される', () => {
+    renderSignupPage();
+
+    expect(screen.getByText('ログインする')).toBeInTheDocument();
+  });
+
+  it('サインアップ失敗時にエラーメッセージが表示される', async () => {
+    mockSignup.mockResolvedValue(false);
+    renderSignupPage();
+
+    const submitButtons = screen.getAllByText('アカウント作成');
+    const submitButton = submitButtons.find(el => el.tagName === 'BUTTON');
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/登録に失敗しました/)).toBeInTheDocument();
+    });
+  });
+
+  it('サインアップ成功時に成功メッセージが表示される', async () => {
+    mockSignup.mockResolvedValue(true);
+    renderSignupPage();
+
+    const submitButtons = screen.getAllByText('アカウント作成');
+    const submitButton = submitButtons.find(el => el.tagName === 'BUTTON');
+    fireEvent.click(submitButton!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/サインアップに成功しました/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/UserProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/UserProfilePage.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserProfilePage from '../UserProfilePage';
+
+const mockFetchMyProfile = vi.fn();
+const mockUpdateProfile = vi.fn();
+
+vi.mock('../../hooks/useUserProfile', () => ({
+  useUserProfile: () => ({
+    profile: null,
+    loading: false,
+    error: null,
+    fetchMyProfile: mockFetchMyProfile,
+    updateProfile: mockUpdateProfile,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+function renderUserProfilePage() {
+  return render(
+    <MemoryRouter>
+      <UserProfilePage />
+    </MemoryRouter>
+  );
+}
+
+describe('UserProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('基本情報セクションが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('基本情報')).toBeInTheDocument();
+  });
+
+  it('コミュニケーションスタイルセクションが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('コミュニケーションスタイル')).toBeInTheDocument();
+  });
+
+  it('AIフィードバック設定セクションが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('AIフィードバック設定')).toBeInTheDocument();
+  });
+
+  it('性格特性の選択肢が表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('内向的')).toBeInTheDocument();
+    expect(screen.getByText('外向的')).toBeInTheDocument();
+    expect(screen.getByText('論理的')).toBeInTheDocument();
+  });
+
+  it('保存ボタンが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByRole('button', { name: /パーソナリティを/ })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Closes #188

未テストだった4つのページコンポーネントにテストを追加しました。

## 追加テスト
- **LoginPage**: 4テスト（フォーム表示、リンク表示、ログイン成功遷移、失敗エラー表示）
- **SignupPage**: 4テスト（フォーム表示、リンク表示、失敗エラー、成功メッセージ）
- **ProfilePage**: 3テスト（ローディング表示、フォーム表示、取得失敗エラー）
- **UserProfilePage**: 5テスト（基本情報/コミュニケーション/AI設定セクション、性格特性、保存ボタン）

## テスト結果
- 追加テスト: +16件
- 全テスト: 232件 全て合格