### PR TITLE
LoginCallbackからuseLoginCallbackフック抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginCallback.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLoginCallback } from '../useLoginCallback';
+
+const mockNavigate = vi.fn();
+const mockDispatch = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams(mockSearchParams)],
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => mockDispatch,
+}));
+
+vi.mock('../../repositories/AuthRepository', () => ({
+  default: {
+    callback: vi.fn(),
+  },
+}));
+
+vi.mock('../../store/authSlice', () => ({
+  setAuthData: () => ({ type: 'auth/setAuthData' }),
+}));
+
+import authRepository from '../../repositories/AuthRepository';
+
+let mockSearchParams = '';
+
+describe('useLoginCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = '';
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
+  });
+
+  it('codeがある場合にauthRepository.callbackを呼び出す', async () => {
+    mockSearchParams = 'code=test-code';
+    vi.mocked(authRepository.callback).mockResolvedValue({} as any);
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(authRepository.callback).toHaveBeenCalledWith('test-code');
+  });
+
+  it('callback成功時にsetAuthDataをdispatchしホームに遷移する', async () => {
+    mockSearchParams = 'code=test-code';
+    vi.mocked(authRepository.callback).mockResolvedValue({} as any);
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'auth/setAuthData' });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('callback失敗時にアラートを表示しログインページに遷移する', async () => {
+    mockSearchParams = 'code=test-code';
+    vi.mocked(authRepository.callback).mockRejectedValue(new Error('認証失敗'));
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(window.alert).toHaveBeenCalledWith('認証に失敗しました。');
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+
+  it('errorパラメータがある場合にアラートを表示しログインページに遷移する', async () => {
+    mockSearchParams = 'error=access_denied';
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(window.alert).toHaveBeenCalledWith('認証エラーが発生しました。access_denied');
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(authRepository.callback).not.toHaveBeenCalled();
+  });
+
+  it('codeもerrorもない場合にログインページに遷移する', async () => {
+    mockSearchParams = '';
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(authRepository.callback).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useLoginCallback.ts
+++ b/frontend/src/hooks/useLoginCallback.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setAuthData } from '../store/authSlice';
+import authRepository from '../repositories/AuthRepository';
+
+export function useLoginCallback() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const code = searchParams.get('code');
+  const error = searchParams.get('error');
+
+  useEffect(() => {
+    if (error) {
+      alert('認証エラーが発生しました。' + error);
+      navigate('/login');
+      return;
+    }
+
+    if (code) {
+      authRepository
+        .callback(code)
+        .then(() => {
+          dispatch(setAuthData());
+          navigate('/');
+        })
+        .catch(() => {
+          alert('認証に失敗しました。');
+          navigate('/login');
+        });
+    } else {
+      navigate('/login');
+    }
+  }, [code, error, dispatch, navigate]);
+}

--- a/frontend/src/pages/LoginCallback.tsx
+++ b/frontend/src/pages/LoginCallback.tsx
@@ -1,38 +1,7 @@
-import { useEffect } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
-import { setAuthData } from '../store/authSlice';
-import authRepository from '../repositories/AuthRepository';
+import { useLoginCallback } from '../hooks/useLoginCallback';
 
 export default function LoginCallback() {
-  const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const code = searchParams.get('code');
-  const error = searchParams.get('error');
-
-  useEffect(() => {
-    if (error) {
-      alert('認証エラーが発生しました。' + error);
-      navigate('/login');
-      return;
-    }
-
-    if (code) {
-      authRepository
-        .callback(code)
-        .then(() => {
-          dispatch(setAuthData());
-          navigate('/');
-        })
-        .catch(() => {
-          alert('認証に失敗しました。');
-          navigate('/login');
-        });
-    } else {
-      navigate('/login');
-    }
-  }, [code, error, dispatch, navigate]);
+  useLoginCallback();
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-surface">


### PR DESCRIPTION
## 概要
LoginCallback.tsxからOAuth認証処理のビジネスロジックをuseLoginCallbackフックに抽出。

## 変更内容
- `useLoginCallback`フック新規作成（認証コールバック処理・エラーハンドリング・ナビゲーション）
- LoginCallback.tsx簡素化（54行→23行）
- 5テスト追加（587テスト全パス）

## リファクタ前後
### Before
LoginCallback.tsx: useEffect内でauthRepository.callback、dispatch、navigate処理

### After
LoginCallback.tsx: useLoginCallback()を呼ぶだけのUI専用コンポーネント

closes #336