### PR TITLE
refactor: ConfirmForgotPasswordPageのビジネスロジックをHooksに抽出

### DIFF
--- a/frontend/src/hooks/useConfirmForgotPassword.ts
+++ b/frontend/src/hooks/useConfirmForgotPassword.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import authRepository from '../repositories/AuthRepository';
+import { AxiosError } from 'axios';
+
+interface FormMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+export function useConfirmForgotPassword() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const [form, setForm] = useState({
+    email: (location.state as { email?: string })?.email || '',
+    code: '',
+    newPassword: '',
+  });
+  const [message, setMessage] = useState<FormMessage | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await authRepository.confirmForgotPassword({
+        email: form.email,
+        confirmationCode: form.code,
+        newPassword: form.newPassword,
+      });
+      navigate('/login', {
+        state: {
+          message: 'パスワードリセットに成功しました。ログインしてください。',
+        },
+      });
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data?.error) {
+        setMessage({ type: 'error', text: error.response.data.error });
+      } else {
+        setMessage({ type: 'error', text: '通信エラーが発生しました。' });
+      }
+    }
+  };
+
+  return { form, message, handleChange, handleConfirm };
+}

--- a/frontend/src/pages/ConfirmForgotPasswordPage.tsx
+++ b/frontend/src/pages/ConfirmForgotPasswordPage.tsx
@@ -1,56 +1,10 @@
-import { useState } from 'react';
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
-import { useNavigate, useLocation } from 'react-router-dom';
-import authRepository from '../repositories/AuthRepository';
-import { AxiosError } from 'axios';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import { useConfirmForgotPassword } from '../hooks/useConfirmForgotPassword';
 
 export default function ConfirmForgotPasswordPage() {
-  const location = useLocation();
-  const navigate = useNavigate();
-
-  const [form, setForm] = useState({
-    email: (location.state as { email?: string })?.email || '',
-    code: '',
-    newPassword: '',
-  });
-  const [message, setMessage] = useState<FormMessage | null>(null);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({
-      ...form,
-      [e.target.name]: e.target.value,
-    });
-  };
-
-  const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      await authRepository.confirmForgotPassword({
-        email: form.email,
-        confirmationCode: form.code,
-        newPassword: form.newPassword,
-      });
-      navigate('/login', {
-        state: {
-          message: 'パスワードリセットに成功しました。ログインしてください。',
-        },
-      });
-    } catch (error) {
-      if (error instanceof AxiosError && error.response?.data?.error) {
-        setMessage({ type: 'error', text: error.response.data.error });
-      } else {
-        setMessage({ type: 'error', text: '通信エラーが発生しました。' });
-      }
-    }
-  };
+  const { form, message, handleChange, handleConfirm } = useConfirmForgotPassword();
 
   return (
     <AuthLayout>


### PR DESCRIPTION
## 概要
- ConfirmForgotPasswordPageからビジネスロジックをuseConfirmForgotPasswordフックに抽出
- ページコンポーネントはUIのみに集中（89行→43行）

## 変更内容
- `useConfirmForgotPassword`フック新規作成
- フォーム状態管理・送信処理・エラーハンドリングをフックに移動
- functional updateパターンでsetFormの安定性向上
- テスト5件追加（合計524件）

## テスト
- [x] 全524テストがパス