### PR TITLE
refactor: Cardコンポーネントの抽出と適用 #570

### DIFF
--- a/frontend/src/components/PersonalBestCard.tsx
+++ b/frontend/src/components/PersonalBestCard.tsx
@@ -1,4 +1,5 @@
 import { TrophyIcon } from '@heroicons/react/24/solid';
+import Card from './Card';
 
 interface PersonalBestCardProps {
   history: { sessionId: number; overallScore: number; createdAt: string }[];
@@ -12,7 +13,7 @@ export default function PersonalBestCard({ history }: PersonalBestCardProps) {
   );
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center gap-2 mb-3">
         <TrophyIcon className="w-5 h-5 text-amber-400" />
         <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">自己ベスト</h3>
@@ -26,6 +27,6 @@ export default function PersonalBestCard({ history }: PersonalBestCardProps) {
           </p>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/RecentSessionsCard.tsx
+++ b/frontend/src/components/RecentSessionsCard.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { getScoreTextColor } from '../utils/scoreColor';
+import Card from './Card';
 
 interface Session {
   sessionId: number;
@@ -19,7 +20,7 @@ export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps
   if (recent.length === 0) return null;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">直近のセッション</h3>
         <button
@@ -47,6 +48,6 @@ export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreCard.tsx
+++ b/frontend/src/components/ScoreCard.tsx
@@ -1,6 +1,7 @@
 import type { ScoreCard as ScoreCardType } from '../types';
 import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { getScoreLevel, getScoreBarColor } from '../utils/scoreColor';
+import Card from './Card';
 
 interface ScoreCardProps {
   scoreCard: ScoreCardType;
@@ -10,7 +11,7 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
   const level = getScoreLevel(scoreCard.overallScore);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 my-3 max-w-[85%] self-start">
+    <Card className="my-3 max-w-[85%] self-start">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-medium text-[var(--color-text-secondary)]">スコアカード</h3>
         <div className="flex items-center gap-2">
@@ -50,6 +51,6 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreComparisonCard.tsx
+++ b/frontend/src/components/ScoreComparisonCard.tsx
@@ -1,4 +1,5 @@
 import { getDeltaColor, formatDelta } from '../utils/scoreColor';
+import Card from './Card';
 
 interface AxisScore {
   axis: string;
@@ -22,7 +23,7 @@ export default function ScoreComparisonCard({
   const overallDelta = Math.round((latestOverall - firstOverall) * 10) / 10;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">成長の記録</p>
 
       <div className="flex items-center justify-between mb-4">
@@ -60,6 +61,6 @@ export default function ScoreComparisonCard({
           );
         })}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreGrowthTrendCard.tsx
+++ b/frontend/src/components/ScoreGrowthTrendCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { getDeltaColor, formatDelta } from '../utils/scoreColor';
+import Card from './Card';
 
 type TrendType = 'up' | 'down' | 'stable';
 
@@ -57,7 +58,7 @@ export default function ScoreGrowthTrendCard({ scores }: Props) {
   const config = TREND_CONFIG[analysis.trend];
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-2">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">成長トレンド</p>
         <span className={`text-sm font-bold ${config.color}`}>
@@ -76,6 +77,6 @@ export default function ScoreGrowthTrendCard({ scores }: Props) {
       </div>
 
       <p className="text-xs text-[var(--color-text-muted)]">{config.message}</p>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
- 共通カードスタイル（`bg-surface-1 rounded-lg border border-surface-3 p-4`）をCardコンポーネントに抽出
- 5つのカードコンポーネントにCardコンポーネントを適用

## 変更内容
- `Card.tsx`: 再利用可能なカードラッパーコンポーネント（新規）
- `Card.test.tsx`: 4テスト（新規）
- `RecentSessionsCard.tsx`: Card適用
- `ScoreComparisonCard.tsx`: Card適用
- `ScoreGrowthTrendCard.tsx`: Card適用
- `ScoreCard.tsx`: Card適用（className propで追加クラス指定）
- `PersonalBestCard.tsx`: Card適用

## テスト
- 全1191テスト合格