### PR TITLE
test: PrimaryButton・LinkText・AuthLayoutテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/components/__tests__/AuthLayout.test.tsx
@@ -14,4 +14,22 @@ describe('AuthLayout', () => {
 
     expect(screen.getByText('子コンテンツ')).toBeInTheDocument();
   });
+
+  it('複数の子要素が表示される', () => {
+    render(
+      <AuthLayout>
+        <p>要素1</p>
+        <p>要素2</p>
+      </AuthLayout>
+    );
+
+    expect(screen.getByText('要素1')).toBeInTheDocument();
+    expect(screen.getByText('要素2')).toBeInTheDocument();
+  });
+
+  it('プライマリカラーのボーダーが適用される', () => {
+    const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
+    const card = container.querySelector('.border-t-primary-500');
+    expect(card).toBeTruthy();
+  });
 });

--- a/frontend/src/components/__tests__/LinkText.test.tsx
+++ b/frontend/src/components/__tests__/LinkText.test.tsx
@@ -23,4 +23,36 @@ describe('LinkText', () => {
 
     expect(screen.getByText('新規登録').closest('a')).toHaveAttribute('href', '/signup');
   });
+
+  it('aタグとしてレンダリングされる', () => {
+    render(
+      <MemoryRouter>
+        <LinkText to="/test">テスト</LinkText>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('テスト').closest('a')).toBeTruthy();
+  });
+
+  it('テキストスタイルが適用される', () => {
+    render(
+      <MemoryRouter>
+        <LinkText to="/test">テスト</LinkText>
+      </MemoryRouter>
+    );
+
+    const link = screen.getByText('テスト').closest('a');
+    expect(link?.className).toContain('text-primary-500');
+    expect(link?.className).toContain('font-medium');
+  });
+
+  it('異なるパスで正しいリンク先が設定される', () => {
+    render(
+      <MemoryRouter>
+        <LinkText to="/forgot-password">パスワードリセット</LinkText>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('パスワードリセット').closest('a')).toHaveAttribute('href', '/forgot-password');
+  });
 });

--- a/frontend/src/components/__tests__/PrimaryButton.test.tsx
+++ b/frontend/src/components/__tests__/PrimaryButton.test.tsx
@@ -24,4 +24,19 @@ describe('PrimaryButton', () => {
     const button = screen.getByText('送信');
     expect(button).toBeDisabled();
   });
+
+  it('デフォルトのtype属性がbuttonである', () => {
+    render(<PrimaryButton>テスト</PrimaryButton>);
+    expect(screen.getByText('テスト')).toHaveAttribute('type', 'button');
+  });
+
+  it('type=submitを指定できる', () => {
+    render(<PrimaryButton type="submit">送信</PrimaryButton>);
+    expect(screen.getByText('送信')).toHaveAttribute('type', 'submit');
+  });
+
+  it('全幅のスタイルが適用される', () => {
+    render(<PrimaryButton>テスト</PrimaryButton>);
+    expect(screen.getByText('テスト').className).toContain('w-full');
+  });
 });


### PR DESCRIPTION
## 概要
テスト数の少ないコンポーネントのエッジケーステストを追加

## 変更内容
- **PrimaryButton**: 3→6テスト（type属性デフォルト値、type=submit、全幅スタイル）
- **LinkText**: 2→5テスト（aタグレンダリング、スタイル検証、複数パス検証）
- **AuthLayout**: 2→4テスト（複数子要素、プライマリボーダースタイル）

## テスト
- 8テスト追加、全テスト通過

closes #422