### PR TITLE
feat: スキル別成長トレンド表示の追加

### DIFF
--- a/frontend/src/components/SkillTrendChart.tsx
+++ b/frontend/src/components/SkillTrendChart.tsx
@@ -1,0 +1,67 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+}
+
+interface HistoryItem {
+  sessionId: number;
+  scores: AxisScore[];
+}
+
+interface SkillTrendChartProps {
+  history: HistoryItem[];
+}
+
+export default function SkillTrendChart({ history }: SkillTrendChartProps) {
+  if (history.length === 0) return null;
+
+  const latest = history[history.length - 1];
+  const previous = history.length > 1 ? history[history.length - 2] : null;
+
+  const skills = latest.scores.map((s) => {
+    const prevScore = previous?.scores.find((p) => p.axis === s.axis)?.score;
+    const delta = prevScore !== undefined ? s.score - prevScore : null;
+
+    return {
+      axis: s.axis,
+      score: s.score,
+      delta,
+    };
+  });
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">スキル別推移</p>
+      <div className="space-y-2">
+        {skills.map((skill) => (
+          <div key={skill.axis} className="flex items-center gap-2">
+            <span className="text-xs text-slate-500 w-24 flex-shrink-0 truncate">
+              {skill.axis}
+            </span>
+            <div className="flex-1 bg-slate-100 rounded-full h-2">
+              <div
+                className="h-2 rounded-full bg-primary-500 transition-all"
+                style={{ width: `${skill.score * 10}%` }}
+              />
+            </div>
+            <span
+              data-testid="skill-latest-score"
+              className="text-xs font-medium text-slate-700 w-5 text-right"
+            >
+              {skill.score}
+            </span>
+            {skill.delta !== null && skill.delta !== 0 && (
+              <span
+                className={`text-xs font-medium w-6 text-right ${
+                  skill.delta > 0 ? 'text-emerald-600' : 'text-rose-600'
+                }`}
+              >
+                {skill.delta > 0 ? `+${skill.delta}` : skill.delta}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SkillTrendChart.test.tsx
+++ b/frontend/src/components/__tests__/SkillTrendChart.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SkillTrendChart from '../SkillTrendChart';
+
+const mockHistory = [
+  {
+    sessionId: 1,
+    scores: [
+      { axis: '論理的構成力', score: 6 },
+      { axis: '配慮表現', score: 7 },
+      { axis: '要約力', score: 5 },
+      { axis: '提案力', score: 4 },
+      { axis: '質問・傾聴力', score: 8 },
+    ],
+  },
+  {
+    sessionId: 2,
+    scores: [
+      { axis: '論理的構成力', score: 8 },
+      { axis: '配慮表現', score: 7 },
+      { axis: '要約力', score: 6 },
+      { axis: '提案力', score: 5 },
+      { axis: '質問・傾聴力', score: 9 },
+    ],
+  },
+];
+
+describe('SkillTrendChart', () => {
+  it('タイトルが表示される', () => {
+    render(<SkillTrendChart history={mockHistory} />);
+
+    expect(screen.getByText('スキル別推移')).toBeInTheDocument();
+  });
+
+  it('各スキル軸名が表示される', () => {
+    render(<SkillTrendChart history={mockHistory} />);
+
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('配慮表現')).toBeInTheDocument();
+    expect(screen.getByText('要約力')).toBeInTheDocument();
+    expect(screen.getByText('提案力')).toBeInTheDocument();
+    expect(screen.getByText('質問・傾聴力')).toBeInTheDocument();
+  });
+
+  it('最新スコアが表示される', () => {
+    render(<SkillTrendChart history={mockHistory} />);
+
+    // 最新セッション(sessionId:2)のスコア
+    const scoreElements = screen.getAllByTestId('skill-latest-score');
+    expect(scoreElements).toHaveLength(5);
+  });
+
+  it('スコア変動が表示される', () => {
+    render(<SkillTrendChart history={mockHistory} />);
+
+    // 論理的構成力: 6→8 = +2
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+
+  it('履歴が空の場合は何も表示しない', () => {
+    const { container } = render(<SkillTrendChart history={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -4,6 +4,7 @@ import { useAiChat } from '../hooks/useAiChat';
 import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
 import PracticeCalendar from '../components/PracticeCalendar';
+import SkillTrendChart from '../components/SkillTrendChart';
 
 interface AxisScore {
   axis: string;
@@ -118,6 +119,9 @@ export default function ScoreHistoryPage() {
           ))}
         </div>
       </div>
+
+      {/* スキル別推移 */}
+      <SkillTrendChart history={history} />
 
       {/* 練習カレンダー */}
       <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />


### PR DESCRIPTION
## 概要
- ScoreHistoryPageにスキル別のスコア推移バーチャートを追加
- 各スキル軸の最新スコアと前回からの変動を表示

## 機能
- 5軸スキル（論理的構成力・配慮表現・要約力・提案力・質問傾聴力）のバー表示
- 前回からの変動を+/-で色付き表示
- 履歴がない場合は非表示

## テスト
- SkillTrendChartコンポーネント: 5テスト
- 全392テスト合格

closes #230