### PR TITLE
test: Tooltip・Cardのエッジケーステスト追加 #572

### DIFF
--- a/frontend/src/components/__tests__/Card.test.tsx
+++ b/frontend/src/components/__tests__/Card.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Card from '../Card';
+
+describe('Card', () => {
+  it('子要素が表示される', () => {
+    render(<Card><p>コンテンツ</p></Card>);
+    expect(screen.getByText('コンテンツ')).toBeInTheDocument();
+  });
+
+  it('デフォルトのスタイルクラスが適用される', () => {
+    const { container } = render(<Card><p>テスト</p></Card>);
+    expect(container.firstChild).toHaveClass('bg-surface-1');
+    expect(container.firstChild).toHaveClass('rounded-lg');
+    expect(container.firstChild).toHaveClass('border');
+    expect(container.firstChild).toHaveClass('border-surface-3');
+    expect(container.firstChild).toHaveClass('p-4');
+  });
+
+  it('追加のclassNameが適用される', () => {
+    const { container } = render(<Card className="mt-4"><p>テスト</p></Card>);
+    expect(container.firstChild).toHaveClass('mt-4');
+    expect(container.firstChild).toHaveClass('bg-surface-1');
+  });
+
+  it('classNameが未指定でもデフォルトスタイルが適用される', () => {
+    const { container } = render(<Card><p>テスト</p></Card>);
+    expect(container.firstChild).toHaveClass('bg-surface-1');
+  });
+
+  it('複数の子要素がすべて表示される', () => {
+    render(
+      <Card>
+        <p>要素1</p>
+        <p>要素2</p>
+        <p>要素3</p>
+      </Card>
+    );
+    expect(screen.getByText('要素1')).toBeInTheDocument();
+    expect(screen.getByText('要素2')).toBeInTheDocument();
+    expect(screen.getByText('要素3')).toBeInTheDocument();
+  });
+
+  it('複数のclassNameが同時に適用される', () => {
+    const { container } = render(<Card className="my-3 max-w-[85%]"><p>テスト</p></Card>);
+    expect(container.firstChild).toHaveClass('my-3');
+    expect(container.firstChild).toHaveClass('max-w-[85%]');
+    expect(container.firstChild).toHaveClass('bg-surface-1');
+    expect(container.firstChild).toHaveClass('p-4');
+  });
+});

--- a/frontend/src/components/__tests__/Tooltip.test.tsx
+++ b/frontend/src/components/__tests__/Tooltip.test.tsx
@@ -74,4 +74,47 @@ describe('Tooltip', () => {
     });
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
   });
+
+  it('position=bottomでツールチップが下に表示される', () => {
+    render(
+      <Tooltip content="下部説明" position="bottom">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('ボタン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('top-full');
+    expect(tooltip.className).toContain('mt-1.5');
+  });
+
+  it('position=topでツールチップが上に表示される', () => {
+    render(
+      <Tooltip content="上部説明">
+        <button>ボタン</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('ボタン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip.className).toContain('bottom-full');
+    expect(tooltip.className).toContain('mb-1.5');
+  });
+
+  it('ツールチップにcontent文字列が表示される', () => {
+    render(
+      <Tooltip content="ヘルプテキスト">
+        <span>アイコン</span>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('アイコン').parentElement!);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByText('ヘルプテキスト')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
Tooltip・Cardコンポーネントのエッジケーステストを追加

## 変更内容
- Tooltip: position=bottom/topの表示位置検証、content文字列表示（+3テスト）
- Card: 複数子要素表示、複数className結合（+2テスト）

## テスト
- 全1196テスト合格