### PR TITLE
feat: TextareaFieldコンポーネント（文字数カウント付き）

### DIFF
--- a/frontend/src/components/TextareaField.tsx
+++ b/frontend/src/components/TextareaField.tsx
@@ -1,0 +1,36 @@
+import { ChangeEvent } from 'react';
+
+interface TextareaFieldProps {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  rows?: number;
+  maxLength?: number;
+}
+
+export default function TextareaField({ label, name, value, onChange, placeholder, rows = 3, maxLength }: TextareaFieldProps) {
+  return (
+    <div>
+      <label htmlFor={name} className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+        {label}
+      </label>
+      <textarea
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        rows={rows}
+        maxLength={maxLength}
+        className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
+      />
+      {maxLength && (
+        <p className="text-xs text-[var(--color-text-muted)] text-right mt-1">
+          {value.length} / {maxLength}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/TextareaField.test.tsx
+++ b/frontend/src/components/__tests__/TextareaField.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import TextareaField from '../TextareaField';
+
+describe('TextareaField', () => {
+  it('ラベルが表示される', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('自己紹介')).toBeInTheDocument();
+  });
+
+  it('値が反映される', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="テスト値" onChange={vi.fn()} />);
+    expect(screen.getByDisplayValue('テスト値')).toBeInTheDocument();
+  });
+
+  it('入力時にonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('自己紹介'), { target: { value: 'テスト' } });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('文字数カウントが表示される', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="こんにちは" onChange={vi.fn()} maxLength={100} />);
+    expect(screen.getByText('5 / 100')).toBeInTheDocument();
+  });
+
+  it('maxLength未指定時は文字数カウントが非表示', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="テスト" onChange={vi.fn()} />);
+    expect(screen.queryByText(/\//)).not.toBeInTheDocument();
+  });
+
+  it('プレースホルダーが表示される', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} placeholder="入力してください" />);
+    expect(screen.getByPlaceholderText('入力してください')).toBeInTheDocument();
+  });
+
+  it('rows属性が反映される', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} rows={5} />);
+    expect(screen.getByLabelText('自己紹介')).toHaveAttribute('rows', '5');
+  });
+});

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import InputField from '../components/InputField';
+import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
 import FormMessage from '../components/FormMessage';
 import { useProfileEdit } from '../hooks/useProfileEdit';
@@ -46,21 +47,17 @@ export default function ProfilePage() {
               updateField('name', e.target.value)
             }
           />
-          <div>
-            <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
-              自己紹介
-            </label>
-            <textarea
-              name="bio"
-              value={form.bio}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                updateField('bio', e.target.value)
-              }
-              placeholder="あなたについて教えてください..."
-              rows={4}
-              className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
-            />
-          </div>
+          <TextareaField
+            label="自己紹介"
+            name="bio"
+            value={form.bio}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              updateField('bio', e.target.value)
+            }
+            placeholder="あなたについて教えてください..."
+            rows={4}
+            maxLength={200}
+          />
           <PrimaryButton type="submit">プロフィールを更新</PrimaryButton>
         </form>
       </div>

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,4 +1,5 @@
 import InputField from '../components/InputField';
+import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
 import Loading from '../components/Loading';
 import PersonalityTraitSelector from '../components/PersonalityTraitSelector';
@@ -60,21 +61,16 @@ export default function UserProfilePage() {
                 }
                 placeholder="例：タロウ、たろちゃん"
               />
-              <div>
-                <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
-                  自己紹介
-                </label>
-                <textarea
-                  name="selfIntroduction"
-                  value={form.selfIntroduction}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    setForm((prev) => ({ ...prev, selfIntroduction: e.target.value }))
-                  }
-                  placeholder="あなた自身について自由に書いてください..."
-                  rows={3}
-                  className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
-                />
-              </div>
+              <TextareaField
+                label="自己紹介"
+                name="selfIntroduction"
+                value={form.selfIntroduction}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setForm((prev) => ({ ...prev, selfIntroduction: e.target.value }))
+                }
+                placeholder="あなた自身について自由に書いてください..."
+                maxLength={300}
+              />
             </div>
           </div>
 
@@ -118,37 +114,27 @@ export default function UserProfilePage() {
               <h3 className="text-sm font-bold text-[var(--color-text-primary)]">AIフィードバック設定</h3>
             </div>
             <div className="space-y-3">
-              <div>
-                <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
-                  コミュニケーションで改善したい点・目標
-                </label>
-                <textarea
-                  name="goals"
-                  value={form.goals}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    setForm((prev) => ({ ...prev, goals: e.target.value }))
-                  }
-                  placeholder="例：もっと簡潔に伝えられるようになりたい..."
-                  rows={3}
-                  className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
-                />
-              </div>
+              <TextareaField
+                label="コミュニケーションで改善したい点・目標"
+                name="goals"
+                value={form.goals}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setForm((prev) => ({ ...prev, goals: e.target.value }))
+                }
+                placeholder="例：もっと簡潔に伝えられるようになりたい..."
+                maxLength={300}
+              />
 
-              <div>
-                <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
-                  苦手なこと・気になっていること
-                </label>
-                <textarea
-                  name="concerns"
-                  value={form.concerns}
-                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                    setForm((prev) => ({ ...prev, concerns: e.target.value }))
-                  }
-                  placeholder="例：話が長くなりがち、相手の反応が気になる..."
-                  rows={3}
-                  className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
-                />
-              </div>
+              <TextareaField
+                label="苦手なこと・気になっていること"
+                name="concerns"
+                value={form.concerns}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setForm((prev) => ({ ...prev, concerns: e.target.value }))
+                }
+                placeholder="例：話が長くなりがち、相手の反応が気になる..."
+                maxLength={300}
+              />
 
               <div>
                 <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">


### PR DESCRIPTION
## 概要
- 再利用可能なTextareaFieldコンポーネントを新規作成
- maxLength指定時に文字数カウント表示（例: 5 / 200）
- ProfilePage（bio）とUserProfilePage（selfIntroduction, goals, concerns）に適用
- 4つのインラインtextareaをTextareaFieldに置換

## テスト
- TextareaFieldコンポーネントのテスト7件追加
- 全1096テストパス

Closes #528