### PR TITLE
feat: スキルギャップ分析カード（SkillGapAnalysisCard）追加

### DIFF
--- a/frontend/src/components/SkillGapAnalysisCard.tsx
+++ b/frontend/src/components/SkillGapAnalysisCard.tsx
@@ -1,0 +1,63 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+}
+
+interface SkillGapAnalysisCardProps {
+  scores: AxisScore[];
+  goal: number;
+}
+
+export default function SkillGapAnalysisCard({ scores, goal }: SkillGapAnalysisCardProps) {
+  if (scores.length === 0) return null;
+
+  const gaps = scores
+    .map((s) => ({
+      axis: s.axis,
+      score: s.score,
+      gap: Math.round((goal - s.score) * 10) / 10,
+      achieved: s.score >= goal,
+    }))
+    .sort((a, b) => b.gap - a.gap);
+
+  const allAchieved = gaps.every((g) => g.achieved);
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">スキルギャップ分析</p>
+
+      {allAchieved && (
+        <p className="text-xs text-emerald-600 font-medium mb-3">
+          全スキル目標達成！次の目標を設定しましょう！
+        </p>
+      )}
+
+      <div className="space-y-2">
+        {gaps.map((item) => (
+          <div key={item.axis} className="flex items-center gap-2">
+            <span data-testid="gap-axis" className="text-xs text-slate-500 w-24 flex-shrink-0 truncate">
+              {item.axis}
+            </span>
+            <div className="flex-1 bg-slate-100 rounded-full h-3">
+              <div
+                className={`h-3 rounded-full transition-all ${
+                  item.achieved ? 'bg-emerald-400' : 'bg-rose-400'
+                }`}
+                style={{ width: `${Math.min((item.score / goal) * 100, 100)}%` }}
+              />
+            </div>
+            {item.achieved ? (
+              <span data-testid="gap-achieved" className="text-xs font-medium text-emerald-600 w-10 text-right">
+                達成
+              </span>
+            ) : (
+              <span data-testid="gap-value" className="text-xs font-medium text-rose-600 w-10 text-right">
+                -{item.gap.toFixed(1)}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SkillGapAnalysisCard.test.tsx
+++ b/frontend/src/components/__tests__/SkillGapAnalysisCard.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SkillGapAnalysisCard from '../SkillGapAnalysisCard';
+
+describe('SkillGapAnalysisCard', () => {
+  const defaultScores = [
+    { axis: '論理的構成力', score: 6.0 },
+    { axis: '配慮表現', score: 8.0 },
+    { axis: '要約力', score: 5.0 },
+    { axis: '提案力', score: 7.0 },
+    { axis: '質問・傾聴力', score: 9.0 },
+  ];
+
+  it('タイトルが表示される', () => {
+    render(<SkillGapAnalysisCard scores={defaultScores} goal={8.0} />);
+    expect(screen.getByText('スキルギャップ分析')).toBeInTheDocument();
+  });
+
+  it('各軸名が表示される', () => {
+    render(<SkillGapAnalysisCard scores={defaultScores} goal={8.0} />);
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('配慮表現')).toBeInTheDocument();
+    expect(screen.getByText('要約力')).toBeInTheDocument();
+    expect(screen.getByText('提案力')).toBeInTheDocument();
+    expect(screen.getByText('質問・傾聴力')).toBeInTheDocument();
+  });
+
+  it('ギャップが大きい順にソートされる', () => {
+    render(<SkillGapAnalysisCard scores={defaultScores} goal={8.0} />);
+    const axisLabels = screen.getAllByTestId('gap-axis');
+    // 要約力(gap=3.0) > 論理的構成力(gap=2.0) > 提案力(gap=1.0) > 配慮表現(gap=0) > 質問(gap=0, over)
+    expect(axisLabels[0]).toHaveTextContent('要約力');
+    expect(axisLabels[1]).toHaveTextContent('論理的構成力');
+    expect(axisLabels[2]).toHaveTextContent('提案力');
+  });
+
+  it('ギャップ値が表示される', () => {
+    render(<SkillGapAnalysisCard scores={defaultScores} goal={8.0} />);
+    const gapValues = screen.getAllByTestId('gap-value');
+    expect(gapValues[0]).toHaveTextContent('-3.0');
+    expect(gapValues[1]).toHaveTextContent('-2.0');
+    expect(gapValues[2]).toHaveTextContent('-1.0');
+  });
+
+  it('目標達成済みの軸には達成表示がある', () => {
+    render(<SkillGapAnalysisCard scores={defaultScores} goal={8.0} />);
+    const achievedItems = screen.getAllByTestId('gap-achieved');
+    expect(achievedItems.length).toBeGreaterThanOrEqual(2); // 配慮表現(8.0), 質問・傾聴力(9.0)
+  });
+
+  it('全軸達成時に祝福メッセージが表示される', () => {
+    const highScores = [
+      { axis: '論理的構成力', score: 9.0 },
+      { axis: '配慮表現', score: 8.5 },
+      { axis: '要約力', score: 8.0 },
+      { axis: '提案力', score: 9.5 },
+      { axis: '質問・傾聴力', score: 8.0 },
+    ];
+    render(<SkillGapAnalysisCard scores={highScores} goal={8.0} />);
+    expect(screen.getByText(/全スキル目標達成/)).toBeInTheDocument();
+  });
+
+  it('空のスコア配列の場合は何も表示しない', () => {
+    const { container } = render(<SkillGapAnalysisCard scores={[]} goal={8.0} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -13,6 +13,7 @@ import CommunicationStyleCard from '../components/CommunicationStyleCard';
 import ScoreGoalCard from '../components/ScoreGoalCard';
 import ScoreDistributionCard from '../components/ScoreDistributionCard';
 import SessionTimeCard from '../components/SessionTimeCard';
+import SkillGapAnalysisCard from '../components/SkillGapAnalysisCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -59,6 +60,21 @@ export default function ScoreHistoryPage() {
       <ScoreGoalCard
         averageScore={Math.round((history.reduce((sum, h) => sum + h.overallScore, 0) / history.length) * 10) / 10}
       />
+
+      {/* スキルギャップ分析 */}
+      {latestSession && latestSession.scores.length > 0 && (
+        <SkillGapAnalysisCard
+          scores={latestSession.scores}
+          goal={(() => {
+            try {
+              const stored = localStorage.getItem('scoreGoal');
+              return stored ? parseFloat(stored) : 8.0;
+            } catch {
+              return 8.0;
+            }
+          })()}
+        />
+      )}
 
       {/* 統計サマリー */}
       <ScoreStatsSummary history={history} />


### PR DESCRIPTION
## 概要
- 目標スコアと各スキル軸の現在スコアのギャップを可視化するカードを追加
- ギャップが大きい順にソートし、優先的に取り組むべきスキル軸を明示
- 目標達成済みの軸には達成マーク、全軸達成時は祝福メッセージ
- ScoreHistoryPageに統合

## 変更内容
- `frontend/src/components/SkillGapAnalysisCard.tsx` 新規作成
- `frontend/src/components/__tests__/SkillGapAnalysisCard.test.tsx` テスト7件追加
- `frontend/src/pages/ScoreHistoryPage.tsx` SkillGapAnalysisCard統合

## テスト
- 全722テスト通過

closes #390