### PR TITLE
refactor: UserProfilePageからPersonalityTraitSelectorを抽出

### DIFF
--- a/frontend/src/components/PersonalityTraitSelector.tsx
+++ b/frontend/src/components/PersonalityTraitSelector.tsx
@@ -1,0 +1,39 @@
+interface PersonalityTraitSelectorProps {
+  options: string[];
+  selected: string[];
+  onToggle: (trait: string) => void;
+  label?: string;
+}
+
+export default function PersonalityTraitSelector({
+  options,
+  selected,
+  onToggle,
+  label,
+}: PersonalityTraitSelectorProps) {
+  return (
+    <div>
+      {label && (
+        <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-2">
+          {label}
+        </label>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((trait) => (
+          <button
+            key={trait}
+            type="button"
+            onClick={() => onToggle(trait)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              selected.includes(trait)
+                ? 'bg-primary-500 text-white'
+                : 'bg-surface-3 text-[var(--color-text-secondary)] hover:bg-surface-3'
+            }`}
+          >
+            {trait}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PersonalityTraitSelector.test.tsx
+++ b/frontend/src/components/__tests__/PersonalityTraitSelector.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PersonalityTraitSelector from '../PersonalityTraitSelector';
+
+const traits = ['社交的', '慎重', '論理的', '共感的', '積極的'];
+
+describe('PersonalityTraitSelector', () => {
+  it('すべての性格特性が表示される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+      />
+    );
+    traits.forEach((trait) => {
+      expect(screen.getByText(trait)).toBeInTheDocument();
+    });
+  });
+
+  it('選択済みの特性にアクティブスタイルが適用される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={['社交的']}
+        onToggle={vi.fn()}
+      />
+    );
+    const button = screen.getByText('社交的');
+    expect(button.className).toContain('bg-primary-500');
+    expect(button.className).toContain('text-white');
+  });
+
+  it('未選択の特性に非アクティブスタイルが適用される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+      />
+    );
+    const button = screen.getByText('社交的');
+    expect(button.className).toContain('bg-surface-3');
+  });
+
+  it('クリックでonToggleが呼ばれる', () => {
+    const onToggle = vi.fn();
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={onToggle}
+      />
+    );
+    fireEvent.click(screen.getByText('論理的'));
+    expect(onToggle).toHaveBeenCalledWith('論理的');
+  });
+
+  it('ラベルが表示される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+        label="性格特性"
+      />
+    );
+    expect(screen.getByText('性格特性')).toBeInTheDocument();
+  });
+
+  it('ボタンがtype=buttonである', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+      />
+    );
+    const button = screen.getByText('社交的');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('複数の特性を選択できる', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={['社交的', '論理的']}
+        onToggle={vi.fn()}
+      />
+    );
+    expect(screen.getByText('社交的').className).toContain('bg-primary-500');
+    expect(screen.getByText('論理的').className).toContain('bg-primary-500');
+    expect(screen.getByText('慎重').className).toContain('bg-surface-3');
+  });
+});

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,6 +1,7 @@
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import Loading from '../components/Loading';
+import PersonalityTraitSelector from '../components/PersonalityTraitSelector';
 import {
   ChatBubbleLeftRightIcon,
   LightBulbIcon,
@@ -111,27 +112,12 @@ export default function UserProfilePage() {
                 </select>
               </div>
 
-              <div>
-                <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-2">
-                  性格特性（当てはまるものを選んでください）
-                </label>
-                <div className="flex flex-wrap gap-1.5">
-                  {PERSONALITY_OPTIONS.map((trait) => (
-                    <button
-                      key={trait}
-                      type="button"
-                      onClick={() => togglePersonalityTrait(trait)}
-                      className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-                        form.personalityTraits.includes(trait)
-                          ? 'bg-primary-500 text-white'
-                          : 'bg-surface-3 text-[var(--color-text-secondary)] hover:bg-surface-3'
-                      }`}
-                    >
-                      {trait}
-                    </button>
-                  ))}
-                </div>
-              </div>
+              <PersonalityTraitSelector
+                options={PERSONALITY_OPTIONS}
+                selected={form.personalityTraits}
+                onToggle={togglePersonalityTrait}
+                label="性格特性（当てはまるものを選んでください）"
+              />
             </div>
           </div>
 


### PR DESCRIPTION
## 概要
- UserProfilePage.tsxの性格特性選択UIを`PersonalityTraitSelector`コンポーネントに抽出
- 再利用可能なチップ選択UIコンポーネント
- UserProfilePage: 206行 → 192行

## テスト
- 7テスト追加（全特性表示、アクティブ/非アクティブスタイル、トグル、ラベル、button type、複数選択）
- 全914テストパス

closes #460