### PR TITLE
test: FilterTabsキーボードナビゲーションのエッジケーステスト追加 #580

### DIFF
--- a/frontend/src/components/__tests__/FilterTabs.test.tsx
+++ b/frontend/src/components/__tests__/FilterTabs.test.tsx
@@ -120,4 +120,27 @@ describe('FilterTabs', () => {
     expect(screen.getByRole('tab', { name: 'すべて' })).toHaveAttribute('tabindex', '-1');
     expect(screen.getByRole('tab', { name: 'カテゴリB' })).toHaveAttribute('tabindex', '-1');
   });
+
+  it('タブが1つの場合に右矢印キーで自分自身が選択される', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={['唯一']} selected="唯一" onSelect={onSelect} />);
+    const tab = screen.getByRole('tab', { name: '唯一' });
+    fireEvent.keyDown(tab, { key: 'ArrowRight' });
+    expect(onSelect).toHaveBeenCalledWith('唯一');
+  });
+
+  it('無関係なキー入力ではonSelectが呼ばれない', () => {
+    const onSelect = vi.fn();
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={onSelect} />);
+    const tab = screen.getByRole('tab', { name: 'すべて' });
+    fireEvent.keyDown(tab, { key: 'a' });
+    fireEvent.keyDown(tab, { key: 'Enter' });
+    fireEvent.keyDown(tab, { key: 'Escape' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('role=tablistがコンテナに設定される', () => {
+    render(<FilterTabs tabs={[...TABS]} selected="すべて" onSelect={() => {}} />);
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
FilterTabsキーボードナビゲーションのエッジケーステストを追加

## 変更内容
- タブ1つの場合のループナビゲーション確認
- 無関係なキー入力（a, Enter, Escape）でonSelectが呼ばれないことを確認
- role=tablistがコンテナに設定されることを確認

## テスト
- FilterTabsテスト: 16→19（+3テスト）
- 全1206テスト合格