### PR TITLE
feat: スコアトレンドインジケーター追加

### DIFF
--- a/frontend/src/components/ScoreTrendIndicator.tsx
+++ b/frontend/src/components/ScoreTrendIndicator.tsx
@@ -1,0 +1,57 @@
+import { ArrowTrendingUpIcon, ArrowTrendingDownIcon, MinusIcon } from '@heroicons/react/24/outline';
+
+interface ScoreTrendIndicatorProps {
+  scores: number[];
+}
+
+type Trend = 'up' | 'down' | 'stable';
+
+function calculateTrend(scores: number[]): Trend {
+  const recent = scores.slice(-5);
+  const firstHalf = recent.slice(0, Math.ceil(recent.length / 2));
+  const secondHalf = recent.slice(Math.floor(recent.length / 2));
+
+  const avgFirst = firstHalf.reduce((s, v) => s + v, 0) / firstHalf.length;
+  const avgSecond = secondHalf.reduce((s, v) => s + v, 0) / secondHalf.length;
+
+  const diff = avgSecond - avgFirst;
+  if (diff > 0.3) return 'up';
+  if (diff < -0.3) return 'down';
+  return 'stable';
+}
+
+const TREND_CONFIG = {
+  up: {
+    label: '上昇傾向',
+    icon: ArrowTrendingUpIcon,
+    color: 'text-emerald-400',
+  },
+  down: {
+    label: '下降傾向',
+    icon: ArrowTrendingDownIcon,
+    color: 'text-red-400',
+  },
+  stable: {
+    label: '安定',
+    icon: MinusIcon,
+    color: 'text-[var(--color-text-muted)]',
+  },
+} as const;
+
+export default function ScoreTrendIndicator({ scores }: ScoreTrendIndicatorProps) {
+  if (scores.length < 2) return null;
+
+  const trend = calculateTrend(scores);
+  const config = TREND_CONFIG[trend];
+  const Icon = config.icon;
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-3 flex items-center gap-3">
+      <Icon className={`w-5 h-5 ${config.color} flex-shrink-0`} />
+      <div>
+        <p className="text-[10px] text-[var(--color-text-muted)]">直近トレンド</p>
+        <p className={`text-sm font-semibold ${config.color}`}>{config.label}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreTrendIndicator.test.tsx
+++ b/frontend/src/components/__tests__/ScoreTrendIndicator.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ScoreTrendIndicator from '../ScoreTrendIndicator';
+
+describe('ScoreTrendIndicator', () => {
+  it('上昇トレンドのメッセージが表示される', () => {
+    render(<ScoreTrendIndicator scores={[5.0, 6.0, 7.0, 8.0, 9.0]} />);
+    expect(screen.getByText('上昇傾向')).toBeInTheDocument();
+  });
+
+  it('下降トレンドのメッセージが表示される', () => {
+    render(<ScoreTrendIndicator scores={[9.0, 8.0, 7.0, 6.0, 5.0]} />);
+    expect(screen.getByText('下降傾向')).toBeInTheDocument();
+  });
+
+  it('横ばいトレンドのメッセージが表示される', () => {
+    render(<ScoreTrendIndicator scores={[7.0, 7.0, 7.0, 7.0, 7.0]} />);
+    expect(screen.getByText('安定')).toBeInTheDocument();
+  });
+
+  it('スコアが1件以下の場合は表示されない', () => {
+    const { container } = render(<ScoreTrendIndicator scores={[7.0]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('スコアが空の場合は表示されない', () => {
+    const { container } = render(<ScoreTrendIndicator scores={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('2件のスコアでもトレンドが計算される', () => {
+    render(<ScoreTrendIndicator scores={[5.0, 8.0]} />);
+    expect(screen.getByText('上昇傾向')).toBeInTheDocument();
+  });
+
+  it('トレンドラベルが表示される', () => {
+    render(<ScoreTrendIndicator scores={[5.0, 6.0, 7.0]} />);
+    expect(screen.getByText('直近トレンド')).toBeInTheDocument();
+  });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<ScoreTrendIndicator scores={[5.0, 6.0, 7.0]} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -19,6 +19,7 @@ import SkillRadarOverlayCard from '../components/SkillRadarOverlayCard';
 import SessionDetailModal from '../components/SessionDetailModal';
 import ScoreHistorySessionCard from '../components/ScoreHistorySessionCard';
 import ScoreFilterSummary from '../components/ScoreFilterSummary';
+import ScoreTrendIndicator from '../components/ScoreTrendIndicator';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 const AXIS_ADVICE: Record<string, string> = {
@@ -198,6 +199,9 @@ export default function ScoreHistoryPage() {
 
       {/* フィルタサマリー */}
       <ScoreFilterSummary scores={filteredHistory.map(h => h.overallScore)} />
+
+      {/* トレンドインジケーター */}
+      <ScoreTrendIndicator scores={filteredHistory.map(h => h.overallScore)} />
 
       {filteredHistory.map((item) => {
         const originalIndex = history.indexOf(item);


### PR DESCRIPTION
## 概要
- 直近5回のスコアから上昇/下降/安定のトレンドを矢印アイコンで視覚表示
- ScoreHistoryPageのフィルタサマリー下に統合

## 変更内容
- `ScoreTrendIndicator` コンポーネント新規作成
- 前半・後半の平均値比較でトレンド判定（閾値0.3）
- ArrowTrendingUpIcon/ArrowTrendingDownIcon/MinusIconで色分け表示
- 8テスト追加

## テスト
- `npx vitest run` 132ファイル 837テスト全パス

closes #434