### PR TITLE
feat: PracticeFrequencyCard - 週別練習頻度カード

### DIFF
--- a/frontend/src/components/PracticeFrequencyCard.tsx
+++ b/frontend/src/components/PracticeFrequencyCard.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from 'react';
+
+interface PracticeFrequencyCardProps {
+  dates: string[];
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = day === 0 ? 6 : day - 1; // 月曜始まり
+  d.setDate(d.getDate() - diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export default function PracticeFrequencyCard({ dates }: PracticeFrequencyCardProps) {
+  const weeks = useMemo(() => {
+    const now = new Date();
+    const currentWeekStart = getWeekStart(now);
+
+    const result: { label: string; count: number }[] = [];
+
+    for (let i = 3; i >= 0; i--) {
+      const weekStart = new Date(currentWeekStart);
+      weekStart.setDate(weekStart.getDate() - i * 7);
+      const weekEnd = new Date(weekStart);
+      weekEnd.setDate(weekEnd.getDate() + 7);
+
+      const count = dates.filter((d) => {
+        const date = new Date(d);
+        return date >= weekStart && date < weekEnd;
+      }).length;
+
+      const label = i === 0 ? '今週' : `${i}週前`;
+      result.push({ label, count });
+    }
+
+    return result;
+  }, [dates]);
+
+  const maxCount = Math.max(...weeks.map((w) => w.count), 1);
+  const currentWeek = weeks[weeks.length - 1];
+  const lastWeek = weeks[weeks.length - 2];
+  const delta = currentWeek.count - lastWeek.count;
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-[#D0D0D0]">週別練習頻度</p>
+        <div className="flex items-center gap-2">
+          <span className="text-lg font-bold text-[#F0F0F0]">{currentWeek.count}回</span>
+          {delta !== 0 && (
+            <span
+              className={`text-xs font-medium ${delta > 0 ? 'text-emerald-400' : 'text-rose-400'}`}
+            >
+              {delta > 0 ? `+${delta}` : `\u2212${Math.abs(delta)}`}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-end gap-2 h-16">
+        {weeks.map((week) => (
+          <div key={week.label} className="flex-1 flex flex-col items-center gap-1">
+            <div className="w-full flex items-end h-12">
+              <div
+                data-testid="frequency-bar"
+                className={`w-full rounded-t ${
+                  week.label === '今週' ? 'bg-primary-500' : 'bg-surface-3'
+                }`}
+                style={{ height: `${(week.count / maxCount) * 100}%` }}
+              />
+            </div>
+            <span
+              className={`text-[10px] ${
+                week.label === '今週' ? 'font-semibold text-primary-300' : 'text-[#888888]'
+              }`}
+            >
+              {week.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PracticeFrequencyCard.test.tsx
+++ b/frontend/src/components/__tests__/PracticeFrequencyCard.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import PracticeFrequencyCard from '../PracticeFrequencyCard';
+
+describe('PracticeFrequencyCard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-07-14T10:00:00')); // 月曜日
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<PracticeFrequencyCard dates={[]} />);
+    expect(screen.getByText('週別練習頻度')).toBeInTheDocument();
+  });
+
+  it('練習日がない場合は全て0回と表示する', () => {
+    render(<PracticeFrequencyCard dates={[]} />);
+    const bars = screen.getAllByTestId('frequency-bar');
+    expect(bars).toHaveLength(4);
+    bars.forEach(bar => {
+      expect(bar.style.height).toBe('0%');
+    });
+  });
+
+  it('今週の練習回数を正しくカウントする', () => {
+    const dates = [
+      '2025-07-14T09:00:00', // 今週月曜
+      '2025-07-14T15:00:00', // 今週月曜（2回目）
+    ];
+    render(<PracticeFrequencyCard dates={dates} />);
+    expect(screen.getByText('2回')).toBeInTheDocument();
+  });
+
+  it('4週間分のバーが表示される', () => {
+    render(<PracticeFrequencyCard dates={[]} />);
+    const bars = screen.getAllByTestId('frequency-bar');
+    expect(bars).toHaveLength(4);
+  });
+
+  it('今週ラベルがハイライトされる', () => {
+    render(<PracticeFrequencyCard dates={[]} />);
+    expect(screen.getByText('今週')).toBeInTheDocument();
+  });
+
+  it('前週比の増減を表示する', () => {
+    const dates = [
+      '2025-07-14T09:00:00', // 今週: 1回
+      '2025-07-07T09:00:00', // 先週: 1回
+      '2025-07-08T09:00:00', // 先週: 2回目
+    ];
+    render(<PracticeFrequencyCard dates={dates} />);
+    // 今週1回 - 先週2回 = -1
+    expect(screen.getByText(/\u22121/)).toBeInTheDocument();
+  });
+
+  it('前週比が増加の場合はプラス表示する', () => {
+    const dates = [
+      '2025-07-14T09:00:00', // 今週: 1回
+      '2025-07-14T15:00:00', // 今週: 2回目
+      '2025-07-14T20:00:00', // 今週: 3回目
+      '2025-07-07T09:00:00', // 先週: 1回
+    ];
+    render(<PracticeFrequencyCard dates={dates} />);
+    expect(screen.getByText('+2')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -22,6 +22,7 @@ import WeeklyGoalProgressCard from '../components/WeeklyGoalProgressCard';
 import WeeklyReportCard from '../components/WeeklyReportCard';
 import LearningPatternCard from '../components/LearningPatternCard';
 import ScoreGrowthTrendCard from '../components/ScoreGrowthTrendCard';
+import PracticeFrequencyCard from '../components/PracticeFrequencyCard';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
@@ -95,6 +96,13 @@ export default function MenuPage() {
       <div className="mb-6">
         <AchievementBadgeCard totalSessions={totalSessions} />
       </div>
+
+      {/* 練習頻度 */}
+      {practiceDates.length > 0 && (
+        <div className="mb-6">
+          <PracticeFrequencyCard dates={practiceDates} />
+        </div>
+      )}
 
       {/* 練習ストリークカレンダー */}
       <div className="mb-6">


### PR DESCRIPTION
## 概要
- 直近4週間の練習回数をバーチャートで可視化するカードコンポーネント

## 変更内容
- PracticeFrequencyCard: 週単位の練習回数バーチャート、今週ハイライト、前週比増減
- MenuPageに統合
- 7テスト追加（753テスト合格）

closes #408