### PR TITLE
feat: 練習セッション完了カード追加

### DIFF
--- a/frontend/src/components/SessionCompleteCard.tsx
+++ b/frontend/src/components/SessionCompleteCard.tsx
@@ -1,0 +1,54 @@
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
+
+interface SessionCompleteCardProps {
+  duration: number;
+  messageCount: number;
+  onViewScores: () => void;
+  onPracticeAgain: () => void;
+}
+
+function formatDuration(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}:${String(secs).padStart(2, '0')}`;
+}
+
+export default function SessionCompleteCard({
+  duration,
+  messageCount,
+  onViewScores,
+  onPracticeAgain,
+}: SessionCompleteCardProps) {
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-6 text-center">
+      <CheckCircleIcon className="w-10 h-10 text-emerald-400 mx-auto mb-3" />
+      <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">セッション完了</h3>
+
+      <div className="grid grid-cols-2 gap-4 mb-5">
+        <div>
+          <p className="text-[10px] text-[var(--color-text-muted)]">経過時間</p>
+          <p className="text-lg font-semibold text-[var(--color-text-primary)]">{formatDuration(duration)}</p>
+        </div>
+        <div>
+          <p className="text-[10px] text-[var(--color-text-muted)]">メッセージ数</p>
+          <p className="text-lg font-semibold text-[var(--color-text-primary)]">{messageCount}</p>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          onClick={onViewScores}
+          className="flex-1 bg-primary-500 hover:bg-primary-600 text-white font-medium py-2.5 px-4 rounded-lg text-sm transition-colors"
+        >
+          スコアを確認
+        </button>
+        <button
+          onClick={onPracticeAgain}
+          className="flex-1 bg-surface-3 hover:bg-surface-3 text-[var(--color-text-secondary)] font-medium py-2.5 px-4 rounded-lg text-sm transition-colors"
+        >
+          もう一度練習
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SessionCompleteCard.test.tsx
+++ b/frontend/src/components/__tests__/SessionCompleteCard.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SessionCompleteCard from '../SessionCompleteCard';
+
+describe('SessionCompleteCard', () => {
+  const defaultProps = {
+    duration: 300,
+    messageCount: 12,
+    onViewScores: vi.fn(),
+    onPracticeAgain: vi.fn(),
+  };
+
+  it('完了メッセージが表示される', () => {
+    render(<SessionCompleteCard {...defaultProps} />);
+    expect(screen.getByText('セッション完了')).toBeInTheDocument();
+  });
+
+  it('経過時間がフォーマットされて表示される', () => {
+    render(<SessionCompleteCard {...defaultProps} />);
+    expect(screen.getByText('5:00')).toBeInTheDocument();
+  });
+
+  it('メッセージ数が表示される', () => {
+    render(<SessionCompleteCard {...defaultProps} />);
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('スコア確認ボタンクリックでonViewScoresが呼ばれる', () => {
+    const onViewScores = vi.fn();
+    render(<SessionCompleteCard {...defaultProps} onViewScores={onViewScores} />);
+    fireEvent.click(screen.getByText('スコアを確認'));
+    expect(onViewScores).toHaveBeenCalled();
+  });
+
+  it('もう一度練習ボタンクリックでonPracticeAgainが呼ばれる', () => {
+    const onPracticeAgain = vi.fn();
+    render(<SessionCompleteCard {...defaultProps} onPracticeAgain={onPracticeAgain} />);
+    fireEvent.click(screen.getByText('もう一度練習'));
+    expect(onPracticeAgain).toHaveBeenCalled();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<SessionCompleteCard {...defaultProps} />);
+    expect(screen.getByText('経過時間')).toBeInTheDocument();
+    expect(screen.getByText('メッセージ数')).toBeInTheDocument();
+  });
+
+  it('1時間以上の場合も正しくフォーマットされる', () => {
+    render(<SessionCompleteCard {...defaultProps} duration={3661} />);
+    expect(screen.getByText('61:01')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- セッション完了時に経過時間・メッセージ数を表示する達成カード
- スコア確認・もう一度練習ボタンで次のアクションへの導線

## 変更内容
- `SessionCompleteCard` コンポーネント新規作成
- CheckCircleIconで達成感を演出
- 7テスト追加

## テスト
- `npx vitest run` 136ファイル 883テスト全パス

closes #450