### PR TITLE
feat: スコアフィルタサマリーカード追加

### DIFF
--- a/frontend/src/components/ScoreFilterSummary.tsx
+++ b/frontend/src/components/ScoreFilterSummary.tsx
@@ -1,0 +1,29 @@
+interface ScoreFilterSummaryProps {
+  scores: number[];
+}
+
+export default function ScoreFilterSummary({ scores }: ScoreFilterSummaryProps) {
+  if (scores.length === 0) return null;
+
+  const avg = Math.round((scores.reduce((s, v) => s + v, 0) / scores.length) * 10) / 10;
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+
+  const items = [
+    { label: '件数', value: String(scores.length) },
+    { label: '平均', value: avg.toFixed(1) },
+    { label: '最高', value: max.toFixed(1) },
+    { label: '最低', value: min.toFixed(1) },
+  ];
+
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {items.map((item) => (
+        <div key={item.label} className="bg-surface-1 rounded-lg border border-surface-3 p-3 text-center">
+          <p className="text-[10px] text-[var(--color-text-muted)]">{item.label}</p>
+          <p className="text-sm font-semibold text-[var(--color-text-primary)] mt-0.5">{item.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreFilterSummary.test.tsx
+++ b/frontend/src/components/__tests__/ScoreFilterSummary.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ScoreFilterSummary from '../ScoreFilterSummary';
+
+describe('ScoreFilterSummary', () => {
+  it('セッション数が表示される', () => {
+    render(<ScoreFilterSummary scores={[7.5, 8.0, 6.5]} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('平均スコアが表示される', () => {
+    render(<ScoreFilterSummary scores={[7.0, 8.0, 9.0]} />);
+    expect(screen.getByText('8.0')).toBeInTheDocument();
+  });
+
+  it('最高スコアが表示される', () => {
+    render(<ScoreFilterSummary scores={[5.0, 8.5, 7.0]} />);
+    expect(screen.getByText('8.5')).toBeInTheDocument();
+  });
+
+  it('最低スコアが表示される', () => {
+    render(<ScoreFilterSummary scores={[5.0, 8.5, 7.0]} />);
+    expect(screen.getByText('5.0')).toBeInTheDocument();
+  });
+
+  it('スコアが空の場合は表示されない', () => {
+    const { container } = render(<ScoreFilterSummary scores={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('単一スコアの場合も正しく表示される', () => {
+    render(<ScoreFilterSummary scores={[7.5]} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getAllByText('7.5')).toHaveLength(3);
+  });
+
+  it('ラベルが表示される', () => {
+    render(<ScoreFilterSummary scores={[7.0, 8.0]} />);
+    expect(screen.getByText('件数')).toBeInTheDocument();
+    expect(screen.getByText('平均')).toBeInTheDocument();
+    expect(screen.getByText('最高')).toBeInTheDocument();
+    expect(screen.getByText('最低')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -18,6 +18,7 @@ import SkillTrendChart from '../components/SkillTrendChart';
 import SkillRadarOverlayCard from '../components/SkillRadarOverlayCard';
 import SessionDetailModal from '../components/SessionDetailModal';
 import ScoreHistorySessionCard from '../components/ScoreHistorySessionCard';
+import ScoreFilterSummary from '../components/ScoreFilterSummary';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 const AXIS_ADVICE: Record<string, string> = {
@@ -195,9 +196,8 @@ export default function ScoreHistoryPage() {
         ))}
       </div>
 
-      <p className="text-xs text-[var(--color-text-muted)]">
-        全 {filteredHistory.length} 件のフィードバック履歴
-      </p>
+      {/* フィルタサマリー */}
+      <ScoreFilterSummary scores={filteredHistory.map(h => h.overallScore)} />
 
       {filteredHistory.map((item) => {
         const originalIndex = history.indexOf(item);


### PR DESCRIPTION
## 概要
- フィルタ結果の件数・平均・最高・最低スコアを一目で確認できるサマリーカードを追加
- ScoreHistoryPageのフィルタタブ直下に統合

## 変更内容
- `ScoreFilterSummary` コンポーネント新規作成（4カラムグリッドレイアウト）
- ScoreHistoryPageに統合（従来のテキスト件数表示を置換）
- 7テスト追加

## テスト
- `npx vitest run` 130ファイル 808テスト全パス

closes #426