### PR TITLE
feat: AIチャットメッセージコピー機能

### DIFF
--- a/frontend/src/components/MessageBubbleAi.tsx
+++ b/frontend/src/components/MessageBubbleAi.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon, TrashIcon } from '@heroicons/react/24/outline';
 
 interface MessageBubbleAiProps {
   isSender: boolean;
@@ -6,6 +7,8 @@ interface MessageBubbleAiProps {
   content: string;
   id: number;
   onDelete?: (id: number) => void;
+  onCopy?: ((id: number, content: string) => void) | null;
+  isCopied?: boolean;
   isDeleted?: boolean;
 }
 
@@ -15,6 +18,8 @@ export default function MessageBubbleAi({
   content,
   id,
   onDelete,
+  onCopy,
+  isCopied = false,
   isDeleted = false,
 }: MessageBubbleAiProps) {
   const [showDelete, setShowDelete] = useState(false);
@@ -59,16 +64,27 @@ export default function MessageBubbleAi({
             className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 transition-colors duration-150"
             title="削除"
           >
-            <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-              <path
-                fillRule="evenodd"
-                d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <TrashIcon className="w-3 h-3" />
           </button>
         )}
       </div>
+
+      {!isDeleted && onCopy && (
+        <div className={`flex items-center mt-1 ${isSender ? 'justify-end' : 'justify-start'}`}>
+          <button
+            onClick={() => onCopy(id, content)}
+            title={isCopied ? 'コピー済み' : 'コピー'}
+            aria-label={isCopied ? 'コピー済み' : 'メッセージをコピー'}
+            className="text-[var(--color-text-faint)] hover:text-[var(--color-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
+          >
+            {isCopied ? (
+              <ClipboardDocumentCheckIcon className="w-3.5 h-3.5 text-green-500" />
+            ) : (
+              <ClipboardDocumentIcon className="w-3.5 h-3.5" />
+            )}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import MessageBubbleAi from '../MessageBubbleAi';
 
 describe('MessageBubbleAi', () => {
@@ -43,5 +43,40 @@ describe('MessageBubbleAi', () => {
     const longMessage = 'テスト'.repeat(100);
     render(<MessageBubbleAi isSender={false} content={longMessage} id={1} />);
     expect(screen.getByText(longMessage)).toBeInTheDocument();
+  });
+
+  it('コピーボタンが非削除メッセージに表示される', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubbleAi isSender={false} content="テスト" id={1} onCopy={mockCopy} />);
+
+    expect(screen.getByTitle('コピー')).toBeInTheDocument();
+  });
+
+  it('コピーボタンクリックでonCopyが呼ばれる', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubbleAi isSender={false} content="AI応答" id={3} onCopy={mockCopy} />);
+
+    fireEvent.click(screen.getByTitle('コピー'));
+    expect(mockCopy).toHaveBeenCalledWith(3, 'AI応答');
+  });
+
+  it('削除済みメッセージにコピーボタンが表示されない', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubbleAi isSender={false} content="テスト" id={1} isDeleted={true} onCopy={mockCopy} />);
+
+    expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
+  });
+
+  it('コピー済み状態でチェックアイコンが表示される', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubbleAi isSender={false} content="テスト" id={1} onCopy={mockCopy} isCopied={true} />);
+
+    expect(screen.getByTitle('コピー済み')).toBeInTheDocument();
+  });
+
+  it('onCopy未指定の場合コピーボタンが表示されない', () => {
+    render(<MessageBubbleAi isSender={false} content="テスト" id={1} />);
+
+    expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -10,9 +10,11 @@ import ExportSessionButton from '../components/ExportSessionButton';
 import AiSessionListItem from '../components/AiSessionListItem';
 import { useAskAi } from '../hooks/useAskAi';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 
 export default function AskAiPage() {
   const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
+  const { copiedId, copyToClipboard } = useCopyToClipboard();
   const {
     sessions,
     messages,
@@ -135,8 +137,11 @@ export default function AskAiPage() {
             <div key={msg.id} className="max-w-3xl mx-auto w-full">
               <MessageBubbleAi
                 {...msg}
+                isSender={msg.isSender ?? false}
                 type={msg.isSender ? 'text' : 'bot'}
                 onDelete={handleDeleteMessage}
+                onCopy={copyToClipboard}
+                isCopied={copiedId === msg.id}
               />
             </div>
           ))}


### PR DESCRIPTION
## 概要
- AskAiPageのMessageBubbleAiにコピーボタンを追加
- ChatPageのMessageBubbleと同等の機能パリティ実現
- 削除ボタンをHeroicons TrashIconに置換

## テスト
- MessageBubbleAi: +5テスト（コピーボタン表示、クリック、削除済み非表示、コピー済み状態、未指定時非表示）
- 全1061テスト通過

closes #512