### PR TITLE
refactor: ScoreHistoryPageのビジネスロジックをuseScoreHistoryフックに分離

### DIFF
--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useAiChat } from './useAiChat';
+
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+export interface ScoreHistoryItem {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  scores: AxisScore[];
+  createdAt: string;
+}
+
+const FILTERS = ['すべて', '練習', 'フリー'] as const;
+export type FilterType = (typeof FILTERS)[number];
+export { FILTERS };
+
+function isPracticeSession(title: string): boolean {
+  return title.startsWith('練習:') || title.startsWith('練習：');
+}
+
+export function useScoreHistory() {
+  const [history, setHistory] = useState<ScoreHistoryItem[]>([]);
+  const [filter, setFilter] = useState<FilterType>('すべて');
+  const { fetchScoreHistory, loading } = useAiChat();
+
+  useEffect(() => {
+    const loadHistory = async () => {
+      const data = await fetchScoreHistory();
+      setHistory(data);
+    };
+    loadHistory();
+  }, [fetchScoreHistory]);
+
+  const filteredHistory = useMemo(() => {
+    return history.filter((item) => {
+      if (filter === '練習') return isPracticeSession(item.sessionTitle);
+      if (filter === 'フリー') return !isPracticeSession(item.sessionTitle);
+      return true;
+    });
+  }, [history, filter]);
+
+  const latestSession = history.length > 0 ? history[history.length - 1] : null;
+
+  const weakestAxis = useMemo(() => {
+    if (!latestSession) return null;
+    return [...latestSession.scores].sort((a, b) => a.score - b.score)[0] ?? null;
+  }, [latestSession]);
+
+  return {
+    history,
+    filteredHistory,
+    filter,
+    setFilter,
+    loading,
+    latestSession,
+    weakestAxis,
+  };
+}


### PR DESCRIPTION
## 概要
- ScoreHistoryPageのデータ取得・フィルタリング・算出ロジックをカスタムフックに分離
- Hooks → Repository → apiClient のクリーンアーキテクチャパターンに統一

## 変更内容
- `useScoreHistory.ts` を新規作成（history, filteredHistory, filter, latestSession, weakestAxis）
- `ScoreHistoryPage.tsx` をUIのみに簡素化（244行 → 201行）
- ScoreHistoryItem型とFILTERS定数をフックからエクスポート

## テスト
- 全475テスト通過

closes #274