### PR TITLE
test: サイクル36テスト品質向上

### DIFF
--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -77,4 +77,29 @@ describe('MessageBubble', () => {
 
     expect(screen.getByTitle('コピー')).toBeInTheDocument();
   });
+
+  it('onCopyがnullの場合コピーボタンが表示されない', () => {
+    render(<MessageBubble isSender={false} content="テスト" id={1} onCopy={null} />);
+
+    expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
+  });
+
+  it('onCopy未指定の場合コピーボタンが表示されない', () => {
+    render(<MessageBubble isSender={false} content="テスト" id={1} />);
+
+    expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
+  });
+
+  it('画像メッセージが表示される', () => {
+    render(<MessageBubble isSender={false} content="https://example.com/img.jpg" id={1} type="image" />);
+
+    const img = screen.getByAltText('画像');
+    expect(img).toBeInTheDocument();
+  });
+
+  it('時刻が正しく表示される', () => {
+    render(<MessageBubble isSender={false} content="テスト" id={1} createdAt="2026-02-14T10:30:00" />);
+
+    expect(screen.getByText('10:30')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/hooks/__tests__/useCopyToClipboard.test.ts
+++ b/frontend/src/hooks/__tests__/useCopyToClipboard.test.ts
@@ -68,6 +68,61 @@ describe('useCopyToClipboard', () => {
     expect(result.current.copiedId).toBeNull();
   });
 
+  it('空文字列もクリップボードに書き込める', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, '');
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('');
+    expect(result.current.copiedId).toBe(1);
+  });
+
+  it('2秒未満ではcopiedIdが維持される', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+
+    expect(result.current.copiedId).toBe(1);
+  });
+
+  it('同じIDで再コピーしてもタイマーがリセットされる', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(result.current.copiedId).toBe(1);
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(result.current.copiedId).toBe(1);
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.copiedId).toBeNull();
+  });
+
   it('連続コピーで前のタイマーがクリアされる', async () => {
     const { result } = renderHook(() => useCopyToClipboard());
 

--- a/frontend/src/hooks/__tests__/useMobilePanelState.test.ts
+++ b/frontend/src/hooks/__tests__/useMobilePanelState.test.ts
@@ -52,4 +52,24 @@ describe('useMobilePanelState', () => {
     act(() => result.current.close());
     expect(result.current.isOpen).toBe(false);
   });
+
+  it('openを連続で呼んでもtrueのまま', () => {
+    const { result } = renderHook(() => useMobilePanelState());
+
+    act(() => result.current.open());
+    act(() => result.current.open());
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('open/closeの関数参照が安定している', () => {
+    const { result, rerender } = renderHook(() => useMobilePanelState());
+
+    const openRef = result.current.open;
+    const closeRef = result.current.close;
+
+    rerender();
+
+    expect(result.current.open).toBe(openRef);
+    expect(result.current.close).toBe(closeRef);
+  });
 });


### PR DESCRIPTION
## 概要
サイクル36で追加した機能のエッジケーステストを追加。

## 追加テスト
- useCopyToClipboard: +3テスト（空文字コピー、タイマー未到達での維持、同IDリコピーのタイマーリセット）
- useMobilePanelState: +2テスト（open冪等性、関数参照安定性）
- MessageBubble: +4テスト（onCopy null/未指定、画像メッセージ、時刻表示）

## テスト
- 全1056テスト通過

closes #508