### PR TITLE
test: useUserSearchとuseAiChatのテスト拡充

### DIFF
--- a/frontend/src/hooks/__tests__/useAiChat.test.ts
+++ b/frontend/src/hooks/__tests__/useAiChat.test.ts
@@ -113,6 +113,30 @@ describe('useAiChat', () => {
     expect(rephrased).toBe('言い換え文');
   });
 
+  it('初期状態でsessions/messages/scoreCardが空・null', () => {
+    const { result } = renderHook(() => useAiChat());
+    expect(result.current.sessions).toEqual([]);
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.scoreCard).toBeNull();
+    expect(result.current.currentSession).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetchScoreHistory: スコア履歴を取得する', async () => {
+    const mockHistory = [{ sessionId: 1, overallScore: 7.5 }];
+    mockedRepo.getScoreHistory.mockResolvedValue(mockHistory as any);
+
+    const { result } = renderHook(() => useAiChat());
+
+    let history: any[];
+    await act(async () => {
+      history = await result.current.fetchScoreHistory();
+    });
+
+    expect(history!).toEqual(mockHistory);
+  });
+
   it('fetchScoreCard: スコアカードを取得する', async () => {
     const mockScoreCard = { overallScore: 7.5, scores: [] };
     mockedRepo.getScoreCard.mockResolvedValue(mockScoreCard as any);

--- a/frontend/src/hooks/__tests__/useUserSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useUserSearch.test.ts
@@ -98,6 +98,23 @@ describe('useUserSearch', () => {
     }, { timeout: 2000 });
   });
 
+  it('初期状態でsearchQueryが空文字・loadingに関わらずusersが空', () => {
+    const { result } = renderHook(() => useUserSearch());
+    expect(result.current.searchQuery).toBe('');
+    expect(result.current.debounceQuery).toBe('');
+    expect(result.current.users).toEqual([]);
+  });
+
+  it('non-Errorオブジェクトのreject時にデフォルトメッセージが表示されない', async () => {
+    vi.mocked(UserSearchRepository.searchUsers).mockRejectedValue('文字列エラー');
+
+    const { result } = renderHook(() => useUserSearch());
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+
   it('アンマウント時にキャンセルされた検索結果は反映されない', async () => {
     let resolveSearch: (value: any) => void;
     vi.mocked(UserSearchRepository.searchUsers).mockImplementation(


### PR DESCRIPTION
## 概要
- テスト数が少ないhooksのテスト品質向上

## 変更内容
- useUserSearch: 7→9テスト（初期状態テスト、non-Errorリジェクトテスト追加）
- useAiChat: 8→10テスト（初期状態テスト、fetchScoreHistoryテスト追加）
- 全767テスト合格

closes #412