### PR TITLE
feat: SessionCountMilestoneCard（セッション数マイルストーンカード）追加

### DIFF
--- a/frontend/src/components/SessionCountMilestoneCard.tsx
+++ b/frontend/src/components/SessionCountMilestoneCard.tsx
@@ -1,0 +1,57 @@
+import { StarIcon } from '@heroicons/react/24/solid';
+
+interface SessionCountMilestoneCardProps {
+  sessionCount: number;
+}
+
+const MILESTONES = [10, 25, 50, 100];
+
+function getNextMilestone(count: number): number | null {
+  return MILESTONES.find((m) => m > count) ?? null;
+}
+
+export default function SessionCountMilestoneCard({ sessionCount }: SessionCountMilestoneCardProps) {
+  const nextMilestone = getNextMilestone(sessionCount);
+  const allAchieved = nextMilestone === null;
+
+  const prevMilestone = allAchieved
+    ? MILESTONES[MILESTONES.length - 2]
+    : MILESTONES[MILESTONES.indexOf(nextMilestone) - 1] ?? 0;
+
+  const progress = allAchieved
+    ? 100
+    : Math.round(((sessionCount - prevMilestone) / (nextMilestone - prevMilestone)) * 100);
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <StarIcon className="w-5 h-5 text-amber-400" />
+        <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">セッション達成</h3>
+      </div>
+
+      <div className="flex items-baseline gap-2 mb-2">
+        <span className="text-2xl font-bold text-[var(--color-text-primary)]">{sessionCount}</span>
+        <span className="text-xs text-[var(--color-text-muted)]">
+          {allAchieved ? '全マイルストーン達成!' : `/ ${nextMilestone} 回`}
+        </span>
+      </div>
+
+      <div
+        role="progressbar"
+        aria-valuenow={progress}
+        className="w-full h-2 bg-surface-3 rounded-full overflow-hidden"
+      >
+        <div
+          className="h-full bg-amber-400 rounded-full transition-all"
+          style={{ width: `${Math.min(progress, 100)}%` }}
+        />
+      </div>
+
+      {allAchieved && (
+        <p className="text-xs text-amber-400 mt-2 font-medium">
+          素晴らしい! 100回以上の練習を達成しました!
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SessionCountMilestoneCard.test.tsx
+++ b/frontend/src/components/__tests__/SessionCountMilestoneCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SessionCountMilestoneCard from '../SessionCountMilestoneCard';
+
+describe('SessionCountMilestoneCard', () => {
+  it('現在のセッション数が表示される', () => {
+    render(<SessionCountMilestoneCard sessionCount={7} />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('次のマイルストーンが表示される', () => {
+    render(<SessionCountMilestoneCard sessionCount={7} />);
+    expect(screen.getByText(/10/)).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<SessionCountMilestoneCard sessionCount={7} />);
+    expect(screen.getByText('セッション達成')).toBeInTheDocument();
+  });
+
+  it('0セッションの場合も表示される', () => {
+    render(<SessionCountMilestoneCard sessionCount={0} />);
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('マイルストーン達成時に祝福メッセージが表示される', () => {
+    render(<SessionCountMilestoneCard sessionCount={100} />);
+    expect(screen.getByText(/100回以上の練習を達成/)).toBeInTheDocument();
+  });
+
+  it('プログレスバーが表示される', () => {
+    const { container } = render(<SessionCountMilestoneCard sessionCount={5} />);
+    const progressBar = container.querySelector('[role="progressbar"]');
+    expect(progressBar).toBeTruthy();
+  });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<SessionCountMilestoneCard sessionCount={5} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -17,6 +17,7 @@ import LearningPatternCard from '../components/LearningPatternCard';
 import ScoreGrowthTrendCard from '../components/ScoreGrowthTrendCard';
 import PracticeFrequencyCard from '../components/PracticeFrequencyCard';
 import MenuNavigationCard from '../components/MenuNavigationCard';
+import SessionCountMilestoneCard from '../components/SessionCountMilestoneCard';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
@@ -57,6 +58,11 @@ export default function MenuPage() {
       {/* 達成バッジ */}
       <div className="mb-6">
         <AchievementBadgeCard totalSessions={totalSessions} />
+      </div>
+
+      {/* セッション数マイルストーン */}
+      <div className="mb-6">
+        <SessionCountMilestoneCard sessionCount={totalSessions} />
       </div>
 
       {/* 練習頻度 */}


### PR DESCRIPTION
## 概要
- 次のマイルストーン（10/25/50/100回）までの進捗をプログレスバーで表示
- 全マイルストーン達成時の祝福メッセージ
- ダッシュボード（MenuPage）に統合

## テスト
- 7テスト追加
- 全929テストパス

closes #466