### PR TITLE
feat: スコア成長トレンドカード（ScoreGrowthTrendCard）の実装

### DIFF
--- a/frontend/src/components/ScoreGrowthTrendCard.tsx
+++ b/frontend/src/components/ScoreGrowthTrendCard.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+
+type TrendType = 'up' | 'down' | 'stable';
+
+const TREND_CONFIG: Record<TrendType, { label: string; message: string; color: string; icon: string }> = {
+  up: {
+    label: '上昇',
+    message: 'スコアが上昇傾向です。この調子で練習を続けましょう！',
+    color: 'text-emerald-600',
+    icon: '↑',
+  },
+  down: {
+    label: '低下',
+    message: 'スコアが少し低下しています。基礎に立ち返って練習してみましょう。',
+    color: 'text-rose-600',
+    icon: '↓',
+  },
+  stable: {
+    label: '安定',
+    message: 'スコアが安定しています。新しいシナリオに挑戦してレベルアップしましょう！',
+    color: 'text-blue-600',
+    icon: '→',
+  },
+};
+
+interface Props {
+  scores: number[];
+}
+
+export default function ScoreGrowthTrendCard({ scores }: Props) {
+  const analysis = useMemo(() => {
+    if (scores.length < 2) return null;
+
+    const mid = Math.floor(scores.length / 2);
+    const firstHalf = scores.slice(0, mid);
+    const secondHalf = scores.slice(mid);
+
+    const firstAvg = firstHalf.reduce((s, v) => s + v, 0) / firstHalf.length;
+    const secondAvg = secondHalf.reduce((s, v) => s + v, 0) / secondHalf.length;
+    const delta = Math.round((secondAvg - firstAvg) * 10) / 10;
+
+    let trend: TrendType;
+    if (delta > 0.3) trend = 'up';
+    else if (delta < -0.3) trend = 'down';
+    else trend = 'stable';
+
+    return {
+      trend,
+      delta,
+      latestScore: scores[scores.length - 1],
+    };
+  }, [scores]);
+
+  if (!analysis) return null;
+
+  const config = TREND_CONFIG[analysis.trend];
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-medium text-slate-700">成長トレンド</p>
+        <span className={`text-sm font-bold ${config.color}`}>
+          {config.icon} {config.label}
+        </span>
+      </div>
+
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="text-2xl font-bold text-slate-800">{analysis.latestScore}</span>
+        <span className="text-xs text-slate-400">最新スコア</span>
+        {analysis.delta !== 0 && (
+          <span className={`text-xs font-medium ${analysis.delta > 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+            {analysis.delta > 0 ? '+' : ''}{analysis.delta.toFixed(1)}
+          </span>
+        )}
+      </div>
+
+      <p className="text-xs text-slate-500">{config.message}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreGrowthTrendCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreGrowthTrendCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreGrowthTrendCard from '../ScoreGrowthTrendCard';
+
+describe('ScoreGrowthTrendCard', () => {
+  it('セッションが2件未満の場合は何も表示しない', () => {
+    const { container } = render(<ScoreGrowthTrendCard scores={[7.0]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('成長トレンドタイトルが表示される', () => {
+    render(<ScoreGrowthTrendCard scores={[6.0, 7.0, 8.0]} />);
+    expect(screen.getByText('成長トレンド')).toBeInTheDocument();
+  });
+
+  it('スコアが上昇傾向の場合に上昇メッセージが表示される', () => {
+    render(<ScoreGrowthTrendCard scores={[5.0, 6.0, 7.0, 8.0, 9.0]} />);
+    expect(screen.getAllByText(/上昇/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('スコアが下降傾向の場合に下降メッセージが表示される', () => {
+    render(<ScoreGrowthTrendCard scores={[9.0, 8.0, 7.0, 6.0, 5.0]} />);
+    expect(screen.getAllByText(/低下/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('スコアが横ばいの場合に安定メッセージが表示される', () => {
+    render(<ScoreGrowthTrendCard scores={[7.0, 7.0, 7.0, 7.0]} />);
+    expect(screen.getAllByText(/安定/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('差分値が表示される', () => {
+    // 前半平均: 6.0, 後半平均: 8.0 → 差分 +2.0
+    render(<ScoreGrowthTrendCard scores={[6.0, 6.0, 8.0, 8.0]} />);
+    expect(screen.getByText(/\+2\.0/)).toBeInTheDocument();
+  });
+
+  it('最新スコアが表示される', () => {
+    render(<ScoreGrowthTrendCard scores={[5.0, 7.5]} />);
+    expect(screen.getByText('7.5')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -21,6 +21,7 @@ import RecentSessionsCard from '../components/RecentSessionsCard';
 import WeeklyGoalProgressCard from '../components/WeeklyGoalProgressCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
 import LearningPatternCard from '../components/LearningPatternCard';
+import ScoreGrowthTrendCard from '../components/ScoreGrowthTrendCard';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
@@ -70,6 +71,13 @@ export default function MenuPage() {
             averageScore={averageScore}
             streakDays={uniqueDays}
           />
+        </div>
+      )}
+
+      {/* 成長トレンド */}
+      {allScores.length >= 2 && (
+        <div className="mb-6">
+          <ScoreGrowthTrendCard scores={allScores.map(s => s.overallScore)} />
         </div>
       )}
 


### PR DESCRIPTION
## 概要
closes #358

スコア履歴から成長トレンドを分析し、ユーザーの成長実感を促進するカードコンポーネントを実装。

### 機能
- 前半 vs 後半のスコア平均を比較して成長トレンドを分析
- 3パターン判定: 上昇/下降/安定
- 差分値・最新スコア表示
- トレンドに応じた励ましメッセージ表示
- ダッシュボード（MenuPage）に統合

## テスト
- ScoreGrowthTrendCardテスト7件追加
- 全640テスト通過