### PR TITLE
feat: お気に入り統計カード（FavoriteStatsCard）追加

### DIFF
--- a/frontend/src/components/FavoriteStatsCard.tsx
+++ b/frontend/src/components/FavoriteStatsCard.tsx
@@ -1,0 +1,56 @@
+import type { FavoritePhrase } from '../types';
+
+interface FavoriteStatsCardProps {
+  phrases: FavoritePhrase[];
+}
+
+const PATTERN_COLORS: Record<string, string> = {
+  'フォーマル': 'bg-blue-500',
+  'ソフト': 'bg-emerald-500',
+  '簡潔': 'bg-amber-500',
+  '質問型': 'bg-purple-500',
+  '提案型': 'bg-rose-500',
+};
+
+export default function FavoriteStatsCard({ phrases }: FavoriteStatsCardProps) {
+  if (phrases.length === 0) return null;
+
+  const patternCounts = phrases.reduce<Record<string, number>>((acc, phrase) => {
+    acc[phrase.pattern] = (acc[phrase.pattern] || 0) + 1;
+    return acc;
+  }, {});
+
+  const sortedPatterns = Object.entries(patternCounts).sort((a, b) => b[1] - a[1]);
+  const maxCount = Math.max(...Object.values(patternCounts));
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-slate-700">お気に入り統計</p>
+        <div className="flex items-baseline gap-1">
+          <span className="text-lg font-bold text-slate-800">{phrases.length}</span>
+          <span className="text-xs text-slate-500">フレーズ</span>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {sortedPatterns.map(([pattern, count]) => (
+          <div key={pattern} className="flex items-center gap-2">
+            <span className="text-xs text-slate-500 w-16 text-right truncate">{pattern}</span>
+            <div className="flex-1 bg-slate-100 rounded-full h-3">
+              {maxCount > 0 && count > 0 && (
+                <div
+                  className={`h-3 rounded-full ${PATTERN_COLORS[pattern] || 'bg-slate-400'} transition-all`}
+                  style={{ width: `${(count / maxCount) * 100}%` }}
+                />
+              )}
+            </div>
+            <span data-testid="pattern-count" className="text-xs font-medium text-slate-600 w-5 text-right">
+              {count}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/FavoriteStatsCard.test.tsx
+++ b/frontend/src/components/__tests__/FavoriteStatsCard.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FavoriteStatsCard from '../FavoriteStatsCard';
+
+const phrases = [
+  { id: '1', originalText: 'a', rephrasedText: 'b', pattern: 'フォーマル', createdAt: '' },
+  { id: '2', originalText: 'c', rephrasedText: 'd', pattern: 'フォーマル', createdAt: '' },
+  { id: '3', originalText: 'e', rephrasedText: 'f', pattern: 'ソフト', createdAt: '' },
+  { id: '4', originalText: 'g', rephrasedText: 'h', pattern: '簡潔', createdAt: '' },
+  { id: '5', originalText: 'i', rephrasedText: 'j', pattern: '質問型', createdAt: '' },
+];
+
+describe('FavoriteStatsCard', () => {
+  it('タイトルが表示される', () => {
+    render(<FavoriteStatsCard phrases={phrases} />);
+    expect(screen.getByText('お気に入り統計')).toBeInTheDocument();
+  });
+
+  it('総数が表示される', () => {
+    render(<FavoriteStatsCard phrases={phrases} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('フレーズ')).toBeInTheDocument();
+  });
+
+  it('パターン別の件数が表示される', () => {
+    render(<FavoriteStatsCard phrases={phrases} />);
+    const counts = screen.getAllByTestId('pattern-count');
+    // フォーマル: 2, ソフト: 1, 簡潔: 1, 質問型: 1
+    expect(counts.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('パターンラベルが表示される', () => {
+    render(<FavoriteStatsCard phrases={phrases} />);
+    expect(screen.getByText('フォーマル')).toBeInTheDocument();
+    expect(screen.getByText('ソフト')).toBeInTheDocument();
+    expect(screen.getByText('簡潔')).toBeInTheDocument();
+    expect(screen.getByText('質問型')).toBeInTheDocument();
+  });
+
+  it('フレーズが空の場合は何も表示しない', () => {
+    const { container } = render(<FavoriteStatsCard phrases={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('1つのパターンのみの場合も正しく表示される', () => {
+    const singlePattern = [
+      { id: '1', originalText: 'a', rephrasedText: 'b', pattern: '提案型', createdAt: '' },
+    ];
+    render(<FavoriteStatsCard phrases={singlePattern} />);
+    expect(screen.getAllByText('1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('提案型')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/FavoritesPage.tsx
+++ b/frontend/src/pages/FavoritesPage.tsx
@@ -1,5 +1,6 @@
 import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
 import SearchBox from '../components/SearchBox';
+import FavoriteStatsCard from '../components/FavoriteStatsCard';
 
 const PATTERN_FILTERS = ['すべて', 'フォーマル', 'ソフト', '簡潔'] as const;
 
@@ -9,6 +10,10 @@ export default function FavoritesPage() {
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
       <h2 className="text-sm font-semibold text-slate-800">お気に入りフレーズ</h2>
+
+      {phrases.length > 0 && (
+        <FavoriteStatsCard phrases={phrases} />
+      )}
 
       {phrases.length > 0 && (
         <>


### PR DESCRIPTION
## 概要
- お気に入りフレーズの総数とパターン別（フォーマル/ソフト/簡潔/質問型/提案型）の内訳を横棒グラフで表示
- FavoritesPageのフレーズ一覧の上に配置

## テスト結果
- 6テスト追加、全679テスト通過

close #374