### PR TITLE
feat: InputFieldフィールドレベルバリデーションエラー表示

### DIFF
--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -8,6 +8,7 @@ interface InputFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement> | { target: { name: string; value: string } }) => void;
   placeholder?: string;
+  error?: string;
 }
 
 export default function InputField({
@@ -16,6 +17,7 @@ export default function InputField({
   type = 'text',
   value,
   onChange,
+  error,
 }: InputFieldProps) {
   const [inputValue, setInputValue] = useState(value || '');
 
@@ -42,7 +44,13 @@ export default function InputField({
             setInputValue(e.target.value);
             onChange(e);
           }}
-          className="w-full border border-surface-3 rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors duration-150"
+          aria-invalid={!!error}
+          aria-describedby={error ? `${name}-error` : undefined}
+          className={`w-full border rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:ring-1 transition-colors duration-150 ${
+            error
+              ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
+              : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500'
+          }`}
         />
         {inputValue && (
           <button
@@ -54,6 +62,11 @@ export default function InputField({
           </button>
         )}
       </div>
+      {error && (
+        <p id={`${name}-error`} className="text-xs text-rose-400 mt-1">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/InputField.test.tsx
+++ b/frontend/src/components/__tests__/InputField.test.tsx
@@ -45,4 +45,31 @@ describe('InputField', () => {
     render(<InputField label="名前" name="name" value="" onChange={mockOnChange} />);
     expect(screen.getByLabelText('名前')).toHaveAttribute('type', 'text');
   });
+
+  it('エラーメッセージが表示される', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} error="必須項目です" />);
+    expect(screen.getByText('必須項目です')).toBeInTheDocument();
+  });
+
+  it('エラー時にaria-invalidがtrueになる', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} error="エラー" />);
+    expect(screen.getByLabelText('メール')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('エラー時にaria-describedbyが設定される', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} error="エラー" />);
+    expect(screen.getByLabelText('メール')).toHaveAttribute('aria-describedby', 'email-error');
+    expect(screen.getByText('エラー')).toHaveAttribute('id', 'email-error');
+  });
+
+  it('エラーがない場合はエラーメッセージが表示されない', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+    expect(screen.queryByText('必須項目です')).not.toBeInTheDocument();
+  });
+
+  it('エラー時にボーダーが赤色になる', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} error="エラー" />);
+    const input = screen.getByLabelText('メール');
+    expect(input.className).toContain('border-rose-500');
+  });
 });


### PR DESCRIPTION
## 概要
InputFieldコンポーネントにフィールドレベルのバリデーションエラー表示機能を追加

## 変更内容
- `error` prop追加でフィールド下に赤いエラーテキスト表示
- エラー時にボーダー色をrose-500に変更
- `aria-invalid`, `aria-describedby`のアクセシビリティ属性追加

## テスト結果
- テスト5件追加（合計1136）
- 全テスト通過

closes #552