### PR TITLE
refactor: ScoreHistoryPageのselectedSession管理をuseScoreHistoryに統合

### DIFF
--- a/frontend/src/hooks/__tests__/useScoreHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreHistory.test.ts
@@ -155,6 +155,37 @@ describe('useScoreHistory', () => {
     expect(result.current.filteredHistory).toHaveLength(2);
   });
 
+  it('selectedSessionの初期値がnullである', async () => {
+    mockFetchScoreHistory.mockResolvedValue([]);
+    const { result } = renderHook(() => useScoreHistory());
+    expect(result.current.selectedSession).toBeNull();
+  });
+
+  it('setSelectedSessionでセッションを選択できる', async () => {
+    const mockData = [
+      { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.0, scores: [], createdAt: '2026-02-10' },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.setSelectedSession(result.current.history[0]);
+    });
+
+    expect(result.current.selectedSession?.sessionId).toBe(1);
+
+    act(() => {
+      result.current.setSelectedSession(null);
+    });
+
+    expect(result.current.selectedSession).toBeNull();
+  });
+
   it('最新セッションのスコアが空の場合にweakestAxisがnullになる', async () => {
     const mockData = [
       { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.0, scores: [], createdAt: '2026-02-10' },

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -26,6 +26,7 @@ function isPracticeSession(title: string): boolean {
 export function useScoreHistory() {
   const [history, setHistory] = useState<ScoreHistoryItem[]>([]);
   const [filter, setFilter] = useState<FilterType>('すべて');
+  const [selectedSession, setSelectedSession] = useState<ScoreHistoryItem | null>(null);
   const { fetchScoreHistory, loading } = useAiChat();
 
   useEffect(() => {
@@ -59,5 +60,7 @@ export function useScoreHistory() {
     loading,
     latestSession,
     weakestAxis,
+    selectedSession,
+    setSelectedSession,
   };
 }

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
@@ -17,7 +16,7 @@ import SkillGapAnalysisCard from '../components/SkillGapAnalysisCard';
 import WeeklyComparisonCard from '../components/WeeklyComparisonCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SessionDetailModal from '../components/SessionDetailModal';
-import { useScoreHistory, FILTERS, type ScoreHistoryItem } from '../hooks/useScoreHistory';
+import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 const AXIS_ADVICE: Record<string, string> = {
   '論理的構成力': '論理的構成力を伸ばすシナリオで練習しましょう',
@@ -28,9 +27,8 @@ const AXIS_ADVICE: Record<string, string> = {
 };
 
 export default function ScoreHistoryPage() {
-  const { history, filteredHistory, filter, setFilter, loading, latestSession, weakestAxis } = useScoreHistory();
+  const { history, filteredHistory, filter, setFilter, loading, latestSession, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
   const navigate = useNavigate();
-  const [selectedSession, setSelectedSession] = useState<ScoreHistoryItem | null>(null);
 
   if (loading) {
     return (


### PR DESCRIPTION
## 概要
- ScoreHistoryPageの最後のuseState（selectedSession）をuseScoreHistoryに移行
- 全ページからuseState完全除去を達成

## 変更内容
- `frontend/src/hooks/useScoreHistory.ts` selectedSession管理追加
- `frontend/src/hooks/__tests__/useScoreHistory.test.ts` テスト2件追加
- `frontend/src/pages/ScoreHistoryPage.tsx` useState除去

## テスト
- 全744テスト通過

closes #400