### PR TITLE
feat: スキルレーダーチャートをスコア履歴ページに追加

### DIFF
--- a/frontend/src/components/SkillRadarChart.tsx
+++ b/frontend/src/components/SkillRadarChart.tsx
@@ -1,0 +1,132 @@
+import type { AxisScore } from '../types';
+
+interface SkillRadarChartProps {
+  scores: AxisScore[];
+  title?: string;
+}
+
+const SIZE = 200;
+const CENTER = SIZE / 2;
+const RADIUS = 70;
+const GRID_LEVELS = [2, 4, 6, 8, 10];
+
+function polarToCartesian(angle: number, radius: number): { x: number; y: number } {
+  // Start from top (-90 degrees)
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return {
+    x: CENTER + radius * Math.cos(rad),
+    y: CENTER + radius * Math.sin(rad),
+  };
+}
+
+function getPolygonPoints(values: number[], maxValue: number): string {
+  if (values.length === 0) return '';
+  const angleStep = 360 / values.length;
+  return values
+    .map((value, i) => {
+      const ratio = value / maxValue;
+      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+}
+
+function getGridPoints(level: number, count: number): string {
+  if (count === 0) return '';
+  const angleStep = 360 / count;
+  const ratio = level / 10;
+  return Array.from({ length: count })
+    .map((_, i) => {
+      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+}
+
+export default function SkillRadarChart({ scores, title }: SkillRadarChartProps) {
+  const axisCount = scores.length || 5;
+  const angleStep = 360 / axisCount;
+
+  return (
+    <div className="flex flex-col items-center">
+      {title && (
+        <h4 className="text-xs font-semibold text-slate-700 mb-2">{title}</h4>
+      )}
+      <svg viewBox={`0 0 ${SIZE} ${SIZE}`} width={SIZE} height={SIZE}>
+        {/* グリッド線 */}
+        {GRID_LEVELS.map((level) => (
+          <polygon
+            key={level}
+            className="grid"
+            points={getGridPoints(level, axisCount)}
+            fill="none"
+            stroke="rgb(226, 232, 240)"
+            strokeWidth={level === 10 ? 1 : 0.5}
+          />
+        ))}
+
+        {/* 軸線 */}
+        {scores.map((_, i) => {
+          const point = polarToCartesian(i * angleStep, RADIUS);
+          return (
+            <line
+              key={i}
+              x1={CENTER}
+              y1={CENTER}
+              x2={point.x}
+              y2={point.y}
+              stroke="rgb(226, 232, 240)"
+              strokeWidth={0.5}
+            />
+          );
+        })}
+
+        {/* スコアポリゴン */}
+        {scores.length > 0 && (
+          <polygon
+            points={getPolygonPoints(
+              scores.map((s) => s.score),
+              10
+            )}
+            fill="rgba(99, 102, 241, 0.2)"
+            stroke="rgb(99, 102, 241)"
+            strokeWidth={1.5}
+          />
+        )}
+
+        {/* スコアドット */}
+        {scores.map((s, i) => {
+          const ratio = s.score / 10;
+          const point = polarToCartesian(i * angleStep, RADIUS * ratio);
+          return (
+            <circle
+              key={i}
+              cx={point.x}
+              cy={point.y}
+              r={2.5}
+              fill="rgb(99, 102, 241)"
+            />
+          );
+        })}
+
+        {/* ラベル */}
+        {scores.map((s, i) => {
+          const point = polarToCartesian(i * angleStep, RADIUS + 18);
+          return (
+            <text
+              key={i}
+              x={point.x}
+              y={point.y}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              className="fill-slate-600"
+              fontSize={8}
+            >
+              {s.axis}
+            </text>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SkillRadarChart.test.tsx
+++ b/frontend/src/components/__tests__/SkillRadarChart.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SkillRadarChart from '../SkillRadarChart';
+import type { AxisScore } from '../../types';
+
+const mockScores: AxisScore[] = [
+  { axis: '論理的構成力', score: 8, comment: '' },
+  { axis: '配慮表現', score: 6, comment: '' },
+  { axis: '要約力', score: 7, comment: '' },
+  { axis: '提案力', score: 5, comment: '' },
+  { axis: '質問・傾聴力', score: 9, comment: '' },
+];
+
+describe('SkillRadarChart', () => {
+  it('レーダーチャートが描画される', () => {
+    const { container } = render(<SkillRadarChart scores={mockScores} />);
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('5軸のラベルが表示される', () => {
+    render(<SkillRadarChart scores={mockScores} />);
+
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('配慮表現')).toBeInTheDocument();
+    expect(screen.getByText('要約力')).toBeInTheDocument();
+    expect(screen.getByText('提案力')).toBeInTheDocument();
+    expect(screen.getByText('質問・傾聴力')).toBeInTheDocument();
+  });
+
+  it('スコアのポリゴンが描画される', () => {
+    const { container } = render(<SkillRadarChart scores={mockScores} />);
+
+    const polygon = container.querySelector('polygon');
+    expect(polygon).toBeInTheDocument();
+  });
+
+  it('グリッド線が描画される', () => {
+    const { container } = render(<SkillRadarChart scores={mockScores} />);
+
+    // 5段階のグリッド（2, 4, 6, 8, 10）
+    const circles = container.querySelectorAll('polygon[class*="grid"]');
+    expect(circles.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('タイトルが表示される', () => {
+    render(<SkillRadarChart scores={mockScores} title="スキルバランス" />);
+
+    expect(screen.getByText('スキルバランス')).toBeInTheDocument();
+  });
+
+  it('空のスコアでもクラッシュしない', () => {
+    const { container } = render(<SkillRadarChart scores={[]} />);
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAiChat } from '../hooks/useAiChat';
 import { SkeletonCard } from '../components/Skeleton';
+import SkillRadarChart from '../components/SkillRadarChart';
 
 interface AxisScore {
   axis: string;
@@ -91,6 +92,13 @@ export default function ScoreHistoryPage() {
           >
             練習一覧を見る
           </button>
+        </div>
+      )}
+
+      {/* スキルレーダーチャート */}
+      {latestSession && latestSession.scores.length > 0 && (
+        <div className="bg-white rounded-lg border border-slate-200 p-4 flex justify-center">
+          <SkillRadarChart scores={latestSession.scores} title="最新のスキルバランス" />
         </div>
       )}
 


### PR DESCRIPTION
## 概要
closes #192

スコア履歴ページに最新セッションのスキルバランスをレーダーチャートで表示する機能を追加しました。

## 変更内容
- SVGベースのレーダーチャートコンポーネント (`SkillRadarChart.tsx`) を新規作成
- 5軸（論理的構成力・配慮表現・要約力・提案力・質問・傾聴力）のスコアをポリゴン表示
- 5段階グリッド線・スコアドット・軸ラベルを描画
- スコア履歴ページに最新セッションのレーダーチャートを統合

## テスト
- SkillRadarChart テスト6件追加（全258テスト通過）
  - SVG描画確認
  - 5軸ラベル表示
  - スコアポリゴン描画
  - グリッド線描画
  - タイトル表示
  - 空データでのクラッシュ防止