### PR TITLE
test: useConfirmForgotPassword・useForgotPasswordのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useConfirmForgotPassword.test.ts
+++ b/frontend/src/hooks/__tests__/useConfirmForgotPassword.test.ts
@@ -99,4 +99,28 @@ describe('useConfirmForgotPassword', () => {
     expect(result.current.message?.type).toBe('error');
     expect(result.current.message?.text).toBe('通信エラーが発生しました。');
   });
+
+  it('初期messageがnull', () => {
+    const { result } = renderHook(() => useConfirmForgotPassword());
+    expect(result.current.message).toBeNull();
+  });
+
+  it('code・newPasswordの初期値が空文字', () => {
+    const { result } = renderHook(() => useConfirmForgotPassword());
+    expect(result.current.form.code).toBe('');
+    expect(result.current.form.newPassword).toBe('');
+  });
+
+  it('handleConfirmでpreventDefaultが呼ばれる', async () => {
+    const preventDefault = vi.fn();
+    const { result } = renderHook(() => useConfirmForgotPassword());
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault,
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/__tests__/useForgotPassword.test.ts
+++ b/frontend/src/hooks/__tests__/useForgotPassword.test.ts
@@ -87,4 +87,39 @@ describe('useForgotPassword', () => {
     expect(result.current.message?.type).toBe('error');
     expect(result.current.message?.text).toBe('通信エラーが発生しました。');
   });
+
+  it('初期messageがnull', () => {
+    const { result } = renderHook(() => useForgotPassword());
+    expect(result.current.message).toBeNull();
+  });
+
+  it('handleSubmit成功時にsuccessメッセージが設定される', async () => {
+    const { result } = renderHook(() => useForgotPassword());
+
+    act(() => {
+      result.current.setEmail('test@example.com');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message?.type).toBe('success');
+    expect(result.current.message?.text).toBe('コード送信済み');
+  });
+
+  it('handleSubmitでpreventDefaultが呼ばれる', async () => {
+    const preventDefault = vi.fn();
+    const { result } = renderHook(() => useForgotPassword());
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault,
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 概要
- useConfirmForgotPasswordのテストを5→8に拡充（初期message、初期値、preventDefault）
- useForgotPasswordのテストを5→8に拡充（初期message、successメッセージ、preventDefault）

## テスト結果
- 全695テスト通過

close #378