### PR TITLE
feat: スキル強弱サマリーカード追加

### DIFF
--- a/frontend/src/components/SkillSummaryCard.tsx
+++ b/frontend/src/components/SkillSummaryCard.tsx
@@ -1,0 +1,49 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface SkillSummaryCardProps {
+  scores: AxisScore[];
+}
+
+export default function SkillSummaryCard({ scores }: SkillSummaryCardProps) {
+  if (scores.length === 0) return null;
+
+  const sorted = [...scores].sort((a, b) => b.score - a.score);
+  const strengths = sorted.slice(0, 2);
+  const weaknesses = sorted.slice(-2).reverse();
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">スキル強弱サマリー</p>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div data-testid="strengths">
+          <p className="text-[10px] font-medium text-emerald-600 mb-2">強み</p>
+          <div className="space-y-2">
+            {strengths.map((s) => (
+              <div key={s.axis} className="flex items-center justify-between">
+                <span className="text-xs text-slate-700 truncate mr-2">{s.axis}</span>
+                <span className="text-sm font-bold text-emerald-600">{s.score}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div data-testid="weaknesses">
+          <p className="text-[10px] font-medium text-rose-600 mb-2">課題</p>
+          <div className="space-y-2">
+            {weaknesses.map((s) => (
+              <div key={s.axis} className="flex items-center justify-between">
+                <span className="text-xs text-slate-700 truncate mr-2">{s.axis}</span>
+                <span className="text-sm font-bold text-rose-600">{s.score}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SkillSummaryCard.test.tsx
+++ b/frontend/src/components/__tests__/SkillSummaryCard.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SkillSummaryCard from '../SkillSummaryCard';
+
+const mockScores = [
+  { axis: '論理的構成力', score: 9, comment: '素晴らしい' },
+  { axis: '配慮表現', score: 8, comment: '良い' },
+  { axis: '要約力', score: 5, comment: '改善が必要' },
+  { axis: '提案力', score: 7, comment: '普通' },
+  { axis: '質問・傾聴力', score: 4, comment: '要改善' },
+];
+
+describe('SkillSummaryCard', () => {
+  it('タイトルが表示される', () => {
+    render(<SkillSummaryCard scores={mockScores} />);
+    expect(screen.getByText('スキル強弱サマリー')).toBeInTheDocument();
+  });
+
+  it('強みの上位2軸が表示される', () => {
+    render(<SkillSummaryCard scores={mockScores} />);
+    const strengthSection = screen.getByTestId('strengths');
+    expect(strengthSection).toHaveTextContent('論理的構成力');
+    expect(strengthSection).toHaveTextContent('配慮表現');
+  });
+
+  it('弱みの下位2軸が表示される', () => {
+    render(<SkillSummaryCard scores={mockScores} />);
+    const weaknessSection = screen.getByTestId('weaknesses');
+    expect(weaknessSection).toHaveTextContent('質問・傾聴力');
+    expect(weaknessSection).toHaveTextContent('要約力');
+  });
+
+  it('スコアが空の場合はnullを返す', () => {
+    const { container } = render(<SkillSummaryCard scores={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('各軸のスコアが表示される', () => {
+    render(<SkillSummaryCard scores={mockScores} />);
+    expect(screen.getByText('9')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -8,6 +8,7 @@ import ScoreStatsSummary from '../components/ScoreStatsSummary';
 import SkillMilestoneCard from '../components/SkillMilestoneCard';
 import ScoreComparisonCard from '../components/ScoreComparisonCard';
 import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
+import SkillSummaryCard from '../components/SkillSummaryCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -92,6 +93,11 @@ export default function ScoreHistoryPage() {
           firstOverall={history[0].overallScore}
           latestOverall={latestSession.overallScore}
         />
+      )}
+
+      {/* スキル強弱サマリー */}
+      {latestSession && latestSession.scores.length > 0 && (
+        <SkillSummaryCard scores={latestSession.scores} />
       )}
 
       {/* 改善アドバイス */}


### PR DESCRIPTION
## 概要
- 最新セッションの強み・弱みを一目で把握できるSkillSummaryCard追加
- スコア履歴ページに統合

## 変更内容
- `SkillSummaryCard` コンポーネント新規作成
- テスト5件追加（合計533件）
- ScoreHistoryPageに統合

## テスト
- [x] 全533テストがパス