### PR TITLE
refactor: ChatListPageのユーティリティ関数をutils/に抽出

### DIFF
--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -7,6 +7,7 @@ import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import { useChatList } from '../hooks/useChatList';
+import { formatTime, truncateMessage } from '../utils/formatters';
 
 export default function ChatListPage() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -46,32 +47,6 @@ export default function ChatListPage() {
     }, 300);
     return () => clearTimeout(timer);
   }, [searchQuery, fetchChatUsers]);
-
-  const formatTime = (dateString: string): string => {
-    if (!dateString) return '';
-    const date = new Date(dateString);
-    const now = new Date();
-    const diff = now.getTime() - date.getTime();
-    const oneDay = 24 * 60 * 60 * 1000;
-    const oneWeek = 7 * oneDay;
-
-    if (diff < oneDay && date.getDate() === now.getDate()) {
-      return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
-    } else if (diff < oneDay * 2 && date.getDate() === now.getDate() - 1) {
-      return '昨日';
-    } else if (diff < oneWeek) {
-      const days = ['日', '月', '火', '水', '木', '金', '土'];
-      return days[date.getDay()] + '曜日';
-    } else {
-      return date.toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' });
-    }
-  };
-
-  const truncateMessage = (message: string | undefined, maxLength = 30): string => {
-    if (!message) return 'メッセージはありません';
-    if (message.length <= maxLength) return message;
-    return message.substring(0, maxLength) + '...';
-  };
 
   return (
     <div className="flex h-full">

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { formatTime, truncateMessage } from '../formatters';
+
+describe('formatTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-06-15T14:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('空文字の場合は空文字を返す', () => {
+    expect(formatTime('')).toBe('');
+  });
+
+  it('今日の日付はHH:mm形式で返す', () => {
+    const result = formatTime('2025-06-15T10:30:00');
+    expect(result).toMatch(/10:30/);
+  });
+
+  it('昨日の場合は「昨日」を返す', () => {
+    const result = formatTime('2025-06-14T10:30:00');
+    expect(result).toBe('昨日');
+  });
+
+  it('1週間以内の場合は曜日を返す', () => {
+    const result = formatTime('2025-06-12T10:30:00');
+    expect(result).toMatch(/曜日/);
+  });
+
+  it('1週間以上前の場合は月日で返す', () => {
+    const result = formatTime('2025-05-01T10:30:00');
+    expect(result).toMatch(/5/);
+  });
+});
+
+describe('truncateMessage', () => {
+  it('undefinedの場合はデフォルトメッセージを返す', () => {
+    expect(truncateMessage(undefined)).toBe('メッセージはありません');
+  });
+
+  it('短いメッセージはそのまま返す', () => {
+    expect(truncateMessage('こんにちは')).toBe('こんにちは');
+  });
+
+  it('長いメッセージは省略される', () => {
+    const long = 'あ'.repeat(50);
+    const result = truncateMessage(long, 30);
+    expect(result).toHaveLength(33); // 30 + '...'
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  it('maxLengthを指定できる', () => {
+    const result = truncateMessage('1234567890', 5);
+    expect(result).toBe('12345...');
+  });
+});

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,0 +1,25 @@
+export function formatTime(dateString: string): string {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const oneDay = 24 * 60 * 60 * 1000;
+  const oneWeek = 7 * oneDay;
+
+  if (diff < oneDay && date.getDate() === now.getDate()) {
+    return date.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+  } else if (diff < oneDay * 2 && date.getDate() === now.getDate() - 1) {
+    return '昨日';
+  } else if (diff < oneWeek) {
+    const days = ['日', '月', '火', '水', '木', '金', '土'];
+    return days[date.getDay()] + '曜日';
+  } else {
+    return date.toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' });
+  }
+}
+
+export function truncateMessage(message: string | undefined, maxLength = 30): string {
+  if (!message) return 'メッセージはありません';
+  if (message.length <= maxLength) return message;
+  return message.substring(0, maxLength) + '...';
+}


### PR DESCRIPTION
## 概要
- formatTime、truncateMessageをutils/formatters.tsに抽出
- ChatListPageの行数削減（157行→132行）

## 変更内容
- `utils/formatters.ts` 新規作成
- テスト9件追加（合計569件）

## テスト
- [x] 全569テストがパス