### PR TITLE
fix: LoginCallbackをLoadingコンポーネントに変更・難易度バッジをNotion風に修正

### DIFF
--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -26,9 +26,9 @@ const difficultyDescription: Record<string, string> = {
 };
 
 const difficultyColor: Record<string, string> = {
-  beginner: 'bg-emerald-900/30 text-emerald-400 border-emerald-800',
-  intermediate: 'bg-amber-900/30 text-amber-400 border-amber-800',
-  advanced: 'bg-rose-900/30 text-rose-400 border-rose-800',
+  beginner: 'bg-surface-3 text-[var(--color-text-secondary)] border-surface-3',
+  intermediate: 'bg-surface-3 text-[var(--color-text-secondary)] border-surface-3',
+  advanced: 'bg-surface-3 text-[var(--color-text-secondary)] border-surface-3',
 };
 
 export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggleBookmark }: ScenarioCardProps) {

--- a/frontend/src/pages/LoginCallback.tsx
+++ b/frontend/src/pages/LoginCallback.tsx
@@ -1,22 +1,8 @@
+import Loading from '../components/Loading';
 import { useLoginCallback } from '../hooks/useLoginCallback';
 
 export default function LoginCallback() {
   useLoginCallback();
 
-  return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-surface">
-      <div className="flex flex-col items-center space-y-6">
-        <div className="relative w-20 h-20">
-          <div className="absolute inset-0 rounded-full border-4 border-[var(--color-border-hover)]"></div>
-          <div className="absolute inset-0 rounded-full border-4 border-transparent border-t-primary-600 border-r-primary-600 animate-spin"></div>
-        </div>
-        <div className="text-center">
-          <h3 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">
-            ログイン中...
-          </h3>
-          <p className="text-[var(--color-text-secondary)]">お待たせしています</p>
-        </div>
-      </div>
-    </div>
-  );
+  return <Loading fullscreen message="ログイン中..." />;
 }


### PR DESCRIPTION
## 概要
- LoginCallback: 独自ローディング表示をLoadingコンポーネント（fullscreen）に統一
- ScenarioCard: 難易度バッジ（初級/中級/上級）の派手な色をNotion風サーフェス色に変更

## 変更前 → 変更後
- LoginCallback: 22行 → 9行（Loadingコンポーネント再利用）
- 難易度バッジ: emerald/amber/rose → surface-3ベースのシンプルな色

## テスト
- 全929テストパス

closes #470