### PR TITLE
feat: 練習カレンダーヒートマップの追加

### DIFF
--- a/frontend/src/components/PracticeCalendar.tsx
+++ b/frontend/src/components/PracticeCalendar.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from 'react';
+
+interface PracticeCalendarProps {
+  practiceDates: string[];
+}
+
+function getCalendarDays(weeks: number): Date[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayOfWeek = today.getDay();
+  const endOfWeek = new Date(today);
+  endOfWeek.setDate(today.getDate() + (6 - dayOfWeek));
+
+  const startDate = new Date(endOfWeek);
+  startDate.setDate(endOfWeek.getDate() - weeks * 7 + 1);
+
+  const days: Date[] = [];
+  const current = new Date(startDate);
+  while (current <= endOfWeek) {
+    days.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return days;
+}
+
+function getIntensityClass(count: number): string {
+  if (count === 0) return 'bg-slate-100';
+  if (count === 1) return 'bg-emerald-200';
+  if (count === 2) return 'bg-emerald-400';
+  return 'bg-emerald-600';
+}
+
+export default function PracticeCalendar({ practiceDates }: PracticeCalendarProps) {
+  const dateCountMap = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const date of practiceDates) {
+      const key = date.split('T')[0];
+      map[key] = (map[key] || 0) + 1;
+    }
+    return map;
+  }, [practiceDates]);
+
+  const days = useMemo(() => getCalendarDays(12), []);
+
+  const weeks: Date[][] = useMemo(() => {
+    const result: Date[][] = [];
+    for (let i = 0; i < days.length; i += 7) {
+      result.push(days.slice(i, i + 7));
+    }
+    return result;
+  }, [days]);
+
+  const dayLabels = ['日', '月', '火', '水', '木', '金', '土'];
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">練習カレンダー</p>
+
+      <div className="flex gap-0.5">
+        {/* 曜日ラベル */}
+        <div className="flex flex-col gap-0.5 mr-1">
+          {dayLabels.map((label, i) => (
+            <div
+              key={label}
+              className={`h-3 text-[9px] leading-3 text-slate-400 ${
+                i % 2 === 1 ? '' : 'invisible'
+              }`}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+
+        {/* カレンダーグリッド */}
+        {weeks.map((week, wi) => (
+          <div key={wi} className="flex flex-col gap-0.5">
+            {week.map((day) => {
+              const key = day.toISOString().split('T')[0];
+              const count = dateCountMap[key] || 0;
+              const today = new Date();
+              today.setHours(0, 0, 0, 0);
+              const isFuture = day > today;
+
+              return (
+                <div
+                  key={key}
+                  className={`w-3 h-3 rounded-sm ${
+                    isFuture ? 'bg-transparent' : getIntensityClass(count)
+                  }`}
+                  data-active={count > 0 ? 'true' : 'false'}
+                  data-count={count}
+                  title={`${key}: ${count}回`}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeCalendar.test.tsx
+++ b/frontend/src/components/__tests__/PracticeCalendar.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PracticeCalendar from '../PracticeCalendar';
+
+interface ScoreHistory {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  createdAt: string;
+}
+
+describe('PracticeCalendar', () => {
+  it('タイトルが表示される', () => {
+    render(<PracticeCalendar practiceDates={[]} />);
+
+    expect(screen.getByText('練習カレンダー')).toBeInTheDocument();
+  });
+
+  it('曜日ラベルが表示される', () => {
+    render(<PracticeCalendar practiceDates={[]} />);
+
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('水')).toBeInTheDocument();
+    expect(screen.getByText('金')).toBeInTheDocument();
+  });
+
+  it('練習日のセルがアクティブなスタイルになる', () => {
+    const today = new Date().toISOString().split('T')[0];
+    render(<PracticeCalendar practiceDates={[today]} />);
+
+    const activeCells = document.querySelectorAll('[data-active="true"]');
+    expect(activeCells.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('練習がない日は非アクティブなスタイルになる', () => {
+    render(<PracticeCalendar practiceDates={[]} />);
+
+    const inactiveCells = document.querySelectorAll('[data-active="false"]');
+    expect(inactiveCells.length).toBeGreaterThan(0);
+  });
+
+  it('複数回練習した日はより濃い色になる', () => {
+    const today = new Date().toISOString().split('T')[0];
+    render(<PracticeCalendar practiceDates={[today, today, today]} />);
+
+    const activeCells = document.querySelectorAll('[data-count="3"]');
+    expect(activeCells.length).toBe(1);
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAiChat } from '../hooks/useAiChat';
 import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
+import PracticeCalendar from '../components/PracticeCalendar';
 
 interface AxisScore {
   axis: string;
@@ -117,6 +118,9 @@ export default function ScoreHistoryPage() {
           ))}
         </div>
       </div>
+
+      {/* 練習カレンダー */}
+      <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />
 
       {/* フィルタタブ */}
       <div className="flex gap-1 border-b border-slate-200">


### PR DESCRIPTION
## 概要
- ScoreHistoryPageに練習活動のカレンダーヒートマップを追加
- 過去12週間の練習日をGitHub風のグリッドで可視化

## 機能
- 練習回数に応じた色の濃淡（0回: 灰色, 1回: 薄緑, 2回: 中緑, 3回以上: 濃緑）
- 曜日ラベル表示
- ホバーで日付と練習回数を確認可能

## テスト
- PracticeCalendarコンポーネント: 5テスト
- 全363テスト合格

closes #220