### PR TITLE
test: Toast・TextareaField・SelectFieldのエッジケーステスト追加

### DIFF
--- a/frontend/src/components/__tests__/SelectField.test.tsx
+++ b/frontend/src/components/__tests__/SelectField.test.tsx
@@ -74,4 +74,15 @@ describe('SelectField', () => {
     render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} error="エラー" />);
     expect(screen.getByLabelText('スタイル').className).toContain('border-rose-500');
   });
+
+  it('エラーなし時にaria-invalidがfalseになる', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByLabelText('スタイル')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('エラーなし時にボーダーが通常色になる', () => {
+    render(<SelectField label="スタイル" name="style" value="a" onChange={vi.fn()} options={OPTIONS} />);
+    expect(screen.getByLabelText('スタイル').className).toContain('border-surface-3');
+    expect(screen.getByLabelText('スタイル').className).not.toContain('border-rose-500');
+  });
 });

--- a/frontend/src/components/__tests__/TextareaField.test.tsx
+++ b/frontend/src/components/__tests__/TextareaField.test.tsx
@@ -73,4 +73,15 @@ describe('TextareaField', () => {
     render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} error="エラー" />);
     expect(screen.getByLabelText('自己紹介').className).toContain('border-rose-500');
   });
+
+  it('エラーなし時にaria-invalidがfalseになる', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('自己紹介')).toHaveAttribute('aria-invalid', 'false');
+  });
+
+  it('エラーなし時にボーダーが通常色になる', () => {
+    render(<TextareaField label="自己紹介" name="bio" value="" onChange={vi.fn()} />);
+    expect(screen.getByLabelText('自己紹介').className).toContain('border-surface-3');
+    expect(screen.getByLabelText('自己紹介').className).not.toContain('border-rose-500');
+  });
 });

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -45,4 +45,23 @@ describe('Toast', () => {
     const { container } = render(<Toast type="success" message="テスト" onClose={vi.fn()} />);
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
+
+  it('3秒未満ではonCloseが呼ばれない', () => {
+    const onClose = vi.fn();
+    render(<Toast type="success" message="テスト" onClose={onClose} />);
+    act(() => {
+      vi.advanceTimersByTime(2999);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('エラータイプでもアイコンが表示される', () => {
+    const { container } = render(<Toast type="error" message="エラー" onClose={vi.fn()} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('情報タイプでもアイコンが表示される', () => {
+    const { container } = render(<Toast type="info" message="情報" onClose={vi.fn()} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
サイクル43 Phase1/Phase2で追加した機能のエッジケーステスト追加

## 追加テスト
### Toast (+3)
- 3秒未満でonCloseが呼ばれない
- エラータイプでもアイコン表示
- 情報タイプでもアイコン表示

### TextareaField (+2)
- エラーなし時にaria-invalidがfalse
- エラーなし時にボーダーが通常色

### SelectField (+2)
- エラーなし時にaria-invalidがfalse
- エラーなし時にボーダーが通常色

## テスト結果
- 全1182テスト通過（+7）

closes #564