### PR TITLE
feat: スコアに応じたランクバッジ表示を追加

### DIFF
--- a/frontend/src/components/ScoreRankBadge.tsx
+++ b/frontend/src/components/ScoreRankBadge.tsx
@@ -1,0 +1,29 @@
+interface ScoreRankBadgeProps {
+  score: number;
+}
+
+interface Rank {
+  letter: string;
+  label: string;
+  bgColor: string;
+  textColor: string;
+}
+
+function getRank(score: number): Rank {
+  if (score >= 9.0) return { letter: 'S', label: 'エキスパート', bgColor: 'bg-amber-100', textColor: 'text-amber-700' };
+  if (score >= 8.0) return { letter: 'A', label: '上級', bgColor: 'bg-slate-200', textColor: 'text-slate-700' };
+  if (score >= 7.0) return { letter: 'B', label: '中級', bgColor: 'bg-orange-100', textColor: 'text-orange-700' };
+  if (score >= 6.0) return { letter: 'C', label: '初級', bgColor: 'bg-emerald-100', textColor: 'text-emerald-700' };
+  return { letter: 'D', label: '入門', bgColor: 'bg-slate-100', textColor: 'text-slate-500' };
+}
+
+export default function ScoreRankBadge({ score }: ScoreRankBadgeProps) {
+  const rank = getRank(score);
+
+  return (
+    <div className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full ${rank.bgColor}`}>
+      <span className={`text-sm font-bold ${rank.textColor}`}>{rank.letter}</span>
+      <span className={`text-[10px] font-medium ${rank.textColor}`}>{rank.label}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreRankBadge.test.tsx
+++ b/frontend/src/components/__tests__/ScoreRankBadge.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreRankBadge from '../ScoreRankBadge';
+
+describe('ScoreRankBadge', () => {
+  it('スコア9.0以上でSランクが表示される', () => {
+    render(<ScoreRankBadge score={9.5} />);
+
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('エキスパート')).toBeInTheDocument();
+  });
+
+  it('スコア8.0以上でAランクが表示される', () => {
+    render(<ScoreRankBadge score={8.3} />);
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('上級')).toBeInTheDocument();
+  });
+
+  it('スコア7.0以上でBランクが表示される', () => {
+    render(<ScoreRankBadge score={7.0} />);
+
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('中級')).toBeInTheDocument();
+  });
+
+  it('スコア6.0以上でCランクが表示される', () => {
+    render(<ScoreRankBadge score={6.5} />);
+
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('初級')).toBeInTheDocument();
+  });
+
+  it('スコア6.0未満でDランクが表示される', () => {
+    render(<ScoreRankBadge score={4.0} />);
+
+    expect(screen.getByText('D')).toBeInTheDocument();
+    expect(screen.getByText('入門')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -4,6 +4,7 @@ import { useAiChat } from '../hooks/useAiChat';
 import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
 import PracticeCalendar from '../components/PracticeCalendar';
+import ScoreRankBadge from '../components/ScoreRankBadge';
 import SkillTrendChart from '../components/SkillTrendChart';
 
 interface AxisScore {
@@ -81,6 +82,17 @@ export default function ScoreHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
+      {/* 最新スコアとランクバッジ */}
+      {latestSession && (
+        <div className="bg-white rounded-lg border border-slate-200 p-4 flex items-center justify-between">
+          <div>
+            <p className="text-xs text-slate-500 mb-1">最新スコア</p>
+            <p className="text-2xl font-bold text-slate-800">{latestSession.overallScore.toFixed(1)}</p>
+          </div>
+          <ScoreRankBadge score={latestSession.overallScore} />
+        </div>
+      )}
+
       {/* 弱点ベースのおすすめ練習 */}
       {weakestAxis && (
         <div className="bg-primary-50 rounded-lg border border-primary-100 p-4">


### PR DESCRIPTION
## 概要
closes #246

- ScoreRankBadge: スコアに応じたS/A/B/C/Dランクバッジ表示
- ScoreHistoryPage最上部に最新スコア＋ランクバッジを配置
- モチベーション向上のための可視化

## テスト
- 全430テスト合格（+5テスト）