### PR TITLE
test: noteStats・useDebounce・NoteEditorのテスト品質向上

### DIFF
--- a/frontend/src/components/__tests__/NoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteEditor.test.tsx
@@ -60,4 +60,20 @@ describe('NoteEditor', () => {
     render(<NoteEditor {...defaultProps} content="" />);
     expect(screen.getByText('0文字')).toBeInTheDocument();
   });
+
+  it('空の内容で読了時間が表示されない', () => {
+    render(<NoteEditor {...defaultProps} content="" />);
+    expect(screen.queryByText(/約\d+分/)).not.toBeInTheDocument();
+  });
+
+  it('長い内容で正しい文字数を表示する', () => {
+    const longContent = 'あ'.repeat(1000);
+    render(<NoteEditor {...defaultProps} content={longContent} />);
+    expect(screen.getByText('1000文字')).toBeInTheDocument();
+  });
+
+  it('スペースのみの内容で0文字を表示する', () => {
+    render(<NoteEditor {...defaultProps} content="   " />);
+    expect(screen.getByText('0文字')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/hooks/__tests__/useDebounce.test.ts
+++ b/frontend/src/hooks/__tests__/useDebounce.test.ts
@@ -79,4 +79,44 @@ describe('useDebounce', () => {
 
     expect(result.current).toBe(42);
   });
+
+  it('同じ値で再レンダリングされてもデバウンス値は変わらない', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'A', delay: 300 } }
+    );
+
+    rerender({ value: 'A', delay: 300 });
+
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(result.current).toBe('A');
+  });
+
+  it('アンマウント時にタイマーがクリアされる', () => {
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+
+    const { unmount } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'A', delay: 300 } }
+    );
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('空文字でも動作する', () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'テスト', delay: 300 } }
+    );
+
+    rerender({ value: '', delay: 300 });
+
+    act(() => { vi.advanceTimersByTime(300); });
+
+    expect(result.current).toBe('');
+  });
 });

--- a/frontend/src/utils/__tests__/noteStats.test.ts
+++ b/frontend/src/utils/__tests__/noteStats.test.ts
@@ -39,4 +39,26 @@ describe('getNoteStats', () => {
     const stats = getNoteStats('hello world');
     expect(stats.charCount).toBe(10);
   });
+
+  it('全スペースの場合0文字・0分を返す', () => {
+    const stats = getNoteStats('   \n\n  \t  ');
+    expect(stats.charCount).toBe(0);
+    expect(stats.readingTimeMin).toBe(0);
+  });
+
+  it('日本語と英語の混合文字をカウントする', () => {
+    const stats = getNoteStats('Hello世界');
+    expect(stats.charCount).toBe(7);
+  });
+
+  it('長文で正しい読了時間を計算する', () => {
+    const text = 'あ'.repeat(1200);
+    const stats = getNoteStats(text);
+    expect(stats.readingTimeMin).toBe(3);
+  });
+
+  it('タブ文字を除外してカウントする', () => {
+    const stats = getNoteStats('テスト\tデータ');
+    expect(stats.charCount).toBe(6);
+  });
 });


### PR DESCRIPTION
## 概要
今サイクルで追加した機能のエッジケーステスト追加

## 追加テスト
### noteStats (+4テスト)
- 全スペース入力で0文字・0分
- 日本語と英語の混合文字カウント
- 長文（1200文字）の読了時間
- タブ文字の除外

### useDebounce (+3テスト)
- 同じ値の再レンダリングで値不変
- アンマウント時のタイマークリーンアップ
- 空文字のデバウンス

### NoteEditor (+3テスト)
- 空内容で読了時間非表示
- 長文（1000文字）の正確な表示
- スペースのみの内容で0文字

## テスト結果
- 全1031テスト通過

closes #500