### PR TITLE
feat: ノート検索・ピン留めUI機能を追加

### DIFF
--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -1,4 +1,6 @@
 import { TrashIcon } from '@heroicons/react/24/outline';
+import { MapPinIcon as MapPinOutline } from '@heroicons/react/24/outline';
+import { MapPinIcon as MapPinSolid } from '@heroicons/react/24/solid';
 
 interface NoteListItemProps {
   noteId: string;
@@ -9,6 +11,7 @@ interface NoteListItemProps {
   isActive: boolean;
   onSelect: (noteId: string) => void;
   onDelete: (noteId: string) => void;
+  onTogglePin: (noteId: string) => void;
 }
 
 export default function NoteListItem({
@@ -16,9 +19,11 @@ export default function NoteListItem({
   title,
   content,
   updatedAt,
+  isPinned,
   isActive,
   onSelect,
   onDelete,
+  onTogglePin,
 }: NoteListItemProps) {
   const displayTitle = title || '無題';
   const preview = content.replace(/\n/g, ' ').slice(0, 60);
@@ -29,6 +34,13 @@ export default function NoteListItem({
     e.stopPropagation();
     onDelete(noteId);
   };
+
+  const handleTogglePin = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onTogglePin(noteId);
+  };
+
+  const PinIcon = isPinned ? MapPinSolid : MapPinOutline;
 
   return (
     <div
@@ -45,6 +57,7 @@ export default function NoteListItem({
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+            {isPinned && <PinIcon className="w-3.5 h-3.5 inline mr-1 text-primary-500" />}
             {displayTitle}
           </p>
           {preview && (
@@ -56,13 +69,24 @@ export default function NoteListItem({
             {dateStr}
           </p>
         </div>
-        <button
-          onClick={handleDelete}
-          aria-label="ノートを削除"
-          className="p-1 opacity-0 group-hover:opacity-100 hover:bg-surface-3 rounded transition-all"
-        >
-          <TrashIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
-        </button>
+        <div className="flex items-center gap-0.5">
+          <button
+            onClick={handleTogglePin}
+            aria-label={isPinned ? 'ピン留め解除' : 'ピン留め'}
+            className={`p-1 rounded transition-all ${
+              isPinned ? 'opacity-100 text-primary-500' : 'opacity-0 group-hover:opacity-100 hover:bg-surface-3'
+            }`}
+          >
+            <PinIcon className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={handleDelete}
+            aria-label="ノートを削除"
+            className="p-1 opacity-0 group-hover:opacity-100 hover:bg-surface-3 rounded transition-all"
+          >
+            <TrashIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/__tests__/NoteListItem.test.tsx
+++ b/frontend/src/components/__tests__/NoteListItem.test.tsx
@@ -11,6 +11,7 @@ const defaultProps = {
   isActive: false,
   onSelect: vi.fn(),
   onDelete: vi.fn(),
+  onTogglePin: vi.fn(),
 };
 
 describe('NoteListItem', () => {
@@ -46,5 +47,30 @@ describe('NoteListItem', () => {
   it('タイトルが空の場合は「無題」を表示する', () => {
     render(<NoteListItem {...defaultProps} title="" />);
     expect(screen.getByText('無題')).toBeInTheDocument();
+  });
+
+  it('ピン留めボタンが表示される', () => {
+    render(<NoteListItem {...defaultProps} />);
+    expect(screen.getByLabelText('ピン留め')).toBeInTheDocument();
+  });
+
+  it('ピン留め状態のときピンアイコンがソリッドになる', () => {
+    render(<NoteListItem {...defaultProps} isPinned={true} />);
+    expect(screen.getByLabelText('ピン留め解除')).toBeInTheDocument();
+  });
+
+  it('ピン留めボタンクリックでonTogglePinが呼ばれる', () => {
+    const onTogglePin = vi.fn();
+    render(<NoteListItem {...defaultProps} onTogglePin={onTogglePin} />);
+    fireEvent.click(screen.getByLabelText('ピン留め'));
+    expect(onTogglePin).toHaveBeenCalledWith('note-1');
+  });
+
+  it('ピン留めボタンクリックでonSelectは呼ばれない', () => {
+    const onSelect = vi.fn();
+    const onTogglePin = vi.fn();
+    render(<NoteListItem {...defaultProps} onSelect={onSelect} onTogglePin={onTogglePin} />);
+    fireEvent.click(screen.getByLabelText('ピン留め'));
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -3,20 +3,24 @@ import SecondaryPanel from '../components/layout/SecondaryPanel';
 import NoteListItem from '../components/NoteListItem';
 import NoteEditor from '../components/NoteEditor';
 import EmptyState from '../components/EmptyState';
-import { DocumentTextIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { useNotes } from '../hooks/useNotes';
 
 export default function NotesPage() {
   const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
   const {
     notes,
+    filteredNotes,
     selectedNoteId,
     loading,
+    searchQuery,
+    setSearchQuery,
     fetchNotes,
     createNote,
     updateNote,
     deleteNote,
     selectNote,
+    togglePin,
   } = useNotes();
 
   const [editTitle, setEditTitle] = useState('');
@@ -83,13 +87,25 @@ export default function NotesPage() {
         mobileOpen={mobilePanelOpen}
         onMobileClose={() => setMobilePanelOpen(false)}
         headerContent={
-          <button
-            onClick={handleCreateNote}
-            className="w-full bg-primary-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
-          >
-            <PlusIcon className="w-4 h-4" />
-            新しいノート
-          </button>
+          <div className="space-y-2">
+            <div className="relative">
+              <MagnifyingGlassIcon className="w-4 h-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />
+              <input
+                type="text"
+                placeholder="ノートを検索..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+              />
+            </div>
+            <button
+              onClick={handleCreateNote}
+              className="w-full bg-primary-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
+            >
+              <PlusIcon className="w-4 h-4" />
+              新しいノート
+            </button>
+          </div>
         }
       >
         <div className="p-2 space-y-0.5">
@@ -97,12 +113,12 @@ export default function NotesPage() {
             <div className="flex items-center justify-center py-8">
               <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-500" />
             </div>
-          ) : notes.length === 0 ? (
+          ) : filteredNotes.length === 0 ? (
             <div className="p-4 text-center text-xs text-[var(--color-text-muted)]">
               ノートがありません
             </div>
           ) : (
-            notes.map((note) => (
+            filteredNotes.map((note) => (
               <NoteListItem
                 key={note.noteId}
                 noteId={note.noteId}
@@ -113,6 +129,7 @@ export default function NotesPage() {
                 isActive={selectedNoteId === note.noteId}
                 onSelect={handleSelectNote}
                 onDelete={handleDeleteNote}
+                onTogglePin={togglePin}
               />
             ))
           )}


### PR DESCRIPTION
## 概要
- ノート検索機能（タイトル・内容のインクリメンタルサーチ）
- ピン留めUI（NoteListItemにピンアイコン追加、トグル操作）
- ピン留めノートの先頭表示（ピン留め内・非ピン留め内でそれぞれ更新日時降順）

## 変更内容
- `useNotes`フックに`searchQuery`/`setSearchQuery`/`filteredNotes`/`togglePin`を追加
- `NoteListItem`にMapPinアイコン表示とピン留めトグルボタンを追加
- `NotesPage`に検索入力欄を追加し`filteredNotes`で一覧表示

## テスト
- useNotes: +7テスト（検索・ピン留め関連）
- NoteListItem: +4テスト（ピンボタン表示・操作）
- NotesPage: +4テスト（検索入力・filteredNotes使用・ピントグル）
- 全985テスト通過

closes #488