### PR TITLE
refactor: ChatPageからMessageSelectionPanel抽出

### DIFF
--- a/frontend/src/components/MessageSelectionPanel.tsx
+++ b/frontend/src/components/MessageSelectionPanel.tsx
@@ -1,0 +1,80 @@
+interface MessageSelectionPanelProps {
+  selectedCount: number;
+  onQuickSelect: (n: number) => void;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onCancel: () => void;
+  onSend: () => void;
+}
+
+const QUICK_SELECT_OPTIONS = [5, 10, 20];
+
+export default function MessageSelectionPanel({
+  selectedCount,
+  onQuickSelect,
+  onSelectAll,
+  onDeselectAll,
+  onCancel,
+  onSend,
+}: MessageSelectionPanelProps) {
+  return (
+    <div className="space-y-3">
+      <div className="bg-surface-2 border border-[var(--color-border-hover)] rounded-lg p-3">
+        <p className="text-sm text-primary-300">
+          {selectedCount > 0
+            ? `${selectedCount}件のメッセージを選択しました`
+            : '開始位置のメッセージをタップしてください'
+          }
+        </p>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        <span className="text-xs text-[var(--color-text-muted)] self-center">クイック選択:</span>
+        {QUICK_SELECT_OPTIONS.map((n) => (
+          <button
+            key={n}
+            onClick={() => onQuickSelect(n)}
+            className="px-3 py-1 text-xs bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] rounded-full transition-colors"
+          >
+            直近{n}件
+          </button>
+        ))}
+        <button
+          onClick={onSelectAll}
+          className="px-3 py-1 text-xs bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] rounded-full transition-colors"
+        >
+          すべて
+        </button>
+        <button
+          onClick={onDeselectAll}
+          className="px-3 py-1 text-xs text-rose-500 hover:bg-rose-900/30 rounded-full transition-colors"
+        >
+          リセット
+        </button>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={onCancel}
+          className="flex-1 bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] font-medium py-2.5 px-4 rounded-lg text-sm transition-colors"
+        >
+          キャンセル
+        </button>
+        <button
+          onClick={onSend}
+          disabled={selectedCount === 0}
+          className={`flex-1 font-medium py-2.5 px-4 rounded-lg text-sm transition-colors ${
+            selectedCount > 0
+              ? 'bg-primary-500 hover:bg-primary-600 text-white'
+              : 'bg-surface-3 text-[var(--color-text-muted)] cursor-not-allowed'
+          }`}
+        >
+          {selectedCount > 0
+            ? `${selectedCount}件をAIに送信`
+            : '範囲を選択してください'
+          }
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/MessageSelectionPanel.test.tsx
+++ b/frontend/src/components/__tests__/MessageSelectionPanel.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import MessageSelectionPanel from '../MessageSelectionPanel';
+
+describe('MessageSelectionPanel', () => {
+  const defaultProps = {
+    selectedCount: 0,
+    onQuickSelect: vi.fn(),
+    onSelectAll: vi.fn(),
+    onDeselectAll: vi.fn(),
+    onCancel: vi.fn(),
+    onSend: vi.fn(),
+  };
+
+  it('選択件数0の場合にガイドメッセージが表示される', () => {
+    render(<MessageSelectionPanel {...defaultProps} />);
+    expect(screen.getByText('開始位置のメッセージをタップしてください')).toBeInTheDocument();
+  });
+
+  it('選択件数1以上の場合に件数メッセージが表示される', () => {
+    render(<MessageSelectionPanel {...defaultProps} selectedCount={3} />);
+    expect(screen.getByText('3件のメッセージを選択しました')).toBeInTheDocument();
+  });
+
+  it('クイック選択ボタンが表示される', () => {
+    render(<MessageSelectionPanel {...defaultProps} />);
+    expect(screen.getByText('直近5件')).toBeInTheDocument();
+    expect(screen.getByText('直近10件')).toBeInTheDocument();
+    expect(screen.getByText('直近20件')).toBeInTheDocument();
+    expect(screen.getByText('すべて')).toBeInTheDocument();
+  });
+
+  it('クイック選択ボタンクリックでonQuickSelectが呼ばれる', () => {
+    const onQuickSelect = vi.fn();
+    render(<MessageSelectionPanel {...defaultProps} onQuickSelect={onQuickSelect} />);
+    fireEvent.click(screen.getByText('直近10件'));
+    expect(onQuickSelect).toHaveBeenCalledWith(10);
+  });
+
+  it('すべてボタンクリックでonSelectAllが呼ばれる', () => {
+    const onSelectAll = vi.fn();
+    render(<MessageSelectionPanel {...defaultProps} onSelectAll={onSelectAll} />);
+    fireEvent.click(screen.getByText('すべて'));
+    expect(onSelectAll).toHaveBeenCalled();
+  });
+
+  it('リセットボタンクリックでonDeselectAllが呼ばれる', () => {
+    const onDeselectAll = vi.fn();
+    render(<MessageSelectionPanel {...defaultProps} onDeselectAll={onDeselectAll} />);
+    fireEvent.click(screen.getByText('リセット'));
+    expect(onDeselectAll).toHaveBeenCalled();
+  });
+
+  it('キャンセルボタンクリックでonCancelが呼ばれる', () => {
+    const onCancel = vi.fn();
+    render(<MessageSelectionPanel {...defaultProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('選択件数0の場合に送信ボタンが無効', () => {
+    render(<MessageSelectionPanel {...defaultProps} />);
+    expect(screen.getByText('範囲を選択してください')).toBeDisabled();
+  });
+
+  it('選択件数1以上の場合に送信ボタンが有効', () => {
+    const onSend = vi.fn();
+    render(<MessageSelectionPanel {...defaultProps} selectedCount={5} onSend={onSend} />);
+    const button = screen.getByText('5件をAIに送信');
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(onSend).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -3,6 +3,7 @@ import MessageInput from '../components/MessageInput';
 import ConfirmModal from '../components/ConfirmModal';
 import SceneSelector from '../components/SceneSelector';
 import RephraseModal from '../components/RephraseModal';
+import MessageSelectionPanel from '../components/MessageSelectionPanel';
 import { useChat } from '../hooks/useChat';
 
 export default function ChatPage() {
@@ -102,64 +103,14 @@ export default function ChatPage() {
       <div className="bg-surface-1 border-t border-surface-3 p-4">
         <div className="max-w-3xl mx-auto w-full space-y-3">
           {selectionMode ? (
-            <div className="space-y-3">
-              <div className="bg-surface-2 border border-[var(--color-border-hover)] rounded-lg p-3">
-                <p className="text-sm text-primary-300">
-                  {selectedMessages.size > 0
-                    ? `${selectedMessages.size}件のメッセージを選択しました`
-                    : '開始位置のメッセージをタップしてください'
-                  }
-                </p>
-              </div>
-
-              <div className="flex gap-2 flex-wrap">
-                <span className="text-xs text-[var(--color-text-muted)] self-center">クイック選択:</span>
-                {[5, 10, 20].map((n) => (
-                  <button
-                    key={n}
-                    onClick={() => handleQuickSelect(n)}
-                    className="px-3 py-1 text-xs bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] rounded-full transition-colors"
-                  >
-                    直近{n}件
-                  </button>
-                ))}
-                <button
-                  onClick={handleSelectAll}
-                  className="px-3 py-1 text-xs bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] rounded-full transition-colors"
-                >
-                  すべて
-                </button>
-                <button
-                  onClick={handleDeselectAll}
-                  className="px-3 py-1 text-xs text-rose-500 hover:bg-rose-900/30 rounded-full transition-colors"
-                >
-                  リセット
-                </button>
-              </div>
-
-              <div className="flex gap-2">
-                <button
-                  onClick={handleCancelSelection}
-                  className="flex-1 bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] font-medium py-2.5 px-4 rounded-lg text-sm transition-colors"
-                >
-                  キャンセル
-                </button>
-                <button
-                  onClick={handleSendToAi}
-                  disabled={selectedMessages.size === 0}
-                  className={`flex-1 font-medium py-2.5 px-4 rounded-lg text-sm transition-colors ${
-                    selectedMessages.size > 0
-                      ? 'bg-primary-500 hover:bg-primary-600 text-white'
-                      : 'bg-surface-3 text-[var(--color-text-muted)] cursor-not-allowed'
-                  }`}
-                >
-                  {selectedMessages.size > 0
-                    ? `${selectedMessages.size}件をAIに送信`
-                    : '範囲を選択してください'
-                  }
-                </button>
-              </div>
-            </div>
+            <MessageSelectionPanel
+              selectedCount={selectedMessages.size}
+              onQuickSelect={handleQuickSelect}
+              onSelectAll={handleSelectAll}
+              onDeselectAll={handleDeselectAll}
+              onCancel={handleCancelSelection}
+              onSend={handleSendToAi}
+            />
           ) : (
             <>
               {messages.length > 0 && (


### PR DESCRIPTION
## 概要
- ChatPageのメッセージ選択モードUIをMessageSelectionPanelコンポーネントに抽出
- ChatPage: 206行→157行（24%削減）

## 変更内容
- `MessageSelectionPanel` コンポーネント新規作成（選択件数表示・クイック選択・送信ボタン）
- ChatPageからインラインUIを除去し、コンポーネント呼び出しに置換
- 9テスト追加

## テスト
- `npx vitest run` 133ファイル 846テスト全パス

closes #436