### PR TITLE
test: DailyGoalCard・SearchBox・RoomListItem・SNSSignInButtonテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/DailyGoalCard.test.tsx
+++ b/frontend/src/components/__tests__/DailyGoalCard.test.tsx
@@ -52,4 +52,23 @@ describe('DailyGoalCard', () => {
       incrementCompleted: vi.fn(),
     };
   });
+
+  it('未達成時に達成メッセージが表示されない', () => {
+    render(<DailyGoalCard />);
+    expect(screen.queryByText(/達成/)).toBeNull();
+  });
+
+  it('プログレスバーにaria属性が設定される', () => {
+    const { container } = render(<DailyGoalCard />);
+
+    const progressBar = container.querySelector('[role="progressbar"]');
+    expect(progressBar).toHaveAttribute('aria-valuenow', '33');
+    expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressBar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('回ラベルが表示される', () => {
+    render(<DailyGoalCard />);
+    expect(screen.getByText(/回/)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/RoomListItem.test.tsx
+++ b/frontend/src/components/__tests__/RoomListItem.test.tsx
@@ -21,4 +21,22 @@ describe('RoomListItem', () => {
 
     expect(screen.getByText('5')).toBeInTheDocument();
   });
+
+  it('長いメッセージが切り詰められるスタイルが適用される', () => {
+    const { container } = render(<RoomListItem name="テスト" lastMessage="とても長いメッセージ" unreadCount={0} />);
+    const messageEl = container.querySelector('.truncate');
+    expect(messageEl).toBeTruthy();
+  });
+
+  it('名前がフォント太字で表示される', () => {
+    const { container } = render(<RoomListItem name="太字テスト" lastMessage="メッセージ" unreadCount={0} />);
+    const nameEl = container.querySelector('.font-semibold');
+    expect(nameEl).toHaveTextContent('太字テスト');
+  });
+
+  it('未読バッジにprimary背景色が適用される', () => {
+    render(<RoomListItem name="テスト" lastMessage="メッセージ" unreadCount={3} />);
+    const badge = screen.getByText('3');
+    expect(badge.className).toContain('bg-primary-500');
+  });
 });

--- a/frontend/src/components/__tests__/SNSSignInButton.test.tsx
+++ b/frontend/src/components/__tests__/SNSSignInButton.test.tsx
@@ -22,4 +22,23 @@ describe('SNSSignInButton', () => {
 
     expect(screen.getByText('Facebookでログイン')).toBeInTheDocument();
   });
+
+  it('Xログインボタンが表示される', () => {
+    render(<SNSSignInButton provider="x" onClick={vi.fn()} />);
+
+    expect(screen.getByText('Xでログイン')).toBeInTheDocument();
+  });
+
+  it('プロバイダーアイコンが表示される', () => {
+    render(<SNSSignInButton provider="google" onClick={vi.fn()} />);
+
+    const img = screen.getByAltText('google');
+    expect(img).toBeInTheDocument();
+  });
+
+  it('ボタン要素としてレンダリングされる', () => {
+    render(<SNSSignInButton provider="google" onClick={vi.fn()} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/SearchBox.test.tsx
+++ b/frontend/src/components/__tests__/SearchBox.test.tsx
@@ -22,4 +22,21 @@ describe('SearchBox', () => {
     fireEvent.change(screen.getByPlaceholderText('検索'), { target: { value: 'テスト' } });
     expect(mockOnChange).toHaveBeenCalledWith('テスト');
   });
+
+  it('値が反映される', () => {
+    render(<SearchBox value="初期値" onChange={vi.fn()} />);
+    expect(screen.getByDisplayValue('初期値')).toBeInTheDocument();
+  });
+
+  it('テキスト入力フィールドとしてレンダリングされる', () => {
+    render(<SearchBox value="" onChange={vi.fn()} />);
+    const input = screen.getByPlaceholderText('検索');
+    expect(input).toHaveAttribute('type', 'text');
+  });
+
+  it('検索アイコンが表示される', () => {
+    const { container } = render(<SearchBox value="" onChange={vi.fn()} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## 概要
- テスト数が3のコンポーネント4つを各6テストに拡充

## 変更内容
- DailyGoalCard: 3→6テスト（aria属性・未達成時・回ラベル）
- SearchBox: 3→6テスト（値反映・input type・検索アイコン）
- RoomListItem: 3→6テスト（truncate・フォント太字・バッジ色）
- SNSSignInButton: 3→6テスト（Xプロバイダー・アイコン・ボタン要素）

## テスト
- `npx vitest run` 131ファイル 829テスト全パス

closes #430