### PR TITLE
feat: ホームページに直近セッション一覧を追加

### DIFF
--- a/frontend/src/components/RecentSessionsCard.tsx
+++ b/frontend/src/components/RecentSessionsCard.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from 'react-router-dom';
+
+interface Session {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  createdAt: string;
+}
+
+interface RecentSessionsCardProps {
+  sessions: Session[];
+}
+
+function scoreColor(score: number): string {
+  if (score >= 8) return 'text-emerald-600';
+  if (score >= 6) return 'text-amber-600';
+  return 'text-rose-600';
+}
+
+export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps) {
+  const navigate = useNavigate();
+  const recent = sessions.slice(0, 3);
+
+  if (recent.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-xs font-semibold text-slate-800">直近のセッション</h3>
+        <button
+          onClick={() => navigate('/scores')}
+          className="text-[10px] text-primary-600 hover:text-primary-700"
+        >
+          すべて見る
+        </button>
+      </div>
+      <div className="space-y-2">
+        {recent.map((session) => (
+          <div
+            key={session.sessionId}
+            className="flex items-center justify-between py-1.5 border-b border-slate-100 last:border-0"
+          >
+            <div className="flex-1 min-w-0 mr-3">
+              <p className="text-sm text-slate-700 truncate">{session.sessionTitle}</p>
+              <p className="text-[10px] text-slate-400">
+                {new Date(session.createdAt).toLocaleDateString('ja-JP')}
+              </p>
+            </div>
+            <span className={`text-sm font-semibold ${scoreColor(session.overallScore)}`}>
+              {session.overallScore}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/RecentSessionsCard.test.tsx
+++ b/frontend/src/components/__tests__/RecentSessionsCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import RecentSessionsCard from '../RecentSessionsCard';
+
+const mockSessions = [
+  { sessionId: 1, sessionTitle: '練習: クレーム対応', overallScore: 8.5, createdAt: '2025-01-15T10:00:00' },
+  { sessionId: 2, sessionTitle: 'フリーチャット', overallScore: 7.2, createdAt: '2025-01-14T09:00:00' },
+  { sessionId: 3, sessionTitle: '練習: 会議ファシリ', overallScore: 6.8, createdAt: '2025-01-13T08:00:00' },
+];
+
+describe('RecentSessionsCard', () => {
+  it('タイトルが表示される', () => {
+    render(<BrowserRouter><RecentSessionsCard sessions={mockSessions} /></BrowserRouter>);
+
+    expect(screen.getByText('直近のセッション')).toBeInTheDocument();
+  });
+
+  it('セッション名が表示される', () => {
+    render(<BrowserRouter><RecentSessionsCard sessions={mockSessions} /></BrowserRouter>);
+
+    expect(screen.getByText('練習: クレーム対応')).toBeInTheDocument();
+    expect(screen.getByText('フリーチャット')).toBeInTheDocument();
+    expect(screen.getByText('練習: 会議ファシリ')).toBeInTheDocument();
+  });
+
+  it('スコアが表示される', () => {
+    render(<BrowserRouter><RecentSessionsCard sessions={mockSessions} /></BrowserRouter>);
+
+    expect(screen.getByText('8.5')).toBeInTheDocument();
+    expect(screen.getByText('7.2')).toBeInTheDocument();
+    expect(screen.getByText('6.8')).toBeInTheDocument();
+  });
+
+  it('最大3件まで表示される', () => {
+    const manySessions = [
+      ...mockSessions,
+      { sessionId: 4, sessionTitle: '追加セッション', overallScore: 5.0, createdAt: '2025-01-12T08:00:00' },
+    ];
+    render(<BrowserRouter><RecentSessionsCard sessions={manySessions} /></BrowserRouter>);
+
+    expect(screen.queryByText('追加セッション')).not.toBeInTheDocument();
+  });
+
+  it('セッションがない場合は何も表示しない', () => {
+    const { container } = render(<BrowserRouter><RecentSessionsCard sessions={[]} /></BrowserRouter>);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -9,6 +9,7 @@ import {
 import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
+import RecentSessionsCard from '../components/RecentSessionsCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
 import { useMenuData } from '../hooks/useMenuData';
 
@@ -97,6 +98,13 @@ export default function MenuPage() {
       <div className="mb-6">
         <DailyGoalCard />
       </div>
+
+      {/* 直近のセッション */}
+      {allScores.length > 0 && (
+        <div className="mb-6">
+          <RecentSessionsCard sessions={allScores} />
+        </div>
+      )}
 
       {/* コミュニケーションTips */}
       <div className="mb-6">


### PR DESCRIPTION
## 概要
closes #240

- 直近3件のセッションをスコア付きで表示するRecentSessionsCard
- スコアに応じた色分け（8以上:緑/6以上:黄/それ以下:赤）
- 「すべて見る」ボタンでスコア履歴ページへ遷移
- セッションがない場合は非表示

## テスト
- 全418テスト合格（+5テスト）