### PR TITLE
test: メッセージ系・レイアウト系コンポーネントのテスト追加

### DIFF
--- a/frontend/src/components/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/components/__tests__/AuthLayout.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AuthLayout from '../AuthLayout';
+
+describe('AuthLayout', () => {
+  it('FreStyleロゴが表示される', () => {
+    render(<AuthLayout><div>テスト</div></AuthLayout>);
+
+    expect(screen.getByText('FreStyle')).toBeInTheDocument();
+  });
+
+  it('子要素が表示される', () => {
+    render(<AuthLayout><p>子コンテンツ</p></AuthLayout>);
+
+    expect(screen.getByText('子コンテンツ')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/MemberList.test.tsx
+++ b/frontend/src/components/__tests__/MemberList.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MemberList from '../MemberList';
+
+vi.mock('../../repositories/ChatRepository');
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('MemberList', () => {
+  it('メンバー一覧が表示される', () => {
+    const users = [
+      { id: 1, name: 'ユーザー1', email: 'user1@example.com' },
+      { id: 2, name: 'ユーザー2', email: 'user2@example.com', roomId: 5 },
+    ];
+
+    render(
+      <MemoryRouter>
+        <MemberList users={users} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('ユーザー1')).toBeInTheDocument();
+    expect(screen.getByText('ユーザー2')).toBeInTheDocument();
+  });
+
+  it('空のリストでは何も表示されない', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <MemberList users={[]} />
+      </MemoryRouter>
+    );
+
+    expect(container.querySelector('.space-y-4')?.children).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MessageBubble from '../MessageBubble';
+
+describe('MessageBubble', () => {
+  it('テキストメッセージが表示される', () => {
+    render(<MessageBubble isSender={false} content="こんにちは" id={1} />);
+
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+  });
+
+  it('送信者名が表示される（受信側）', () => {
+    render(<MessageBubble isSender={false} content="テスト" id={1} senderName="田中太郎" />);
+
+    expect(screen.getByText('田中太郎')).toBeInTheDocument();
+  });
+
+  it('送信側では送信者名が表示されない', () => {
+    render(<MessageBubble isSender={true} content="テスト" id={1} senderName="田中太郎" />);
+
+    expect(screen.queryByText('田中太郎')).not.toBeInTheDocument();
+  });
+
+  it('削除済みメッセージが表示される', () => {
+    render(<MessageBubble isSender={true} content="テスト" id={1} isDeleted={true} />);
+
+    expect(screen.getByText('メッセージを削除しました')).toBeInTheDocument();
+  });
+
+  it('言い換えボタンが送信者メッセージに表示される', () => {
+    const mockRephrase = vi.fn();
+    render(<MessageBubble isSender={true} content="テスト" id={1} onRephrase={mockRephrase} />);
+
+    expect(screen.getByText('言い換え')).toBeInTheDocument();
+  });
+
+  it('言い換えボタンクリックでonRephraseが呼ばれる', () => {
+    const mockRephrase = vi.fn();
+    render(<MessageBubble isSender={true} content="テストメッセージ" id={1} onRephrase={mockRephrase} />);
+
+    fireEvent.click(screen.getByText('言い換え'));
+    expect(mockRephrase).toHaveBeenCalledWith('テストメッセージ');
+  });
+});

--- a/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MessageBubbleAi from '../MessageBubbleAi';
+
+describe('MessageBubbleAi', () => {
+  it('テキストメッセージが表示される', () => {
+    render(<MessageBubbleAi isSender={false} content="AIの応答です" id={1} />);
+
+    expect(screen.getByText('AIの応答です')).toBeInTheDocument();
+  });
+
+  it('送信者メッセージが表示される', () => {
+    render(<MessageBubbleAi isSender={true} content="ユーザーの質問" id={1} />);
+
+    expect(screen.getByText('ユーザーの質問')).toBeInTheDocument();
+  });
+
+  it('削除済みメッセージが表示される', () => {
+    render(<MessageBubbleAi isSender={false} content="テスト" id={1} isDeleted={true} />);
+
+    expect(screen.getByText('メッセージを削除しました')).toBeInTheDocument();
+  });
+
+  it('画像タイプでimgが表示される', () => {
+    render(<MessageBubbleAi isSender={false} type="image" content="https://example.com/image.png" id={1} />);
+
+    expect(screen.getByAltText('画像')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/SNSSignInButton.test.tsx
+++ b/frontend/src/components/__tests__/SNSSignInButton.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SNSSignInButton from '../SNSSignInButton';
+
+describe('SNSSignInButton', () => {
+  it('Googleログインボタンが表示される', () => {
+    render(<SNSSignInButton provider="google" onClick={vi.fn()} />);
+
+    expect(screen.getByText('Googleでログイン')).toBeInTheDocument();
+  });
+
+  it('クリックでonClickが呼ばれる', () => {
+    const mockOnClick = vi.fn();
+    render(<SNSSignInButton provider="google" onClick={mockOnClick} />);
+
+    fireEvent.click(screen.getByText('Googleでログイン'));
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('Facebookログインボタンが表示される', () => {
+    render(<SNSSignInButton provider="facebook" onClick={vi.fn()} />);
+
+    expect(screen.getByText('Facebookでログイン')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/__tests__/UserAvatar.test.tsx
+++ b/frontend/src/components/layout/__tests__/UserAvatar.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import UserAvatar from '../UserAvatar';
+
+describe('UserAvatar', () => {
+  it('名前の頭文字が表示される', () => {
+    render(<UserAvatar name="テストユーザー" />);
+
+    expect(screen.getByText('テ')).toBeInTheDocument();
+  });
+
+  it('英字名の大文字頭文字が表示される', () => {
+    render(<UserAvatar name="alice" />);
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('名前が空の場合?が表示される', () => {
+    render(<UserAvatar name="" />);
+
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Closes #190

残りの未テストコンポーネント6つにテストを追加しました。

## 追加テスト
- **MessageBubble**: 6テスト（テキスト表示、送信者名、削除済み、言い換えボタン）
- **MessageBubbleAi**: 4テスト（テキスト、送信者、削除済み、画像タイプ）
- **AuthLayout**: 2テスト（ロゴ表示、子要素表示）
- **SNSSignInButton**: 3テスト（Google/Facebookボタン、クリック）
- **UserAvatar**: 3テスト（日本語/英字頭文字、空名前）
- **MemberList**: 2テスト（一覧表示、空リスト）

## テスト結果
- 追加テスト: +20件
- 全テスト: 252件 全て合格