### PR TITLE
test: useUserProfile・useBookmarkフックのテスト拡充（7→8件）

### DIFF
--- a/frontend/src/hooks/__tests__/useBookmark.test.ts
+++ b/frontend/src/hooks/__tests__/useBookmark.test.ts
@@ -80,6 +80,31 @@ describe('useBookmark', () => {
     expect(result.current.bookmarkedIds).toEqual([1, 2]);
   });
 
+  it('連続toggleで追加・削除が正しく動作する', () => {
+    mockGetAll
+      .mockReturnValueOnce([])     // 初期
+      .mockReturnValueOnce([5])    // 追加後
+      .mockReturnValueOnce([]);    // 削除後
+    mockIsBookmarked
+      .mockReturnValueOnce(false)  // 追加時
+      .mockReturnValueOnce(true);  // 削除時
+
+    const { result } = renderHook(() => useBookmark());
+    expect(result.current.bookmarkedIds).toEqual([]);
+
+    act(() => {
+      result.current.toggleBookmark(5);
+    });
+    expect(mockAdd).toHaveBeenCalledWith(5);
+    expect(result.current.bookmarkedIds).toEqual([5]);
+
+    act(() => {
+      result.current.toggleBookmark(5);
+    });
+    expect(mockRemove).toHaveBeenCalledWith(5);
+    expect(result.current.bookmarkedIds).toEqual([]);
+  });
+
   it('toggle削除後にbookmarkedIdsが更新される', () => {
     mockGetAll.mockReturnValueOnce([1, 3]).mockReturnValueOnce([3]);
     mockIsBookmarked.mockReturnValue(true);

--- a/frontend/src/hooks/__tests__/useUserProfile.test.ts
+++ b/frontend/src/hooks/__tests__/useUserProfile.test.ts
@@ -93,6 +93,13 @@ describe('useUserProfile', () => {
     expect(result.current.error).toBe('プロファイルの更新に失敗しました。');
   });
 
+  it('初期状態でprofileがnull・loadingがfalse・errorがnull', () => {
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
   it('fetchMyProfile: loading状態が正しく変化する', async () => {
     let resolvePromise: (value: any) => void;
     const pendingPromise = new Promise((resolve) => {


### PR DESCRIPTION
## 概要
テスト数が7件のフックを8件に拡充し、テスト品質を向上。

## 変更内容
- useUserProfile: 7→8件（初期状態テスト）
- useBookmark: 7→8件（連続toggle動作テスト）

## テスト
- 全746テスト通過

closes #402