### PR TITLE
feat: 本日のチャレンジカードを追加

### DIFF
--- a/frontend/src/components/DailyChallengeCard.tsx
+++ b/frontend/src/components/DailyChallengeCard.tsx
@@ -1,0 +1,65 @@
+import { useNavigate } from 'react-router-dom';
+
+interface Challenge {
+  title: string;
+  description: string;
+  category: string;
+  difficulty: '初級' | '中級' | '上級';
+}
+
+const CHALLENGES: Challenge[] = [
+  { title: '報連相マスター', description: '今日は報告・連絡・相談の3つを意識して練習しましょう。結論から先に伝えることを心がけてください。', category: '報連相', difficulty: '初級' },
+  { title: '敬語チャレンジ', description: '尊敬語・謙譲語・丁寧語を正しく使い分ける練習をしましょう。', category: '敬語', difficulty: '中級' },
+  { title: '要約力トレーニング', description: '長い説明を3文以内にまとめる練習をしましょう。ポイントを絞って伝える力を鍛えます。', category: '要約', difficulty: '中級' },
+  { title: '質問力アップ', description: '5W1Hを意識した質問を5つ以上考えてみましょう。相手から情報を引き出す力を磨きます。', category: '質問', difficulty: '初級' },
+  { title: '提案力チャレンジ', description: '課題に対して3つ以上の解決策を提案する練習をしましょう。それぞれのメリット・デメリットも添えてください。', category: '提案', difficulty: '上級' },
+  { title: 'クッション言葉', description: '「恐れ入りますが」「お手数ですが」など、クッション言葉を5種類以上使って会話しましょう。', category: '配慮', difficulty: '初級' },
+  { title: '技術説明の平易化', description: '技術用語を非エンジニアにも分かるように説明する練習をしましょう。', category: '要約', difficulty: '上級' },
+  { title: 'エスカレーション判断', description: '問題発生時に上長へのエスカレーションが必要かどうか判断する練習をしましょう。', category: '報連相', difficulty: '中級' },
+  { title: 'メール文面作成', description: '社外向けのフォーマルなメールを作成する練習をしましょう。件名・挨拶・本文・結びの構成を意識してください。', category: '配慮', difficulty: '中級' },
+  { title: '会議ファシリテーション', description: '会議で議題を整理し、参加者から意見を引き出す練習をしましょう。', category: '質問', difficulty: '上級' },
+];
+
+const DIFFICULTY_STYLES: Record<string, string> = {
+  '初級': 'bg-emerald-100 text-emerald-700',
+  '中級': 'bg-amber-100 text-amber-700',
+  '上級': 'bg-rose-100 text-rose-700',
+};
+
+export default function DailyChallengeCard() {
+  const navigate = useNavigate();
+  const today = new Date();
+  const dayIndex = Math.floor(today.getTime() / (1000 * 60 * 60 * 24)) % CHALLENGES.length;
+  const challenge = CHALLENGES[dayIndex];
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-medium text-slate-700">本日のチャレンジ</p>
+        <span
+          data-testid="challenge-difficulty"
+          className={`text-[10px] font-medium px-2 py-0.5 rounded-full ${DIFFICULTY_STYLES[challenge.difficulty]}`}
+        >
+          {challenge.difficulty}
+        </span>
+      </div>
+
+      <p className="text-sm font-semibold text-slate-800 mb-1">{challenge.title}</p>
+      <p data-testid="challenge-description" className="text-xs text-slate-500 mb-2">
+        {challenge.description}
+      </p>
+
+      <div className="flex items-center justify-between">
+        <span data-testid="challenge-category" className="text-[10px] text-slate-400">
+          {challenge.category}
+        </span>
+        <button
+          onClick={() => navigate('/practice')}
+          className="text-xs font-medium text-primary-600 hover:text-primary-700 transition-colors"
+        >
+          チャレンジする
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/DailyChallengeCard.test.tsx
+++ b/frontend/src/components/__tests__/DailyChallengeCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DailyChallengeCard from '../DailyChallengeCard';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('DailyChallengeCard', () => {
+  it('タイトルが表示される', () => {
+    render(<DailyChallengeCard />);
+
+    expect(screen.getByText('本日のチャレンジ')).toBeInTheDocument();
+  });
+
+  it('チャレンジの内容が表示される', () => {
+    render(<DailyChallengeCard />);
+
+    const description = screen.getByTestId('challenge-description');
+    expect(description.textContent).toBeTruthy();
+  });
+
+  it('難易度が表示される', () => {
+    render(<DailyChallengeCard />);
+
+    const difficulty = screen.getByTestId('challenge-difficulty');
+    expect(difficulty.textContent).toMatch(/初級|中級|上級/);
+  });
+
+  it('チャレンジボタンが表示される', () => {
+    render(<DailyChallengeCard />);
+
+    expect(screen.getByText('チャレンジする')).toBeInTheDocument();
+  });
+
+  it('チャレンジカテゴリが表示される', () => {
+    render(<DailyChallengeCard />);
+
+    const category = screen.getByTestId('challenge-category');
+    expect(category.textContent).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -7,6 +7,7 @@ import {
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
 import CommunicationTipCard from '../components/CommunicationTipCard';
+import DailyChallengeCard from '../components/DailyChallengeCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
 import PracticeLevelCard from '../components/PracticeLevelCard';
@@ -125,6 +126,11 @@ export default function MenuPage() {
           <RecentSessionsCard sessions={allScores} />
         </div>
       )}
+
+      {/* 本日のチャレンジ */}
+      <div className="mb-6">
+        <DailyChallengeCard />
+      </div>
 
       {/* コミュニケーションTips */}
       <div className="mb-6">


### PR DESCRIPTION
## 概要
- MenuPageに日替わりのビジネスコミュニケーションチャレンジカードを追加
- 報連相、敬語、要約、質問力等の10種類のチャレンジを日ベースでローテーション

## 変更内容
- `DailyChallengeCard.tsx` を新規作成
- `MenuPage.tsx` にDailyChallengeCardを統合

## テスト
- DailyChallengeCardのテスト5件を追加
- 全485テスト通過

closes #280