### PR TITLE
refactor: AskAiPageのロジックをuseAskAiフックに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useAskAi.test.ts
+++ b/frontend/src/hooks/__tests__/useAskAi.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAskAi } from '../useAskAi';
+
+const mockGetCurrentUser = vi.fn();
+const mockFetchSessions = vi.fn();
+const mockFetchMessages = vi.fn();
+const mockDeleteSession = vi.fn();
+const mockUpdateSessionTitle = vi.fn();
+const mockSubscribe = vi.fn(() => vi.fn());
+const mockPublish = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ sessionId: undefined }),
+  useLocation: () => ({ state: null }),
+}));
+
+vi.mock('../useAuth', () => ({
+  useAuth: () => ({
+    getCurrentUser: mockGetCurrentUser,
+    user: { id: 1 },
+  }),
+}));
+
+vi.mock('../useAiChat', () => ({
+  useAiChat: () => ({
+    sessions: [],
+    messages: [],
+    scoreCard: null,
+    fetchSessions: mockFetchSessions,
+    fetchMessages: mockFetchMessages,
+    deleteSession: mockDeleteSession,
+    updateSessionTitle: mockUpdateSessionTitle,
+  }),
+}));
+
+vi.mock('../useWebSocket', () => ({
+  useWebSocket: (opts: any) => {
+    return {
+      subscribe: mockSubscribe,
+      publish: mockPublish,
+    };
+  },
+}));
+
+vi.mock('../useAiSession', () => ({
+  useAiSession: (opts: any) => ({
+    currentSessionId: null,
+    setCurrentSessionId: vi.fn(),
+    deleteModal: { isOpen: false, sessionId: null },
+    editingSessionId: null,
+    editingTitle: '',
+    setEditingTitle: vi.fn(),
+    handleNewSession: vi.fn(),
+    handleSelectSession: vi.fn(),
+    handleDeleteSession: vi.fn(),
+    confirmDeleteSession: vi.fn(),
+    cancelDeleteSession: vi.fn(),
+    handleStartEditTitle: vi.fn(),
+    handleSaveTitle: vi.fn(),
+    handleCancelEditTitle: vi.fn(),
+  }),
+}));
+
+describe('useAskAi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期化時にgetCurrentUserが呼ばれる', () => {
+    renderHook(() => useAskAi());
+    expect(mockGetCurrentUser).toHaveBeenCalled();
+  });
+
+  it('user取得後にfetchSessionsが呼ばれる', () => {
+    renderHook(() => useAskAi());
+    expect(mockFetchSessions).toHaveBeenCalled();
+  });
+
+  it('messagesEndRefが存在する', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.messagesEndRef).toBeDefined();
+  });
+
+  it('isPracticeModeの初期値がfalse', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.isPracticeMode).toBe(false);
+  });
+
+  it('scenarioNameの初期値がnull', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.scenarioName).toBeNull();
+  });
+
+  it('handleSendがpublishを呼ぶ', () => {
+    const { result } = renderHook(() => useAskAi());
+    act(() => {
+      result.current.handleSend('テストメッセージ');
+    });
+    expect(mockPublish).toHaveBeenCalledWith('/app/ai-chat/send', expect.objectContaining({
+      content: 'テストメッセージ',
+      role: 'user',
+    }));
+  });
+
+  it('sessionsが空配列で返される', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('messagesが空配列で返される', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it('scoreCardがnullで返される', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.scoreCard).toBeNull();
+  });
+
+  it('deleteModalが閉じた状態で返される', () => {
+    const { result } = renderHook(() => useAskAi());
+    expect(result.current.deleteModal.isOpen).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -1,0 +1,182 @@
+import { useState, useEffect, useRef } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { useAuth } from './useAuth';
+import { useAiChat } from './useAiChat';
+import { useWebSocket } from './useWebSocket';
+import { useAiSession } from './useAiSession';
+
+/**
+ * AskAiPageフック
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>AskAiページのビジネスロジックを管理</li>
+ *   <li>WebSocket購読・メッセージ送受信・セッション管理</li>
+ * </ul>
+ */
+export function useAskAi() {
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+  const [initialPromptSent, setInitialPromptSent] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  const location = useLocation();
+  const { sessionId: urlSessionId } = useParams<{ sessionId: string }>();
+
+  const { getCurrentUser, user } = useAuth();
+  const {
+    sessions,
+    messages,
+    scoreCard,
+    fetchSessions,
+    fetchMessages,
+    deleteSession,
+    updateSessionTitle,
+  } = useAiChat();
+
+  const aiSession = useAiSession({ deleteSession, updateSessionTitle });
+  const { currentSessionId, setCurrentSessionId } = aiSession;
+
+  const locationState = location.state as {
+    initialPrompt?: string;
+    fromChatFeedback?: boolean;
+    scene?: string;
+    sessionType?: string;
+    scenarioId?: number;
+    scenarioName?: string;
+  } | null;
+
+  const initialPrompt = locationState?.initialPrompt;
+  const fromChatFeedback = locationState?.fromChatFeedback || false;
+  const scene = locationState?.scene || null;
+  const sessionType = locationState?.sessionType || 'normal';
+  const scenarioId = locationState?.scenarioId || null;
+  const scenarioName = locationState?.scenarioName || null;
+  const isPracticeMode = sessionType === 'practice';
+
+  // メッセージ送信
+  const handleSend = (text: string): void => {
+    const payload: Record<string, unknown> = {
+      userId: user?.id,
+      sessionId: currentSessionId,
+      content: text,
+      role: 'user',
+      fromChatFeedback: fromChatFeedback,
+    };
+
+    if (scene) {
+      payload.scene = scene;
+    }
+
+    if (isPracticeMode && scenarioId) {
+      payload.sessionType = 'practice';
+      payload.scenarioId = scenarioId;
+    }
+
+    publish('/app/ai-chat/send', payload);
+  };
+
+  // WebSocket接続
+  const { subscribe, publish } = useWebSocket({
+    url: `${API_BASE_URL}/ws/ai-chat`,
+    userId: user?.id || null,
+    onConnect: () => {
+      if (currentSessionId) {
+        subscribeToSession(currentSessionId);
+      }
+
+      if (initialPrompt && !initialPromptSent) {
+        handleSend(initialPrompt);
+        setInitialPromptSent(true);
+      }
+    },
+  });
+
+  // セッション購読
+  const subscribeToSession = (sessionId: number): void => {
+    subscribe(`/topic/ai-chat/session/${sessionId}`, () => {
+      // メッセージはuseAiChatフックで管理
+    });
+  };
+
+  // ユーザー情報取得
+  useEffect(() => {
+    getCurrentUser();
+  }, [getCurrentUser]);
+
+  // セッション一覧取得
+  useEffect(() => {
+    if (user?.id) {
+      fetchSessions();
+    }
+  }, [user?.id, fetchSessions]);
+
+  // URLパラメータのセッションID変更時
+  useEffect(() => {
+    if (urlSessionId) {
+      setCurrentSessionId(parseInt(urlSessionId));
+    }
+  }, [urlSessionId]);
+
+  // セッション内のメッセージ履歴取得
+  useEffect(() => {
+    if (currentSessionId) {
+      fetchMessages(currentSessionId);
+    }
+  }, [currentSessionId, fetchMessages]);
+
+  // WebSocket購読設定
+  useEffect(() => {
+    if (!user?.id) return;
+
+    subscribe(`/topic/ai-chat/user/${user.id}/session`, (message) => {
+      const newSession = JSON.parse(message.body);
+      setCurrentSessionId(newSession.id);
+    });
+
+    subscribe(`/topic/ai-chat/user/${user.id}/scorecard`, () => {
+      // スコアカードはuseAiChatフックで管理
+    });
+
+    subscribe(`/topic/ai-chat/user/${user.id}/session-deleted`, (message) => {
+      const data = JSON.parse(message.body);
+      if (currentSessionId === data.sessionId) {
+        setCurrentSessionId(null);
+      }
+    });
+  }, [user?.id, subscribe, currentSessionId]);
+
+  // セッション変更時の購読
+  useEffect(() => {
+    if (currentSessionId) {
+      subscribeToSession(currentSessionId);
+    }
+  }, [currentSessionId]);
+
+  // メッセージ最下部へスクロール
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  // メッセージ削除処理
+  const handleDeleteMessage = (_messageId: number): void => {
+    // メッセージ削除はローカル状態のみ更新（サーバー側の削除は未実装）
+  };
+
+  return {
+    // データ
+    sessions,
+    messages,
+    scoreCard,
+    messagesEndRef,
+    isPracticeMode,
+    scenarioName,
+
+    // セッション管理
+    ...aiSession,
+
+    // アクション
+    handleSend,
+    handleDeleteMessage,
+  };
+}


### PR DESCRIPTION
## 概要
- AskAiPageに直接書かれていた7つのuseEffect・1つのuseState・1つのuseRefをuseAskAiカスタムフックに抽出
- AskAiPage: 372→219行（41%削減）
- ページコンポーネントはUIのみに集中

## テスト結果
- useAskAiテスト10件追加、全667テスト通過

close #368