### PR TITLE
feat: 達成バッジカード追加

### DIFF
--- a/frontend/src/components/AchievementBadgeCard.tsx
+++ b/frontend/src/components/AchievementBadgeCard.tsx
@@ -1,0 +1,66 @@
+interface AchievementBadgeCardProps {
+  totalSessions: number;
+}
+
+interface Badge {
+  name: string;
+  threshold: number;
+  icon: string;
+}
+
+const BADGES: Badge[] = [
+  { name: 'ファーストステップ', threshold: 1, icon: '🎯' },
+  { name: 'コツコツ練習', threshold: 3, icon: '📝' },
+  { name: 'ウィークリーチャレンジ', threshold: 5, icon: '🏅' },
+  { name: 'テンセッション', threshold: 10, icon: '⭐' },
+  { name: 'ハーフウェイ', threshold: 25, icon: '🔥' },
+  { name: 'フィフティ達成', threshold: 50, icon: '🏆' },
+  { name: 'センチュリー', threshold: 100, icon: '👑' },
+];
+
+export default function AchievementBadgeCard({ totalSessions }: AchievementBadgeCardProps) {
+  const unlockedCount = BADGES.filter((b) => totalSessions >= b.threshold).length;
+  const nextBadge = BADGES.find((b) => totalSessions < b.threshold);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-slate-700">達成バッジ</p>
+        <span className="text-[10px] text-slate-400">
+          {unlockedCount}/{BADGES.length}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-3">
+        {BADGES.map((badge) => {
+          const unlocked = totalSessions >= badge.threshold;
+          return (
+            <div
+              key={badge.name}
+              data-testid={unlocked ? 'badge-unlocked' : 'badge-locked'}
+              className={`flex flex-col items-center gap-0.5 w-16 ${
+                unlocked ? 'opacity-100' : 'opacity-30'
+              }`}
+              title={`${badge.name}（${badge.threshold}回）`}
+            >
+              <span className="text-lg">{badge.icon}</span>
+              <span className="text-[9px] text-slate-500 text-center leading-tight truncate w-full">
+                {badge.name}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {nextBadge ? (
+        <p data-testid="next-badge-info" className="text-xs text-slate-500">
+          次のバッジ「{nextBadge.name}」まであと{nextBadge.threshold - totalSessions}回
+        </p>
+      ) : (
+        <p data-testid="next-badge-info" className="text-xs text-emerald-600 font-medium">
+          全バッジを獲得しました！
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/AchievementBadgeCard.test.tsx
+++ b/frontend/src/components/__tests__/AchievementBadgeCard.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AchievementBadgeCard from '../AchievementBadgeCard';
+
+describe('AchievementBadgeCard', () => {
+  it('タイトルが表示される', () => {
+    render(<AchievementBadgeCard totalSessions={0} />);
+
+    expect(screen.getByText('達成バッジ')).toBeInTheDocument();
+  });
+
+  it('セッション0回で全バッジが未達成', () => {
+    render(<AchievementBadgeCard totalSessions={0} />);
+
+    const unlocked = screen.queryAllByTestId('badge-unlocked');
+    expect(unlocked).toHaveLength(0);
+  });
+
+  it('セッション1回でファーストステップバッジが達成', () => {
+    render(<AchievementBadgeCard totalSessions={1} />);
+
+    const unlocked = screen.getAllByTestId('badge-unlocked');
+    expect(unlocked.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('セッション50回で複数バッジが達成', () => {
+    render(<AchievementBadgeCard totalSessions={50} />);
+
+    const unlocked = screen.getAllByTestId('badge-unlocked');
+    expect(unlocked.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('次のバッジまでの情報が表示される', () => {
+    render(<AchievementBadgeCard totalSessions={3} />);
+
+    expect(screen.getByTestId('next-badge-info')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -6,6 +6,7 @@ import {
   AcademicCapIcon,
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
+import AchievementBadgeCard from '../components/AchievementBadgeCard';
 import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyChallengeCard from '../components/DailyChallengeCard';
 import MotivationQuoteCard from '../components/MotivationQuoteCard';
@@ -71,6 +72,11 @@ export default function MenuPage() {
       {/* 練習レベル */}
       <div className="mb-6">
         <PracticeLevelCard totalSessions={totalSessions} />
+      </div>
+
+      {/* 達成バッジ */}
+      <div className="mb-6">
+        <AchievementBadgeCard totalSessions={totalSessions} />
       </div>
 
       {/* サマリー */}


### PR DESCRIPTION
## 概要
- 練習セッション数に応じた達成バッジカードを追加
- 7段階のバッジレベル（1回〜100回）
- メニューページに統合

## 変更内容
- `AchievementBadgeCard` コンポーネント新規作成
- テスト5件追加（合計514件）
- MenuPageに統合

## テスト
- [x] 全514テストがパス