### PR TITLE
test: useSessionNote・useSidebarフックのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useSidebar.test.ts
+++ b/frontend/src/hooks/__tests__/useSidebar.test.ts
@@ -112,6 +112,11 @@ describe('useSidebar', () => {
     });
   });
 
+  it('初期状態でtotalUnreadが0である', () => {
+    const { result } = renderHook(() => useSidebar());
+    expect(result.current.totalUnread).toBe(0);
+  });
+
   it('ログアウト失敗時にdispatchも呼ばれない', async () => {
     mockLogout.mockRejectedValue(new Error('Network Error'));
 


### PR DESCRIPTION
## 概要
テスト数が少ないフックを拡充し、テスト品質を向上。

## 変更内容
- useSessionNote: 6→8件（保存後即座更新テスト、複数回保存テスト）
- useSidebar: 7→8件（初期状態テスト）

## テスト
- 全735テスト通過

closes #394