### PR TITLE
refactor: console.logの残留を削除

### DIFF
--- a/frontend/src/hooks/useChatList.ts
+++ b/frontend/src/hooks/useChatList.ts
@@ -18,8 +18,8 @@ export function useChatList() {
       setLoading(true);
       const users = await ChatRepository.fetchChatUsers(query);
       setChatUsers(users);
-    } catch (e) {
-      console.error('チャットユーザー取得失敗', e);
+    } catch {
+      // サイレントに処理
     } finally {
       setLoading(false);
     }
@@ -29,8 +29,8 @@ export function useChatList() {
     try {
       const user = await ChatRepository.fetchCurrentUser();
       setUserId(user.id);
-    } catch (e) {
-      console.error('ユーザー情報取得エラー:', e);
+    } catch {
+      // サイレントに処理
     }
   }, []);
 

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -42,8 +42,8 @@ export function useMenuData() {
           setLatestScore(scoresData.value[0]);
           setAllScores(scoresData.value);
         }
-      } catch (err) {
-        console.error('ダッシュボードデータ取得エラー:', err);
+      } catch {
+        // サイレントに処理
       }
     };
     fetchAll();

--- a/frontend/src/hooks/useSidebar.ts
+++ b/frontend/src/hooks/useSidebar.ts
@@ -30,8 +30,8 @@ export function useSidebar() {
       await AuthRepository.logout();
       dispatch(clearAuth());
       navigate('/login');
-    } catch (err) {
-      console.error('ログアウトエラー:', err);
+    } catch {
+      // サイレントに処理
     }
   }, [dispatch, navigate]);
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -64,7 +64,6 @@ export const useWebSocket = ({ url, userId, onConnect, onDisconnect, onError }: 
       },
 
       onStompError: (frame) => {
-        console.error('STOMP Error:', frame);
         onError?.(frame);
       },
     });
@@ -111,8 +110,6 @@ export const useWebSocket = ({ url, userId, onConnect, onDisconnect, onError }: 
         destination,
         body: JSON.stringify(body),
       });
-    } else {
-      console.error('WebSocket is not connected');
     }
   }, []);
 

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -3,11 +3,6 @@ export function getCognitoAuthUrl(provider: string): string {
     `https://${import.meta.env.VITE_COGNITO_DOMAIN}/oauth2/authorize`
   );
 
-  console.log(import.meta.env.VITE_CLIENT_ID);
-  console.log(import.meta.env.VITE_REDIRECT_URI);
-  console.log(import.meta.env.VITE_RESPONSE_TYPE);
-  console.log(import.meta.env.VITE_SCOPE);
-
   url.searchParams.append('client_id', import.meta.env.VITE_CLIENT_ID);
   url.searchParams.append('redirect_uri', import.meta.env.VITE_REDIRECT_URI);
   url.searchParams.append('response_type', import.meta.env.VITE_RESPONSE_TYPE);


### PR DESCRIPTION
## 概要
- フロントエンドに残留していたデバッグ用 `console.log` / `console.error` を削除
- `auth.ts`: 4つの `console.log` を削除
- `useMenuData.ts`: `console.error` を削除
- `useChatList.ts`: 2つの `console.error` を削除
- `useSidebar.ts`: `console.error` を削除
- `useWebSocket.ts`: 2つの `console.error` を削除
- catch ブロックはサイレント処理（`// サイレントに処理`）に統一

## テスト
- 490テスト全パス

closes #284