### PR TITLE
feat: Tooltipコンポーネントの実装

### DIFF
--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,48 @@
+import { ReactNode, useCallback, useRef, useState } from 'react';
+
+interface TooltipProps {
+  content: string;
+  position?: 'top' | 'bottom';
+  children: ReactNode;
+}
+
+export default function Tooltip({ content, position = 'top', children }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    timerRef.current = setTimeout(() => {
+      setVisible(true);
+    }, 300);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setVisible(false);
+  }, []);
+
+  const positionClass = position === 'top'
+    ? 'bottom-full left-1/2 -translate-x-1/2 mb-1.5'
+    : 'top-full left-1/2 -translate-x-1/2 mt-1.5';
+
+  return (
+    <div
+      className="relative inline-flex"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      {visible && (
+        <div
+          role="tooltip"
+          className={`absolute ${positionClass} px-2 py-1 text-xs text-white bg-gray-900 rounded whitespace-nowrap pointer-events-none z-50 animate-fade-in`}
+        >
+          {content}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/Tooltip.test.tsx
+++ b/frontend/src/components/__tests__/Tooltip.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Tooltip from '../Tooltip';
+
+describe('Tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('子要素が表示される', () => {
+    render(
+      <Tooltip content="説明文">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    expect(screen.getByText('ボタン')).toBeInTheDocument();
+  });
+
+  it('初期状態ではツールチップが非表示', () => {
+    render(
+      <Tooltip content="説明文">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('マウスオーバーでツールチップが表示される', () => {
+    render(
+      <Tooltip content="説明文">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('ボタン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByText('説明文')).toBeInTheDocument();
+  });
+
+  it('マウスアウトでツールチップが非表示になる', () => {
+    render(
+      <Tooltip content="説明文">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('ボタン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.mouseLeave(screen.getByText('ボタン').parentElement!);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('遅延前にマウスアウトするとツールチップが表示されない', () => {
+    render(
+      <Tooltip content="説明文">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('ボタン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    fireEvent.mouseLeave(screen.getByText('ボタン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Heroiconsアイコンボタンにホバー時のビジュアル説明を提供するTooltipコンポーネントを実装

## 変更内容
- `Tooltip.tsx`: ホバー時にテキスト表示するラッパーコンポーネント
- position指定（top/bottom）、300ms遅延表示でちらつき防止
- role="tooltip"でアクセシビリティ対応

## テスト結果
- テスト5件追加（合計1187）
- 全テスト通過

closes #568