### PR TITLE
refactor: LoginPageのロジックをuseLoginPageフックに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useLoginPage.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginPage.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLoginPage } from '../useLoginPage';
+
+const mockLogin = vi.fn();
+const mockNavigate = vi.fn();
+const mockLocationState = { message: '' };
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ state: mockLocationState }),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../useAuth', () => ({
+  useAuth: () => ({ login: mockLogin }),
+}));
+
+describe('useLoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocationState.message = '';
+  });
+
+  it('初期状態でformが空文字列である', () => {
+    const { result } = renderHook(() => useLoginPage());
+    expect(result.current.form).toEqual({ email: '', password: '' });
+  });
+
+  it('初期状態でloginMessageがnullである', () => {
+    const { result } = renderHook(() => useLoginPage());
+    expect(result.current.loginMessage).toBeNull();
+  });
+
+  it('handleChangeでフォーム値が更新される', () => {
+    const { result } = renderHook(() => useLoginPage());
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'email', value: 'test@example.com' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    expect(result.current.form.email).toBe('test@example.com');
+  });
+
+  it('handleChangeでパスワードが更新される', () => {
+    const { result } = renderHook(() => useLoginPage());
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'password', value: 'secret123' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    expect(result.current.form.password).toBe('secret123');
+  });
+
+  it('ログイン成功時にナビゲートされる', async () => {
+    mockLogin.mockResolvedValue(true);
+    const { result } = renderHook(() => useLoginPage());
+
+    await act(async () => {
+      await result.current.handleLogin({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(mockLogin).toHaveBeenCalledWith({ email: '', password: '' });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('ログイン失敗時にエラーメッセージが設定される', async () => {
+    mockLogin.mockResolvedValue(false);
+    const { result } = renderHook(() => useLoginPage());
+
+    await act(async () => {
+      await result.current.handleLogin({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.loginMessage).toEqual({
+      type: 'error',
+      text: 'ログインに失敗しました。',
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('handleLoginでpreventDefaultが呼ばれる', async () => {
+    mockLogin.mockResolvedValue(true);
+    const { result } = renderHook(() => useLoginPage());
+    const preventDefault = vi.fn();
+
+    await act(async () => {
+      await result.current.handleLogin({
+        preventDefault,
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('locationStateのメッセージが取得される', () => {
+    mockLocationState.message = '確認メールを送信しました';
+    const { result } = renderHook(() => useLoginPage());
+    expect(result.current.flashMessage).toBe('確認メールを送信しました');
+  });
+
+  it('locationStateにメッセージがない場合はundefined', () => {
+    mockLocationState.message = '';
+    const { result } = renderHook(() => useLoginPage());
+    expect(result.current.flashMessage).toBe('');
+  });
+
+  it('ログイン時にフォームの値が送信される', async () => {
+    mockLogin.mockResolvedValue(true);
+    const { result } = renderHook(() => useLoginPage());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'email', value: 'user@test.com' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'password', value: 'pass123' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleLogin({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(mockLogin).toHaveBeenCalledWith({ email: 'user@test.com', password: 'pass123' });
+  });
+});

--- a/frontend/src/hooks/useLoginPage.ts
+++ b/frontend/src/hooks/useLoginPage.ts
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from './useAuth';
+
+interface LoginForm {
+  email: string;
+  password: string;
+}
+
+interface LoginMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+/**
+ * LoginPageフック
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>LoginPageのフォーム管理・バリデーション</li>
+ *   <li>ログイン処理のロジック</li>
+ * </ul>
+ */
+export function useLoginPage() {
+  const [form, setForm] = useState<LoginForm>({ email: '', password: '' });
+  const [loginMessage, setLoginMessage] = useState<LoginMessage | null>(null);
+
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  const flashMessage = (location.state as { message?: string })?.message || '';
+
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const success = await login({ email: form.email, password: form.password });
+
+    if (success) {
+      navigate('/');
+    } else {
+      setLoginMessage({
+        type: 'error',
+        text: 'ログインに失敗しました。',
+      });
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({
+      ...form,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  return {
+    form,
+    loginMessage,
+    flashMessage,
+    handleLogin,
+    handleChange,
+  };
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,56 +1,21 @@
-import { useState } from 'react';
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import SNSSignInButton from '../components/SNSSignInButton';
 import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useAuth } from '../hooks/useAuth';
-
-interface LoginMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import { useLoginPage } from '../hooks/useLoginPage';
 
 export default function LoginPage() {
-  const [form, setForm] = useState({ email: '', password: '' });
-  const [loginMessage, setLoginMessage] = useState<LoginMessage | null>(null);
-
-  const location = useLocation();
-  const navigate = useNavigate();
-  const { login } = useAuth();
-  const message = (location.state as { message?: string })?.message;
-
-  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const success = await login({ email: form.email, password: form.password });
-
-    if (success) {
-      navigate('/');
-    } else {
-      setLoginMessage({
-        type: 'error',
-        text: 'ログインに失敗しました。',
-      });
-    }
-  };
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({
-      ...form,
-      [e.target.name]: e.target.value,
-    });
-  };
+  const { form, loginMessage, flashMessage, handleLogin, handleChange } = useLoginPage();
 
   return (
     <AuthLayout>
       {/* flash Message */}
       <div>
-        {message && (
+        {flashMessage && (
           <p className="text-emerald-600 text-center mb-4 p-3 bg-emerald-50 rounded-lg font-medium">
-            {message}
+            {flashMessage}
           </p>
         )}
         {loginMessage?.type === 'error' && (


### PR DESCRIPTION
## 概要
- LoginPageの2つのuseState・ハンドラーをuseLoginPageカスタムフックに抽出
- LoginPage: 107→81行（24%削減）

## 変更内容
- `frontend/src/hooks/useLoginPage.ts` 新規作成
- `frontend/src/hooks/__tests__/useLoginPage.test.ts` テスト10件追加
- `frontend/src/pages/LoginPage.tsx` リファクタ

## テスト
- 全711テスト通過

closes #384