### PR TITLE
test: ノート検索・ピン留め・エディタフックのテスト品質向上

### DIFF
--- a/frontend/src/components/__tests__/NoteListItem.test.tsx
+++ b/frontend/src/components/__tests__/NoteListItem.test.tsx
@@ -73,4 +73,34 @@ describe('NoteListItem', () => {
     fireEvent.click(screen.getByLabelText('ピン留め'));
     expect(onSelect).not.toHaveBeenCalled();
   });
+
+  it('削除ボタンクリックでonSelectは呼ばれない', () => {
+    const onSelect = vi.fn();
+    render(<NoteListItem {...defaultProps} onSelect={onSelect} />);
+    fireEvent.click(screen.getByLabelText('ノートを削除'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('EnterキーでonSelectが呼ばれる', () => {
+    const onSelect = vi.fn();
+    const { container } = render(<NoteListItem {...defaultProps} onSelect={onSelect} />);
+    const item = container.querySelector('[role="button"]')!;
+    fireEvent.keyDown(item, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith('note-1');
+  });
+
+  it('SpaceキーでonSelectが呼ばれる', () => {
+    const onSelect = vi.fn();
+    const { container } = render(<NoteListItem {...defaultProps} onSelect={onSelect} />);
+    const item = container.querySelector('[role="button"]')!;
+    fireEvent.keyDown(item, { key: ' ' });
+    expect(onSelect).toHaveBeenCalledWith('note-1');
+  });
+
+  it('長い内容が60文字で切り詰められる', () => {
+    const longContent = 'あ'.repeat(100);
+    render(<NoteListItem {...defaultProps} content={longContent} />);
+    const preview = screen.getByText('あ'.repeat(60));
+    expect(preview).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
ノート検索・ピン留め・エディタフック関連のエッジケーステストを追加

## 追加テスト
### useNotes (+5テスト)
- 大文字小文字を区別しない検索
- togglePinエラー時の状態保持
- 存在しないnoteIdのtogglePin
- 検索クエリクリアで全ノート表示
- ヒットしない検索で空配列

### useNoteEditor (+3テスト)
- ピン留めノートの自動保存でisPinned=true
- selectedNoteId=nullで自動保存無効
- タイトルと内容の交互変更時のデバウンス

### NoteListItem (+4テスト)
- 削除ボタンクリック時onSelect未呼出
- Enter/SpaceキーでのonSelect呼出
- 長い内容の60文字切り詰め

## テスト結果
- フロントエンド: 全1006テスト通過
- バックエンド: 109テスト通過（contextLoadsは既知のDB接続問題）

closes #492