### PR TITLE
feat: SkillRadarOverlayCard - 前回/今回のスキルレーダー重ね合わせ表示

### DIFF
--- a/frontend/src/components/SkillRadarOverlayCard.tsx
+++ b/frontend/src/components/SkillRadarOverlayCard.tsx
@@ -1,0 +1,139 @@
+import type { AxisScore } from '../types';
+
+interface SkillRadarOverlayCardProps {
+  previousScores: AxisScore[];
+  currentScores: AxisScore[];
+}
+
+const SIZE = 200;
+const CENTER = SIZE / 2;
+const RADIUS = 70;
+const GRID_LEVELS = [2, 4, 6, 8, 10];
+
+function polarToCartesian(angle: number, radius: number): { x: number; y: number } {
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return {
+    x: CENTER + radius * Math.cos(rad),
+    y: CENTER + radius * Math.sin(rad),
+  };
+}
+
+function getPolygonPoints(values: number[], maxValue: number): string {
+  if (values.length === 0) return '';
+  const angleStep = 360 / values.length;
+  return values
+    .map((value, i) => {
+      const ratio = value / maxValue;
+      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+}
+
+function getGridPoints(level: number, count: number): string {
+  if (count === 0) return '';
+  const angleStep = 360 / count;
+  const ratio = level / 10;
+  return Array.from({ length: count })
+    .map((_, i) => {
+      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+}
+
+export default function SkillRadarOverlayCard({ previousScores, currentScores }: SkillRadarOverlayCardProps) {
+  const axisCount = Math.max(previousScores.length, currentScores.length, 5);
+  const angleStep = 360 / axisCount;
+  const labels = currentScores.length > 0 ? currentScores : previousScores;
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <p className="text-xs font-medium text-[#D0D0D0] mb-3">スキル変化レーダー</p>
+
+      <div className="flex justify-center">
+        <svg viewBox={`0 0 ${SIZE} ${SIZE}`} width={SIZE} height={SIZE}>
+          {/* グリッド線 */}
+          {GRID_LEVELS.map((level) => (
+            <polygon
+              key={level}
+              points={getGridPoints(level, axisCount)}
+              fill="none"
+              stroke="#333333"
+              strokeWidth={level === 10 ? 1 : 0.5}
+            />
+          ))}
+
+          {/* 軸線 */}
+          {labels.map((_, i) => {
+            const point = polarToCartesian(i * angleStep, RADIUS);
+            return (
+              <line
+                key={i}
+                x1={CENTER}
+                y1={CENTER}
+                x2={point.x}
+                y2={point.y}
+                stroke="#333333"
+                strokeWidth={0.5}
+              />
+            );
+          })}
+
+          {/* 前回のポリゴン */}
+          {previousScores.length > 0 && (
+            <polygon
+              data-testid="prev-polygon"
+              points={getPolygonPoints(previousScores.map((s) => s.score), 10)}
+              fill="rgba(148, 163, 184, 0.15)"
+              stroke="rgba(148, 163, 184, 0.6)"
+              strokeWidth={1}
+              strokeDasharray="4 2"
+            />
+          )}
+
+          {/* 今回のポリゴン */}
+          {currentScores.length > 0 && (
+            <polygon
+              data-testid="current-polygon"
+              points={getPolygonPoints(currentScores.map((s) => s.score), 10)}
+              fill="rgba(99, 102, 241, 0.2)"
+              stroke="rgb(99, 102, 241)"
+              strokeWidth={1.5}
+            />
+          )}
+
+          {/* ラベル */}
+          {labels.map((s, i) => {
+            const point = polarToCartesian(i * angleStep, RADIUS + 18);
+            return (
+              <text
+                key={i}
+                x={point.x}
+                y={point.y}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill="#A0A0A0"
+                fontSize={8}
+              >
+                {s.axis}
+              </text>
+            );
+          })}
+        </svg>
+      </div>
+
+      {/* 凡例 */}
+      <div className="flex justify-center gap-4 mt-2">
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-0.5 bg-[#94a3b8] opacity-60" style={{ borderTop: '2px dashed #94a3b8' }} />
+          <span className="text-[10px] text-[#888888]">前回</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <div className="w-3 h-0.5 bg-indigo-500" />
+          <span className="text-[10px] text-[#888888]">今回</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SkillRadarOverlayCard.test.tsx
+++ b/frontend/src/components/__tests__/SkillRadarOverlayCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SkillRadarOverlayCard from '../SkillRadarOverlayCard';
+
+const prevScores = [
+  { axis: '論理的構成力', score: 5, comment: '' },
+  { axis: '配慮表現', score: 6, comment: '' },
+  { axis: '要約力', score: 4, comment: '' },
+  { axis: '提案力', score: 7, comment: '' },
+  { axis: '質問・傾聴力', score: 5, comment: '' },
+];
+
+const currentScores = [
+  { axis: '論理的構成力', score: 7, comment: '' },
+  { axis: '配慮表現', score: 8, comment: '' },
+  { axis: '要約力', score: 6, comment: '' },
+  { axis: '提案力', score: 8, comment: '' },
+  { axis: '質問・傾聴力', score: 7, comment: '' },
+];
+
+describe('SkillRadarOverlayCard', () => {
+  it('タイトルが表示される', () => {
+    render(<SkillRadarOverlayCard previousScores={prevScores} currentScores={currentScores} />);
+    expect(screen.getByText('スキル変化レーダー')).toBeInTheDocument();
+  });
+
+  it('SVGが表示される', () => {
+    const { container } = render(
+      <SkillRadarOverlayCard previousScores={prevScores} currentScores={currentScores} />
+    );
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('前回と今回の2つのポリゴンが表示される', () => {
+    const { container } = render(
+      <SkillRadarOverlayCard previousScores={prevScores} currentScores={currentScores} />
+    );
+    const polygons = container.querySelectorAll('polygon');
+    // グリッドポリゴン(5) + 前回(1) + 今回(1) = 7
+    const dataPolygons = Array.from(polygons).filter(p => p.getAttribute('data-testid'));
+    expect(dataPolygons).toHaveLength(2);
+  });
+
+  it('凡例が表示される', () => {
+    render(<SkillRadarOverlayCard previousScores={prevScores} currentScores={currentScores} />);
+    expect(screen.getByText('前回')).toBeInTheDocument();
+    expect(screen.getByText('今回')).toBeInTheDocument();
+  });
+
+  it('軸ラベルが表示される', () => {
+    const { container } = render(
+      <SkillRadarOverlayCard previousScores={prevScores} currentScores={currentScores} />
+    );
+    const texts = container.querySelectorAll('text');
+    const labels = Array.from(texts).map(t => t.textContent);
+    expect(labels).toContain('論理的構成力');
+    expect(labels).toContain('配慮表現');
+  });
+
+  it('スコアが空の場合はポリゴンが表示されない', () => {
+    const { container } = render(
+      <SkillRadarOverlayCard previousScores={[]} currentScores={[]} />
+    );
+    const dataPolygons = container.querySelectorAll('[data-testid]');
+    expect(dataPolygons).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -15,6 +15,7 @@ import SessionTimeCard from '../components/SessionTimeCard';
 import SkillGapAnalysisCard from '../components/SkillGapAnalysisCard';
 import WeeklyComparisonCard from '../components/WeeklyComparisonCard';
 import SkillTrendChart from '../components/SkillTrendChart';
+import SkillRadarOverlayCard from '../components/SkillRadarOverlayCard';
 import SessionDetailModal from '../components/SessionDetailModal';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
@@ -113,6 +114,14 @@ export default function ScoreHistoryPage() {
         <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex justify-center">
           <SkillRadarChart scores={latestSession.scores} title="最新のスキルバランス" />
         </div>
+      )}
+
+      {/* スキル変化レーダー（前回vs今回） */}
+      {history.length >= 2 && latestSession && (
+        <SkillRadarOverlayCard
+          previousScores={history[history.length - 2].scores}
+          currentScores={latestSession.scores}
+        />
       )}
 
       {/* 初回vs最新スコア比較 */}


### PR DESCRIPTION
## 概要
- 前回と今回のスキルレーダーチャートを1つのチャートに重ね合わせ表示

## 変更内容
- SkillRadarOverlayCard: 前回(破線)/今回(実線)の重ね合わせレーダー
- ScoreHistoryPageに統合
- 6テスト追加（773テスト合格）

closes #416