### PR TITLE
refactor: FilterTabsコンポーネント抽出

### DIFF
--- a/frontend/src/components/FilterTabs.tsx
+++ b/frontend/src/components/FilterTabs.tsx
@@ -1,0 +1,26 @@
+interface FilterTabsProps<T extends string> {
+  tabs: T[];
+  selected: T;
+  onSelect: (tab: T) => void;
+  className?: string;
+}
+
+export default function FilterTabs<T extends string>({ tabs, selected, onSelect, className = '' }: FilterTabsProps<T>) {
+  return (
+    <div className={`flex gap-1 border-b border-surface-3 ${className}`}>
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => onSelect(tab)}
+          className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
+            selected === tab
+              ? 'border-primary-500 text-primary-400'
+              : 'border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
+          }`}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/FilterTabs.test.tsx
+++ b/frontend/src/components/__tests__/FilterTabs.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import FilterTabs from '../FilterTabs';
+
+const TABS = ['すべて', 'カテゴリA', 'カテゴリB'] as const;
+
+describe('FilterTabs', () => {
+  it('すべてのタブが表示される', () => {
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={() => {}} />);
+    TABS.forEach((tab) => {
+      expect(screen.getByRole('button', { name: tab })).toBeInTheDocument();
+    });
+  });
+
+  it('選択中のタブにアクティブスタイルが適用される', () => {
+    render(<FilterTabs tabs={[...TABS]} selected="カテゴリA" onSelect={() => {}} />);
+    const active = screen.getByRole('button', { name: 'カテゴリA' });
+    expect(active.className).toContain('border-primary-500');
+    expect(active.className).toContain('text-primary-400');
+  });
+
+  it('非選択のタブに非アクティブスタイルが適用される', () => {
+    render(<FilterTabs tabs={[...TABS]} selected="カテゴリA" onSelect={() => {}} />);
+    const inactive = screen.getByRole('button', { name: 'すべて' });
+    expect(inactive.className).toContain('border-transparent');
+  });
+
+  it('タブクリックでonSelectが呼ばれる', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'カテゴリB' }));
+    expect(onSelect).toHaveBeenCalledWith('カテゴリB');
+  });
+
+  it('classNameを追加できる', () => {
+    const { container } = render(
+      <FilterTabs tabs={[...TABS]} selected="すべて" onSelect={() => {}} className="mb-5" />
+    );
+    expect(container.firstChild).toHaveClass('mb-5');
+  });
+});

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -1,5 +1,6 @@
 import ScenarioCard from '../components/ScenarioCard';
 import { SkeletonCard } from '../components/Skeleton';
+import FilterTabs from '../components/FilterTabs';
 import { usePracticePage } from '../hooks/usePracticePage';
 
 const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
@@ -26,21 +27,12 @@ export default function PracticePage() {
       </div>
 
       {/* カテゴリタブ */}
-      <div className="flex gap-1 mb-5 border-b border-surface-3">
-        {CATEGORIES.map((category) => (
-          <button
-            key={category}
-            onClick={() => setSelectedCategory(category)}
-            className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
-              selectedCategory === category
-                ? 'border-primary-500 text-primary-400'
-                : 'border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
-            }`}
-          >
-            {category}
-          </button>
-        ))}
-      </div>
+      <FilterTabs
+        tabs={[...CATEGORIES]}
+        selected={selectedCategory}
+        onSelect={setSelectedCategory}
+        className="mb-5"
+      />
 
       {/* シナリオ一覧 */}
       {loading ? (

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -22,6 +22,7 @@ import ScoreTrendIndicator from '../components/ScoreTrendIndicator';
 import SessionFeedbackSummary from '../components/SessionFeedbackSummary';
 import WeakAxisAdviceCard from '../components/WeakAxisAdviceCard';
 import PersonalBestCard from '../components/PersonalBestCard';
+import FilterTabs from '../components/FilterTabs';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 
 export default function ScoreHistoryPage() {
@@ -169,21 +170,7 @@ export default function ScoreHistoryPage() {
       <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />
 
       {/* フィルタタブ */}
-      <div className="flex gap-1 border-b border-surface-3">
-        {FILTERS.map((f) => (
-          <button
-            key={f}
-            onClick={() => setFilter(f)}
-            className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
-              filter === f
-                ? 'border-primary-500 text-primary-400'
-                : 'border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]'
-            }`}
-          >
-            {f}
-          </button>
-        ))}
-      </div>
+      <FilterTabs tabs={[...FILTERS]} selected={filter} onSelect={setFilter} />
 
       {/* フィルタサマリー */}
       <ScoreFilterSummary scores={filteredHistory.map(h => h.overallScore)} />


### PR DESCRIPTION
## 概要
- PracticePageとScoreHistoryPageの重複タブUIパターンをFilterTabsコンポーネントに抽出
- ジェネリクスで型安全なタブ選択を実現
- `className`プロップで外部からスタイル追加可能

## テスト
- FilterTabsコンポーネントのテスト5件追加
- 全1082テストパス

Closes #522