### PR TITLE
test: AddUserPage・MemberPageのテスト追加

### DIFF
--- a/frontend/src/pages/__tests__/AddUserPage.test.tsx
+++ b/frontend/src/pages/__tests__/AddUserPage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import AddUserPage from '../AddUserPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => vi.fn(),
+}));
+
+describe('AddUserPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ users: [] }),
+    });
+  });
+
+  it('検索ボックスが表示される', () => {
+    render(<BrowserRouter><AddUserPage /></BrowserRouter>);
+
+    expect(screen.getByPlaceholderText('ユーザー名またはメールアドレスで検索...')).toBeInTheDocument();
+  });
+
+  it('初期状態で検索案内を表示する', () => {
+    render(<BrowserRouter><AddUserPage /></BrowserRouter>);
+
+    expect(screen.getByText('ユーザーを検索してみましょう')).toBeInTheDocument();
+  });
+
+  it('ユーザー取得後にユーザー一覧を表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        users: [
+          { id: 1, name: '山田太郎', email: 'yamada@example.com', roomId: null },
+        ],
+      }),
+    });
+
+    render(<BrowserRouter><AddUserPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(screen.getByText('山田太郎')).toBeInTheDocument();
+    });
+  });
+
+  it('fetch失敗時にエラーメッセージを表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({}),
+    });
+
+    render(<BrowserRouter><AddUserPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(screen.getByText('ユーザー取得に失敗しました')).toBeInTheDocument();
+    });
+  });
+
+  it('401レスポンス時にログインページへリダイレクトする', async () => {
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ status: 401, ok: false })
+      .mockResolvedValueOnce({ ok: false, status: 401 });
+
+    render(<BrowserRouter><AddUserPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('ユーザー数を表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        users: [
+          { id: 1, name: 'ユーザー1', email: 'u1@example.com', roomId: null },
+          { id: 2, name: 'ユーザー2', email: 'u2@example.com', roomId: null },
+        ],
+      }),
+    });
+
+    render(<BrowserRouter><AddUserPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(screen.getByText('2人のユーザーが見つかりました')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/MemberPage.test.tsx
+++ b/frontend/src/pages/__tests__/MemberPage.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import MemberPage from '../MemberPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('MemberPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ users: [] }),
+    });
+  });
+
+  it('ヘッダーが表示される', () => {
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    expect(screen.getByText('チャットメンバー')).toBeInTheDocument();
+    expect(screen.getByText('メンバーを検索または選択')).toBeInTheDocument();
+  });
+
+  it('検索ボックスが表示される', () => {
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    expect(screen.getByPlaceholderText('メンバーを検索...')).toBeInTheDocument();
+  });
+
+  it('メンバーがいない場合にメッセージを表示する', () => {
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    expect(screen.getByText('メンバーがまだいません')).toBeInTheDocument();
+  });
+
+  it('メンバー取得後に一覧を表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        users: [
+          { id: 1, name: '鈴木一郎', email: 'suzuki@example.com', roomId: 10 },
+        ],
+      }),
+    });
+
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(screen.getByText('鈴木一郎')).toBeInTheDocument();
+    });
+  });
+
+  it('401レスポンス時にログインページへリダイレクトする', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    });
+
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('500レスポンス時にトップページへリダイレクトする', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
- AddUserPageに6テスト、MemberPageに6テストを追加
- テスト総数: 346 → 358

## テスト内容
### AddUserPage (6テスト)
- 検索ボックス表示
- 初期状態の検索案内表示
- ユーザー一覧表示
- fetch失敗時のエラーメッセージ
- 401レスポンス時のログインリダイレクト
- ユーザー数の表示

### MemberPage (6テスト)
- ヘッダー表示
- 検索ボックス表示
- メンバーなし時のメッセージ
- メンバー一覧表示
- 401レスポンス時のログインリダイレクト
- 500レスポンス時のトップリダイレクト

closes #218