### PR TITLE
refactor: SelectFieldコンポーネント抽出

### DIFF
--- a/frontend/src/components/SelectField.tsx
+++ b/frontend/src/components/SelectField.tsx
@@ -1,0 +1,35 @@
+import { ChangeEvent } from 'react';
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectFieldProps {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
+  options: SelectOption[];
+}
+
+export default function SelectField({ label, name, value, onChange, options }: SelectFieldProps) {
+  return (
+    <div>
+      <label htmlFor={name} className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+        {label}
+      </label>
+      <select
+        id={name}
+        name={name}
+        value={value}
+        onChange={onChange}
+        className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SelectField.test.tsx
+++ b/frontend/src/components/__tests__/SelectField.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SelectField from '../SelectField';
+
+const OPTIONS = [
+  { value: 'a', label: 'オプションA' },
+  { value: 'b', label: 'オプションB' },
+  { value: 'c', label: 'オプションC' },
+];
+
+describe('SelectField', () => {
+  it('ラベルが表示される', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByLabelText('スタイル')).toBeInTheDocument();
+  });
+
+  it('すべてのオプションが表示される', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} />);
+    OPTIONS.forEach((opt) => {
+      expect(screen.getByText(opt.label)).toBeInTheDocument();
+    });
+  });
+
+  it('選択値が反映される', () => {
+    render(<SelectField label="スタイル" name="style" value="b" onChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByLabelText('スタイル')).toHaveValue('b');
+  });
+
+  it('変更時にonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<SelectField label="スタイル" name="style" value="a" onChange={onChange} options={OPTIONS} />);
+    fireEvent.change(screen.getByLabelText('スタイル'), { target: { value: 'c' } });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('select要素がレンダリングされる', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByLabelText('スタイル').tagName).toBe('SELECT');
+  });
+});

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,5 +1,6 @@
 import InputField from '../components/InputField';
 import TextareaField from '../components/TextareaField';
+import SelectField from '../components/SelectField';
 import PrimaryButton from '../components/PrimaryButton';
 import Loading from '../components/Loading';
 import PersonalityTraitSelector from '../components/PersonalityTraitSelector';
@@ -81,22 +82,15 @@ export default function UserProfilePage() {
               <h3 className="text-sm font-bold text-[var(--color-text-primary)]">コミュニケーションスタイル</h3>
             </div>
             <div className="space-y-3">
-              <div>
-                <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
-                  あなたのコミュニケーションスタイル
-                </label>
-                <select
-                  value={form.communicationStyle}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                    setForm((prev) => ({ ...prev, communicationStyle: e.target.value }))
-                  }
-                  className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
-                >
-                  {COMMUNICATION_STYLES.map((style) => (
-                    <option key={style.value} value={style.value}>{style.label}</option>
-                  ))}
-                </select>
-              </div>
+              <SelectField
+                label="あなたのコミュニケーションスタイル"
+                name="communicationStyle"
+                value={form.communicationStyle}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setForm((prev) => ({ ...prev, communicationStyle: e.target.value }))
+                }
+                options={COMMUNICATION_STYLES}
+              />
 
               <PersonalityTraitSelector
                 options={PERSONALITY_OPTIONS}
@@ -136,22 +130,15 @@ export default function UserProfilePage() {
                 maxLength={300}
               />
 
-              <div>
-                <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
-                  フィードバックの受け取り方
-                </label>
-                <select
-                  value={form.preferredFeedbackStyle}
-                  onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                    setForm((prev) => ({ ...prev, preferredFeedbackStyle: e.target.value }))
-                  }
-                  className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
-                >
-                  {FEEDBACK_STYLES.map((style) => (
-                    <option key={style.value} value={style.value}>{style.label}</option>
-                  ))}
-                </select>
-              </div>
+              <SelectField
+                label="フィードバックの受け取り方"
+                name="preferredFeedbackStyle"
+                value={form.preferredFeedbackStyle}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setForm((prev) => ({ ...prev, preferredFeedbackStyle: e.target.value }))
+                }
+                options={FEEDBACK_STYLES}
+              />
             </div>
           </div>
 


### PR DESCRIPTION
## 概要
- 再利用可能なSelectFieldコンポーネントを新規作成
- UserProfilePageの2つのインラインselect要素を置換
- label + select + options を統一的に管理

## テスト
- SelectFieldコンポーネントのテスト5件追加
- 全1101テストパス

Closes #530