### PR TITLE
feat: 週間練習目標の達成度カードを追加

### DIFF
--- a/frontend/src/components/WeeklyGoalProgressCard.tsx
+++ b/frontend/src/components/WeeklyGoalProgressCard.tsx
@@ -1,0 +1,44 @@
+interface WeeklyGoalProgressCardProps {
+  sessionsThisWeek: number;
+  weeklyGoal: number;
+}
+
+function getMessage(current: number, goal: number): string {
+  if (current === 0) return '今週はまだ練習していません。始めてみましょう！';
+  if (current >= goal) return '目標達成！素晴らしいです！';
+  const remaining = goal - current;
+  return `いい調子です！あと${remaining}回で目標達成！`;
+}
+
+export default function WeeklyGoalProgressCard({
+  sessionsThisWeek,
+  weeklyGoal,
+}: WeeklyGoalProgressCardProps) {
+  const percentage = Math.min((sessionsThisWeek / weeklyGoal) * 100, 100);
+  const isCompleted = sessionsThisWeek >= weeklyGoal;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-2">今週の練習目標</p>
+
+      <div className="flex items-baseline gap-1 mb-2">
+        <span className={`text-2xl font-bold ${isCompleted ? 'text-emerald-600' : 'text-primary-600'}`}>
+          {sessionsThisWeek}
+        </span>
+        <span className="text-sm text-slate-500">/ {weeklyGoal} 回</span>
+      </div>
+
+      <div className="w-full bg-slate-100 rounded-full h-2 mb-2">
+        <div
+          data-testid="progress-bar"
+          className={`h-2 rounded-full transition-all ${isCompleted ? 'bg-emerald-500' : 'bg-primary-500'}`}
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+
+      <p className={`text-xs ${isCompleted ? 'text-emerald-600 font-medium' : 'text-slate-500'}`}>
+        {getMessage(sessionsThisWeek, weeklyGoal)}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/WeeklyGoalProgressCard.test.tsx
+++ b/frontend/src/components/__tests__/WeeklyGoalProgressCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import WeeklyGoalProgressCard from '../WeeklyGoalProgressCard';
+
+describe('WeeklyGoalProgressCard', () => {
+  it('タイトルが表示される', () => {
+    render(<WeeklyGoalProgressCard sessionsThisWeek={0} weeklyGoal={5} />);
+
+    expect(screen.getByText('今週の練習目標')).toBeInTheDocument();
+  });
+
+  it('進捗が正しく表示される', () => {
+    render(<WeeklyGoalProgressCard sessionsThisWeek={3} weeklyGoal={5} />);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('/ 5 回')).toBeInTheDocument();
+  });
+
+  it('0回の時に励ましメッセージが表示される', () => {
+    render(<WeeklyGoalProgressCard sessionsThisWeek={0} weeklyGoal={5} />);
+
+    expect(screen.getByText('今週はまだ練習していません。始めてみましょう！')).toBeInTheDocument();
+  });
+
+  it('達成途中のメッセージが表示される', () => {
+    render(<WeeklyGoalProgressCard sessionsThisWeek={3} weeklyGoal={5} />);
+
+    expect(screen.getByText('いい調子です！あと2回で目標達成！')).toBeInTheDocument();
+  });
+
+  it('目標達成時に祝福メッセージが表示される', () => {
+    render(<WeeklyGoalProgressCard sessionsThisWeek={5} weeklyGoal={5} />);
+
+    expect(screen.getByText('目標達成！素晴らしいです！')).toBeInTheDocument();
+  });
+
+  it('プログレスバーが正しい幅で表示される', () => {
+    render(<WeeklyGoalProgressCard sessionsThisWeek={3} weeklyGoal={5} />);
+
+    const bar = document.querySelector('[data-testid="progress-bar"]');
+    expect(bar).toHaveStyle({ width: '60%' });
+  });
+});

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -58,6 +58,15 @@ export function useMenuData() {
     return new Set(allScores.map(s => s.createdAt.split('T')[0])).size;
   }, [allScores]);
 
+  const sessionsThisWeek = useMemo(() => {
+    const now = new Date();
+    const day = now.getDay();
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - (day === 0 ? 6 : day - 1));
+    monday.setHours(0, 0, 0, 0);
+    return allScores.filter(s => new Date(s.createdAt) >= monday).length;
+  }, [allScores]);
+
   return {
     stats,
     totalUnread,
@@ -66,5 +75,6 @@ export function useMenuData() {
     totalSessions,
     averageScore,
     uniqueDays,
+    sessionsThisWeek,
   };
 }

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -11,12 +11,13 @@ import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
 import PracticeReminderCard from '../components/PracticeReminderCard';
 import RecentSessionsCard from '../components/RecentSessionsCard';
+import WeeklyGoalProgressCard from '../components/WeeklyGoalProgressCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
   const navigate = useNavigate();
-  const { stats, totalUnread, latestScore, allScores, totalSessions, averageScore, uniqueDays } = useMenuData();
+  const { stats, totalUnread, latestScore, allScores, totalSessions, averageScore, uniqueDays, sessionsThisWeek } = useMenuData();
 
   const menuItems = [
     {
@@ -101,6 +102,11 @@ export default function MenuPage() {
           <PracticeReminderCard lastPracticeDate={latestScore.createdAt} />
         </div>
       )}
+
+      {/* 週間練習目標 */}
+      <div className="mb-6">
+        <WeeklyGoalProgressCard sessionsThisWeek={sessionsThisWeek} weeklyGoal={5} />
+      </div>
 
       {/* 日次学習目標 */}
       <div className="mb-6">


### PR DESCRIPTION
## 概要
- MenuPageに週間の練習目標達成度カードを追加
- 今週の練習回数と目標（5回）に対する達成率をプログレスバーで表示
- 達成度に応じた励ましメッセージを表示

## 変更内容
- `WeeklyGoalProgressCard.tsx` を新規作成
- `useMenuData.ts` にsessionsThisWeek算出ロジックを追加
- `MenuPage.tsx` にWeeklyGoalProgressCardを統合

## テスト
- WeeklyGoalProgressCardのテスト6件を追加
- 全460テスト通過

closes #262