### PR TITLE
test: ChatRepository新メソッド・useMenuData sessionsThisWeekのテスト追加

### DIFF
--- a/frontend/src/repositories/__tests__/ChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ChatRepository.test.ts
@@ -53,4 +53,38 @@ describe('ChatRepository', () => {
     expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/users/5/create');
     expect(result).toEqual(mockData);
   });
+
+  it('markAsRead: 既読をマークできる', async () => {
+    mockedApiClient.post.mockResolvedValue({ data: undefined });
+
+    await ChatRepository.markAsRead('10');
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/rooms/10/read');
+  });
+
+  it('fetchHistory: チャット履歴を取得できる', async () => {
+    const mockMessages = [
+      { id: 1, content: 'Hello', senderId: 1 },
+      { id: 2, content: 'Hi', senderId: 2 },
+    ];
+    mockedApiClient.get.mockResolvedValue({ data: mockMessages });
+
+    const result = await ChatRepository.fetchHistory('5');
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/users/5/history');
+    expect(result).toEqual(mockMessages);
+  });
+
+  it('rephrase: 言い換え結果を取得できる', async () => {
+    const mockResult = { result: '{"formal":"丁寧版","soft":"柔らかい版","concise":"簡潔版"}' };
+    mockedApiClient.post.mockResolvedValue({ data: mockResult });
+
+    const result = await ChatRepository.rephrase('テスト文', null);
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/rephrase', {
+      originalMessage: 'テスト文',
+      scene: null,
+    });
+    expect(result).toEqual(mockResult);
+  });
 });


### PR DESCRIPTION
## 概要
- Cycle 8で追加・変更した機能のテストカバレッジを向上

## テスト追加内容
- `ChatRepository`: markAsRead, fetchHistory, rephraseの各メソッドテスト（3件追加）
- `useMenuData`: sessionsThisWeek算出ロジックのテスト（1件追加）
- 全464テスト通過（+4件）

closes #266