### PR TITLE
test: authSliceのReduxリデューサーテスト追加

### DIFF
--- a/frontend/src/store/__tests__/authSlice.test.ts
+++ b/frontend/src/store/__tests__/authSlice.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import authReducer, { setAuthData, setAuthenticated, clearAuth, finishLoading } from '../authSlice';
+
+describe('authSlice', () => {
+  const initialState = { isAuthenticated: false, loading: true };
+
+  it('初期状態はisAuthenticated=false, loading=true', () => {
+    const state = authReducer(undefined, { type: 'unknown' });
+    expect(state).toEqual(initialState);
+  });
+
+  it('setAuthDataでisAuthenticated=true, loading=falseになる', () => {
+    const state = authReducer(initialState, setAuthData());
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.loading).toBe(false);
+  });
+
+  it('setAuthenticatedでisAuthenticated=true, loading=falseになる', () => {
+    const state = authReducer(initialState, setAuthenticated());
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.loading).toBe(false);
+  });
+
+  it('clearAuthでisAuthenticated=false, loading=falseになる', () => {
+    const authenticatedState = { isAuthenticated: true, loading: false };
+    const state = authReducer(authenticatedState, clearAuth());
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.loading).toBe(false);
+  });
+
+  it('finishLoadingでloading=falseになりisAuthenticatedは変わらない', () => {
+    const state = authReducer(initialState, finishLoading());
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.loading).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要
ストア層（Redux）のテストカバレッジが0%だったため、authSliceのテストを追加

## テスト内容
- 初期状態（isAuthenticated=false, loading=true）
- setAuthData: 認証済み状態への遷移
- setAuthenticated: 認証済み状態への遷移
- clearAuth: 認証解除
- finishLoading: ローディング完了

## テスト
- [x] authSlice: 5テスト追加
- [x] 全319テスト合格

Closes #208