### PR TITLE
feat: スコア改善アドバイスカードを追加

### DIFF
--- a/frontend/src/components/ScoreImprovementAdvice.tsx
+++ b/frontend/src/components/ScoreImprovementAdvice.tsx
@@ -1,0 +1,53 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface ScoreImprovementAdviceProps {
+  scores: AxisScore[];
+}
+
+const AXIS_ADVICE: Record<string, string> = {
+  '論理的構成力': '結論→理由→具体例の順で話す練習をしましょう。報連相の構造化を意識してみてください。',
+  '配慮表現': 'クッション言葉や敬語のバリエーションを増やしましょう。相手の立場に立った表現を心がけてください。',
+  '要約力': '話す前に要点を3つに絞る練習をしましょう。技術的な内容を非エンジニアにも分かるように説明する訓練が効果的です。',
+  '提案力': '課題だけでなく解決策をセットで伝える習慣をつけましょう。代替案を複数用意するとさらに効果的です。',
+  '質問・傾聴力': '5W1Hを意識した質問を心がけましょう。相手の発言を要約して確認する「オウム返し」も有効です。',
+};
+
+const THRESHOLD = 7;
+
+export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdviceProps) {
+  const weakAxes = scores.filter((s) => s.score < THRESHOLD);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">改善アドバイス</p>
+
+      {weakAxes.length === 0 ? (
+        <p className="text-xs text-emerald-600 font-medium">
+          素晴らしい成績です！この調子で続けましょう。
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {weakAxes.map((axis) => (
+            <div key={axis.axis} data-testid="advice-item" className="flex gap-3">
+              <div className="flex-shrink-0 w-5 h-5 rounded-full bg-amber-100 flex items-center justify-center mt-0.5">
+                <span className="text-amber-600 text-[10px] font-bold">!</span>
+              </div>
+              <div>
+                <p className="text-xs font-medium text-slate-800">
+                  {axis.axis}（{axis.score.toFixed(1)}）
+                </p>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  {AXIS_ADVICE[axis.axis] || `${axis.axis}を伸ばすための練習を続けましょう。`}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreImprovementAdvice.test.tsx
+++ b/frontend/src/components/__tests__/ScoreImprovementAdvice.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreImprovementAdvice from '../ScoreImprovementAdvice';
+
+describe('ScoreImprovementAdvice', () => {
+  const highScores = [
+    { axis: '論理的構成力', score: 9, comment: '' },
+    { axis: '配慮表現', score: 8, comment: '' },
+    { axis: '要約力', score: 8.5, comment: '' },
+    { axis: '提案力', score: 9, comment: '' },
+    { axis: '質問・傾聴力', score: 8, comment: '' },
+  ];
+
+  const mixedScores = [
+    { axis: '論理的構成力', score: 5, comment: '' },
+    { axis: '配慮表現', score: 8, comment: '' },
+    { axis: '要約力', score: 4, comment: '' },
+    { axis: '提案力', score: 9, comment: '' },
+    { axis: '質問・傾聴力', score: 6, comment: '' },
+  ];
+
+  it('タイトルが表示される', () => {
+    render(<ScoreImprovementAdvice scores={mixedScores} />);
+
+    expect(screen.getByText('改善アドバイス')).toBeInTheDocument();
+  });
+
+  it('低スコアの軸にアドバイスが表示される', () => {
+    render(<ScoreImprovementAdvice scores={mixedScores} />);
+
+    expect(screen.getByText(/論理的構成力/)).toBeInTheDocument();
+    expect(screen.getByText(/要約力/)).toBeInTheDocument();
+  });
+
+  it('高スコアの軸にはアドバイスが表示されない', () => {
+    render(<ScoreImprovementAdvice scores={mixedScores} />);
+
+    const adviceItems = screen.getAllByTestId('advice-item');
+    const axisTexts = adviceItems.map((item) => item.textContent);
+    expect(axisTexts.some((t) => t?.includes('提案力'))).toBe(false);
+  });
+
+  it('全軸が高スコアの場合は祝福メッセージが表示される', () => {
+    render(<ScoreImprovementAdvice scores={highScores} />);
+
+    expect(screen.getByText('素晴らしい成績です！この調子で続けましょう。')).toBeInTheDocument();
+  });
+
+  it('スコア7未満の軸のみアドバイス対象になる', () => {
+    render(<ScoreImprovementAdvice scores={mixedScores} />);
+
+    const adviceItems = screen.getAllByTestId('advice-item');
+    expect(adviceItems).toHaveLength(3);
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -7,6 +7,7 @@ import PracticeCalendar from '../components/PracticeCalendar';
 import ScoreRankBadge from '../components/ScoreRankBadge';
 import ScoreStatsSummary from '../components/ScoreStatsSummary';
 import SkillMilestoneCard from '../components/SkillMilestoneCard';
+import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
 import SkillTrendChart from '../components/SkillTrendChart';
 
 interface AxisScore {
@@ -119,6 +120,11 @@ export default function ScoreHistoryPage() {
         <div className="bg-white rounded-lg border border-slate-200 p-4 flex justify-center">
           <SkillRadarChart scores={latestSession.scores} title="最新のスキルバランス" />
         </div>
+      )}
+
+      {/* 改善アドバイス */}
+      {latestSession && latestSession.scores.length > 0 && (
+        <ScoreImprovementAdvice scores={latestSession.scores} />
       )}
 
       {/* スコア推移グラフ */}


### PR DESCRIPTION
## 概要
- ScoreHistoryPageに各スキル軸の改善アドバイスカードを追加
- スコア7未満の軸に具体的な改善アドバイスを表示

## 変更内容
- `ScoreImprovementAdvice.tsx` を新規作成
- `ScoreHistoryPage.tsx` にScoreImprovementAdviceを統合

## テスト
- ScoreImprovementAdviceのテスト5件を追加
- 全469テスト通過

closes #270