### PR TITLE
feat: セッション詳細モーダル追加

### DIFF
--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -1,0 +1,87 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface Session {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  scores: AxisScore[];
+  createdAt: string;
+}
+
+interface SessionDetailModalProps {
+  session: Session;
+  onClose: () => void;
+}
+
+export default function SessionDetailModal({ session, onClose }: SessionDetailModalProps) {
+  return (
+    <div
+      data-testid="modal-overlay"
+      className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-xl shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-5">
+          <div className="flex items-start justify-between mb-4">
+            <div>
+              <h2 className="text-sm font-bold text-slate-800">
+                {session.sessionTitle || `セッション #${session.sessionId}`}
+              </h2>
+              <p className="text-xs text-slate-400 mt-0.5">
+                {new Date(session.createdAt).toLocaleDateString('ja-JP', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </p>
+            </div>
+            <div className="text-right">
+              <p className="text-xs text-slate-500">総合スコア</p>
+              <p className="text-2xl font-bold text-primary-600">
+                {session.overallScore.toFixed(1)}
+              </p>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {session.scores.map((axisScore) => (
+              <div key={axisScore.axis} className="bg-slate-50 rounded-lg p-3">
+                <div className="flex items-center justify-between mb-1.5">
+                  <span className="text-xs font-medium text-slate-700">
+                    {axisScore.axis}
+                  </span>
+                  <span className="text-sm font-bold text-slate-800">
+                    {axisScore.score.toFixed(1)}
+                  </span>
+                </div>
+                <div className="w-full bg-slate-200 rounded-full h-1.5 mb-2">
+                  <div
+                    className="h-1.5 rounded-full bg-primary-500"
+                    style={{ width: `${axisScore.score * 10}%` }}
+                  />
+                </div>
+                {axisScore.comment && (
+                  <p className="text-xs text-slate-500">{axisScore.comment}</p>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <button
+            onClick={onClose}
+            className="w-full mt-4 py-2 text-xs font-medium text-slate-600 bg-slate-100 rounded-lg hover:bg-slate-200 transition-colors"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SessionDetailModal.test.tsx
+++ b/frontend/src/components/__tests__/SessionDetailModal.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SessionDetailModal from '../SessionDetailModal';
+
+const session = {
+  sessionId: 1,
+  sessionTitle: '障害報告の練習',
+  overallScore: 7.5,
+  scores: [
+    { axis: '論理的構成力', score: 8, comment: '構成が明確でした' },
+    { axis: '配慮表現', score: 6, comment: 'もう少し丁寧に' },
+    { axis: '要約力', score: 8.5, comment: '簡潔にまとめられていました' },
+  ],
+  createdAt: '2026-02-13T10:00:00',
+};
+
+describe('SessionDetailModal', () => {
+  it('セッションタイトルと日時が表示される', () => {
+    render(<SessionDetailModal session={session} onClose={vi.fn()} />);
+
+    expect(screen.getByText('障害報告の練習')).toBeInTheDocument();
+    expect(screen.getByText(/2026年/)).toBeInTheDocument();
+  });
+
+  it('総合スコアが表示される', () => {
+    render(<SessionDetailModal session={session} onClose={vi.fn()} />);
+
+    expect(screen.getByText('7.5')).toBeInTheDocument();
+  });
+
+  it('各軸のスコアとコメントが表示される', () => {
+    render(<SessionDetailModal session={session} onClose={vi.fn()} />);
+
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('構成が明確でした')).toBeInTheDocument();
+    expect(screen.getByText('もう少し丁寧に')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンでonCloseが呼ばれる', () => {
+    const onClose = vi.fn();
+    render(<SessionDetailModal session={session} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('オーバーレイクリックでonCloseが呼ばれる', () => {
+    const onClose = vi.fn();
+    render(<SessionDetailModal session={session} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('modal-overlay'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
@@ -8,7 +9,8 @@ import SkillMilestoneCard from '../components/SkillMilestoneCard';
 import ScoreComparisonCard from '../components/ScoreComparisonCard';
 import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
 import SkillTrendChart from '../components/SkillTrendChart';
-import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
+import SessionDetailModal from '../components/SessionDetailModal';
+import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
 
 const AXIS_ADVICE: Record<string, string> = {
   '論理的構成力': '論理的構成力を伸ばすシナリオで練習しましょう',
@@ -21,6 +23,7 @@ const AXIS_ADVICE: Record<string, string> = {
 export default function ScoreHistoryPage() {
   const { history, filteredHistory, filter, setFilter, loading, latestSession, weakestAxis } = useScoreHistory();
   const navigate = useNavigate();
+  const [selectedSession, setSelectedSession] = useState<ScoreHistoryItem | null>(null);
 
   if (loading) {
     return (
@@ -154,7 +157,8 @@ export default function ScoreHistoryPage() {
         return (
           <div
             key={item.sessionId}
-            className="bg-white rounded-lg border border-slate-200 p-4"
+            className="bg-white rounded-lg border border-slate-200 p-4 cursor-pointer hover:border-primary-300 transition-colors"
+            onClick={() => setSelectedSession(item)}
           >
             <div className="flex items-center justify-between mb-3">
               <div>
@@ -206,6 +210,13 @@ export default function ScoreHistoryPage() {
           </div>
         );
       })}
+
+      {selectedSession && (
+        <SessionDetailModal
+          session={selectedSession}
+          onClose={() => setSelectedSession(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- スコア履歴ページでセッションカードをクリックすると詳細モーダルを表示
- セッションタイトル・日時・総合スコア・各軸スコアとコメントを表示
- オーバーレイクリック or 閉じるボタンでモーダルを閉じる

## テスト
- SessionDetailModal: 5テスト追加
- 500テスト全パス

closes #290