### PR TITLE
feat: モチベーション名言カード追加

### DIFF
--- a/frontend/src/components/MotivationQuoteCard.tsx
+++ b/frontend/src/components/MotivationQuoteCard.tsx
@@ -1,0 +1,41 @@
+interface Quote {
+  text: string;
+  author: string;
+}
+
+const QUOTES: Quote[] = [
+  { text: 'コミュニケーションで最も大切なのは、相手が言わなかったことを聞くことだ。', author: 'ピーター・ドラッカー' },
+  { text: '話し上手は聞き上手。まず相手の話を聴くことから始めよう。', author: 'デール・カーネギー' },
+  { text: '伝えることと伝わることは違う。伝わるまでが、コミュニケーション。', author: '松下幸之助' },
+  { text: '言葉は、考えを伝える道具ではなく、関係を築く道具である。', author: 'ジョン・パウエル' },
+  { text: '成功するチームの共通点は、心理的安全性が高いこと。', author: 'エイミー・エドモンドソン' },
+  { text: '準備を怠ることは、失敗の準備をすることだ。', author: 'ベンジャミン・フランクリン' },
+  { text: '質問する勇気が、成長への第一歩になる。', author: '稲盛和夫' },
+  { text: 'フィードバックは贈り物。受け取る勇気が、あなたを強くする。', author: 'ケン・ブランチャード' },
+  { text: '報連相は、チームの信頼を築く最も確実な方法である。', author: 'ビジネス格言' },
+  { text: '今日の小さな一歩が、明日の大きな成長につながる。', author: '老子' },
+];
+
+function getDailyIndex(): number {
+  const now = new Date();
+  const dayOfYear = Math.floor(
+    (now.getTime() - new Date(now.getFullYear(), 0, 0).getTime()) / 86400000
+  );
+  return dayOfYear % QUOTES.length;
+}
+
+export default function MotivationQuoteCard() {
+  const quote = QUOTES[getDailyIndex()];
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-2">今日の一言</p>
+      <p data-testid="quote-text" className="text-xs text-slate-600 leading-relaxed italic">
+        「{quote.text}」
+      </p>
+      <p data-testid="quote-author" className="text-[10px] text-slate-400 mt-1.5 text-right">
+        — {quote.author}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/MotivationQuoteCard.test.tsx
+++ b/frontend/src/components/__tests__/MotivationQuoteCard.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MotivationQuoteCard from '../MotivationQuoteCard';
+
+describe('MotivationQuoteCard', () => {
+  it('名言テキストが表示される', () => {
+    render(<MotivationQuoteCard />);
+
+    const quoteElements = screen.getAllByTestId('quote-text');
+    expect(quoteElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('著者名が表示される', () => {
+    render(<MotivationQuoteCard />);
+
+    const authorElements = screen.getAllByTestId('quote-author');
+    expect(authorElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('タイトルが表示される', () => {
+    render(<MotivationQuoteCard />);
+
+    expect(screen.getByText("今日の一言")).toBeInTheDocument();
+  });
+
+  it('同じ日には同じ名言が表示される', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01'));
+
+    const { unmount } = render(<MotivationQuoteCard />);
+    const first = screen.getByTestId('quote-text').textContent;
+    unmount();
+
+    render(<MotivationQuoteCard />);
+    const second = screen.getByTestId('quote-text').textContent;
+
+    expect(first).toBe(second);
+    vi.useRealTimers();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyChallengeCard from '../components/DailyChallengeCard';
+import MotivationQuoteCard from '../components/MotivationQuoteCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
 import PracticeLevelCard from '../components/PracticeLevelCard';
@@ -130,6 +131,11 @@ export default function MenuPage() {
       {/* 本日のチャレンジ */}
       <div className="mb-6">
         <DailyChallengeCard />
+      </div>
+
+      {/* 今日の一言 */}
+      <div className="mb-6">
+        <MotivationQuoteCard />
       </div>
 
       {/* コミュニケーションTips */}


### PR DESCRIPTION
## 概要
- ビジネスコミュニケーションに関する日替わり名言カードをメニューページに追加
- 10種類の名言を収録（ドラッカー、カーネギー、松下幸之助等）
- 日付に基づく決定的なローテーション

## テスト
- MotivationQuoteCard: 4テスト追加
- 504テスト全パス

closes #292