### PR TITLE
feat: SearchBoxクリアボタン追加

### DIFF
--- a/frontend/src/components/SearchBox.tsx
+++ b/frontend/src/components/SearchBox.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from '@heroicons/react/24/solid';
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/solid';
 
 interface SearchBoxProps {
   value: string;
@@ -15,8 +15,17 @@ export default function SearchBox({ value, onChange, placeholder = '検索' }: S
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full rounded-lg border border-surface-3 py-2.5 pl-12 pr-4 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 focus:outline-none transition-colors duration-150 placeholder-slate-400"
+        className="w-full rounded-lg border border-surface-3 py-2.5 pl-12 pr-9 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 focus:outline-none transition-colors duration-150 placeholder-slate-400"
       />
+      {value && (
+        <button
+          onClick={() => onChange('')}
+          aria-label="検索をクリア"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-faint)] hover:text-[var(--color-text-secondary)] transition-colors"
+        >
+          <XMarkIcon className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/SearchBox.test.tsx
+++ b/frontend/src/components/__tests__/SearchBox.test.tsx
@@ -39,4 +39,24 @@ describe('SearchBox', () => {
     const svg = container.querySelector('svg');
     expect(svg).toBeTruthy();
   });
+
+  it('値が入力されている時にクリアボタンが表示される', () => {
+    render(<SearchBox value="テスト" onChange={vi.fn()} />);
+
+    expect(screen.getByLabelText('検索をクリア')).toBeInTheDocument();
+  });
+
+  it('値が空の時にクリアボタンが表示されない', () => {
+    render(<SearchBox value="" onChange={vi.fn()} />);
+
+    expect(screen.queryByLabelText('検索をクリア')).not.toBeInTheDocument();
+  });
+
+  it('クリアボタンクリックで空文字列でonChangeが呼ばれる', () => {
+    const mockOnChange = vi.fn();
+    render(<SearchBox value="テスト" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByLabelText('検索をクリア'));
+    expect(mockOnChange).toHaveBeenCalledWith('');
+  });
 });


### PR DESCRIPTION
## 概要
- SearchBoxに検索クリアボタン（XMarkIcon）を追加
- 値が入力されている場合のみ表示
- ワンクリックで検索文字列をリセット
- ChatListPage等6ページで自動的に利用可能

## テスト
- SearchBox: +3テスト（クリアボタン表示/非表示、クリア動作）
- 全1077テスト通過

closes #520