### PR TITLE
feat: 次のステップ提案カード追加

### DIFF
--- a/frontend/src/components/NextStepCard.tsx
+++ b/frontend/src/components/NextStepCard.tsx
@@ -1,0 +1,59 @@
+interface NextStepCardProps {
+  totalSessions: number;
+  averageScore: number;
+}
+
+interface Step {
+  emoji: string;
+  title: string;
+  description: string;
+}
+
+function getNextStep(totalSessions: number, averageScore: number): Step {
+  if (totalSessions === 0) {
+    return {
+      emoji: '🚀',
+      title: '最初の練習を始めよう',
+      description: '練習モードでビジネスシナリオに挑戦し、コミュニケーションスキルを磨きましょう。',
+    };
+  }
+
+  if (totalSessions <= 2) {
+    return {
+      emoji: '💪',
+      title: '練習を続けましょう',
+      description: 'まだ始めたばかりです。繰り返し練習することでスキルが定着します。',
+    };
+  }
+
+  if (averageScore < 7) {
+    return {
+      emoji: '📈',
+      title: 'スコアアップを目指そう',
+      description: '弱点軸を意識して練習すると、効率よくスコアを伸ばせます。',
+    };
+  }
+
+  return {
+    emoji: '⭐',
+    title: '新しいシナリオに挑戦',
+    description: '素晴らしい成績です！まだ試していないシナリオで経験を広げましょう。',
+  };
+}
+
+export default function NextStepCard({ totalSessions, averageScore }: NextStepCardProps) {
+  const step = getNextStep(totalSessions, averageScore);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-2">次のステップ</p>
+      <div className="flex items-start gap-3">
+        <span className="text-2xl">{step.emoji}</span>
+        <div>
+          <p className="text-sm font-medium text-slate-800">{step.title}</p>
+          <p className="text-xs text-slate-500 mt-0.5">{step.description}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NextStepCard.test.tsx
+++ b/frontend/src/components/__tests__/NextStepCard.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import NextStepCard from '../NextStepCard';
+
+describe('NextStepCard', () => {
+  it('タイトルが表示される', () => {
+    render(<NextStepCard totalSessions={0} averageScore={0} />);
+    expect(screen.getByText('次のステップ')).toBeInTheDocument();
+  });
+
+  it('練習0回の場合は最初の練習を促す', () => {
+    render(<NextStepCard totalSessions={0} averageScore={0} />);
+    expect(screen.getByText(/最初の練習/)).toBeInTheDocument();
+  });
+
+  it('練習1-2回の場合は継続を促す', () => {
+    render(<NextStepCard totalSessions={2} averageScore={5} />);
+    expect(screen.getByText(/練習を続けましょう/)).toBeInTheDocument();
+  });
+
+  it('3回以上で低スコアの場合は弱点改善を提案', () => {
+    render(<NextStepCard totalSessions={5} averageScore={5} />);
+    expect(screen.getByText(/スコアアップ/)).toBeInTheDocument();
+  });
+
+  it('3回以上で高スコアの場合は新シナリオを提案', () => {
+    render(<NextStepCard totalSessions={5} averageScore={8} />);
+    expect(screen.getByText(/新しいシナリオ/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -13,6 +13,7 @@ import DailyChallengeCard from '../components/DailyChallengeCard';
 import MotivationQuoteCard from '../components/MotivationQuoteCard';
 import DailyGoalCard from '../components/DailyGoalCard';
 import LearningInsightsCard from '../components/LearningInsightsCard';
+import NextStepCard from '../components/NextStepCard';
 import PracticeLevelCard from '../components/PracticeLevelCard';
 import PracticeReminderCard from '../components/PracticeReminderCard';
 import RecentNotesCard from '../components/RecentNotesCard';
@@ -70,6 +71,11 @@ export default function MenuPage() {
           />
         </div>
       )}
+
+      {/* 次のステップ提案 */}
+      <div className="mb-6">
+        <NextStepCard totalSessions={totalSessions} averageScore={averageScore} />
+      </div>
 
       {/* 練習レベル */}
       <div className="mb-6">


### PR DESCRIPTION
## 概要
- ユーザーの練習状況に応じた次のアクション提案カード追加
- メニューページに統合

## 変更内容
- `NextStepCard` コンポーネント新規作成
- 4段階の提案ロジック
- テスト5件追加（合計560件）

## テスト
- [x] 全560テストがパス