### PR TITLE
feat: PersonalBestCard（自己ベストスコアカード）追加

### DIFF
--- a/frontend/src/components/PersonalBestCard.tsx
+++ b/frontend/src/components/PersonalBestCard.tsx
@@ -1,0 +1,31 @@
+import { TrophyIcon } from '@heroicons/react/24/solid';
+
+interface PersonalBestCardProps {
+  history: { sessionId: number; overallScore: number; createdAt: string }[];
+}
+
+export default function PersonalBestCard({ history }: PersonalBestCardProps) {
+  if (history.length === 0) return null;
+
+  const best = history.reduce((prev, curr) =>
+    curr.overallScore > prev.overallScore ? curr : prev
+  );
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <TrophyIcon className="w-5 h-5 text-amber-400" />
+        <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">自己ベスト</h3>
+      </div>
+      <div className="text-center">
+        <p className="text-3xl font-bold text-amber-400">{best.overallScore}</p>
+        <div className="mt-1">
+          <p className="text-[10px] text-[var(--color-text-muted)]">達成日</p>
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            {new Date(best.createdAt).toLocaleDateString('ja-JP')}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PersonalBestCard.test.tsx
+++ b/frontend/src/components/__tests__/PersonalBestCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PersonalBestCard from '../PersonalBestCard';
+
+const mockHistory = [
+  { sessionId: 1, overallScore: 7.5, createdAt: '2025-01-10T10:00:00' },
+  { sessionId: 2, overallScore: 9.2, createdAt: '2025-01-15T14:00:00' },
+  { sessionId: 3, overallScore: 8.0, createdAt: '2025-01-20T09:00:00' },
+];
+
+describe('PersonalBestCard', () => {
+  it('自己ベストスコアが表示される', () => {
+    render(<PersonalBestCard history={mockHistory} />);
+    expect(screen.getByText('9.2')).toBeInTheDocument();
+  });
+
+  it('自己ベストのタイトルが表示される', () => {
+    render(<PersonalBestCard history={mockHistory} />);
+    expect(screen.getByText('自己ベスト')).toBeInTheDocument();
+  });
+
+  it('達成日が表示される', () => {
+    render(<PersonalBestCard history={mockHistory} />);
+    expect(screen.getByText('2025/1/15')).toBeInTheDocument();
+  });
+
+  it('履歴が空の場合は何も表示しない', () => {
+    const { container } = render(<PersonalBestCard history={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('単一セッションでも表示される', () => {
+    render(<PersonalBestCard history={[mockHistory[0]]} />);
+    expect(screen.getByText('7.5')).toBeInTheDocument();
+  });
+
+  it('トロフィーアイコンが表示される', () => {
+    const { container } = render(<PersonalBestCard history={mockHistory} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+
+  it('達成ラベルが表示される', () => {
+    render(<PersonalBestCard history={mockHistory} />);
+    expect(screen.getByText('達成日')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -21,6 +21,7 @@ import ScoreFilterSummary from '../components/ScoreFilterSummary';
 import ScoreTrendIndicator from '../components/ScoreTrendIndicator';
 import SessionFeedbackSummary from '../components/SessionFeedbackSummary';
 import WeakAxisAdviceCard from '../components/WeakAxisAdviceCard';
+import PersonalBestCard from '../components/PersonalBestCard';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 export default function ScoreHistoryPage() {
@@ -73,6 +74,9 @@ export default function ScoreHistoryPage() {
 
       {/* 統計サマリー */}
       <ScoreStatsSummary history={history} />
+
+      {/* 自己ベスト */}
+      <PersonalBestCard history={history} />
 
       {/* 週間比較 */}
       <WeeklyComparisonCard sessions={history} />


### PR DESCRIPTION
## 概要
- 総合スコアの自己ベストを日付付きで表示するカードを追加
- トロフィーアイコン（TrophyIcon）でモチベーション向上
- スコア履歴ページの統計サマリー下に配置

## テスト
- 7テスト追加（スコア表示、タイトル、達成日、空履歴、単一セッション、アイコン、ラベル）
- 全907テストパス

closes #458