### PR TITLE
refactor: スコア色判定ロジックをscoreColorユーティリティに統一

### DIFF
--- a/frontend/src/components/RecentSessionsCard.tsx
+++ b/frontend/src/components/RecentSessionsCard.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { getScoreTextColor } from '../utils/scoreColor';
 
 interface Session {
   sessionId: number;
@@ -9,12 +10,6 @@ interface Session {
 
 interface RecentSessionsCardProps {
   sessions: Session[];
-}
-
-function scoreColor(score: number): string {
-  if (score >= 8) return 'text-emerald-400';
-  if (score >= 6) return 'text-amber-400';
-  return 'text-rose-400';
 }
 
 export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps) {
@@ -46,7 +41,7 @@ export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps
                 {new Date(session.createdAt).toLocaleDateString('ja-JP')}
               </p>
             </div>
-            <span className={`text-sm font-semibold ${scoreColor(session.overallScore)}`}>
+            <span className={`text-sm font-semibold ${getScoreTextColor(session.overallScore)}`}>
               {session.overallScore}
             </span>
           </div>

--- a/frontend/src/components/ScoreCard.tsx
+++ b/frontend/src/components/ScoreCard.tsx
@@ -1,24 +1,13 @@
 import type { ScoreCard as ScoreCardType } from '../types';
 import { LightBulbIcon } from '@heroicons/react/24/outline';
+import { getScoreLevel, getScoreBarColor } from '../utils/scoreColor';
 
 interface ScoreCardProps {
   scoreCard: ScoreCardType;
 }
 
-function getOverallLevel(score: number): { label: string; color: string } {
-  if (score >= 8) return { label: '優秀レベル', color: 'bg-emerald-900/30 text-emerald-400 border-emerald-800' };
-  if (score >= 5) return { label: '実務レベル', color: 'bg-amber-900/30 text-amber-400 border-amber-800' };
-  return { label: '基礎レベル', color: 'bg-rose-900/30 text-rose-400 border-rose-800' };
-}
-
-function getBarColor(score: number): string {
-  if (score >= 8) return 'bg-emerald-900/300';
-  if (score >= 6) return 'bg-amber-900/300';
-  return 'bg-rose-900/300';
-}
-
 export default function ScoreCard({ scoreCard }: ScoreCardProps) {
-  const level = getOverallLevel(scoreCard.overallScore);
+  const level = getScoreLevel(scoreCard.overallScore);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 my-3 max-w-[85%] self-start">
@@ -47,7 +36,7 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
             </div>
             <div className="w-full bg-surface-3 rounded-full h-1.5">
               <div
-                className={`h-1.5 rounded-full ${getBarColor(axisScore.score)}`}
+                className={`h-1.5 rounded-full ${getScoreBarColor(axisScore.score)}`}
                 style={{ width: `${axisScore.score * 10}%` }}
               />
             </div>

--- a/frontend/src/components/ScoreComparisonCard.tsx
+++ b/frontend/src/components/ScoreComparisonCard.tsx
@@ -1,3 +1,5 @@
+import { getDeltaColor, formatDelta } from '../utils/scoreColor';
+
 interface AxisScore {
   axis: string;
   score: number;
@@ -9,17 +11,6 @@ interface ScoreComparisonCardProps {
   latestScores: AxisScore[];
   firstOverall: number;
   latestOverall: number;
-}
-
-function formatDelta(delta: number): string {
-  if (delta === 0) return '±0';
-  return delta > 0 ? `+${delta.toFixed(1)}` : `${delta.toFixed(1)}`;
-}
-
-function deltaColor(delta: number): string {
-  if (delta > 0) return 'text-emerald-400';
-  if (delta < 0) return 'text-rose-400';
-  return 'text-[var(--color-text-faint)]';
 }
 
 export default function ScoreComparisonCard({
@@ -40,7 +31,7 @@ export default function ScoreComparisonCard({
           <p className="text-xl font-bold text-[var(--color-text-tertiary)]">{firstOverall.toFixed(1)}</p>
         </div>
         <div className="text-center">
-          <span className={`text-sm font-bold ${deltaColor(overallDelta)}`}>
+          <span className={`text-sm font-bold ${getDeltaColor(overallDelta)}`}>
             {formatDelta(overallDelta)}
           </span>
         </div>
@@ -61,7 +52,7 @@ export default function ScoreComparisonCard({
                 <span className="text-xs text-[var(--color-text-faint)] w-6 text-right">{first?.score ?? '-'}</span>
                 <span className="text-xs text-[var(--color-text-subtle)]">→</span>
                 <span className="text-xs text-[var(--color-text-secondary)] w-6">{latest.score}</span>
-                <span className={`text-xs font-medium w-8 text-right ${deltaColor(delta)}`}>
+                <span className={`text-xs font-medium w-8 text-right ${getDeltaColor(delta)}`}>
                   {formatDelta(delta)}
                 </span>
               </div>

--- a/frontend/src/components/ScoreGrowthTrendCard.tsx
+++ b/frontend/src/components/ScoreGrowthTrendCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { getDeltaColor, formatDelta } from '../utils/scoreColor';
 
 type TrendType = 'up' | 'down' | 'stable';
 
@@ -68,8 +69,8 @@ export default function ScoreGrowthTrendCard({ scores }: Props) {
         <span className="text-2xl font-bold text-[var(--color-text-primary)]">{analysis.latestScore}</span>
         <span className="text-xs text-[var(--color-text-faint)]">最新スコア</span>
         {analysis.delta !== 0 && (
-          <span className={`text-xs font-medium ${analysis.delta > 0 ? 'text-emerald-400' : 'text-rose-400'}`}>
-            {analysis.delta > 0 ? '+' : ''}{analysis.delta.toFixed(1)}
+          <span className={`text-xs font-medium ${getDeltaColor(analysis.delta)}`}>
+            {formatDelta(analysis.delta)}
           </span>
         )}
       </div>

--- a/frontend/src/utils/__tests__/scoreColor.test.ts
+++ b/frontend/src/utils/__tests__/scoreColor.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { getScoreTextColor, getScoreBarColor, getScoreLevel, getDeltaColor, formatDelta } from '../scoreColor';
+
+describe('scoreColor', () => {
+  describe('getScoreTextColor', () => {
+    it('スコア8以上でemeraldを返す', () => {
+      expect(getScoreTextColor(8)).toBe('text-emerald-400');
+      expect(getScoreTextColor(10)).toBe('text-emerald-400');
+    });
+
+    it('スコア6以上8未満でamberを返す', () => {
+      expect(getScoreTextColor(6)).toBe('text-amber-400');
+      expect(getScoreTextColor(7.9)).toBe('text-amber-400');
+    });
+
+    it('スコア6未満でroseを返す', () => {
+      expect(getScoreTextColor(5.9)).toBe('text-rose-400');
+      expect(getScoreTextColor(0)).toBe('text-rose-400');
+    });
+  });
+
+  describe('getScoreBarColor', () => {
+    it('スコア8以上でemeraldを返す', () => {
+      expect(getScoreBarColor(8)).toContain('emerald');
+    });
+
+    it('スコア6以上8未満でamberを返す', () => {
+      expect(getScoreBarColor(6)).toContain('amber');
+    });
+
+    it('スコア6未満でroseを返す', () => {
+      expect(getScoreBarColor(5)).toContain('rose');
+    });
+  });
+
+  describe('getScoreLevel', () => {
+    it('スコア8以上で優秀レベルを返す', () => {
+      const result = getScoreLevel(8);
+      expect(result.label).toBe('優秀レベル');
+      expect(result.color).toContain('emerald');
+    });
+
+    it('スコア5以上8未満で実務レベルを返す', () => {
+      const result = getScoreLevel(5);
+      expect(result.label).toBe('実務レベル');
+      expect(result.color).toContain('amber');
+    });
+
+    it('スコア5未満で基礎レベルを返す', () => {
+      const result = getScoreLevel(4.9);
+      expect(result.label).toBe('基礎レベル');
+      expect(result.color).toContain('rose');
+    });
+  });
+
+  describe('getDeltaColor', () => {
+    it('正の値でemeraldを返す', () => {
+      expect(getDeltaColor(0.5)).toBe('text-emerald-400');
+    });
+
+    it('負の値でroseを返す', () => {
+      expect(getDeltaColor(-0.5)).toBe('text-rose-400');
+    });
+
+    it('0でfaintを返す', () => {
+      expect(getDeltaColor(0)).toBe('text-[var(--color-text-faint)]');
+    });
+  });
+
+  describe('formatDelta', () => {
+    it('正の値で+を付ける', () => {
+      expect(formatDelta(1.5)).toBe('+1.5');
+    });
+
+    it('負の値でそのまま表示する', () => {
+      expect(formatDelta(-1.5)).toBe('-1.5');
+    });
+
+    it('0で±0を返す', () => {
+      expect(formatDelta(0)).toBe('±0');
+    });
+  });
+});

--- a/frontend/src/utils/scoreColor.ts
+++ b/frontend/src/utils/scoreColor.ts
@@ -1,0 +1,28 @@
+export function getScoreTextColor(score: number): string {
+  if (score >= 8) return 'text-emerald-400';
+  if (score >= 6) return 'text-amber-400';
+  return 'text-rose-400';
+}
+
+export function getScoreBarColor(score: number): string {
+  if (score >= 8) return 'bg-emerald-900/300';
+  if (score >= 6) return 'bg-amber-900/300';
+  return 'bg-rose-900/300';
+}
+
+export function getScoreLevel(score: number): { label: string; color: string } {
+  if (score >= 8) return { label: '優秀レベル', color: 'bg-emerald-900/30 text-emerald-400 border-emerald-800' };
+  if (score >= 5) return { label: '実務レベル', color: 'bg-amber-900/30 text-amber-400 border-amber-800' };
+  return { label: '基礎レベル', color: 'bg-rose-900/30 text-rose-400 border-rose-800' };
+}
+
+export function getDeltaColor(delta: number): string {
+  if (delta > 0) return 'text-emerald-400';
+  if (delta < 0) return 'text-rose-400';
+  return 'text-[var(--color-text-faint)]';
+}
+
+export function formatDelta(delta: number): string {
+  if (delta === 0) return '±0';
+  return delta > 0 ? `+${delta.toFixed(1)}` : `${delta.toFixed(1)}`;
+}


### PR DESCRIPTION
## 概要
4つのコンポーネントに散在していたスコア値→色判定ロジックを`scoreColor.ts`ユーティリティに集約

## 変更内容
### 新規
- `src/utils/scoreColor.ts`: 5つの共通関数（getScoreTextColor, getScoreBarColor, getScoreLevel, getDeltaColor, formatDelta）

### リファクタリング対象
- ScoreCard: getOverallLevel, getBarColor → ユーティリティ使用
- RecentSessionsCard: scoreColor → getScoreTextColor
- ScoreComparisonCard: deltaColor, formatDelta → ユーティリティ使用
- ScoreGrowthTrendCard: インライン色判定 → getDeltaColor, formatDelta

## テスト結果
- 15件のユニットテスト追加（合計1151）
- 全テスト通過

closes #554