### PR TITLE
fix: ライトテーマの背景色をNotion風ウォームグレーに変更

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,10 +21,10 @@
 }
 
 .light {
-  --color-surface: #F9FAFB;
+  --color-surface: #F7F6F3;
   --color-surface-1: #FFFFFF;
-  --color-surface-2: #F3F4F6;
-  --color-surface-3: #E5E7EB;
+  --color-surface-2: #F1F0ED;
+  --color-surface-3: #E8E7E4;
   --color-text-primary: #1A1A1A;
   --color-text-secondary: #374151;
   --color-text-tertiary: #6B7280;


### PR DESCRIPTION
## 概要
ライトテーマの背景色をNotionのコードスニペット風ウォームグレーに変更

## 変更
- surface: #F9FAFB → #F7F6F3
- surface-2: #F3F4F6 → #F1F0ED
- surface-3: #E5E7EB → #E8E7E4

## テスト
- 全929テストパス

closes #472