### PR TITLE
test: ConfirmPage・LoginCallbackのテスト追加

### DIFF
--- a/frontend/src/pages/__tests__/ConfirmPage.test.tsx
+++ b/frontend/src/pages/__tests__/ConfirmPage.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ConfirmPage from '../ConfirmPage';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+describe('ConfirmPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('タイトルが表示される', () => {
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    expect(screen.getByText('確認コードの入力')).toBeInTheDocument();
+  });
+
+  it('メールアドレス入力欄が表示される', () => {
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+  });
+
+  it('確認コード入力欄が表示される', () => {
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    expect(screen.getByLabelText('確認コード')).toBeInTheDocument();
+  });
+
+  it('確認ボタンが表示される', () => {
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    expect(screen.getByText('確認する')).toBeInTheDocument();
+  });
+
+  it('アカウント作成リンクが表示される', () => {
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    expect(screen.getByText('アカウント作成に戻る')).toBeInTheDocument();
+  });
+
+  it('確認成功時にログインページへ遷移する', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: '確認成功' }),
+    } as Response);
+
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'test@example.com', name: 'email' },
+    });
+    fireEvent.change(screen.getByLabelText('確認コード'), {
+      target: { value: '123456', name: 'code' },
+    });
+    fireEvent.click(screen.getByText('確認する'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login', {
+        state: { message: '確認に成功しました。ログインしてください。' },
+      });
+    });
+  });
+
+  it('確認失敗時にエラーメッセージを表示する', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: '確認コードが無効です' }),
+    } as Response);
+
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'test@example.com', name: 'email' },
+    });
+    fireEvent.change(screen.getByLabelText('確認コード'), {
+      target: { value: '000000', name: 'code' },
+    });
+    fireEvent.click(screen.getByText('確認する'));
+
+    await waitFor(() => {
+      expect(screen.getByText('確認コードが無効です')).toBeInTheDocument();
+    });
+  });
+
+  it('通信エラー時にエラーメッセージを表示する', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network error'));
+
+    render(<BrowserRouter><ConfirmPage /></BrowserRouter>);
+
+    fireEvent.click(screen.getByText('確認する'));
+
+    await waitFor(() => {
+      expect(screen.getByText('通信エラーが発生しました。')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/__tests__/LoginCallback.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import LoginCallback from '../LoginCallback';
+import authReducer from '../../store/authSlice';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function renderWithRoute(search: string) {
+  const store = configureStore({ reducer: { auth: authReducer } });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[`/callback${search}`]}>
+        <LoginCallback />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('LoginCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal('alert', vi.fn());
+  });
+
+  it('ローディング表示がされる', () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      headers: new Headers(),
+    } as Response);
+
+    renderWithRoute('?code=test-code');
+
+    expect(screen.getByText('ログイン中...')).toBeInTheDocument();
+  });
+
+  it('codeがない場合はログインページへリダイレクトする', async () => {
+    renderWithRoute('');
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('errorパラメータがある場合はアラート表示しログインページへリダイレクトする', async () => {
+    renderWithRoute('?error=access_denied');
+
+    await waitFor(() => {
+      expect(alert).toHaveBeenCalledWith('認証エラーが発生しました。access_denied');
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+
+  it('認証成功時にホームページへリダイレクトする', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { id: 1, name: 'テスト' } }),
+      headers: new Headers(),
+    } as Response);
+
+    renderWithRoute('?code=valid-code');
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/cognito/callback'),
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ code: 'valid-code' }),
+          credentials: 'include',
+        }),
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('認証失敗時にアラート表示しログインページへリダイレクトする', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+      headers: new Headers(),
+    } as Response);
+
+    renderWithRoute('?code=invalid-code');
+
+    await waitFor(() => {
+      expect(alert).toHaveBeenCalledWith('認証に失敗しました。');
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+});


### PR DESCRIPTION
## 概要
closes #236

- ConfirmPage: 8テスト（タイトル・入力欄・ボタン・リンク・確認成功/失敗・通信エラー）
- LoginCallback: 5テスト（ローディング表示・認証成功/失敗・errorパラメータ・codeなし）

## テスト
- 全409テスト合格（+13テスト）