### PR TITLE
test: useConfirmSignup・usePracticeTimerのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useConfirmSignup.test.ts
+++ b/frontend/src/hooks/__tests__/useConfirmSignup.test.ts
@@ -98,4 +98,35 @@ describe('useConfirmSignup', () => {
     expect(result.current.message?.type).toBe('error');
     expect(result.current.message?.text).toBe('通信エラーが発生しました。');
   });
+
+  it('初期messageがnull', () => {
+    const { result } = renderHook(() => useConfirmSignup());
+    expect(result.current.message).toBeNull();
+  });
+
+  it('codeフィールドのhandleChangeで値が更新される', () => {
+    const { result } = renderHook(() => useConfirmSignup());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'code', value: '654321' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(result.current.form.code).toBe('654321');
+    expect(result.current.form.email).toBe('');
+  });
+
+  it('handleConfirmでpreventDefaultが呼ばれる', async () => {
+    const preventDefault = vi.fn();
+    const { result } = renderHook(() => useConfirmSignup());
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault,
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/src/hooks/__tests__/usePracticeTimer.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticeTimer.test.ts
@@ -92,4 +92,70 @@ describe('usePracticeTimer', () => {
 
     expect(result.current.formattedTime).toBe('01:05');
   });
+
+  it('二重start防止: 既にrunning中のstartは無視される', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    // 二重start
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    // 3 + 2 = 5秒（二重startで倍速にならない）
+    expect(result.current.seconds).toBe(5);
+  });
+
+  it('stop後のstartで秒数が維持されたまま再開する', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(result.current.seconds).toBe(5);
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(result.current.seconds).toBe(8);
+  });
+
+  it('10分超のformattedTimeが正しく表示される', () => {
+    const { result } = renderHook(() => usePracticeTimer());
+
+    act(() => {
+      result.current.start();
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(754000); // 12分34秒
+    });
+
+    expect(result.current.formattedTime).toBe('12:34');
+  });
 });


### PR DESCRIPTION
## 概要
closes #354

テスト数が少ないフックに追加テストを実装。

### useConfirmSignup: 5→8件（+3件）
- 初期messageがnull
- codeフィールドのhandleChangeで値更新
- handleConfirmでpreventDefaultが呼ばれる

### usePracticeTimer: 5→8件（+3件）
- 二重start防止（既にrunning中のstartは無視）
- stop後のstartで秒数維持したまま再開
- 10分超のformattedTime表示

## テスト
- 全633テスト通過