### PR TITLE
test: ForgotPasswordPage・ConfirmForgotPasswordPageのテスト追加

### DIFF
--- a/frontend/src/pages/__tests__/ConfirmForgotPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ConfirmForgotPasswordPage.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ConfirmForgotPasswordPage from '../ConfirmForgotPasswordPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ state: { email: 'test@example.com' } }),
+  };
+});
+
+describe('ConfirmForgotPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByText('パスワードリセット確認')).toBeInTheDocument();
+  });
+
+  it('メールアドレスが事前入力される', () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    const emailInput = screen.getByLabelText('メールアドレス') as HTMLInputElement;
+    expect(emailInput.value).toBe('test@example.com');
+  });
+
+  it('確認コード入力欄が表示される', () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByLabelText('確認コード')).toBeInTheDocument();
+  });
+
+  it('新しいパスワード入力欄が表示される', () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByLabelText('新しいパスワード')).toBeInTheDocument();
+  });
+
+  it('リセットボタンが表示される', () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByText('パスワードをリセット')).toBeInTheDocument();
+  });
+
+  it('リセット成功時にログインページへ遷移する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ message: 'リセット成功' }),
+    });
+
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('確認コード'), {
+      target: { value: '123456', name: 'code' },
+    });
+    fireEvent.change(screen.getByLabelText('新しいパスワード'), {
+      target: { value: 'newPassword123', name: 'newPassword' },
+    });
+    fireEvent.click(screen.getByText('パスワードをリセット'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login', {
+        state: { message: 'パスワードリセットに成功しました。ログインしてください。' },
+      });
+    });
+  });
+
+  it('リセット失敗時にエラーメッセージを表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: '確認コードが無効です' }),
+    });
+
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('確認コード'), {
+      target: { value: '000000', name: 'code' },
+    });
+    fireEvent.click(screen.getByText('パスワードをリセット'));
+
+    await waitFor(() => {
+      expect(screen.getByText('確認コードが無効です')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ForgotPasswordPage from '../ForgotPasswordPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('ForgotPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByText('パスワードリセット')).toBeInTheDocument();
+  });
+
+  it('メールアドレス入力欄が表示される', () => {
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+  });
+
+  it('送信ボタンが表示される', () => {
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByText('確認コードを送信')).toBeInTheDocument();
+  });
+
+  it('送信成功時にリセット確認ページへ遷移する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ message: '確認コードを送信しました' }),
+    });
+
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByText('確認コードを送信'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/confirm-forgot-password', {
+        state: { email: 'test@example.com' },
+      });
+    });
+  });
+
+  it('送信失敗時にエラーメッセージを表示する', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: 'メールアドレスが見つかりません' }),
+    });
+
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'invalid@example.com' },
+    });
+    fireEvent.click(screen.getByText('確認コードを送信'));
+
+    await waitFor(() => {
+      expect(screen.getByText('メールアドレスが見つかりません')).toBeInTheDocument();
+    });
+  });
+
+  it('通信エラー時にエラーメッセージを表示する', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByText('確認コードを送信'));
+
+    await waitFor(() => {
+      expect(screen.getByText('通信エラーが発生しました。')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## 概要
- 認証関連ページ2つにテストを追加
- テスト総数: 374 → 387

## テスト内容
### ForgotPasswordPage (6テスト)
- タイトル・入力欄・ボタン表示
- 送信成功時のページ遷移
- 送信失敗時のエラーメッセージ
- 通信エラー時のエラーメッセージ

### ConfirmForgotPasswordPage (7テスト)
- タイトル・入力欄・ボタン表示
- メールアドレスの事前入力
- リセット成功時のログインページ遷移
- リセット失敗時のエラーメッセージ

closes #228