### PR TITLE
useProfileEdit・useScoreHistoryテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useProfileEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileEdit.test.ts
@@ -88,4 +88,49 @@ describe('useProfileEdit', () => {
     expect(result.current.message?.type).toBe('error');
     expect(result.current.message?.text).toBe('通信エラーが発生しました。');
   });
+
+  it('loading状態が初期trueからfalseに変化する', async () => {
+    const { result } = renderHook(() => useProfileEdit());
+
+    // 初期状態はloading true
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+  });
+
+  it('updateFieldでbioフィールドも更新できる', async () => {
+    const { result } = renderHook(() => useProfileEdit());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.updateField('bio', '新しい自己紹介');
+    });
+
+    expect(result.current.form.bio).toBe('新しい自己紹介');
+    // nameは変更されていないこと
+    expect(result.current.form.name).toBe('テスト太郎');
+  });
+
+  it('handleUpdate時にupdateProfileにフォーム値が渡される', async () => {
+    const { result } = renderHook(() => useProfileEdit());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.updateField('name', '更新太郎');
+    });
+
+    await act(async () => {
+      await result.current.handleUpdate();
+    });
+
+    expect(mockUpdateProfile).toHaveBeenCalledWith({ name: '更新太郎', bio: '自己紹介文' });
+  });
 });


### PR DESCRIPTION
## 概要
useProfileEdit（5→8テスト）とuseScoreHistory（5→8テスト）のテストカバレッジを拡充。

## 追加テスト
### useProfileEdit (+3)
- loading状態が初期trueからfalseに変化する
- updateFieldでbioフィールドも更新できる
- handleUpdate時にupdateProfileにフォーム値が渡される

### useScoreHistory (+3)
- フリーフィルタでフリーセッションのみ返す
- 「すべて」フィルタで全セッションを返す
- 最新セッションのスコアが空の場合にweakestAxisがnullになる

## テスト結果
593テスト全てパス（+6テスト）

closes #338