### PR TITLE
refactor: Cardコンポーネントの追加適用（5コンポーネント） #578

### DIFF
--- a/frontend/src/components/MotivationQuoteCard.tsx
+++ b/frontend/src/components/MotivationQuoteCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface Quote {
   text: string;
   author: string;
@@ -28,7 +30,7 @@ export default function MotivationQuoteCard() {
   const quote = QUOTES[getDailyIndex()];
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-2">今日の一言</p>
       <p data-testid="quote-text" className="text-xs text-[var(--color-text-tertiary)] leading-relaxed italic">
         「{quote.text}」
@@ -36,6 +38,6 @@ export default function MotivationQuoteCard() {
       <p data-testid="quote-author" className="text-[10px] text-[var(--color-text-faint)] mt-1.5 text-right">
         — {quote.author}
       </p>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SessionCountMilestoneCard.tsx
+++ b/frontend/src/components/SessionCountMilestoneCard.tsx
@@ -1,4 +1,5 @@
 import { StarIcon } from '@heroicons/react/24/solid';
+import Card from './Card';
 
 interface SessionCountMilestoneCardProps {
   sessionCount: number;
@@ -23,7 +24,7 @@ export default function SessionCountMilestoneCard({ sessionCount }: SessionCount
     : Math.round(((sessionCount - prevMilestone) / (nextMilestone - prevMilestone)) * 100);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center gap-2 mb-3">
         <StarIcon className="w-5 h-5 text-amber-400" />
         <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">セッション達成</h3>
@@ -52,6 +53,6 @@ export default function SessionCountMilestoneCard({ sessionCount }: SessionCount
           素晴らしい! 100回以上の練習を達成しました!
         </p>
       )}
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SessionFeedbackSummary.tsx
+++ b/frontend/src/components/SessionFeedbackSummary.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface AxisScore {
   axis: string;
   score: number;
@@ -30,7 +32,7 @@ export default function SessionFeedbackSummary({ scores, overallScore }: Session
   const grade = getGrade(overallScore);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">スキル別スコア</p>
         <span className={`text-sm font-bold ${grade.color}`}>{grade.label}</span>
@@ -60,6 +62,6 @@ export default function SessionFeedbackSummary({ scores, overallScore }: Session
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/WeeklyGoalProgressCard.tsx
+++ b/frontend/src/components/WeeklyGoalProgressCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface WeeklyGoalProgressCardProps {
   sessionsThisWeek: number;
   weeklyGoal: number;
@@ -18,7 +20,7 @@ export default function WeeklyGoalProgressCard({
   const isCompleted = sessionsThisWeek >= weeklyGoal;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-2">今週の練習目標</p>
 
       <div className="flex items-baseline gap-1 mb-2">
@@ -39,6 +41,6 @@ export default function WeeklyGoalProgressCard({
       <p className={`text-xs ${isCompleted ? 'text-emerald-400 font-medium' : 'text-[var(--color-text-muted)]'}`}>
         {getMessage(sessionsThisWeek, weeklyGoal)}
       </p>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/WeeklyReportCard.tsx
+++ b/frontend/src/components/WeeklyReportCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import Card from './Card';
 
 interface ScoreHistory {
   sessionId: number;
@@ -61,7 +62,7 @@ export default function WeeklyReportCard({ allScores }: WeeklyReportCardProps) {
   const dayLabels = ['日', '月', '火', '水', '木', '金', '土'];
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">今週のレポート</p>
 
       <div className="grid grid-cols-2 gap-4 mb-3">
@@ -107,6 +108,6 @@ export default function WeeklyReportCard({ allScores }: WeeklyReportCardProps) {
           ))}
         </div>
       </div>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
Cardコンポーネントをさらに5つのカードコンポーネントに適用し、共通スタイルの一元管理を推進

## 変更内容
- `SessionCountMilestoneCard.tsx`: Card適用
- `SessionFeedbackSummary.tsx`: Card適用
- `WeeklyGoalProgressCard.tsx`: Card適用
- `WeeklyReportCard.tsx`: Card適用
- `MotivationQuoteCard.tsx`: Card適用

## テスト
- 全1203テスト合格