### PR TITLE
fix: ダーク/ライトテーマのテキスト色修正

### DIFF
--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -63,10 +63,10 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
       </div>
       <h3 className="text-sm font-medium text-[var(--color-text-primary)] mb-1">{scenario.name}</h3>
       <p className="text-xs text-[var(--color-text-muted)] mb-2">{scenario.description}</p>
-      <p className="text-[11px] text-[var(--color-text-faint)] mb-3">
+      <p className="text-[11px] text-[var(--color-text-muted)] mb-3">
         {difficultyDescription[scenario.difficulty] || ''} ・ 約5〜10分
       </p>
-      <div className="flex items-center gap-1 text-xs text-[var(--color-text-faint)]">
+      <div className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
         <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
         </svg>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,7 +39,14 @@
 
 @layer base {
   body {
-    @apply bg-surface;
+    @apply bg-surface text-[var(--color-text-primary)];
+  }
+
+  select,
+  textarea,
+  input {
+    color: var(--color-text-primary);
+    background-color: var(--color-surface-2);
   }
 }
 

--- a/frontend/src/pages/LoginCallback.tsx
+++ b/frontend/src/pages/LoginCallback.tsx
@@ -11,10 +11,10 @@ export default function LoginCallback() {
           <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-primary-600 border-r-primary-600 animate-spin"></div>
         </div>
         <div className="text-center">
-          <h3 className="text-2xl font-bold text-gray-800 mb-2">
+          <h3 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">
             ログイン中...
           </h3>
-          <p className="text-gray-600">お待たせしています</p>
+          <p className="text-[var(--color-text-secondary)]">お待たせしています</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要
- bodyにデフォルトテキスト色（CSS変数）を追加し、全要素がテーマに連動するように修正
- select/textarea/input要素にグローバルなテーマ対応色設定追加
- LoginCallback: ハードコード色をCSS変数に変更
- ScenarioCard: 報連相・難易度テキストの可読性向上

## 修正内容
- ダークモード: テキストは白系（#F0F0F0）
- ライトモード: テキストは黒系（#1A1A1A）

## テスト
- 全929テストパス

closes #468