### PR TITLE
test: LearningInsightsCard・SessionNoteEditor・ProfilePageテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/LearningInsightsCard.test.tsx
+++ b/frontend/src/components/__tests__/LearningInsightsCard.test.tsx
@@ -43,4 +43,43 @@ describe('LearningInsightsCard', () => {
 
     expect(screen.getByText('学習インサイト')).toBeInTheDocument();
   });
+
+  it('単位が表示される', () => {
+    render(
+      <LearningInsightsCard
+        totalSessions={5}
+        averageScore={6.5}
+        streakDays={3}
+      />
+    );
+
+    expect(screen.getByText('回')).toBeInTheDocument();
+    expect(screen.getByText('/10')).toBeInTheDocument();
+    expect(screen.getByText('日')).toBeInTheDocument();
+  });
+
+  it('平均スコアが小数点1桁で表示される', () => {
+    render(
+      <LearningInsightsCard
+        totalSessions={1}
+        averageScore={7}
+        streakDays={1}
+      />
+    );
+
+    expect(screen.getByText('7.0')).toBeInTheDocument();
+  });
+
+  it('3カラムグリッドレイアウトが適用される', () => {
+    const { container } = render(
+      <LearningInsightsCard
+        totalSessions={1}
+        averageScore={5.0}
+        streakDays={1}
+      />
+    );
+
+    const grid = container.querySelector('.grid-cols-3');
+    expect(grid).toBeTruthy();
+  });
 });

--- a/frontend/src/components/__tests__/SessionNoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/SessionNoteEditor.test.tsx
@@ -39,4 +39,22 @@ describe('SessionNoteEditor', () => {
 
     mockNote = '';
   });
+
+  it('振り返りメモラベルが表示される', () => {
+    render(<SessionNoteEditor sessionId={1} />);
+    expect(screen.getByText('振り返りメモ')).toBeInTheDocument();
+  });
+
+  it('保存ボタンが表示される', () => {
+    render(<SessionNoteEditor sessionId={1} />);
+    expect(screen.getByText('保存')).toBeInTheDocument();
+  });
+
+  it('テキストエリアの入力内容が更新される', () => {
+    render(<SessionNoteEditor sessionId={1} />);
+
+    const textarea = screen.getByPlaceholderText(/振り返りメモ/);
+    fireEvent.change(textarea, { target: { value: '新しいメモ' } });
+    expect(screen.getByDisplayValue('新しいメモ')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -39,4 +39,34 @@ describe('ProfilePage', () => {
       expect(screen.getByText('プロフィール取得に失敗しました。')).toBeInTheDocument();
     });
   });
+
+  it('プロファイル取得後にニックネーム欄が表示される', async () => {
+    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テストユーザー', bio: '自己紹介文' });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('テストユーザー')).toBeInTheDocument();
+    });
+  });
+
+  it('プロファイル取得後に自己紹介欄が表示される', async () => {
+    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: 'テスト自己紹介' });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('テスト自己紹介')).toBeInTheDocument();
+    });
+  });
+
+  it('アバターのイニシャルが表示される', async () => {
+    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テストユーザー', bio: '' });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('テ')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## 概要
- テスト数が3のコンポーネント/ページ3つを各6テストに拡充

## 変更内容
- LearningInsightsCard: 3→6テスト（単位表示・小数点フォーマット・グリッドレイアウト）
- SessionNoteEditor: 3→6テスト（ラベル・保存ボタン・テキスト更新）
- ProfilePage: 3→6テスト（ニックネーム・自己紹介・アバターイニシャル）

## テスト
- `npx vitest run` 133ファイル 855テスト全パス

closes #438