### PR TITLE
refactor: ScoreHistoryPageからセッション履歴カードを分離

### DIFF
--- a/frontend/src/components/ScoreHistorySessionCard.tsx
+++ b/frontend/src/components/ScoreHistorySessionCard.tsx
@@ -1,0 +1,64 @@
+import type { ScoreHistoryItem } from '../hooks/useScoreHistory';
+
+interface ScoreHistorySessionCardProps {
+  item: ScoreHistoryItem;
+  delta: number | null;
+  onClick: () => void;
+}
+
+export default function ScoreHistorySessionCard({ item, delta, onClick }: ScoreHistorySessionCardProps) {
+  return (
+    <div
+      className="bg-surface-1 rounded-lg border border-surface-3 p-4 cursor-pointer hover:border-[var(--color-border-hover)] transition-colors"
+      onClick={onClick}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <h3 className="text-sm font-medium text-[var(--color-text-primary)]">
+            {item.sessionTitle || `セッション #${item.sessionId}`}
+          </h3>
+          <p className="text-xs text-[var(--color-text-faint)] mt-0.5">
+            {new Date(item.createdAt).toLocaleDateString('ja-JP', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {delta !== null && delta !== 0 && (
+            <span className={`text-xs font-medium ${delta > 0 ? 'text-emerald-400' : 'text-rose-400'}`}>
+              {delta > 0 ? `+${delta.toFixed(1)}` : `\u2212${Math.abs(delta).toFixed(1)}`}
+            </span>
+          )}
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-[var(--color-text-muted)]">総合</span>
+            <span className="text-lg font-semibold text-[var(--color-text-primary)]">
+              {item.overallScore.toFixed(1)}
+            </span>
+            <span className="text-xs text-[var(--color-text-faint)]">/10</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        {item.scores.map((axisScore) => (
+          <div key={axisScore.axis} className="flex items-center gap-2">
+            <span className="text-xs text-[var(--color-text-muted)] w-24 flex-shrink-0 truncate">
+              {axisScore.axis}
+            </span>
+            <div className="flex-1 bg-surface-3 rounded-full h-1.5">
+              <div
+                className="h-1.5 rounded-full bg-primary-500"
+                style={{ width: `${axisScore.score * 10}%` }}
+              />
+            </div>
+            <span className="text-xs text-[var(--color-text-tertiary)] w-5 text-right">
+              {axisScore.score}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreHistorySessionCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreHistorySessionCard.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ScoreHistorySessionCard from '../ScoreHistorySessionCard';
+import type { ScoreHistoryItem } from '../../hooks/useScoreHistory';
+
+const baseItem: ScoreHistoryItem = {
+  sessionId: 1,
+  sessionTitle: '障害報告の練習',
+  overallScore: 7.5,
+  scores: [
+    { axis: '論理的構成力', score: 8, comment: '' },
+    { axis: '配慮表現', score: 7, comment: '' },
+    { axis: '要約力', score: 7, comment: '' },
+    { axis: '提案力', score: 8, comment: '' },
+    { axis: '質問・傾聴力', score: 7, comment: '' },
+  ],
+  createdAt: '2026-02-10T10:00:00Z',
+};
+
+describe('ScoreHistorySessionCard', () => {
+  it('セッションタイトルが表示される', () => {
+    render(<ScoreHistorySessionCard item={baseItem} delta={null} onClick={vi.fn()} />);
+    expect(screen.getByText('障害報告の練習')).toBeInTheDocument();
+  });
+
+  it('総合スコアが表示される', () => {
+    render(<ScoreHistorySessionCard item={baseItem} delta={null} onClick={vi.fn()} />);
+    expect(screen.getByText('7.5')).toBeInTheDocument();
+  });
+
+  it('日付がフォーマットされて表示される', () => {
+    render(<ScoreHistorySessionCard item={baseItem} delta={null} onClick={vi.fn()} />);
+    expect(screen.getByText(/2026年/)).toBeInTheDocument();
+  });
+
+  it('各スキル軸が表示される', () => {
+    render(<ScoreHistorySessionCard item={baseItem} delta={null} onClick={vi.fn()} />);
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('配慮表現')).toBeInTheDocument();
+  });
+
+  it('プラスのdeltaが緑色で表示される', () => {
+    render(<ScoreHistorySessionCard item={baseItem} delta={1.2} onClick={vi.fn()} />);
+    expect(screen.getByText('+1.2')).toBeInTheDocument();
+  });
+
+  it('マイナスのdeltaが赤色で表示される', () => {
+    render(<ScoreHistorySessionCard item={baseItem} delta={-0.5} onClick={vi.fn()} />);
+    const el = screen.getByText(/0\.5/);
+    expect(el.className).toContain('text-rose-400');
+  });
+
+  it('deltaがnullの場合は変動表示がない', () => {
+    const { container } = render(<ScoreHistorySessionCard item={baseItem} delta={null} onClick={vi.fn()} />);
+    expect(container.querySelector('.text-emerald-400')).toBeNull();
+    expect(container.querySelector('.text-rose-400')).toBeNull();
+  });
+
+  it('クリックでonClickが呼ばれる', () => {
+    const handleClick = vi.fn();
+    render(<ScoreHistorySessionCard item={baseItem} delta={null} onClick={handleClick} />);
+    fireEvent.click(screen.getByText('障害報告の練習').closest('div')!.parentElement!.parentElement!);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('タイトルがない場合はセッションIDで表示される', () => {
+    const noTitle = { ...baseItem, sessionTitle: '' };
+    render(<ScoreHistorySessionCard item={noTitle} delta={null} onClick={vi.fn()} />);
+    expect(screen.getByText('セッション #1')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -17,6 +17,7 @@ import WeeklyComparisonCard from '../components/WeeklyComparisonCard';
 import SkillTrendChart from '../components/SkillTrendChart';
 import SkillRadarOverlayCard from '../components/SkillRadarOverlayCard';
 import SessionDetailModal from '../components/SessionDetailModal';
+import ScoreHistorySessionCard from '../components/ScoreHistorySessionCard';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 const AXIS_ADVICE: Record<string, string> = {
@@ -206,59 +207,12 @@ export default function ScoreHistoryPage() {
           : null;
 
         return (
-          <div
+          <ScoreHistorySessionCard
             key={item.sessionId}
-            className="bg-surface-1 rounded-lg border border-surface-3 p-4 cursor-pointer hover:border-[var(--color-border-hover)] transition-colors"
+            item={item}
+            delta={delta}
             onClick={() => setSelectedSession(item)}
-          >
-            <div className="flex items-center justify-between mb-3">
-              <div>
-                <h3 className="text-sm font-medium text-[var(--color-text-primary)]">
-                  {item.sessionTitle || `セッション #${item.sessionId}`}
-                </h3>
-                <p className="text-xs text-[var(--color-text-faint)] mt-0.5">
-                  {new Date(item.createdAt).toLocaleDateString('ja-JP', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                {delta !== null && delta !== 0 && (
-                  <span className={`text-xs font-medium ${delta > 0 ? 'text-emerald-400' : 'text-rose-400'}`}>
-                    {delta > 0 ? `+${delta.toFixed(1)}` : `\u2212${Math.abs(delta).toFixed(1)}`}
-                  </span>
-                )}
-                <div className="flex items-center gap-1">
-                  <span className="text-xs text-[var(--color-text-muted)]">総合</span>
-                  <span className="text-lg font-semibold text-[var(--color-text-primary)]">
-                    {item.overallScore.toFixed(1)}
-                  </span>
-                  <span className="text-xs text-[var(--color-text-faint)]">/10</span>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-1.5">
-              {item.scores.map((axisScore) => (
-                <div key={axisScore.axis} className="flex items-center gap-2">
-                  <span className="text-xs text-[var(--color-text-muted)] w-24 flex-shrink-0 truncate">
-                    {axisScore.axis}
-                  </span>
-                  <div className="flex-1 bg-surface-3 rounded-full h-1.5">
-                    <div
-                      className="h-1.5 rounded-full bg-primary-500"
-                      style={{ width: `${axisScore.score * 10}%` }}
-                    />
-                  </div>
-                  <span className="text-xs text-[var(--color-text-tertiary)] w-5 text-right">
-                    {axisScore.score}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
+          />
         );
       })}
 


### PR DESCRIPTION
## 概要
- ScoreHistoryPage（273行）からセッション履歴カード表示をScoreHistorySessionCardに抽出
- ページの責務を軽減し、コンポーネントの再利用性を向上

## 変更内容
- `ScoreHistorySessionCard`コンポーネント新規作成（セッション表示・スコアバー・delta表示）
- `ScoreHistoryPage`: 273→227行（17%削減）
- 9テスト追加（タイトル表示、スコア表示、delta表示、クリック動作等）

## テスト
- ScoreHistorySessionCard: 9テスト追加
- 既存ScoreHistoryPageテスト: 11テスト全パス
- 全793テスト通過

closes #420