### PR TITLE
fix: ToastContainerアクセシビリティ改善・README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,11 @@
 - **SectionHeaderコンポーネント**：アイコン＋タイトルのセクション見出しを再利用可能コンポーネント化・UserProfilePageで適用
 - **InputFieldバリデーションエラー表示**：error prop追加でフィールドレベルエラー表示・aria-invalid/aria-describedby/role="alert"のアクセシビリティ対応
 - **scoreColorユーティリティ**：スコア色判定ロジックを一元管理（ScoreCard/RecentSessionsCard/ScoreComparisonCard/ScoreGrowthTrendCardで共有）
+- **トースト通知システム**：操作結果（成功/エラー/情報）を画面右下にスタック表示・3秒後自動消去・Heroiconsアイコン・aria-live対応
+- **フォームバリデーション統一**：InputField/TextareaField/SelectField全てにerror prop追加・aria-invalid/aria-describedby/role="alert"のアクセシビリティ対応
 
 ### テスト品質
-- **フロントエンド1159テスト**：Vitest + React Testing Library
+- **フロントエンド1182テスト**：Vitest + React Testing Library
   - Repository層テスト（13リポジトリ・62テスト）
   - Hooks層テスト（32フック・319テスト）
   - Store層テスト（1スライス・5テスト）

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -7,7 +7,7 @@ export default function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 space-y-2">
+    <div aria-live="polite" className="fixed bottom-4 right-4 z-50 space-y-2">
       {toasts.map((toast) => (
         <Toast
           key={toast.id}


### PR DESCRIPTION
## 概要
- ToastContainerにaria-live属性追加
- READMEにサイクル43の新機能とテスト数を反映

## 変更内容
### アクセシビリティ改善
- `aria-live="polite"`追加でスクリーンリーダーがトースト通知を自動読み上げ

### README更新
- トースト通知システム追記
- フォームバリデーション統一追記
- テスト数: 1159 → 1182

## テスト結果
- 全1182テスト通過

closes #566