### PR TITLE
feat: 日次学習目標機能の追加

### DIFF
--- a/frontend/src/components/DailyGoalCard.tsx
+++ b/frontend/src/components/DailyGoalCard.tsx
@@ -1,0 +1,40 @@
+import { useDailyGoal } from '../hooks/useDailyGoal';
+
+export default function DailyGoalCard() {
+  const { goal, isAchieved, progress } = useDailyGoal();
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-medium text-slate-700">今日の目標</p>
+        <span className="text-xs text-slate-500">
+          <span className="font-semibold text-slate-800">{goal.completed}</span>
+          {' / '}
+          <span>{goal.target}</span>
+          {' 回'}
+        </span>
+      </div>
+
+      <div
+        role="progressbar"
+        aria-valuenow={progress}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className="w-full bg-slate-100 rounded-full h-2"
+      >
+        <div
+          className={`h-2 rounded-full transition-all duration-300 ${
+            isAchieved ? 'bg-emerald-500' : 'bg-primary-500'
+          }`}
+          style={{ width: `${Math.min(progress, 100)}%` }}
+        />
+      </div>
+
+      {isAchieved && (
+        <p className="text-xs text-emerald-600 font-medium mt-2">
+          目標達成！お疲れさまでした
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/DailyGoalCard.test.tsx
+++ b/frontend/src/components/__tests__/DailyGoalCard.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DailyGoalCard from '../DailyGoalCard';
+
+vi.mock('../../hooks/useDailyGoal', () => ({
+  useDailyGoal: () => mockGoalState,
+}));
+
+let mockGoalState = {
+  goal: { date: '2026-02-13', target: 3, completed: 1 },
+  isAchieved: false,
+  progress: 33,
+  setTarget: vi.fn(),
+  incrementCompleted: vi.fn(),
+};
+
+describe('DailyGoalCard', () => {
+  it('今日の目標と進捗が表示される', () => {
+    render(<DailyGoalCard />);
+
+    expect(screen.getByText('今日の目標')).toBeInTheDocument();
+    expect(screen.getByText(/1/)).toBeInTheDocument();
+    expect(screen.getByText(/3/)).toBeInTheDocument();
+  });
+
+  it('プログレスバーが表示される', () => {
+    const { container } = render(<DailyGoalCard />);
+
+    const progressBar = container.querySelector('[role="progressbar"]');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('目標達成時にメッセージが表示される', () => {
+    mockGoalState = {
+      goal: { date: '2026-02-13', target: 3, completed: 3 },
+      isAchieved: true,
+      progress: 100,
+      setTarget: vi.fn(),
+      incrementCompleted: vi.fn(),
+    };
+
+    render(<DailyGoalCard />);
+
+    expect(screen.getByText(/達成/)).toBeInTheDocument();
+
+    // 元に戻す
+    mockGoalState = {
+      goal: { date: '2026-02-13', target: 3, completed: 1 },
+      isAchieved: false,
+      progress: 33,
+      setTarget: vi.fn(),
+      incrementCompleted: vi.fn(),
+    };
+  });
+});

--- a/frontend/src/hooks/__tests__/useDailyGoal.test.ts
+++ b/frontend/src/hooks/__tests__/useDailyGoal.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDailyGoal } from '../useDailyGoal';
+import { DailyGoalRepository } from '../../repositories/DailyGoalRepository';
+
+vi.mock('../../repositories/DailyGoalRepository');
+
+const mockedRepo = vi.mocked(DailyGoalRepository);
+
+describe('useDailyGoal', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態で今日の目標を取得する', () => {
+    mockedRepo.getToday.mockReturnValue({ date: '2026-02-13', target: 3, completed: 1 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    expect(result.current.goal.target).toBe(3);
+    expect(result.current.goal.completed).toBe(1);
+    expect(result.current.isAchieved).toBe(false);
+  });
+
+  it('目標達成時にisAchievedがtrueになる', () => {
+    mockedRepo.getToday.mockReturnValue({ date: '2026-02-13', target: 3, completed: 3 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    expect(result.current.isAchieved).toBe(true);
+  });
+
+  it('目標数を更新できる', () => {
+    mockedRepo.getToday
+      .mockReturnValueOnce({ date: '2026-02-13', target: 3, completed: 0 })
+      .mockReturnValueOnce({ date: '2026-02-13', target: 5, completed: 0 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    act(() => {
+      result.current.setTarget(5);
+    });
+
+    expect(mockedRepo.setTarget).toHaveBeenCalledWith(5);
+    expect(result.current.goal.target).toBe(5);
+  });
+
+  it('完了数を増加できる', () => {
+    mockedRepo.getToday
+      .mockReturnValueOnce({ date: '2026-02-13', target: 3, completed: 0 })
+      .mockReturnValueOnce({ date: '2026-02-13', target: 3, completed: 1 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    act(() => {
+      result.current.incrementCompleted();
+    });
+
+    expect(mockedRepo.incrementCompleted).toHaveBeenCalled();
+    expect(result.current.goal.completed).toBe(1);
+  });
+
+  it('進捗率が正しく計算される', () => {
+    mockedRepo.getToday.mockReturnValue({ date: '2026-02-13', target: 4, completed: 2 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    expect(result.current.progress).toBe(50);
+  });
+});

--- a/frontend/src/hooks/useDailyGoal.ts
+++ b/frontend/src/hooks/useDailyGoal.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback, useMemo } from 'react';
+import { DailyGoalRepository } from '../repositories/DailyGoalRepository';
+import type { DailyGoal } from '../types';
+
+export function useDailyGoal() {
+  const [goal, setGoal] = useState<DailyGoal>(() => DailyGoalRepository.getToday());
+
+  const setTarget = useCallback((target: number) => {
+    DailyGoalRepository.setTarget(target);
+    setGoal(DailyGoalRepository.getToday());
+  }, []);
+
+  const incrementCompleted = useCallback(() => {
+    DailyGoalRepository.incrementCompleted();
+    setGoal(DailyGoalRepository.getToday());
+  }, []);
+
+  const isAchieved = useMemo(() => goal.completed >= goal.target, [goal]);
+  const progress = useMemo(() => {
+    if (goal.target === 0) return 100;
+    return Math.round((goal.completed / goal.target) * 100);
+  }, [goal]);
+
+  return { goal, setTarget, incrementCompleted, isAchieved, progress };
+}

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -7,6 +7,7 @@ import {
   AcademicCapIcon,
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
+import DailyGoalCard from '../components/DailyGoalCard';
 
 interface ChatStats {
   chatPartnerCount: number;
@@ -138,6 +139,11 @@ export default function MenuPage() {
           </p>
         </div>
       )}
+
+      {/* 日次学習目標 */}
+      <div className="mb-6">
+        <DailyGoalCard />
+      </div>
 
       {/* メニュー */}
       <div className="space-y-2">

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -13,6 +13,10 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
+vi.mock('../../components/DailyGoalCard', () => ({
+  default: () => <div data-testid="daily-goal-card">DailyGoalCard</div>,
+}));
+
 // フェッチモック
 const mockFetch = vi.fn();
 global.fetch = mockFetch;

--- a/frontend/src/repositories/DailyGoalRepository.ts
+++ b/frontend/src/repositories/DailyGoalRepository.ts
@@ -1,0 +1,33 @@
+import type { DailyGoal } from '../types';
+
+const STORAGE_KEY = 'freestyle_daily_goal';
+const DEFAULT_TARGET = 3;
+
+function getTodayStr(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+export const DailyGoalRepository = {
+  getToday(): DailyGoal {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const goal: DailyGoal = JSON.parse(raw);
+      if (goal.date === getTodayStr()) {
+        return goal;
+      }
+    }
+    return { date: getTodayStr(), target: DEFAULT_TARGET, completed: 0 };
+  },
+
+  setTarget(target: number): void {
+    const goal = this.getToday();
+    goal.target = target;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(goal));
+  },
+
+  incrementCompleted(): void {
+    const goal = this.getToday();
+    goal.completed += 1;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(goal));
+  },
+};

--- a/frontend/src/repositories/__tests__/DailyGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/DailyGoalRepository.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DailyGoalRepository } from '../DailyGoalRepository';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+describe('DailyGoalRepository', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('初期状態ではデフォルト目標を返す', () => {
+    const goal = DailyGoalRepository.getToday();
+    expect(goal.target).toBe(3);
+    expect(goal.completed).toBe(0);
+    expect(goal.date).toBeDefined();
+  });
+
+  it('目標数を設定できる', () => {
+    DailyGoalRepository.setTarget(5);
+    const goal = DailyGoalRepository.getToday();
+    expect(goal.target).toBe(5);
+  });
+
+  it('完了数を増加できる', () => {
+    DailyGoalRepository.incrementCompleted();
+    const goal = DailyGoalRepository.getToday();
+    expect(goal.completed).toBe(1);
+
+    DailyGoalRepository.incrementCompleted();
+    expect(DailyGoalRepository.getToday().completed).toBe(2);
+  });
+
+  it('日付が変わるとリセットされる', () => {
+    DailyGoalRepository.incrementCompleted();
+    expect(DailyGoalRepository.getToday().completed).toBe(1);
+
+    // 別の日付のデータを直接セット
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yesterdayStr = yesterday.toISOString().split('T')[0];
+    localStorage.setItem(
+      'freestyle_daily_goal',
+      JSON.stringify({ date: yesterdayStr, target: 3, completed: 2 })
+    );
+
+    const goal = DailyGoalRepository.getToday();
+    expect(goal.completed).toBe(0);
+    expect(goal.target).toBe(3);
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -126,3 +126,10 @@ export interface FavoritePhrase {
   pattern: string;
   createdAt: string;
 }
+
+/** 日次学習目標 */
+export interface DailyGoal {
+  date: string;
+  target: number;
+  completed: number;
+}


### PR DESCRIPTION
## 概要
closes #198

1日の練習目標を設定し、進捗をプログレスバーで可視化する日次学習目標機能を追加。

## 変更内容
- `DailyGoalRepository`: LocalStorageベースの目標・進捗管理（日付変更で自動リセット）
- `useDailyGoal` Hook: 目標設定・進捗更新・達成判定・進捗率計算
- `DailyGoalCard` コンポーネント: プログレスバー・達成メッセージ表示
- `MenuPage`: ホームダッシュボードに日次学習目標カードを追加

## テスト
- 新規テスト12件追加（全293テスト通過）
  - DailyGoalRepository: 4件（初期値・目標設定・進捗増加・日付リセット）
  - useDailyGoal Hook: 5件（初期状態・達成判定・目標更新・進捗増加・進捗率）
  - DailyGoalCard: 3件（表示・プログレスバー・達成メッセージ）