### PR TITLE
feat: 練習シナリオブックマーク機能

### DIFF
--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -3,6 +3,8 @@ import type { PracticeScenario } from '../types';
 interface ScenarioCardProps {
   scenario: PracticeScenario;
   onSelect: (scenario: PracticeScenario) => void;
+  isBookmarked?: boolean;
+  onToggleBookmark?: (scenarioId: number) => void;
 }
 
 const difficultyLabel: Record<string, string> = {
@@ -29,7 +31,12 @@ const difficultyColor: Record<string, string> = {
   advanced: 'bg-rose-50 text-rose-700 border-rose-200',
 };
 
-export default function ScenarioCard({ scenario, onSelect }: ScenarioCardProps) {
+export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggleBookmark }: ScenarioCardProps) {
+  const handleBookmarkClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onToggleBookmark?.(scenario.id);
+  };
+
   return (
     <div
       onClick={() => onSelect(scenario)}
@@ -37,9 +44,22 @@ export default function ScenarioCard({ scenario, onSelect }: ScenarioCardProps) 
     >
       <div className="flex items-center justify-between mb-2">
         <span className="text-xs text-slate-500">{categoryLabel[scenario.category] || scenario.category}</span>
-        <span className={`text-xs px-2 py-0.5 rounded border ${difficultyColor[scenario.difficulty] || 'bg-slate-50 text-slate-500 border-slate-200'}`}>
-          {difficultyLabel[scenario.difficulty] || scenario.difficulty}
-        </span>
+        <div className="flex items-center gap-2">
+          {onToggleBookmark && (
+            <button
+              onClick={handleBookmarkClick}
+              title={isBookmarked ? 'ブックマーク解除' : 'ブックマーク'}
+              className="p-0.5 hover:bg-slate-100 rounded transition-colors"
+            >
+              <svg className="w-4 h-4" fill={isBookmarked ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
+              </svg>
+            </button>
+          )}
+          <span className={`text-xs px-2 py-0.5 rounded border ${difficultyColor[scenario.difficulty] || 'bg-slate-50 text-slate-500 border-slate-200'}`}>
+            {difficultyLabel[scenario.difficulty] || scenario.difficulty}
+          </span>
+        </div>
       </div>
       <h3 className="text-sm font-medium text-slate-800 mb-1">{scenario.name}</h3>
       <p className="text-xs text-slate-500 mb-2">{scenario.description}</p>

--- a/frontend/src/components/__tests__/ScenarioCard.test.tsx
+++ b/frontend/src/components/__tests__/ScenarioCard.test.tsx
@@ -85,4 +85,14 @@ describe('ScenarioCard', () => {
     card?.click();
     expect(onSelect).toHaveBeenCalledWith(mockScenario);
   });
+
+  it('ブックマークボタンを表示する', () => {
+    render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} isBookmarked={false} onToggleBookmark={vi.fn()} />);
+    expect(screen.getByTitle('ブックマーク')).toBeDefined();
+  });
+
+  it('ブックマーク済みの場合は塗りつぶしアイコンを表示する', () => {
+    render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} isBookmarked={true} onToggleBookmark={vi.fn()} />);
+    expect(screen.getByTitle('ブックマーク解除')).toBeDefined();
+  });
 });

--- a/frontend/src/hooks/__tests__/useBookmark.test.ts
+++ b/frontend/src/hooks/__tests__/useBookmark.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useBookmark } from '../useBookmark';
+
+const mockGetAll = vi.fn();
+const mockAdd = vi.fn();
+const mockRemove = vi.fn();
+const mockIsBookmarked = vi.fn();
+
+vi.mock('../../repositories/BookmarkRepository', () => ({
+  BookmarkRepository: {
+    getAll: (...args: unknown[]) => mockGetAll(...args),
+    add: (...args: unknown[]) => mockAdd(...args),
+    remove: (...args: unknown[]) => mockRemove(...args),
+    isBookmarked: (...args: unknown[]) => mockIsBookmarked(...args),
+  },
+}));
+
+describe('useBookmark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAll.mockReturnValue([1, 3]);
+    mockIsBookmarked.mockImplementation((id: number) => [1, 3].includes(id));
+  });
+
+  it('ブックマーク済みIDの一覧を返す', () => {
+    const { result } = renderHook(() => useBookmark());
+    expect(result.current.bookmarkedIds).toEqual([1, 3]);
+  });
+
+  it('toggleBookmarkでブックマーク追加・削除を切り替える', () => {
+    mockGetAll.mockReturnValueOnce([1, 3]).mockReturnValueOnce([1, 3, 5]);
+
+    const { result } = renderHook(() => useBookmark());
+
+    act(() => {
+      result.current.toggleBookmark(5);
+    });
+
+    expect(mockAdd).toHaveBeenCalledWith(5);
+  });
+
+  it('ブックマーク済みの場合はtoggleで削除する', () => {
+    mockIsBookmarked.mockReturnValue(true);
+    mockGetAll.mockReturnValueOnce([1, 3]).mockReturnValueOnce([3]);
+
+    const { result } = renderHook(() => useBookmark());
+
+    act(() => {
+      result.current.toggleBookmark(1);
+    });
+
+    expect(mockRemove).toHaveBeenCalledWith(1);
+  });
+
+  it('isBookmarkedで判定できる', () => {
+    const { result } = renderHook(() => useBookmark());
+    expect(result.current.isBookmarked(1)).toBe(true);
+    expect(result.current.isBookmarked(2)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useBookmark.ts
+++ b/frontend/src/hooks/useBookmark.ts
@@ -1,0 +1,21 @@
+import { useState, useCallback } from 'react';
+import { BookmarkRepository } from '../repositories/BookmarkRepository';
+
+export function useBookmark() {
+  const [bookmarkedIds, setBookmarkedIds] = useState<number[]>(() => BookmarkRepository.getAll());
+
+  const toggleBookmark = useCallback((scenarioId: number) => {
+    if (BookmarkRepository.isBookmarked(scenarioId)) {
+      BookmarkRepository.remove(scenarioId);
+    } else {
+      BookmarkRepository.add(scenarioId);
+    }
+    setBookmarkedIds(BookmarkRepository.getAll());
+  }, []);
+
+  const isBookmarked = useCallback((scenarioId: number) => {
+    return BookmarkRepository.isBookmarked(scenarioId);
+  }, []);
+
+  return { bookmarkedIds, toggleBookmark, isBookmarked };
+}

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -4,8 +4,9 @@ import ScenarioCard from '../components/ScenarioCard';
 import { SkeletonCard } from '../components/Skeleton';
 import type { PracticeScenario } from '../types';
 import { usePractice } from '../hooks/usePractice';
+import { useBookmark } from '../hooks/useBookmark';
 
-const CATEGORIES = ['すべて', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
+const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
 
 const CATEGORY_LABEL_TO_DB: Record<string, string> = {
   '顧客折衝': 'customer',
@@ -18,6 +19,7 @@ export default function PracticePage() {
 
   const [selectedCategory, setSelectedCategory] = useState<string>('すべて');
   const { scenarios, loading, fetchScenarios, createPracticeSession } = usePractice();
+  const { bookmarkedIds, toggleBookmark, isBookmarked } = useBookmark();
 
   useEffect(() => {
     fetchScenarios();
@@ -40,6 +42,8 @@ export default function PracticePage() {
 
   const filteredScenarios = selectedCategory === 'すべて'
     ? scenarios
+    : selectedCategory === 'ブックマーク'
+    ? scenarios.filter((s) => bookmarkedIds.includes(s.id))
     : scenarios.filter((s) => s.category === CATEGORY_LABEL_TO_DB[selectedCategory]);
 
   return (
@@ -87,6 +91,8 @@ export default function PracticePage() {
               key={scenario.id}
               scenario={scenario}
               onSelect={handleSelectScenario}
+              isBookmarked={isBookmarked(scenario.id)}
+              onToggleBookmark={toggleBookmark}
             />
           ))}
         </div>

--- a/frontend/src/pages/__tests__/PracticePage.test.tsx
+++ b/frontend/src/pages/__tests__/PracticePage.test.tsx
@@ -51,6 +51,14 @@ vi.mock('../../hooks/usePractice', () => ({
   }),
 }));
 
+vi.mock('../../hooks/useBookmark', () => ({
+  useBookmark: () => ({
+    bookmarkedIds: [1],
+    toggleBookmark: vi.fn(),
+    isBookmarked: (id: number) => id === 1,
+  }),
+}));
+
 describe('PracticePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/repositories/BookmarkRepository.ts
+++ b/frontend/src/repositories/BookmarkRepository.ts
@@ -1,0 +1,26 @@
+const STORAGE_KEY = 'freestyle_scenario_bookmarks';
+
+export const BookmarkRepository = {
+  getAll(): number[] {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw);
+  },
+
+  add(scenarioId: number): void {
+    const ids = this.getAll();
+    if (!ids.includes(scenarioId)) {
+      ids.push(scenarioId);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+    }
+  },
+
+  remove(scenarioId: number): void {
+    const ids = this.getAll().filter(id => id !== scenarioId);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  },
+
+  isBookmarked(scenarioId: number): boolean {
+    return this.getAll().includes(scenarioId);
+  },
+};

--- a/frontend/src/repositories/__tests__/BookmarkRepository.test.ts
+++ b/frontend/src/repositories/__tests__/BookmarkRepository.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BookmarkRepository } from '../BookmarkRepository';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+describe('BookmarkRepository', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('ブックマークを追加できる', () => {
+    BookmarkRepository.add(1);
+    const ids = BookmarkRepository.getAll();
+    expect(ids).toContain(1);
+  });
+
+  it('ブックマークを削除できる', () => {
+    BookmarkRepository.add(1);
+    BookmarkRepository.add(2);
+    BookmarkRepository.remove(1);
+    const ids = BookmarkRepository.getAll();
+    expect(ids).not.toContain(1);
+    expect(ids).toContain(2);
+  });
+
+  it('ブックマーク済みか判定できる', () => {
+    BookmarkRepository.add(5);
+    expect(BookmarkRepository.isBookmarked(5)).toBe(true);
+    expect(BookmarkRepository.isBookmarked(6)).toBe(false);
+  });
+
+  it('重複追加しても1つのみ保存される', () => {
+    BookmarkRepository.add(1);
+    BookmarkRepository.add(1);
+    const ids = BookmarkRepository.getAll();
+    expect(ids.filter(id => id === 1)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## 概要
よく使う練習シナリオをブックマークして素早くアクセスできる機能

## 変更内容
- **BookmarkRepository**: localStorage でシナリオIDのブックマーク管理（追加/削除/一覧/判定）
- **useBookmark Hook**: ブックマーク操作をReact状態と連携
- **ScenarioCard**: ブックマークボタン（★/☆）追加。クリックでトグル
- **PracticePage**: カテゴリタブに「ブックマーク」を追加。ブックマーク済みシナリオのみ表示

## テスト
- [x] BookmarkRepository: 4テスト
- [x] useBookmark: 4テスト
- [x] ScenarioCard: 15テスト（既存13 + 新規2）
- [x] PracticePage: 5テスト（既存維持）
- [x] 全337テスト合格

Closes #212