### PR TITLE
test: InputField・Loading・EmptyState・Skeletonテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/__tests__/EmptyState.test.tsx
@@ -39,4 +39,18 @@ describe('EmptyState', () => {
     render(<EmptyState icon={ChatBubbleLeftRightIcon} title="テスト" />);
     expect(screen.queryByRole('button')).toBeNull();
   });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<EmptyState icon={ChatBubbleLeftRightIcon} title="テスト" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+
+  it('説明文なしの場合説明が表示されない', () => {
+    const { container } = render(<EmptyState icon={ChatBubbleLeftRightIcon} title="テスト" />);
+    const paragraphs = container.querySelectorAll('p');
+    // タイトルのみ
+    const texts = Array.from(paragraphs).map(p => p.textContent);
+    expect(texts).not.toContain('詳しい説明テキスト');
+  });
 });

--- a/frontend/src/components/__tests__/InputField.test.tsx
+++ b/frontend/src/components/__tests__/InputField.test.tsx
@@ -35,4 +35,14 @@ describe('InputField', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(mockOnChange).toHaveBeenCalledWith({ target: { name: 'email', value: '' } });
   });
+
+  it('空の値ではクリアボタンが表示されない', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('デフォルトのtypeがtextである', () => {
+    render(<InputField label="名前" name="name" value="" onChange={mockOnChange} />);
+    expect(screen.getByLabelText('名前')).toHaveAttribute('type', 'text');
+  });
 });

--- a/frontend/src/components/__tests__/Loading.test.tsx
+++ b/frontend/src/components/__tests__/Loading.test.tsx
@@ -26,4 +26,14 @@ describe('Loading', () => {
 
     expect(container.querySelector('p')).toBeNull();
   });
+
+  it('スピナーにaria-labelが設定される', () => {
+    render(<Loading />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', '読み込み中');
+  });
+
+  it('アニメーションクラスが適用される', () => {
+    render(<Loading />);
+    expect(screen.getByRole('status').className).toContain('animate-spin');
+  });
 });

--- a/frontend/src/components/__tests__/Skeleton.test.tsx
+++ b/frontend/src/components/__tests__/Skeleton.test.tsx
@@ -33,4 +33,19 @@ describe('SkeletonList', () => {
     const elements = screen.getAllByRole('status');
     expect(elements.length).toBeGreaterThan(0);
   });
+
+  it('count指定でリスト件数が変わる', () => {
+    render(<SkeletonList count={5} />);
+
+    const elements = screen.getAllByRole('status');
+    expect(elements.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('Skeleton - アニメーション', () => {
+  it('アニメーションクラスが適用される', () => {
+    render(<Skeleton />);
+    const el = screen.getByRole('status');
+    expect(el.className).toContain('animate-skeleton');
+  });
 });


### PR DESCRIPTION
## 概要
- テスト数が4の基盤コンポーネント4つを各6テストに拡充

## 変更内容
- InputField: 4→6テスト（空値クリアボタン非表示・デフォルトtype）
- Loading: 4→6テスト（aria-label・アニメーションクラス）
- EmptyState: 4→6テスト（アイコン表示・説明文なし確認）
- Skeleton: 4→6テスト（リスト件数変更・アニメーションクラス）

## テスト
- `npx vitest run` 135ファイル 876テスト全パス

closes #446