### PR TITLE
test: CommunicationTipCard・ExportSessionButton・PracticeTimer・ScoreStatsSummaryのテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/CommunicationTipCard.test.tsx
+++ b/frontend/src/components/__tests__/CommunicationTipCard.test.tsx
@@ -37,4 +37,18 @@ describe('CommunicationTipCard', () => {
 
     vi.useRealTimers();
   });
+
+  it('Tipsテキストが空でない', () => {
+    render(<CommunicationTipCard />);
+    const text = screen.getByTestId('tip-text').textContent;
+    expect(text).toBeTruthy();
+    expect(text!.length).toBeGreaterThan(0);
+  });
+
+  it('カードの境界線スタイルが適用される', () => {
+    const { container } = render(<CommunicationTipCard />);
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain('border');
+    expect(card.className).toContain('rounded-lg');
+  });
 });

--- a/frontend/src/components/__tests__/ExportSessionButton.test.tsx
+++ b/frontend/src/components/__tests__/ExportSessionButton.test.tsx
@@ -52,4 +52,25 @@ describe('ExportSessionButton', () => {
     const button = screen.getByTitle('会話をコピー');
     expect(button).toBeDisabled();
   });
+
+  it('コピーテキストにロール名が含まれる', async () => {
+    render(<ExportSessionButton messages={mockMessages} />);
+
+    fireEvent.click(screen.getByTitle('会話をコピー'));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('あなた')
+      );
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringContaining('AI')
+      );
+    });
+  });
+
+  it('ボタンがbutton要素である', () => {
+    render(<ExportSessionButton messages={mockMessages} />);
+    const button = screen.getByTitle('会話をコピー');
+    expect(button.tagName).toBe('BUTTON');
+  });
 });

--- a/frontend/src/components/__tests__/PracticeTimer.test.tsx
+++ b/frontend/src/components/__tests__/PracticeTimer.test.tsx
@@ -42,4 +42,17 @@ describe('PracticeTimer', () => {
 
     expect(mockStop).toHaveBeenCalled();
   });
+
+  it('時間がmonospaceフォントで表示される', () => {
+    render(<PracticeTimer />);
+    const timeElement = screen.getByText('02:05');
+    expect(timeElement.className).toContain('font-mono');
+  });
+
+  it('ラベルと時間が同じコンテナ内にある', () => {
+    const { container } = render(<PracticeTimer />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain('flex');
+    expect(wrapper.className).toContain('items-center');
+  });
 });

--- a/frontend/src/components/__tests__/ScoreStatsSummary.test.tsx
+++ b/frontend/src/components/__tests__/ScoreStatsSummary.test.tsx
@@ -35,4 +35,16 @@ describe('ScoreStatsSummary', () => {
 
     expect(container.firstChild).toBeNull();
   });
+
+  it('3カラムグリッドで表示される', () => {
+    const { container } = render(<ScoreStatsSummary history={mockHistory} />);
+    const grid = container.firstElementChild as HTMLElement;
+    expect(grid.className).toContain('grid-cols-3');
+  });
+
+  it('最高スコアがアンバー色で表示される', () => {
+    render(<ScoreStatsSummary history={mockHistory} />);
+    const bestScore = screen.getByText('9.2');
+    expect(bestScore.className).toContain('text-amber-400');
+  });
 });


### PR DESCRIPTION
## 概要
- 4テストのコンポーネント4つを各6テストに拡充（+8テスト）
- CommunicationTipCard: テキスト非空、カード構造
- ExportSessionButton: ロール名含有、button要素
- PracticeTimer: monospaceフォント、flexレイアウト
- ScoreStatsSummary: 3カラムグリッド、最高スコア色

## テスト
- 全900テストパス

closes #454