### PR TITLE
feat: メッセージコピー機能

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 
 interface MessageBubbleProps {
   isSender: boolean;
@@ -9,6 +10,8 @@ interface MessageBubbleProps {
   createdAt?: string;
   onDelete?: ((id: number) => void) | null;
   onRephrase?: ((content: string) => void) | null;
+  onCopy?: ((id: number, content: string) => void) | null;
+  isCopied?: boolean;
   isDeleted?: boolean;
 }
 
@@ -21,6 +24,8 @@ export default function MessageBubble({
   createdAt,
   onDelete,
   onRephrase,
+  onCopy,
+  isCopied = false,
   isDeleted = false,
 }: MessageBubbleProps) {
   const [showDelete, setShowDelete] = useState(false);
@@ -98,6 +103,19 @@ export default function MessageBubble({
               <span className={`text-[10px] ${isSender ? 'mr-1 text-[var(--color-text-faint)]' : 'ml-1 text-[var(--color-text-faint)]'}`}>
                 {formatTime(createdAt)}
               </span>
+            )}
+            {onCopy && (
+              <button
+                onClick={() => onCopy(id, content)}
+                title={isCopied ? 'コピー済み' : 'コピー'}
+                className="text-[var(--color-text-faint)] hover:text-[var(--color-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
+              >
+                {isCopied ? (
+                  <ClipboardDocumentCheckIcon className="w-3.5 h-3.5 text-green-500" />
+                ) : (
+                  <ClipboardDocumentIcon className="w-3.5 h-3.5" />
+                )}
+              </button>
             )}
             {isSender && onRephrase && (
               <button

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -41,4 +41,40 @@ describe('MessageBubble', () => {
     fireEvent.click(screen.getByText('言い換え'));
     expect(mockRephrase).toHaveBeenCalledWith('テストメッセージ');
   });
+
+  it('コピーボタンが非削除メッセージに表示される', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubble isSender={false} content="テスト" id={1} onCopy={mockCopy} />);
+
+    expect(screen.getByTitle('コピー')).toBeInTheDocument();
+  });
+
+  it('コピーボタンクリックでonCopyが呼ばれる', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubble isSender={false} content="コピー対象" id={5} onCopy={mockCopy} />);
+
+    fireEvent.click(screen.getByTitle('コピー'));
+    expect(mockCopy).toHaveBeenCalledWith(5, 'コピー対象');
+  });
+
+  it('削除済みメッセージにコピーボタンが表示されない', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubble isSender={true} content="テスト" id={1} isDeleted={true} onCopy={mockCopy} />);
+
+    expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
+  });
+
+  it('コピー済み状態でチェックアイコンが表示される', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubble isSender={false} content="テスト" id={1} onCopy={mockCopy} isCopied={true} />);
+
+    expect(screen.getByTitle('コピー済み')).toBeInTheDocument();
+  });
+
+  it('送信者メッセージでもコピーボタンが表示される', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubble isSender={true} content="テスト" id={1} onCopy={mockCopy} />);
+
+    expect(screen.getByTitle('コピー')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/hooks/__tests__/useCopyToClipboard.test.ts
+++ b/frontend/src/hooks/__tests__/useCopyToClipboard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useCopyToClipboard } from '../useCopyToClipboard';
+
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('初期状態でcopiedIdはnull', () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+    expect(result.current.copiedId).toBeNull();
+  });
+
+  it('copyToClipboardでクリップボードに書き込む', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テストメッセージ');
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('テストメッセージ');
+  });
+
+  it('コピー成功後にcopiedIdが設定される', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(42, 'テスト');
+    });
+
+    expect(result.current.copiedId).toBe(42);
+  });
+
+  it('コピー後2秒でcopiedIdがnullに戻る', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト');
+    });
+
+    expect(result.current.copiedId).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.copiedId).toBeNull();
+  });
+
+  it('クリップボードAPI失敗時にcopiedIdが設定されない', async () => {
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValue(new Error('失敗'));
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト');
+    });
+
+    expect(result.current.copiedId).toBeNull();
+  });
+
+  it('連続コピーで前のタイマーがクリアされる', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト1');
+    });
+
+    expect(result.current.copiedId).toBe(1);
+
+    await act(async () => {
+      await result.current.copyToClipboard(2, 'テスト2');
+    });
+
+    expect(result.current.copiedId).toBe(2);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.copiedId).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useCopyToClipboard.ts
+++ b/frontend/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,21 @@
+import { useState, useCallback, useRef } from 'react';
+
+export function useCopyToClipboard() {
+  const [copiedId, setCopiedId] = useState<number | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const copyToClipboard = useCallback(async (id: number, text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setCopiedId(id);
+      timerRef.current = setTimeout(() => {
+        setCopiedId(null);
+      }, 2000);
+    } catch {
+      // クリップボードAPI失敗時は何もしない
+    }
+  }, []);
+
+  return { copiedId, copyToClipboard };
+}

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -5,6 +5,7 @@ import SceneSelector from '../components/SceneSelector';
 import RephraseModal from '../components/RephraseModal';
 import MessageSelectionPanel from '../components/MessageSelectionPanel';
 import { useChat } from '../hooks/useChat';
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 
 export default function ChatPage() {
   const {
@@ -34,6 +35,8 @@ export default function ChatPage() {
     isInRange,
     getRangeLabel,
   } = useChat();
+
+  const { copiedId, copyToClipboard } = useCopyToClipboard();
 
   return (
     <div className="flex flex-col h-full">
@@ -92,6 +95,8 @@ export default function ChatPage() {
                 {...msg}
                 onDelete={selectionMode ? null : handleDeleteMessage}
                 onRephrase={selectionMode ? null : handleRephrase}
+                onCopy={selectionMode ? null : copyToClipboard}
+                isCopied={copiedId === msg.id}
               />
             </div>
           </div>


### PR DESCRIPTION
## 概要
- チャットメッセージの個別コピーボタンを追加
- useCopyToClipboardフックでクリップボードAPI管理と2秒間のフィードバック表示
- ClipboardDocumentIcon/ClipboardDocumentCheckIcon（Heroicons）で視覚的フィードバック

## テスト
- useCopyToClipboard: 6テスト（初期状態、書き込み、成功フィードバック、タイマー、失敗時、連続コピー）
- MessageBubble: +5テスト（コピーボタン表示、クリック、削除済み非表示、コピー済み状態、送信者側）
- 全1042テスト通過

closes #504