### PR TITLE
refactor: SignupPageのロジックをuseSignupPageフックに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useSignupPage.test.ts
+++ b/frontend/src/hooks/__tests__/useSignupPage.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSignupPage } from '../useSignupPage';
+
+const mockSignup = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../useAuth', () => ({
+  useAuth: () => ({ signup: mockSignup, loading: false }),
+}));
+
+describe('useSignupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  it('初期状態でformが空文字列である', () => {
+    const { result } = renderHook(() => useSignupPage());
+    expect(result.current.form).toEqual({ email: '', password: '', name: '' });
+  });
+
+  it('初期状態でmessageがnullである', () => {
+    const { result } = renderHook(() => useSignupPage());
+    expect(result.current.message).toBeNull();
+  });
+
+  it('handleChangeでフォーム値が更新される', () => {
+    const { result } = renderHook(() => useSignupPage());
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'email', value: 'test@example.com' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    expect(result.current.form.email).toBe('test@example.com');
+  });
+
+  it('handleChangeで名前が更新される', () => {
+    const { result } = renderHook(() => useSignupPage());
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'name', value: 'テスト太郎' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    expect(result.current.form.name).toBe('テスト太郎');
+  });
+
+  it('サインアップ成功時にメッセージが設定される', async () => {
+    mockSignup.mockResolvedValue(true);
+    const { result } = renderHook(() => useSignupPage());
+
+    await act(async () => {
+      await result.current.handleSignup({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message).toEqual({
+      type: 'success',
+      text: 'サインアップに成功しました！',
+    });
+  });
+
+  it('サインアップ成功後にナビゲートされる', async () => {
+    mockSignup.mockResolvedValue(true);
+    const { result } = renderHook(() => useSignupPage());
+
+    await act(async () => {
+      await result.current.handleSignup({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/confirm', {
+      state: { message: '✓ サインアップに成功しました！メール確認をお願いします。' },
+    });
+  });
+
+  it('サインアップ失敗時にエラーメッセージが設定される', async () => {
+    mockSignup.mockResolvedValue(false);
+    const { result } = renderHook(() => useSignupPage());
+
+    await act(async () => {
+      await result.current.handleSignup({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message).toEqual({
+      type: 'error',
+      text: '登録に失敗しました。',
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('handleSignupでpreventDefaultが呼ばれる', async () => {
+    mockSignup.mockResolvedValue(true);
+    const { result } = renderHook(() => useSignupPage());
+    const preventDefault = vi.fn();
+
+    await act(async () => {
+      await result.current.handleSignup({
+        preventDefault,
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('サインアップ時にフォームの値が送信される', async () => {
+    mockSignup.mockResolvedValue(true);
+    const { result } = renderHook(() => useSignupPage());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'email', value: 'user@test.com' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'password', value: 'pass123' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'name', value: 'テスト' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSignup({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(mockSignup).toHaveBeenCalledWith({
+      email: 'user@test.com',
+      password: 'pass123',
+      name: 'テスト',
+    });
+  });
+
+  it('loadingがuseAuthから取得される', () => {
+    const { result } = renderHook(() => useSignupPage());
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useSignupPage.ts
+++ b/frontend/src/hooks/useSignupPage.ts
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from './useAuth';
+
+interface SignupForm {
+  email: string;
+  password: string;
+  name: string;
+}
+
+interface FormMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
+export function useSignupPage() {
+  const [form, setForm] = useState<SignupForm>({ email: '', password: '', name: '' });
+  const [message, setMessage] = useState<FormMessage | null>(null);
+  const navigate = useNavigate();
+  const { signup, loading } = useAuth();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({
+      ...form,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const success = await signup({
+      email: form.email,
+      password: form.password,
+      name: form.name,
+    });
+
+    if (success) {
+      setMessage({ type: 'success', text: 'サインアップに成功しました！' });
+      setTimeout(() => {
+        navigate('/confirm', {
+          state: {
+            message: '✓ サインアップに成功しました！メール確認をお願いします。',
+          },
+        });
+      }, 1500);
+    } else {
+      setMessage({
+        type: 'error',
+        text: '登録に失敗しました。',
+      });
+    }
+  };
+
+  return {
+    form,
+    message,
+    loading,
+    handleChange,
+    handleSignup,
+  };
+}

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,59 +1,15 @@
-import { useState } from 'react';
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import LinkText from '../components/LinkText';
-import { useNavigate } from 'react-router-dom';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
 } from '@heroicons/react/24/solid';
-import { useAuth } from '../hooks/useAuth';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import { useSignupPage } from '../hooks/useSignupPage';
 
 export default function SignupPage() {
-  const [form, setForm] = useState({ email: '', password: '', name: '' });
-  const [message, setMessage] = useState<FormMessage | null>(null);
-  const navigate = useNavigate();
-  const { signup, loading } = useAuth();
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({
-      ...form,
-      [e.target.name]: e.target.value,
-    });
-  };
-
-  const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    const success = await signup({
-      email: form.email,
-      password: form.password,
-      name: form.name,
-    });
-
-    if (success) {
-      setMessage({ type: 'success', text: 'サインアップに成功しました！' });
-      setTimeout(() => {
-        navigate('/confirm', {
-          state: {
-            message:
-              '✓ サインアップに成功しました！メール確認をお願いします。',
-          },
-        });
-      }, 1500);
-    } else {
-      setMessage({
-        type: 'error',
-        text: '登録に失敗しました。',
-      });
-    }
-  };
+  const { form, message, loading, handleChange, handleSignup } = useSignupPage();
 
   return (
     <AuthLayout>


### PR DESCRIPTION
## 概要
- SignupPageの2つのuseState・ハンドラーをuseSignupPageカスタムフックに抽出
- SignupPage: 115→79行（31%削減）

## 変更内容
- `frontend/src/hooks/useSignupPage.ts` 新規作成
- `frontend/src/hooks/__tests__/useSignupPage.test.ts` テスト10件追加
- `frontend/src/pages/SignupPage.tsx` リファクタ

## テスト
- 全732テスト通過

closes #392