### PR TITLE
test: InputFieldエラー表示・scoreColor境界値のエッジケーステスト追加

### DIFF
--- a/frontend/src/components/__tests__/InputField.test.tsx
+++ b/frontend/src/components/__tests__/InputField.test.tsx
@@ -72,4 +72,21 @@ describe('InputField', () => {
     const input = screen.getByLabelText('メール');
     expect(input.className).toContain('border-rose-500');
   });
+
+  it('エラーがない場合はaria-invalidがfalseになる', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+    expect(screen.getByLabelText('メール')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('エラーがない場合はaria-describedbyが設定されない', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+    expect(screen.getByLabelText('メール')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('エラーがない場合はボーダーが通常色になる', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} />);
+    const input = screen.getByLabelText('メール');
+    expect(input.className).toContain('border-surface-3');
+    expect(input.className).not.toContain('border-rose-500');
+  });
 });

--- a/frontend/src/utils/__tests__/scoreColor.test.ts
+++ b/frontend/src/utils/__tests__/scoreColor.test.ts
@@ -79,5 +79,28 @@ describe('scoreColor', () => {
     it('0で±0を返す', () => {
       expect(formatDelta(0)).toBe('±0');
     });
+
+    it('小数点以下1桁にフォーマットされる', () => {
+      expect(formatDelta(1.23)).toBe('+1.2');
+      expect(formatDelta(-0.78)).toBe('-0.8');
+    });
+  });
+
+  describe('境界値テスト', () => {
+    it('getScoreTextColor: 境界値7.999はamberを返す', () => {
+      expect(getScoreTextColor(7.999)).toBe('text-amber-400');
+    });
+
+    it('getScoreTextColor: 境界値5.999はroseを返す', () => {
+      expect(getScoreTextColor(5.999)).toBe('text-rose-400');
+    });
+
+    it('getScoreLevel: 境界値4.999は基礎レベルを返す', () => {
+      expect(getScoreLevel(4.999).label).toBe('基礎レベル');
+    });
+
+    it('getDeltaColor: 非常に小さい正の値でemeraldを返す', () => {
+      expect(getDeltaColor(0.001)).toBe('text-emerald-400');
+    });
   });
 });


### PR DESCRIPTION
## 概要
サイクル42 Phase1/Phase2で追加した機能のエッジケーステスト追加

## 追加テスト
### InputField (+3)
- エラーなし時にaria-invalidがfalse
- エラーなし時にaria-describedbyが未設定
- エラーなし時にボーダーが通常色（surface-3）

### scoreColor (+5)
- getScoreTextColor: 境界値7.999/5.999
- getScoreLevel: 境界値4.999
- getDeltaColor: 非常に小さい正の値
- formatDelta: 小数点以下1桁フォーマット

## テスト結果
- 全1159テスト通過（+8）

closes #556