### PR TITLE
refactor: ConfirmModalのインラインSVGをHeroiconsに置換

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { TrashIcon, QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 
 interface ConfirmModalProps {
   isOpen: boolean;
@@ -52,33 +53,9 @@ export default function ConfirmModal({
             }`}
           >
             {isDanger ? (
-              <svg
-                className="w-7 h-7 text-red-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                />
-              </svg>
+              <TrashIcon className="w-7 h-7 text-red-600" />
             ) : (
-              <svg
-                className="w-7 h-7 text-primary-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
+              <QuestionMarkCircleIcon className="w-7 h-7 text-primary-400" />
             )}
           </div>
         </div>


### PR DESCRIPTION
## 概要
- ConfirmModalのインラインSVGをHeroiconsのTrashIcon・QuestionMarkCircleIconに置換
- 28行のSVGコードを4行に簡潔化

## テスト
- 全1111テストパス

Closes #538