### PR TITLE
test: useChatListフックのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useChatList.test.ts
+++ b/frontend/src/hooks/__tests__/useChatList.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { useChatList } from '../useChatList';
 import ChatRepository from '../../repositories/ChatRepository';
 
@@ -36,9 +36,67 @@ describe('useChatList', () => {
   it('ローディング状態を管理する', async () => {
     const { result } = renderHook(() => useChatList());
 
-    // 最終的にloadingはfalseになる
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
+  });
+
+  it('updateUnreadCountで未読数が更新される', async () => {
+    const mockUsers = [
+      { roomId: 1, userId: 1, name: 'ユーザー1', unreadCount: 2 },
+      { roomId: 2, userId: 2, name: 'ユーザー2', unreadCount: 0 },
+    ];
+    mockedRepo.fetchChatUsers.mockResolvedValue(mockUsers as any);
+
+    const { result } = renderHook(() => useChatList());
+
+    await waitFor(() => {
+      expect(result.current.chatUsers).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.updateUnreadCount(1, 3);
+    });
+
+    expect(result.current.chatUsers[0].unreadCount).toBe(5);
+    expect(result.current.chatUsers[1].unreadCount).toBe(0);
+  });
+
+  it('fetchChatUsers失敗時にエラーをサイレントに処理する', async () => {
+    mockedRepo.fetchChatUsers.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useChatList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.chatUsers).toEqual([]);
+  });
+
+  it('fetchUserId失敗時にuserIdがnullのまま', async () => {
+    mockedRepo.fetchCurrentUser.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useChatList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.userId).toBeNull();
+  });
+
+  it('fetchChatUsersにクエリパラメータを渡せる', async () => {
+    const { result } = renderHook(() => useChatList());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.fetchChatUsers('検索ワード');
+    });
+
+    expect(mockedRepo.fetchChatUsers).toHaveBeenCalledWith('検索ワード');
   });
 });


### PR DESCRIPTION
## 概要
- useChatListフックのテストカバレッジを3件→7件に拡充
- エッジケースとエラーハンドリングのテストを追加

## 追加テスト
- updateUnreadCountで未読数が更新される
- fetchChatUsers失敗時にエラーをサイレント処理
- fetchUserId失敗時にuserIdがnullのまま
- fetchChatUsersにクエリパラメータを渡せる

## テスト
- [x] 全528テストがパス