### PR TITLE
test: useFavoritePhrase・useDailyGoalのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useDailyGoal.test.ts
+++ b/frontend/src/hooks/__tests__/useDailyGoal.test.ts
@@ -67,4 +67,37 @@ describe('useDailyGoal', () => {
 
     expect(result.current.progress).toBe(50);
   });
+
+  it('target=0の場合progressが100になる', () => {
+    mockedRepo.getToday.mockReturnValue({ date: '2026-02-13', target: 0, completed: 0 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    expect(result.current.progress).toBe(100);
+  });
+
+  it('completed > targetの場合isAchievedがtrue', () => {
+    mockedRepo.getToday.mockReturnValue({ date: '2026-02-13', target: 3, completed: 5 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    expect(result.current.isAchieved).toBe(true);
+    expect(result.current.progress).toBe(167);
+  });
+
+  it('incrementCompleted後の進捗率が更新される', () => {
+    mockedRepo.getToday
+      .mockReturnValueOnce({ date: '2026-02-13', target: 4, completed: 1 })
+      .mockReturnValueOnce({ date: '2026-02-13', target: 4, completed: 2 });
+
+    const { result } = renderHook(() => useDailyGoal());
+
+    expect(result.current.progress).toBe(25);
+
+    act(() => {
+      result.current.incrementCompleted();
+    });
+
+    expect(result.current.progress).toBe(50);
+  });
 });

--- a/frontend/src/hooks/__tests__/useFavoritePhrase.test.ts
+++ b/frontend/src/hooks/__tests__/useFavoritePhrase.test.ts
@@ -73,4 +73,42 @@ describe('useFavoritePhrase', () => {
     expect(result.current.isFavorite('言い換え', 'フォーマル')).toBe(true);
     expect(mockedRepo.exists).toHaveBeenCalledWith('言い換え', 'フォーマル');
   });
+
+  it('未登録時にisFavoriteがfalseを返す', () => {
+    mockedRepo.exists.mockReturnValue(false);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    expect(result.current.isFavorite('未登録', 'カジュアル')).toBe(false);
+    expect(mockedRepo.exists).toHaveBeenCalledWith('未登録', 'カジュアル');
+  });
+
+  it('複数フレーズ保存で一覧が正しく更新される', () => {
+    const phrase1 = { id: '1', originalText: 'テスト1', rephrasedText: '言い換え1', pattern: 'フォーマル', createdAt: '2026-01-01' };
+    const phrase2 = { id: '2', originalText: 'テスト2', rephrasedText: '言い換え2', pattern: 'カジュアル', createdAt: '2026-01-02' };
+    mockedRepo.getAll
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([phrase1])
+      .mockReturnValueOnce([phrase1, phrase2]);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    act(() => {
+      result.current.saveFavorite('テスト1', '言い換え1', 'フォーマル');
+    });
+    expect(result.current.phrases).toEqual([phrase1]);
+
+    act(() => {
+      result.current.saveFavorite('テスト2', '言い換え2', 'カジュアル');
+    });
+    expect(result.current.phrases).toEqual([phrase1, phrase2]);
+  });
+
+  it('初期状態でフレーズが空配列の場合', () => {
+    mockedRepo.getAll.mockReturnValue([]);
+
+    const { result } = renderHook(() => useFavoritePhrase());
+
+    expect(result.current.phrases).toEqual([]);
+  });
 });


### PR DESCRIPTION
## 概要
closes #346

テスト数が少ないフックに追加テストを実装。

### useFavoritePhrase: 4→7件（+3件）
- 未登録時にisFavoriteがfalseを返す
- 複数フレーズ保存で一覧が正しく更新される
- 初期状態でフレーズが空配列

### useDailyGoal: 5→8件（+3件）
- target=0の場合progressが100になる
- completed > targetの場合isAchievedがtrue
- incrementCompleted後の進捗率が更新される

## テスト
- 全609テスト通過