### PR TITLE
fix: スマホサイズでSecondaryPanelのレスポンシブ対応

### DIFF
--- a/frontend/src/components/layout/SecondaryPanel.tsx
+++ b/frontend/src/components/layout/SecondaryPanel.tsx
@@ -2,16 +2,51 @@ interface SecondaryPanelProps {
   title: string;
   headerContent?: React.ReactNode;
   children: React.ReactNode;
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 }
 
-export default function SecondaryPanel({ title, headerContent, children }: SecondaryPanelProps) {
+export default function SecondaryPanel({ title, headerContent, children, mobileOpen = false, onMobileClose }: SecondaryPanelProps) {
   return (
-    <div className="w-72 bg-surface-1 border-r border-surface-3 flex flex-col h-full flex-shrink-0">
-      <div className="px-4 py-3 border-b border-surface-3">
-        <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h2>
-        {headerContent && <div className="mt-2">{headerContent}</div>}
+    <>
+      {/* モバイルオーバーレイ */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 bg-black/40 z-40 md:hidden"
+          onClick={onMobileClose}
+        />
+      )}
+
+      {/* モバイルパネル */}
+      <div
+        className={`fixed inset-y-0 left-0 z-50 w-72 bg-surface-1 border-r border-surface-3 flex flex-col transform transition-transform duration-200 md:hidden ${
+          mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="px-4 py-3 border-b border-surface-3 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h2>
+          <button
+            onClick={onMobileClose}
+            className="p-1 hover:bg-surface-2 rounded transition-colors"
+            aria-label="パネルを閉じる"
+          >
+            <svg className="w-4 h-4 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        {headerContent && <div className="px-4 py-2 border-b border-surface-3">{headerContent}</div>}
+        <div className="flex-1 overflow-y-auto">{children}</div>
       </div>
-      <div className="flex-1 overflow-y-auto">{children}</div>
-    </div>
+
+      {/* デスクトップパネル */}
+      <div className="hidden md:flex w-72 bg-surface-1 border-r border-surface-3 flex-col h-full flex-shrink-0">
+        <div className="px-4 py-3 border-b border-surface-3">
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h2>
+          {headerContent && <div className="mt-2">{headerContent}</div>}
+        </div>
+        <div className="flex-1 overflow-y-auto">{children}</div>
+      </div>
+    </>
   );
 }

--- a/frontend/src/components/layout/__tests__/SecondaryPanel.test.tsx
+++ b/frontend/src/components/layout/__tests__/SecondaryPanel.test.tsx
@@ -9,7 +9,8 @@ describe('SecondaryPanel', () => {
         <div>コンテンツ</div>
       </SecondaryPanel>
     );
-    expect(screen.getByText('チャット')).toBeDefined();
+    const titles = screen.getAllByText('チャット');
+    expect(titles.length).toBeGreaterThanOrEqual(1);
   });
 
   it('子要素を表示する', () => {
@@ -18,7 +19,8 @@ describe('SecondaryPanel', () => {
         <div>子要素コンテンツ</div>
       </SecondaryPanel>
     );
-    expect(screen.getByText('子要素コンテンツ')).toBeDefined();
+    const elements = screen.getAllByText('子要素コンテンツ');
+    expect(elements.length).toBeGreaterThanOrEqual(1);
   });
 
   it('ヘッダーコンテンツを表示する', () => {
@@ -27,6 +29,16 @@ describe('SecondaryPanel', () => {
         <div>内容</div>
       </SecondaryPanel>
     );
-    expect(screen.getByPlaceholderText('検索')).toBeDefined();
+    const inputs = screen.getAllByPlaceholderText('検索');
+    expect(inputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('モバイル閉じるボタンを表示する', () => {
+    render(
+      <SecondaryPanel title="テスト" mobileOpen={true} onMobileClose={() => {}}>
+        <div>内容</div>
+      </SecondaryPanel>
+    );
+    expect(screen.getByLabelText('パネルを閉じる')).toBeDefined();
   });
 });

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import MessageBubbleAi from '../components/MessageBubbleAi';
 import MessageInput from '../components/MessageInput';
 import ConfirmModal from '../components/ConfirmModal';
@@ -11,6 +12,7 @@ import AiSessionListItem from '../components/AiSessionListItem';
 import { useAskAi } from '../hooks/useAskAi';
 
 export default function AskAiPage() {
+  const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
   const {
     sessions,
     messages,
@@ -40,6 +42,8 @@ export default function AskAiPage() {
       {/* セカンダリパネル: セッション一覧 */}
       <SecondaryPanel
         title="セッション"
+        mobileOpen={mobilePanelOpen}
+        onMobileClose={() => setMobilePanelOpen(false)}
         headerContent={
           <button
             onClick={handleNewSession}
@@ -62,7 +66,7 @@ export default function AskAiPage() {
               isActive={currentSessionId === session.id}
               isEditing={editingSessionId === session.id}
               editingTitle={editingTitle}
-              onSelect={handleSelectSession}
+              onSelect={(id: number) => { handleSelectSession(id); setMobilePanelOpen(false); }}
               onStartEdit={handleStartEditTitle}
               onDelete={handleDeleteSession}
               onSaveTitle={handleSaveTitle}
@@ -75,6 +79,20 @@ export default function AskAiPage() {
 
       {/* メインコンテンツ */}
       <div className="flex-1 flex flex-col min-w-0">
+        {/* モバイルヘッダー */}
+        <div className="md:hidden bg-surface-1 border-b border-surface-3 px-4 py-2 flex items-center">
+          <button
+            onClick={() => setMobilePanelOpen(true)}
+            className="p-1.5 hover:bg-surface-2 rounded transition-colors"
+            aria-label="セッション一覧を開く"
+          >
+            <svg className="w-5 h-5 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <span className="ml-2 text-xs text-[var(--color-text-muted)]">セッション一覧</span>
+        </div>
+
         {/* 練習モードヘッダー */}
         {isPracticeMode && (
           <div className="bg-surface-1 border-b border-surface-3 px-4 py-3 flex items-center justify-between">

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import EmptyState from '../components/EmptyState';
@@ -7,6 +8,7 @@ import { useChatList } from '../hooks/useChatList';
 import { formatTime, truncateMessage } from '../utils/formatters';
 
 export default function ChatListPage() {
+  const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
   const navigate = useNavigate();
   const { chatUsers, loading, searchQuery, setSearchQuery } = useChatList();
 
@@ -14,6 +16,8 @@ export default function ChatListPage() {
     <div className="flex h-full">
       <SecondaryPanel
         title="チャット"
+        mobileOpen={mobilePanelOpen}
+        onMobileClose={() => setMobilePanelOpen(false)}
         headerContent={
           <SearchBox
             value={searchQuery}
@@ -34,7 +38,7 @@ export default function ChatListPage() {
           chatUsers.map((user) => (
             <button
               key={user.roomId}
-              onClick={() => navigate(`/chat/users/${user.roomId}`)}
+              onClick={() => { navigate(`/chat/users/${user.roomId}`); setMobilePanelOpen(false); }}
               className="w-full px-4 py-3 flex items-center gap-3 hover:bg-surface-2 transition-colors border-b border-surface-3 text-left"
             >
               <div className="flex-shrink-0">
@@ -80,7 +84,20 @@ export default function ChatListPage() {
         )}
       </SecondaryPanel>
 
-      <div className="flex-1">
+      <div className="flex-1 flex flex-col">
+        {/* モバイルヘッダー */}
+        <div className="md:hidden bg-surface-1 border-b border-surface-3 px-4 py-2 flex items-center">
+          <button
+            onClick={() => setMobilePanelOpen(true)}
+            className="p-1.5 hover:bg-surface-2 rounded transition-colors"
+            aria-label="チャット一覧を開く"
+          >
+            <svg className="w-5 h-5 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+          <span className="ml-2 text-xs text-[var(--color-text-muted)]">チャット一覧</span>
+        </div>
         <EmptyState
           icon={ChatBubbleLeftRightIcon}
           title="チャットを選択してください"

--- a/frontend/src/pages/__tests__/ChatListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatListPage.test.tsx
@@ -71,8 +71,8 @@ describe('ChatListPage', () => {
   it('チャットユーザー一覧を表示する', () => {
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    expect(screen.getByText('田中太郎')).toBeInTheDocument();
-    expect(screen.getByText('佐藤花子')).toBeInTheDocument();
+    expect(screen.getAllByText('田中太郎').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('佐藤花子').length).toBeGreaterThanOrEqual(1);
   });
 
   it('ローディング中はスピナーを表示する', () => {
@@ -95,19 +95,19 @@ describe('ChatListPage', () => {
 
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    expect(screen.getByText('チャット履歴がありません')).toBeInTheDocument();
+    expect(screen.getAllByText('チャット履歴がありません').length).toBeGreaterThanOrEqual(1);
   });
 
   it('未読バッジを表示する', () => {
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1);
   });
 
   it('チャットルームクリックでnavigateが呼ばれる', () => {
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    fireEvent.click(screen.getByText('田中太郎'));
+    fireEvent.click(screen.getAllByText('田中太郎')[0]);
 
     expect(mockNavigate).toHaveBeenCalledWith('/chat/users/1');
   });
@@ -115,20 +115,20 @@ describe('ChatListPage', () => {
   it('自分が送ったメッセージには「あなた:」プレフィックスが付く', () => {
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    expect(screen.getByText(/あなた: ありがとうございます/)).toBeInTheDocument();
+    expect(screen.getAllByText(/あなた: ありがとうございます/).length).toBeGreaterThanOrEqual(1);
   });
 
   it('プロフィール画像がない場合は頭文字アバターを表示する', () => {
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    expect(screen.getByText('田')).toBeInTheDocument();
+    expect(screen.getAllByText('田').length).toBeGreaterThanOrEqual(1);
   });
 
   it('プロフィール画像がある場合はimgタグを表示する', () => {
     render(<BrowserRouter><ChatListPage /></BrowserRouter>);
 
-    const img = screen.getByAltText('佐藤花子');
-    expect(img).toBeInTheDocument();
-    expect(img.getAttribute('src')).toBe('https://example.com/photo.jpg');
+    const imgs = screen.getAllByAltText('佐藤花子');
+    expect(imgs.length).toBeGreaterThanOrEqual(1);
+    expect(imgs[0].getAttribute('src')).toBe('https://example.com/photo.jpg');
   });
 });


### PR DESCRIPTION
## 概要
- SecondaryPanelにモバイル/デスクトップの切り替え実装
  - モバイル（< 768px）: デフォルト非表示、オーバーレイでスライドイン表示
  - デスクトップ（>= 768px）: 従来通り常時表示
- AskAiPage: モバイルヘッダーにセッション一覧トグルボタン追加
- ChatListPage: モバイルヘッダーにチャット一覧トグルボタン追加

## 変更ファイル
- `frontend/src/components/layout/SecondaryPanel.tsx` - レスポンシブ対応
- `frontend/src/pages/AskAiPage.tsx` - モバイルパネルトグル追加
- `frontend/src/pages/ChatListPage.tsx` - モバイルパネルトグル追加
- `frontend/src/components/layout/__tests__/SecondaryPanel.test.tsx` - テスト更新
- `frontend/src/pages/__tests__/ChatListPage.test.tsx` - テスト更新

## テスト結果
- 930テスト全通過（140ファイル）

closes #476