### PR TITLE
feat: 週間比較カード（WeeklyComparisonCard）追加

### DIFF
--- a/frontend/src/components/WeeklyComparisonCard.tsx
+++ b/frontend/src/components/WeeklyComparisonCard.tsx
@@ -1,0 +1,82 @@
+interface Session {
+  overallScore: number;
+  createdAt: string;
+}
+
+interface WeeklyComparisonCardProps {
+  sessions: Session[];
+}
+
+function getMonday(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1));
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export default function WeeklyComparisonCard({ sessions }: WeeklyComparisonCardProps) {
+  const now = new Date();
+  const thisMonday = getMonday(now);
+  const lastMonday = new Date(thisMonday);
+  lastMonday.setDate(thisMonday.getDate() - 7);
+
+  const thisWeek = sessions.filter((s) => new Date(s.createdAt) >= thisMonday);
+  const lastWeek = sessions.filter((s) => {
+    const d = new Date(s.createdAt);
+    return d >= lastMonday && d < thisMonday;
+  });
+
+  const thisAvg =
+    thisWeek.length > 0
+      ? Math.round((thisWeek.reduce((sum, s) => sum + s.overallScore, 0) / thisWeek.length) * 10) / 10
+      : 0;
+  const lastAvg =
+    lastWeek.length > 0
+      ? Math.round((lastWeek.reduce((sum, s) => sum + s.overallScore, 0) / lastWeek.length) * 10) / 10
+      : 0;
+
+  const showDelta = thisWeek.length > 0 && lastWeek.length > 0;
+  const delta = showDelta ? Math.round((thisAvg - lastAvg) * 10) / 10 : 0;
+
+  return (
+    <div className="bg-white rounded-lg border border-slate-200 p-4">
+      <p className="text-xs font-medium text-slate-700 mb-3">週間比較</p>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="text-xs text-slate-500 mb-1">今週</p>
+          <p data-testid="avg-score" className="text-lg font-bold text-slate-800">
+            {thisAvg.toFixed(1)}
+          </p>
+          <p className="text-xs text-slate-400">
+            <span data-testid="session-count">{thisWeek.length}</span> セッション
+          </p>
+        </div>
+        <div>
+          <p className="text-xs text-slate-500 mb-1">先週</p>
+          <p data-testid="avg-score" className="text-lg font-bold text-slate-800">
+            {lastAvg.toFixed(1)}
+          </p>
+          <p className="text-xs text-slate-400">
+            <span data-testid="session-count">{lastWeek.length}</span> セッション
+          </p>
+        </div>
+      </div>
+
+      {showDelta && (
+        <div className="mt-3 pt-3 border-t border-slate-100">
+          <span
+            data-testid="score-delta"
+            className={`text-sm font-medium ${
+              delta > 0 ? 'text-emerald-600' : delta < 0 ? 'text-rose-600' : 'text-slate-500'
+            }`}
+          >
+            {delta > 0 ? `+${delta.toFixed(1)}` : delta < 0 ? `\u2212${Math.abs(delta).toFixed(1)}` : '\u00B10.0'}
+          </span>
+          <span className="text-xs text-slate-400 ml-1">先週比</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/WeeklyComparisonCard.test.tsx
+++ b/frontend/src/components/__tests__/WeeklyComparisonCard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import WeeklyComparisonCard from '../WeeklyComparisonCard';
+
+describe('WeeklyComparisonCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 2026-02-13 (金) に固定
+    vi.setSystemTime(new Date('2026-02-13T12:00:00'));
+  });
+
+  it('タイトルが表示される', () => {
+    render(<WeeklyComparisonCard sessions={[]} />);
+    expect(screen.getByText('週間比較')).toBeInTheDocument();
+  });
+
+  it('今週と先週のラベルが表示される', () => {
+    render(<WeeklyComparisonCard sessions={[]} />);
+    expect(screen.getByText('今週')).toBeInTheDocument();
+    expect(screen.getByText('先週')).toBeInTheDocument();
+  });
+
+  it('今週のセッション数と平均スコアが表示される', () => {
+    const sessions = [
+      { overallScore: 8.0, createdAt: '2026-02-10T10:00:00' }, // 火 (今週)
+      { overallScore: 6.0, createdAt: '2026-02-11T10:00:00' }, // 水 (今週)
+    ];
+    render(<WeeklyComparisonCard sessions={sessions} />);
+    const counts = screen.getAllByTestId('session-count');
+    expect(counts[0]).toHaveTextContent('2');
+    const averages = screen.getAllByTestId('avg-score');
+    expect(averages[0]).toHaveTextContent('7.0');
+  });
+
+  it('先週のセッション数と平均スコアが表示される', () => {
+    const sessions = [
+      { overallScore: 7.0, createdAt: '2026-02-03T10:00:00' }, // 先週火
+      { overallScore: 5.0, createdAt: '2026-02-04T10:00:00' }, // 先週水
+      { overallScore: 9.0, createdAt: '2026-02-05T10:00:00' }, // 先週木
+    ];
+    render(<WeeklyComparisonCard sessions={sessions} />);
+    const counts = screen.getAllByTestId('session-count');
+    expect(counts[1]).toHaveTextContent('3');
+    const averages = screen.getAllByTestId('avg-score');
+    expect(averages[1]).toHaveTextContent('7.0');
+  });
+
+  it('スコア上昇時にプラス表示される', () => {
+    const sessions = [
+      { overallScore: 5.0, createdAt: '2026-02-03T10:00:00' }, // 先週
+      { overallScore: 8.0, createdAt: '2026-02-10T10:00:00' }, // 今週
+    ];
+    render(<WeeklyComparisonCard sessions={sessions} />);
+    expect(screen.getByTestId('score-delta')).toHaveTextContent('+3.0');
+  });
+
+  it('セッションがない場合でもクラッシュしない', () => {
+    render(<WeeklyComparisonCard sessions={[]} />);
+    const counts = screen.getAllByTestId('session-count');
+    expect(counts[0]).toHaveTextContent('0');
+    expect(counts[1]).toHaveTextContent('0');
+  });
+
+  it('今週のみセッションがある場合に変動値が表示されない', () => {
+    const sessions = [
+      { overallScore: 8.0, createdAt: '2026-02-10T10:00:00' },
+    ];
+    render(<WeeklyComparisonCard sessions={sessions} />);
+    expect(screen.queryByTestId('score-delta')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -14,6 +14,7 @@ import ScoreGoalCard from '../components/ScoreGoalCard';
 import ScoreDistributionCard from '../components/ScoreDistributionCard';
 import SessionTimeCard from '../components/SessionTimeCard';
 import SkillGapAnalysisCard from '../components/SkillGapAnalysisCard';
+import WeeklyComparisonCard from '../components/WeeklyComparisonCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
@@ -78,6 +79,9 @@ export default function ScoreHistoryPage() {
 
       {/* 統計サマリー */}
       <ScoreStatsSummary history={history} />
+
+      {/* 週間比較 */}
+      <WeeklyComparisonCard sessions={history} />
 
       {/* 最新スコアとランクバッジ */}
       {latestSession && (


### PR DESCRIPTION
## 概要
- 今週と先週の平均スコア・セッション数を並べて比較するカードを追加
- スコア変動値を色分け表示（上昇:緑/低下:赤/維持:灰）
- ScoreHistoryPageに統合

## 変更内容
- `frontend/src/components/WeeklyComparisonCard.tsx` 新規作成
- `frontend/src/components/__tests__/WeeklyComparisonCard.test.tsx` テスト7件追加
- `frontend/src/pages/ScoreHistoryPage.tsx` WeeklyComparisonCard統合

## テスト
- 全742テスト通過

closes #398