### PR TITLE
feat: 練習レベルアップカードを追加

### DIFF
--- a/frontend/src/components/PracticeLevelCard.tsx
+++ b/frontend/src/components/PracticeLevelCard.tsx
@@ -1,0 +1,66 @@
+interface PracticeLevelCardProps {
+  totalSessions: number;
+}
+
+interface Level {
+  level: number;
+  title: string;
+  threshold: number;
+}
+
+const LEVELS: Level[] = [
+  { level: 1, title: 'ビギナー', threshold: 0 },
+  { level: 2, title: 'ルーキー', threshold: 5 },
+  { level: 3, title: 'レギュラー', threshold: 10 },
+  { level: 4, title: 'ベテラン', threshold: 20 },
+  { level: 5, title: 'エキスパート', threshold: 30 },
+  { level: 6, title: 'マスター', threshold: 50 },
+  { level: 7, title: 'グランドマスター', threshold: 75 },
+  { level: 8, title: 'レジェンド', threshold: 100 },
+];
+
+function getCurrentLevel(sessions: number): { current: Level; next: Level | null } {
+  let current = LEVELS[0];
+  for (let i = LEVELS.length - 1; i >= 0; i--) {
+    if (sessions >= LEVELS[i].threshold) {
+      current = LEVELS[i];
+      break;
+    }
+  }
+  const nextIndex = LEVELS.indexOf(current) + 1;
+  const next = nextIndex < LEVELS.length ? LEVELS[nextIndex] : null;
+  return { current, next };
+}
+
+export default function PracticeLevelCard({ totalSessions }: PracticeLevelCardProps) {
+  const { current, next } = getCurrentLevel(totalSessions);
+
+  const progress = next
+    ? ((totalSessions - current.threshold) / (next.threshold - current.threshold)) * 100
+    : 100;
+
+  const remaining = next ? next.threshold - totalSessions : 0;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-2">練習レベル</p>
+
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="text-xl font-bold text-primary-600">Lv.{current.level}</span>
+        <span className="text-sm font-medium text-slate-600">{current.title}</span>
+      </div>
+
+      <div className="w-full bg-slate-100 rounded-full h-2 mb-2">
+        <div
+          data-testid="level-progress"
+          className="h-2 rounded-full bg-primary-500 transition-all"
+          style={{ width: `${Math.min(progress, 100)}%` }}
+        />
+      </div>
+
+      <p className="text-xs text-slate-500">
+        {next ? `次のレベルまであと${remaining}回` : '最高レベル到達！'}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeLevelCard.test.tsx
+++ b/frontend/src/components/__tests__/PracticeLevelCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PracticeLevelCard from '../PracticeLevelCard';
+
+describe('PracticeLevelCard', () => {
+  it('タイトルが表示される', () => {
+    render(<PracticeLevelCard totalSessions={0} />);
+
+    expect(screen.getByText('練習レベル')).toBeInTheDocument();
+  });
+
+  it('セッション0回でLv.1が表示される', () => {
+    render(<PracticeLevelCard totalSessions={0} />);
+
+    expect(screen.getByText('Lv.1')).toBeInTheDocument();
+    expect(screen.getByText('ビギナー')).toBeInTheDocument();
+  });
+
+  it('セッション5回でLv.2が表示される', () => {
+    render(<PracticeLevelCard totalSessions={5} />);
+
+    expect(screen.getByText('Lv.2')).toBeInTheDocument();
+  });
+
+  it('次のレベルまでの残り回数が表示される', () => {
+    render(<PracticeLevelCard totalSessions={3} />);
+
+    expect(screen.getByText('次のレベルまであと2回')).toBeInTheDocument();
+  });
+
+  it('最高レベルの場合は祝福メッセージが表示される', () => {
+    render(<PracticeLevelCard totalSessions={100} />);
+
+    expect(screen.getByText('最高レベル到達！')).toBeInTheDocument();
+  });
+
+  it('プログレスバーが表示される', () => {
+    render(<PracticeLevelCard totalSessions={3} />);
+
+    const bar = document.querySelector('[data-testid="level-progress"]');
+    expect(bar).toHaveStyle({ width: '60%' });
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -9,6 +9,7 @@ import {
 import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
+import PracticeLevelCard from '../components/PracticeLevelCard';
 import PracticeReminderCard from '../components/PracticeReminderCard';
 import RecentSessionsCard from '../components/RecentSessionsCard';
 import WeeklyGoalProgressCard from '../components/WeeklyGoalProgressCard';
@@ -64,6 +65,11 @@ export default function MenuPage() {
           />
         </div>
       )}
+
+      {/* 練習レベル */}
+      <div className="mb-6">
+        <PracticeLevelCard totalSessions={totalSessions} />
+      </div>
 
       {/* サマリー */}
       <div className="bg-white rounded-lg border border-slate-200 p-4 mb-6">


### PR DESCRIPTION
## 概要
- MenuPageに練習セッション数に応じたレベルシステムカードを追加
- ゲーミフィケーションにより新卒エンジニアの練習モチベーションを向上

## 変更内容
- `PracticeLevelCard.tsx` を新規作成（Lv.1ビギナー〜Lv.8レジェンドの8段階）
- `MenuPage.tsx` にPracticeLevelCardを統合

## テスト
- PracticeLevelCardのテスト6件を追加
- 全475テスト通過

closes #272