### PR TITLE
feat: FilterTabsにキーボードナビゲーション追加 #576

### DIFF
--- a/frontend/src/components/FilterTabs.tsx
+++ b/frontend/src/components/FilterTabs.tsx
@@ -1,3 +1,5 @@
+import { KeyboardEvent, useCallback } from 'react';
+
 interface FilterTabsProps<T extends string> {
   tabs: T[];
   selected: T;
@@ -6,14 +8,38 @@ interface FilterTabsProps<T extends string> {
 }
 
 export default function FilterTabs<T extends string>({ tabs, selected, onSelect, className = '' }: FilterTabsProps<T>) {
+  const handleKeyDown = useCallback((e: KeyboardEvent, index: number) => {
+    let nextIndex: number | null = null;
+    switch (e.key) {
+      case 'ArrowRight':
+        nextIndex = (index + 1) % tabs.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (index - 1 + tabs.length) % tabs.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = tabs.length - 1;
+        break;
+    }
+    if (nextIndex !== null) {
+      e.preventDefault();
+      onSelect(tabs[nextIndex]);
+    }
+  }, [tabs, onSelect]);
+
   return (
     <div role="tablist" className={`flex gap-1 border-b border-surface-3 ${className}`}>
-      {tabs.map((tab) => (
+      {tabs.map((tab, index) => (
         <button
           key={tab}
           role="tab"
           aria-selected={selected === tab}
+          tabIndex={selected === tab ? 0 : -1}
           onClick={() => onSelect(tab)}
+          onKeyDown={(e) => handleKeyDown(e, index)}
           className={`px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px ${
             selected === tab
               ? 'border-primary-500 text-primary-400'

--- a/frontend/src/components/__tests__/FilterTabs.test.tsx
+++ b/frontend/src/components/__tests__/FilterTabs.test.tsx
@@ -65,4 +65,59 @@ describe('FilterTabs', () => {
     expect(container.firstChild).toHaveClass('border-b');
     expect(container.firstChild).toHaveClass('border-surface-3');
   });
+
+  it('右矢印キーで次のタブにフォーカスが移動する', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={onSelect} />);
+    const firstTab = screen.getByRole('tab', { name: 'すべて' });
+    fireEvent.keyDown(firstTab, { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenCalledWith('カテゴリA');
+  });
+
+  it('左矢印キーで前のタブにフォーカスが移動する', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="カテゴリA" onSelect={onSelect} />);
+    const tab = screen.getByRole('tab', { name: 'カテゴリA' });
+    fireEvent.keyDown(tab, { key: 'ArrowLeft' });
+    expect(onSelect).toHaveBeenCalledWith('すべて');
+  });
+
+  it('最後のタブで右矢印キーを押すと最初のタブに移動する', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="カテゴリB" onSelect={onSelect} />);
+    const lastTab = screen.getByRole('tab', { name: 'カテゴリB' });
+    fireEvent.keyDown(lastTab, { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenCalledWith('すべて');
+  });
+
+  it('最初のタブで左矢印キーを押すと最後のタブに移動する', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={onSelect} />);
+    const firstTab = screen.getByRole('tab', { name: 'すべて' });
+    fireEvent.keyDown(firstTab, { key: 'ArrowLeft' });
+    expect(onSelect).toHaveBeenCalledWith('カテゴリB');
+  });
+
+  it('Homeキーで最初のタブに移動する', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="カテゴリB" onSelect={onSelect} />);
+    const lastTab = screen.getByRole('tab', { name: 'カテゴリB' });
+    fireEvent.keyDown(lastTab, { key: 'Home' });
+    expect(onSelect).toHaveBeenCalledWith('すべて');
+  });
+
+  it('Endキーで最後のタブに移動する', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={onSelect} />);
+    const firstTab = screen.getByRole('tab', { name: 'すべて' });
+    fireEvent.keyDown(firstTab, { key: 'End' });
+    expect(onSelect).toHaveBeenCalledWith('カテゴリB');
+  });
+
+  it('選択タブはtabIndex=0で非選択タブはtabIndex=-1', () => {
+    render(<FilterTabs tabs={[...TABS]} selected="カテゴリA" onSelect={() => {}} />);
+    expect(screen.getByRole('tab', { name: 'カテゴリA' })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tab', { name: 'すべて' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: 'カテゴリB' })).toHaveAttribute('tabindex', '-1');
+  });
 });


### PR DESCRIPTION
## 概要
FilterTabsコンポーネントにWAI-ARIAタブパターン準拠のキーボードナビゲーションを追加

## 変更内容
- 左右矢印キーでタブ移動
- Home/Endキーで最初/最後のタブに移動
- ループナビゲーション（最後→最初、最初→最後）
- tabIndex管理（選択タブ=0、非選択タブ=-1）

## テスト
- FilterTabsテスト: 9→16（+7テスト）
- 全1203テスト合格