### PR TITLE
test: useMenuData・useSessionNoteのテスト強化

### DIFF
--- a/frontend/src/hooks/__tests__/useSessionNote.test.ts
+++ b/frontend/src/hooks/__tests__/useSessionNote.test.ts
@@ -43,4 +43,34 @@ describe('useSessionNote', () => {
     expect(mockedRepo.save).toHaveBeenCalledWith(1, '新しいメモ');
     expect(result.current.note).toBe('新しいメモ');
   });
+
+  it('sessionIdがnullの場合は空文字を返す', () => {
+    const { result } = renderHook(() => useSessionNote(null));
+
+    expect(result.current.note).toBe('');
+    expect(mockedRepo.get).not.toHaveBeenCalled();
+  });
+
+  it('sessionIdがnullの場合は保存しない', () => {
+    const { result } = renderHook(() => useSessionNote(null));
+
+    act(() => {
+      result.current.saveNote('テスト');
+    });
+
+    expect(mockedRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('空文字で保存できる', () => {
+    mockedRepo.get.mockReturnValue({ sessionId: 1, note: '既存メモ', updatedAt: '2026-02-13' });
+
+    const { result } = renderHook(() => useSessionNote(1));
+
+    act(() => {
+      result.current.saveNote('');
+    });
+
+    expect(mockedRepo.save).toHaveBeenCalledWith(1, '');
+    expect(result.current.note).toBe('');
+  });
 });


### PR DESCRIPTION
## 概要
closes #244

- useMenuData: 2→5テスト（空データ初期値検証/同日uniqueDays計算/部分的API成功時の動作）
- useSessionNote: 3→6テスト（nullセッションID/保存スキップ/空文字保存）

## テスト
- 全425テスト合格（+6テスト）