### PR TITLE
feat: お気に入りフレーズ集機能の追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import MenuPage from './pages/MenuPage';
 import AskAiPage from './pages/AskAiPage';
 import PracticePage from './pages/PracticePage';
 import ScoreHistoryPage from './pages/ScoreHistoryPage';
+import FavoritesPage from './pages/FavoritesPage';
 import ConfirmPage from './pages/ConfirmPage';
 import MemberPage from './pages/MemberPage';
 import AddUserPage from './pages/AddUserPage';
@@ -55,7 +56,7 @@ export default function App() {
         <Route path="/chat/users/:roomId" element={<ChatPage />} />
         <Route path="/practice" element={<PracticePage />} />
         <Route path="/scores" element={<ScoreHistoryPage />} />
-        <Route path="/scores" element={<ScoreHistoryPage />} />
+        <Route path="/favorites" element={<FavoritesPage />} />
         <Route path="/chat/ask-ai" element={<AskAiPage />} />
         <Route path="/chat/ask-ai/:sessionId" element={<AskAiPage />} />
       </Route>

--- a/frontend/src/components/__tests__/RephraseModal.test.tsx
+++ b/frontend/src/components/__tests__/RephraseModal.test.tsx
@@ -2,6 +2,15 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import RephraseModal from '../RephraseModal';
 
+vi.mock('../../hooks/useFavoritePhrase', () => ({
+  useFavoritePhrase: () => ({
+    saveFavorite: vi.fn(),
+    removeFavorite: vi.fn(),
+    isFavorite: vi.fn().mockReturnValue(false),
+    phrases: [],
+  }),
+}));
+
 describe('RephraseModal', () => {
   const mockOnClose = vi.fn();
   const rephraseResult = {
@@ -17,7 +26,7 @@ describe('RephraseModal', () => {
   });
 
   it('3パターンの言い換え結果が表示される', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     expect(screen.getByText('フォーマル')).toBeInTheDocument();
     expect(screen.getByText('ソフト')).toBeInTheDocument();
@@ -28,52 +37,59 @@ describe('RephraseModal', () => {
   });
 
   it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     fireEvent.click(screen.getByText('閉じる'));
     expect(mockOnClose).toHaveBeenCalled();
   });
 
   it('各パターンにコピーボタンが表示される', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     const copyButtons = screen.getAllByText('コピー');
     expect(copyButtons).toHaveLength(5);
   });
 
   it('ローディング中はスピナーが表示される', () => {
-    render(<RephraseModal result={null} onClose={mockOnClose} />);
+    render(<RephraseModal result={null} onClose={mockOnClose} originalText="元のテキスト" />);
 
     expect(screen.getByText('言い換え中...')).toBeInTheDocument();
   });
 
   it('質問型パターンが表示される', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     expect(screen.getByText('質問型')).toBeInTheDocument();
     expect(screen.getByText('質問型の言い換え文です。')).toBeInTheDocument();
   });
 
   it('提案型パターンが表示される', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     expect(screen.getByText('提案型')).toBeInTheDocument();
     expect(screen.getByText('提案型の言い換え文です。')).toBeInTheDocument();
   });
 
   it('5パターン全てにコピーボタンが表示される', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     const copyButtons = screen.getAllByText('コピー');
     expect(copyButtons).toHaveLength(5);
   });
 
   it('各パターンに利用シーンの説明が表示される', () => {
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     expect(screen.getByText(/上司や顧客への報告/)).toBeInTheDocument();
     expect(screen.getByText(/指摘やお願いをする時/)).toBeInTheDocument();
     expect(screen.getByText(/チャットやSlackで/)).toBeInTheDocument();
+  });
+
+  it('各パターンにお気に入りボタンが表示される', () => {
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
+
+    const favButtons = screen.getAllByLabelText('お気に入りに追加');
+    expect(favButtons).toHaveLength(5);
   });
 
   it('コピーボタンクリックでフィードバックが表示される', async () => {
@@ -82,7 +98,7 @@ describe('RephraseModal', () => {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
 
-    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} />);
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
 
     const copyButtons = screen.getAllByText('コピー');
     fireEvent.click(copyButtons[0]);

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   AcademicCapIcon,
   MagnifyingGlassIcon,
   ChartBarIcon,
+  StarIcon,
   UserCircleIcon,
   LightBulbIcon,
   ArrowLeftOnRectangleIcon,
@@ -23,6 +24,7 @@ const navItems = [
   { icon: AcademicCapIcon, label: '練習', to: '/practice', matchPrefix: '/practice' },
   { icon: MagnifyingGlassIcon, label: 'ユーザー検索', to: '/chat/users', matchExact: true },
   { icon: ChartBarIcon, label: 'スコア履歴', to: '/scores', matchExact: true },
+  { icon: StarIcon, label: 'お気に入り', to: '/favorites', matchExact: true },
 ];
 
 const bottomNavItems = [

--- a/frontend/src/hooks/__tests__/useFavoritePhrase.test.ts
+++ b/frontend/src/hooks/__tests__/useFavoritePhrase.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFavoritePhrase } from '../useFavoritePhrase';
+import { FavoritePhraseRepository } from '../../repositories/FavoritePhraseRepository';
+
+vi.mock('../../repositories/FavoritePhraseRepository');
+
+const mockedRepo = vi.mocked(FavoritePhraseRepository);
+
+describe('useFavoritePhrase', () => {
+  beforeEach(() => {
+    mockedRepo.getAll.mockReturnValue([]);
+    mockedRepo.exists.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態でフレーズ一覧を取得する', () => {
+    const mockPhrases = [
+      { id: '1', originalText: 'テスト', rephrasedText: '言い換え', pattern: 'フォーマル', createdAt: '2026-01-01' },
+    ];
+    mockedRepo.getAll.mockReturnValue(mockPhrases);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    expect(result.current.phrases).toEqual(mockPhrases);
+    expect(mockedRepo.getAll).toHaveBeenCalled();
+  });
+
+  it('フレーズを保存して一覧を更新する', () => {
+    const newPhrase = { id: '1', originalText: 'テスト', rephrasedText: '言い換え', pattern: 'フォーマル', createdAt: '2026-01-01' };
+    mockedRepo.getAll
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([newPhrase]);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    act(() => {
+      result.current.saveFavorite('テスト', '言い換え', 'フォーマル');
+    });
+
+    expect(mockedRepo.save).toHaveBeenCalledWith({
+      originalText: 'テスト',
+      rephrasedText: '言い換え',
+      pattern: 'フォーマル',
+    });
+    expect(result.current.phrases).toEqual([newPhrase]);
+  });
+
+  it('フレーズを削除して一覧を更新する', () => {
+    const phrase = { id: '1', originalText: 'テスト', rephrasedText: '言い換え', pattern: 'フォーマル', createdAt: '2026-01-01' };
+    mockedRepo.getAll
+      .mockReturnValueOnce([phrase])
+      .mockReturnValueOnce([]);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    act(() => {
+      result.current.removeFavorite('1');
+    });
+
+    expect(mockedRepo.remove).toHaveBeenCalledWith('1');
+    expect(result.current.phrases).toEqual([]);
+  });
+
+  it('重複チェックが機能する', () => {
+    mockedRepo.exists.mockReturnValue(true);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    expect(result.current.isFavorite('言い換え', 'フォーマル')).toBe(true);
+    expect(mockedRepo.exists).toHaveBeenCalledWith('言い換え', 'フォーマル');
+  });
+});

--- a/frontend/src/hooks/useFavoritePhrase.ts
+++ b/frontend/src/hooks/useFavoritePhrase.ts
@@ -1,0 +1,23 @@
+import { useState, useCallback } from 'react';
+import { FavoritePhraseRepository } from '../repositories/FavoritePhraseRepository';
+import type { FavoritePhrase } from '../types';
+
+export function useFavoritePhrase() {
+  const [phrases, setPhrases] = useState<FavoritePhrase[]>(() => FavoritePhraseRepository.getAll());
+
+  const saveFavorite = useCallback((originalText: string, rephrasedText: string, pattern: string) => {
+    FavoritePhraseRepository.save({ originalText, rephrasedText, pattern });
+    setPhrases(FavoritePhraseRepository.getAll());
+  }, []);
+
+  const removeFavorite = useCallback((id: string) => {
+    FavoritePhraseRepository.remove(id);
+    setPhrases(FavoritePhraseRepository.getAll());
+  }, []);
+
+  const isFavorite = useCallback((rephrasedText: string, pattern: string) => {
+    return FavoritePhraseRepository.exists(rephrasedText, pattern);
+  }, []);
+
+  return { phrases, saveFavorite, removeFavorite, isFavorite };
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ export default function ChatPage() {
   const [showSceneSelector, setShowSceneSelector] = useState(false);
   const [showRephraseModal, setShowRephraseModal] = useState(false);
   const [rephraseResult, setRephraseResult] = useState<{ formal: string; soft: string; concise: string } | null>(null);
+  const [rephraseOriginalText, setRephraseOriginalText] = useState('');
   const stompClientRef = useRef<Client | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
 
@@ -339,6 +340,7 @@ export default function ChatPage() {
   // --- 言い換え提案 ---
   const handleRephrase = async (content: string) => {
     setRephraseResult(null);
+    setRephraseOriginalText(content);
     setShowRephraseModal(true);
 
     try {
@@ -560,6 +562,7 @@ export default function ChatPage() {
         <RephraseModal
           result={rephraseResult}
           onClose={() => setShowRephraseModal(false)}
+          originalText={rephraseOriginalText}
         />
       )}
 

--- a/frontend/src/pages/FavoritesPage.tsx
+++ b/frontend/src/pages/FavoritesPage.tsx
@@ -1,0 +1,47 @@
+import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
+
+export default function FavoritesPage() {
+  const { phrases, removeFavorite } = useFavoritePhrase();
+
+  return (
+    <div className="max-w-3xl mx-auto p-4 space-y-3">
+      <h2 className="text-sm font-semibold text-slate-800">お気に入りフレーズ</h2>
+
+      {phrases.length === 0 ? (
+        <div className="flex flex-col items-center justify-center h-64 text-slate-500">
+          <p className="text-sm font-medium">お気に入りフレーズがありません</p>
+          <p className="text-xs mt-1">言い換え提案で☆をタップするとここに保存されます</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {phrases.map((phrase) => (
+            <div
+              key={phrase.id}
+              className="bg-white rounded-lg border border-slate-200 p-4"
+            >
+              <div className="flex items-start justify-between mb-2">
+                <span className="text-[10px] font-medium text-primary-600 bg-primary-50 px-2 py-0.5 rounded">
+                  {phrase.pattern}
+                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-[10px] text-slate-400">
+                    {new Date(phrase.createdAt).toLocaleDateString('ja-JP')}
+                  </span>
+                  <button
+                    onClick={() => removeFavorite(phrase.id)}
+                    aria-label="お気に入りから削除"
+                    className="text-xs text-slate-400 hover:text-rose-500 transition-colors"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+              <p className="text-sm text-slate-800 mb-1">{phrase.rephrasedText}</p>
+              <p className="text-xs text-slate-400">元: {phrase.originalText}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/FavoritesPage.test.tsx
+++ b/frontend/src/pages/__tests__/FavoritesPage.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FavoritesPage from '../FavoritesPage';
+
+const mockRemoveFavorite = vi.fn();
+
+vi.mock('../../hooks/useFavoritePhrase', () => ({
+  useFavoritePhrase: () => ({
+    phrases: mockPhrases,
+    removeFavorite: mockRemoveFavorite,
+    saveFavorite: vi.fn(),
+    isFavorite: vi.fn(),
+  }),
+}));
+
+let mockPhrases = [
+  {
+    id: '1',
+    originalText: '確認お願いします',
+    rephrasedText: 'ご確認いただけますでしょうか',
+    pattern: 'フォーマル',
+    createdAt: '2026-01-15T10:00:00.000Z',
+  },
+  {
+    id: '2',
+    originalText: 'これでいいですか',
+    rephrasedText: 'こちらの内容でよろしいでしょうか',
+    pattern: 'ソフト',
+    createdAt: '2026-01-14T10:00:00.000Z',
+  },
+];
+
+describe('FavoritesPage', () => {
+  beforeEach(() => {
+    mockRemoveFavorite.mockClear();
+  });
+
+  it('お気に入りフレーズ一覧が表示される', () => {
+    render(<FavoritesPage />);
+
+    expect(screen.getByText('お気に入りフレーズ')).toBeInTheDocument();
+    expect(screen.getByText('ご確認いただけますでしょうか')).toBeInTheDocument();
+    expect(screen.getByText('こちらの内容でよろしいでしょうか')).toBeInTheDocument();
+  });
+
+  it('パターンラベルが表示される', () => {
+    render(<FavoritesPage />);
+
+    expect(screen.getByText('フォーマル')).toBeInTheDocument();
+    expect(screen.getByText('ソフト')).toBeInTheDocument();
+  });
+
+  it('元のテキストが表示される', () => {
+    render(<FavoritesPage />);
+
+    expect(screen.getByText(/確認お願いします/)).toBeInTheDocument();
+    expect(screen.getByText(/これでいいですか/)).toBeInTheDocument();
+  });
+
+  it('削除ボタンでremoveFavoriteが呼ばれる', () => {
+    render(<FavoritesPage />);
+
+    const deleteButtons = screen.getAllByLabelText('お気に入りから削除');
+    fireEvent.click(deleteButtons[0]);
+
+    expect(mockRemoveFavorite).toHaveBeenCalledWith('1');
+  });
+
+  it('フレーズが空のときメッセージが表示される', () => {
+    mockPhrases = [];
+
+    render(<FavoritesPage />);
+
+    expect(screen.getByText('お気に入りフレーズがありません')).toBeInTheDocument();
+
+    // 元に戻す
+    mockPhrases = [
+      {
+        id: '1',
+        originalText: '確認お願いします',
+        rephrasedText: 'ご確認いただけますでしょうか',
+        pattern: 'フォーマル',
+        createdAt: '2026-01-15T10:00:00.000Z',
+      },
+      {
+        id: '2',
+        originalText: 'これでいいですか',
+        rephrasedText: 'こちらの内容でよろしいでしょうか',
+        pattern: 'ソフト',
+        createdAt: '2026-01-14T10:00:00.000Z',
+      },
+    ];
+  });
+});

--- a/frontend/src/repositories/FavoritePhraseRepository.ts
+++ b/frontend/src/repositories/FavoritePhraseRepository.ts
@@ -1,0 +1,34 @@
+import type { FavoritePhrase } from '../types';
+
+const STORAGE_KEY = 'freestyle_favorite_phrases';
+
+export const FavoritePhraseRepository = {
+  getAll(): FavoritePhrase[] {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const phrases: FavoritePhrase[] = JSON.parse(raw);
+    return phrases.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  },
+
+  save(phrase: Omit<FavoritePhrase, 'id' | 'createdAt'>): void {
+    const all = this.getAll();
+    const newPhrase: FavoritePhrase = {
+      ...phrase,
+      id: `fav_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      createdAt: new Date(Date.now()).toISOString(),
+    };
+    all.push(newPhrase);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  },
+
+  remove(id: string): void {
+    const all = this.getAll();
+    const filtered = all.filter((p) => p.id !== id);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  },
+
+  exists(rephrasedText: string, pattern: string): boolean {
+    const all = this.getAll();
+    return all.some((p) => p.rephrasedText === rephrasedText && p.pattern === pattern);
+  },
+};

--- a/frontend/src/repositories/__tests__/FavoritePhraseRepository.test.ts
+++ b/frontend/src/repositories/__tests__/FavoritePhraseRepository.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FavoritePhraseRepository } from '../FavoritePhraseRepository';
+
+const STORAGE_KEY = 'freestyle_favorite_phrases';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+describe('FavoritePhraseRepository', () => {
+  let mockStorage: Storage;
+
+  beforeEach(() => {
+    mockStorage = createMockStorage();
+    vi.stubGlobal('localStorage', mockStorage);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('初期状態では空配列を返す', () => {
+    const result = FavoritePhraseRepository.getAll();
+    expect(result).toEqual([]);
+  });
+
+  it('フレーズを保存できる', () => {
+    FavoritePhraseRepository.save({
+      originalText: '確認お願いします',
+      rephrasedText: 'ご確認いただけますでしょうか',
+      pattern: 'フォーマル',
+    });
+
+    const all = FavoritePhraseRepository.getAll();
+    expect(all).toHaveLength(1);
+    expect(all[0].originalText).toBe('確認お願いします');
+    expect(all[0].rephrasedText).toBe('ご確認いただけますでしょうか');
+    expect(all[0].pattern).toBe('フォーマル');
+    expect(all[0].id).toBeDefined();
+    expect(all[0].createdAt).toBeDefined();
+  });
+
+  it('複数フレーズを保存でき、新しい順に返される', () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(2000);
+
+    FavoritePhraseRepository.save({
+      originalText: 'テスト1',
+      rephrasedText: '言い換え1',
+      pattern: 'ソフト',
+    });
+    FavoritePhraseRepository.save({
+      originalText: 'テスト2',
+      rephrasedText: '言い換え2',
+      pattern: '簡潔',
+    });
+
+    const all = FavoritePhraseRepository.getAll();
+    expect(all).toHaveLength(2);
+    expect(all[0].originalText).toBe('テスト2');
+    expect(all[1].originalText).toBe('テスト1');
+
+    vi.restoreAllMocks();
+  });
+
+  it('フレーズを削除できる', () => {
+    FavoritePhraseRepository.save({
+      originalText: 'テスト',
+      rephrasedText: '言い換え',
+      pattern: 'フォーマル',
+    });
+
+    const all = FavoritePhraseRepository.getAll();
+    expect(all).toHaveLength(1);
+
+    FavoritePhraseRepository.remove(all[0].id);
+
+    expect(FavoritePhraseRepository.getAll()).toHaveLength(0);
+  });
+
+  it('存在しないIDの削除はエラーにならない', () => {
+    expect(() => FavoritePhraseRepository.remove('nonexistent')).not.toThrow();
+  });
+
+  it('重複チェックが機能する', () => {
+    FavoritePhraseRepository.save({
+      originalText: 'テスト',
+      rephrasedText: '言い換え',
+      pattern: 'フォーマル',
+    });
+
+    expect(FavoritePhraseRepository.exists('言い換え', 'フォーマル')).toBe(true);
+    expect(FavoritePhraseRepository.exists('言い換え', 'ソフト')).toBe(false);
+    expect(FavoritePhraseRepository.exists('別のテキスト', 'フォーマル')).toBe(false);
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -117,3 +117,12 @@ export interface ScoreCard {
 
 /** SNSプロバイダー */
 export type SnsProvider = 'google' | 'facebook' | 'x';
+
+/** お気に入りフレーズ */
+export interface FavoritePhrase {
+  id: string;
+  originalText: string;
+  rephrasedText: string;
+  pattern: string;
+  createdAt: string;
+}


### PR DESCRIPTION
## 概要
closes #194

言い換え提案で生成されたフレーズをお気に入りとしてLocalStorageに保存し、一覧で閲覧・管理できる機能を追加。

## 変更内容
- `FavoritePhraseRepository`: LocalStorageベースのCRUD + 重複チェック
- `useFavoritePhrase` Hook: フレーズ管理のカスタムフック
- `RephraseModal`: 各パターンにお気に入りボタン（☆/★）追加
- `FavoritesPage`: お気に入りフレーズ一覧・パターンラベル・削除機能
- サイドバーに「お気に入り」ナビゲーション追加
- ルーティングに `/favorites` パス追加

## テスト
- 新規テスト16件追加（全274テスト通過）
  - FavoritePhraseRepository: 6件（CRUD・重複チェック）
  - useFavoritePhrase Hook: 4件（保存・削除・重複チェック）
  - RephraseModal: 1件（お気に入りボタン表示）
  - FavoritesPage: 5件（一覧表示・削除・空状態）