### PR TITLE
refactor: ConfirmPageのビジネスロジックをHooksに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useConfirmSignup.test.ts
+++ b/frontend/src/hooks/__tests__/useConfirmSignup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { useConfirmSignup } from '../useConfirmSignup';
+
+const mockConfirmSignup = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../repositories/AuthRepository', () => ({
+  default: {
+    confirmSignup: (...args: unknown[]) => mockConfirmSignup(...args),
+  },
+}));
+
+describe('useConfirmSignup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConfirmSignup.mockResolvedValue({ message: '確認成功' });
+  });
+
+  it('初期フォーム値が空文字', () => {
+    const { result } = renderHook(() => useConfirmSignup());
+    expect(result.current.form.email).toBe('');
+    expect(result.current.form.code).toBe('');
+  });
+
+  it('handleChangeでフォームの値が更新される', () => {
+    const { result } = renderHook(() => useConfirmSignup());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'email', value: 'test@example.com' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(result.current.form.email).toBe('test@example.com');
+  });
+
+  it('handleConfirm成功時にログインページへナビゲートする', async () => {
+    const { result } = renderHook(() => useConfirmSignup());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'email', value: 'test@example.com' },
+      } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({
+        target: { name: 'code', value: '123456' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(mockConfirmSignup).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      code: '123456',
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/login', {
+      state: { message: '確認に成功しました。ログインしてください。' },
+    });
+  });
+
+  it('handleConfirm失敗時にエラーメッセージが表示される', async () => {
+    const axiosError = new AxiosError('Bad Request');
+    (axiosError as any).response = { data: { error: '確認コードが無効です' } };
+    mockConfirmSignup.mockRejectedValue(axiosError);
+
+    const { result } = renderHook(() => useConfirmSignup());
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('確認コードが無効です');
+  });
+
+  it('通信エラー時に汎用エラーメッセージが表示される', async () => {
+    mockConfirmSignup.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useConfirmSignup());
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('通信エラーが発生しました。');
+  });
+});

--- a/frontend/src/hooks/useConfirmSignup.ts
+++ b/frontend/src/hooks/useConfirmSignup.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import authRepository from '../repositories/AuthRepository';
+import { AxiosError } from 'axios';
+
+interface FormMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+export function useConfirmSignup() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({ email: '', code: '' });
+  const [message, setMessage] = useState<FormMessage | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    try {
+      await authRepository.confirmSignup(form);
+      navigate('/login', {
+        state: {
+          message: '確認に成功しました。ログインしてください。',
+        },
+      });
+    } catch (error) {
+      if (error instanceof AxiosError && error.response?.data?.error) {
+        setMessage({ type: 'error', text: error.response.data.error });
+      } else {
+        setMessage({ type: 'error', text: '通信エラーが発生しました。' });
+      }
+    }
+  };
+
+  return { form, message, handleChange, handleConfirm };
+}

--- a/frontend/src/pages/ConfirmPage.tsx
+++ b/frontend/src/pages/ConfirmPage.tsx
@@ -1,47 +1,11 @@
-import { useState } from 'react';
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import LinkText from '../components/LinkText';
-import { useNavigate } from 'react-router-dom';
-import authRepository from '../repositories/AuthRepository';
-import { AxiosError } from 'axios';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import { useConfirmSignup } from '../hooks/useConfirmSignup';
 
 export default function ConfirmPage() {
-  const [form, setForm] = useState({ email: '', code: '' });
-  const [message, setMessage] = useState<FormMessage | null>(null);
-  const navigate = useNavigate();
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({
-      ...form,
-      [e.target.name]: e.target.value,
-    });
-  };
-
-  const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    try {
-      await authRepository.confirmSignup(form);
-      navigate('/login', {
-        state: {
-          message: '確認に成功しました。ログインしてください。',
-        },
-      });
-    } catch (error) {
-      if (error instanceof AxiosError && error.response?.data?.error) {
-        setMessage({ type: 'error', text: error.response.data.error });
-      } else {
-        setMessage({ type: 'error', text: '通信エラーが発生しました。' });
-      }
-    }
-  };
+  const { form, message, handleChange, handleConfirm } = useConfirmSignup();
 
   return (
     <AuthLayout>


### PR DESCRIPTION
## 概要
- ConfirmPageからビジネスロジックをuseConfirmSignupフックに抽出
- ページコンポーネントはUIのみに集中（74行→38行）

## 変更内容
- `useConfirmSignup`フック新規作成
- フォーム状態管理・送信処理・エラーハンドリングをフックに移動
- functional updateパターンでsetFormの安定性向上
- テスト5件追加（合計538件）

## テスト
- [x] 全538テストがパス