### PR TITLE
feat: ノート削除確認ダイアログ追加

### DIFF
--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import NoteListItem from '../components/NoteListItem';
 import NoteEditor from '../components/NoteEditor';
 import EmptyState from '../components/EmptyState';
+import ConfirmModal from '../components/ConfirmModal';
 import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import { useNotes } from '../hooks/useNotes';
 import { useNoteEditor } from '../hooks/useNoteEditor';
@@ -44,8 +45,17 @@ export default function NotesPage() {
     closeMobilePanel();
   };
 
-  const handleDeleteNote = async (noteId: string) => {
-    await deleteNote(noteId);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+
+  const handleDeleteNote = (noteId: string) => {
+    setDeleteTargetId(noteId);
+  };
+
+  const confirmDelete = async () => {
+    if (deleteTargetId) {
+      await deleteNote(deleteTargetId);
+      setDeleteTargetId(null);
+    }
   };
 
   return (
@@ -134,6 +144,13 @@ export default function NotesPage() {
           />
         )}
       </div>
+
+      <ConfirmModal
+        isOpen={deleteTargetId !== null}
+        message="このノートを削除しますか？"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTargetId(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -219,4 +219,54 @@ describe('NotesPage', () => {
     fireEvent.click(pinButtons[0]);
     expect(mockUseNotes.togglePin).toHaveBeenCalledWith('n1');
   });
+
+  it('ノート削除時に確認ダイアログが表示される', () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    const deleteButtons = screen.getAllByLabelText('ノートを削除');
+    fireEvent.click(deleteButtons[0]);
+    expect(screen.getByText('このノートを削除しますか？')).toBeInTheDocument();
+    expect(mockUseNotes.deleteNote).not.toHaveBeenCalled();
+  });
+
+  it('確認ダイアログで削除を実行するとdeleteNoteが呼ばれる', async () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    const deleteButtons = screen.getAllByLabelText('ノートを削除');
+    fireEvent.click(deleteButtons[0]);
+    await act(async () => {
+      fireEvent.click(screen.getByText('削除'));
+    });
+    expect(mockUseNotes.deleteNote).toHaveBeenCalledWith('n1');
+  });
+
+  it('確認ダイアログでキャンセルするとdeleteNoteが呼ばれない', () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    const deleteButtons = screen.getAllByLabelText('ノートを削除');
+    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(mockUseNotes.deleteNote).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 概要
- NotesPageのノート削除時にConfirmModalで確認を求めるように変更
- 誤操作による意図しないノート削除を防止
- キャンセルで削除を取り消し可能

## テスト
- NotesPageに削除確認テスト3件追加
- 全1120テストパス

Closes #544