### PR TITLE
test: AuthLayout・ErrorBoundary・MessageBubbleAi・WeeklyReportCardのテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/components/__tests__/AuthLayout.test.tsx
@@ -32,4 +32,18 @@ describe('AuthLayout', () => {
     const card = container.querySelector('.border-t-primary-500');
     expect(card).toBeTruthy();
   });
+
+  it('中央寄せレイアウトが適用される', () => {
+    const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper.className).toContain('flex');
+    expect(wrapper.className).toContain('items-center');
+    expect(wrapper.className).toContain('justify-center');
+  });
+
+  it('カードに角丸が適用される', () => {
+    const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
+    const card = container.querySelector('.rounded-2xl');
+    expect(card).toBeTruthy();
+  });
 });

--- a/frontend/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/__tests__/ErrorBoundary.test.tsx
@@ -53,4 +53,25 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText(/予期せぬエラーが発生しました/)).toBeInTheDocument();
   });
+
+  it('エラー発生時に子コンテンツが非表示になる', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.queryByText('正常なコンテンツ')).toBeNull();
+  });
+
+  it('再試行ボタンがbutton要素である', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowError shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    const button = screen.getByText('再試行');
+    expect(button.tagName).toBe('BUTTON');
+  });
 });

--- a/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
@@ -26,4 +26,22 @@ describe('MessageBubbleAi', () => {
 
     expect(screen.getByAltText('画像')).toBeInTheDocument();
   });
+
+  it('送信者と受信者で異なるスタイルが適用される', () => {
+    const { container: senderContainer } = render(
+      <MessageBubbleAi isSender={true} content="送信" id={1} />
+    );
+    const { container: receiverContainer } = render(
+      <MessageBubbleAi isSender={false} content="受信" id={2} />
+    );
+    const senderBubble = senderContainer.firstElementChild as HTMLElement;
+    const receiverBubble = receiverContainer.firstElementChild as HTMLElement;
+    expect(senderBubble.className).not.toBe(receiverBubble.className);
+  });
+
+  it('長いメッセージも表示される', () => {
+    const longMessage = 'テスト'.repeat(100);
+    render(<MessageBubbleAi isSender={false} content={longMessage} id={1} />);
+    expect(screen.getByText(longMessage)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/WeeklyReportCard.test.tsx
+++ b/frontend/src/components/__tests__/WeeklyReportCard.test.tsx
@@ -49,4 +49,15 @@ describe('WeeklyReportCard', () => {
 
     expect(screen.getByText('今週のレポート')).toBeInTheDocument();
   });
+
+  it('曜日ラベルが表示される', () => {
+    render(<WeeklyReportCard allScores={[]} />);
+    expect(screen.getByText('月')).toBeInTheDocument();
+    expect(screen.getByText('日')).toBeInTheDocument();
+  });
+
+  it('練習した曜日セクションが表示される', () => {
+    render(<WeeklyReportCard allScores={[]} />);
+    expect(screen.getByText('練習した曜日')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- 4テストのコンポーネント4つを各6テストに拡充（+8テスト）
- AuthLayout: 中央寄せレイアウト、角丸スタイル
- ErrorBoundary: 子コンテンツ非表示、再試行ボタン要素
- MessageBubbleAi: 送受信スタイル差異、長文メッセージ
- WeeklyReportCard: 曜日ラベル、練習曜日セクション

## テスト
- 全922テストパス

closes #462