### PR TITLE
refactor: PracticePageロジックをusePracticePageフックに抽出

### DIFF
--- a/frontend/src/hooks/__tests__/usePracticePage.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticePage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePracticePage } from '../usePracticePage';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockFetchScenarios = vi.fn();
+const mockCreatePracticeSession = vi.fn();
+vi.mock('../usePractice', () => ({
+  usePractice: () => ({
+    scenarios: [
+      { id: 1, name: 'シナリオ1', category: 'customer' },
+      { id: 2, name: 'シナリオ2', category: 'senior' },
+      { id: 3, name: 'シナリオ3', category: 'team' },
+    ],
+    loading: false,
+    fetchScenarios: mockFetchScenarios,
+    createPracticeSession: mockCreatePracticeSession,
+  }),
+}));
+
+const mockBookmarkedIds = [1];
+const mockToggleBookmark = vi.fn();
+const mockIsBookmarked = vi.fn((id: number) => mockBookmarkedIds.includes(id));
+vi.mock('../useBookmark', () => ({
+  useBookmark: () => ({
+    bookmarkedIds: mockBookmarkedIds,
+    toggleBookmark: mockToggleBookmark,
+    isBookmarked: mockIsBookmarked,
+  }),
+}));
+
+describe('usePracticePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期カテゴリはすべて', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.selectedCategory).toBe('すべて');
+  });
+
+  it('カテゴリを変更できる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedCategory('顧客折衝');
+    });
+    expect(result.current.selectedCategory).toBe('顧客折衝');
+  });
+
+  it('すべてカテゴリで全シナリオを返す', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.filteredScenarios).toHaveLength(3);
+  });
+
+  it('カテゴリフィルタでシナリオを絞り込む', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedCategory('顧客折衝');
+    });
+    expect(result.current.filteredScenarios).toHaveLength(1);
+    expect(result.current.filteredScenarios[0].category).toBe('customer');
+  });
+
+  it('ブックマークフィルタでブックマーク済みのみ返す', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedCategory('ブックマーク');
+    });
+    expect(result.current.filteredScenarios).toHaveLength(1);
+    expect(result.current.filteredScenarios[0].id).toBe(1);
+  });
+
+  it('handleSelectScenarioでセッション作成後にナビゲートする', async () => {
+    mockCreatePracticeSession.mockResolvedValue({ id: 99 });
+    const { result } = renderHook(() => usePracticePage());
+
+    await act(async () => {
+      await result.current.handleSelectScenario({ id: 1, name: 'テスト' } as any);
+    });
+
+    expect(mockCreatePracticeSession).toHaveBeenCalledWith({ scenarioId: 1 });
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai/99', {
+      state: {
+        sessionType: 'practice',
+        scenarioId: 1,
+        scenarioName: 'テスト',
+        initialPrompt: '練習開始',
+      },
+    });
+  });
+
+  it('handleSelectScenarioでセッション作成失敗時はナビゲートしない', async () => {
+    mockCreatePracticeSession.mockResolvedValue(null);
+    const { result } = renderHook(() => usePracticePage());
+
+    await act(async () => {
+      await result.current.handleSelectScenario({ id: 1, name: 'テスト' } as any);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('マウント時にfetchScenariosを呼ぶ', () => {
+    renderHook(() => usePracticePage());
+    expect(mockFetchScenarios).toHaveBeenCalled();
+  });
+
+  it('loading状態を返す', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('bookmark関連のプロパティを返す', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.isBookmarked).toBeDefined();
+    expect(result.current.toggleBookmark).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { PracticeScenario } from '../types';
+import { usePractice } from './usePractice';
+import { useBookmark } from './useBookmark';
+
+const CATEGORY_LABEL_TO_DB: Record<string, string> = {
+  '顧客折衝': 'customer',
+  'シニア・上司': 'senior',
+  'チーム内': 'team',
+};
+
+export function usePracticePage() {
+  const navigate = useNavigate();
+  const [selectedCategory, setSelectedCategory] = useState<string>('すべて');
+  const { scenarios, loading, fetchScenarios, createPracticeSession } = usePractice();
+  const { bookmarkedIds, toggleBookmark, isBookmarked } = useBookmark();
+
+  useEffect(() => {
+    fetchScenarios();
+  }, [fetchScenarios]);
+
+  const filteredScenarios = useMemo(() => {
+    if (selectedCategory === 'すべて') return scenarios;
+    if (selectedCategory === 'ブックマーク') {
+      return scenarios.filter((s) => bookmarkedIds.includes(s.id));
+    }
+    return scenarios.filter((s) => s.category === CATEGORY_LABEL_TO_DB[selectedCategory]);
+  }, [scenarios, selectedCategory, bookmarkedIds]);
+
+  const handleSelectScenario = useCallback(async (scenario: PracticeScenario) => {
+    const session = await createPracticeSession({ scenarioId: scenario.id });
+    if (session) {
+      navigate(`/chat/ask-ai/${session.id}`, {
+        state: {
+          sessionType: 'practice',
+          scenarioId: scenario.id,
+          scenarioName: scenario.name,
+          initialPrompt: '練習開始',
+        },
+      });
+    }
+  }, [createPracticeSession, navigate]);
+
+  return {
+    selectedCategory,
+    setSelectedCategory,
+    filteredScenarios,
+    loading,
+    handleSelectScenario,
+    isBookmarked,
+    toggleBookmark,
+  };
+}

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -1,50 +1,19 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import ScenarioCard from '../components/ScenarioCard';
 import { SkeletonCard } from '../components/Skeleton';
-import type { PracticeScenario } from '../types';
-import { usePractice } from '../hooks/usePractice';
-import { useBookmark } from '../hooks/useBookmark';
+import { usePracticePage } from '../hooks/usePracticePage';
 
 const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
 
-const CATEGORY_LABEL_TO_DB: Record<string, string> = {
-  '顧客折衝': 'customer',
-  'シニア・上司': 'senior',
-  'チーム内': 'team',
-};
-
 export default function PracticePage() {
-  const navigate = useNavigate();
-
-  const [selectedCategory, setSelectedCategory] = useState<string>('すべて');
-  const { scenarios, loading, fetchScenarios, createPracticeSession } = usePractice();
-  const { bookmarkedIds, toggleBookmark, isBookmarked } = useBookmark();
-
-  useEffect(() => {
-    fetchScenarios();
-  }, [fetchScenarios]);
-
-  const handleSelectScenario = async (scenario: PracticeScenario) => {
-    const session = await createPracticeSession({ scenarioId: scenario.id });
-
-    if (session) {
-      navigate(`/chat/ask-ai/${session.id}`, {
-        state: {
-          sessionType: 'practice',
-          scenarioId: scenario.id,
-          scenarioName: scenario.name,
-          initialPrompt: '練習開始',
-        },
-      });
-    }
-  };
-
-  const filteredScenarios = selectedCategory === 'すべて'
-    ? scenarios
-    : selectedCategory === 'ブックマーク'
-    ? scenarios.filter((s) => bookmarkedIds.includes(s.id))
-    : scenarios.filter((s) => s.category === CATEGORY_LABEL_TO_DB[selectedCategory]);
+  const {
+    selectedCategory,
+    setSelectedCategory,
+    filteredScenarios,
+    loading,
+    handleSelectScenario,
+    isBookmarked,
+    toggleBookmark,
+  } = usePracticePage();
 
   return (
     <div className="p-6 max-w-2xl mx-auto">


### PR DESCRIPTION
## 概要
- PracticePageの全ロジックをusePracticePageカスタムフックに抽出

## 変更内容
- usePracticePageフック: selectedCategory, filteredScenarios, handleSelectScenario等
- PracticePage: 102→71行（30%削減）、useStateゼロに
- 10テスト追加（763テスト合格）

closes #410