### PR TITLE
test: useWebSocket・useAiSessionのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useAiSession.test.ts
+++ b/frontend/src/hooks/__tests__/useAiSession.test.ts
@@ -112,4 +112,53 @@ describe('useAiSession', () => {
     expect(mockUpdateSessionTitle).toHaveBeenCalledWith(10, { title: '新しいタイトル' });
     expect(result.current.editingSessionId).toBeNull();
   });
+
+  it('deleteModal初期値がclosed状態', () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    expect(result.current.deleteModal.isOpen).toBe(false);
+    expect(result.current.deleteModal.sessionId).toBeNull();
+  });
+
+  it('空タイトル保存時にeditingSessionIdがnullに戻る', async () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleStartEditTitle({ id: 10, title: 'テスト' });
+    });
+
+    act(() => {
+      result.current.setEditingTitle('   ');
+    });
+
+    await act(async () => {
+      await result.current.handleSaveTitle(10);
+    });
+
+    expect(mockUpdateSessionTitle).not.toHaveBeenCalled();
+    expect(result.current.editingSessionId).toBeNull();
+  });
+
+  it('handleCancelEditTitleでeditingTitleが空に戻る', () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleStartEditTitle({ id: 10, title: '既存' });
+    });
+
+    expect(result.current.editingTitle).toBe('既存');
+
+    act(() => {
+      result.current.handleCancelEditTitle();
+    });
+
+    expect(result.current.editingSessionId).toBeNull();
+    expect(result.current.editingTitle).toBe('');
+  });
 });

--- a/frontend/src/hooks/__tests__/useWebSocket.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocket.test.ts
@@ -88,4 +88,35 @@ describe('useWebSocket', () => {
 
     expect(mockDeactivate).toHaveBeenCalledOnce();
   });
+
+  it('subscribe関数が購読解除関数を返す', () => {
+    const { result } = renderHook(() =>
+      useWebSocket({ url: 'http://localhost/ws', userId: 1 })
+    );
+
+    const callback = vi.fn();
+    const unsubscribe = result.current.subscribe('/topic/test', callback);
+
+    expect(typeof unsubscribe).toBe('function');
+  });
+
+  it('isConnectedの初期値がfalse', () => {
+    const { result } = renderHook(() =>
+      useWebSocket({ url: 'http://localhost/ws', userId: 1 })
+    );
+
+    expect(result.current.isConnected()).toBe(false);
+  });
+
+  it('publish関数が未接続時に例外を投げない', () => {
+    const { result } = renderHook(() =>
+      useWebSocket({ url: 'http://localhost/ws', userId: 1 })
+    );
+
+    expect(() => {
+      result.current.publish('/app/test', { data: 'hello' });
+    }).not.toThrow();
+
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 概要
- useWebSocketのテストを5→8に拡充（subscribe購読解除関数、isConnected初期値、publish未接続時）
- useAiSessionのテストを5→8に拡充（deleteModal初期値、空タイトル保存、handleCancelEditTitle）

## テスト結果
- 全650テスト通過

close #362