### PR TITLE
test: PracticeTimer・MemberListのテスト強化

### DIFF
--- a/frontend/src/components/__tests__/MemberList.test.tsx
+++ b/frontend/src/components/__tests__/MemberList.test.tsx
@@ -40,4 +40,46 @@ describe('MemberList', () => {
 
     expect(container.querySelector('.space-y-4')?.children).toHaveLength(0);
   });
+
+  it('メールアドレスが表示される', () => {
+    const users = [
+      { id: 1, name: 'テスト', email: 'test@example.com' },
+    ];
+
+    render(
+      <MemoryRouter>
+        <MemberList users={users} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('roomIdがあるメンバーには「チャット」が表示される', () => {
+    const users = [
+      { id: 1, name: 'テスト', email: 'test@example.com', roomId: 10 },
+    ];
+
+    render(
+      <MemoryRouter>
+        <MemberList users={users} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('チャット')).toBeInTheDocument();
+  });
+
+  it('roomIdがないメンバーには「追加」が表示される', () => {
+    const users = [
+      { id: 1, name: 'テスト', email: 'test@example.com' },
+    ];
+
+    render(
+      <MemoryRouter>
+        <MemberList users={users} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('追加')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/PracticeTimer.test.tsx
+++ b/frontend/src/components/__tests__/PracticeTimer.test.tsx
@@ -2,13 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import PracticeTimer from '../PracticeTimer';
 
+const mockStart = vi.fn();
+const mockStop = vi.fn();
+
 vi.mock('../../hooks/usePracticeTimer', () => ({
   usePracticeTimer: () => ({
     seconds: 125,
     isRunning: true,
     formattedTime: '02:05',
-    start: vi.fn(),
-    stop: vi.fn(),
+    start: mockStart,
+    stop: mockStop,
     reset: vi.fn(),
   }),
 }));
@@ -24,5 +27,19 @@ describe('PracticeTimer', () => {
     render(<PracticeTimer />);
 
     expect(screen.getByText('経過時間')).toBeInTheDocument();
+  });
+
+  it('マウント時にstartが呼ばれる', () => {
+    render(<PracticeTimer />);
+
+    expect(mockStart).toHaveBeenCalled();
+  });
+
+  it('アンマウント時にstopが呼ばれる', () => {
+    const { unmount } = render(<PracticeTimer />);
+
+    unmount();
+
+    expect(mockStop).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 概要
closes #258

- PracticeTimer: 2→4テスト（start/stop呼び出し検証追加）
- MemberList: 2→5テスト（メールアドレス表示・チャット/追加ボタン表示追加）

## テスト
- 全449テスト合格（+5テスト）