### PR TITLE
refactor: useNoteEditorフック抽出・togglePin依存最適化

### DIFF
--- a/frontend/src/hooks/__tests__/useNoteEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useNoteEditor.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNoteEditor } from '../useNoteEditor';
+import type { Note } from '../../types';
+
+const mockUpdateNote = vi.fn();
+
+const baseNote: Note = {
+  noteId: 'n1',
+  userId: 1,
+  title: '元タイトル',
+  content: '元内容',
+  isPinned: false,
+  createdAt: 1000,
+  updatedAt: 2000,
+};
+
+describe('useNoteEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('selectedNoteからeditTitleとeditContentが初期化される', () => {
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+    expect(result.current.editTitle).toBe('元タイトル');
+    expect(result.current.editContent).toBe('元内容');
+  });
+
+  it('selectedNoteがnullの場合は空文字で初期化される', () => {
+    const { result } = renderHook(() => useNoteEditor(null, null, mockUpdateNote));
+    expect(result.current.editTitle).toBe('');
+    expect(result.current.editContent).toBe('');
+  });
+
+  it('handleTitleChangeでeditTitleが更新される', () => {
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => {
+      result.current.handleTitleChange('新タイトル');
+    });
+
+    expect(result.current.editTitle).toBe('新タイトル');
+  });
+
+  it('handleContentChangeでeditContentが更新される', () => {
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => {
+      result.current.handleContentChange('新内容');
+    });
+
+    expect(result.current.editContent).toBe('新内容');
+  });
+
+  it('タイトル変更後800msでupdateNoteが呼ばれる', () => {
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => {
+      result.current.handleTitleChange('新タイトル');
+    });
+
+    expect(mockUpdateNote).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(mockUpdateNote).toHaveBeenCalledWith('n1', {
+      title: '新タイトル',
+      content: '元内容',
+      isPinned: false,
+    });
+  });
+
+  it('内容変更後800msでupdateNoteが呼ばれる', () => {
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => {
+      result.current.handleContentChange('新内容');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(mockUpdateNote).toHaveBeenCalledWith('n1', {
+      title: '元タイトル',
+      content: '新内容',
+      isPinned: false,
+    });
+  });
+
+  it('連続入力でデバウンスされる', () => {
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => { result.current.handleTitleChange('A'); });
+    act(() => { vi.advanceTimersByTime(400); });
+    act(() => { result.current.handleTitleChange('AB'); });
+    act(() => { vi.advanceTimersByTime(400); });
+    act(() => { result.current.handleTitleChange('ABC'); });
+    act(() => { vi.advanceTimersByTime(800); });
+
+    expect(mockUpdateNote).toHaveBeenCalledTimes(1);
+    expect(mockUpdateNote).toHaveBeenCalledWith('n1', {
+      title: 'ABC',
+      content: '元内容',
+      isPinned: false,
+    });
+  });
+
+  it('selectedNoteIdが変わるとeditTitle/editContentがリセットされる', () => {
+    const newNote: Note = { ...baseNote, noteId: 'n2', title: '別ノート', content: '別内容' };
+
+    const { result, rerender } = renderHook(
+      ({ noteId, note }) => useNoteEditor(noteId, note, mockUpdateNote),
+      { initialProps: { noteId: 'n1' as string | null, note: baseNote as Note | null } }
+    );
+
+    expect(result.current.editTitle).toBe('元タイトル');
+
+    rerender({ noteId: 'n2', note: newNote });
+
+    expect(result.current.editTitle).toBe('別ノート');
+    expect(result.current.editContent).toBe('別内容');
+  });
+
+  it('selectedNoteIdがnullになるとeditTitle/editContentが空になる', () => {
+    const { result, rerender } = renderHook(
+      ({ noteId, note }) => useNoteEditor(noteId, note, mockUpdateNote),
+      { initialProps: { noteId: 'n1' as string | null, note: baseNote as Note | null } }
+    );
+
+    rerender({ noteId: null, note: null });
+
+    expect(result.current.editTitle).toBe('');
+    expect(result.current.editContent).toBe('');
+  });
+});

--- a/frontend/src/hooks/useNoteEditor.ts
+++ b/frontend/src/hooks/useNoteEditor.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { Note } from '../types';
+
+export function useNoteEditor(
+  selectedNoteId: string | null,
+  selectedNote: Note | null,
+  updateNote: (noteId: string, data: { title: string; content: string; isPinned: boolean }) => Promise<void>
+) {
+  const [editTitle, setEditTitle] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (selectedNote) {
+      setEditTitle(selectedNote.title);
+      setEditContent(selectedNote.content);
+    } else {
+      setEditTitle('');
+      setEditContent('');
+    }
+  }, [selectedNoteId]);
+
+  const handleAutoSave = useCallback(
+    (title: string, content: string) => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        if (selectedNoteId) {
+          updateNote(selectedNoteId, {
+            title,
+            content,
+            isPinned: selectedNote?.isPinned || false,
+          });
+        }
+      }, 800);
+    },
+    [selectedNoteId, selectedNote, updateNote]
+  );
+
+  const handleTitleChange = useCallback(
+    (title: string) => {
+      setEditTitle(title);
+      handleAutoSave(title, editContent);
+    },
+    [handleAutoSave, editContent]
+  );
+
+  const handleContentChange = useCallback(
+    (content: string) => {
+      setEditContent(content);
+      handleAutoSave(editTitle, content);
+    },
+    [handleAutoSave, editTitle]
+  );
+
+  return {
+    editTitle,
+    editContent,
+    handleTitleChange,
+    handleContentChange,
+  };
+}

--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useRef } from 'react';
 import type { Note } from '../types';
 import NoteRepository from '../repositories/NoteRepository';
 
@@ -7,6 +7,8 @@ export function useNotes() {
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const notesRef = useRef<Note[]>(notes);
+  notesRef.current = notes;
 
   const fetchNotes = useCallback(async () => {
     setLoading(true);
@@ -53,7 +55,7 @@ export function useNotes() {
   }, []);
 
   const togglePin = useCallback(async (noteId: string) => {
-    const note = notes.find((n) => n.noteId === noteId);
+    const note = notesRef.current.find((n) => n.noteId === noteId);
     if (!note) return;
     const newPinned = !note.isPinned;
     try {
@@ -68,7 +70,7 @@ export function useNotes() {
     } catch {
       // エラーハンドリング
     }
-  }, [notes]);
+  }, []);
 
   const selectNote = useCallback((noteId: string | null) => {
     setSelectedNoteId(noteId);

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import NoteListItem from '../components/NoteListItem';
 import NoteEditor from '../components/NoteEditor';
 import EmptyState from '../components/EmptyState';
 import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { useNotes } from '../hooks/useNotes';
+import { useNoteEditor } from '../hooks/useNoteEditor';
 
 export default function NotesPage() {
   const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
@@ -23,48 +24,14 @@ export default function NotesPage() {
     togglePin,
   } = useNotes();
 
-  const [editTitle, setEditTitle] = useState('');
-  const [editContent, setEditContent] = useState('');
-  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   useEffect(() => {
     fetchNotes();
   }, [fetchNotes]);
 
   const selectedNote = notes.find((n) => n.noteId === selectedNoteId) || null;
 
-  useEffect(() => {
-    if (selectedNote) {
-      setEditTitle(selectedNote.title);
-      setEditContent(selectedNote.content);
-    }
-  }, [selectedNoteId]);
-
-  const handleAutoSave = useCallback(
-    (title: string, content: string) => {
-      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      saveTimerRef.current = setTimeout(() => {
-        if (selectedNoteId) {
-          updateNote(selectedNoteId, {
-            title,
-            content,
-            isPinned: selectedNote?.isPinned || false,
-          });
-        }
-      }, 800);
-    },
-    [selectedNoteId, selectedNote, updateNote]
-  );
-
-  const handleTitleChange = (title: string) => {
-    setEditTitle(title);
-    handleAutoSave(title, editContent);
-  };
-
-  const handleContentChange = (content: string) => {
-    setEditContent(content);
-    handleAutoSave(editTitle, content);
-  };
+  const { editTitle, editContent, handleTitleChange, handleContentChange } =
+    useNoteEditor(selectedNoteId, selectedNote, updateNote);
 
   const handleCreateNote = async () => {
     await createNote('無題');


### PR DESCRIPTION
## 概要
- NotesPageのエディタ状態管理＋オートセーブロジックを`useNoteEditor`フックに抽出
- `togglePin`の`notes`依存をuseRefパターンに変更（stale closure対策）

## 変更内容
- `useNoteEditor`フック新規作成（9テスト付き）
- NotesPageからエディタ状態・タイマーロジックを除去し`useNoteEditor`を使用
- `togglePin`の依存配列を`[notes]`→`[]`に最適化

## テスト
- useNoteEditor: 9テスト（初期化、変更、デバウンス、ノート切替）
- 全994テスト通過

closes #490