### PR TITLE
feat: 最近のセッションメモカード追加

### DIFF
--- a/frontend/src/components/RecentNotesCard.tsx
+++ b/frontend/src/components/RecentNotesCard.tsx
@@ -1,0 +1,35 @@
+import { SessionNoteRepository } from '../repositories/SessionNoteRepository';
+
+export default function RecentNotesCard() {
+  const allNotes = SessionNoteRepository.getAll();
+  const noteEntries = Object.values(allNotes);
+
+  if (noteEntries.length === 0) return null;
+
+  const sortedNotes = [...noteEntries]
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+    .slice(0, 3);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-slate-700">最近のメモ</p>
+        <span className="text-[10px] text-slate-400">{noteEntries.length}件</span>
+      </div>
+
+      <div className="space-y-2">
+        {sortedNotes.map((entry) => (
+          <div
+            key={entry.sessionId}
+            className="bg-slate-50 rounded p-2"
+          >
+            <p className="text-xs text-slate-700 line-clamp-2">{entry.note}</p>
+            <p className="text-[10px] text-slate-400 mt-1">
+              {new Date(entry.updatedAt).toLocaleDateString('ja-JP')}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/RecentNotesCard.test.tsx
+++ b/frontend/src/components/__tests__/RecentNotesCard.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import RecentNotesCard from '../RecentNotesCard';
+
+vi.mock('../../repositories/SessionNoteRepository', () => ({
+  SessionNoteRepository: {
+    getAll: vi.fn(),
+  },
+}));
+
+import { SessionNoteRepository } from '../../repositories/SessionNoteRepository';
+
+const mockGetAll = vi.mocked(SessionNoteRepository.getAll);
+
+describe('RecentNotesCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('メモがない場合はnullを返す', () => {
+    mockGetAll.mockReturnValue({});
+    const { container } = render(<RecentNotesCard />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('タイトルが表示される', () => {
+    mockGetAll.mockReturnValue({
+      '1': { sessionId: 1, note: 'テストメモ', updatedAt: '2025-06-15T10:00:00Z' },
+    });
+    render(<RecentNotesCard />);
+    expect(screen.getByText('最近のメモ')).toBeInTheDocument();
+  });
+
+  it('最新3件のメモが表示される', () => {
+    mockGetAll.mockReturnValue({
+      '1': { sessionId: 1, note: 'メモ1', updatedAt: '2025-06-13T10:00:00Z' },
+      '2': { sessionId: 2, note: 'メモ2', updatedAt: '2025-06-14T10:00:00Z' },
+      '3': { sessionId: 3, note: 'メモ3', updatedAt: '2025-06-15T10:00:00Z' },
+      '4': { sessionId: 4, note: 'メモ4', updatedAt: '2025-06-12T10:00:00Z' },
+    });
+    render(<RecentNotesCard />);
+    expect(screen.getByText('メモ3')).toBeInTheDocument();
+    expect(screen.getByText('メモ2')).toBeInTheDocument();
+    expect(screen.getByText('メモ1')).toBeInTheDocument();
+    expect(screen.queryByText('メモ4')).not.toBeInTheDocument();
+  });
+
+  it('メモのプレビューが表示される', () => {
+    mockGetAll.mockReturnValue({
+      '1': { sessionId: 1, note: '振り返りの内容', updatedAt: '2025-06-15T10:00:00Z' },
+    });
+    render(<RecentNotesCard />);
+    expect(screen.getByText('振り返りの内容')).toBeInTheDocument();
+  });
+
+  it('メモ件数が表示される', () => {
+    mockGetAll.mockReturnValue({
+      '1': { sessionId: 1, note: 'メモ1', updatedAt: '2025-06-15T10:00:00Z' },
+      '2': { sessionId: 2, note: 'メモ2', updatedAt: '2025-06-14T10:00:00Z' },
+    });
+    render(<RecentNotesCard />);
+    expect(screen.getByText('2件')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -15,6 +15,7 @@ import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
 import PracticeLevelCard from '../components/PracticeLevelCard';
 import PracticeReminderCard from '../components/PracticeReminderCard';
+import RecentNotesCard from '../components/RecentNotesCard';
 import RecentSessionsCard from '../components/RecentSessionsCard';
 import WeeklyGoalProgressCard from '../components/WeeklyGoalProgressCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
@@ -139,6 +140,11 @@ export default function MenuPage() {
           <RecentSessionsCard sessions={allScores} />
         </div>
       )}
+
+      {/* 最近のメモ */}
+      <div className="mb-6">
+        <RecentNotesCard />
+      </div>
 
       {/* 本日のチャレンジ */}
       <div className="mb-6">

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -27,6 +27,10 @@ vi.mock('../../components/WeeklyReportCard', () => ({
   default: () => <div data-testid="weekly-report">WeeklyReportCard</div>,
 }));
 
+vi.mock('../../components/RecentNotesCard', () => ({
+  default: () => <div data-testid="recent-notes">RecentNotesCard</div>,
+}));
+
 const mockUseMenuData = vi.fn();
 vi.mock('../../hooks/useMenuData', () => ({
   useMenuData: () => mockUseMenuData(),

--- a/frontend/src/repositories/SessionNoteRepository.ts
+++ b/frontend/src/repositories/SessionNoteRepository.ts
@@ -9,6 +9,10 @@ function getAllNotes(): Record<string, SessionNote> {
 }
 
 export const SessionNoteRepository = {
+  getAll(): Record<string, SessionNote> {
+    return getAllNotes();
+  },
+
   get(sessionId: number): SessionNote | null {
     const notes = getAllNotes();
     return notes[String(sessionId)] || null;


### PR DESCRIPTION
## 概要
- セッションメモの最新3件を表示するRecentNotesCard追加
- メニューページに統合

## 変更内容
- `RecentNotesCard` コンポーネント新規作成
- `SessionNoteRepository`に`getAll`メソッド追加
- テスト5件追加（合計547件）

## テスト
- [x] 全547テストがパス