### PR TITLE
refactor: SectionHeaderコンポーネント抽出

### DIFF
--- a/frontend/src/components/SectionHeader.tsx
+++ b/frontend/src/components/SectionHeader.tsx
@@ -1,0 +1,15 @@
+import { ComponentType, SVGProps } from 'react';
+
+interface SectionHeaderProps {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  title: string;
+}
+
+export default function SectionHeader({ icon: Icon, title }: SectionHeaderProps) {
+  return (
+    <div className="flex items-center gap-2 mb-3">
+      <Icon className="w-4 h-4 text-primary-500" />
+      <h3 className="text-sm font-bold text-[var(--color-text-primary)]">{title}</h3>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SectionHeader.test.tsx
+++ b/frontend/src/components/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import SectionHeader from '../SectionHeader';
+import { UserCircleIcon } from '@heroicons/react/24/solid';
+
+describe('SectionHeader', () => {
+  it('タイトルが表示される', () => {
+    render(<SectionHeader icon={UserCircleIcon} title="基本情報" />);
+    expect(screen.getByText('基本情報')).toBeInTheDocument();
+  });
+
+  it('アイコンがレンダリングされる', () => {
+    const { container } = render(<SectionHeader icon={UserCircleIcon} title="基本情報" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('h3要素でタイトルが表示される', () => {
+    render(<SectionHeader icon={UserCircleIcon} title="基本情報" />);
+    const heading = screen.getByText('基本情報');
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('flexレイアウトのコンテナがレンダリングされる', () => {
+    const { container } = render(<SectionHeader icon={UserCircleIcon} title="テスト" />);
+    expect(container.firstChild).toHaveClass('flex');
+    expect(container.firstChild).toHaveClass('items-center');
+  });
+});

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,6 +1,7 @@
 import InputField from '../components/InputField';
 import TextareaField from '../components/TextareaField';
 import SelectField from '../components/SelectField';
+import SectionHeader from '../components/SectionHeader';
 import PrimaryButton from '../components/PrimaryButton';
 import Loading from '../components/Loading';
 import PersonalityTraitSelector from '../components/PersonalityTraitSelector';
@@ -48,10 +49,7 @@ export default function UserProfilePage() {
         <form onSubmit={handleSave} className="divide-y divide-slate-100">
           {/* 基本情報セクション */}
           <div className="p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <UserCircleIcon className="w-4 h-4 text-primary-500" />
-              <h3 className="text-sm font-bold text-[var(--color-text-primary)]">基本情報</h3>
-            </div>
+            <SectionHeader icon={UserCircleIcon} title="基本情報" />
             <div className="space-y-3">
               <InputField
                 label="呼ばれたい名前"
@@ -77,10 +75,7 @@ export default function UserProfilePage() {
 
           {/* コミュニケーションスタイル */}
           <div className="p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <ChatBubbleLeftRightIcon className="w-4 h-4 text-primary-500" />
-              <h3 className="text-sm font-bold text-[var(--color-text-primary)]">コミュニケーションスタイル</h3>
-            </div>
+            <SectionHeader icon={ChatBubbleLeftRightIcon} title="コミュニケーションスタイル" />
             <div className="space-y-3">
               <SelectField
                 label="あなたのコミュニケーションスタイル"
@@ -103,10 +98,7 @@ export default function UserProfilePage() {
 
           {/* AIフィードバック設定 */}
           <div className="p-5">
-            <div className="flex items-center gap-2 mb-3">
-              <LightBulbIcon className="w-4 h-4 text-primary-500" />
-              <h3 className="text-sm font-bold text-[var(--color-text-primary)]">AIフィードバック設定</h3>
-            </div>
+            <SectionHeader icon={LightBulbIcon} title="AIフィードバック設定" />
             <div className="space-y-3">
               <TextareaField
                 label="コミュニケーションで改善したい点・目標"


### PR DESCRIPTION
## 概要
- UserProfilePageの3つの重複セクション見出しをSectionHeaderコンポーネントに抽出
- アイコン＋タイトルのパターンを統一的に管理

## テスト
- SectionHeaderコンポーネントのテスト4件追加
- 全1124テストパス

Closes #546