### PR TITLE
refactor: MenuPageからMenuNavigationCard抽出

### DIFF
--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -1,0 +1,81 @@
+import { useNavigate } from 'react-router-dom';
+import {
+  ChatBubbleLeftRightIcon,
+  SparklesIcon,
+  AcademicCapIcon,
+  ChartBarIcon,
+} from '@heroicons/react/24/outline';
+
+interface MenuNavigationCardProps {
+  totalUnread: number;
+  latestScore: number | null;
+}
+
+const MENU_ITEMS = [
+  {
+    icon: ChatBubbleLeftRightIcon,
+    label: 'チャット',
+    description: 'メンバーとメッセージをやり取り',
+    to: '/chat',
+    badgeKey: 'unread' as const,
+  },
+  {
+    icon: SparklesIcon,
+    label: 'AI アシスタント',
+    description: 'AIにコミュニケーションを分析・フィードバック',
+    to: '/chat/ask-ai',
+    badgeKey: null,
+  },
+  {
+    icon: AcademicCapIcon,
+    label: '練習モード',
+    description: 'ビジネスシナリオでロールプレイ練習',
+    to: '/practice',
+    badgeKey: null,
+  },
+  {
+    icon: ChartBarIcon,
+    label: 'スコア履歴',
+    description: 'フィードバック結果の振り返り',
+    to: '/scores',
+    badgeKey: 'score' as const,
+  },
+];
+
+export default function MenuNavigationCard({ totalUnread, latestScore }: MenuNavigationCardProps) {
+  const navigate = useNavigate();
+
+  const getBadge = (badgeKey: 'unread' | 'score' | null): string | null => {
+    if (badgeKey === 'unread' && totalUnread > 0) return `${totalUnread}件の未読`;
+    if (badgeKey === 'score' && latestScore !== null) return `最新: ${latestScore}`;
+    return null;
+  };
+
+  return (
+    <div className="space-y-2">
+      {MENU_ITEMS.map((item) => {
+        const badge = getBadge(item.badgeKey);
+        return (
+          <button
+            key={item.to}
+            onClick={() => navigate(item.to)}
+            className="w-full flex items-center gap-4 bg-surface-1 rounded-lg border border-surface-3 p-4 text-left hover:bg-surface-2 transition-colors"
+          >
+            <item.icon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium text-[var(--color-text-primary)]">{item.label}</p>
+                {badge && (
+                  <span className="text-[10px] font-medium bg-primary-500 text-white px-1.5 py-0.5 rounded-full">
+                    {badge}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-[var(--color-text-muted)]">{item.description}</p>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/MenuNavigationCard.test.tsx
+++ b/frontend/src/components/__tests__/MenuNavigationCard.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MenuNavigationCard from '../MenuNavigationCard';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('MenuNavigationCard', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('メニュー項目が全て表示される', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    expect(screen.getByText('チャット')).toBeInTheDocument();
+    expect(screen.getByText('AI アシスタント')).toBeInTheDocument();
+    expect(screen.getByText('練習モード')).toBeInTheDocument();
+    expect(screen.getByText('スコア履歴')).toBeInTheDocument();
+  });
+
+  it('説明文が表示される', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    expect(screen.getByText('メンバーとメッセージをやり取り')).toBeInTheDocument();
+    expect(screen.getByText('AIにコミュニケーションを分析・フィードバック')).toBeInTheDocument();
+    expect(screen.getByText('ビジネスシナリオでロールプレイ練習')).toBeInTheDocument();
+    expect(screen.getByText('フィードバック結果の振り返り')).toBeInTheDocument();
+  });
+
+  it('未読バッジが表示される', () => {
+    render(<MenuNavigationCard totalUnread={5} latestScore={null} />);
+    expect(screen.getByText('5件の未読')).toBeInTheDocument();
+  });
+
+  it('未読0件ではバッジが非表示', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    expect(screen.queryByText(/件の未読/)).toBeNull();
+  });
+
+  it('最新スコアバッジが表示される', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={8.5} />);
+    expect(screen.getByText('最新: 8.5')).toBeInTheDocument();
+  });
+
+  it('最新スコアがnullの場合バッジが非表示', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    expect(screen.queryByText(/最新:/)).toBeNull();
+  });
+
+  it('メニュー項目クリックで画面遷移する', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    fireEvent.click(screen.getByText('チャット'));
+    expect(mockNavigate).toHaveBeenCalledWith('/chat');
+  });
+
+  it('練習モードクリックで画面遷移する', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    fireEvent.click(screen.getByText('練習モード'));
+    expect(mockNavigate).toHaveBeenCalledWith('/practice');
+  });
+
+  it('4つのメニュー項目のボタンが存在する', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,11 +1,4 @@
-import { useNavigate } from 'react-router-dom';
-import {
-  UserGroupIcon,
-  ChatBubbleLeftRightIcon,
-  SparklesIcon,
-  AcademicCapIcon,
-  ChartBarIcon,
-} from '@heroicons/react/24/outline';
+import { UserGroupIcon } from '@heroicons/react/24/outline';
 import AchievementBadgeCard from '../components/AchievementBadgeCard';
 import StreakCalendarCard from '../components/StreakCalendarCard';
 import CommunicationTipCard from '../components/CommunicationTipCard';
@@ -23,42 +16,11 @@ import WeeklyReportCard from '../components/WeeklyReportCard';
 import LearningPatternCard from '../components/LearningPatternCard';
 import ScoreGrowthTrendCard from '../components/ScoreGrowthTrendCard';
 import PracticeFrequencyCard from '../components/PracticeFrequencyCard';
+import MenuNavigationCard from '../components/MenuNavigationCard';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
-  const navigate = useNavigate();
   const { stats, totalUnread, latestScore, allScores, totalSessions, averageScore, uniqueDays, practiceDates, sessionsThisWeek } = useMenuData();
-
-  const menuItems = [
-    {
-      icon: ChatBubbleLeftRightIcon,
-      label: 'チャット',
-      description: 'メンバーとメッセージをやり取り',
-      to: '/chat',
-      badge: totalUnread > 0 ? `${totalUnread}件の未読` : null,
-    },
-    {
-      icon: SparklesIcon,
-      label: 'AI アシスタント',
-      description: 'AIにコミュニケーションを分析・フィードバック',
-      to: '/chat/ask-ai',
-      badge: null,
-    },
-    {
-      icon: AcademicCapIcon,
-      label: '練習モード',
-      description: 'ビジネスシナリオでロールプレイ練習',
-      to: '/practice',
-      badge: null,
-    },
-    {
-      icon: ChartBarIcon,
-      label: 'スコア履歴',
-      description: 'フィードバック結果の振り返り',
-      to: '/scores',
-      badge: latestScore ? `最新: ${latestScore.overallScore}` : null,
-    },
-  ];
 
   const showRecommendation = !latestScore && stats?.chatPartnerCount === 0;
 
@@ -192,28 +154,7 @@ export default function MenuPage() {
       </div>
 
       {/* メニュー */}
-      <div className="space-y-2">
-        {menuItems.map((item) => (
-          <button
-            key={item.to}
-            onClick={() => navigate(item.to)}
-            className="w-full flex items-center gap-4 bg-surface-1 rounded-lg border border-surface-3 p-4 text-left hover:bg-surface-2 transition-colors"
-          >
-            <item.icon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-medium text-[var(--color-text-primary)]">{item.label}</p>
-                {item.badge && (
-                  <span className="text-[10px] font-medium bg-primary-500 text-white px-1.5 py-0.5 rounded-full">
-                    {item.badge}
-                  </span>
-                )}
-              </div>
-              <p className="text-xs text-[var(--color-text-muted)]">{item.description}</p>
-            </div>
-          </button>
-        ))}
-      </div>
+      <MenuNavigationCard totalUnread={totalUnread} latestScore={latestScore ? latestScore.overallScore : null} />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- MenuPageのメニューナビゲーション部分をMenuNavigationCardコンポーネントに抽出
- MenuPage: 219行→160行（27%削減）

## 変更内容
- `MenuNavigationCard` コンポーネント新規作成（メニュー項目定義・バッジ表示・画面遷移）
- MenuPageからmenuItems配列・useNavigate・Heroiconsインポートを除去
- 9テスト追加

## テスト
- `npx vitest run` 131ファイル 817テスト全パス

closes #428