### PR TITLE
feat: 学習パターン分析カード（LearningPatternCard）の実装

### DIFF
--- a/frontend/src/components/LearningPatternCard.tsx
+++ b/frontend/src/components/LearningPatternCard.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+
+const DAY_LABELS = ['日', '月', '火', '水', '木', '金', '土'];
+
+type PatternType = '平日集中型' | '週末集中型' | '毎日コツコツ型' | '不定期型';
+
+const PATTERN_MESSAGES: Record<PatternType, string> = {
+  '平日集中型': '平日の空き時間を活用して練習を続けています。業務と並行してスキルアップする姿勢が素晴らしいです！',
+  '週末集中型': '週末にまとめて練習するスタイルです。集中して取り組めるのが強みです！',
+  '毎日コツコツ型': '毎日少しずつ練習を続けるスタイルです。継続は力なり、理想的な学習パターンです！',
+  '不定期型': 'まだ学習パターンが定まっていません。毎日少しずつ取り組むと効果的です！',
+};
+
+const PATTERN_COLORS: Record<PatternType, string> = {
+  '平日集中型': 'text-blue-600 bg-blue-50',
+  '週末集中型': 'text-purple-600 bg-purple-50',
+  '毎日コツコツ型': 'text-emerald-600 bg-emerald-50',
+  '不定期型': 'text-amber-600 bg-amber-50',
+};
+
+function analyzePattern(practiceDates: string[]): { pattern: PatternType; dayCounts: number[] } {
+  const dayCounts = [0, 0, 0, 0, 0, 0, 0]; // 日〜土
+
+  for (const dateStr of practiceDates) {
+    const day = new Date(dateStr).getDay();
+    dayCounts[day]++;
+  }
+
+  const weekdayCount = dayCounts[1] + dayCounts[2] + dayCounts[3] + dayCounts[4] + dayCounts[5];
+  const weekendCount = dayCounts[0] + dayCounts[6];
+  const total = weekdayCount + weekendCount;
+  const activeDays = dayCounts.filter(c => c > 0).length;
+
+  let pattern: PatternType;
+  if (activeDays >= 6) {
+    pattern = '毎日コツコツ型';
+  } else if (total >= 3 && weekdayCount / total >= 0.7) {
+    pattern = '平日集中型';
+  } else if (total >= 3 && weekendCount / total >= 0.7) {
+    pattern = '週末集中型';
+  } else {
+    pattern = '不定期型';
+  }
+
+  return { pattern, dayCounts };
+}
+
+interface Props {
+  practiceDates: string[];
+}
+
+export default function LearningPatternCard({ practiceDates }: Props) {
+  const { pattern, dayCounts } = useMemo(() => analyzePattern(practiceDates), [practiceDates]);
+
+  if (practiceDates.length === 0) return null;
+
+  const maxCount = Math.max(...dayCounts, 1);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-slate-700">学習パターン</p>
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${PATTERN_COLORS[pattern]}`}>
+          {pattern}
+        </span>
+      </div>
+
+      <div className="flex items-end gap-1 h-12 mb-2">
+        {dayCounts.map((count, i) => (
+          <div key={i} className="flex-1 flex flex-col items-center gap-0.5">
+            <div
+              className="w-full bg-primary-400 rounded-t transition-all"
+              style={{ height: `${(count / maxCount) * 100}%`, minHeight: count > 0 ? '4px' : '0' }}
+            />
+            <span className="text-[10px] text-slate-400">{DAY_LABELS[i]}</span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-slate-500">{PATTERN_MESSAGES[pattern]}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/LearningPatternCard.test.tsx
+++ b/frontend/src/components/__tests__/LearningPatternCard.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LearningPatternCard from '../LearningPatternCard';
+
+describe('LearningPatternCard', () => {
+  it('練習日がない場合は何も表示しない', () => {
+    const { container } = render(<LearningPatternCard practiceDates={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('学習パターンタイトルが表示される', () => {
+    const dates = ['2026-02-10T10:00:00Z', '2026-02-11T10:00:00Z'];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText('学習パターン')).toBeInTheDocument();
+  });
+
+  it('曜日ラベルが表示される', () => {
+    const dates = ['2026-02-10T10:00:00Z'];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('日')).toBeInTheDocument();
+  });
+
+  it('平日集中型パターンが判定される', () => {
+    // 月〜金の日付を複数設定
+    const dates = [
+      '2026-02-09T10:00:00Z', // 月
+      '2026-02-10T10:00:00Z', // 火
+      '2026-02-11T10:00:00Z', // 水
+      '2026-02-12T10:00:00Z', // 木
+      '2026-02-13T10:00:00Z', // 金
+    ];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText('平日集中型')).toBeInTheDocument();
+  });
+
+  it('週末集中型パターンが判定される', () => {
+    // 土日の日付を複数設定
+    const dates = [
+      '2026-02-07T10:00:00Z', // 土
+      '2026-02-08T10:00:00Z', // 日
+      '2026-02-14T10:00:00Z', // 土
+      '2026-02-15T10:00:00Z', // 日
+    ];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText('週末集中型')).toBeInTheDocument();
+  });
+
+  it('毎日コツコツ型パターンが判定される', () => {
+    // 全曜日にまんべんなく分布
+    const dates = [
+      '2026-02-09T10:00:00Z', // 月
+      '2026-02-10T10:00:00Z', // 火
+      '2026-02-11T10:00:00Z', // 水
+      '2026-02-12T10:00:00Z', // 木
+      '2026-02-13T10:00:00Z', // 金
+      '2026-02-14T10:00:00Z', // 土
+      '2026-02-15T10:00:00Z', // 日
+    ];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText('毎日コツコツ型')).toBeInTheDocument();
+  });
+
+  it('不定期型パターンが判定される', () => {
+    // 少数の曜日に偏らず、全体的に少ない
+    const dates = [
+      '2026-02-10T10:00:00Z', // 火
+      '2026-02-14T10:00:00Z', // 土
+    ];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText('不定期型')).toBeInTheDocument();
+  });
+
+  it('パターンに応じた説明メッセージが表示される', () => {
+    const dates = [
+      '2026-02-09T10:00:00Z',
+      '2026-02-10T10:00:00Z',
+      '2026-02-11T10:00:00Z',
+      '2026-02-12T10:00:00Z',
+      '2026-02-13T10:00:00Z',
+    ];
+    render(<LearningPatternCard practiceDates={dates} />);
+    expect(screen.getByText(/平日の空き時間/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -20,6 +20,7 @@ import RecentNotesCard from '../components/RecentNotesCard';
 import RecentSessionsCard from '../components/RecentSessionsCard';
 import WeeklyGoalProgressCard from '../components/WeeklyGoalProgressCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
+import LearningPatternCard from '../components/LearningPatternCard';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
@@ -120,6 +121,13 @@ export default function MenuPage() {
       {totalSessions > 0 && (
         <div className="mb-6">
           <WeeklyReportCard allScores={allScores} />
+        </div>
+      )}
+
+      {/* 学習パターン分析 */}
+      {practiceDates.length > 0 && (
+        <div className="mb-6">
+          <LearningPatternCard practiceDates={practiceDates} />
         </div>
       )}
 


### PR DESCRIPTION
## 概要
closes #350

練習日データから曜日パターンを分析し、学習習慣を可視化するカードコンポーネントを実装。

### 機能
- 練習日の曜日分布を分析し4パターンに分類
  - 平日集中型 / 週末集中型 / 毎日コツコツ型 / 不定期型
- 曜日別練習頻度の棒グラフ表示
- パターンに応じた励ましメッセージ表示
- ダッシュボード（MenuPage）に統合

## テスト
- LearningPatternCardテスト8件追加
- 全617テスト通過