### PR TITLE
feat: セッション時間帯分析カード（SessionTimeCard）追加

### DIFF
--- a/frontend/src/components/SessionTimeCard.tsx
+++ b/frontend/src/components/SessionTimeCard.tsx
@@ -1,0 +1,77 @@
+interface SessionTimeCardProps {
+  dates: string[];
+}
+
+const TIME_SLOTS = [
+  { label: '朝', emoji: '🌅', min: 6, max: 11 },
+  { label: '昼', emoji: '☀️', min: 12, max: 16 },
+  { label: '夕方', emoji: '🌇', min: 17, max: 20 },
+  { label: '夜', emoji: '🌙', min: 21, max: 5, isNight: true },
+] as const;
+
+const SLOT_COLORS = [
+  'bg-amber-400',
+  'bg-sky-400',
+  'bg-orange-400',
+  'bg-indigo-400',
+];
+
+function getTimeSlotIndex(hour: number): number {
+  if (hour >= 6 && hour <= 11) return 0;
+  if (hour >= 12 && hour <= 16) return 1;
+  if (hour >= 17 && hour <= 20) return 2;
+  return 3; // 21-5
+}
+
+function getMessage(topIndex: number): string {
+  switch (topIndex) {
+    case 0:
+      return '朝型の学習スタイルです。集中力の高い朝に練習できています！';
+    case 1:
+      return '昼間に集中して練習するタイプです。休憩時間を活用しましょう！';
+    case 2:
+      return '夕方に練習するスタイルです。仕事終わりにしっかり復習できています！';
+    default:
+      return '夜型の学習スタイルです。夜の静かな時間に集中しています！';
+  }
+}
+
+export default function SessionTimeCard({ dates }: SessionTimeCardProps) {
+  if (dates.length === 0) return null;
+
+  const counts = [0, 0, 0, 0];
+  for (const dateStr of dates) {
+    const hour = new Date(dateStr).getHours();
+    counts[getTimeSlotIndex(hour)]++;
+  }
+
+  const maxCount = Math.max(...counts);
+  const topIndex = counts.indexOf(maxCount);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">練習時間帯</p>
+
+      <div className="space-y-2">
+        {TIME_SLOTS.map((slot, i) => (
+          <div key={slot.label} className="flex items-center gap-2">
+            <span className="text-xs text-slate-500 w-8 text-right">{slot.label}</span>
+            <div className="flex-1 bg-slate-100 rounded-full h-4">
+              {maxCount > 0 && counts[i] > 0 && (
+                <div
+                  className={`h-4 rounded-full ${SLOT_COLORS[i]} transition-all`}
+                  style={{ width: `${(counts[i] / maxCount) * 100}%` }}
+                />
+              )}
+            </div>
+            <span data-testid="time-count" className="text-xs font-medium text-slate-600 w-5 text-right">
+              {counts[i]}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <p className="text-xs text-slate-500 mt-3">{getMessage(topIndex)}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SessionTimeCard.test.tsx
+++ b/frontend/src/components/__tests__/SessionTimeCard.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SessionTimeCard from '../SessionTimeCard';
+
+describe('SessionTimeCard', () => {
+  it('タイトルが表示される', () => {
+    render(<SessionTimeCard dates={['2026-01-15T09:00:00']} />);
+    expect(screen.getByText('練習時間帯')).toBeInTheDocument();
+  });
+
+  it('4つの時間帯ラベルが表示される', () => {
+    render(<SessionTimeCard dates={['2026-01-15T09:00:00']} />);
+    expect(screen.getByText('朝')).toBeInTheDocument();
+    expect(screen.getByText('昼')).toBeInTheDocument();
+    expect(screen.getByText('夕方')).toBeInTheDocument();
+    expect(screen.getByText('夜')).toBeInTheDocument();
+  });
+
+  it('各時間帯の件数が表示される', () => {
+    const dates = [
+      '2026-01-15T08:00:00',
+      '2026-01-15T10:00:00',
+      '2026-01-15T14:00:00',
+      '2026-01-15T19:00:00',
+      '2026-01-15T23:00:00',
+    ];
+    render(<SessionTimeCard dates={dates} />);
+    const counts = screen.getAllByTestId('time-count');
+    expect(counts[0]).toHaveTextContent('2'); // 朝 (8, 10)
+    expect(counts[1]).toHaveTextContent('1'); // 昼 (14)
+    expect(counts[2]).toHaveTextContent('1'); // 夕方 (19)
+    expect(counts[3]).toHaveTextContent('1'); // 夜 (23)
+  });
+
+  it('最頻時間帯のメッセージが表示される', () => {
+    const dates = [
+      '2026-01-15T08:00:00',
+      '2026-01-15T09:00:00',
+      '2026-01-15T10:00:00',
+    ];
+    render(<SessionTimeCard dates={dates} />);
+    expect(screen.getByText(/朝型/)).toBeInTheDocument();
+  });
+
+  it('夜型のメッセージが表示される', () => {
+    const dates = [
+      '2026-01-15T22:00:00',
+      '2026-01-15T23:00:00',
+      '2026-01-15T01:00:00',
+    ];
+    render(<SessionTimeCard dates={dates} />);
+    expect(screen.getByText(/夜型/)).toBeInTheDocument();
+  });
+
+  it('空配列の場合は何も表示しない', () => {
+    const { container } = render(<SessionTimeCard dates={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -12,6 +12,7 @@ import SkillSummaryCard from '../components/SkillSummaryCard';
 import CommunicationStyleCard from '../components/CommunicationStyleCard';
 import ScoreGoalCard from '../components/ScoreGoalCard';
 import ScoreDistributionCard from '../components/ScoreDistributionCard';
+import SessionTimeCard from '../components/SessionTimeCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -142,6 +143,9 @@ export default function ScoreHistoryPage() {
 
       {/* スキル別推移 */}
       <SkillTrendChart history={history} />
+
+      {/* セッション時間帯 */}
+      <SessionTimeCard dates={history.map(h => h.createdAt)} />
 
       {/* 練習カレンダー */}
       <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />


### PR DESCRIPTION
## 概要
- セッション時間帯分析カード（SessionTimeCard）を新規追加
- 練習セッションの時間帯分布（朝・昼・夕方・夜）を横棒グラフで可視化
- 最頻時間帯に応じたメッセージ表示（朝型/昼型/夕方型/夜型）
- ScoreHistoryPageに統合

## 変更内容
- `frontend/src/components/SessionTimeCard.tsx` 新規作成
- `frontend/src/components/__tests__/SessionTimeCard.test.tsx` テスト6件追加
- `frontend/src/pages/ScoreHistoryPage.tsx` SessionTimeCard統合

## テスト
- 全701テスト通過

closes #382