### PR TITLE
refactor: MenuPageのfetch→apiClient移行とRepository/Hooks層分離

### DIFF
--- a/frontend/src/hooks/__tests__/useMenuData.test.ts
+++ b/frontend/src/hooks/__tests__/useMenuData.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMenuData } from '../useMenuData';
+import { MenuRepository } from '../../repositories/MenuRepository';
+
+vi.mock('../../repositories/MenuRepository');
+
+const mockedRepo = vi.mocked(MenuRepository);
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('useMenuData', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ダッシュボードデータを取得する', async () => {
+    mockedRepo.fetchChatStats.mockResolvedValue({ chatPartnerCount: 5 });
+    mockedRepo.fetchChatRooms.mockResolvedValue({
+      chatUsers: [
+        { roomId: 1, unreadCount: 3 },
+        { roomId: 2, unreadCount: 2 },
+      ],
+    });
+    mockedRepo.fetchScoreHistory.mockResolvedValue([
+      { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.5, createdAt: '2026-02-13T00:00:00' },
+      { sessionId: 2, sessionTitle: 'テスト2', overallScore: 8.5, createdAt: '2026-02-12T00:00:00' },
+    ]);
+
+    const { result } = renderHook(() => useMenuData());
+
+    await waitFor(() => {
+      expect(result.current.stats).not.toBeNull();
+    });
+
+    expect(result.current.stats?.chatPartnerCount).toBe(5);
+    expect(result.current.totalUnread).toBe(5);
+    expect(result.current.latestScore?.overallScore).toBe(7.5);
+    expect(result.current.totalSessions).toBe(2);
+    expect(result.current.averageScore).toBe(8.0);
+    expect(result.current.uniqueDays).toBe(2);
+  });
+
+  it('APIエラー時にクラッシュしない', async () => {
+    mockedRepo.fetchChatStats.mockRejectedValue(new Error('Network error'));
+    mockedRepo.fetchChatRooms.mockRejectedValue(new Error('Network error'));
+    mockedRepo.fetchScoreHistory.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useMenuData());
+
+    // エラーでもクラッシュしないことを確認
+    await waitFor(() => {
+      expect(result.current.stats).toBeNull();
+    });
+  });
+});

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -1,0 +1,70 @@
+import { useState, useEffect, useMemo } from 'react';
+import { MenuRepository } from '../repositories/MenuRepository';
+
+interface ChatStats {
+  chatPartnerCount: number;
+}
+
+interface ScoreHistory {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  createdAt: string;
+}
+
+export function useMenuData() {
+  const [stats, setStats] = useState<ChatStats | null>(null);
+  const [totalUnread, setTotalUnread] = useState(0);
+  const [latestScore, setLatestScore] = useState<ScoreHistory | null>(null);
+  const [allScores, setAllScores] = useState<ScoreHistory[]>([]);
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        const [statsData, roomsData, scoresData] = await Promise.allSettled([
+          MenuRepository.fetchChatStats(),
+          MenuRepository.fetchChatRooms(),
+          MenuRepository.fetchScoreHistory(),
+        ]);
+
+        if (statsData.status === 'fulfilled') {
+          setStats(statsData.value);
+        }
+
+        if (roomsData.status === 'fulfilled' && roomsData.value?.chatUsers) {
+          const unread = roomsData.value.chatUsers.reduce(
+            (sum, u) => sum + u.unreadCount, 0
+          );
+          setTotalUnread(unread);
+        }
+
+        if (scoresData.status === 'fulfilled' && scoresData.value.length > 0) {
+          setLatestScore(scoresData.value[0]);
+          setAllScores(scoresData.value);
+        }
+      } catch (err) {
+        console.error('ダッシュボードデータ取得エラー:', err);
+      }
+    };
+    fetchAll();
+  }, []);
+
+  const totalSessions = allScores.length;
+  const averageScore = useMemo(() => {
+    if (totalSessions === 0) return 0;
+    return Math.round((allScores.reduce((sum, s) => sum + s.overallScore, 0) / totalSessions) * 10) / 10;
+  }, [allScores, totalSessions]);
+  const uniqueDays = useMemo(() => {
+    return new Set(allScores.map(s => s.createdAt.split('T')[0])).size;
+  }, [allScores]);
+
+  return {
+    stats,
+    totalUnread,
+    latestScore,
+    allScores,
+    totalSessions,
+    averageScore,
+    uniqueDays,
+  };
+}

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import MenuPage from '../MenuPage';
 
@@ -23,118 +23,81 @@ vi.mock('../../components/LearningInsightsCard', () => ({
   ),
 }));
 
-// フェッチモック
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+const mockUseMenuData = vi.fn();
+vi.mock('../../hooks/useMenuData', () => ({
+  useMenuData: () => mockUseMenuData(),
+}));
 
-function createFetchResponse(data: unknown, ok = true, status = 200) {
-  return Promise.resolve({
-    ok,
-    status,
-    json: () => Promise.resolve(data),
-  });
+function defaultMenuData() {
+  return {
+    stats: { chatPartnerCount: 5 },
+    totalUnread: 5,
+    latestScore: { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.5, createdAt: '2026-02-13' },
+    allScores: [{ sessionId: 1, sessionTitle: 'テスト', overallScore: 7.5, createdAt: '2026-02-13' }],
+    totalSessions: 1,
+    averageScore: 7.5,
+    uniqueDays: 1,
+  };
 }
 
 describe('MenuPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFetch.mockImplementation((url: string) => {
-      if (url.includes('/api/chat/stats')) {
-        return createFetchResponse({ chatPartnerCount: 5 });
-      }
-      if (url.includes('/api/chat/rooms')) {
-        return createFetchResponse({
-          chatUsers: [
-            { roomId: 1, unreadCount: 3 },
-            { roomId: 2, unreadCount: 2 },
-          ],
-        });
-      }
-      if (url.includes('/api/scores/history')) {
-        return createFetchResponse([
-          { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.5, createdAt: '2026-02-13' },
-        ]);
-      }
-      return createFetchResponse({});
-    });
+    mockUseMenuData.mockReturnValue(defaultMenuData());
   });
 
-  it('メニュー項目が全て表示される', async () => {
+  it('メニュー項目が全て表示される', () => {
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('チャット')).toBeInTheDocument();
-      expect(screen.getByText('AI アシスタント')).toBeInTheDocument();
-      expect(screen.getByText('練習モード')).toBeInTheDocument();
-      expect(screen.getByText('スコア履歴')).toBeInTheDocument();
-    });
+    expect(screen.getByText('チャット')).toBeInTheDocument();
+    expect(screen.getByText('AI アシスタント')).toBeInTheDocument();
+    expect(screen.getByText('練習モード')).toBeInTheDocument();
+    expect(screen.getByText('スコア履歴')).toBeInTheDocument();
   });
 
-  it('会話した人数を表示する', async () => {
+  it('会話した人数を表示する', () => {
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('5')).toBeInTheDocument();
-    });
+    expect(screen.getByText('5')).toBeInTheDocument();
   });
 
-  it('未読メッセージ数バッジをチャットカードに表示する', async () => {
+  it('未読メッセージ数バッジをチャットカードに表示する', () => {
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('5件の未読')).toBeInTheDocument();
-    });
+    expect(screen.getByText('5件の未読')).toBeInTheDocument();
   });
 
-  it('最新スコアをスコア履歴カードに表示する', async () => {
+  it('最新スコアをスコア履歴カードに表示する', () => {
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText(/最新: 7\.5/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/最新: 7\.5/)).toBeInTheDocument();
   });
 
-  it('スコア履歴がない場合はおすすめアクションを表示する', async () => {
-    mockFetch.mockImplementation((url: string) => {
-      if (url.includes('/api/chat/stats')) {
-        return createFetchResponse({ chatPartnerCount: 0 });
-      }
-      if (url.includes('/api/chat/rooms')) {
-        return createFetchResponse({ chatUsers: [] });
-      }
-      if (url.includes('/api/scores/history')) {
-        return createFetchResponse([]);
-      }
-      return createFetchResponse({});
+  it('スコア履歴がない場合はおすすめアクションを表示する', () => {
+    mockUseMenuData.mockReturnValue({
+      stats: { chatPartnerCount: 0 },
+      totalUnread: 0,
+      latestScore: null,
+      allScores: [],
+      totalSessions: 0,
+      averageScore: 0,
+      uniqueDays: 0,
     });
 
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText(/練習モードから始めてみましょう/)).toBeInTheDocument();
-    });
+    expect(screen.getByText(/練習モードから始めてみましょう/)).toBeInTheDocument();
   });
 
-  it('未読がない場合は未読バッジを表示しない', async () => {
-    mockFetch.mockImplementation((url: string) => {
-      if (url.includes('/api/chat/stats')) {
-        return createFetchResponse({ chatPartnerCount: 3 });
-      }
-      if (url.includes('/api/chat/rooms')) {
-        return createFetchResponse({ chatUsers: [{ roomId: 1, unreadCount: 0 }] });
-      }
-      if (url.includes('/api/scores/history')) {
-        return createFetchResponse([]);
-      }
-      return createFetchResponse({});
+  it('未読がない場合は未読バッジを表示しない', () => {
+    mockUseMenuData.mockReturnValue({
+      ...defaultMenuData(),
+      totalUnread: 0,
     });
 
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('チャット')).toBeInTheDocument();
-    });
-
+    expect(screen.getByText('チャット')).toBeInTheDocument();
     expect(screen.queryByText(/件の未読/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/repositories/MenuRepository.ts
+++ b/frontend/src/repositories/MenuRepository.ts
@@ -1,0 +1,33 @@
+import apiClient from '../lib/axios';
+
+interface ChatStats {
+  chatPartnerCount: number;
+}
+
+interface ChatRoomsResponse {
+  chatUsers: Array<{ roomId: number; unreadCount: number }>;
+}
+
+interface ScoreHistory {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  createdAt: string;
+}
+
+export const MenuRepository = {
+  async fetchChatStats(): Promise<ChatStats> {
+    const { data } = await apiClient.get('/api/chat/stats');
+    return data;
+  },
+
+  async fetchChatRooms(): Promise<ChatRoomsResponse> {
+    const { data } = await apiClient.get('/api/chat/rooms');
+    return data;
+  },
+
+  async fetchScoreHistory(): Promise<ScoreHistory[]> {
+    const { data } = await apiClient.get('/api/scores/history');
+    return data;
+  },
+};

--- a/frontend/src/repositories/__tests__/MenuRepository.test.ts
+++ b/frontend/src/repositories/__tests__/MenuRepository.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import apiClient from '../../lib/axios';
+import { MenuRepository } from '../MenuRepository';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('MenuRepository', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('チャット統計を取得できる', async () => {
+    mockedApiClient.get.mockResolvedValue({ data: { chatPartnerCount: 5 } });
+
+    const result = await MenuRepository.fetchChatStats();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/stats');
+    expect(result).toEqual({ chatPartnerCount: 5 });
+  });
+
+  it('チャットルーム一覧を取得できる', async () => {
+    const mockRooms = { chatUsers: [{ roomId: 1, unreadCount: 3 }] };
+    mockedApiClient.get.mockResolvedValue({ data: mockRooms });
+
+    const result = await MenuRepository.fetchChatRooms();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/rooms');
+    expect(result).toEqual(mockRooms);
+  });
+
+  it('スコア履歴を取得できる', async () => {
+    const mockScores = [{ sessionId: 1, overallScore: 7.5 }];
+    mockedApiClient.get.mockResolvedValue({ data: mockScores });
+
+    const result = await MenuRepository.fetchScoreHistory();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/scores/history');
+    expect(result).toEqual(mockScores);
+  });
+});


### PR DESCRIPTION
## 概要
MenuPageのインラインfetchロジックをクリーンアーキテクチャに基づいてRepository/Hooks層に分離

## 変更内容
- **MenuRepository**: apiClient経由でチャット統計・ルーム・スコア履歴を取得する3つのメソッド
- **useMenuData Hook**: Promise.allSettledによるデータ取得と派生値（総セッション数、平均スコア、練習日数）の計算をカプセル化
- **MenuPage**: ~55行のインラインfetch/fetchWithRetryロジックを削除し、useMenuData()フック1行に置換
- **テスト**: global.fetchモックからuseMenuDataモックに移行し、テストの安定性向上

## テスト
- [x] MenuRepository: 3テスト
- [x] useMenuData: 2テスト
- [x] MenuPage: 6テスト（既存テスト維持）
- [x] 全311テスト合格

Closes #204