### PR TITLE
feat: 初回vs最新スコア比較カードを追加

### DIFF
--- a/frontend/src/components/ScoreComparisonCard.tsx
+++ b/frontend/src/components/ScoreComparisonCard.tsx
@@ -1,0 +1,74 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface ScoreComparisonCardProps {
+  firstScores: AxisScore[];
+  latestScores: AxisScore[];
+  firstOverall: number;
+  latestOverall: number;
+}
+
+function formatDelta(delta: number): string {
+  if (delta === 0) return '±0';
+  return delta > 0 ? `+${delta.toFixed(1)}` : `${delta.toFixed(1)}`;
+}
+
+function deltaColor(delta: number): string {
+  if (delta > 0) return 'text-emerald-600';
+  if (delta < 0) return 'text-rose-600';
+  return 'text-slate-400';
+}
+
+export default function ScoreComparisonCard({
+  firstScores,
+  latestScores,
+  firstOverall,
+  latestOverall,
+}: ScoreComparisonCardProps) {
+  const overallDelta = Math.round((latestOverall - firstOverall) * 10) / 10;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">成長の記録</p>
+
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-center">
+          <p className="text-[10px] text-slate-400 mb-1">初回</p>
+          <p className="text-xl font-bold text-slate-600">{firstOverall.toFixed(1)}</p>
+        </div>
+        <div className="text-center">
+          <span className={`text-sm font-bold ${deltaColor(overallDelta)}`}>
+            {formatDelta(overallDelta)}
+          </span>
+        </div>
+        <div className="text-center">
+          <p className="text-[10px] text-slate-400 mb-1">最新</p>
+          <p className="text-xl font-bold text-primary-600">{latestOverall.toFixed(1)}</p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {latestScores.map((latest) => {
+          const first = firstScores.find((f) => f.axis === latest.axis);
+          const delta = first ? Math.round((latest.score - first.score) * 10) / 10 : 0;
+          return (
+            <div key={latest.axis} className="flex items-center justify-between">
+              <span className="text-xs text-slate-500 w-24 truncate">{latest.axis}</span>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-slate-400 w-6 text-right">{first?.score ?? '-'}</span>
+                <span className="text-xs text-slate-300">→</span>
+                <span className="text-xs text-slate-700 w-6">{latest.score}</span>
+                <span className={`text-xs font-medium w-8 text-right ${deltaColor(delta)}`}>
+                  {formatDelta(delta)}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreComparisonCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreComparisonCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreComparisonCard from '../ScoreComparisonCard';
+
+const firstScores = [
+  { axis: '論理的構成力', score: 5, comment: '' },
+  { axis: '配慮表現', score: 4, comment: '' },
+  { axis: '要約力', score: 6, comment: '' },
+];
+
+const latestScores = [
+  { axis: '論理的構成力', score: 8, comment: '' },
+  { axis: '配慮表現', score: 7, comment: '' },
+  { axis: '要約力', score: 6, comment: '' },
+];
+
+describe('ScoreComparisonCard', () => {
+  it('タイトルが表示される', () => {
+    render(<ScoreComparisonCard firstScores={firstScores} latestScores={latestScores} firstOverall={5.0} latestOverall={7.0} />);
+
+    expect(screen.getByText('成長の記録')).toBeInTheDocument();
+  });
+
+  it('初回と最新の総合スコアが表示される', () => {
+    render(<ScoreComparisonCard firstScores={firstScores} latestScores={latestScores} firstOverall={5.0} latestOverall={7.0} />);
+
+    expect(screen.getByText('5.0')).toBeInTheDocument();
+    expect(screen.getByText('7.0')).toBeInTheDocument();
+  });
+
+  it('スコア増加時にプラス表示される', () => {
+    render(<ScoreComparisonCard firstScores={firstScores} latestScores={latestScores} firstOverall={5.0} latestOverall={7.0} />);
+
+    expect(screen.getByText('+2.0')).toBeInTheDocument();
+  });
+
+  it('各軸の変化量が表示される', () => {
+    render(<ScoreComparisonCard firstScores={firstScores} latestScores={latestScores} firstOverall={5.0} latestOverall={7.0} />);
+
+    const plusThreeElements = screen.getAllByText('+3.0');
+    expect(plusThreeElements.length).toBe(2);
+  });
+
+  it('変化なしの軸は±0と表示される', () => {
+    render(<ScoreComparisonCard firstScores={firstScores} latestScores={latestScores} firstOverall={5.0} latestOverall={7.0} />);
+
+    expect(screen.getByText('±0')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -5,6 +5,7 @@ import PracticeCalendar from '../components/PracticeCalendar';
 import ScoreRankBadge from '../components/ScoreRankBadge';
 import ScoreStatsSummary from '../components/ScoreStatsSummary';
 import SkillMilestoneCard from '../components/SkillMilestoneCard';
+import ScoreComparisonCard from '../components/ScoreComparisonCard';
 import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
 import SkillTrendChart from '../components/SkillTrendChart';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
@@ -78,6 +79,16 @@ export default function ScoreHistoryPage() {
         <div className="bg-white rounded-lg border border-slate-200 p-4 flex justify-center">
           <SkillRadarChart scores={latestSession.scores} title="最新のスキルバランス" />
         </div>
+      )}
+
+      {/* 初回vs最新スコア比較 */}
+      {history.length >= 2 && latestSession && history[0].scores.length > 0 && (
+        <ScoreComparisonCard
+          firstScores={history[0].scores}
+          latestScores={latestSession.scores}
+          firstOverall={history[0].overallScore}
+          latestOverall={latestSession.overallScore}
+        />
       )}
 
       {/* 改善アドバイス */}

--- a/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
@@ -88,8 +88,8 @@ describe('ScoreHistoryPage', () => {
     render(<ScoreHistoryPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('7.4')).toBeInTheDocument();
-      expect(screen.getByText('6.0')).toBeInTheDocument();
+      expect(screen.getAllByText('7.4').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText('6.0').length).toBeGreaterThanOrEqual(1);
     }, { timeout: 3000 });
   });
 


### PR DESCRIPTION
## 概要
- ScoreHistoryPageに初回セッションと最新セッションのスコア比較カードを追加
- 成長を可視化してモチベーション向上に貢献

## 変更内容
- `ScoreComparisonCard.tsx` を新規作成
- `ScoreHistoryPage.tsx` にScoreComparisonCardを統合
- `ScoreHistoryPage.test.tsx` の既存テストを修正（getAllByText対応）

## テスト
- ScoreComparisonCardのテスト5件を追加
- 全490テスト通過

closes #282