### PR TITLE
refactor: UserProfilePageのロジックをuseUserProfilePageフックに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useUserProfilePage.test.ts
+++ b/frontend/src/hooks/__tests__/useUserProfilePage.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUserProfilePage } from '../useUserProfilePage';
+
+const mockFetchMyProfile = vi.fn();
+const mockUpdateProfile = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../useUserProfile', () => ({
+  useUserProfile: () => ({
+    profile: null,
+    loading: false,
+    fetchMyProfile: mockFetchMyProfile,
+    updateProfile: mockUpdateProfile,
+  }),
+}));
+
+describe('useUserProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期化時にfetchMyProfileが呼ばれる', () => {
+    renderHook(() => useUserProfilePage());
+    expect(mockFetchMyProfile).toHaveBeenCalled();
+  });
+
+  it('formの初期値が空', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.form.displayName).toBe('');
+    expect(result.current.form.selfIntroduction).toBe('');
+    expect(result.current.form.personalityTraits).toEqual([]);
+  });
+
+  it('messageの初期値がnull', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.message).toBeNull();
+  });
+
+  it('isNewProfileの初期値がfalse', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.isNewProfile).toBe(false);
+  });
+
+  it('loadingの値が返される', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('setFormでフォーム値を更新できる', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+
+    act(() => {
+      result.current.setForm(prev => ({ ...prev, displayName: 'テスト' }));
+    });
+
+    expect(result.current.form.displayName).toBe('テスト');
+  });
+
+  it('togglePersonalityTraitで特性を追加できる', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+
+    act(() => {
+      result.current.togglePersonalityTrait('論理的');
+    });
+
+    expect(result.current.form.personalityTraits).toContain('論理的');
+  });
+
+  it('togglePersonalityTraitで特性を削除できる', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+
+    act(() => {
+      result.current.togglePersonalityTrait('論理的');
+    });
+
+    act(() => {
+      result.current.togglePersonalityTrait('論理的');
+    });
+
+    expect(result.current.form.personalityTraits).not.toContain('論理的');
+  });
+
+  it('handleSave成功時にsuccessメッセージを設定する', async () => {
+    mockUpdateProfile.mockResolvedValue(true);
+    const { result } = renderHook(() => useUserProfilePage());
+
+    await act(async () => {
+      await result.current.handleSave({ preventDefault: vi.fn() } as any);
+    });
+
+    expect(result.current.message?.type).toBe('success');
+  });
+
+  it('handleSave失敗時にerrorメッセージを設定する', async () => {
+    mockUpdateProfile.mockResolvedValue(false);
+    const { result } = renderHook(() => useUserProfilePage());
+
+    await act(async () => {
+      await result.current.handleSave({ preventDefault: vi.fn() } as any);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+  });
+});

--- a/frontend/src/hooks/useUserProfilePage.ts
+++ b/frontend/src/hooks/useUserProfilePage.ts
@@ -1,0 +1,113 @@
+import { useState, useEffect } from 'react';
+import { useUserProfile } from './useUserProfile';
+
+interface UserProfileForm {
+  displayName: string;
+  selfIntroduction: string;
+  communicationStyle: string;
+  personalityTraits: string[];
+  goals: string;
+  concerns: string;
+  preferredFeedbackStyle: string;
+}
+
+interface FormMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+export const COMMUNICATION_STYLES = [
+  { value: '', label: '選択してください' },
+  { value: 'casual', label: 'カジュアル' },
+  { value: 'formal', label: 'フォーマル' },
+  { value: 'friendly', label: 'フレンドリー' },
+  { value: 'professional', label: 'プロフェッショナル' },
+] as const;
+
+export const PERSONALITY_OPTIONS = [
+  '内向的', '外向的', '論理的', '感情的', '共感力が高い',
+  '分析的', 'クリエイティブ', '計画的', '柔軟性がある', 'リーダーシップがある',
+] as const;
+
+export const FEEDBACK_STYLES = [
+  { value: '', label: '選択してください' },
+  { value: 'direct', label: 'ストレート（はっきり伝えてほしい）' },
+  { value: 'gentle', label: 'やさしく（配慮を持って伝えてほしい）' },
+  { value: 'detailed', label: '詳細に（具体的に説明してほしい）' },
+] as const;
+
+/**
+ * UserProfilePageフック
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>UserProfilePageのフォーム管理・バリデーション</li>
+ *   <li>プロフィール取得・更新のロジック</li>
+ * </ul>
+ */
+export function useUserProfilePage() {
+  const [form, setForm] = useState<UserProfileForm>({
+    displayName: '',
+    selfIntroduction: '',
+    communicationStyle: '',
+    personalityTraits: [],
+    goals: '',
+    concerns: '',
+    preferredFeedbackStyle: '',
+  });
+  const [message, setMessage] = useState<FormMessage | null>(null);
+  const [isNewProfile, setIsNewProfile] = useState(false);
+
+  const { profile, loading, fetchMyProfile, updateProfile } = useUserProfile();
+
+  useEffect(() => {
+    fetchMyProfile();
+  }, [fetchMyProfile]);
+
+  useEffect(() => {
+    if (profile) {
+      setForm({
+        displayName: profile.displayName || '',
+        selfIntroduction: profile.selfIntroduction || '',
+        communicationStyle: profile.communicationStyle || '',
+        personalityTraits: profile.personalityTraits || [],
+        goals: profile.goals || '',
+        concerns: profile.concerns || '',
+        preferredFeedbackStyle: profile.preferredFeedbackStyle || '',
+      });
+      setIsNewProfile(false);
+    }
+  }, [profile]);
+
+  const togglePersonalityTrait = (trait: string) => {
+    setForm((prev) => {
+      const traits = prev.personalityTraits.includes(trait)
+        ? prev.personalityTraits.filter((t) => t !== trait)
+        : [...prev.personalityTraits, trait];
+      return { ...prev, personalityTraits: traits };
+    });
+  };
+
+  const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const success = await updateProfile(form);
+
+    if (success) {
+      setMessage({ type: 'success', text: 'パーソナリティ設定を保存しました。' });
+      setIsNewProfile(false);
+    } else {
+      setMessage({ type: 'error', text: '保存に失敗しました。' });
+    }
+  };
+
+  return {
+    form,
+    setForm,
+    message,
+    isNewProfile,
+    loading,
+    togglePersonalityTrait,
+    handleSave,
+  };
+}

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,105 +1,28 @@
-import { useState, useEffect } from 'react';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import Loading from '../components/Loading';
-import { useNavigate } from 'react-router-dom';
 import {
   ChatBubbleLeftRightIcon,
   LightBulbIcon,
   UserCircleIcon,
 } from '@heroicons/react/24/solid';
-import { useUserProfile } from '../hooks/useUserProfile';
-
-interface UserProfileForm {
-  displayName: string;
-  selfIntroduction: string;
-  communicationStyle: string;
-  personalityTraits: string[];
-  goals: string;
-  concerns: string;
-  preferredFeedbackStyle: string;
-}
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import {
+  useUserProfilePage,
+  COMMUNICATION_STYLES,
+  PERSONALITY_OPTIONS,
+  FEEDBACK_STYLES,
+} from '../hooks/useUserProfilePage';
 
 export default function UserProfilePage() {
-  const [form, setForm] = useState<UserProfileForm>({
-    displayName: '',
-    selfIntroduction: '',
-    communicationStyle: '',
-    personalityTraits: [],
-    goals: '',
-    concerns: '',
-    preferredFeedbackStyle: '',
-  });
-  const [message, setMessage] = useState<FormMessage | null>(null);
-  const [isNewProfile, setIsNewProfile] = useState<boolean>(false);
-  const navigate = useNavigate();
-  const { profile, loading, fetchMyProfile, updateProfile } = useUserProfile();
-
-  const communicationStyles = [
-    { value: '', label: '選択してください' },
-    { value: 'casual', label: 'カジュアル' },
-    { value: 'formal', label: 'フォーマル' },
-    { value: 'friendly', label: 'フレンドリー' },
-    { value: 'professional', label: 'プロフェッショナル' },
-  ];
-
-  const personalityOptions = [
-    '内向的', '外向的', '論理的', '感情的', '共感力が高い',
-    '分析的', 'クリエイティブ', '計画的', '柔軟性がある', 'リーダーシップがある',
-  ];
-
-  const feedbackStyles = [
-    { value: '', label: '選択してください' },
-    { value: 'direct', label: 'ストレート（はっきり伝えてほしい）' },
-    { value: 'gentle', label: 'やさしく（配慮を持って伝えてほしい）' },
-    { value: 'detailed', label: '詳細に（具体的に説明してほしい）' },
-  ];
-
-  useEffect(() => {
-    fetchMyProfile();
-  }, [fetchMyProfile]);
-
-  useEffect(() => {
-    if (profile) {
-      setForm({
-        displayName: profile.displayName || '',
-        selfIntroduction: profile.selfIntroduction || '',
-        communicationStyle: profile.communicationStyle || '',
-        personalityTraits: profile.personalityTraits || [],
-        goals: profile.goals || '',
-        concerns: profile.concerns || '',
-        preferredFeedbackStyle: profile.preferredFeedbackStyle || '',
-      });
-      setIsNewProfile(false);
-    }
-  }, [profile]);
-
-  const togglePersonalityTrait = (trait: string) => {
-    setForm((prev) => {
-      const traits = prev.personalityTraits.includes(trait)
-        ? prev.personalityTraits.filter((t) => t !== trait)
-        : [...prev.personalityTraits, trait];
-      return { ...prev, personalityTraits: traits };
-    });
-  };
-
-  const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const success = await updateProfile(form);
-
-    if (success) {
-      setMessage({ type: 'success', text: 'パーソナリティ設定を保存しました。' });
-      setIsNewProfile(false);
-    } else {
-      setMessage({ type: 'error', text: '保存に失敗しました。' });
-    }
-  };
+  const {
+    form,
+    setForm,
+    message,
+    isNewProfile,
+    loading,
+    togglePersonalityTrait,
+    handleSave,
+  } = useUserProfilePage();
 
   if (loading) {
     return <Loading fullscreen message="プロファイルを読み込み中..." />;
@@ -182,7 +105,7 @@ export default function UserProfilePage() {
                   }
                   className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
                 >
-                  {communicationStyles.map((style) => (
+                  {COMMUNICATION_STYLES.map((style) => (
                     <option key={style.value} value={style.value}>{style.label}</option>
                   ))}
                 </select>
@@ -193,7 +116,7 @@ export default function UserProfilePage() {
                   性格特性（当てはまるものを選んでください）
                 </label>
                 <div className="flex flex-wrap gap-1.5">
-                  {personalityOptions.map((trait) => (
+                  {PERSONALITY_OPTIONS.map((trait) => (
                     <button
                       key={trait}
                       type="button"
@@ -262,7 +185,7 @@ export default function UserProfilePage() {
                   }
                   className="w-full border border-slate-300 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
                 >
-                  {feedbackStyles.map((style) => (
+                  {FEEDBACK_STYLES.map((style) => (
                     <option key={style.value} value={style.value}>{style.label}</option>
                   ))}
                 </select>


### PR DESCRIPTION
## 概要
- UserProfilePageの3つのuseState・2つのuseEffect・フォームロジックをuseUserProfilePageフックに抽出
- 定数（COMMUNICATION_STYLES/PERSONALITY_OPTIONS/FEEDBACK_STYLES）もフックからexport
- UserProfilePage: 284→207行（27%削減）

## テスト結果
- useUserProfilePageテスト10件追加、全689テスト通過

close #376