### PR TITLE
ScoreGoalCard: 目標スコア設定・進捗表示カード

### DIFF
--- a/frontend/src/components/ScoreGoalCard.tsx
+++ b/frontend/src/components/ScoreGoalCard.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+interface Props {
+  averageScore: number;
+}
+
+const GOAL_OPTIONS = [6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0];
+const STORAGE_KEY = 'scoreGoal';
+
+function getStoredGoal(): number {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    const parsed = parseFloat(stored);
+    if (!isNaN(parsed)) return parsed;
+  }
+  return 8.0;
+}
+
+export default function ScoreGoalCard({ averageScore }: Props) {
+  const [goal, setGoal] = useState(getStoredGoal);
+
+  const handleGoalChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newGoal = parseFloat(e.target.value);
+    setGoal(newGoal);
+    localStorage.setItem(STORAGE_KEY, String(newGoal));
+  };
+
+  const achieved = averageScore >= goal;
+  const gap = Math.round((goal - averageScore) * 10) / 10;
+  const progress = Math.min((averageScore / goal) * 100, 100);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-slate-700">目標スコア</p>
+        <select
+          value={goal}
+          onChange={handleGoalChange}
+          className="text-xs border border-slate-200 rounded px-2 py-1 text-slate-600"
+        >
+          {GOAL_OPTIONS.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt.toFixed(1)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-end justify-between mb-2">
+        <div>
+          <p className="text-xs text-slate-500">現在の平均</p>
+          <p className="text-xl font-bold text-slate-800">{averageScore.toFixed(1)}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-slate-500">目標</p>
+          <p className="text-xl font-bold text-primary-600">{goal.toFixed(1)}</p>
+        </div>
+      </div>
+
+      <div className="w-full bg-slate-100 rounded-full h-2 mb-2">
+        <div
+          className={`h-2 rounded-full transition-all ${achieved ? 'bg-emerald-500' : 'bg-primary-500'}`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+
+      <p className={`text-xs ${achieved ? 'text-emerald-600 font-medium' : 'text-slate-500'}`}>
+        {achieved
+          ? '目標達成！素晴らしいです！'
+          : `あと ${gap.toFixed(1)} ポイントで目標達成です`}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreGoalCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreGoalCard.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ScoreGoalCard from '../ScoreGoalCard';
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => { store[key] = value; }),
+    removeItem: vi.fn((key: string) => { delete store[key]; }),
+    clear: vi.fn(() => { store = {}; }),
+    get length() { return Object.keys(store).length; },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}
+
+describe('ScoreGoalCard', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  it('平均スコアが表示される', () => {
+    render(<ScoreGoalCard averageScore={7.2} />);
+    expect(screen.getByText('7.2')).toBeInTheDocument();
+  });
+
+  it('デフォルト目標スコア8.0が目標欄に表示される', () => {
+    render(<ScoreGoalCard averageScore={7.0} />);
+    // 目標欄のテキストを確認（selectのoptionにも8.0があるのでtext-primary-600で絞る）
+    const goalDisplay = screen.getByText('8.0', { selector: '.text-primary-600' });
+    expect(goalDisplay).toBeInTheDocument();
+  });
+
+  it('目標達成時に達成メッセージが表示される', () => {
+    render(<ScoreGoalCard averageScore={8.5} />);
+    expect(screen.getByText(/目標達成/)).toBeInTheDocument();
+  });
+
+  it('目標未達成時に励ましメッセージが表示される', () => {
+    render(<ScoreGoalCard averageScore={6.0} />);
+    expect(screen.getByText(/あと/)).toBeInTheDocument();
+  });
+
+  it('目標スコアを変更できる', () => {
+    render(<ScoreGoalCard averageScore={7.0} />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: '9' } });
+    const goalDisplay = screen.getByText('9.0', { selector: '.text-primary-600' });
+    expect(goalDisplay).toBeInTheDocument();
+  });
+
+  it('目標スコアがLocalStorageに保存される', () => {
+    render(<ScoreGoalCard averageScore={7.0} />);
+    const select = screen.getByRole('combobox');
+    fireEvent.change(select, { target: { value: '9' } });
+    expect(localStorage.setItem).toHaveBeenCalledWith('scoreGoal', '9');
+  });
+
+  it('LocalStorageから目標スコアを復元する', () => {
+    (localStorage.getItem as ReturnType<typeof vi.fn>).mockReturnValue('9.5');
+    render(<ScoreGoalCard averageScore={6.0} />);
+    const goalDisplay = screen.getByText('9.5', { selector: '.text-primary-600' });
+    expect(goalDisplay).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -10,6 +10,7 @@ import ScoreComparisonCard from '../components/ScoreComparisonCard';
 import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
 import SkillSummaryCard from '../components/SkillSummaryCard';
 import CommunicationStyleCard from '../components/CommunicationStyleCard';
+import ScoreGoalCard from '../components/ScoreGoalCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -51,6 +52,11 @@ export default function ScoreHistoryPage() {
     <div className="max-w-3xl mx-auto p-4 space-y-3">
       {/* コミュニケーションスタイル */}
       <CommunicationStyleCard sessions={history} />
+
+      {/* 目標スコア */}
+      <ScoreGoalCard
+        averageScore={Math.round((history.reduce((sum, h) => sum + h.overallScore, 0) / history.length) * 10) / 10}
+      />
 
       {/* 統計サマリー */}
       <ScoreStatsSummary history={history} />

--- a/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
@@ -7,6 +7,12 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+vi.mock('../../components/ScoreGoalCard', () => ({
+  default: ({ averageScore }: { averageScore: number }) => (
+    <div data-testid="score-goal-card">目標: {averageScore}</div>
+  ),
+}));
+
 const mockHistory = [
   {
     sessionId: 1,


### PR DESCRIPTION
## 概要
目標スコアを設定し、現在の平均スコアとの差分をプログレスバーで可視化するカード。

## 機能
- 目標スコア設定（6.0〜10.0、デフォルト8.0）
- LocalStorageに目標を永続化
- 現在の平均スコアvs目標のプログレスバー
- 達成/未達成に応じたメッセージ表示
- ScoreHistoryPageに配置

## テスト
7テスト追加（600テスト全パス）

closes #342