### PR TITLE
refactor: AddUserPageのfetchロジックをHooksに分離

### DIFF
--- a/frontend/src/hooks/__tests__/useUserSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useUserSearch.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useUserSearch } from '../useUserSearch';
+import UserSearchRepository from '../../repositories/UserSearchRepository';
+
+vi.mock('../../repositories/UserSearchRepository');
+
+describe('useUserSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(UserSearchRepository.searchUsers).mockResolvedValue([]);
+  });
+
+  it('初期状態ではusersが空配列である', () => {
+    const { result } = renderHook(() => useUserSearch());
+
+    expect(result.current.users).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('初回マウント時にユーザー検索が実行される', async () => {
+    const mockUsers = [{ id: 1, name: 'テスト', email: 'test@example.com' }];
+    vi.mocked(UserSearchRepository.searchUsers).mockResolvedValue(mockUsers);
+
+    const { result } = renderHook(() => useUserSearch());
+
+    await waitFor(() => {
+      expect(result.current.users).toEqual(mockUsers);
+    });
+
+    expect(UserSearchRepository.searchUsers).toHaveBeenCalled();
+  });
+
+  it('検索エラー時にerrorが設定される', async () => {
+    vi.mocked(UserSearchRepository.searchUsers).mockRejectedValue(new Error('ネットワークエラー'));
+
+    const { result } = renderHook(() => useUserSearch());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('ネットワークエラー');
+    });
+  });
+
+  it('setSearchQueryで検索クエリを更新できる', () => {
+    const { result } = renderHook(() => useUserSearch());
+
+    act(() => {
+      result.current.setSearchQuery('テスト');
+    });
+
+    expect(result.current.searchQuery).toBe('テスト');
+  });
+});

--- a/frontend/src/hooks/useUserSearch.ts
+++ b/frontend/src/hooks/useUserSearch.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useMemo } from 'react';
+import { debounce } from 'lodash';
+import UserSearchRepository from '../repositories/UserSearchRepository';
+import type { MemberUser } from '../types';
+
+export function useUserSearch() {
+  const [users, setUsers] = useState<MemberUser[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debounceQuery, setDebounceQuery] = useState('');
+
+  const debounceSearch = useMemo(
+    () => debounce((query: string) => setDebounceQuery(query), 500),
+    []
+  );
+
+  useEffect(() => {
+    debounceSearch(searchQuery);
+    return () => debounceSearch.cancel();
+  }, [searchQuery, debounceSearch]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const search = async () => {
+      try {
+        const result = await UserSearchRepository.searchUsers(debounceQuery || undefined);
+        if (!cancelled) {
+          setUsers(result);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError((err as Error).message);
+        }
+      }
+    };
+
+    search();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debounceQuery]);
+
+  return {
+    users,
+    error,
+    searchQuery,
+    setSearchQuery,
+    debounceQuery,
+  };
+}

--- a/frontend/src/pages/__tests__/AddUserPage.test.tsx
+++ b/frontend/src/pages/__tests__/AddUserPage.test.tsx
@@ -1,30 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import AddUserPage from '../AddUserPage';
 
-const mockNavigate = vi.fn();
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  };
-});
-
-vi.mock('react-redux', () => ({
-  useDispatch: () => vi.fn(),
+const mockUseUserSearch = vi.fn();
+vi.mock('../../hooks/useUserSearch', () => ({
+  useUserSearch: () => mockUseUserSearch(),
 }));
+
+function defaultData() {
+  return {
+    users: [],
+    error: null,
+    searchQuery: '',
+    setSearchQuery: vi.fn(),
+    debounceQuery: '',
+  };
+}
 
 describe('AddUserPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ users: [] }),
-    });
+    mockUseUserSearch.mockReturnValue(defaultData());
   });
 
   it('検索ボックスが表示される', () => {
@@ -39,66 +36,52 @@ describe('AddUserPage', () => {
     expect(screen.getByText('ユーザーを検索してみましょう')).toBeInTheDocument();
   });
 
-  it('ユーザー取得後にユーザー一覧を表示する', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({
-        users: [
-          { id: 1, name: '山田太郎', email: 'yamada@example.com', roomId: null },
-        ],
-      }),
+  it('ユーザー一覧を表示する', () => {
+    mockUseUserSearch.mockReturnValue({
+      ...defaultData(),
+      users: [
+        { id: 1, name: '山田太郎', email: 'yamada@example.com', roomId: null },
+      ],
     });
 
     render(<BrowserRouter><AddUserPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('山田太郎')).toBeInTheDocument();
-    });
+    expect(screen.getByText('山田太郎')).toBeInTheDocument();
   });
 
-  it('fetch失敗時にエラーメッセージを表示する', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: false,
-      status: 500,
-      json: () => Promise.resolve({}),
+  it('エラーメッセージを表示する', () => {
+    mockUseUserSearch.mockReturnValue({
+      ...defaultData(),
+      error: 'ユーザー取得に失敗しました',
     });
 
     render(<BrowserRouter><AddUserPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('ユーザー取得に失敗しました')).toBeInTheDocument();
-    });
+    expect(screen.getByText('ユーザー取得に失敗しました')).toBeInTheDocument();
   });
 
-  it('401レスポンス時にログインページへリダイレクトする', async () => {
-    global.fetch = vi.fn()
-      .mockResolvedValueOnce({ status: 401, ok: false })
-      .mockResolvedValueOnce({ ok: false, status: 401 });
+  it('検索結果なしの場合メッセージを表示する', () => {
+    mockUseUserSearch.mockReturnValue({
+      ...defaultData(),
+      debounceQuery: 'テスト',
+    });
 
     render(<BrowserRouter><AddUserPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/login');
-    });
+    expect(screen.getByText('ユーザーが見つかりませんでした')).toBeInTheDocument();
   });
 
-  it('ユーザー数を表示する', async () => {
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({
-        users: [
-          { id: 1, name: 'ユーザー1', email: 'u1@example.com', roomId: null },
-          { id: 2, name: 'ユーザー2', email: 'u2@example.com', roomId: null },
-        ],
-      }),
+  it('ユーザー数を表示する', () => {
+    mockUseUserSearch.mockReturnValue({
+      ...defaultData(),
+      users: [
+        { id: 1, name: 'ユーザー1', email: 'u1@example.com', roomId: null },
+        { id: 2, name: 'ユーザー2', email: 'u2@example.com', roomId: null },
+      ],
     });
 
     render(<BrowserRouter><AddUserPage /></BrowserRouter>);
 
-    await waitFor(() => {
-      expect(screen.getByText('2人のユーザーが見つかりました')).toBeInTheDocument();
-    });
+    expect(screen.getByText('2人のユーザーが見つかりました')).toBeInTheDocument();
   });
 });

--- a/frontend/src/repositories/UserSearchRepository.ts
+++ b/frontend/src/repositories/UserSearchRepository.ts
@@ -1,0 +1,13 @@
+import apiClient from '../lib/axios';
+import type { MemberUser } from '../types';
+
+const UserSearchRepository = {
+  async searchUsers(query?: string): Promise<MemberUser[]> {
+    const params: Record<string, string> = {};
+    if (query) params.query = query;
+    const res = await apiClient.get('/api/chat/users', { params });
+    return res.data.users || [];
+  },
+};
+
+export default UserSearchRepository;

--- a/frontend/src/repositories/__tests__/UserSearchRepository.test.ts
+++ b/frontend/src/repositories/__tests__/UserSearchRepository.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import UserSearchRepository from '../UserSearchRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+describe('UserSearchRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ユーザー検索結果を返す', async () => {
+    const mockUsers = [
+      { id: 1, name: '山田太郎', email: 'yamada@example.com', roomId: null },
+    ];
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { users: mockUsers } });
+
+    const result = await UserSearchRepository.searchUsers('山田');
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/chat/users', { params: { query: '山田' } });
+    expect(result).toEqual(mockUsers);
+  });
+
+  it('クエリなしで全ユーザーを返す', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { users: [] } });
+
+    const result = await UserSearchRepository.searchUsers();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/chat/users', { params: {} });
+    expect(result).toEqual([]);
+  });
+
+  it('usersが未定義の場合は空配列を返す', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: {} });
+
+    const result = await UserSearchRepository.searchUsers();
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要
- AddUserPageのfetch直接呼び出しをRepository+Hooksパターンに置き換え
- apiClientインターセプターによる自動トークンリフレッシュを活用

## 変更内容
- UserSearchRepository新規作成（3テスト）
- useUserSearchフック新規作成（4テスト）
- AddUserPage: ~65行のfetchロジックを削除、useUserSearch利用に変更
- AddUserPageテスト: useUserSearchモックに更新

## テスト
- 全374テスト合格

closes #224