### PR TITLE
refactor: useMobilePanelStateフック抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useMobilePanelState.test.ts
+++ b/frontend/src/hooks/__tests__/useMobilePanelState.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMobilePanelState } from '../useMobilePanelState';
+
+describe('useMobilePanelState', () => {
+  it('初期状態でisOpenはfalse', () => {
+    const { result } = renderHook(() => useMobilePanelState());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('openでisOpenがtrueになる', () => {
+    const { result } = renderHook(() => useMobilePanelState());
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('closeでisOpenがfalseになる', () => {
+    const { result } = renderHook(() => useMobilePanelState());
+
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('open→close→openで正しく切り替わる', () => {
+    const { result } = renderHook(() => useMobilePanelState());
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('closeを連続で呼んでもfalseのまま', () => {
+    const { result } = renderHook(() => useMobilePanelState());
+
+    act(() => result.current.close());
+    act(() => result.current.close());
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useMobilePanelState.ts
+++ b/frontend/src/hooks/useMobilePanelState.ts
@@ -1,0 +1,10 @@
+import { useState, useCallback } from 'react';
+
+export function useMobilePanelState() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return { isOpen, open, close };
+}

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import MessageBubbleAi from '../components/MessageBubbleAi';
 import MessageInput from '../components/MessageInput';
 import ConfirmModal from '../components/ConfirmModal';
@@ -10,9 +9,10 @@ import SessionNoteEditor from '../components/SessionNoteEditor';
 import ExportSessionButton from '../components/ExportSessionButton';
 import AiSessionListItem from '../components/AiSessionListItem';
 import { useAskAi } from '../hooks/useAskAi';
+import { useMobilePanelState } from '../hooks/useMobilePanelState';
 
 export default function AskAiPage() {
-  const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
+  const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
   const {
     sessions,
     messages,
@@ -43,7 +43,7 @@ export default function AskAiPage() {
       <SecondaryPanel
         title="セッション"
         mobileOpen={mobilePanelOpen}
-        onMobileClose={() => setMobilePanelOpen(false)}
+        onMobileClose={closeMobilePanel}
         headerContent={
           <button
             onClick={handleNewSession}
@@ -66,7 +66,7 @@ export default function AskAiPage() {
               isActive={currentSessionId === session.id}
               isEditing={editingSessionId === session.id}
               editingTitle={editingTitle}
-              onSelect={(id: number) => { handleSelectSession(id); setMobilePanelOpen(false); }}
+              onSelect={(id: number) => { handleSelectSession(id); closeMobilePanel(); }}
               onStartEdit={handleStartEditTitle}
               onDelete={handleDeleteSession}
               onSaveTitle={handleSaveTitle}
@@ -82,7 +82,7 @@ export default function AskAiPage() {
         {/* モバイルヘッダー */}
         <div className="md:hidden bg-surface-1 border-b border-surface-3 px-4 py-2 flex items-center">
           <button
-            onClick={() => setMobilePanelOpen(true)}
+            onClick={openMobilePanel}
             className="p-1.5 hover:bg-surface-2 rounded transition-colors"
             aria-label="セッション一覧を開く"
           >

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import EmptyState from '../components/EmptyState';
@@ -6,9 +5,10 @@ import SearchBox from '../components/SearchBox';
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import { useChatList } from '../hooks/useChatList';
 import { formatTime, truncateMessage } from '../utils/formatters';
+import { useMobilePanelState } from '../hooks/useMobilePanelState';
 
 export default function ChatListPage() {
-  const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
+  const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
   const navigate = useNavigate();
   const { chatUsers, loading, searchQuery, setSearchQuery } = useChatList();
 
@@ -17,7 +17,7 @@ export default function ChatListPage() {
       <SecondaryPanel
         title="チャット"
         mobileOpen={mobilePanelOpen}
-        onMobileClose={() => setMobilePanelOpen(false)}
+        onMobileClose={closeMobilePanel}
         headerContent={
           <SearchBox
             value={searchQuery}
@@ -38,7 +38,7 @@ export default function ChatListPage() {
           chatUsers.map((user) => (
             <button
               key={user.roomId}
-              onClick={() => { navigate(`/chat/users/${user.roomId}`); setMobilePanelOpen(false); }}
+              onClick={() => { navigate(`/chat/users/${user.roomId}`); closeMobilePanel(); }}
               className="w-full px-4 py-3 flex items-center gap-3 hover:bg-surface-2 transition-colors border-b border-surface-3 text-left"
             >
               <div className="flex-shrink-0">
@@ -88,7 +88,7 @@ export default function ChatListPage() {
         {/* モバイルヘッダー */}
         <div className="md:hidden bg-surface-1 border-b border-surface-3 px-4 py-2 flex items-center">
           <button
-            onClick={() => setMobilePanelOpen(true)}
+            onClick={openMobilePanel}
             className="p-1.5 hover:bg-surface-2 rounded transition-colors"
             aria-label="チャット一覧を開く"
           >

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import NoteListItem from '../components/NoteListItem';
 import NoteEditor from '../components/NoteEditor';
@@ -6,9 +6,10 @@ import EmptyState from '../components/EmptyState';
 import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import { useNotes } from '../hooks/useNotes';
 import { useNoteEditor } from '../hooks/useNoteEditor';
+import { useMobilePanelState } from '../hooks/useMobilePanelState';
 
 export default function NotesPage() {
-  const [mobilePanelOpen, setMobilePanelOpen] = useState(false);
+  const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
   const {
     notes,
     filteredNotes,
@@ -35,12 +36,12 @@ export default function NotesPage() {
 
   const handleCreateNote = async () => {
     await createNote('無題');
-    setMobilePanelOpen(false);
+    closeMobilePanel();
   };
 
   const handleSelectNote = (noteId: string) => {
     selectNote(noteId);
-    setMobilePanelOpen(false);
+    closeMobilePanel();
   };
 
   const handleDeleteNote = async (noteId: string) => {
@@ -52,7 +53,7 @@ export default function NotesPage() {
       <SecondaryPanel
         title="ノート"
         mobileOpen={mobilePanelOpen}
-        onMobileClose={() => setMobilePanelOpen(false)}
+        onMobileClose={closeMobilePanel}
         headerContent={
           <div className="space-y-2">
             <div className="relative">
@@ -108,7 +109,7 @@ export default function NotesPage() {
         {/* モバイルヘッダー */}
         <div className="md:hidden bg-surface-1 border-b border-surface-3 px-4 py-2 flex items-center">
           <button
-            onClick={() => setMobilePanelOpen(true)}
+            onClick={openMobilePanel}
             className="p-1.5 hover:bg-surface-2 rounded transition-colors"
             aria-label="ノート一覧を開く"
           >


### PR DESCRIPTION
## 概要
- AskAiPage・NotesPage・ChatListPageに重複するモバイルパネル状態管理を`useMobilePanelState`フックに共通化
- `isOpen`/`open`/`close`の明確なインターフェース

## テスト
- useMobilePanelState: 5テスト（初期状態、open、close、連続操作、冪等性）
- 全1047テスト通過

closes #506