### PR TITLE
feat: ホームページにコミュニケーションTipsカードを追加

### DIFF
--- a/frontend/src/components/CommunicationTipCard.tsx
+++ b/frontend/src/components/CommunicationTipCard.tsx
@@ -1,0 +1,43 @@
+const TIPS = [
+  { category: 'メール', text: '件名は「結論＋具体情報」で書くと開封率が上がります。例：「【承認依頼】○○プロジェクト予算案」' },
+  { category: '会議', text: '発言の冒頭に「結論→理由→補足」の順で話すと、短い時間で的確に伝わります。' },
+  { category: '報連相', text: '報告は「事実→影響→対応案」の3点セットで伝えると、上司の判断を助けられます。' },
+  { category: 'チャット', text: 'テキストチャットでは感情が伝わりにくいため、ポジティブな表現を1つ添えると誤解を防げます。' },
+  { category: 'メール', text: '長文メールは箇条書きに置き換えるだけで、読み手の理解速度が大幅に上がります。' },
+  { category: '会議', text: '質問するときは「○○について確認したいのですが」と前置きすると、相手が答えやすくなります。' },
+  { category: '報連相', text: '悪い報告こそ早めに。「まだ解決できていませんが、現状をお伝えします」が信頼を築きます。' },
+  { category: 'チャット', text: '依頼メッセージには期限と優先度を明記すると、相手がスケジュールを立てやすくなります。' },
+  { category: 'メール', text: '返信の冒頭で相手のメールの要点を一文で要約すると「ちゃんと読んでいる」と伝わります。' },
+  { category: '会議', text: '議論が長引いたら「一度整理させてください」と切り出すと、場の流れをコントロールできます。' },
+  { category: '報連相', text: '相談は「自分はAだと思うが、Bも検討したい」のように自分の意見を先に出すと建設的になります。' },
+  { category: 'チャット', text: '「了解です」だけでなく「了解です、○○の件ですね」と一言添えると、認識ズレを防げます。' },
+  { category: 'メール', text: 'CCに入れる人は「この情報を知っておくべき人」に絞ると、組織全体の生産性が上がります。' },
+  { category: '会議', text: '会議の最後に「次のアクション」を全員で確認するだけで、タスクの抜け漏れが激減します。' },
+];
+
+function getTipOfTheDay(): (typeof TIPS)[number] {
+  const today = new Date();
+  const dayIndex = Math.floor(today.getTime() / (1000 * 60 * 60 * 24));
+  return TIPS[dayIndex % TIPS.length];
+}
+
+export default function CommunicationTipCard() {
+  const tip = getTipOfTheDay();
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-xs font-semibold text-slate-800">今日のTips</h3>
+        <span
+          data-testid="tip-category"
+          className="text-[10px] font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded"
+        >
+          {tip.category}
+        </span>
+      </div>
+      <p data-testid="tip-text" className="text-sm text-slate-600 leading-relaxed">
+        {tip.text}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/CommunicationTipCard.test.tsx
+++ b/frontend/src/components/__tests__/CommunicationTipCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CommunicationTipCard from '../CommunicationTipCard';
+
+describe('CommunicationTipCard', () => {
+  it('Tipsテキストが表示される', () => {
+    render(<CommunicationTipCard />);
+
+    expect(screen.getByTestId('tip-text')).toBeInTheDocument();
+  });
+
+  it('カテゴリラベルが表示される', () => {
+    render(<CommunicationTipCard />);
+
+    expect(screen.getByTestId('tip-category')).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<CommunicationTipCard />);
+
+    expect(screen.getByText('今日のTips')).toBeInTheDocument();
+  });
+
+  it('日付によって異なるTipsが表示される', () => {
+    vi.useFakeTimers();
+
+    vi.setSystemTime(new Date('2025-01-01'));
+    const { unmount } = render(<CommunicationTipCard />);
+    const tip1 = screen.getByTestId('tip-text').textContent;
+    unmount();
+
+    vi.setSystemTime(new Date('2025-01-02'));
+    render(<CommunicationTipCard />);
+    const tip2 = screen.getByTestId('tip-text').textContent;
+
+    expect(tip1).not.toBe(tip2);
+
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -6,6 +6,7 @@ import {
   AcademicCapIcon,
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
+import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
@@ -95,6 +96,11 @@ export default function MenuPage() {
       {/* 日次学習目標 */}
       <div className="mb-6">
         <DailyGoalCard />
+      </div>
+
+      {/* コミュニケーションTips */}
+      <div className="mb-6">
+        <CommunicationTipCard />
       </div>
 
       {/* メニュー */}


### PR DESCRIPTION
## 概要
closes #238

- 日替わりビジネスコミュニケーションTips表示（14種類）
- カテゴリラベル付き（メール/会議/報連相/チャット）
- MenuPageのメニュー一覧上部に配置

## テスト
- 全413テスト合格（+4テスト）