### PR TITLE
refactor: TextareaField・SelectFieldにerror prop追加でバリデーション統一

### DIFF
--- a/frontend/src/components/SelectField.tsx
+++ b/frontend/src/components/SelectField.tsx
@@ -11,9 +11,10 @@ interface SelectFieldProps {
   value: string;
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   options: SelectOption[];
+  error?: string;
 }
 
-export default function SelectField({ label, name, value, onChange, options }: SelectFieldProps) {
+export default function SelectField({ label, name, value, onChange, options, error }: SelectFieldProps) {
   return (
     <div>
       <label htmlFor={name} className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
@@ -24,12 +25,23 @@ export default function SelectField({ label, name, value, onChange, options }: S
         name={name}
         value={value}
         onChange={onChange}
-        className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors"
+        aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
+        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-1 transition-colors ${
+          error
+            ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
+            : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500'
+        }`}
       >
         {options.map((opt) => (
           <option key={opt.value} value={opt.value}>{opt.label}</option>
         ))}
       </select>
+      {error && (
+        <p id={`${name}-error`} role="alert" className="text-xs text-rose-400 mt-1">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/TextareaField.tsx
+++ b/frontend/src/components/TextareaField.tsx
@@ -8,9 +8,10 @@ interface TextareaFieldProps {
   placeholder?: string;
   rows?: number;
   maxLength?: number;
+  error?: string;
 }
 
-export default function TextareaField({ label, name, value, onChange, placeholder, rows = 3, maxLength }: TextareaFieldProps) {
+export default function TextareaField({ label, name, value, onChange, placeholder, rows = 3, maxLength, error }: TextareaFieldProps) {
   return (
     <div>
       <label htmlFor={name} className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
@@ -24,8 +25,19 @@ export default function TextareaField({ label, name, value, onChange, placeholde
         placeholder={placeholder}
         rows={rows}
         maxLength={maxLength}
-        className="w-full border border-surface-3 rounded-lg px-3 py-2 text-sm focus:border-primary-500 focus:ring-1 focus:ring-primary-500 transition-colors resize-none"
+        aria-invalid={!!error}
+        aria-describedby={error ? `${name}-error` : undefined}
+        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-1 transition-colors resize-none ${
+          error
+            ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
+            : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500'
+        }`}
       />
+      {error && (
+        <p id={`${name}-error`} role="alert" className="text-xs text-rose-400 mt-1">
+          {error}
+        </p>
+      )}
       {maxLength && (
         <p className={`text-xs text-right mt-1 ${
           value.length >= maxLength

--- a/frontend/src/components/__tests__/SelectField.test.tsx
+++ b/frontend/src/components/__tests__/SelectField.test.tsx
@@ -59,4 +59,19 @@ describe('SelectField', () => {
     expect(optionElements[1]).toHaveValue('b');
     expect(optionElements[2]).toHaveValue('c');
   });
+
+  it('エラーメッセージが表示される', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} error="選択してください" />);
+    expect(screen.getByText('選択してください')).toBeInTheDocument();
+  });
+
+  it('エラー時にaria-invalidがtrueになる', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} error="エラー" />);
+    expect(screen.getByLabelText('スタイル')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('エラー時にボーダーが赤色になる', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} error="エラー" />);
+    expect(screen.getByLabelText('スタイル').className).toContain('border-rose-500');
+  });
 });

--- a/frontend/src/components/__tests__/TextareaField.test.tsx
+++ b/frontend/src/components/__tests__/TextareaField.test.tsx
@@ -58,4 +58,19 @@ describe('TextareaField', () => {
     render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} />);
     expect(screen.getByLabelText('自己紹介').tagName).toBe('TEXTAREA');
   });
+
+  it('エラーメッセージが表示される', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} error="必須項目です" />);
+    expect(screen.getByText('必須項目です')).toBeInTheDocument();
+  });
+
+  it('エラー時にaria-invalidがtrueになる', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} error="エラー" />);
+    expect(screen.getByLabelText('自己紹介')).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('エラー時にボーダーが赤色になる', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} error="エラー" />);
+    expect(screen.getByLabelText('自己紹介').className).toContain('border-rose-500');
+  });
 });


### PR DESCRIPTION
## 概要
InputFieldと同じerror propパターンをTextareaFieldとSelectFieldに追加し、フォームバリデーション表示を統一

## 変更内容
- TextareaField: error prop、aria-invalid、aria-describedby、role="alert"追加
- SelectField: 同上のバリデーション表示パターンを適用
- 3つのフォームフィールドコンポーネントで統一されたエラー表示

## テスト結果
- テスト6件追加（合計1175）
- 全テスト通過

closes #562