### PR TITLE
feat: セッションフィードバックサマリーカード追加

### DIFF
--- a/frontend/src/components/SessionFeedbackSummary.tsx
+++ b/frontend/src/components/SessionFeedbackSummary.tsx
@@ -1,0 +1,65 @@
+interface AxisScore {
+  axis: string;
+  score: number;
+  comment: string;
+}
+
+interface SessionFeedbackSummaryProps {
+  scores: AxisScore[];
+  overallScore: number;
+}
+
+function getGrade(score: number): { label: string; color: string } {
+  if (score >= 9.0) return { label: '秀', color: 'text-emerald-400' };
+  if (score >= 8.0) return { label: '優', color: 'text-blue-400' };
+  if (score >= 7.0) return { label: '良', color: 'text-primary-400' };
+  if (score >= 5.0) return { label: '可', color: 'text-yellow-400' };
+  return { label: '努力', color: 'text-red-400' };
+}
+
+function getBarColor(score: number): string {
+  if (score >= 8.0) return 'bg-emerald-500';
+  if (score >= 6.0) return 'bg-primary-500';
+  if (score >= 4.0) return 'bg-yellow-500';
+  return 'bg-red-500';
+}
+
+export default function SessionFeedbackSummary({ scores, overallScore }: SessionFeedbackSummaryProps) {
+  if (scores.length === 0) return null;
+
+  const grade = getGrade(overallScore);
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-[var(--color-text-secondary)]">スキル別スコア</p>
+        <span className={`text-sm font-bold ${grade.color}`}>{grade.label}</span>
+      </div>
+
+      <div className="space-y-2">
+        {scores.map((s) => (
+          <div key={s.axis} className="flex items-center gap-2">
+            <span className="text-[10px] text-[var(--color-text-muted)] w-20 flex-shrink-0 truncate">
+              {s.axis}
+            </span>
+            <div
+              role="progressbar"
+              aria-valuenow={s.score}
+              aria-valuemin={0}
+              aria-valuemax={10}
+              className="flex-1 bg-surface-3 rounded-full h-1.5"
+            >
+              <div
+                className={`h-1.5 rounded-full ${getBarColor(s.score)}`}
+                style={{ width: `${s.score * 10}%` }}
+              />
+            </div>
+            <span className="text-xs font-semibold text-[var(--color-text-primary)] w-8 text-right">
+              {s.score.toFixed(1)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SessionFeedbackSummary.test.tsx
+++ b/frontend/src/components/__tests__/SessionFeedbackSummary.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SessionFeedbackSummary from '../SessionFeedbackSummary';
+
+const mockScores = [
+  { axis: '論理的構成力', score: 8.5, comment: '良い' },
+  { axis: '配慮表現', score: 7.0, comment: '普通' },
+  { axis: '要約力', score: 9.0, comment: '優秀' },
+  { axis: '提案力', score: 6.0, comment: '改善点あり' },
+  { axis: '質問・傾聴力', score: 5.5, comment: '要練習' },
+];
+
+describe('SessionFeedbackSummary', () => {
+  it('全スキル軸名が表示される', () => {
+    render(<SessionFeedbackSummary scores={mockScores} overallScore={7.2} />);
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+    expect(screen.getByText('配慮表現')).toBeInTheDocument();
+    expect(screen.getByText('要約力')).toBeInTheDocument();
+    expect(screen.getByText('提案力')).toBeInTheDocument();
+    expect(screen.getByText('質問・傾聴力')).toBeInTheDocument();
+  });
+
+  it('各スキル軸のスコアが表示される', () => {
+    render(<SessionFeedbackSummary scores={mockScores} overallScore={7.2} />);
+    expect(screen.getByText('8.5')).toBeInTheDocument();
+    expect(screen.getByText('7.0')).toBeInTheDocument();
+    expect(screen.getByText('9.0')).toBeInTheDocument();
+    expect(screen.getByText('6.0')).toBeInTheDocument();
+    expect(screen.getByText('5.5')).toBeInTheDocument();
+  });
+
+  it('総合スコアが高い場合に秀の判定が表示される', () => {
+    render(<SessionFeedbackSummary scores={mockScores} overallScore={9.5} />);
+    expect(screen.getByText('秀')).toBeInTheDocument();
+  });
+
+  it('総合スコアが中程度の場合に良の判定が表示される', () => {
+    render(<SessionFeedbackSummary scores={mockScores} overallScore={7.0} />);
+    expect(screen.getByText('良')).toBeInTheDocument();
+  });
+
+  it('スコアが空の場合は表示されない', () => {
+    const { container } = render(<SessionFeedbackSummary scores={[]} overallScore={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('見出しが表示される', () => {
+    render(<SessionFeedbackSummary scores={mockScores} overallScore={7.2} />);
+    expect(screen.getByText('スキル別スコア')).toBeInTheDocument();
+  });
+
+  it('プログレスバーが表示される', () => {
+    const { container } = render(<SessionFeedbackSummary scores={mockScores} overallScore={7.0} />);
+    const bars = container.querySelectorAll('[role="progressbar"]');
+    expect(bars).toHaveLength(5);
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -20,6 +20,7 @@ import SessionDetailModal from '../components/SessionDetailModal';
 import ScoreHistorySessionCard from '../components/ScoreHistorySessionCard';
 import ScoreFilterSummary from '../components/ScoreFilterSummary';
 import ScoreTrendIndicator from '../components/ScoreTrendIndicator';
+import SessionFeedbackSummary from '../components/SessionFeedbackSummary';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 const AXIS_ADVICE: Record<string, string> = {
@@ -94,6 +95,11 @@ export default function ScoreHistoryPage() {
           </div>
           <ScoreRankBadge score={latestSession.overallScore} />
         </div>
+      )}
+
+      {/* セッションフィードバックサマリー */}
+      {latestSession && latestSession.scores.length > 0 && (
+        <SessionFeedbackSummary scores={latestSession.scores} overallScore={latestSession.overallScore} />
       )}
 
       {/* 弱点ベースのおすすめ練習 */}


### PR DESCRIPTION
## 概要
- 各スキル軸のスコアを横棒グラフで表示
- 総合スコアに応じたレベル判定（秀/優/良/可/努力）を色分け表示
- ScoreHistoryPageの最新スコア下に統合

## 変更内容
- `SessionFeedbackSummary` コンポーネント新規作成
- スコアに応じた色分けバー（emerald/primary/yellow/red）
- 7テスト追加

## テスト
- `npx vitest run` 134ファイル 862テスト全パス

closes #442