### PR TITLE
refactor: FormMessageコンポーネント抽出

### DIFF
--- a/frontend/src/components/FormMessage.tsx
+++ b/frontend/src/components/FormMessage.tsx
@@ -1,0 +1,28 @@
+import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/solid';
+
+interface FormMessageProps {
+  message: { type: 'error' | 'success'; text: string } | null;
+}
+
+export default function FormMessage({ message }: FormMessageProps) {
+  if (!message) return null;
+
+  const isError = message.type === 'error';
+
+  return (
+    <div
+      className={`mb-4 p-3 rounded-lg text-sm font-medium flex items-start gap-2 ${
+        isError
+          ? 'bg-rose-900/30 text-rose-400 border border-rose-800'
+          : 'bg-emerald-900/30 text-emerald-400 border border-emerald-800'
+      }`}
+    >
+      {isError ? (
+        <ExclamationCircleIcon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+      ) : (
+        <CheckCircleIcon className="w-5 h-5 flex-shrink-0 mt-0.5" />
+      )}
+      <span>{message.text}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/FormMessage.test.tsx
+++ b/frontend/src/components/__tests__/FormMessage.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FormMessage from '../FormMessage';
+
+describe('FormMessage', () => {
+  it('エラーメッセージを表示する', () => {
+    render(<FormMessage message={{ type: 'error', text: 'エラーが発生しました' }} />);
+
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('成功メッセージを表示する', () => {
+    render(<FormMessage message={{ type: 'success', text: '保存しました' }} />);
+
+    expect(screen.getByText('保存しました')).toBeInTheDocument();
+  });
+
+  it('messageがnullの場合何も表示しない', () => {
+    const { container } = render(<FormMessage message={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('エラーメッセージにエラースタイルが適用される', () => {
+    render(<FormMessage message={{ type: 'error', text: 'エラー' }} />);
+
+    const el = screen.getByText('エラー').closest('div');
+    expect(el?.className).toContain('rose');
+  });
+
+  it('成功メッセージに成功スタイルが適用される', () => {
+    render(<FormMessage message={{ type: 'success', text: '成功' }} />);
+
+    const el = screen.getByText('成功').closest('div');
+    expect(el?.className).toContain('emerald');
+  });
+
+  it('エラーメッセージにExclamationCircleIconが表示される', () => {
+    render(<FormMessage message={{ type: 'error', text: 'エラー' }} />);
+
+    expect(screen.getByText('エラー').closest('div')?.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('成功メッセージにCheckCircleIconが表示される', () => {
+    render(<FormMessage message={{ type: 'success', text: '成功' }} />);
+
+    expect(screen.getByText('成功').closest('div')?.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ConfirmForgotPasswordPage.tsx
+++ b/frontend/src/pages/ConfirmForgotPasswordPage.tsx
@@ -1,6 +1,7 @@
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
+import FormMessage from '../components/FormMessage';
 import { useConfirmForgotPassword } from '../hooks/useConfirmForgotPassword';
 
 export default function ConfirmForgotPasswordPage() {
@@ -8,9 +9,7 @@ export default function ConfirmForgotPasswordPage() {
 
   return (
     <AuthLayout>
-      {message?.type === 'error' && (
-        <p className="text-rose-400 text-center">{message.text}</p>
-      )}
+      <FormMessage message={message} />
       <h2 className="text-2xl font-bold mb-6 text-center">
         パスワードリセット確認
       </h2>

--- a/frontend/src/pages/ConfirmPage.tsx
+++ b/frontend/src/pages/ConfirmPage.tsx
@@ -2,6 +2,7 @@ import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import LinkText from '../components/LinkText';
+import FormMessage from '../components/FormMessage';
 import { useConfirmSignup } from '../hooks/useConfirmSignup';
 
 export default function ConfirmPage() {
@@ -9,9 +10,7 @@ export default function ConfirmPage() {
 
   return (
     <AuthLayout>
-      {message?.type === 'error' && (
-        <p className="text-rose-400 text-center">{message.text}</p>
-      )}
+      <FormMessage message={message} />
       <h2 className="text-2xl font-bold mb-6 text-center">確認コードの入力</h2>
       <form onSubmit={handleConfirm}>
         <InputField

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -1,6 +1,7 @@
 import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
+import FormMessage from '../components/FormMessage';
 import { useForgotPassword } from '../hooks/useForgotPassword';
 
 export default function ForgotPasswordPage() {
@@ -8,9 +9,7 @@ export default function ForgotPasswordPage() {
 
   return (
     <AuthLayout>
-      {message?.type === 'error' && (
-        <p className="text-rose-400 text-center">{message.text}</p>
-      )}
+      <FormMessage message={message} />
       <h2 className="text-2xl font-bold mb-6 text-center">
         パスワードリセット
       </h2>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
+import FormMessage from '../components/FormMessage';
 import { useProfileEdit } from '../hooks/useProfileEdit';
 
 export default function ProfilePage() {
@@ -15,17 +16,7 @@ export default function ProfilePage() {
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
-      {message && (
-        <div
-          className={`mb-4 p-3 rounded-lg text-sm font-medium ${
-            message.type === 'error'
-              ? 'bg-rose-900/30 text-rose-400 border border-rose-800'
-              : 'bg-emerald-900/30 text-emerald-400 border border-emerald-800'
-          }`}
-        >
-          {message.text}
-        </div>
-      )}
+      <FormMessage message={message} />
 
       <div className="bg-surface-1 rounded-lg border border-surface-3 p-6">
         <div className="flex items-center gap-4 mb-6">

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -2,10 +2,7 @@ import AuthLayout from '../components/AuthLayout';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import LinkText from '../components/LinkText';
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-} from '@heroicons/react/24/solid';
+import FormMessage from '../components/FormMessage';
 import { useSignupPage } from '../hooks/useSignupPage';
 
 export default function SignupPage() {
@@ -13,22 +10,7 @@ export default function SignupPage() {
 
   return (
     <AuthLayout>
-      <div>
-        {message?.type === 'error' && (
-          <div className="mb-6 p-4 bg-rose-900/30 border-l-4 border-rose-500 rounded-lg flex items-start">
-            <ExclamationCircleIcon className="w-5 h-5 text-rose-400 mr-3 flex-shrink-0 mt-0.5" />
-            <p className="text-rose-400 font-medium text-sm">{message.text}</p>
-          </div>
-        )}
-        {message?.type === 'success' && (
-          <div className="mb-6 p-4 bg-emerald-900/30 border-l-4 border-emerald-500 rounded-lg flex items-start">
-            <CheckCircleIcon className="w-5 h-5 text-emerald-400 mr-3 flex-shrink-0" />
-            <p className="text-emerald-400 font-medium text-sm">
-              {message.text}
-            </p>
-          </div>
-        )}
-      </div>
+      <FormMessage message={message} />
       <h2 className="text-3xl font-bold mb-2 text-center text-[var(--color-text-primary)]">
         アカウント作成
       </h2>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -2,6 +2,7 @@ import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import Loading from '../components/Loading';
 import PersonalityTraitSelector from '../components/PersonalityTraitSelector';
+import FormMessage from '../components/FormMessage';
 import {
   ChatBubbleLeftRightIcon,
   LightBulbIcon,
@@ -31,18 +32,7 @@ export default function UserProfilePage() {
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
-      {/* メッセージ */}
-      {message && (
-        <div
-          className={`mb-4 p-3 rounded-lg text-sm font-medium ${
-            message.type === 'error'
-              ? 'bg-rose-900/30 text-rose-400 border border-rose-800'
-              : 'bg-emerald-900/30 text-emerald-400 border border-emerald-800'
-          }`}
-        >
-          {message.text}
-        </div>
-      )}
+      <FormMessage message={message} />
 
       {/* 説明カード */}
       <div className="bg-surface-2 rounded-lg p-3 mb-4 border border-[var(--color-border-hover)]">


### PR DESCRIPTION
## 概要
- 6ページに重複するフォームメッセージ表示ロジックをFormMessageコンポーネントに共通化
- Heroiconsアイコン付きのエラー/成功メッセージ統一表示
- 対象: ProfilePage, UserProfilePage, SignupPage, ForgotPasswordPage, ConfirmPage, ConfirmForgotPasswordPage

## テスト
- FormMessage: 7テスト（エラー/成功表示、null非表示、スタイル確認、アイコン表示）
- 全1068テスト通過

closes #514