### PR TITLE
test: サイクル37テスト品質向上

### DIFF
--- a/frontend/src/components/__tests__/FormMessage.test.tsx
+++ b/frontend/src/components/__tests__/FormMessage.test.tsx
@@ -46,4 +46,24 @@ describe('FormMessage', () => {
 
     expect(screen.getByText('成功').closest('div')?.querySelector('svg')).toBeInTheDocument();
   });
+
+  it('長いメッセージテキストが正しく表示される', () => {
+    const longText = 'エラー'.repeat(50);
+    render(<FormMessage message={{ type: 'error', text: longText }} />);
+
+    expect(screen.getByText(longText)).toBeInTheDocument();
+  });
+
+  it('HTMLタグを含むテキストがエスケープされる', () => {
+    render(<FormMessage message={{ type: 'error', text: '<script>alert("xss")</script>' }} />);
+
+    expect(screen.getByText('<script>alert("xss")</script>')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージにborder-rose-800クラスが含まれる', () => {
+    render(<FormMessage message={{ type: 'error', text: 'テスト' }} />);
+
+    const el = screen.getByText('テスト').closest('div');
+    expect(el?.className).toContain('border');
+  });
 });

--- a/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubbleAi.test.tsx
@@ -79,4 +79,23 @@ describe('MessageBubbleAi', () => {
 
     expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
   });
+
+  it('onCopyがnullの場合コピーボタンが表示されない', () => {
+    render(<MessageBubbleAi isSender={false} content="テスト" id={1} onCopy={null} />);
+
+    expect(screen.queryByTitle('コピー')).not.toBeInTheDocument();
+  });
+
+  it('送信者メッセージでもコピーボタンが表示される', () => {
+    const mockCopy = vi.fn();
+    render(<MessageBubbleAi isSender={true} content="テスト" id={1} onCopy={mockCopy} />);
+
+    expect(screen.getByTitle('コピー')).toBeInTheDocument();
+  });
+
+  it('botタイプメッセージが表示される', () => {
+    render(<MessageBubbleAi isSender={false} type="bot" content="AI応答" id={1} />);
+
+    expect(screen.getByText('AI応答')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
サイクル37で追加した機能のエッジケーステストを追加。

## 追加テスト
- MessageBubbleAi: +3テスト（onCopy null、送信者コピー、botタイプ表示）
- FormMessage: +3テスト（長文テキスト、XSSエスケープ、border確認）

## テスト
- 全1074テスト通過

closes #516