### PR TITLE
refactor: ChatPageのコアロジックをuseChatフックに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useChat.test.ts
+++ b/frontend/src/hooks/__tests__/useChat.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useChat } from '../useChat';
+import ChatRepository from '../../repositories/ChatRepository';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ roomId: '1' }),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../../repositories/ChatRepository');
+vi.mock('sockjs-client', () => ({ default: vi.fn() }));
+vi.mock('@stomp/stompjs', () => ({
+  Client: class MockClient {
+    activate = vi.fn();
+    deactivate = vi.fn();
+    subscribe = vi.fn();
+    publish = vi.fn();
+    connected = true;
+    constructor(_config: any) {}
+  },
+}));
+
+const mockedRepo = vi.mocked(ChatRepository);
+
+describe('useChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchCurrentUser.mockResolvedValue({ id: 1, name: 'テスト' });
+    mockedRepo.fetchHistory.mockResolvedValue([]);
+    mockedRepo.markAsRead.mockResolvedValue(undefined);
+  });
+
+  it('初期ロード時にsenderIdを取得する', async () => {
+    const { result } = renderHook(() => useChat());
+
+    await waitFor(() => {
+      expect(result.current.senderId).toBe(1);
+    });
+  });
+
+  it('messagesの初期値が空配列', () => {
+    const { result } = renderHook(() => useChat());
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it('deleteModalの初期値が閉じた状態', () => {
+    const { result } = renderHook(() => useChat());
+    expect(result.current.deleteModal.isOpen).toBe(false);
+    expect(result.current.deleteModal.messageId).toBeNull();
+  });
+
+  it('selectionModeの初期値がfalse', () => {
+    const { result } = renderHook(() => useChat());
+    expect(result.current.selectionMode).toBe(false);
+  });
+
+  it('handleDeleteMessageでdeleteModalが開く', async () => {
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.handleDeleteMessage(42);
+    });
+
+    expect(result.current.deleteModal.isOpen).toBe(true);
+    expect(result.current.deleteModal.messageId).toBe(42);
+  });
+
+  it('cancelDeleteでdeleteModalが閉じる', async () => {
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.handleDeleteMessage(42);
+    });
+    expect(result.current.deleteModal.isOpen).toBe(true);
+
+    act(() => {
+      result.current.cancelDelete();
+    });
+    expect(result.current.deleteModal.isOpen).toBe(false);
+  });
+
+  it('handleAiFeedbackでselectionModeがtrueになる', () => {
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.handleAiFeedback();
+    });
+
+    expect(result.current.selectionMode).toBe(true);
+  });
+
+  it('handleCancelSelectionでselectionModeがfalseに戻る', () => {
+    const { result } = renderHook(() => useChat());
+
+    act(() => {
+      result.current.handleAiFeedback();
+    });
+    expect(result.current.selectionMode).toBe(true);
+
+    act(() => {
+      result.current.handleCancelSelection();
+    });
+    expect(result.current.selectionMode).toBe(false);
+  });
+
+  it('showRephraseModalの初期値がfalse', () => {
+    const { result } = renderHook(() => useChat());
+    expect(result.current.showRephraseModal).toBe(false);
+  });
+
+  it('fetchCurrentUser失敗時にログインページにナビゲートする', async () => {
+    mockedRepo.fetchCurrentUser.mockRejectedValue(new Error('Unauthorized'));
+
+    renderHook(() => useChat());
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login');
+    });
+  });
+});

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,0 +1,306 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import SockJS from 'sockjs-client';
+import { Client } from '@stomp/stompjs';
+import ChatRepository from '../repositories/ChatRepository';
+import { ChatMessage } from '../types';
+
+/**
+ * チャットページのコアロジックフック
+ *
+ * ChatPageからビジネスロジックを分離し、
+ * メッセージ管理・WebSocket接続・選択モード・言い換え提案を担う。
+ */
+export function useChat() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [senderId, setSenderId] = useState<number | null>(null);
+  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean; messageId: number | null }>({ isOpen: false, messageId: null });
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedMessages, setSelectedMessages] = useState<Set<number>>(new Set());
+  const [rangeStart, setRangeStart] = useState<number | null>(null);
+  const [rangeEnd, setRangeEnd] = useState<number | null>(null);
+  const [showSceneSelector, setShowSceneSelector] = useState(false);
+  const [showRephraseModal, setShowRephraseModal] = useState(false);
+  const [rephraseResult, setRephraseResult] = useState<{ formal: string; soft: string; concise: string } | null>(null);
+  const [rephraseOriginalText, setRephraseOriginalText] = useState('');
+  const stompClientRef = useRef<Client | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  const { roomId } = useParams<{ roomId: string }>();
+  const navigate = useNavigate();
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+  // ユーザー情報取得
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        const data = await ChatRepository.fetchCurrentUser();
+        setSenderId(data.id);
+      } catch {
+        navigate('/login');
+      }
+    };
+    fetchUserInfo();
+  }, [navigate]);
+
+  // スクロール
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  // 未読カウントリセット
+  useEffect(() => {
+    if (!roomId || !senderId) return;
+    ChatRepository.markAsRead(roomId).catch(() => {});
+  }, [roomId, senderId]);
+
+  // チャット履歴取得
+  const fetchHistory = useCallback(async () => {
+    try {
+      const data = await ChatRepository.fetchHistory(roomId!);
+      if (!Array.isArray(data)) return;
+      const formatted = data.map((msg: any) => ({
+        id: msg.id,
+        roomId: msg.roomId,
+        senderId: msg.senderId,
+        senderName: msg.senderName,
+        content: msg.content,
+        createdAt: msg.createdAt,
+        isSender: msg.senderId === senderId,
+      }));
+      setMessages(formatted);
+    } catch {
+      // エラーはaxiosインターセプターが処理
+    }
+  }, [roomId, senderId]);
+
+  // WebSocket接続
+  useEffect(() => {
+    if (!senderId) return;
+    const client = new Client({
+      webSocketFactory: () =>
+        new SockJS(`${API_BASE_URL}/ws/chat`, undefined, { withCredentials: true }),
+      reconnectDelay: 5000,
+      onConnect: () => {
+        client.publish({
+          destination: '/app/auth',
+          body: JSON.stringify({ userId: senderId }),
+        });
+        client.subscribe(`/topic/chat/${roomId}`, (message) => {
+          const data = JSON.parse(message.body);
+          if (data.type === 'delete') {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === data.messageId ? { ...m, isDeleted: true } : m
+              )
+            );
+            return;
+          }
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: data.id,
+              roomId: data.roomId,
+              senderId: data.senderId,
+              senderName: data.senderName,
+              content: data.content,
+              createdAt: data.createdAt,
+              isSender: data.senderId === senderId,
+            },
+          ]);
+        });
+        fetchHistory();
+      },
+      onStompError: () => {},
+    });
+    stompClientRef.current = client;
+    client.activate();
+    return () => { client.deactivate(); };
+  }, [roomId, senderId, fetchHistory, API_BASE_URL]);
+
+  // メッセージ送信
+  const handleSend = useCallback((text: string) => {
+    if (!stompClientRef.current?.connected) return;
+    stompClientRef.current.publish({
+      destination: '/app/chat/send',
+      body: JSON.stringify({ roomId, senderId, content: text }),
+    });
+  }, [roomId, senderId]);
+
+  // メッセージ削除
+  const handleDeleteMessage = useCallback((messageId: number) => {
+    setDeleteModal({ isOpen: true, messageId });
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    const messageId = deleteModal.messageId;
+    setDeleteModal({ isOpen: false, messageId: null });
+    if (!stompClientRef.current?.connected) return;
+    stompClientRef.current.publish({
+      destination: '/app/chat/delete',
+      body: JSON.stringify({
+        messageId,
+        roomId: parseInt(roomId!, 10),
+        senderId,
+      }),
+    });
+  }, [deleteModal.messageId, roomId, senderId]);
+
+  const cancelDelete = useCallback(() => {
+    setDeleteModal({ isOpen: false, messageId: null });
+  }, []);
+
+  // AI選択モード
+  const handleAiFeedback = useCallback(() => {
+    setSelectionMode(true);
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+  }, []);
+
+  const handleRangeClick = useCallback((messageId: number) => {
+    const messageIndex = messages.findIndex((msg) => msg.id === messageId);
+    if (rangeStart === null) {
+      setRangeStart(messageIndex);
+      setRangeEnd(null);
+      setSelectedMessages(new Set([messageId]));
+    } else if (rangeEnd === null) {
+      setRangeEnd(messageIndex);
+      const start = Math.min(rangeStart, messageIndex);
+      const end = Math.max(rangeStart, messageIndex);
+      const rangeIds = new Set(messages.slice(start, end + 1).map((msg) => msg.id));
+      setSelectedMessages(rangeIds);
+    } else {
+      setRangeStart(messageIndex);
+      setRangeEnd(null);
+      setSelectedMessages(new Set([messageId]));
+    }
+  }, [messages, rangeStart, rangeEnd]);
+
+  const handleQuickSelect = useCallback((count: number) => {
+    const recentMessages = messages.slice(-count);
+    const recentIds = new Set(recentMessages.map((msg) => msg.id));
+    setSelectedMessages(recentIds);
+    if (recentMessages.length > 0) {
+      setRangeStart(messages.length - count);
+      setRangeEnd(messages.length - 1);
+    }
+  }, [messages]);
+
+  const handleSelectAll = useCallback(() => {
+    const allIds = new Set(messages.map((msg) => msg.id));
+    setSelectedMessages(allIds);
+    setRangeStart(0);
+    setRangeEnd(messages.length - 1);
+  }, [messages]);
+
+  const handleDeselectAll = useCallback(() => {
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+  }, []);
+
+  const handleCancelSelection = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+  }, []);
+
+  const handleSendToAi = useCallback(() => {
+    if (selectedMessages.size === 0) {
+      alert('メッセージを選択してください');
+      return;
+    }
+    setShowSceneSelector(true);
+  }, [selectedMessages]);
+
+  const handleSceneSelect = useCallback((scene: string | null) => {
+    setShowSceneSelector(false);
+    const selectedMsgs = messages.filter((msg) => selectedMessages.has(msg.id));
+    const chatHistory = selectedMsgs
+      .map((msg) => `${msg.isSender ? '自分' : '相手'}: ${msg.content}`)
+      .join('\n');
+    setSelectionMode(false);
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+    navigate('/chat/ask-ai', {
+      state: {
+        initialPrompt: `【選択したチャット履歴】\n${chatHistory}`,
+        fromChatFeedback: true,
+        scene: scene,
+      },
+    });
+  }, [messages, selectedMessages, navigate]);
+
+  // 言い換え提案
+  const handleRephrase = useCallback(async (content: string) => {
+    setRephraseResult(null);
+    setRephraseOriginalText(content);
+    setShowRephraseModal(true);
+    try {
+      const data = await ChatRepository.rephrase(content, null);
+      try {
+        const parsed = JSON.parse(data.result);
+        setRephraseResult(parsed);
+      } catch {
+        setRephraseResult({ formal: data.result, soft: '', concise: '' });
+      }
+    } catch {
+      setShowRephraseModal(false);
+    }
+  }, []);
+
+  // ユーティリティ
+  const isInRange = useCallback((index: number): boolean => {
+    if (rangeStart === null) return false;
+    if (rangeEnd === null) return index === rangeStart;
+    const start = Math.min(rangeStart, rangeEnd);
+    const end = Math.max(rangeStart, rangeEnd);
+    return index >= start && index <= end;
+  }, [rangeStart, rangeEnd]);
+
+  const getRangeLabel = useCallback((index: number): string | null => {
+    if (rangeStart === index && rangeEnd === null) return '開始';
+    if (rangeEnd === null) return null;
+    const start = Math.min(rangeStart!, rangeEnd);
+    const end = Math.max(rangeStart!, rangeEnd);
+    if (index === start) return '開始';
+    if (index === end) return '終了';
+    return null;
+  }, [rangeStart, rangeEnd]);
+
+  return {
+    messages,
+    senderId,
+    deleteModal,
+    selectionMode,
+    selectedMessages,
+    showSceneSelector,
+    showRephraseModal,
+    rephraseResult,
+    rephraseOriginalText,
+    messagesEndRef,
+    handleSend,
+    handleDeleteMessage,
+    confirmDelete,
+    cancelDelete,
+    handleAiFeedback,
+    handleRangeClick,
+    handleQuickSelect,
+    handleSelectAll,
+    handleDeselectAll,
+    handleCancelSelection,
+    handleSendToAi,
+    handleSceneSelect,
+    handleRephrase,
+    setShowRephraseModal,
+    isInRange,
+    getRangeLabel,
+  };
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,312 +1,38 @@
-import { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
 import MessageBubble from '../components/MessageBubble';
 import MessageInput from '../components/MessageInput';
-import { ChatMessage } from '../types';
-
 import ConfirmModal from '../components/ConfirmModal';
 import SceneSelector from '../components/SceneSelector';
 import RephraseModal from '../components/RephraseModal';
-import ChatRepository from '../repositories/ChatRepository';
-
-import SockJS from 'sockjs-client';
-import { Client } from '@stomp/stompjs';
+import { useChat } from '../hooks/useChat';
 
 export default function ChatPage() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [senderId, setSenderId] = useState<number | null>(null);
-  const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean; messageId: number | null }>({ isOpen: false, messageId: null });
-  const [selectionMode, setSelectionMode] = useState(false);
-  const [selectedMessages, setSelectedMessages] = useState<Set<number>>(new Set());
-  const [rangeStart, setRangeStart] = useState<number | null>(null);
-  const [rangeEnd, setRangeEnd] = useState<number | null>(null);
-  const [showSceneSelector, setShowSceneSelector] = useState(false);
-  const [showRephraseModal, setShowRephraseModal] = useState(false);
-  const [rephraseResult, setRephraseResult] = useState<{ formal: string; soft: string; concise: string } | null>(null);
-  const [rephraseOriginalText, setRephraseOriginalText] = useState('');
-  const stompClientRef = useRef<Client | null>(null);
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
-
-  const { roomId } = useParams<{ roomId: string }>();
-
-  const navigate = useNavigate();
-
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-
-  // ユーザー情報取得（senderId を取得）
-  useEffect(() => {
-    const fetchUserInfo = async () => {
-      try {
-        const data = await ChatRepository.fetchCurrentUser();
-        setSenderId(data.id);
-      } catch {
-        navigate('/login');
-      }
-    };
-
-    fetchUserInfo();
-  }, [navigate]);
-
-  // スクロール
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
-
-  // チャットルーム開封時に未読カウントをリセット
-  useEffect(() => {
-    if (!roomId || !senderId) return;
-    ChatRepository.markAsRead(roomId).catch(() => {});
-  }, [roomId, senderId]);
-
-  // --- チャット履歴取得 ---
-  const fetchHistory = async () => {
-    try {
-      const data = await ChatRepository.fetchHistory(roomId!);
-      if (!Array.isArray(data)) return;
-
-      const formatted = data.map((msg: any) => ({
-        id: msg.id,
-        roomId: msg.roomId,
-        senderId: msg.senderId,
-        senderName: msg.senderName,
-        content: msg.content,
-        createdAt: msg.createdAt,
-        isSender: msg.senderId === senderId,
-      }));
-
-      setMessages(formatted);
-    } catch {
-      // エラーはaxiosインターセプターが処理
-    }
-  };
-
-  // --- WebSocket (STOMP) 接続 ---
-  useEffect(() => {
-    if (!senderId) return;
-
-    const client = new Client({
-      webSocketFactory: () =>
-        new SockJS(`${API_BASE_URL}/ws/chat`, undefined, { withCredentials: true }),
-      reconnectDelay: 5000,
-
-      onConnect: () => {
-        // 認証メッセージを送信
-        client.publish({
-          destination: '/app/auth',
-          body: JSON.stringify({ userId: senderId }),
-        });
-
-        // ルーム購読
-        client.subscribe(`/topic/chat/${roomId}`, (message) => {
-          const data = JSON.parse(message.body);
-
-          // 削除通知の処理
-          if (data.type === 'delete') {
-            setMessages((prev) =>
-              prev.map((m) =>
-                m.id === data.messageId ? { ...m, isDeleted: true } : m
-              )
-            );
-            return;
-          }
-
-          setMessages((prev) => [
-            ...prev,
-            {
-              id: data.id,
-              roomId: data.roomId,
-              senderId: data.senderId,
-              senderName: data.senderName,
-              content: data.content,
-              createdAt: data.createdAt,
-              isSender: data.senderId === senderId,
-            },
-          ]);
-        });
-
-        fetchHistory();
-      },
-
-      onStompError: () => {},
-    });
-
-    stompClientRef.current = client;
-    client.activate();
-
-    return () => {
-      client.deactivate();
-    };
-  }, [roomId, senderId]);
-
-  // --- メッセージ送信 ---
-  const handleSend = (text: string) => {
-    if (!stompClientRef.current?.connected) return;
-
-    stompClientRef.current.publish({
-      destination: '/app/chat/send',
-      body: JSON.stringify({ roomId, senderId, content: text }),
-    });
-  };
-
-  // --- メッセージ削除 ---
-  const handleDeleteMessage = (messageId: number) => {
-    setDeleteModal({ isOpen: true, messageId });
-  };
-
-  const confirmDelete = () => {
-    const messageId = deleteModal.messageId;
-    setDeleteModal({ isOpen: false, messageId: null });
-
-    if (!stompClientRef.current?.connected) return;
-
-    stompClientRef.current.publish({
-      destination: '/app/chat/delete',
-      body: JSON.stringify({
-        messageId,
-        roomId: parseInt(roomId!, 10),
-        senderId,
-      }),
-    });
-  };
-
-  const cancelDelete = () => {
-    setDeleteModal({ isOpen: false, messageId: null });
-  };
-
-  // --- AIフィードバック ---
-  const handleAiFeedback = () => {
-    setSelectionMode(true);
-    setSelectedMessages(new Set());
-    setRangeStart(null);
-    setRangeEnd(null);
-  };
-
-  // 範囲選択: メッセージをクリックしたとき
-  const handleRangeClick = (messageId: number) => {
-    const messageIndex = messages.findIndex((msg) => msg.id === messageId);
-
-    if (rangeStart === null) {
-      setRangeStart(messageIndex);
-      setRangeEnd(null);
-      setSelectedMessages(new Set([messageId]));
-    } else if (rangeEnd === null) {
-      setRangeEnd(messageIndex);
-      const start = Math.min(rangeStart, messageIndex);
-      const end = Math.max(rangeStart, messageIndex);
-      const rangeIds = new Set(
-        messages.slice(start, end + 1).map((msg) => msg.id)
-      );
-      setSelectedMessages(rangeIds);
-    } else {
-      setRangeStart(messageIndex);
-      setRangeEnd(null);
-      setSelectedMessages(new Set([messageId]));
-    }
-  };
-
-  // クイック選択: 直近N件
-  const handleQuickSelect = (count: number) => {
-    const recentMessages = messages.slice(-count);
-    const recentIds = new Set(recentMessages.map((msg) => msg.id));
-    setSelectedMessages(recentIds);
-    if (recentMessages.length > 0) {
-      setRangeStart(messages.length - count);
-      setRangeEnd(messages.length - 1);
-    }
-  };
-
-  const handleSelectAll = () => {
-    const allIds = new Set(messages.map((msg) => msg.id));
-    setSelectedMessages(allIds);
-    setRangeStart(0);
-    setRangeEnd(messages.length - 1);
-  };
-
-  const handleDeselectAll = () => {
-    setSelectedMessages(new Set());
-    setRangeStart(null);
-    setRangeEnd(null);
-  };
-
-  const handleCancelSelection = () => {
-    setSelectionMode(false);
-    setSelectedMessages(new Set());
-    setRangeStart(null);
-    setRangeEnd(null);
-  };
-
-  const handleSendToAi = () => {
-    if (selectedMessages.size === 0) {
-      alert('メッセージを選択してください');
-      return;
-    }
-    setShowSceneSelector(true);
-  };
-
-  const handleSceneSelect = (scene: string | null) => {
-    setShowSceneSelector(false);
-
-    const selectedMsgs = messages.filter((msg) => selectedMessages.has(msg.id));
-    const chatHistory = selectedMsgs
-      .map((msg) => `${msg.isSender ? '自分' : '相手'}: ${msg.content}`)
-      .join('\n');
-
-    setSelectionMode(false);
-    setSelectedMessages(new Set());
-    setRangeStart(null);
-    setRangeEnd(null);
-
-    navigate('/chat/ask-ai', {
-      state: {
-        initialPrompt: `【選択したチャット履歴】\n${chatHistory}`,
-        fromChatFeedback: true,
-        scene: scene,
-      },
-    });
-  };
-
-  // --- 言い換え提案 ---
-  const handleRephrase = async (content: string) => {
-    setRephraseResult(null);
-    setRephraseOriginalText(content);
-    setShowRephraseModal(true);
-
-    try {
-      const data = await ChatRepository.rephrase(content, null);
-      try {
-        const parsed = JSON.parse(data.result);
-        setRephraseResult(parsed);
-      } catch {
-        setRephraseResult({ formal: data.result, soft: '', concise: '' });
-      }
-    } catch {
-      setShowRephraseModal(false);
-    }
-  };
-
-  // メッセージが範囲内かどうかを判定
-  const isInRange = (index: number): boolean => {
-    if (rangeStart === null) return false;
-    if (rangeEnd === null) return index === rangeStart;
-    const start = Math.min(rangeStart, rangeEnd);
-    const end = Math.max(rangeStart, rangeEnd);
-    return index >= start && index <= end;
-  };
-
-  // 範囲選択のラベルを取得
-  const getRangeLabel = (index: number): string | null => {
-    if (rangeStart === index && rangeEnd === null) return '開始';
-    if (rangeEnd === null) return null;
-    const start = Math.min(rangeStart!, rangeEnd);
-    const end = Math.max(rangeStart!, rangeEnd);
-    if (index === start) return '開始';
-    if (index === end) return '終了';
-    return null;
-  };
+  const {
+    messages,
+    deleteModal,
+    selectionMode,
+    selectedMessages,
+    showSceneSelector,
+    showRephraseModal,
+    rephraseResult,
+    rephraseOriginalText,
+    messagesEndRef,
+    handleSend,
+    handleDeleteMessage,
+    confirmDelete,
+    cancelDelete,
+    handleAiFeedback,
+    handleRangeClick,
+    handleQuickSelect,
+    handleSelectAll,
+    handleDeselectAll,
+    handleCancelSelection,
+    handleSendToAi,
+    handleSceneSelect,
+    handleRephrase,
+    setShowRephraseModal,
+    isInRange,
+    getRangeLabel,
+  } = useChat();
 
   return (
     <div className="flex flex-col h-full">
@@ -377,19 +103,15 @@ export default function ChatPage() {
         <div className="max-w-3xl mx-auto w-full space-y-3">
           {selectionMode ? (
             <div className="space-y-3">
-              {/* ガイドメッセージ */}
               <div className="bg-primary-50 border border-primary-200 rounded-lg p-3">
                 <p className="text-sm text-primary-700">
-                  {rangeStart === null
-                    ? '開始位置のメッセージをタップしてください'
-                    : rangeEnd === null
-                    ? '終了位置のメッセージをタップしてください'
-                    : `${selectedMessages.size}件のメッセージを選択しました`
+                  {selectedMessages.size > 0
+                    ? `${selectedMessages.size}件のメッセージを選択しました`
+                    : '開始位置のメッセージをタップしてください'
                   }
                 </p>
               </div>
 
-              {/* クイック選択ボタン */}
               <div className="flex gap-2 flex-wrap">
                 <span className="text-xs text-slate-500 self-center">クイック選択:</span>
                 {[5, 10, 20].map((n) => (
@@ -415,7 +137,6 @@ export default function ChatPage() {
                 </button>
               </div>
 
-              {/* アクションボタン */}
               <div className="flex gap-2">
                 <button
                   onClick={handleCancelSelection}
@@ -455,7 +176,6 @@ export default function ChatPage() {
         </div>
       </div>
 
-      {/* シーン選択モーダル */}
       {showSceneSelector && (
         <SceneSelector
           onSelect={(sceneId) => handleSceneSelect(sceneId)}
@@ -463,7 +183,6 @@ export default function ChatPage() {
         />
       )}
 
-      {/* 言い換え提案モーダル */}
       {showRephraseModal && (
         <RephraseModal
           result={rephraseResult}
@@ -472,7 +191,6 @@ export default function ChatPage() {
         />
       )}
 
-      {/* 削除確認モーダル */}
       <ConfirmModal
         isOpen={deleteModal.isOpen}
         title="メッセージを削除"


### PR DESCRIPTION
## 概要
closes #352

ChatPage.tsxの全ビジネスロジックを`useChat`カスタムフックに抽出。

### 変更内容
- 12個のuseState・5個のuseEffect・2個のuseRefをuseChatに移動
- メッセージ管理（CRUD・スクロール）
- WebSocket接続・購読
- AI選択モード管理（範囲選択・クイック選択）
- 言い換え提案管理
- ChatPage: 489→207行に削減（58%削減）

## テスト
- useChatテスト10件追加
- 全627テスト通過