### PR TITLE
test: SearchBox・FilterTabsエッジケーステスト追加

### DIFF
--- a/frontend/src/components/__tests__/FilterTabs.test.tsx
+++ b/frontend/src/components/__tests__/FilterTabs.test.tsx
@@ -37,4 +37,32 @@ describe('FilterTabs', () => {
     );
     expect(container.firstChild).toHaveClass('mb-5');
   });
+
+  it('classNameが未指定でもエラーにならない', () => {
+    const { container } = render(
+      <FilterTabs tabs={[...TABS]} selected="すべて" onSelect={() => {}} />
+    );
+    expect(container.firstChild).toHaveClass('flex');
+  });
+
+  it('選択中のタブを再クリックしてもonSelectが呼ばれる', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'すべて' }));
+    expect(onSelect).toHaveBeenCalledWith('すべて');
+  });
+
+  it('タブが1つでも正常にレンダリングされる', () => {
+    render(<FilterTabs tabs={['唯一']} selected="唯一" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: '唯一' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '唯一' }).className).toContain('border-primary-500');
+  });
+
+  it('ボーダー付きのコンテナがレンダリングされる', () => {
+    const { container } = render(
+      <FilterTabs tabs={[...TABS]} selected="すべて" onSelect={() => {}} />
+    );
+    expect(container.firstChild).toHaveClass('border-b');
+    expect(container.firstChild).toHaveClass('border-surface-3');
+  });
 });

--- a/frontend/src/components/__tests__/SearchBox.test.tsx
+++ b/frontend/src/components/__tests__/SearchBox.test.tsx
@@ -59,4 +59,22 @@ describe('SearchBox', () => {
     fireEvent.click(screen.getByLabelText('検索をクリア'));
     expect(mockOnChange).toHaveBeenCalledWith('');
   });
+
+  it('スペースのみの値でもクリアボタンが表示される', () => {
+    render(<SearchBox value=" " onChange={vi.fn()} />);
+    expect(screen.getByLabelText('検索をクリア')).toBeInTheDocument();
+  });
+
+  it('長い文字列でも正常に表示される', () => {
+    const longText = 'テ'.repeat(200);
+    render(<SearchBox value={longText} onChange={vi.fn()} />);
+    expect(screen.getByDisplayValue(longText)).toBeInTheDocument();
+    expect(screen.getByLabelText('検索をクリア')).toBeInTheDocument();
+  });
+
+  it('クリアボタンにbutton要素が使用される', () => {
+    render(<SearchBox value="テスト" onChange={vi.fn()} />);
+    const clearButton = screen.getByLabelText('検索をクリア');
+    expect(clearButton.tagName).toBe('BUTTON');
+  });
 });


### PR DESCRIPTION
## 概要
- SearchBoxクリアボタンのエッジケーステスト3件追加
- FilterTabsコンポーネントのエッジケーステスト4件追加
- 全1089テストパス

Closes #524