### PR TITLE
feat: スキル別マイルストーン到達カードを追加

### DIFF
--- a/frontend/src/components/PracticeCalendar.tsx
+++ b/frontend/src/components/PracticeCalendar.tsx
@@ -4,6 +4,13 @@ interface PracticeCalendarProps {
   practiceDates: string[];
 }
 
+function toLocalDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 function getCalendarDays(weeks: number): Date[] {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -77,7 +84,7 @@ export default function PracticeCalendar({ practiceDates }: PracticeCalendarProp
         {weeks.map((week, wi) => (
           <div key={wi} className="flex flex-col gap-0.5">
             {week.map((day) => {
-              const key = day.toISOString().split('T')[0];
+              const key = toLocalDateKey(day);
               const count = dateCountMap[key] || 0;
               const today = new Date();
               today.setHours(0, 0, 0, 0);

--- a/frontend/src/components/SkillMilestoneCard.tsx
+++ b/frontend/src/components/SkillMilestoneCard.tsx
@@ -1,0 +1,80 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface SkillMilestoneCardProps {
+  scores: AxisScore[];
+}
+
+interface Milestone {
+  label: string;
+  threshold: number;
+  color: string;
+  bgColor: string;
+}
+
+const MILESTONES: Milestone[] = [
+  { label: '入門', threshold: 0, color: 'text-slate-500', bgColor: 'bg-slate-100' },
+  { label: '初級', threshold: 4, color: 'text-emerald-600', bgColor: 'bg-emerald-50' },
+  { label: '中級', threshold: 6, color: 'text-blue-600', bgColor: 'bg-blue-50' },
+  { label: '上級', threshold: 7, color: 'text-purple-600', bgColor: 'bg-purple-50' },
+  { label: 'エキスパート', threshold: 9, color: 'text-amber-600', bgColor: 'bg-amber-50' },
+];
+
+function getCurrentMilestone(score: number): Milestone {
+  for (let i = MILESTONES.length - 1; i >= 0; i--) {
+    if (score >= MILESTONES[i].threshold) return MILESTONES[i];
+  }
+  return MILESTONES[0];
+}
+
+function getNextMilestone(score: number): Milestone | null {
+  for (const m of MILESTONES) {
+    if (score < m.threshold) return m;
+  }
+  return null;
+}
+
+export default function SkillMilestoneCard({ scores }: SkillMilestoneCardProps) {
+  if (scores.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <h3 className="text-xs font-semibold text-slate-800 mb-3">スキル到達レベル</h3>
+      <div className="space-y-3">
+        {scores.map((s) => {
+          const current = getCurrentMilestone(s.score);
+          const next = getNextMilestone(s.score);
+          const remaining = next ? Math.round((next.threshold - s.score) * 10) / 10 : null;
+          const progress = next
+            ? ((s.score - current.threshold) / (next.threshold - current.threshold)) * 100
+            : 100;
+
+          return (
+            <div key={s.axis}>
+              <div className="flex items-center justify-between mb-1">
+                <span className="text-xs text-slate-700">{s.axis}</span>
+                <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${current.bgColor} ${current.color}`}>
+                  {current.label}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="flex-1 bg-slate-100 rounded-full h-1.5">
+                  <div
+                    className="h-1.5 rounded-full bg-primary-500 transition-all"
+                    style={{ width: `${Math.min(progress, 100)}%` }}
+                  />
+                </div>
+                {remaining !== null && (
+                  <span className="text-[10px] text-slate-400 whitespace-nowrap">あと {remaining}</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeCalendar.test.tsx
+++ b/frontend/src/components/__tests__/PracticeCalendar.test.tsx
@@ -25,7 +25,8 @@ describe('PracticeCalendar', () => {
   });
 
   it('練習日のセルがアクティブなスタイルになる', () => {
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     render(<PracticeCalendar practiceDates={[today]} />);
 
     const activeCells = document.querySelectorAll('[data-active="true"]');
@@ -40,7 +41,8 @@ describe('PracticeCalendar', () => {
   });
 
   it('複数回練習した日はより濃い色になる', () => {
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     render(<PracticeCalendar practiceDates={[today, today, today]} />);
 
     const activeCells = document.querySelectorAll('[data-count="3"]');

--- a/frontend/src/components/__tests__/SkillMilestoneCard.test.tsx
+++ b/frontend/src/components/__tests__/SkillMilestoneCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SkillMilestoneCard from '../SkillMilestoneCard';
+
+const mockScores = [
+  { axis: '論理的構成力', score: 8.5, comment: '' },
+  { axis: '配慮表現', score: 6.2, comment: '' },
+  { axis: '要約力', score: 4.0, comment: '' },
+  { axis: '提案力', score: 9.1, comment: '' },
+  { axis: '質問・傾聴力', score: 2.5, comment: '' },
+];
+
+describe('SkillMilestoneCard', () => {
+  it('タイトルが表示される', () => {
+    render(<SkillMilestoneCard scores={mockScores} />);
+
+    expect(screen.getByText('スキル到達レベル')).toBeInTheDocument();
+  });
+
+  it('各スキル軸が表示される', () => {
+    render(<SkillMilestoneCard scores={mockScores} />);
+
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('配慮表現')).toBeInTheDocument();
+    expect(screen.getByText('要約力')).toBeInTheDocument();
+    expect(screen.getByText('提案力')).toBeInTheDocument();
+    expect(screen.getByText('質問・傾聴力')).toBeInTheDocument();
+  });
+
+  it('スコアに応じたレベルラベルが表示される', () => {
+    render(<SkillMilestoneCard scores={mockScores} />);
+
+    expect(screen.getByText('上級')).toBeInTheDocument();
+    expect(screen.getByText('エキスパート')).toBeInTheDocument();
+  });
+
+  it('次のマイルストーン情報が表示される', () => {
+    render(<SkillMilestoneCard scores={mockScores} />);
+
+    // 配慮表現 6.2 → 上級(7.0)まであと0.8
+    expect(screen.getByText('あと 0.8')).toBeInTheDocument();
+  });
+
+  it('スコアがない場合は何も表示しない', () => {
+    const { container } = render(<SkillMilestoneCard scores={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -6,6 +6,7 @@ import SkillRadarChart from '../components/SkillRadarChart';
 import PracticeCalendar from '../components/PracticeCalendar';
 import ScoreRankBadge from '../components/ScoreRankBadge';
 import ScoreStatsSummary from '../components/ScoreStatsSummary';
+import SkillMilestoneCard from '../components/SkillMilestoneCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 
 interface AxisScore {
@@ -135,6 +136,11 @@ export default function ScoreHistoryPage() {
           ))}
         </div>
       </div>
+
+      {/* スキル別マイルストーン */}
+      {latestSession && latestSession.scores.length > 0 && (
+        <SkillMilestoneCard scores={latestSession.scores} />
+      )}
 
       {/* スキル別推移 */}
       <SkillTrendChart history={history} />


### PR DESCRIPTION
## 概要
- スキル別のマイルストーン到達状況を表示するカードコンポーネントを追加
- 入門・初級・中級・上級・エキスパートの5段階で各スキルの到達レベルを表示
- ScoreHistoryPageに統合

## 変更内容
- `SkillMilestoneCard.tsx` を新規作成
- `ScoreHistoryPage.tsx` にSkillMilestoneCardを追加
- `PracticeCalendar.tsx` のタイムゾーンバグを修正（toISOStringからローカル日付キーに変更）

## テスト
- SkillMilestoneCardのテスト5件を追加
- PracticeCalendarのテスト2件を修正
- 全454テスト通過

closes #260