### PR TITLE
fix: TextareaField文字数警告色・README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@
 - **メッセージコピー機能**：チャット・AIチャット両方のメッセージ個別コピーボタン・コピー済みフィードバック表示（2秒間）・Heroiconsアイコン使用
 - **検索ボックスクリアボタン**：SearchBoxコンポーネントにXMarkIconによるワンタップクリア機能・値が空の場合は非表示
 - **FilterTabsコンポーネント**：ジェネリクス型安全なタブ切り替えUI・WAI-ARIAタブパターン対応・PracticePage/ScoreHistoryPageで再利用
+- **TextareaFieldコンポーネント**：文字数カウント付きtextarea・maxLength指定時に残り文字数表示（90%超で警告色・上限到達で赤色）
+- **SelectFieldコンポーネント**：ラベル付きselect要素の統一コンポーネント・UserProfilePageで再利用
 
 ### テスト品質
-- **フロントエンド1089テスト**：Vitest + React Testing Library
+- **フロントエンド1108テスト**：Vitest + React Testing Library
   - Repository層テスト（13リポジトリ・62テスト）
   - Hooks層テスト（32フック・319テスト）
   - Store層テスト（1スライス・5テスト）

--- a/frontend/src/components/TextareaField.tsx
+++ b/frontend/src/components/TextareaField.tsx
@@ -27,7 +27,13 @@ export default function TextareaField({ label, name, value, onChange, placeholde
         className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
       />
       {maxLength && (
-        <p className="text-xs text-[var(--color-text-muted)] text-right mt-1">
+        <p className={`text-xs text-right mt-1 ${
+          value.length >= maxLength
+            ? 'text-rose-400'
+            : value.length >= maxLength * 0.9
+              ? 'text-amber-400'
+              : 'text-[var(--color-text-muted)]'
+        }`}>
           {value.length} / {maxLength}
         </p>
       )}


### PR DESCRIPTION
## 概要
- TextareaFieldの文字数カウントに段階的な警告色表示を追加（90%超:amber、上限:rose）
- READMEにサイクル39の成果を反映（テスト数1108）

## テスト
- 全1108テストパス

Closes #534