### PR TITLE
test: SectionHeader・NotesPage削除確認のエッジケーステスト追加

### DIFF
--- a/frontend/src/components/__tests__/SectionHeader.test.tsx
+++ b/frontend/src/components/__tests__/SectionHeader.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import SectionHeader from '../SectionHeader';
-import { UserCircleIcon } from '@heroicons/react/24/solid';
+import { UserCircleIcon, LightBulbIcon, ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 
 describe('SectionHeader', () => {
   it('タイトルが表示される', () => {
@@ -24,5 +24,27 @@ describe('SectionHeader', () => {
     const { container } = render(<SectionHeader icon={UserCircleIcon} title="テスト" />);
     expect(container.firstChild).toHaveClass('flex');
     expect(container.firstChild).toHaveClass('items-center');
+  });
+
+  it('異なるアイコンでも正しくレンダリングされる', () => {
+    const { container } = render(<SectionHeader icon={LightBulbIcon} title="設定" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByText('設定')).toBeInTheDocument();
+  });
+
+  it('長いタイトルが正しく表示される', () => {
+    const longTitle = 'コミュニケーションスタイルの設定について';
+    render(<SectionHeader icon={ChatBubbleLeftRightIcon} title={longTitle} />);
+    expect(screen.getByText(longTitle)).toBeInTheDocument();
+  });
+
+  it('アイコンとタイトルの間にgapがある', () => {
+    const { container } = render(<SectionHeader icon={UserCircleIcon} title="テスト" />);
+    expect(container.firstChild).toHaveClass('gap-2');
+  });
+
+  it('下マージンが設定されている', () => {
+    const { container } = render(<SectionHeader icon={UserCircleIcon} title="テスト" />);
+    expect(container.firstChild).toHaveClass('mb-3');
   });
 });

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -269,4 +269,56 @@ describe('NotesPage', () => {
     fireEvent.click(screen.getByText('キャンセル'));
     expect(mockUseNotes.deleteNote).not.toHaveBeenCalled();
   });
+
+  it('削除確認ダイアログのキャンセル後にダイアログが閉じる', () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    const deleteButtons = screen.getAllByLabelText('ノートを削除');
+    fireEvent.click(deleteButtons[0]);
+    expect(screen.getByText('このノートを削除しますか？')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(screen.queryByText('このノートを削除しますか？')).not.toBeInTheDocument();
+  });
+
+  it('複数ノートがある場合、正しいノートが削除される', async () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: 'ノート1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+      { noteId: 'n2', userId: 1, title: 'ノート2', content: '内容2', isPinned: false, createdAt: 1500, updatedAt: 3000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    const deleteButtons = screen.getAllByLabelText('ノートを削除');
+    fireEvent.click(deleteButtons[1]);
+    await act(async () => {
+      fireEvent.click(screen.getByText('削除'));
+    });
+    expect(mockUseNotes.deleteNote).toHaveBeenCalledWith('n2');
+  });
+
+  it('削除ボタンを押してもdeleteNoteが直接呼ばれない（確認が必要）', () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: 'テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    const deleteButtons = screen.getAllByLabelText('ノートを削除');
+    fireEvent.click(deleteButtons[0]);
+    expect(mockUseNotes.deleteNote).not.toHaveBeenCalled();
+    expect(screen.getByText('このノートを削除しますか？')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- SectionHeaderコンポーネントのエッジケーステスト追加（+4テスト）
- NotesPage削除確認ダイアログのエッジケーステスト追加（+3テスト）

## 追加テスト
### SectionHeader
- 異なるアイコン（LightBulbIcon）でも正しくレンダリングされる
- 長いタイトルが正しく表示される
- アイコンとタイトルの間にgapがある
- 下マージンが設定されている

### NotesPage 削除確認
- キャンセル後にダイアログが閉じる
- 複数ノートがある場合、正しいノートが削除される
- 削除ボタンを押しても直接deleteNoteが呼ばれない（確認が必要）

## テスト結果
- 全1131テスト通過（+7）

closes #548