### PR TITLE
refactor: ScoreHistoryPageからWeakAxisAdviceCard抽出

### DIFF
--- a/frontend/src/components/WeakAxisAdviceCard.tsx
+++ b/frontend/src/components/WeakAxisAdviceCard.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom';
+
+interface WeakAxisAdviceCardProps {
+  axis: string;
+}
+
+const AXIS_ADVICE: Record<string, string> = {
+  '論理的構成力': '論理的構成力を伸ばすシナリオで練習しましょう',
+  '配慮表現': '配慮表現を伸ばすシナリオで練習しましょう',
+  '要約力': '要約力を伸ばすシナリオで練習しましょう',
+  '提案力': '提案力を伸ばすシナリオで練習しましょう',
+  '質問・傾聴力': '質問・傾聴力を伸ばすシナリオで練習しましょう',
+};
+
+export default function WeakAxisAdviceCard({ axis }: WeakAxisAdviceCardProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="bg-surface-2 rounded-lg border border-[var(--color-border-hover)] p-4">
+      <p className="text-xs font-semibold text-primary-300 mb-1">おすすめ練習</p>
+      <p className="text-xs text-primary-400 mb-2">
+        {AXIS_ADVICE[axis] || `${axis}を伸ばすシナリオで練習しましょう`}
+      </p>
+      <button
+        onClick={() => navigate('/practice')}
+        className="text-xs font-medium text-primary-300 bg-surface-1 px-3 py-1.5 rounded-lg border border-[var(--color-border-hover)] hover:bg-surface-3 transition-colors"
+      >
+        練習一覧を見る
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/WeakAxisAdviceCard.test.tsx
+++ b/frontend/src/components/__tests__/WeakAxisAdviceCard.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import WeakAxisAdviceCard from '../WeakAxisAdviceCard';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe('WeakAxisAdviceCard', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('おすすめ練習のタイトルが表示される', () => {
+    render(<WeakAxisAdviceCard axis="論理的構成力" />);
+    expect(screen.getByText('おすすめ練習')).toBeInTheDocument();
+  });
+
+  it('既知の軸に対応するアドバイスが表示される', () => {
+    render(<WeakAxisAdviceCard axis="配慮表現" />);
+    expect(screen.getByText('配慮表現を伸ばすシナリオで練習しましょう')).toBeInTheDocument();
+  });
+
+  it('未知の軸に対してもアドバイスが表示される', () => {
+    render(<WeakAxisAdviceCard axis="カスタム軸" />);
+    expect(screen.getByText('カスタム軸を伸ばすシナリオで練習しましょう')).toBeInTheDocument();
+  });
+
+  it('練習一覧ボタンが表示される', () => {
+    render(<WeakAxisAdviceCard axis="論理的構成力" />);
+    expect(screen.getByText('練習一覧を見る')).toBeInTheDocument();
+  });
+
+  it('ボタンクリックで練習ページに遷移する', () => {
+    render(<WeakAxisAdviceCard axis="論理的構成力" />);
+    fireEvent.click(screen.getByText('練習一覧を見る'));
+    expect(mockNavigate).toHaveBeenCalledWith('/practice');
+  });
+
+  it('要約力のアドバイスが正しく表示される', () => {
+    render(<WeakAxisAdviceCard axis="要約力" />);
+    expect(screen.getByText('要約力を伸ばすシナリオで練習しましょう')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import { SkeletonCard } from '../components/Skeleton';
 import SkillRadarChart from '../components/SkillRadarChart';
 import PracticeCalendar from '../components/PracticeCalendar';
@@ -21,19 +20,11 @@ import ScoreHistorySessionCard from '../components/ScoreHistorySessionCard';
 import ScoreFilterSummary from '../components/ScoreFilterSummary';
 import ScoreTrendIndicator from '../components/ScoreTrendIndicator';
 import SessionFeedbackSummary from '../components/SessionFeedbackSummary';
+import WeakAxisAdviceCard from '../components/WeakAxisAdviceCard';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
-
-const AXIS_ADVICE: Record<string, string> = {
-  '論理的構成力': '論理的構成力を伸ばすシナリオで練習しましょう',
-  '配慮表現': '配慮表現を伸ばすシナリオで練習しましょう',
-  '要約力': '要約力を伸ばすシナリオで練習しましょう',
-  '提案力': '提案力を伸ばすシナリオで練習しましょう',
-  '質問・傾聴力': '質問・傾聴力を伸ばすシナリオで練習しましょう',
-};
 
 export default function ScoreHistoryPage() {
   const { history, filteredHistory, filter, setFilter, loading, latestSession, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
-  const navigate = useNavigate();
 
   if (loading) {
     return (
@@ -103,20 +94,7 @@ export default function ScoreHistoryPage() {
       )}
 
       {/* 弱点ベースのおすすめ練習 */}
-      {weakestAxis && (
-        <div className="bg-surface-2 rounded-lg border border-[var(--color-border-hover)] p-4">
-          <p className="text-xs font-semibold text-primary-300 mb-1">おすすめ練習</p>
-          <p className="text-xs text-primary-400 mb-2">
-            {AXIS_ADVICE[weakestAxis.axis] || `${weakestAxis.axis}を伸ばすシナリオで練習しましょう`}
-          </p>
-          <button
-            onClick={() => navigate('/practice')}
-            className="text-xs font-medium text-primary-300 bg-surface-1 px-3 py-1.5 rounded-lg border border-[var(--color-border-hover)] hover:bg-surface-3 transition-colors"
-          >
-            練習一覧を見る
-          </button>
-        </div>
-      )}
+      {weakestAxis && <WeakAxisAdviceCard axis={weakestAxis.axis} />}
 
       {/* スキルレーダーチャート */}
       {latestSession && latestSession.scores.length > 0 && (


### PR DESCRIPTION
## 概要
- ScoreHistoryPageの弱点ベースおすすめ練習セクションをWeakAxisAdviceCardに抽出
- ScoreHistoryPage: 237行→215行、useNavigateインポート除去

## 変更内容
- `WeakAxisAdviceCard` コンポーネント新規作成（AXIS_ADVICE定数・アドバイス表示・練習ボタン）
- ScoreHistoryPageからインラインUI・AXIS_ADVICE定数を除去
- 6テスト追加

## テスト
- `npx vitest run` 135ファイル 868テスト全パス

closes #444