### PR TITLE
refactor: AskAiPageのセッション管理ロジックをHooksに分離

### DIFF
--- a/frontend/src/hooks/__tests__/useAiSession.test.ts
+++ b/frontend/src/hooks/__tests__/useAiSession.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAiSession } from '../useAiSession';
+
+const mockNavigate = vi.fn();
+const mockDeleteSession = vi.fn();
+const mockUpdateSessionTitle = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('useAiSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteSession.mockResolvedValue(true);
+    mockUpdateSessionTitle.mockResolvedValue(true);
+  });
+
+  it('セッション選択でcurrentSessionIdが更新される', () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleSelectSession(42);
+    });
+
+    expect(result.current.currentSessionId).toBe(42);
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai/42');
+  });
+
+  it('新規セッション作成でcurrentSessionIdがnullになる', () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleSelectSession(42);
+    });
+
+    act(() => {
+      result.current.handleNewSession();
+    });
+
+    expect(result.current.currentSessionId).toBeNull();
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai');
+  });
+
+  it('セッション削除確認モーダルの開閉ができる', () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleDeleteSession(5);
+    });
+
+    expect(result.current.deleteModal.isOpen).toBe(true);
+    expect(result.current.deleteModal.sessionId).toBe(5);
+
+    act(() => {
+      result.current.cancelDeleteSession();
+    });
+
+    expect(result.current.deleteModal.isOpen).toBe(false);
+  });
+
+  it('セッション削除確定でdeleteSessionが呼ばれる', async () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleSelectSession(5);
+    });
+
+    act(() => {
+      result.current.handleDeleteSession(5);
+    });
+
+    await act(async () => {
+      await result.current.confirmDeleteSession();
+    });
+
+    expect(mockDeleteSession).toHaveBeenCalledWith(5);
+    expect(result.current.currentSessionId).toBeNull();
+  });
+
+  it('タイトル編集の開始・保存・キャンセルができる', async () => {
+    const session = { id: 10, title: '既存タイトル', createdAt: '2026-01-01' };
+
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleStartEditTitle(session);
+    });
+
+    expect(result.current.editingSessionId).toBe(10);
+    expect(result.current.editingTitle).toBe('既存タイトル');
+
+    act(() => {
+      result.current.setEditingTitle('新しいタイトル');
+    });
+
+    await act(async () => {
+      await result.current.handleSaveTitle(10);
+    });
+
+    expect(mockUpdateSessionTitle).toHaveBeenCalledWith(10, { title: '新しいタイトル' });
+    expect(result.current.editingSessionId).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useAiSession.ts
+++ b/frontend/src/hooks/useAiSession.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface DeleteModal {
+  isOpen: boolean;
+  sessionId: number | null;
+}
+
+interface UseAiSessionProps {
+  deleteSession: (sessionId: number) => Promise<boolean>;
+  updateSessionTitle: (sessionId: number, data: { title: string }) => Promise<boolean>;
+}
+
+export function useAiSession({ deleteSession, updateSessionTitle }: UseAiSessionProps) {
+  const navigate = useNavigate();
+  const [currentSessionId, setCurrentSessionId] = useState<number | null>(null);
+  const [deleteModal, setDeleteModal] = useState<DeleteModal>({ isOpen: false, sessionId: null });
+  const [editingSessionId, setEditingSessionId] = useState<number | null>(null);
+  const [editingTitle, setEditingTitle] = useState('');
+
+  const handleNewSession = useCallback(() => {
+    setCurrentSessionId(null);
+    navigate('/chat/ask-ai');
+  }, [navigate]);
+
+  const handleSelectSession = useCallback((sessionId: number) => {
+    setCurrentSessionId(sessionId);
+    navigate(`/chat/ask-ai/${sessionId}`);
+  }, [navigate]);
+
+  const handleDeleteSession = useCallback((sessionId: number) => {
+    setDeleteModal({ isOpen: true, sessionId });
+  }, []);
+
+  const confirmDeleteSession = useCallback(async () => {
+    const sessionId = deleteModal.sessionId;
+    setDeleteModal({ isOpen: false, sessionId: null });
+
+    if (sessionId) {
+      const success = await deleteSession(sessionId);
+      if (success && currentSessionId === sessionId) {
+        setCurrentSessionId(null);
+        navigate('/chat/ask-ai');
+      }
+    }
+  }, [deleteModal.sessionId, deleteSession, currentSessionId, navigate]);
+
+  const cancelDeleteSession = useCallback(() => {
+    setDeleteModal({ isOpen: false, sessionId: null });
+  }, []);
+
+  const handleStartEditTitle = useCallback((session: { id: number; title?: string }) => {
+    setEditingSessionId(session.id);
+    setEditingTitle(session.title || '');
+  }, []);
+
+  const handleSaveTitle = useCallback(async (sessionId: number) => {
+    if (!editingTitle.trim()) {
+      setEditingSessionId(null);
+      return;
+    }
+
+    const success = await updateSessionTitle(sessionId, { title: editingTitle.trim() });
+    if (success) {
+      setEditingSessionId(null);
+    }
+  }, [editingTitle, updateSessionTitle]);
+
+  const handleCancelEditTitle = useCallback(() => {
+    setEditingSessionId(null);
+    setEditingTitle('');
+  }, []);
+
+  return {
+    currentSessionId,
+    setCurrentSessionId,
+    deleteModal,
+    editingSessionId,
+    editingTitle,
+    setEditingTitle,
+    handleNewSession,
+    handleSelectSession,
+    handleDeleteSession,
+    confirmDeleteSession,
+    cancelDeleteSession,
+    handleStartEditTitle,
+    handleSaveTitle,
+    handleCancelEditTitle,
+  };
+}


### PR DESCRIPTION
## 概要
- AskAiPageのセッション管理ロジック（選択・削除・タイトル編集）をuseAiSessionフックに分離
- AskAiPageの責務をUI描画に集中させた

## 変更内容
- `useAiSession`フック新規作成（5テスト）
- AskAiPage.tsxから重複ハンドラー関数を削除
- handleStartEditTitleのe.stopPropagation()をコールサイトに移動

## テスト
- 346テスト全て合格

closes #216