### PR TITLE
feat: ノート機能バックエンドAPI（DynamoDB）

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/NoteController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/NoteController.java
@@ -1,0 +1,82 @@
+package com.example.FreStyle.controller;
+
+import com.example.FreStyle.dto.NoteDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.NoteService;
+import com.example.FreStyle.service.UserIdentityService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notes")
+public class NoteController {
+
+    private static final Logger logger = LoggerFactory.getLogger(NoteController.class);
+    private final NoteService noteService;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping
+    public ResponseEntity<List<NoteDto>> getNotes(@AuthenticationPrincipal Jwt jwt) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+
+        List<NoteDto> notes = noteService.getNotesByUserId(user.getId());
+        logger.info("ノート一覧取得成功 - 件数: {}", notes.size());
+
+        return ResponseEntity.ok(notes);
+    }
+
+    @PostMapping
+    public ResponseEntity<NoteDto> createNote(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody CreateNoteRequest request
+    ) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+
+        NoteDto note = noteService.createNote(user.getId(), request.title());
+        logger.info("ノート作成成功 - noteId: {}", note.getNoteId());
+
+        return ResponseEntity.ok(note);
+    }
+
+    @PutMapping("/{noteId}")
+    public ResponseEntity<Void> updateNote(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String noteId,
+            @RequestBody UpdateNoteRequest request
+    ) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+
+        noteService.updateNote(user.getId(), noteId, request.title(), request.content(), request.isPinned());
+        logger.info("ノート更新成功 - noteId: {}", noteId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{noteId}")
+    public ResponseEntity<Void> deleteNote(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String noteId
+    ) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+
+        noteService.deleteNote(user.getId(), noteId);
+        logger.info("ノート削除成功 - noteId: {}", noteId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    public record CreateNoteRequest(String title) {}
+    public record UpdateNoteRequest(String title, String content, Boolean isPinned) {}
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/NoteDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/NoteDto.java
@@ -1,0 +1,18 @@
+package com.example.FreStyle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoteDto {
+    private String noteId;
+    private Integer userId;
+    private String title;
+    private String content;
+    private Boolean isPinned;
+    private Long createdAt;
+    private Long updatedAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/service/NoteService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/NoteService.java
@@ -1,0 +1,156 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.dto.NoteDto;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+public class NoteService {
+
+    private DynamoDbClient dynamoDbClient;
+    private String tableName;
+
+    @Value("${aws.access-key:}")
+    private String accessKey;
+
+    @Value("${aws.secret-key:}")
+    private String secretKey;
+
+    @Value("${aws.region:}")
+    private String region;
+
+    @Value("${aws.dynamodb.table-name.notes:fre_style_notes}")
+    private String configTableName;
+
+    // テスト用コンストラクタ
+    public NoteService(DynamoDbClient dynamoDbClient, String tableName) {
+        this.dynamoDbClient = dynamoDbClient;
+        this.tableName = tableName;
+    }
+
+    // Spring DI用デフォルトコンストラクタ
+    public NoteService() {
+    }
+
+    @PostConstruct
+    public void init() {
+        if (dynamoDbClient == null && !accessKey.isEmpty()) {
+            dynamoDbClient = DynamoDbClient.builder()
+                    .region(Region.of(region))
+                    .credentialsProvider(
+                            StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create(accessKey, secretKey)
+                            )
+                    )
+                    .build();
+        }
+        if (tableName == null) {
+            tableName = configTableName;
+        }
+    }
+
+    public List<NoteDto> getNotesByUserId(Integer userId) {
+        QueryRequest queryRequest = QueryRequest.builder()
+                .tableName(tableName)
+                .keyConditionExpression("user_id = :user_id")
+                .expressionAttributeValues(Map.of(
+                        ":user_id", AttributeValue.builder().n(userId.toString()).build()
+                ))
+                .scanIndexForward(false)
+                .build();
+
+        QueryResponse response = dynamoDbClient.query(queryRequest);
+
+        return response.items().stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    public NoteDto createNote(Integer userId, String title) {
+        String noteId = UUID.randomUUID().toString();
+        long now = Instant.now().toEpochMilli();
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().n(userId.toString()).build());
+        item.put("note_id", AttributeValue.builder().s(noteId).build());
+        item.put("title", AttributeValue.builder().s(title).build());
+        item.put("content", AttributeValue.builder().s("").build());
+        item.put("is_pinned", AttributeValue.builder().bool(false).build());
+        item.put("created_at", AttributeValue.builder().n(String.valueOf(now)).build());
+        item.put("updated_at", AttributeValue.builder().n(String.valueOf(now)).build());
+
+        PutItemRequest putRequest = PutItemRequest.builder()
+                .tableName(tableName)
+                .item(item)
+                .build();
+
+        dynamoDbClient.putItem(putRequest);
+
+        NoteDto dto = new NoteDto();
+        dto.setNoteId(noteId);
+        dto.setUserId(userId);
+        dto.setTitle(title);
+        dto.setContent("");
+        dto.setIsPinned(false);
+        dto.setCreatedAt(now);
+        dto.setUpdatedAt(now);
+        return dto;
+    }
+
+    public void updateNote(Integer userId, String noteId, String title, String content, Boolean isPinned) {
+        long now = Instant.now().toEpochMilli();
+
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("user_id", AttributeValue.builder().n(userId.toString()).build());
+        key.put("note_id", AttributeValue.builder().s(noteId).build());
+
+        UpdateItemRequest updateRequest = UpdateItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                .updateExpression("SET title = :title, content = :content, is_pinned = :is_pinned, updated_at = :updated_at")
+                .expressionAttributeValues(Map.of(
+                        ":title", AttributeValue.builder().s(title).build(),
+                        ":content", AttributeValue.builder().s(content).build(),
+                        ":is_pinned", AttributeValue.builder().bool(isPinned).build(),
+                        ":updated_at", AttributeValue.builder().n(String.valueOf(now)).build()
+                ))
+                .build();
+
+        dynamoDbClient.updateItem(updateRequest);
+    }
+
+    public void deleteNote(Integer userId, String noteId) {
+        Map<String, AttributeValue> key = new HashMap<>();
+        key.put("user_id", AttributeValue.builder().n(userId.toString()).build());
+        key.put("note_id", AttributeValue.builder().s(noteId).build());
+
+        DeleteItemRequest deleteRequest = DeleteItemRequest.builder()
+                .tableName(tableName)
+                .key(key)
+                .build();
+
+        dynamoDbClient.deleteItem(deleteRequest);
+    }
+
+    private NoteDto toDto(Map<String, AttributeValue> item) {
+        NoteDto dto = new NoteDto();
+        dto.setUserId(Integer.parseInt(item.get("user_id").n()));
+        dto.setNoteId(item.get("note_id").s());
+        dto.setTitle(item.containsKey("title") ? item.get("title").s() : "");
+        dto.setContent(item.containsKey("content") ? item.get("content").s() : "");
+        dto.setIsPinned(item.containsKey("is_pinned") ? item.get("is_pinned").bool() : false);
+        dto.setCreatedAt(item.containsKey("created_at") ? Long.parseLong(item.get("created_at").n()) : 0L);
+        dto.setUpdatedAt(item.containsKey("updated_at") ? Long.parseLong(item.get("updated_at").n()) : 0L);
+        return dto;
+    }
+}

--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -38,6 +38,7 @@ aws.region=${AWS_REGION}
 
 aws.dynamodb.table-name.ai-chat=fre_style_ai_chat
 aws.dynamodb.table-name.chat=fre_style_chat
+aws.dynamodb.table-name.notes=fre_style_notes
 
 # ========== ロギング設定 ==========
 # Spring Security

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/NoteControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/NoteControllerTest.java
@@ -1,0 +1,120 @@
+package com.example.FreStyle.controller;
+
+import com.example.FreStyle.dto.NoteDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.NoteService;
+import com.example.FreStyle.service.UserIdentityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NoteControllerTest {
+
+    @Mock
+    private NoteService noteService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private NoteController noteController;
+
+    private Jwt jwt;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("test-sub");
+
+        user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+    }
+
+    @Nested
+    @DisplayName("GET /api/notes - ノート一覧取得")
+    class GetNotesTest {
+
+        @Test
+        @DisplayName("ユーザーのノート一覧を返す")
+        void shouldReturnUserNotes() {
+            NoteDto note1 = new NoteDto("note-1", 1, "タイトル1", "内容1", false, 1000L, 2000L);
+            NoteDto note2 = new NoteDto("note-2", 1, "タイトル2", "内容2", true, 1500L, 3000L);
+            when(noteService.getNotesByUserId(1)).thenReturn(List.of(note1, note2));
+
+            ResponseEntity<List<NoteDto>> response = noteController.getNotes(jwt);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).hasSize(2);
+            assertThat(response.getBody().get(0).getTitle()).isEqualTo("タイトル1");
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/notes - ノート作成")
+    class CreateNoteTest {
+
+        @Test
+        @DisplayName("新しいノートを作成して返す")
+        void shouldCreateAndReturnNote() {
+            NoteDto created = new NoteDto("note-new", 1, "新しいノート", "", false, 1000L, 1000L);
+            when(noteService.createNote(1, "新しいノート")).thenReturn(created);
+
+            ResponseEntity<NoteDto> response = noteController.createNote(jwt,
+                    new NoteController.CreateNoteRequest("新しいノート"));
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody().getTitle()).isEqualTo("新しいノート");
+            assertThat(response.getBody().getNoteId()).isEqualTo("note-new");
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/notes/{noteId} - ノート更新")
+    class UpdateNoteTest {
+
+        @Test
+        @DisplayName("ノートを更新して204を返す")
+        void shouldUpdateNoteAndReturnNoContent() {
+            doNothing().when(noteService).updateNote(1, "note-1", "更新タイトル", "更新内容", false);
+
+            ResponseEntity<Void> response = noteController.updateNote(jwt, "note-1",
+                    new NoteController.UpdateNoteRequest("更新タイトル", "更新内容", false));
+
+            assertThat(response.getStatusCode().value()).isEqualTo(204);
+            verify(noteService).updateNote(1, "note-1", "更新タイトル", "更新内容", false);
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/notes/{noteId} - ノート削除")
+    class DeleteNoteTest {
+
+        @Test
+        @DisplayName("ノートを削除して204を返す")
+        void shouldDeleteNoteAndReturnNoContent() {
+            doNothing().when(noteService).deleteNote(1, "note-1");
+
+            ResponseEntity<Void> response = noteController.deleteNote(jwt, "note-1");
+
+            assertThat(response.getStatusCode().value()).isEqualTo(204);
+            verify(noteService).deleteNote(1, "note-1");
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/NoteServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/NoteServiceTest.java
@@ -1,0 +1,156 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.dto.NoteDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NoteServiceTest {
+
+    @Mock
+    private DynamoDbClient dynamoDbClient;
+
+    private NoteService noteService;
+
+    @BeforeEach
+    void setUp() {
+        noteService = new NoteService(dynamoDbClient, "fre_style_notes");
+    }
+
+    @Nested
+    @DisplayName("getNotesByUserId - ユーザーのノート一覧取得")
+    class GetNotesByUserIdTest {
+
+        @Test
+        @DisplayName("ユーザーのノートを更新日時降順で取得する")
+        void shouldReturnNotesSortedByUpdatedAtDesc() {
+            // Arrange
+            Map<String, AttributeValue> item1 = createNoteItem(1, "note-1", "タイトル1", "内容1", false, 1000L, 2000L);
+            Map<String, AttributeValue> item2 = createNoteItem(1, "note-2", "タイトル2", "内容2", true, 1500L, 3000L);
+
+            QueryResponse response = QueryResponse.builder()
+                    .items(List.of(item1, item2))
+                    .build();
+            when(dynamoDbClient.query(any(QueryRequest.class))).thenReturn(response);
+
+            // Act
+            List<NoteDto> result = noteService.getNotesByUserId(1);
+
+            // Assert
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getNoteId()).isEqualTo("note-1");
+            assertThat(result.get(1).getNoteId()).isEqualTo("note-2");
+        }
+
+        @Test
+        @DisplayName("ノートが存在しない場合は空リストを返す")
+        void shouldReturnEmptyListWhenNoNotes() {
+            QueryResponse response = QueryResponse.builder()
+                    .items(List.of())
+                    .build();
+            when(dynamoDbClient.query(any(QueryRequest.class))).thenReturn(response);
+
+            List<NoteDto> result = noteService.getNotesByUserId(1);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("createNote - ノート作成")
+    class CreateNoteTest {
+
+        @Test
+        @DisplayName("新しいノートを作成して返す")
+        void shouldCreateNoteAndReturnDto() {
+            when(dynamoDbClient.putItem(any(PutItemRequest.class)))
+                    .thenReturn(PutItemResponse.builder().build());
+
+            NoteDto result = noteService.createNote(1, "新しいノート");
+
+            assertThat(result).isNotNull();
+            assertThat(result.getUserId()).isEqualTo(1);
+            assertThat(result.getTitle()).isEqualTo("新しいノート");
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getIsPinned()).isFalse();
+            assertThat(result.getNoteId()).isNotBlank();
+
+            verify(dynamoDbClient, times(1)).putItem(any(PutItemRequest.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateNote - ノート更新")
+    class UpdateNoteTest {
+
+        @Test
+        @DisplayName("タイトルと内容を更新する")
+        void shouldUpdateTitleAndContent() {
+            when(dynamoDbClient.updateItem(any(UpdateItemRequest.class)))
+                    .thenReturn(UpdateItemResponse.builder().build());
+
+            noteService.updateNote(1, "note-1", "更新タイトル", "更新内容", false);
+
+            ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+            verify(dynamoDbClient).updateItem(captor.capture());
+
+            UpdateItemRequest request = captor.getValue();
+            assertThat(request.tableName()).isEqualTo("fre_style_notes");
+            assertThat(request.key().get("user_id").n()).isEqualTo("1");
+            assertThat(request.key().get("note_id").s()).isEqualTo("note-1");
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteNote - ノート削除")
+    class DeleteNoteTest {
+
+        @Test
+        @DisplayName("指定されたノートを削除する")
+        void shouldDeleteNote() {
+            when(dynamoDbClient.deleteItem(any(DeleteItemRequest.class)))
+                    .thenReturn(DeleteItemResponse.builder().build());
+
+            noteService.deleteNote(1, "note-1");
+
+            ArgumentCaptor<DeleteItemRequest> captor = ArgumentCaptor.forClass(DeleteItemRequest.class);
+            verify(dynamoDbClient).deleteItem(captor.capture());
+
+            DeleteItemRequest request = captor.getValue();
+            assertThat(request.tableName()).isEqualTo("fre_style_notes");
+            assertThat(request.key().get("user_id").n()).isEqualTo("1");
+            assertThat(request.key().get("note_id").s()).isEqualTo("note-1");
+        }
+    }
+
+    private Map<String, AttributeValue> createNoteItem(
+            Integer userId, String noteId, String title, String content,
+            boolean isPinned, Long createdAt, Long updatedAt) {
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("user_id", AttributeValue.builder().n(userId.toString()).build());
+        item.put("note_id", AttributeValue.builder().s(noteId).build());
+        item.put("title", AttributeValue.builder().s(title).build());
+        item.put("content", AttributeValue.builder().s(content).build());
+        item.put("is_pinned", AttributeValue.builder().bool(isPinned).build());
+        item.put("created_at", AttributeValue.builder().n(createdAt.toString()).build());
+        item.put("updated_at", AttributeValue.builder().n(updatedAt.toString()).build());
+        return item;
+    }
+}


### PR DESCRIPTION
## 概要
DynamoDBを使用したNotionライクなノート機能のバックエンドAPIを実装。

## DynamoDBテーブル設計
- テーブル名: `fre_style_notes`
- パーティションキー: `user_id` (Number)
- ソートキー: `note_id` (String - UUID)
- 属性: `title`, `content`, `is_pinned`, `created_at`, `updated_at`

## REST API
| メソッド | パス | 説明 |
|---------|------|------|
| GET | `/api/notes` | ユーザーのノート一覧取得 |
| POST | `/api/notes` | ノート作成 |
| PUT | `/api/notes/{noteId}` | ノート更新 |
| DELETE | `/api/notes/{noteId}` | ノート削除 |

## 新規ファイル
- `NoteDto.java` - データ転送オブジェクト
- `NoteService.java` - DynamoDB CRUD操作
- `NoteController.java` - REST APIエンドポイント
- `NoteServiceTest.java` - サービス層テスト（4テスト）
- `NoteControllerTest.java` - コントローラー層テスト（4テスト）

## テスト結果
- 全ユニットテスト通過

closes #478