### PR TITLE
test: usePractice・useLoginCallbackのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginCallback.test.ts
@@ -92,4 +92,35 @@ describe('useLoginCallback', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/login');
     expect(authRepository.callback).not.toHaveBeenCalled();
   });
+
+  it('errorパラメータがある場合にcallbackを呼ばない', async () => {
+    mockSearchParams = 'error=server_error&code=test-code';
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(authRepository.callback).not.toHaveBeenCalled();
+  });
+
+  it('callback成功時にalertが呼ばれない', async () => {
+    mockSearchParams = 'code=valid-code';
+    vi.mocked(authRepository.callback).mockResolvedValue({} as any);
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(window.alert).not.toHaveBeenCalled();
+  });
+
+  it('codeもerrorもない場合にdispatchが呼ばれない', async () => {
+    mockSearchParams = '';
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/__tests__/usePractice.test.ts
+++ b/frontend/src/hooks/__tests__/usePractice.test.ts
@@ -80,4 +80,29 @@ describe('usePractice', () => {
     expect(created).toBeNull();
     expect(result.current.error).toBe('作成失敗');
   });
+
+  it('初期状態のscenariosが空配列', () => {
+    const { result } = renderHook(() => usePractice());
+    expect(result.current.scenarios).toEqual([]);
+  });
+
+  it('初期状態のloadingがfalseでerrorがnull', () => {
+    const { result } = renderHook(() => usePractice());
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetchScenario: エラー時にnullを返しerrorを設定する', async () => {
+    mockedRepo.getScenario.mockRejectedValue(new Error('詳細取得失敗'));
+
+    const { result } = renderHook(() => usePractice());
+
+    let fetched: any;
+    await act(async () => {
+      fetched = await result.current.fetchScenario(999);
+    });
+
+    expect(fetched).toBeNull();
+    expect(result.current.error).toBe('詳細取得失敗');
+  });
 });


### PR DESCRIPTION
## 概要
- usePracticeのテストを5→8に拡充（初期状態、fetchScenarioエラー時）
- useLoginCallbackのテストを5→8に拡充（error+code同時、callback成功時alert不呼出、dispatch不呼出）

## テスト結果
- 全673テスト通過

close #370