### PR TITLE
feat: スコア履歴に総合統計サマリーを追加

### DIFF
--- a/frontend/src/components/ScoreStatsSummary.tsx
+++ b/frontend/src/components/ScoreStatsSummary.tsx
@@ -1,0 +1,28 @@
+interface ScoreStatsSummaryProps {
+  history: { sessionId: number; overallScore: number }[];
+}
+
+export default function ScoreStatsSummary({ history }: ScoreStatsSummaryProps) {
+  if (history.length === 0) return null;
+
+  const total = history.length;
+  const avg = Math.round((history.reduce((sum, h) => sum + h.overallScore, 0) / total) * 10) / 10;
+  const best = Math.max(...history.map((h) => h.overallScore));
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      <div className="bg-white rounded-lg border border-slate-200 p-3 text-center">
+        <p className="text-lg font-bold text-slate-800">{total}</p>
+        <p className="text-[10px] text-slate-500">総セッション</p>
+      </div>
+      <div className="bg-white rounded-lg border border-slate-200 p-3 text-center">
+        <p className="text-lg font-bold text-slate-800">{avg}</p>
+        <p className="text-[10px] text-slate-500">平均スコア</p>
+      </div>
+      <div className="bg-white rounded-lg border border-slate-200 p-3 text-center">
+        <p className="text-lg font-bold text-amber-600">{best}</p>
+        <p className="text-[10px] text-slate-500">最高スコア</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreStatsSummary.test.tsx
+++ b/frontend/src/components/__tests__/ScoreStatsSummary.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreStatsSummary from '../ScoreStatsSummary';
+
+const mockHistory = [
+  { sessionId: 1, overallScore: 8.5 },
+  { sessionId: 2, overallScore: 7.0 },
+  { sessionId: 3, overallScore: 9.2 },
+];
+
+describe('ScoreStatsSummary', () => {
+  it('総セッション数が表示される', () => {
+    render(<ScoreStatsSummary history={mockHistory} />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('総セッション')).toBeInTheDocument();
+  });
+
+  it('平均スコアが表示される', () => {
+    render(<ScoreStatsSummary history={mockHistory} />);
+
+    expect(screen.getByText('8.2')).toBeInTheDocument();
+    expect(screen.getByText('平均スコア')).toBeInTheDocument();
+  });
+
+  it('最高スコアが表示される', () => {
+    render(<ScoreStatsSummary history={mockHistory} />);
+
+    expect(screen.getByText('9.2')).toBeInTheDocument();
+    expect(screen.getByText('最高スコア')).toBeInTheDocument();
+  });
+
+  it('セッションがない場合は何も表示しない', () => {
+    const { container } = render(<ScoreStatsSummary history={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -5,6 +5,7 @@ import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
 import PracticeCalendar from '../components/PracticeCalendar';
 import ScoreRankBadge from '../components/ScoreRankBadge';
+import ScoreStatsSummary from '../components/ScoreStatsSummary';
 import SkillTrendChart from '../components/SkillTrendChart';
 
 interface AxisScore {
@@ -82,6 +83,9 @@ export default function ScoreHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
+      {/* 統計サマリー */}
+      <ScoreStatsSummary history={history} />
+
       {/* 最新スコアとランクバッジ */}
       {latestSession && (
         <div className="bg-white rounded-lg border border-slate-200 p-4 flex items-center justify-between">


### PR DESCRIPTION
## 概要
closes #254

- ScoreStatsSummary: 総セッション数・平均スコア・最高スコアをグリッド表示
- ScoreHistoryPage最上部に配置
- セッションがない場合は非表示

## テスト
- 全444テスト合格（+4テスト）