### PR TITLE
feat: スコア分布カード（ScoreDistributionCard）追加

### DIFF
--- a/frontend/src/components/ScoreDistributionCard.tsx
+++ b/frontend/src/components/ScoreDistributionCard.tsx
@@ -1,0 +1,68 @@
+interface ScoreDistributionCardProps {
+  scores: number[];
+}
+
+const RANGES = [
+  { label: '9-10', min: 9, max: 10 },
+  { label: '7-8', min: 7, max: 8.9 },
+  { label: '4-6', min: 4, max: 6.9 },
+  { label: '1-3', min: 1, max: 3.9 },
+] as const;
+
+const RANGE_COLORS = [
+  'bg-emerald-500',
+  'bg-blue-500',
+  'bg-amber-500',
+  'bg-rose-500',
+];
+
+function getMessage(topRangeIndex: number): string {
+  switch (topRangeIndex) {
+    case 0:
+      return '高スコア帯に集中しています。素晴らしい成果です！';
+    case 1:
+      return '安定した実力が身についています。さらに上を目指しましょう！';
+    case 2:
+      return '基礎力がついてきています。練習を続けてレベルアップしましょう！';
+    default:
+      return '伸びしろがたくさんあります。練習を重ねてスキルを磨きましょう！';
+  }
+}
+
+export default function ScoreDistributionCard({ scores }: ScoreDistributionCardProps) {
+  if (scores.length === 0) return null;
+
+  const counts = RANGES.map((range) =>
+    scores.filter((s) => s >= range.min && s <= range.max).length
+  );
+
+  const maxCount = Math.max(...counts);
+  const topRangeIndex = counts.indexOf(maxCount);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">スコア分布</p>
+
+      <div className="space-y-2">
+        {RANGES.map((range, i) => (
+          <div key={range.label} className="flex items-center gap-2">
+            <span className="text-xs text-slate-500 w-8 text-right">{range.label}</span>
+            <div className="flex-1 bg-slate-100 rounded-full h-4">
+              {maxCount > 0 && counts[i] > 0 && (
+                <div
+                  className={`h-4 rounded-full ${RANGE_COLORS[i]} transition-all`}
+                  style={{ width: `${(counts[i] / maxCount) * 100}%` }}
+                />
+              )}
+            </div>
+            <span data-testid="range-count" className="text-xs font-medium text-slate-600 w-6 text-right">
+              {counts[i]}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-slate-500 mt-3">{getMessage(topRangeIndex)}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreDistributionCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreDistributionCard.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreDistributionCard from '../ScoreDistributionCard';
+
+describe('ScoreDistributionCard', () => {
+  it('タイトルが表示される', () => {
+    render(<ScoreDistributionCard scores={[5, 7, 8]} />);
+    expect(screen.getByText('スコア分布')).toBeInTheDocument();
+  });
+
+  it('4つのレンジラベルが表示される', () => {
+    render(<ScoreDistributionCard scores={[5, 7, 8]} />);
+    expect(screen.getByText('9-10')).toBeInTheDocument();
+    expect(screen.getByText('7-8')).toBeInTheDocument();
+    expect(screen.getByText('4-6')).toBeInTheDocument();
+    expect(screen.getByText('1-3')).toBeInTheDocument();
+  });
+
+  it('各レンジの件数が表示される', () => {
+    render(<ScoreDistributionCard scores={[2, 5, 7, 8, 9]} />);
+    // 1-3: 1件, 4-6: 1件, 7-8: 2件, 9-10: 1件
+    const counts = screen.getAllByTestId('range-count');
+    expect(counts[0]).toHaveTextContent('1'); // 9-10
+    expect(counts[1]).toHaveTextContent('2'); // 7-8
+    expect(counts[2]).toHaveTextContent('1'); // 4-6
+    expect(counts[3]).toHaveTextContent('1'); // 1-3
+  });
+
+  it('最頻レンジに応じたメッセージが表示される（高スコア帯）', () => {
+    render(<ScoreDistributionCard scores={[9, 9.5, 10, 8]} />);
+    expect(screen.getByText(/高スコア帯/)).toBeInTheDocument();
+  });
+
+  it('最頻レンジに応じたメッセージが表示される（中スコア帯）', () => {
+    render(<ScoreDistributionCard scores={[7, 7.5, 8, 5]} />);
+    expect(screen.getByText(/安定した実力/)).toBeInTheDocument();
+  });
+
+  it('最頻レンジに応じたメッセージが表示される（低スコア帯）', () => {
+    render(<ScoreDistributionCard scores={[2, 3, 1, 5]} />);
+    expect(screen.getByText(/伸びしろ/)).toBeInTheDocument();
+  });
+
+  it('スコアが空の場合は何も表示しない', () => {
+    const { container } = render(<ScoreDistributionCard scores={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -11,6 +11,7 @@ import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
 import SkillSummaryCard from '../components/SkillSummaryCard';
 import CommunicationStyleCard from '../components/CommunicationStyleCard';
 import ScoreGoalCard from '../components/ScoreGoalCard';
+import ScoreDistributionCard from '../components/ScoreDistributionCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -114,6 +115,9 @@ export default function ScoreHistoryPage() {
       {latestSession && latestSession.scores.length > 0 && (
         <ScoreImprovementAdvice scores={latestSession.scores} />
       )}
+
+      {/* スコア分布 */}
+      <ScoreDistributionCard scores={history.map(h => h.overallScore)} />
 
       {/* スコア推移グラフ */}
       <div className="bg-white rounded-lg border border-slate-200 p-4">


### PR DESCRIPTION
## 概要
- スコアを4レンジ（9-10/7-8/4-6/1-3）に分類して横棒グラフで分布を表示
- 最頻レンジに応じた励ましメッセージを表示
- ScoreHistoryPageのスキル別マイルストーンの上に配置

## テスト結果
- 7テスト追加、全657テスト通過

close #366