### PR TITLE
fix: AuthInitializerのローディングをLoadingコンポーネントに統一・テーマ事前適用

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/image.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FreStyle</title>
+    <script>
+      try {
+        if (localStorage.getItem('theme') === 'light') {
+          document.documentElement.classList.add('light');
+        }
+      } catch (e) {}
+    </script>
   </head>
   <body style="background-color: var(--color-surface, #1A1A1A);">
     <div id="root"></div>

--- a/frontend/src/components/Loading.tsx
+++ b/frontend/src/components/Loading.tsx
@@ -58,7 +58,7 @@ export default function Loading({
     return (
       <div className="fixed inset-0 bg-surface-1/80 backdrop-blur-sm flex items-center justify-center z-50">
         <div className="flex flex-col items-center gap-4">
-          <div className="w-12 h-12 border-3 border-[var(--color-border-hover)] border-t-primary-500 rounded-full animate-spin" />
+          <div className="w-12 h-12 border-3 border-[var(--color-border-hover)] border-t-primary-500 rounded-full animate-spin" role="status" aria-label="読み込み中" />
           {message && (
             <p className="text-sm font-medium text-[var(--color-text-secondary)] animate-pulse">
               {message}

--- a/frontend/src/utils/AuthInitializer.tsx
+++ b/frontend/src/utils/AuthInitializer.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { setAuthData, clearAuth, finishLoading } from '../store/authSlice';
 import type { RootState } from '../store';
 import authRepository from '../repositories/AuthRepository';
+import Loading from '../components/Loading';
 
 interface AuthInitializerProps {
   children: ReactNode;
@@ -28,11 +29,7 @@ export default function AuthInitializer({ children }: AuthInitializerProps) {
   }, [dispatch]);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <p className="text-lg">認証確認中...</p>
-      </div>
-    );
+    return <Loading fullscreen />;
   }
 
   return children;

--- a/frontend/src/utils/__tests__/AuthInitializer.test.tsx
+++ b/frontend/src/utils/__tests__/AuthInitializer.test.tsx
@@ -32,7 +32,7 @@ describe('AuthInitializer', () => {
     vi.clearAllMocks();
   });
 
-  it('ローディング中は「認証確認中...」を表示する', () => {
+  it('ローディング中はLoadingコンポーネントを表示する', () => {
     vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
       id: 1,
       email: 'test@example.com',
@@ -42,7 +42,7 @@ describe('AuthInitializer', () => {
 
     renderWithStore(true);
 
-    expect(screen.getByText('認証確認中...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
   it('認証成功時にchildrenを表示する', async () => {


### PR DESCRIPTION
## 概要
- AuthInitializerの「認証確認中...」テキストをLoadingコンポーネント(fullscreen)に置換
- index.htmlにインラインスクリプトを追加し、localStorageのテーマ設定をJS bundle読み込み前に適用
- Loadingコンポーネントのfullscreenスピナーにrole="status"とaria-labelを追加

## 変更ファイル
- `frontend/index.html` - テーマ事前適用スクリプト追加
- `frontend/src/utils/AuthInitializer.tsx` - Loadingコンポーネント使用
- `frontend/src/utils/__tests__/AuthInitializer.test.tsx` - テスト更新
- `frontend/src/components/Loading.tsx` - fullscreenスピナーにrole属性追加

## テスト結果
- 929テスト全通過（140ファイル）

closes #474