### PR TITLE
feat: 練習タイマー機能の追加

### DIFF
--- a/frontend/src/components/PracticeTimer.tsx
+++ b/frontend/src/components/PracticeTimer.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+import { usePracticeTimer } from '../hooks/usePracticeTimer';
+
+export default function PracticeTimer() {
+  const { formattedTime, start, stop } = usePracticeTimer();
+
+  useEffect(() => {
+    start();
+    return () => stop();
+  }, [start, stop]);
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-slate-500">
+      <span>経過時間</span>
+      <span className="font-mono font-medium text-slate-700">{formattedTime}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeTimer.test.tsx
+++ b/frontend/src/components/__tests__/PracticeTimer.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PracticeTimer from '../PracticeTimer';
+
+vi.mock('../../hooks/usePracticeTimer', () => ({
+  usePracticeTimer: () => ({
+    seconds: 125,
+    isRunning: true,
+    formattedTime: '02:05',
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+describe('PracticeTimer', () => {
+  it('経過時間が表示される', () => {
+    render(<PracticeTimer />);
+
+    expect(screen.getByText('02:05')).toBeInTheDocument();
+  });
+
+  it('タイマーラベルが表示される', () => {
+    render(<PracticeTimer />);
+
+    expect(screen.getByText('経過時間')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/usePracticeTimer.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticeTimer.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePracticeTimer } from '../usePracticeTimer';
+
+describe('usePracticeTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('初期状態は停止中で0秒', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    expect(result.current.seconds).toBe(0);
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.formattedTime).toBe('00:00');
+  });
+
+  it('startで計測開始し、秒数が増加する', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(result.current.isRunning).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.seconds).toBe(3);
+  });
+
+  it('stopで計測停止する', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(result.current.isRunning).toBe(false);
+    expect(result.current.seconds).toBe(5);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.seconds).toBe(5);
+  });
+
+  it('resetでタイマーをリセットする', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.seconds).toBe(0);
+    expect(result.current.isRunning).toBe(false);
+  });
+
+  it('formattedTimeが正しいフォーマットで返される', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(65000); // 1分5秒
+    });
+
+    expect(result.current.formattedTime).toBe('01:05');
+  });
+});

--- a/frontend/src/hooks/usePracticeTimer.ts
+++ b/frontend/src/hooks/usePracticeTimer.ts
@@ -1,0 +1,36 @@
+import { useState, useRef, useCallback, useMemo } from 'react';
+
+export function usePracticeTimer() {
+  const [seconds, setSeconds] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const start = useCallback(() => {
+    if (intervalRef.current) return;
+    setIsRunning(true);
+    intervalRef.current = setInterval(() => {
+      setSeconds((prev) => prev + 1);
+    }, 1000);
+  }, []);
+
+  const stop = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setIsRunning(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    stop();
+    setSeconds(0);
+  }, [stop]);
+
+  const formattedTime = useMemo(() => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  }, [seconds]);
+
+  return { seconds, isRunning, formattedTime, start, stop, reset };
+}

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -5,6 +5,7 @@ import ConfirmModal from '../components/ConfirmModal';
 import ScoreCardComponent from '../components/ScoreCard';
 import PracticeResultSummary from '../components/PracticeResultSummary';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
+import PracticeTimer from '../components/PracticeTimer';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { AiMessage, AiSession, ScoreCard } from '../types';
 import { useAuth } from '../hooks/useAuth';
@@ -336,12 +337,15 @@ export default function AskAiPage() {
               </h2>
               <p className="text-xs text-slate-500">AIが相手役を演じます</p>
             </div>
-            <button
-              onClick={() => handleSend('練習を終了して、今回の会話全体に対するフィードバックとスコアカードをお願いします。')}
-              className="bg-rose-500 text-white text-xs px-3 py-1.5 rounded-lg hover:bg-rose-600 transition-colors"
-            >
-              練習終了
-            </button>
+            <div className="flex items-center gap-3">
+              <PracticeTimer />
+              <button
+                onClick={() => handleSend('練習を終了して、今回の会話全体に対するフィードバックとスコアカードをお願いします。')}
+                className="bg-rose-500 text-white text-xs px-3 py-1.5 rounded-lg hover:bg-rose-600 transition-colors"
+              >
+                練習終了
+              </button>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## 概要
closes #196

練習セッション中に経過時間をリアルタイム表示するタイマー機能を追加。

## 変更内容
- `usePracticeTimer` Hook: 開始・停止・リセット・MM:SSフォーマット表示
- `PracticeTimer` コンポーネント: 自動開始のタイマーUI
- `AskAiPage`: 練習モードヘッダーにタイマーと練習終了ボタンを横並び配置

## テスト
- 新規テスト7件追加（全281テスト通過）
  - usePracticeTimer Hook: 5件（初期状態・開始・停止・リセット・フォーマット）
  - PracticeTimer コンポーネント: 2件（時間表示・ラベル表示）