### PR TITLE
feat: ホームページに練習リマインダーカードを追加

### DIFF
--- a/frontend/src/components/PracticeReminderCard.tsx
+++ b/frontend/src/components/PracticeReminderCard.tsx
@@ -1,0 +1,45 @@
+import { useNavigate } from 'react-router-dom';
+
+interface PracticeReminderCardProps {
+  lastPracticeDate: string | null;
+}
+
+function getDaysAgo(dateStr: string): number {
+  const now = new Date();
+  const then = new Date(dateStr);
+  const diffMs = now.getTime() - then.getTime();
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24));
+}
+
+export default function PracticeReminderCard({ lastPracticeDate }: PracticeReminderCardProps) {
+  const navigate = useNavigate();
+
+  if (!lastPracticeDate) return null;
+
+  const daysAgo = getDaysAgo(lastPracticeDate);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4 flex items-center justify-between">
+      <div>
+        {daysAgo === 0 ? (
+          <p className="text-sm font-medium text-emerald-600">今日も練習済み！</p>
+        ) : (
+          <>
+            <p className="text-sm font-medium text-slate-700">最後の練習: {daysAgo}日前</p>
+            {daysAgo >= 3 && (
+              <p className="text-xs text-amber-600 mt-0.5">そろそろ練習しませんか？</p>
+            )}
+          </>
+        )}
+      </div>
+      {daysAgo > 0 && (
+        <button
+          onClick={() => navigate('/practice')}
+          className="text-xs font-medium text-white bg-primary-500 px-3 py-1.5 rounded-lg hover:bg-primary-600 transition-colors"
+        >
+          練習する
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeReminderCard.test.tsx
+++ b/frontend/src/components/__tests__/PracticeReminderCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import PracticeReminderCard from '../PracticeReminderCard';
+
+describe('PracticeReminderCard', () => {
+  it('今日練習した場合は「今日も練習済み」と表示される', () => {
+    const today = new Date().toISOString();
+    render(<BrowserRouter><PracticeReminderCard lastPracticeDate={today} /></BrowserRouter>);
+
+    expect(screen.getByText('今日も練習済み！')).toBeInTheDocument();
+  });
+
+  it('1日前の場合は「1日前に練習」と表示される', () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    render(<BrowserRouter><PracticeReminderCard lastPracticeDate={yesterday} /></BrowserRouter>);
+
+    expect(screen.getByText('最後の練習: 1日前')).toBeInTheDocument();
+  });
+
+  it('3日以上前の場合は練習を促すメッセージが表示される', () => {
+    const threeDaysAgo = new Date(Date.now() - 86400000 * 3).toISOString();
+    render(<BrowserRouter><PracticeReminderCard lastPracticeDate={threeDaysAgo} /></BrowserRouter>);
+
+    expect(screen.getByText('最後の練習: 3日前')).toBeInTheDocument();
+    expect(screen.getByText('そろそろ練習しませんか？')).toBeInTheDocument();
+  });
+
+  it('「練習する」ボタンが表示される', () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    render(<BrowserRouter><PracticeReminderCard lastPracticeDate={yesterday} /></BrowserRouter>);
+
+    expect(screen.getByText('練習する')).toBeInTheDocument();
+  });
+
+  it('練習日がない場合は何も表示しない', () => {
+    const { container } = render(<BrowserRouter><PracticeReminderCard lastPracticeDate={null} /></BrowserRouter>);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -9,6 +9,7 @@ import {
 import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
+import PracticeReminderCard from '../components/PracticeReminderCard';
 import RecentSessionsCard from '../components/RecentSessionsCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
 import { useMenuData } from '../hooks/useMenuData';
@@ -91,6 +92,13 @@ export default function MenuPage() {
       {totalSessions > 0 && (
         <div className="mb-6">
           <WeeklyReportCard allScores={allScores} />
+        </div>
+      )}
+
+      {/* 練習リマインダー */}
+      {latestScore && (
+        <div className="mb-6">
+          <PracticeReminderCard lastPracticeDate={latestScore.createdAt} />
         </div>
       )}
 


### PR DESCRIPTION
## 概要
closes #248

- PracticeReminderCard: 最後の練習からの経過日数を表示
- 当日練習済みなら肯定メッセージ、3日以上経過で促すメッセージ
- 「練習する」ボタンで練習ページへ遷移

## テスト
- 全435テスト合格（+5テスト）