### PR TITLE
test: useMenuData・useAuthフックのテスト拡充（6→8件）

### DIFF
--- a/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -104,6 +104,34 @@ describe('useAuth', () => {
     expect(result.current.isAuthenticated).toBe(true);
   });
 
+  it('signup: サインアップ失敗時にfalseとエラーメッセージを返す', async () => {
+    mockedRepo.signup.mockRejectedValue(new Error('メールアドレスが既に使用されています'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let success: boolean = true;
+    await act(async () => {
+      success = await result.current.signup({ email: 'test@example.com', password: 'password', name: 'テスト' });
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('メールアドレスが既に使用されています');
+  });
+
+  it('getCurrentUser: ユーザー情報取得失敗時にnullを返す', async () => {
+    mockedRepo.getCurrentUser.mockRejectedValue(new Error('セッション切れ'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    let user: any;
+    await act(async () => {
+      user = await result.current.getCurrentUser();
+    });
+
+    expect(user).toBeNull();
+    expect(result.current.error).toBe('セッション切れ');
+  });
+
   it('refreshToken: リフレッシュ失敗時にログインページに遷移する', async () => {
     mockedRepo.refreshToken.mockRejectedValue(new Error('トークン期限切れ'));
 

--- a/frontend/src/hooks/__tests__/useMenuData.test.ts
+++ b/frontend/src/hooks/__tests__/useMenuData.test.ts
@@ -123,6 +123,39 @@ describe('useMenuData', () => {
     expect(result.current.sessionsThisWeek).toBe(2);
   });
 
+  it('初期状態でstatsがnullである', () => {
+    mockedRepo.fetchChatStats.mockResolvedValue({ chatPartnerCount: 0 });
+    mockedRepo.fetchChatRooms.mockResolvedValue({ chatUsers: [] });
+    mockedRepo.fetchScoreHistory.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useMenuData());
+
+    expect(result.current.stats).toBeNull();
+    expect(result.current.totalUnread).toBe(0);
+    expect(result.current.latestScore).toBeNull();
+    expect(result.current.allScores).toEqual([]);
+  });
+
+  it('practiceDatesが重複なしの日付配列を返す', async () => {
+    mockedRepo.fetchChatStats.mockResolvedValue({ chatPartnerCount: 0 });
+    mockedRepo.fetchChatRooms.mockResolvedValue({ chatUsers: [] });
+    mockedRepo.fetchScoreHistory.mockResolvedValue([
+      { sessionId: 1, sessionTitle: 'A', overallScore: 7.0, createdAt: '2026-02-13T10:00:00' },
+      { sessionId: 2, sessionTitle: 'B', overallScore: 8.0, createdAt: '2026-02-13T14:00:00' },
+      { sessionId: 3, sessionTitle: 'C', overallScore: 6.0, createdAt: '2026-02-12T09:00:00' },
+    ]);
+
+    const { result } = renderHook(() => useMenuData());
+
+    await waitFor(() => {
+      expect(result.current.totalSessions).toBe(3);
+    });
+
+    expect(result.current.practiceDates).toHaveLength(2);
+    expect(result.current.practiceDates).toContain('2026-02-13');
+    expect(result.current.practiceDates).toContain('2026-02-12');
+  });
+
   it('一部のAPIのみ成功した場合でも動作する', async () => {
     mockedRepo.fetchChatStats.mockResolvedValue({ chatPartnerCount: 3 });
     mockedRepo.fetchChatRooms.mockRejectedValue(new Error('error'));


### PR DESCRIPTION
## 概要
テスト数が6件のフックを8件に拡充し、テスト品質を向上。

## 変更内容
- useMenuData: 6→8件（初期状態テスト、practiceDates重複排除テスト）
- useAuth: 6→8件（signup失敗テスト、getCurrentUser失敗テスト）

## テスト
- 全715テスト通過

closes #386