### PR TITLE
refactor: 認証ページのfetchロジックをRepositoryに分離

### DIFF
--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -3,6 +3,8 @@ import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import { useNavigate } from 'react-router-dom';
+import authRepository from '../repositories/AuthRepository';
+import { AxiosError } from 'axios';
 
 interface FormMessage {
   type: 'success' | 'error';
@@ -13,35 +15,20 @@ export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState<FormMessage | null>(null);
   const navigate = useNavigate();
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     try {
-      const response = await fetch(
-        `${API_BASE_URL}/api/auth/cognito/forgot-password`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email }),
-        }
-      );
-
-      const data = await response.json();
-
-      if (response.ok) {
-        setMessage({ type: 'success', text: data.message });
-        navigate('/confirm-forgot-password', { state: { email } });
-      } else {
-        setMessage({
-          type: 'error',
-          text: data.error || '送信に失敗しました。',
-        });
-      }
+      const data = await authRepository.forgotPassword({ email });
+      setMessage({ type: 'success', text: data.message });
+      navigate('/confirm-forgot-password', { state: { email } });
     } catch (error) {
-      console.log(error);
-      setMessage({ type: 'error', text: '通信エラーが発生しました。' });
+      if (error instanceof AxiosError && error.response?.data?.error) {
+        setMessage({ type: 'error', text: error.response.data.error });
+      } else {
+        setMessage({ type: 'error', text: '通信エラーが発生しました。' });
+      }
     }
   };
 

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -75,15 +75,17 @@ class AuthRepository {
   /**
    * パスワード再設定リクエスト
    */
-  async forgotPassword(request: ForgotPasswordRequest): Promise<void> {
-    await apiClient.post('/api/auth/cognito/forgot-password', request);
+  async forgotPassword(request: ForgotPasswordRequest): Promise<{ message: string }> {
+    const response = await apiClient.post('/api/auth/cognito/forgot-password', request);
+    return response.data;
   }
 
   /**
    * パスワード再設定確認
    */
-  async confirmForgotPassword(request: ConfirmForgotPasswordRequest): Promise<void> {
-    await apiClient.post('/api/auth/cognito/confirm-forgot-password', request);
+  async confirmForgotPassword(request: ConfirmForgotPasswordRequest): Promise<{ message: string }> {
+    const response = await apiClient.post('/api/auth/cognito/confirm-forgot-password', request);
+    return response.data;
   }
 
   /**

--- a/frontend/src/repositories/__tests__/AuthRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AuthRepository.test.ts
@@ -38,17 +38,18 @@ describe('AuthRepository', () => {
   });
 
   it('forgotPassword: パスワード再設定リクエストを送信できる', async () => {
-    mockedApiClient.post.mockResolvedValue({});
+    mockedApiClient.post.mockResolvedValue({ data: { message: '確認コードを送信しました' } });
 
-    await authRepository.forgotPassword({ email: 'test@example.com' });
+    const result = await authRepository.forgotPassword({ email: 'test@example.com' });
 
     expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/forgot-password', { email: 'test@example.com' });
+    expect(result).toEqual({ message: '確認コードを送信しました' });
   });
 
   it('confirmForgotPassword: パスワード再設定確認ができる', async () => {
-    mockedApiClient.post.mockResolvedValue({});
+    mockedApiClient.post.mockResolvedValue({ data: { message: 'パスワードをリセットしました' } });
 
-    await authRepository.confirmForgotPassword({
+    const result = await authRepository.confirmForgotPassword({
       email: 'test@example.com',
       confirmationCode: '123456',
       newPassword: 'newPassword123',
@@ -59,6 +60,7 @@ describe('AuthRepository', () => {
       confirmationCode: '123456',
       newPassword: 'newPassword123',
     });
+    expect(result).toEqual({ message: 'パスワードをリセットしました' });
   });
 
   it('logout: ログアウトできる', async () => {


### PR DESCRIPTION
## 概要
closes #234

- ForgotPasswordPage/ConfirmForgotPasswordPageの直接fetchをauthRepositoryに移行
- AuthRepositoryのforgotPassword/confirmForgotPasswordの戻り値を`{ message: string }`に変更
- テストをAuthRepositoryモックベースに統一（AxiosError活用）

## テスト
- 全396テスト合格