### PR TITLE
feat: ノートエディタに文字数カウント・読了時間表示を追加

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -1,3 +1,6 @@
+import { useMemo } from 'react';
+import { getNoteStats } from '../utils/noteStats';
+
 interface NoteEditorProps {
   title: string;
   content: string;
@@ -11,6 +14,8 @@ export default function NoteEditor({
   onTitleChange,
   onContentChange,
 }: NoteEditorProps) {
+  const stats = useMemo(() => getNoteStats(content), [content]);
+
   return (
     <div className="flex flex-col h-full p-6 max-w-3xl mx-auto w-full">
       <input
@@ -28,6 +33,10 @@ export default function NoteEditor({
         aria-label="ノートの内容"
         className="flex-1 text-sm text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full resize-none leading-relaxed placeholder:text-[var(--color-text-faint)]"
       />
+      <div className="flex items-center gap-3 pt-3 border-t border-surface-3 text-[11px] text-[var(--color-text-faint)]">
+        <span>{stats.charCount}文字</span>
+        {stats.readingTimeMin > 0 && <span>約{stats.readingTimeMin}分</span>}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/__tests__/NoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteEditor.test.tsx
@@ -45,4 +45,19 @@ describe('NoteEditor', () => {
     render(<NoteEditor {...defaultProps} content="" />);
     expect(screen.getByPlaceholderText('ここに入力...')).toBeInTheDocument();
   });
+
+  it('文字数カウントが表示される', () => {
+    render(<NoteEditor {...defaultProps} content="テスト内容" />);
+    expect(screen.getByText('5文字')).toBeInTheDocument();
+  });
+
+  it('読了時間が表示される', () => {
+    render(<NoteEditor {...defaultProps} content="テスト内容" />);
+    expect(screen.getByText(/約\d+分/)).toBeInTheDocument();
+  });
+
+  it('空の内容で0文字と表示される', () => {
+    render(<NoteEditor {...defaultProps} content="" />);
+    expect(screen.getByText('0文字')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/utils/__tests__/noteStats.test.ts
+++ b/frontend/src/utils/__tests__/noteStats.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { getNoteStats } from '../noteStats';
+
+describe('getNoteStats', () => {
+  it('空文字で0文字・0分を返す', () => {
+    const stats = getNoteStats('');
+    expect(stats.charCount).toBe(0);
+    expect(stats.readingTimeMin).toBe(0);
+  });
+
+  it('文字数を正しくカウントする', () => {
+    const stats = getNoteStats('こんにちは世界');
+    expect(stats.charCount).toBe(7);
+  });
+
+  it('改行を含む文字数を正しくカウントする', () => {
+    const stats = getNoteStats('こんにちは\n世界');
+    expect(stats.charCount).toBe(7);
+  });
+
+  it('読了時間を日本語400文字/分で計算する', () => {
+    const text = 'あ'.repeat(400);
+    const stats = getNoteStats(text);
+    expect(stats.readingTimeMin).toBe(1);
+  });
+
+  it('800文字で2分の読了時間を返す', () => {
+    const text = 'あ'.repeat(800);
+    const stats = getNoteStats(text);
+    expect(stats.readingTimeMin).toBe(2);
+  });
+
+  it('1文字でも最低1分の読了時間を返す', () => {
+    const stats = getNoteStats('あ');
+    expect(stats.readingTimeMin).toBe(1);
+  });
+
+  it('スペースを除外して文字数をカウントする', () => {
+    const stats = getNoteStats('hello world');
+    expect(stats.charCount).toBe(10);
+  });
+});

--- a/frontend/src/utils/noteStats.ts
+++ b/frontend/src/utils/noteStats.ts
@@ -1,0 +1,14 @@
+const CHARS_PER_MINUTE = 400;
+
+export interface NoteStats {
+  charCount: number;
+  readingTimeMin: number;
+}
+
+export function getNoteStats(content: string): NoteStats {
+  const cleaned = content.replace(/[\s\n]/g, '');
+  const charCount = cleaned.length;
+  const readingTimeMin = charCount === 0 ? 0 : Math.max(1, Math.round(charCount / CHARS_PER_MINUTE));
+
+  return { charCount, readingTimeMin };
+}


### PR DESCRIPTION
## 概要
ノートエディタのフッターにステータスバーを追加し、文字数と読了時間を表示

## 変更内容
- `noteStats`ユーティリティ新規作成（文字数・読了時間計算）
- NoteEditorフッターにステータスバー（文字数、約N分）

## テスト
- noteStats: 7テスト（空文字、改行、スペース除外、読了時間計算）
- NoteEditor: +3テスト（文字数表示、読了時間表示、空内容）
- 全1016テスト通過

closes #496