### PR TITLE
feat: トースト通知システムの実装

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,11 +21,14 @@ import AuthInitializer from './utils/AuthInitializer';
 import Protected from './utils/Protected';
 import AppShell from './components/layout/AppShell';
 import ErrorBoundary from './components/ErrorBoundary';
+import { ToastProvider } from './hooks/useToast';
+import ToastContainer from './components/ToastContainer';
 
 
 export default function App() {
   return (
     <ErrorBoundary>
+    <ToastProvider>
     <Routes>
       {/* 誰でもアクセス可能 */}
       <Route path="/login" element={<LoginPage />} />
@@ -63,6 +66,8 @@ export default function App() {
         <Route path="/notes" element={<NotesPage />} />
       </Route>
     </Routes>
+    <ToastContainer />
+    </ToastProvider>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { CheckCircleIcon, ExclamationCircleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface ToastProps {
+  type: ToastType;
+  message: string;
+  onClose: () => void;
+}
+
+const ICON_MAP = {
+  success: CheckCircleIcon,
+  error: ExclamationCircleIcon,
+  info: InformationCircleIcon,
+};
+
+const COLOR_MAP = {
+  success: 'border-emerald-500 bg-emerald-900/20 text-emerald-400',
+  error: 'border-rose-500 bg-rose-900/20 text-rose-400',
+  info: 'border-primary-500 bg-primary-900/20 text-primary-400',
+};
+
+export default function Toast({ type, message, onClose }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  const Icon = ICON_MAP[type];
+
+  return (
+    <div
+      role="alert"
+      className={`flex items-center gap-2 px-4 py-3 rounded-lg border shadow-lg ${COLOR_MAP[type]} animate-fade-in`}
+    >
+      <Icon className="w-5 h-5 flex-shrink-0" />
+      <p className="text-sm">{message}</p>
+    </div>
+  );
+}

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,0 +1,21 @@
+import Toast from './Toast';
+import { useToast } from '../hooks/useToast';
+
+export default function ToastContainer() {
+  const { toasts, removeToast } = useToast();
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 space-y-2">
+      {toasts.map((toast) => (
+        <Toast
+          key={toast.id}
+          type={toast.type}
+          message={toast.message}
+          onClose={() => removeToast(toast.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Toast from '../Toast';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('成功メッセージが表示される', () => {
+    render(<Toast type="success" message="保存しました" onClose={vi.fn()} />);
+    expect(screen.getByText('保存しました')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<Toast type="error" message="エラーが発生しました" onClose={vi.fn()} />);
+    expect(screen.getByText('エラーが発生しました')).toBeInTheDocument();
+  });
+
+  it('情報メッセージが表示される', () => {
+    render(<Toast type="info" message="お知らせ" onClose={vi.fn()} />);
+    expect(screen.getByText('お知らせ')).toBeInTheDocument();
+  });
+
+  it('3秒後にonCloseが呼ばれる', () => {
+    const onClose = vi.fn();
+    render(<Toast type="success" message="テスト" onClose={onClose} />);
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('role="alert"が設定されている', () => {
+    render(<Toast type="success" message="テスト" onClose={vi.fn()} />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('成功時にアイコンが表示される', () => {
+    const { container } = render(<Toast type="success" message="テスト" onClose={vi.fn()} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/useToast.test.tsx
+++ b/frontend/src/hooks/__tests__/useToast.test.tsx
@@ -1,0 +1,54 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ToastProvider, useToast } from '../useToast';
+import { ReactNode } from 'react';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ToastProvider>{children}</ToastProvider>
+);
+
+describe('useToast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('初期状態でトーストが空である', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('showToastでトーストが追加される', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.showToast('success', 'テストメッセージ');
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].type).toBe('success');
+    expect(result.current.toasts[0].message).toBe('テストメッセージ');
+  });
+
+  it('removeToastでトーストが削除される', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.showToast('success', 'テスト');
+    });
+    const id = result.current.toasts[0].id;
+    act(() => {
+      result.current.removeToast(id);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('複数のトーストを追加できる', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.showToast('success', 'メッセージ1');
+      result.current.showToast('error', 'メッセージ2');
+    });
+    expect(result.current.toasts).toHaveLength(2);
+  });
+});

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -1,0 +1,45 @@
+import { createContext, useCallback, useContext, useState, ReactNode } from 'react';
+import type { ToastType } from '../components/Toast';
+
+interface ToastItem {
+  id: string;
+  type: ToastType;
+  message: string;
+}
+
+interface ToastContextValue {
+  toasts: ToastItem[];
+  showToast: (type: ToastType, message: string) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+let toastId = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const showToast = useCallback((type: ToastType, message: string) => {
+    const id = String(++toastId);
+    setToasts((prev) => [...prev, { id, type, message }]);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, showToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
## 概要
操作結果（成功/エラー/情報）をユーザーに即座に通知するトースト通知システムを実装

## 変更内容
### 新規
- `Toast.tsx`: 3タイプ（success/error/info）の通知表示、3秒後自動消去、Heroiconsアイコン
- `useToast.tsx`: Context APIベースのトースト管理フック
- `ToastContainer.tsx`: 画面右下にスタック表示

### 変更
- `App.tsx`: ToastProvider/ToastContainerを組み込み

## テスト結果
- テスト10件追加（合計1169）
- 全テスト通過

closes #560