### PR TITLE
feat: ノート機能フロントエンドUI実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import MemberPage from './pages/MemberPage';
 import AddUserPage from './pages/AddUserPage';
 import ProfilePage from './pages/ProfilePage';
 import UserProfilePage from './pages/UserProfilePage';
+import NotesPage from './pages/NotesPage';
 import ForgotPasswordPage from './pages/ForgotPasswordPage';
 import ConfirmForgotPasswordPage from './pages/ConfirmForgotPasswordPage';
 import AuthInitializer from './utils/AuthInitializer';
@@ -59,6 +60,7 @@ export default function App() {
         <Route path="/favorites" element={<FavoritesPage />} />
         <Route path="/chat/ask-ai" element={<AskAiPage />} />
         <Route path="/chat/ask-ai/:sessionId" element={<AskAiPage />} />
+        <Route path="/notes" element={<NotesPage />} />
       </Route>
     </Routes>
     </ErrorBoundary>

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -1,0 +1,31 @@
+interface NoteEditorProps {
+  title: string;
+  content: string;
+  onTitleChange: (title: string) => void;
+  onContentChange: (content: string) => void;
+}
+
+export default function NoteEditor({
+  title,
+  content,
+  onTitleChange,
+  onContentChange,
+}: NoteEditorProps) {
+  return (
+    <div className="flex flex-col h-full p-6 max-w-3xl mx-auto w-full">
+      <input
+        type="text"
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        placeholder="無題"
+        className="text-xl font-bold text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full mb-4 placeholder:text-[var(--color-text-faint)]"
+      />
+      <textarea
+        value={content}
+        onChange={(e) => onContentChange(e.target.value)}
+        placeholder="ここに入力..."
+        className="flex-1 text-sm text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full resize-none leading-relaxed placeholder:text-[var(--color-text-faint)]"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -1,0 +1,67 @@
+import { TrashIcon } from '@heroicons/react/24/outline';
+
+interface NoteListItemProps {
+  noteId: string;
+  title: string;
+  content: string;
+  updatedAt: number;
+  isPinned: boolean;
+  isActive: boolean;
+  onSelect: (noteId: string) => void;
+  onDelete: (noteId: string) => void;
+}
+
+export default function NoteListItem({
+  noteId,
+  title,
+  content,
+  updatedAt,
+  isActive,
+  onSelect,
+  onDelete,
+}: NoteListItemProps) {
+  const displayTitle = title || '無題';
+  const preview = content.replace(/\n/g, ' ').slice(0, 60);
+  const date = new Date(updatedAt);
+  const dateStr = `${date.getMonth() + 1}/${date.getDate()}`;
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(noteId);
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(noteId)}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(noteId); } }}
+      className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors group cursor-pointer ${
+        isActive ? 'bg-surface-2' : 'hover:bg-surface-2'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+            {displayTitle}
+          </p>
+          {preview && (
+            <p className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">
+              {preview}
+            </p>
+          )}
+          <p className="text-[11px] text-[var(--color-text-faint)] mt-1">
+            {dateStr}
+          </p>
+        </div>
+        <button
+          onClick={handleDelete}
+          aria-label="ノートを削除"
+          className="p-1 opacity-0 group-hover:opacity-100 hover:bg-surface-3 rounded transition-all"
+        >
+          <TrashIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteEditor.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NoteEditor from '../NoteEditor';
+
+const defaultProps = {
+  title: 'テストノート',
+  content: 'テスト内容',
+  onTitleChange: vi.fn(),
+  onContentChange: vi.fn(),
+};
+
+describe('NoteEditor', () => {
+  it('タイトル入力欄を表示する', () => {
+    render(<NoteEditor {...defaultProps} />);
+    const input = screen.getByDisplayValue('テストノート');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('内容入力欄を表示する', () => {
+    render(<NoteEditor {...defaultProps} />);
+    const textarea = screen.getByDisplayValue('テスト内容');
+    expect(textarea).toBeInTheDocument();
+  });
+
+  it('タイトル変更でonTitleChangeが呼ばれる', () => {
+    render(<NoteEditor {...defaultProps} />);
+    const input = screen.getByDisplayValue('テストノート');
+    fireEvent.change(input, { target: { value: '更新タイトル' } });
+    expect(defaultProps.onTitleChange).toHaveBeenCalledWith('更新タイトル');
+  });
+
+  it('内容変更でonContentChangeが呼ばれる', () => {
+    render(<NoteEditor {...defaultProps} />);
+    const textarea = screen.getByDisplayValue('テスト内容');
+    fireEvent.change(textarea, { target: { value: '更新内容' } });
+    expect(defaultProps.onContentChange).toHaveBeenCalledWith('更新内容');
+  });
+
+  it('タイトルのプレースホルダーが表示される', () => {
+    render(<NoteEditor {...defaultProps} title="" />);
+    expect(screen.getByPlaceholderText('無題')).toBeInTheDocument();
+  });
+
+  it('内容のプレースホルダーが表示される', () => {
+    render(<NoteEditor {...defaultProps} content="" />);
+    expect(screen.getByPlaceholderText('ここに入力...')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/NoteListItem.test.tsx
+++ b/frontend/src/components/__tests__/NoteListItem.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NoteListItem from '../NoteListItem';
+
+const defaultProps = {
+  noteId: 'note-1',
+  title: 'テストノート',
+  content: 'テスト内容のプレビュー',
+  updatedAt: 1707900000000,
+  isPinned: false,
+  isActive: false,
+  onSelect: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe('NoteListItem', () => {
+  it('タイトルを表示する', () => {
+    render(<NoteListItem {...defaultProps} />);
+    expect(screen.getByText('テストノート')).toBeInTheDocument();
+  });
+
+  it('内容のプレビューを表示する', () => {
+    render(<NoteListItem {...defaultProps} />);
+    expect(screen.getByText('テスト内容のプレビュー')).toBeInTheDocument();
+  });
+
+  it('クリックでonSelectが呼ばれる', () => {
+    render(<NoteListItem {...defaultProps} />);
+    fireEvent.click(screen.getByText('テストノート'));
+    expect(defaultProps.onSelect).toHaveBeenCalledWith('note-1');
+  });
+
+  it('削除ボタンでonDeleteが呼ばれる', () => {
+    render(<NoteListItem {...defaultProps} />);
+    const deleteBtn = screen.getByLabelText('ノートを削除');
+    fireEvent.click(deleteBtn);
+    expect(defaultProps.onDelete).toHaveBeenCalledWith('note-1');
+  });
+
+  it('アクティブ状態でスタイルが変わる', () => {
+    const { container } = render(<NoteListItem {...defaultProps} isActive={true} />);
+    const item = container.querySelector('[role="button"]');
+    expect(item?.className).toContain('bg-surface-2');
+  });
+
+  it('タイトルが空の場合は「無題」を表示する', () => {
+    render(<NoteListItem {...defaultProps} title="" />);
+    expect(screen.getByText('無題')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -13,6 +13,7 @@ const pageTitles: Record<string, string> = {
   '/chat/members': 'メンバー',
   '/profile/me': 'プロフィール',
   '/profile/personality': 'パーソナリティ設定',
+  '/notes': 'ノート',
 };
 
 function getPageTitle(pathname: string): string {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   MagnifyingGlassIcon,
   ChartBarIcon,
   StarIcon,
+  DocumentTextIcon,
   UserCircleIcon,
   LightBulbIcon,
   ArrowLeftOnRectangleIcon,
@@ -25,6 +26,7 @@ const navItems = [
   { icon: MagnifyingGlassIcon, label: 'ユーザー検索', to: '/chat/users', matchExact: true },
   { icon: ChartBarIcon, label: 'スコア履歴', to: '/scores', matchExact: true },
   { icon: StarIcon, label: 'お気に入り', to: '/favorites', matchExact: true },
+  { icon: DocumentTextIcon, label: 'ノート', to: '/notes', matchPrefix: '/notes' },
 ];
 
 const bottomNavItems = [

--- a/frontend/src/hooks/__tests__/useNotes.test.ts
+++ b/frontend/src/hooks/__tests__/useNotes.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useNotes } from '../useNotes';
+import NoteRepository from '../../repositories/NoteRepository';
+
+vi.mock('../../repositories/NoteRepository');
+
+const mockNotes = [
+  { noteId: 'note-1', userId: 1, title: 'ノート1', content: '内容1', isPinned: true, createdAt: 1000, updatedAt: 3000 },
+  { noteId: 'note-2', userId: 1, title: 'ノート2', content: '内容2', isPinned: false, createdAt: 2000, updatedAt: 2000 },
+];
+
+describe('useNotes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(mockNotes);
+  });
+
+  it('初期状態でnotesが空配列である', () => {
+    const { result } = renderHook(() => useNotes());
+    expect(result.current.notes).toEqual([]);
+  });
+
+  it('fetchNotesでノート一覧を取得する', async () => {
+    const { result } = renderHook(() => useNotes());
+
+    await act(async () => {
+      await result.current.fetchNotes();
+    });
+
+    expect(result.current.notes).toHaveLength(2);
+    expect(result.current.notes[0].title).toBe('ノート1');
+  });
+
+  it('createNoteで新しいノートを作成する', async () => {
+    const newNote = { noteId: 'note-3', userId: 1, title: '新規', content: '', isPinned: false, createdAt: 4000, updatedAt: 4000 };
+    vi.mocked(NoteRepository.createNote).mockResolvedValue(newNote);
+    vi.mocked(NoteRepository.fetchNotes).mockResolvedValue([...mockNotes, newNote]);
+
+    const { result } = renderHook(() => useNotes());
+
+    await act(async () => {
+      await result.current.createNote('新規');
+    });
+
+    expect(NoteRepository.createNote).toHaveBeenCalledWith('新規');
+  });
+
+  it('deleteNoteでノートを削除する', async () => {
+    vi.mocked(NoteRepository.deleteNote).mockResolvedValue(undefined);
+    vi.mocked(NoteRepository.fetchNotes)
+      .mockResolvedValueOnce(mockNotes)
+      .mockResolvedValueOnce([mockNotes[1]]);
+
+    const { result } = renderHook(() => useNotes());
+
+    await act(async () => {
+      await result.current.fetchNotes();
+    });
+
+    await act(async () => {
+      await result.current.deleteNote('note-1');
+    });
+
+    expect(NoteRepository.deleteNote).toHaveBeenCalledWith('note-1');
+  });
+
+  it('selectedNoteIdの初期値がnullである', () => {
+    const { result } = renderHook(() => useNotes());
+    expect(result.current.selectedNoteId).toBeNull();
+  });
+
+  it('selectNoteでノートを選択できる', async () => {
+    const { result } = renderHook(() => useNotes());
+
+    await act(async () => {
+      result.current.selectNote('note-1');
+    });
+
+    expect(result.current.selectedNoteId).toBe('note-1');
+  });
+});

--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback } from 'react';
+import type { Note } from '../types';
+import NoteRepository from '../repositories/NoteRepository';
+
+export function useNotes() {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchNotes = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await NoteRepository.fetchNotes();
+      setNotes(data);
+    } catch {
+      // エラーハンドリング
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const createNote = useCallback(async (title: string) => {
+    try {
+      const note = await NoteRepository.createNote(title);
+      await fetchNotes();
+      setSelectedNoteId(note.noteId);
+      return note;
+    } catch {
+      return null;
+    }
+  }, [fetchNotes]);
+
+  const updateNote = useCallback(async (noteId: string, data: { title: string; content: string; isPinned: boolean }) => {
+    try {
+      await NoteRepository.updateNote(noteId, data);
+      setNotes((prev) =>
+        prev.map((n) => (n.noteId === noteId ? { ...n, ...data, updatedAt: Date.now() } : n))
+      );
+    } catch {
+      // エラーハンドリング
+    }
+  }, []);
+
+  const deleteNote = useCallback(async (noteId: string) => {
+    try {
+      await NoteRepository.deleteNote(noteId);
+      await fetchNotes();
+      if (selectedNoteId === noteId) {
+        setSelectedNoteId(null);
+      }
+    } catch {
+      // エラーハンドリング
+    }
+  }, [fetchNotes, selectedNoteId]);
+
+  const selectNote = useCallback((noteId: string | null) => {
+    setSelectedNoteId(noteId);
+  }, []);
+
+  return {
+    notes,
+    selectedNoteId,
+    loading,
+    fetchNotes,
+    createNote,
+    updateNote,
+    deleteNote,
+    selectNote,
+  };
+}

--- a/frontend/src/repositories/NoteRepository.ts
+++ b/frontend/src/repositories/NoteRepository.ts
@@ -1,0 +1,24 @@
+import apiClient from '../lib/axios';
+import type { Note } from '../types';
+
+const NoteRepository = {
+  async fetchNotes(): Promise<Note[]> {
+    const res = await apiClient.get('/api/notes');
+    return res.data;
+  },
+
+  async createNote(title: string): Promise<Note> {
+    const res = await apiClient.post('/api/notes', { title });
+    return res.data;
+  },
+
+  async updateNote(noteId: string, data: { title: string; content: string; isPinned: boolean }): Promise<void> {
+    await apiClient.put(`/api/notes/${noteId}`, data);
+  },
+
+  async deleteNote(noteId: string): Promise<void> {
+    await apiClient.delete(`/api/notes/${noteId}`);
+  },
+};
+
+export default NoteRepository;

--- a/frontend/src/repositories/__tests__/NoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteRepository.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NoteRepository from '../NoteRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+describe('NoteRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchNotesがGETリクエストを送信する', async () => {
+    const mockNotes = [
+      { noteId: 'note-1', userId: 1, title: 'テスト', content: '', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    ];
+    vi.mocked(apiClient.get).mockResolvedValue({ data: mockNotes });
+
+    const result = await NoteRepository.fetchNotes();
+
+    expect(apiClient.get).toHaveBeenCalledWith('/api/notes');
+    expect(result).toEqual(mockNotes);
+  });
+
+  it('createNoteがPOSTリクエストを送信する', async () => {
+    const mockNote = { noteId: 'note-new', userId: 1, title: '新しいノート', content: '', isPinned: false, createdAt: 1000, updatedAt: 1000 };
+    vi.mocked(apiClient.post).mockResolvedValue({ data: mockNote });
+
+    const result = await NoteRepository.createNote('新しいノート');
+
+    expect(apiClient.post).toHaveBeenCalledWith('/api/notes', { title: '新しいノート' });
+    expect(result.title).toBe('新しいノート');
+  });
+
+  it('updateNoteがPUTリクエストを送信する', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({ data: undefined });
+
+    await NoteRepository.updateNote('note-1', { title: '更新', content: '内容', isPinned: false });
+
+    expect(apiClient.put).toHaveBeenCalledWith('/api/notes/note-1', { title: '更新', content: '内容', isPinned: false });
+  });
+
+  it('deleteNoteがDELETEリクエストを送信する', async () => {
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: undefined });
+
+    await NoteRepository.deleteNote('note-1');
+
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/notes/note-1');
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -140,3 +140,14 @@ export interface SessionNote {
   note: string;
   updatedAt: string;
 }
+
+/** ノート */
+export interface Note {
+  noteId: string;
+  userId: number;
+  title: string;
+  content: string;
+  isPinned: boolean;
+  createdAt: number;
+  updatedAt: number;
+}


### PR DESCRIPTION
## 概要
Notionライクなノート機能のフロントエンドUIを実装。

## 変更内容
- **NoteRepository**: ノートCRUD API通信レイヤー
- **useNotes**: ノート状態管理Hooks（一覧取得・作成・更新・削除・選択）
- **NoteListItem**: ノート一覧アイテムコンポーネント（プレビュー・日付・削除）
- **NoteEditor**: Notionライクなエディタ（タイトル・コンテンツ編集）
- **NotesPage**: ノートページ（自動保存800ms、SecondaryPanel対応、モバイルレスポンシブ）
- **Sidebar/AppShell/App**: ルーティング・ナビゲーション追加

## テスト
- NoteRepository: 4テスト
- useNotes: 6テスト
- NoteListItem: 6テスト
- NoteEditor: 6テスト
- 計22テスト追加（全952テスト合格）

closes #480