### PR TITLE
feat: 練習ストリークカレンダーカード追加

### DIFF
--- a/frontend/src/components/StreakCalendarCard.tsx
+++ b/frontend/src/components/StreakCalendarCard.tsx
@@ -1,0 +1,89 @@
+interface StreakCalendarCardProps {
+  practiceDates: string[];
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function calculateStreak(practiceDates: string[]): number {
+  if (practiceDates.length === 0) return 0;
+
+  const dateSet = new Set(practiceDates);
+  let streak = 0;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const current = new Date(today);
+  while (dateSet.has(formatDate(current))) {
+    streak++;
+    current.setDate(current.getDate() - 1);
+  }
+
+  return streak;
+}
+
+function getLast28Days(): Date[] {
+  const days: Date[] = [];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  for (let i = 27; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    days.push(d);
+  }
+  return days;
+}
+
+const WEEKDAY_LABELS = ['月', '火', '水', '木', '金', '土', '日'];
+
+export default function StreakCalendarCard({ practiceDates }: StreakCalendarCardProps) {
+  const dateSet = new Set(practiceDates);
+  const days = getLast28Days();
+  const streak = calculateStreak(practiceDates);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-slate-700">練習カレンダー</p>
+        <div className="flex items-baseline gap-1">
+          <span className="text-lg font-bold text-primary-600">{streak}</span>
+          <span className="text-[10px] text-slate-500">日連続</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-7 gap-1 mb-1">
+        {WEEKDAY_LABELS.map((label) => (
+          <div key={label} className="text-[9px] text-slate-400 text-center">
+            {label}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 gap-1">
+        {days.map((day) => {
+          const dateStr = formatDate(day);
+          const isActive = dateSet.has(dateStr);
+          const isToday = formatDate(new Date()) === dateStr;
+
+          return (
+            <div
+              key={dateStr}
+              data-testid={`calendar-cell-${dateStr}`}
+              className={`aspect-square rounded-sm ${
+                isActive
+                  ? 'bg-primary-500'
+                  : 'bg-slate-100'
+              } ${isToday ? 'ring-1 ring-primary-300' : ''}`}
+              title={dateStr}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/StreakCalendarCard.test.tsx
+++ b/frontend/src/components/__tests__/StreakCalendarCard.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import StreakCalendarCard from '../StreakCalendarCard';
+
+describe('StreakCalendarCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<StreakCalendarCard practiceDates={[]} />);
+    expect(screen.getByText('練習カレンダー')).toBeInTheDocument();
+  });
+
+  it('練習日がない場合、連続日数が0と表示される', () => {
+    render(<StreakCalendarCard practiceDates={[]} />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('日連続')).toBeInTheDocument();
+  });
+
+  it('28日分のセルが表示される', () => {
+    render(<StreakCalendarCard practiceDates={[]} />);
+    const cells = screen.getAllByTestId(/^calendar-cell-/);
+    expect(cells).toHaveLength(28);
+  });
+
+  it('練習した日のセルがアクティブスタイルになる', () => {
+    render(<StreakCalendarCard practiceDates={['2025-06-15', '2025-06-14']} />);
+    const today = screen.getByTestId('calendar-cell-2025-06-15');
+    expect(today.className).toContain('bg-primary-500');
+  });
+
+  it('現在の連続日数が正しく計算される', () => {
+    render(
+      <StreakCalendarCard
+        practiceDates={['2025-06-15', '2025-06-14', '2025-06-13']}
+      />
+    );
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -54,9 +54,10 @@ export function useMenuData() {
     if (totalSessions === 0) return 0;
     return Math.round((allScores.reduce((sum, s) => sum + s.overallScore, 0) / totalSessions) * 10) / 10;
   }, [allScores, totalSessions]);
-  const uniqueDays = useMemo(() => {
-    return new Set(allScores.map(s => s.createdAt.split('T')[0])).size;
+  const practiceDates = useMemo(() => {
+    return [...new Set(allScores.map(s => s.createdAt.split('T')[0]))];
   }, [allScores]);
+  const uniqueDays = practiceDates.length;
 
   const sessionsThisWeek = useMemo(() => {
     const now = new Date();
@@ -75,6 +76,7 @@ export function useMenuData() {
     totalSessions,
     averageScore,
     uniqueDays,
+    practiceDates,
     sessionsThisWeek,
   };
 }

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -7,6 +7,7 @@ import {
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
 import AchievementBadgeCard from '../components/AchievementBadgeCard';
+import StreakCalendarCard from '../components/StreakCalendarCard';
 import CommunicationTipCard from '../components/CommunicationTipCard';
 import DailyChallengeCard from '../components/DailyChallengeCard';
 import MotivationQuoteCard from '../components/MotivationQuoteCard';
@@ -21,7 +22,7 @@ import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
   const navigate = useNavigate();
-  const { stats, totalUnread, latestScore, allScores, totalSessions, averageScore, uniqueDays, sessionsThisWeek } = useMenuData();
+  const { stats, totalUnread, latestScore, allScores, totalSessions, averageScore, uniqueDays, practiceDates, sessionsThisWeek } = useMenuData();
 
   const menuItems = [
     {
@@ -77,6 +78,11 @@ export default function MenuPage() {
       {/* 達成バッジ */}
       <div className="mb-6">
         <AchievementBadgeCard totalSessions={totalSessions} />
+      </div>
+
+      {/* 練習ストリークカレンダー */}
+      <div className="mb-6">
+        <StreakCalendarCard practiceDates={practiceDates} />
       </div>
 
       {/* サマリー */}

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -41,6 +41,8 @@ function defaultMenuData() {
     totalSessions: 1,
     averageScore: 7.5,
     uniqueDays: 1,
+    practiceDates: ['2026-02-13'],
+    sessionsThisWeek: 1,
   };
 }
 
@@ -86,6 +88,8 @@ describe('MenuPage', () => {
       totalSessions: 0,
       averageScore: 0,
       uniqueDays: 0,
+      practiceDates: [],
+      sessionsThisWeek: 0,
     });
 
     render(<BrowserRouter><MenuPage /></BrowserRouter>);


### PR DESCRIPTION
## 概要
- 過去28日間の練習日をカレンダー形式で表示するStreakCalendarCard追加
- 連続練習日数の表示でモチベーション維持を支援
- メニューページに統合

## 変更内容
- `StreakCalendarCard` コンポーネント新規作成
- `useMenuData`に`practiceDates`追加
- `MenuPage`に統合
- テスト5件追加（合計519件）

## テスト
- [x] 全519テストがパス