### PR TITLE
feat: AIチャットセッションのテキストエクスポート機能

### DIFF
--- a/frontend/src/components/ExportSessionButton.tsx
+++ b/frontend/src/components/ExportSessionButton.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+interface Message {
+  id: number;
+  content: string;
+  role: 'user' | 'assistant';
+}
+
+interface ExportSessionButtonProps {
+  messages: Message[];
+}
+
+export default function ExportSessionButton({ messages }: ExportSessionButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const text = messages
+      .map((msg) => `${msg.role === 'user' ? 'あなた' : 'AI'}: ${msg.content}`)
+      .join('\n\n');
+
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      disabled={messages.length === 0}
+      title={copied ? 'コピーしました' : '会話をコピー'}
+      className="p-1.5 rounded-lg hover:bg-slate-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    >
+      {copied ? (
+        <svg className="w-4 h-4 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4 text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/ExportSessionButton.test.tsx
+++ b/frontend/src/components/__tests__/ExportSessionButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ExportSessionButton from '../ExportSessionButton';
+
+const mockMessages = [
+  { id: 1, sessionId: 1, content: 'こんにちは', role: 'user' as const, isSender: true },
+  { id: 2, sessionId: 1, content: 'こんにちは！何かお手伝いしましょうか？', role: 'assistant' as const, isSender: false },
+  { id: 3, sessionId: 1, content: 'フィードバックをお願いします', role: 'user' as const, isSender: true },
+];
+
+describe('ExportSessionButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it('ボタンが表示される', () => {
+    render(<ExportSessionButton messages={mockMessages} />);
+
+    expect(screen.getByTitle('会話をコピー')).toBeInTheDocument();
+  });
+
+  it('クリックでクリップボードにコピーされる', async () => {
+    render(<ExportSessionButton messages={mockMessages} />);
+
+    fireEvent.click(screen.getByTitle('会話をコピー'));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('こんにちは')
+      );
+    });
+  });
+
+  it('コピー後に完了メッセージが表示される', async () => {
+    render(<ExportSessionButton messages={mockMessages} />);
+
+    fireEvent.click(screen.getByTitle('会話をコピー'));
+
+    await waitFor(() => {
+      expect(screen.getByTitle('コピーしました')).toBeInTheDocument();
+    });
+  });
+
+  it('メッセージが空の場合はボタンが無効になる', () => {
+    render(<ExportSessionButton messages={[]} />);
+
+    const button = screen.getByTitle('会話をコピー');
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -7,6 +7,7 @@ import PracticeResultSummary from '../components/PracticeResultSummary';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import PracticeTimer from '../components/PracticeTimer';
 import SessionNoteEditor from '../components/SessionNoteEditor';
+import ExportSessionButton from '../components/ExportSessionButton';
 import { useLocation, useParams } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
 import { useAiChat } from '../hooks/useAiChat';
@@ -345,8 +346,11 @@ export default function AskAiPage() {
 
         {/* 入力欄 */}
         <div className="bg-white border-t border-slate-200 p-4">
-          <div className="max-w-3xl mx-auto w-full">
-            <MessageInput onSend={handleSend} />
+          <div className="max-w-3xl mx-auto w-full flex items-end gap-2">
+            <div className="flex-1">
+              <MessageInput onSend={handleSend} />
+            </div>
+            <ExportSessionButton messages={messages} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
- AIチャットの会話内容をクリップボードにコピーするボタンを追加
- AskAiPageの入力欄横に配置

## 機能
- ワンクリックで全メッセージをテキスト形式でコピー
- コピー完了時にチェックマークアイコンで視覚的フィードバック
- メッセージがない場合はボタン無効化

## テスト
- ExportSessionButtonコンポーネント: 4テスト
- 全367テスト合格

closes #222