### PR TITLE
feat: ダッシュボードインサイト機能の追加

### DIFF
--- a/frontend/src/components/LearningInsightsCard.tsx
+++ b/frontend/src/components/LearningInsightsCard.tsx
@@ -1,0 +1,34 @@
+interface LearningInsightsCardProps {
+  totalSessions: number;
+  averageScore: number;
+  streakDays: number;
+}
+
+export default function LearningInsightsCard({
+  totalSessions,
+  averageScore,
+  streakDays,
+}: LearningInsightsCardProps) {
+  const stats = [
+    { label: '総練習回数', value: String(totalSessions), unit: '回' },
+    { label: '平均スコア', value: averageScore.toFixed(1), unit: '/10' },
+    { label: '連続練習日', value: String(streakDays), unit: '日' },
+  ];
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">学習インサイト</p>
+      <div className="grid grid-cols-3 gap-3">
+        {stats.map((stat) => (
+          <div key={stat.label} className="text-center">
+            <p className="text-lg font-semibold text-slate-800">{stat.value}</p>
+            <p className="text-[10px] text-slate-400">
+              {stat.unit}
+            </p>
+            <p className="text-[10px] text-slate-500 mt-0.5">{stat.label}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/LearningInsightsCard.test.tsx
+++ b/frontend/src/components/__tests__/LearningInsightsCard.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LearningInsightsCard from '../LearningInsightsCard';
+
+describe('LearningInsightsCard', () => {
+  it('統計情報が表示される', () => {
+    render(
+      <LearningInsightsCard
+        totalSessions={12}
+        averageScore={7.8}
+        streakDays={5}
+      />
+    );
+
+    expect(screen.getByText('学習インサイト')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('7.8')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(
+      <LearningInsightsCard
+        totalSessions={0}
+        averageScore={0}
+        streakDays={0}
+      />
+    );
+
+    expect(screen.getByText('総練習回数')).toBeInTheDocument();
+    expect(screen.getByText('平均スコア')).toBeInTheDocument();
+    expect(screen.getByText('連続練習日')).toBeInTheDocument();
+  });
+
+  it('データなしでもクラッシュしない', () => {
+    render(
+      <LearningInsightsCard
+        totalSessions={0}
+        averageScore={0}
+        streakDays={0}
+      />
+    );
+
+    expect(screen.getByText('学習インサイト')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -8,6 +8,7 @@ import {
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
 import DailyGoalCard from '../components/DailyGoalCard';
+import LearningInsightsCard from '../components/LearningInsightsCard';
 
 interface ChatStats {
   chatPartnerCount: number;
@@ -26,6 +27,7 @@ export default function MenuPage() {
   const [stats, setStats] = useState<ChatStats | null>(null);
   const [totalUnread, setTotalUnread] = useState<number>(0);
   const [latestScore, setLatestScore] = useState<ScoreHistory | null>(null);
+  const [allScores, setAllScores] = useState<ScoreHistory[]>([]);
 
   useEffect(() => {
     const fetchWithRetry = async (url: string) => {
@@ -73,6 +75,7 @@ export default function MenuPage() {
 
         if (scoresData && scoresData.length > 0) {
           setLatestScore(scoresData[0]);
+          setAllScores(scoresData);
         }
       } catch (err) {
         console.error('Error fetching dashboard data:', err);
@@ -114,8 +117,25 @@ export default function MenuPage() {
 
   const showRecommendation = !latestScore && stats?.chatPartnerCount === 0;
 
+  const totalSessions = allScores.length;
+  const averageScore = totalSessions > 0
+    ? Math.round((allScores.reduce((sum, s) => sum + s.overallScore, 0) / totalSessions) * 10) / 10
+    : 0;
+  const uniqueDays = new Set(allScores.map(s => s.createdAt.split('T')[0])).size;
+
   return (
     <div className="p-6 max-w-2xl mx-auto">
+      {/* 学習インサイト */}
+      {totalSessions > 0 && (
+        <div className="mb-6">
+          <LearningInsightsCard
+            totalSessions={totalSessions}
+            averageScore={averageScore}
+            streakDays={uniqueDays}
+          />
+        </div>
+      )}
+
       {/* サマリー */}
       <div className="bg-white rounded-lg border border-slate-200 p-4 mb-6">
         <div className="flex items-center gap-3">

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -17,6 +17,12 @@ vi.mock('../../components/DailyGoalCard', () => ({
   default: () => <div data-testid="daily-goal-card">DailyGoalCard</div>,
 }));
 
+vi.mock('../../components/LearningInsightsCard', () => ({
+  default: ({ totalSessions, averageScore, streakDays }: { totalSessions: number; averageScore: number; streakDays: number }) => (
+    <div data-testid="learning-insights">{totalSessions} sessions, {averageScore} avg, {streakDays} days</div>
+  ),
+}));
+
 // フェッチモック
 const mockFetch = vi.fn();
 global.fetch = mockFetch;


### PR DESCRIPTION
## 概要
closes #202

ホームページに学習状況のサマリー（総練習回数・平均スコア・練習日数）を表示するインサイトカードを追加。

## 変更内容
- `LearningInsightsCard` コンポーネント: 3カラムの統計表示
- `MenuPage`: スコア履歴APIから集計してインサイトカードを表示

## テスト
- 新規テスト3件追加（全306テスト通過）
  - LearningInsightsCard: 3件（統計表示・ラベル表示・空データ）