### PR TITLE
feat: セッションメモ機能の追加

### DIFF
--- a/frontend/src/components/SessionNoteEditor.tsx
+++ b/frontend/src/components/SessionNoteEditor.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect } from 'react';
+import { useSessionNote } from '../hooks/useSessionNote';
+
+interface SessionNoteEditorProps {
+  sessionId: number;
+}
+
+export default function SessionNoteEditor({ sessionId }: SessionNoteEditorProps) {
+  const { note, saveNote } = useSessionNote(sessionId);
+  const [text, setText] = useState(note);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setText(note);
+  }, [note]);
+
+  const handleSave = () => {
+    saveNote(text);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-2">振り返りメモ</p>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="振り返りメモを入力..."
+        className="w-full text-sm text-slate-700 border border-slate-200 rounded-lg p-2 resize-none h-20 focus:outline-none focus:ring-1 focus:ring-primary-400"
+      />
+      <div className="flex items-center justify-end gap-2 mt-2">
+        {saved && <span className="text-xs text-emerald-600">保存しました</span>}
+        <button
+          onClick={handleSave}
+          className="text-xs font-medium text-white bg-primary-500 px-3 py-1.5 rounded-lg hover:bg-primary-600 transition-colors"
+        >
+          保存
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SessionNoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/SessionNoteEditor.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SessionNoteEditor from '../SessionNoteEditor';
+
+const mockSaveNote = vi.fn();
+
+vi.mock('../../hooks/useSessionNote', () => ({
+  useSessionNote: () => ({
+    note: mockNote,
+    saveNote: mockSaveNote,
+  }),
+}));
+
+let mockNote = '';
+
+describe('SessionNoteEditor', () => {
+  it('メモ入力欄が表示される', () => {
+    render(<SessionNoteEditor sessionId={1} />);
+
+    expect(screen.getByPlaceholderText(/振り返りメモ/)).toBeInTheDocument();
+  });
+
+  it('保存ボタンでsaveNoteが呼ばれる', () => {
+    render(<SessionNoteEditor sessionId={1} />);
+
+    const textarea = screen.getByPlaceholderText(/振り返りメモ/);
+    fireEvent.change(textarea, { target: { value: '学びメモ' } });
+    fireEvent.click(screen.getByText('保存'));
+
+    expect(mockSaveNote).toHaveBeenCalledWith('学びメモ');
+  });
+
+  it('既存メモが表示される', () => {
+    mockNote = '既存のメモ';
+
+    render(<SessionNoteEditor sessionId={1} />);
+
+    expect(screen.getByDisplayValue('既存のメモ')).toBeInTheDocument();
+
+    mockNote = '';
+  });
+});

--- a/frontend/src/hooks/__tests__/useSessionNote.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionNote.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionNote } from '../useSessionNote';
+import { SessionNoteRepository } from '../../repositories/SessionNoteRepository';
+
+vi.mock('../../repositories/SessionNoteRepository');
+
+const mockedRepo = vi.mocked(SessionNoteRepository);
+
+describe('useSessionNote', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('セッションIDでメモを取得する', () => {
+    mockedRepo.get.mockReturnValue({ sessionId: 1, note: 'テストメモ', updatedAt: '2026-02-13' });
+
+    const { result } = renderHook(() => useSessionNote(1));
+
+    expect(result.current.note).toBe('テストメモ');
+    expect(mockedRepo.get).toHaveBeenCalledWith(1);
+  });
+
+  it('メモがない場合は空文字', () => {
+    mockedRepo.get.mockReturnValue(null);
+
+    const { result } = renderHook(() => useSessionNote(1));
+
+    expect(result.current.note).toBe('');
+  });
+
+  it('メモを保存できる', () => {
+    mockedRepo.get
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({ sessionId: 1, note: '新しいメモ', updatedAt: '2026-02-13' });
+
+    const { result } = renderHook(() => useSessionNote(1));
+
+    act(() => {
+      result.current.saveNote('新しいメモ');
+    });
+
+    expect(mockedRepo.save).toHaveBeenCalledWith(1, '新しいメモ');
+    expect(result.current.note).toBe('新しいメモ');
+  });
+});

--- a/frontend/src/hooks/useSessionNote.ts
+++ b/frontend/src/hooks/useSessionNote.ts
@@ -1,0 +1,18 @@
+import { useState, useCallback } from 'react';
+import { SessionNoteRepository } from '../repositories/SessionNoteRepository';
+
+export function useSessionNote(sessionId: number | null) {
+  const [note, setNote] = useState<string>(() => {
+    if (!sessionId) return '';
+    const saved = SessionNoteRepository.get(sessionId);
+    return saved?.note || '';
+  });
+
+  const saveNote = useCallback((text: string) => {
+    if (!sessionId) return;
+    SessionNoteRepository.save(sessionId, text);
+    setNote(text);
+  }, [sessionId]);
+
+  return { note, saveNote };
+}

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -6,6 +6,7 @@ import ScoreCardComponent from '../components/ScoreCard';
 import PracticeResultSummary from '../components/PracticeResultSummary';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import PracticeTimer from '../components/PracticeTimer';
+import SessionNoteEditor from '../components/SessionNoteEditor';
 import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { AiMessage, AiSession, ScoreCard } from '../types';
 import { useAuth } from '../hooks/useAuth';
@@ -377,10 +378,13 @@ export default function AskAiPage() {
           ))}
 
           {scoreCard && (
-            <div className="max-w-3xl mx-auto w-full">
+            <div className="max-w-3xl mx-auto w-full space-y-3">
               <ScoreCardComponent scoreCard={scoreCard} />
               {isPracticeMode && (
                 <PracticeResultSummary scoreCard={scoreCard} scenarioName={scenarioName || '練習'} />
+              )}
+              {currentSessionId && (
+                <SessionNoteEditor sessionId={currentSessionId} />
               )}
             </div>
           )}

--- a/frontend/src/repositories/SessionNoteRepository.ts
+++ b/frontend/src/repositories/SessionNoteRepository.ts
@@ -1,0 +1,26 @@
+import type { SessionNote } from '../types';
+
+const STORAGE_KEY = 'freestyle_session_notes';
+
+function getAllNotes(): Record<string, SessionNote> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return {};
+  return JSON.parse(raw);
+}
+
+export const SessionNoteRepository = {
+  get(sessionId: number): SessionNote | null {
+    const notes = getAllNotes();
+    return notes[String(sessionId)] || null;
+  },
+
+  save(sessionId: number, note: string): void {
+    const notes = getAllNotes();
+    notes[String(sessionId)] = {
+      sessionId,
+      note,
+      updatedAt: new Date().toISOString(),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+  },
+};

--- a/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionNoteRepository } from '../SessionNoteRepository';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+describe('SessionNoteRepository', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('初期状態ではnullを返す', () => {
+    expect(SessionNoteRepository.get(1)).toBeNull();
+  });
+
+  it('メモを保存・取得できる', () => {
+    SessionNoteRepository.save(1, '良い練習でした');
+    const note = SessionNoteRepository.get(1);
+    expect(note).not.toBeNull();
+    expect(note!.note).toBe('良い練習でした');
+    expect(note!.sessionId).toBe(1);
+    expect(note!.updatedAt).toBeDefined();
+  });
+
+  it('メモを上書き保存できる', () => {
+    SessionNoteRepository.save(1, '初回メモ');
+    SessionNoteRepository.save(1, '更新メモ');
+    const note = SessionNoteRepository.get(1);
+    expect(note!.note).toBe('更新メモ');
+  });
+
+  it('異なるセッションのメモを独立して保存できる', () => {
+    SessionNoteRepository.save(1, 'セッション1のメモ');
+    SessionNoteRepository.save(2, 'セッション2のメモ');
+    expect(SessionNoteRepository.get(1)!.note).toBe('セッション1のメモ');
+    expect(SessionNoteRepository.get(2)!.note).toBe('セッション2のメモ');
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -133,3 +133,10 @@ export interface DailyGoal {
   target: number;
   completed: number;
 }
+
+/** セッションメモ */
+export interface SessionNote {
+  sessionId: number;
+  note: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 概要
closes #200

AIチャットセッションのスコアカード表示後に、振り返りメモを記録・閲覧できる機能を追加。

## 変更内容
- `SessionNoteRepository`: LocalStorageベースのメモCRUD（セッション別保存）
- `useSessionNote` Hook: セッションIDに紐づくメモの取得・保存
- `SessionNoteEditor` コンポーネント: テキストエリア・保存ボタン・保存フィードバック
- `AskAiPage`: スコアカード表示後にメモ入力エリアを統合

## テスト
- 新規テスト10件追加（全303テスト通過）
  - SessionNoteRepository: 4件（初期値・保存・上書き・複数セッション独立）
  - useSessionNote Hook: 3件（取得・空状態・保存）
  - SessionNoteEditor: 3件（入力欄・保存・既存メモ表示）