### PR TITLE
CommunicationStyleCard: コミュニケーションスタイル判定カード

### DIFF
--- a/frontend/src/components/CommunicationStyleCard.tsx
+++ b/frontend/src/components/CommunicationStyleCard.tsx
@@ -1,0 +1,97 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface Session {
+  scores: AxisScore[];
+}
+
+interface Props {
+  sessions: Session[];
+}
+
+const STYLE_MAP: Record<string, { label: string; description: string; color: string }> = {
+  '論理的構成力': {
+    label: '論理型コミュニケーター',
+    description: '情報を整理し、筋道立てて伝えることが得意です',
+    color: 'text-blue-600 bg-blue-50 border-blue-200',
+  },
+  '配慮表現': {
+    label: '共感型コミュニケーター',
+    description: '相手の気持ちに寄り添い、丁寧に伝えることが得意です',
+    color: 'text-pink-600 bg-pink-50 border-pink-200',
+  },
+  '要約力': {
+    label: '簡潔型コミュニケーター',
+    description: '要点を短くまとめて伝えることが得意です',
+    color: 'text-emerald-600 bg-emerald-50 border-emerald-200',
+  },
+  '提案力': {
+    label: '提案型コミュニケーター',
+    description: '解決策を積極的に提示することが得意です',
+    color: 'text-amber-600 bg-amber-50 border-amber-200',
+  },
+  '質問・傾聴力': {
+    label: '傾聴型コミュニケーター',
+    description: '相手の話を引き出し、深く理解することが得意です',
+    color: 'text-violet-600 bg-violet-50 border-violet-200',
+  },
+};
+
+function getAverageScores(sessions: Session[]): Map<string, number> {
+  const totals = new Map<string, { sum: number; count: number }>();
+
+  for (const session of sessions) {
+    for (const score of session.scores) {
+      const current = totals.get(score.axis) || { sum: 0, count: 0 };
+      current.sum += score.score;
+      current.count += 1;
+      totals.set(score.axis, current);
+    }
+  }
+
+  const averages = new Map<string, number>();
+  for (const [axis, { sum, count }] of totals) {
+    averages.set(axis, sum / count);
+  }
+  return averages;
+}
+
+export default function CommunicationStyleCard({ sessions }: Props) {
+  if (sessions.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-slate-200 p-4">
+        <p className="text-xs font-medium text-slate-500 mb-1">あなたのスタイル</p>
+        <p className="text-sm text-slate-400">まだスタイルが判定できません</p>
+        <p className="text-xs text-slate-400 mt-1">練習セッションを完了するとスタイルが判定されます</p>
+      </div>
+    );
+  }
+
+  const averages = getAverageScores(sessions);
+  let topAxis = '';
+  let topScore = -1;
+
+  for (const [axis, avg] of averages) {
+    if (avg > topScore) {
+      topScore = avg;
+      topAxis = axis;
+    }
+  }
+
+  const style = STYLE_MAP[topAxis];
+
+  if (!style) {
+    return null;
+  }
+
+  return (
+    <div className={`rounded-lg border p-4 ${style.color}`}>
+      <p className="text-xs font-medium opacity-75 mb-1">あなたのスタイル</p>
+      <p className="text-base font-bold">{style.label}</p>
+      <p className="text-xs mt-1 opacity-75">{style.description}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
+++ b/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CommunicationStyleCard from '../CommunicationStyleCard';
+
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface Session {
+  scores: AxisScore[];
+}
+
+describe('CommunicationStyleCard', () => {
+  it('セッションがない場合は未判定メッセージを表示する', () => {
+    render(<CommunicationStyleCard sessions={[]} />);
+    expect(screen.getByText('まだスタイルが判定できません')).toBeInTheDocument();
+  });
+
+  it('論理的構成力が最高の場合は論理型を表示する', () => {
+    const sessions: Session[] = [{
+      scores: [
+        { axis: '論理的構成力', score: 9, comment: '' },
+        { axis: '配慮表現', score: 5, comment: '' },
+        { axis: '要約力', score: 5, comment: '' },
+        { axis: '提案力', score: 5, comment: '' },
+        { axis: '質問・傾聴力', score: 5, comment: '' },
+      ],
+    }];
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(screen.getByText('論理型コミュニケーター')).toBeInTheDocument();
+  });
+
+  it('配慮表現が最高の場合は共感型を表示する', () => {
+    const sessions: Session[] = [{
+      scores: [
+        { axis: '論理的構成力', score: 5, comment: '' },
+        { axis: '配慮表現', score: 9, comment: '' },
+        { axis: '要約力', score: 5, comment: '' },
+        { axis: '提案力', score: 5, comment: '' },
+        { axis: '質問・傾聴力', score: 5, comment: '' },
+      ],
+    }];
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(screen.getByText('共感型コミュニケーター')).toBeInTheDocument();
+  });
+
+  it('要約力が最高の場合は簡潔型を表示する', () => {
+    const sessions: Session[] = [{
+      scores: [
+        { axis: '論理的構成力', score: 5, comment: '' },
+        { axis: '配慮表現', score: 5, comment: '' },
+        { axis: '要約力', score: 9, comment: '' },
+        { axis: '提案力', score: 5, comment: '' },
+        { axis: '質問・傾聴力', score: 5, comment: '' },
+      ],
+    }];
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(screen.getByText('簡潔型コミュニケーター')).toBeInTheDocument();
+  });
+
+  it('提案力が最高の場合は提案型を表示する', () => {
+    const sessions: Session[] = [{
+      scores: [
+        { axis: '論理的構成力', score: 5, comment: '' },
+        { axis: '配慮表現', score: 5, comment: '' },
+        { axis: '要約力', score: 5, comment: '' },
+        { axis: '提案力', score: 9, comment: '' },
+        { axis: '質問・傾聴力', score: 5, comment: '' },
+      ],
+    }];
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(screen.getByText('提案型コミュニケーター')).toBeInTheDocument();
+  });
+
+  it('質問・傾聴力が最高の場合は傾聴型を表示する', () => {
+    const sessions: Session[] = [{
+      scores: [
+        { axis: '論理的構成力', score: 5, comment: '' },
+        { axis: '配慮表現', score: 5, comment: '' },
+        { axis: '要約力', score: 5, comment: '' },
+        { axis: '提案力', score: 5, comment: '' },
+        { axis: '質問・傾聴力', score: 9, comment: '' },
+      ],
+    }];
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(screen.getByText('傾聴型コミュニケーター')).toBeInTheDocument();
+  });
+
+  it('複数セッションの平均からスタイルを判定する', () => {
+    const sessions: Session[] = [
+      {
+        scores: [
+          { axis: '論理的構成力', score: 8, comment: '' },
+          { axis: '配慮表現', score: 6, comment: '' },
+          { axis: '要約力', score: 7, comment: '' },
+          { axis: '提案力', score: 5, comment: '' },
+          { axis: '質問・傾聴力', score: 6, comment: '' },
+        ],
+      },
+      {
+        scores: [
+          { axis: '論理的構成力', score: 6, comment: '' },
+          { axis: '配慮表現', score: 4, comment: '' },
+          { axis: '要約力', score: 9, comment: '' },
+          { axis: '提案力', score: 5, comment: '' },
+          { axis: '質問・傾聴力', score: 6, comment: '' },
+        ],
+      },
+    ];
+    // 平均: 論理7, 配慮5, 要約8, 提案5, 傾聴6 → 要約力が最高 → 簡潔型
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(screen.getByText('簡潔型コミュニケーター')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -9,6 +9,7 @@ import SkillMilestoneCard from '../components/SkillMilestoneCard';
 import ScoreComparisonCard from '../components/ScoreComparisonCard';
 import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
 import SkillSummaryCard from '../components/SkillSummaryCard';
+import CommunicationStyleCard from '../components/CommunicationStyleCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -48,6 +49,9 @@ export default function ScoreHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
+      {/* コミュニケーションスタイル */}
+      <CommunicationStyleCard sessions={history} />
+
       {/* 統計サマリー */}
       <ScoreStatsSummary history={history} />
 


### PR DESCRIPTION
## 概要
練習スコアの5軸平均からユーザーのコミュニケーションスタイルを自動判定し、ScoreHistoryPageに表示するカード。

## スタイル判定
- 論理的構成力が最高 → 論理型コミュニケーター（青）
- 配慮表現が最高 → 共感型コミュニケーター（ピンク）
- 要約力が最高 → 簡潔型コミュニケーター（緑）
- 提案力が最高 → 提案型コミュニケーター（琥珀）
- 質問・傾聴力が最高 → 傾聴型コミュニケーター（紫）

## テスト
7テスト追加（582テスト全パス）

closes #334