### PR TITLE
feat: PrimaryButtonローディングスピナー対応

### DIFF
--- a/frontend/src/components/PrimaryButton.tsx
+++ b/frontend/src/components/PrimaryButton.tsx
@@ -5,6 +5,7 @@ interface PrimaryButtonProps {
   onClick?: () => void;
   type?: 'button' | 'submit' | 'reset';
   disabled?: boolean;
+  loading?: boolean;
 }
 
 export default function PrimaryButton({
@@ -12,14 +13,21 @@ export default function PrimaryButton({
   onClick,
   type = 'button',
   disabled,
+  loading,
 }: PrimaryButtonProps) {
   return (
     <button
       type={type}
       onClick={onClick}
-      disabled={disabled}
-      className="w-full bg-primary-500 text-white font-medium py-2.5 rounded-lg hover:bg-primary-600 active:bg-primary-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+      disabled={disabled || loading}
+      className="w-full bg-primary-500 text-white font-medium py-2.5 rounded-lg hover:bg-primary-600 active:bg-primary-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
     >
+      {loading && (
+        <svg data-testid="loading-spinner" className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+      )}
       {children}
     </button>
   );

--- a/frontend/src/components/__tests__/PrimaryButton.test.tsx
+++ b/frontend/src/components/__tests__/PrimaryButton.test.tsx
@@ -39,4 +39,19 @@ describe('PrimaryButton', () => {
     render(<PrimaryButton>テスト</PrimaryButton>);
     expect(screen.getByText('テスト').className).toContain('w-full');
   });
+
+  it('loading時にスピナーが表示される', () => {
+    const { container } = render(<PrimaryButton loading>送信</PrimaryButton>);
+    expect(container.querySelector('[data-testid="loading-spinner"]')).toBeInTheDocument();
+  });
+
+  it('loading時にボタンが無効化される', () => {
+    render(<PrimaryButton loading>送信</PrimaryButton>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('loading=false時にスピナーが表示されない', () => {
+    const { container } = render(<PrimaryButton>送信</PrimaryButton>);
+    expect(container.querySelector('[data-testid="loading-spinner"]')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- PrimaryButtonにloading propを追加
- loading時にアニメーションスピナーを表示しボタンを自動無効化
- 既存のdisabled propとの併用も対応

## テスト
- PrimaryButtonにloading関連テスト3件追加
- 全1111テストパス

Closes #536