### PR TITLE
refactor: ノート機能のクリーンアーキテクチャリファクタリング

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/NoteController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/NoteController.java
@@ -2,8 +2,11 @@ package com.example.FreStyle.controller;
 
 import com.example.FreStyle.dto.NoteDto;
 import com.example.FreStyle.entity.User;
-import com.example.FreStyle.service.NoteService;
 import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.CreateNoteUseCase;
+import com.example.FreStyle.usecase.DeleteNoteUseCase;
+import com.example.FreStyle.usecase.GetNotesByUserIdUseCase;
+import com.example.FreStyle.usecase.UpdateNoteUseCase;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +23,10 @@ import java.util.List;
 public class NoteController {
 
     private static final Logger logger = LoggerFactory.getLogger(NoteController.class);
-    private final NoteService noteService;
+    private final GetNotesByUserIdUseCase getNotesByUserIdUseCase;
+    private final CreateNoteUseCase createNoteUseCase;
+    private final UpdateNoteUseCase updateNoteUseCase;
+    private final DeleteNoteUseCase deleteNoteUseCase;
     private final UserIdentityService userIdentityService;
 
     @GetMapping
@@ -28,7 +34,7 @@ public class NoteController {
         String sub = jwt.getSubject();
         User user = userIdentityService.findUserBySub(sub);
 
-        List<NoteDto> notes = noteService.getNotesByUserId(user.getId());
+        List<NoteDto> notes = getNotesByUserIdUseCase.execute(user.getId());
         logger.info("ノート一覧取得成功 - 件数: {}", notes.size());
 
         return ResponseEntity.ok(notes);
@@ -42,7 +48,7 @@ public class NoteController {
         String sub = jwt.getSubject();
         User user = userIdentityService.findUserBySub(sub);
 
-        NoteDto note = noteService.createNote(user.getId(), request.title());
+        NoteDto note = createNoteUseCase.execute(user.getId(), request.title());
         logger.info("ノート作成成功 - noteId: {}", note.getNoteId());
 
         return ResponseEntity.ok(note);
@@ -57,7 +63,7 @@ public class NoteController {
         String sub = jwt.getSubject();
         User user = userIdentityService.findUserBySub(sub);
 
-        noteService.updateNote(user.getId(), noteId, request.title(), request.content(), request.isPinned());
+        updateNoteUseCase.execute(user.getId(), noteId, request.title(), request.content(), request.isPinned());
         logger.info("ノート更新成功 - noteId: {}", noteId);
 
         return ResponseEntity.noContent().build();
@@ -71,7 +77,7 @@ public class NoteController {
         String sub = jwt.getSubject();
         User user = userIdentityService.findUserBySub(sub);
 
-        noteService.deleteNote(user.getId(), noteId);
+        deleteNoteUseCase.execute(user.getId(), noteId);
         logger.info("ノート削除成功 - noteId: {}", noteId);
 
         return ResponseEntity.noContent().build();

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/NoteRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/NoteRepository.java
@@ -1,0 +1,16 @@
+package com.example.FreStyle.repository;
+
+import com.example.FreStyle.dto.NoteDto;
+
+import java.util.List;
+
+public interface NoteRepository {
+
+    List<NoteDto> findByUserId(Integer userId);
+
+    NoteDto save(Integer userId, String title);
+
+    void update(Integer userId, String noteId, String title, String content, Boolean isPinned);
+
+    void delete(Integer userId, String noteId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateNoteUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateNoteUseCase.java
@@ -1,0 +1,17 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.dto.NoteDto;
+import com.example.FreStyle.repository.NoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateNoteUseCase {
+
+    private final NoteRepository noteRepository;
+
+    public NoteDto execute(Integer userId, String title) {
+        return noteRepository.save(userId, title);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteNoteUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteNoteUseCase.java
@@ -1,0 +1,16 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.repository.NoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteNoteUseCase {
+
+    private final NoteRepository noteRepository;
+
+    public void execute(Integer userId, String noteId) {
+        noteRepository.delete(userId, noteId);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetNotesByUserIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetNotesByUserIdUseCase.java
@@ -1,0 +1,19 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.dto.NoteDto;
+import com.example.FreStyle.repository.NoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetNotesByUserIdUseCase {
+
+    private final NoteRepository noteRepository;
+
+    public List<NoteDto> execute(Integer userId) {
+        return noteRepository.findByUserId(userId);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateNoteUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateNoteUseCase.java
@@ -1,0 +1,16 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.repository.NoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateNoteUseCase {
+
+    private final NoteRepository noteRepository;
+
+    public void execute(Integer userId, String noteId, String title, String content, Boolean isPinned) {
+        noteRepository.update(userId, noteId, title, content, isPinned);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/NoteControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/NoteControllerTest.java
@@ -2,8 +2,11 @@ package com.example.FreStyle.controller;
 
 import com.example.FreStyle.dto.NoteDto;
 import com.example.FreStyle.entity.User;
-import com.example.FreStyle.service.NoteService;
 import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.CreateNoteUseCase;
+import com.example.FreStyle.usecase.DeleteNoteUseCase;
+import com.example.FreStyle.usecase.GetNotesByUserIdUseCase;
+import com.example.FreStyle.usecase.UpdateNoteUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,7 +27,16 @@ import static org.mockito.Mockito.*;
 class NoteControllerTest {
 
     @Mock
-    private NoteService noteService;
+    private GetNotesByUserIdUseCase getNotesByUserIdUseCase;
+
+    @Mock
+    private CreateNoteUseCase createNoteUseCase;
+
+    @Mock
+    private UpdateNoteUseCase updateNoteUseCase;
+
+    @Mock
+    private DeleteNoteUseCase deleteNoteUseCase;
 
     @Mock
     private UserIdentityService userIdentityService;
@@ -52,17 +64,18 @@ class NoteControllerTest {
     class GetNotesTest {
 
         @Test
-        @DisplayName("ユーザーのノート一覧を返す")
-        void shouldReturnUserNotes() {
+        @DisplayName("UseCase経由でユーザーのノート一覧を返す")
+        void shouldReturnUserNotesViaUseCase() {
             NoteDto note1 = new NoteDto("note-1", 1, "タイトル1", "内容1", false, 1000L, 2000L);
             NoteDto note2 = new NoteDto("note-2", 1, "タイトル2", "内容2", true, 1500L, 3000L);
-            when(noteService.getNotesByUserId(1)).thenReturn(List.of(note1, note2));
+            when(getNotesByUserIdUseCase.execute(1)).thenReturn(List.of(note1, note2));
 
             ResponseEntity<List<NoteDto>> response = noteController.getNotes(jwt);
 
             assertThat(response.getStatusCode().value()).isEqualTo(200);
             assertThat(response.getBody()).hasSize(2);
             assertThat(response.getBody().get(0).getTitle()).isEqualTo("タイトル1");
+            verify(getNotesByUserIdUseCase).execute(1);
         }
     }
 
@@ -71,10 +84,10 @@ class NoteControllerTest {
     class CreateNoteTest {
 
         @Test
-        @DisplayName("新しいノートを作成して返す")
-        void shouldCreateAndReturnNote() {
+        @DisplayName("UseCase経由で新しいノートを作成して返す")
+        void shouldCreateNoteViaUseCase() {
             NoteDto created = new NoteDto("note-new", 1, "新しいノート", "", false, 1000L, 1000L);
-            when(noteService.createNote(1, "新しいノート")).thenReturn(created);
+            when(createNoteUseCase.execute(1, "新しいノート")).thenReturn(created);
 
             ResponseEntity<NoteDto> response = noteController.createNote(jwt,
                     new NoteController.CreateNoteRequest("新しいノート"));
@@ -82,6 +95,7 @@ class NoteControllerTest {
             assertThat(response.getStatusCode().value()).isEqualTo(200);
             assertThat(response.getBody().getTitle()).isEqualTo("新しいノート");
             assertThat(response.getBody().getNoteId()).isEqualTo("note-new");
+            verify(createNoteUseCase).execute(1, "新しいノート");
         }
     }
 
@@ -90,15 +104,15 @@ class NoteControllerTest {
     class UpdateNoteTest {
 
         @Test
-        @DisplayName("ノートを更新して204を返す")
-        void shouldUpdateNoteAndReturnNoContent() {
-            doNothing().when(noteService).updateNote(1, "note-1", "更新タイトル", "更新内容", false);
+        @DisplayName("UseCase経由でノートを更新して204を返す")
+        void shouldUpdateNoteViaUseCase() {
+            doNothing().when(updateNoteUseCase).execute(1, "note-1", "更新タイトル", "更新内容", false);
 
             ResponseEntity<Void> response = noteController.updateNote(jwt, "note-1",
                     new NoteController.UpdateNoteRequest("更新タイトル", "更新内容", false));
 
             assertThat(response.getStatusCode().value()).isEqualTo(204);
-            verify(noteService).updateNote(1, "note-1", "更新タイトル", "更新内容", false);
+            verify(updateNoteUseCase).execute(1, "note-1", "更新タイトル", "更新内容", false);
         }
     }
 
@@ -107,14 +121,14 @@ class NoteControllerTest {
     class DeleteNoteTest {
 
         @Test
-        @DisplayName("ノートを削除して204を返す")
-        void shouldDeleteNoteAndReturnNoContent() {
-            doNothing().when(noteService).deleteNote(1, "note-1");
+        @DisplayName("UseCase経由でノートを削除して204を返す")
+        void shouldDeleteNoteViaUseCase() {
+            doNothing().when(deleteNoteUseCase).execute(1, "note-1");
 
             ResponseEntity<Void> response = noteController.deleteNote(jwt, "note-1");
 
             assertThat(response.getStatusCode().value()).isEqualTo(204);
-            verify(noteService).deleteNote(1, "note-1");
+            verify(deleteNoteUseCase).execute(1, "note-1");
         }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/service/NoteServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/NoteServiceTest.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -35,13 +34,12 @@ class NoteServiceTest {
     }
 
     @Nested
-    @DisplayName("getNotesByUserId - ユーザーのノート一覧取得")
-    class GetNotesByUserIdTest {
+    @DisplayName("findByUserId - ユーザーのノート一覧取得")
+    class FindByUserIdTest {
 
         @Test
         @DisplayName("ユーザーのノートを更新日時降順で取得する")
         void shouldReturnNotesSortedByUpdatedAtDesc() {
-            // Arrange
             Map<String, AttributeValue> item1 = createNoteItem(1, "note-1", "タイトル1", "内容1", false, 1000L, 2000L);
             Map<String, AttributeValue> item2 = createNoteItem(1, "note-2", "タイトル2", "内容2", true, 1500L, 3000L);
 
@@ -50,10 +48,8 @@ class NoteServiceTest {
                     .build();
             when(dynamoDbClient.query(any(QueryRequest.class))).thenReturn(response);
 
-            // Act
-            List<NoteDto> result = noteService.getNotesByUserId(1);
+            List<NoteDto> result = noteService.findByUserId(1);
 
-            // Assert
             assertThat(result).hasSize(2);
             assertThat(result.get(0).getNoteId()).isEqualTo("note-1");
             assertThat(result.get(1).getNoteId()).isEqualTo("note-2");
@@ -67,15 +63,15 @@ class NoteServiceTest {
                     .build();
             when(dynamoDbClient.query(any(QueryRequest.class))).thenReturn(response);
 
-            List<NoteDto> result = noteService.getNotesByUserId(1);
+            List<NoteDto> result = noteService.findByUserId(1);
 
             assertThat(result).isEmpty();
         }
     }
 
     @Nested
-    @DisplayName("createNote - ノート作成")
-    class CreateNoteTest {
+    @DisplayName("save - ノート作成")
+    class SaveTest {
 
         @Test
         @DisplayName("新しいノートを作成して返す")
@@ -83,7 +79,7 @@ class NoteServiceTest {
             when(dynamoDbClient.putItem(any(PutItemRequest.class)))
                     .thenReturn(PutItemResponse.builder().build());
 
-            NoteDto result = noteService.createNote(1, "新しいノート");
+            NoteDto result = noteService.save(1, "新しいノート");
 
             assertThat(result).isNotNull();
             assertThat(result.getUserId()).isEqualTo(1);
@@ -97,8 +93,8 @@ class NoteServiceTest {
     }
 
     @Nested
-    @DisplayName("updateNote - ノート更新")
-    class UpdateNoteTest {
+    @DisplayName("update - ノート更新")
+    class UpdateTest {
 
         @Test
         @DisplayName("タイトルと内容を更新する")
@@ -106,7 +102,7 @@ class NoteServiceTest {
             when(dynamoDbClient.updateItem(any(UpdateItemRequest.class)))
                     .thenReturn(UpdateItemResponse.builder().build());
 
-            noteService.updateNote(1, "note-1", "更新タイトル", "更新内容", false);
+            noteService.update(1, "note-1", "更新タイトル", "更新内容", false);
 
             ArgumentCaptor<UpdateItemRequest> captor = ArgumentCaptor.forClass(UpdateItemRequest.class);
             verify(dynamoDbClient).updateItem(captor.capture());
@@ -119,8 +115,8 @@ class NoteServiceTest {
     }
 
     @Nested
-    @DisplayName("deleteNote - ノート削除")
-    class DeleteNoteTest {
+    @DisplayName("delete - ノート削除")
+    class DeleteTest {
 
         @Test
         @DisplayName("指定されたノートを削除する")
@@ -128,7 +124,7 @@ class NoteServiceTest {
             when(dynamoDbClient.deleteItem(any(DeleteItemRequest.class)))
                     .thenReturn(DeleteItemResponse.builder().build());
 
-            noteService.deleteNote(1, "note-1");
+            noteService.delete(1, "note-1");
 
             ArgumentCaptor<DeleteItemRequest> captor = ArgumentCaptor.forClass(DeleteItemRequest.class);
             verify(dynamoDbClient).deleteItem(captor.capture());

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateNoteUseCaseTest.java
@@ -1,0 +1,44 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.dto.NoteDto;
+import com.example.FreStyle.repository.NoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateNoteUseCaseTest {
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @InjectMocks
+    private CreateNoteUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - ノート作成")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("新しいノートを作成して返す")
+        void shouldCreateNoteAndReturnDto() {
+            NoteDto expected = new NoteDto("note-new", 1, "新しいノート", "", false, 1000L, 1000L);
+            when(noteRepository.save(1, "新しいノート")).thenReturn(expected);
+
+            NoteDto result = useCase.execute(1, "新しいノート");
+
+            assertThat(result).isNotNull();
+            assertThat(result.getNoteId()).isEqualTo("note-new");
+            assertThat(result.getTitle()).isEqualTo("新しいノート");
+            assertThat(result.getUserId()).isEqualTo(1);
+            verify(noteRepository, times(1)).save(1, "新しいノート");
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteNoteUseCaseTest.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.repository.NoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteNoteUseCaseTest {
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @InjectMocks
+    private DeleteNoteUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - ノート削除")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("指定されたノートを削除する")
+        void shouldDeleteNote() {
+            doNothing().when(noteRepository).delete(1, "note-1");
+
+            useCase.execute(1, "note-1");
+
+            verify(noteRepository, times(1)).delete(1, "note-1");
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetNotesByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetNotesByUserIdUseCaseTest.java
@@ -1,0 +1,57 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.dto.NoteDto;
+import com.example.FreStyle.repository.NoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetNotesByUserIdUseCaseTest {
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @InjectMocks
+    private GetNotesByUserIdUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - ユーザーIDでノート一覧取得")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("ユーザーのノート一覧をRepository経由で取得する")
+        void shouldReturnNotesByUserId() {
+            NoteDto note1 = new NoteDto("note-1", 1, "タイトル1", "内容1", false, 1000L, 2000L);
+            NoteDto note2 = new NoteDto("note-2", 1, "タイトル2", "内容2", true, 1500L, 3000L);
+            when(noteRepository.findByUserId(1)).thenReturn(List.of(note1, note2));
+
+            List<NoteDto> result = useCase.execute(1);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getNoteId()).isEqualTo("note-1");
+            assertThat(result.get(1).getNoteId()).isEqualTo("note-2");
+            verify(noteRepository, times(1)).findByUserId(1);
+        }
+
+        @Test
+        @DisplayName("ノートが存在しない場合は空リストを返す")
+        void shouldReturnEmptyListWhenNoNotes() {
+            when(noteRepository.findByUserId(1)).thenReturn(List.of());
+
+            List<NoteDto> result = useCase.execute(1);
+
+            assertThat(result).isEmpty();
+            verify(noteRepository, times(1)).findByUserId(1);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateNoteUseCaseTest.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.repository.NoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateNoteUseCaseTest {
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @InjectMocks
+    private UpdateNoteUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - ノート更新")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("ノートのタイトル・内容・ピン留めを更新する")
+        void shouldUpdateNote() {
+            doNothing().when(noteRepository).update(1, "note-1", "更新タイトル", "更新内容", true);
+
+            useCase.execute(1, "note-1", "更新タイトル", "更新内容", true);
+
+            verify(noteRepository, times(1)).update(1, "note-1", "更新タイトル", "更新内容", true);
+        }
+    }
+}


### PR DESCRIPTION
## 概要
ノート機能をクリーンアーキテクチャに準拠するようリファクタリング。

## 変更内容
- **NoteRepository**: データアクセス層のインターフェース作成
- **NoteService**: `@Service`→`@Repository`に変更、`NoteRepository`を実装
- **UseCase層追加**: 4つのUseCaseを新規作成
  - `GetNotesByUserIdUseCase` - ノート一覧取得
  - `CreateNoteUseCase` - ノート作成
  - `UpdateNoteUseCase` - ノート更新
  - `DeleteNoteUseCase` - ノート削除
- **NoteController**: Service直接呼び出し→UseCase経由に変更

## アーキテクチャ
```
NoteController → UseCase → NoteRepository (Interface) → NoteService (DynamoDB実装)
```

## テスト
- UseCaseテスト4件追加
- 既存テスト更新（NoteControllerTest, NoteServiceTest）
- 全105テスト合格（contextLoads除く）

closes #482