### PR TITLE
test: ノート機能のテスト品質向上

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateNoteUseCaseTest.java
@@ -40,5 +40,17 @@ class CreateNoteUseCaseTest {
             assertThat(result.getUserId()).isEqualTo(1);
             verify(noteRepository, times(1)).save(1, "新しいノート");
         }
+
+        @Test
+        @DisplayName("空文字タイトルでもノートを作成できる")
+        void shouldCreateNoteWithEmptyTitle() {
+            NoteDto expected = new NoteDto("note-empty", 1, "", "", false, 1000L, 1000L);
+            when(noteRepository.save(1, "")).thenReturn(expected);
+
+            NoteDto result = useCase.execute(1, "");
+
+            assertThat(result.getTitle()).isEmpty();
+            verify(noteRepository, times(1)).save(1, "");
+        }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetNotesByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetNotesByUserIdUseCaseTest.java
@@ -53,5 +53,19 @@ class GetNotesByUserIdUseCaseTest {
             assertThat(result).isEmpty();
             verify(noteRepository, times(1)).findByUserId(1);
         }
+
+        @Test
+        @DisplayName("ピン留めされたノートが含まれる場合も正しく返す")
+        void shouldReturnNotesWithPinnedStatus() {
+            NoteDto pinned = new NoteDto("note-p", 1, "ピン留め", "内容", true, 1000L, 4000L);
+            NoteDto unpinned = new NoteDto("note-u", 1, "通常", "内容", false, 2000L, 3000L);
+            when(noteRepository.findByUserId(1)).thenReturn(List.of(pinned, unpinned));
+
+            List<NoteDto> result = useCase.execute(1);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getIsPinned()).isTrue();
+            assertThat(result.get(1).getIsPinned()).isFalse();
+        }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateNoteUseCaseTest.java
@@ -33,5 +33,25 @@ class UpdateNoteUseCaseTest {
 
             verify(noteRepository, times(1)).update(1, "note-1", "更新タイトル", "更新内容", true);
         }
+
+        @Test
+        @DisplayName("ピン留め状態のみを変更する")
+        void shouldUpdateOnlyPinnedStatus() {
+            doNothing().when(noteRepository).update(1, "note-1", "同じタイトル", "同じ内容", true);
+
+            useCase.execute(1, "note-1", "同じタイトル", "同じ内容", true);
+
+            verify(noteRepository, times(1)).update(1, "note-1", "同じタイトル", "同じ内容", true);
+        }
+
+        @Test
+        @DisplayName("空文字のタイトルと内容で更新する")
+        void shouldUpdateWithEmptyValues() {
+            doNothing().when(noteRepository).update(1, "note-1", "", "", false);
+
+            useCase.execute(1, "note-1", "", "", false);
+
+            verify(noteRepository, times(1)).update(1, "note-1", "", "", false);
+        }
     }
 }

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NotesPage from '../NotesPage';
+import { useNotes } from '../../hooks/useNotes';
+
+vi.mock('../../hooks/useNotes');
+
+const mockUseNotes = {
+  notes: [],
+  selectedNoteId: null,
+  loading: false,
+  fetchNotes: vi.fn(),
+  createNote: vi.fn(),
+  updateNote: vi.fn(),
+  deleteNote: vi.fn(),
+  selectNote: vi.fn(),
+};
+
+describe('NotesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.mocked(useNotes).mockReturnValue({ ...mockUseNotes });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('マウント時にfetchNotesが呼ばれる', () => {
+    render(<NotesPage />);
+    expect(mockUseNotes.fetchNotes).toHaveBeenCalled();
+  });
+
+  it('ローディング中はスピナーを表示する', () => {
+    vi.mocked(useNotes).mockReturnValue({ ...mockUseNotes, loading: true, notes: [] });
+    const { container } = render(<NotesPage />);
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('ノートが空の場合は「ノートがありません」を表示する', () => {
+    render(<NotesPage />);
+    expect(screen.getAllByText('ノートがありません').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ノート未選択時にEmptyStateを表示する', () => {
+    render(<NotesPage />);
+    expect(screen.getByText('ノートを選択してください')).toBeInTheDocument();
+  });
+
+  it('ノート一覧を表示する', () => {
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: [
+        { noteId: 'n1', userId: 1, title: 'テスト1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+        { noteId: 'n2', userId: 1, title: 'テスト2', content: '内容2', isPinned: true, createdAt: 1500, updatedAt: 3000 },
+      ],
+    });
+    render(<NotesPage />);
+    expect(screen.getAllByText('テスト1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('テスト2').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ノート選択時にエディタが表示される', () => {
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: [
+        { noteId: 'n1', userId: 1, title: '選択ノート', content: '選択内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+      ],
+      selectedNoteId: 'n1',
+    });
+    render(<NotesPage />);
+    expect(screen.getByDisplayValue('選択ノート')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('選択内容')).toBeInTheDocument();
+  });
+
+  it('新しいノートボタンでcreateNoteが呼ばれる', async () => {
+    mockUseNotes.createNote.mockResolvedValue(null);
+    render(<NotesPage />);
+
+    const createButtons = screen.getAllByText('新しいノート');
+    await act(async () => {
+      fireEvent.click(createButtons[0]);
+    });
+
+    expect(mockUseNotes.createNote).toHaveBeenCalledWith('無題');
+  });
+
+  it('タイトル変更で自動保存が800ms後に呼ばれる', async () => {
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: [
+        { noteId: 'n1', userId: 1, title: '元タイトル', content: '元内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+      ],
+      selectedNoteId: 'n1',
+    });
+    render(<NotesPage />);
+
+    const titleInput = screen.getByDisplayValue('元タイトル');
+    fireEvent.change(titleInput, { target: { value: '新タイトル' } });
+
+    expect(mockUseNotes.updateNote).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(mockUseNotes.updateNote).toHaveBeenCalledWith('n1', {
+      title: '新タイトル',
+      content: '元内容',
+      isPinned: false,
+    });
+  });
+
+  it('内容変更で自動保存が800ms後に呼ばれる', async () => {
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: [
+        { noteId: 'n1', userId: 1, title: 'タイトル', content: '元内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+      ],
+      selectedNoteId: 'n1',
+    });
+    render(<NotesPage />);
+
+    const textarea = screen.getByDisplayValue('元内容');
+    fireEvent.change(textarea, { target: { value: '新内容' } });
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(mockUseNotes.updateNote).toHaveBeenCalledWith('n1', {
+      title: 'タイトル',
+      content: '新内容',
+      isPinned: false,
+    });
+  });
+
+  it('連続入力で自動保存がデバウンスされる', async () => {
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: [
+        { noteId: 'n1', userId: 1, title: 'タイトル', content: '', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+      ],
+      selectedNoteId: 'n1',
+    });
+    render(<NotesPage />);
+
+    const titleInput = screen.getByDisplayValue('タイトル');
+    fireEvent.change(titleInput, { target: { value: 'A' } });
+    act(() => { vi.advanceTimersByTime(400); });
+
+    fireEvent.change(titleInput, { target: { value: 'AB' } });
+    act(() => { vi.advanceTimersByTime(400); });
+
+    fireEvent.change(titleInput, { target: { value: 'ABC' } });
+    act(() => { vi.advanceTimersByTime(800); });
+
+    expect(mockUseNotes.updateNote).toHaveBeenCalledTimes(1);
+    expect(mockUseNotes.updateNote).toHaveBeenCalledWith('n1', {
+      title: 'ABC',
+      content: '',
+      isPinned: false,
+    });
+  });
+
+  it('モバイルでノート一覧ボタンが表示される', () => {
+    render(<NotesPage />);
+    expect(screen.getByLabelText('ノート一覧を開く')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
ノート機能のテストカバレッジとエッジケースを強化。

## 変更内容
### フロントエンド
- **NotesPage.tsxテスト新規作成**（11テスト）
  - 初期化時のfetchNotes呼び出し
  - ローディングスピナー表示
  - ノート一覧・空状態・EmptyState表示
  - エディタ表示（選択時）
  - 自動保存（800msデバウンス）・連続入力デバウンス
  - ノート作成・モバイルUI
- **useNotesエッジケース追加**（+7テスト）
  - エラーハンドリング（fetchNotes/createNote）
  - selectedNoteId自動更新・ローカル更新
  - 選択中ノート削除時のnullリセット
  - loading状態遷移確認

### バックエンド
- **UseCaseエッジケース追加**（+4テスト）
  - ピン留めノート取得
  - 空文字タイトル作成・更新

## テスト結果
- フロントエンド: 970テスト合格（+18テスト）
- バックエンド: 109テスト合格（+4テスト、contextLoads除く）

closes #484