### PR TITLE
refactor: ChatPageのdirect fetchをChatRepository経由に移行

### DIFF
--- a/frontend/src/repositories/ChatRepository.ts
+++ b/frontend/src/repositories/ChatRepository.ts
@@ -25,6 +25,20 @@ const ChatRepository = {
     const res = await apiClient.post(`/api/chat/users/${userId}/create`);
     return res.data;
   },
+
+  async markAsRead(roomId: string): Promise<void> {
+    await apiClient.post(`/api/chat/rooms/${roomId}/read`);
+  },
+
+  async fetchHistory(roomId: string): Promise<unknown[]> {
+    const res = await apiClient.get(`/api/chat/users/${roomId}/history`);
+    return res.data;
+  },
+
+  async rephrase(originalMessage: string, scene: string | null): Promise<{ result: string }> {
+    const res = await apiClient.post('/api/chat/ai/rephrase', { originalMessage, scene });
+    return res.data;
+  },
 };
 
 export default ChatRepository;


### PR DESCRIPTION
## 概要
- ChatPage.tsxが使用していたdirect fetch呼び出しをChatRepository経由に移行
- axiosインターセプターによる自動トークンリフレッシュを活用

## 変更内容
- `ChatRepository.ts`: markAsRead, fetchHistory, rephraseメソッドを追加
- `ChatPage.tsx`: direct fetch → ChatRepository呼び出しに変更
- 手動の401ハンドリング・refresh-tokenコードを全て削除
- console.log/error/warnを削除
- useDispatch/clearAuthの不要なimportを削除
- **582行 → 488行に簡素化（-94行）**

## テスト
- 全460テスト通過

closes #264