### PR TITLE
refactor: ConfirmPage・LoginCallbackのfetchをRepository/apiClientに移行

### DIFF
--- a/frontend/src/pages/LoginCallback.tsx
+++ b/frontend/src/pages/LoginCallback.tsx
@@ -2,78 +2,34 @@ import { useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setAuthData } from '../store/authSlice';
+import authRepository from '../repositories/AuthRepository';
 
 export default function LoginCallback() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
   const code = searchParams.get('code');
   const error = searchParams.get('error');
 
   useEffect(() => {
-    console.log('========== [LoginCallback] Callbackページ読み込み ==========');
-    console.log('[LoginCallback] API_BASE_URL:', API_BASE_URL);
-    console.log('[LoginCallback] code:', code ? code.substring(0, 20) + '...' : 'null');
-    console.log('[LoginCallback] error:', error);
-
     if (error) {
-      console.error('[LoginCallback] 認証エラー:', error);
       alert('認証エラーが発生しました。' + error);
       navigate('/login');
       return;
     }
 
     if (code) {
-      const callbackUrl = `${API_BASE_URL}/api/auth/cognito/callback`;
-      console.log('[LoginCallback] POSTリクエスト送信先:', callbackUrl);
-      console.log('[LoginCallback] リクエスト設定: credentials=include, Content-Type=application/json');
-
-      fetch(callbackUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code }),
-        credentials: 'include',
-      })
-        .then((res) => {
-          console.log('[LoginCallback] レスポンス受信:');
-          console.log('   - status:', res.status);
-          console.log('   - ok:', res.ok);
-          console.log('   - statusText:', res.statusText);
-
-          console.log('[LoginCallback] レスポンスヘッダー:');
-          res.headers.forEach((value, key) => {
-            console.log(`   - ${key}: ${value}`);
-          });
-
-          if (!res.ok) {
-            throw new Error(`認証に失敗しました。Status: ${res.status}`);
-          }
-          return res.json();
-        })
-        .then((data) => {
-          console.log('[LoginCallback] 認証成功:', data);
+      authRepository
+        .callback(code)
+        .then(() => {
           dispatch(setAuthData());
           navigate('/');
         })
-        .catch((err: Error) => {
-          console.error('[LoginCallback] エラー発生:', err);
-          console.error('[LoginCallback] エラータイプ:', err.name);
-          console.error('[LoginCallback] エラーメッセージ:', err.message);
-
-          if (err.message.includes('Failed to fetch') || err.name === 'TypeError') {
-            console.error('[LoginCallback] ⚠️ CORSエラーの可能性があります');
-            console.error('[LoginCallback] 確認事項:');
-            console.error('   1. バックエンドのCORS設定でOriginが許可されているか');
-            console.error('   2. ALB/CloudFrontがCORSヘッダーを削除していないか');
-            console.error('   3. プリフライト(OPTIONS)リクエストが正常に処理されているか');
-          }
-
+        .catch(() => {
           alert('認証に失敗しました。');
           navigate('/login');
         });
     } else {
-      console.warn('[LoginCallback] codeパラメータがありません。/loginへリダイレクト');
       navigate('/login');
     }
   }, [code, error, dispatch, navigate]);
@@ -81,12 +37,10 @@ export default function LoginCallback() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-surface">
       <div className="flex flex-col items-center space-y-6">
-        {/* ローディングスピナー */}
         <div className="relative w-20 h-20">
           <div className="absolute inset-0 rounded-full border-4 border-primary-200"></div>
           <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-primary-600 border-r-primary-600 animate-spin"></div>
         </div>
-        {/* ローディングテキスト */}
         <div className="text-center">
           <h3 className="text-2xl font-bold text-gray-800 mb-2">
             ログイン中...

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -29,7 +29,7 @@ export interface SignupRequest {
 
 export interface ConfirmSignupRequest {
   email: string;
-  confirmationCode: string;
+  code: string;
 }
 
 export interface ForgotPasswordRequest {
@@ -68,8 +68,17 @@ class AuthRepository {
   /**
    * サインアップ確認
    */
-  async confirmSignup(request: ConfirmSignupRequest): Promise<void> {
-    await apiClient.post('/api/auth/cognito/confirm-signup', request);
+  async confirmSignup(request: ConfirmSignupRequest): Promise<{ message: string }> {
+    const response = await apiClient.post('/api/auth/cognito/confirm', request);
+    return response.data;
+  }
+
+  /**
+   * OAuthコールバック
+   */
+  async callback(code: string): Promise<unknown> {
+    const response = await apiClient.post('/api/auth/cognito/callback', { code });
+    return response.data;
   }
 
   /**

--- a/frontend/src/repositories/__tests__/AuthRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AuthRepository.test.ts
@@ -30,11 +30,22 @@ describe('AuthRepository', () => {
   });
 
   it('confirmSignup: サインアップ確認ができる', async () => {
-    mockedApiClient.post.mockResolvedValue({});
+    mockedApiClient.post.mockResolvedValue({ data: { message: '確認成功' } });
 
-    await authRepository.confirmSignup({ email: 'test@example.com', confirmationCode: '123456' });
+    const result = await authRepository.confirmSignup({ email: 'test@example.com', code: '123456' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/confirm-signup', { email: 'test@example.com', confirmationCode: '123456' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/confirm', { email: 'test@example.com', code: '123456' });
+    expect(result).toEqual({ message: '確認成功' });
+  });
+
+  it('callback: OAuthコールバックを処理できる', async () => {
+    const mockData = { user: { id: 1, name: 'テスト' } };
+    mockedApiClient.post.mockResolvedValue({ data: mockData });
+
+    const result = await authRepository.callback('auth-code-123');
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/callback', { code: 'auth-code-123' });
+    expect(result).toEqual(mockData);
   });
 
   it('forgotPassword: パスワード再設定リクエストを送信できる', async () => {


### PR DESCRIPTION
## 概要
closes #242

- ConfirmPage: 直接fetchからauthRepository.confirmSignupに移行
- LoginCallback: 直接fetchからauthRepository.callbackに移行（100→53行、console.logも削除）
- AuthRepositoryにcallbackメソッド追加
- confirmSignupのエンドポイントをバックエンドの実際のパス `/confirm` に修正
- ConfirmSignupRequestの `confirmationCode` を `code` に修正（バックエンド準拠）

## テスト
- 全419テスト合格（+1テスト: callback）