### PR TITLE
feat: ProgressRingコンポーネント追加 #584

### DIFF
--- a/frontend/src/components/ProgressRing.tsx
+++ b/frontend/src/components/ProgressRing.tsx
@@ -1,0 +1,59 @@
+interface ProgressRingProps {
+  value: number;
+  max: number;
+  label?: string;
+  size?: number;
+}
+
+function getStrokeColor(percentage: number): string {
+  if (percentage >= 80) return 'text-emerald-400';
+  if (percentage >= 60) return 'text-amber-400';
+  return 'text-rose-400';
+}
+
+export default function ProgressRing({ value, max, label, size = 64 }: ProgressRingProps) {
+  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+  const strokeWidth = 4;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (percentage / 100) * circumference;
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={max}
+      className="relative inline-flex items-center justify-center"
+    >
+      <svg width={size} height={size} className="-rotate-90">
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-surface-3"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          className={`${getStrokeColor(percentage)} transition-all`}
+        />
+      </svg>
+      {label && (
+        <span className="absolute text-xs font-semibold text-[var(--color-text-primary)]">
+          {label}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ProgressRing.test.tsx
+++ b/frontend/src/components/__tests__/ProgressRing.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import ProgressRing from '../ProgressRing';
+
+describe('ProgressRing', () => {
+  it('ラベルが表示される', () => {
+    render(<ProgressRing value={75} max={100} label="75%" />);
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('SVG要素がレンダリングされる', () => {
+    const { container } = render(<ProgressRing value={50} max={100} />);
+    expect(container.querySelector('svg')).toBeTruthy();
+  });
+
+  it('role=progressbarが設定される', () => {
+    render(<ProgressRing value={30} max={100} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('aria-valuenowが正しく設定される', () => {
+    render(<ProgressRing value={60} max={100} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '60');
+  });
+
+  it('aria-valuemaxが正しく設定される', () => {
+    render(<ProgressRing value={60} max={100} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('高スコア時（80%以上）に緑色のストロークが適用される', () => {
+    const { container } = render(<ProgressRing value={85} max={100} />);
+    const circles = container.querySelectorAll('circle');
+    const progressCircle = circles[1];
+    expect(progressCircle.getAttribute('class')).toContain('text-emerald-400');
+  });
+
+  it('中スコア時（60-80%）に黄色のストロークが適用される', () => {
+    const { container } = render(<ProgressRing value={65} max={100} />);
+    const circles = container.querySelectorAll('circle');
+    const progressCircle = circles[1];
+    expect(progressCircle.getAttribute('class')).toContain('text-amber-400');
+  });
+
+  it('低スコア時（60%未満）に赤色のストロークが適用される', () => {
+    const { container } = render(<ProgressRing value={40} max={100} />);
+    const circles = container.querySelectorAll('circle');
+    const progressCircle = circles[1];
+    expect(progressCircle.getAttribute('class')).toContain('text-rose-400');
+  });
+
+  it('value=0の場合にプログレスが0になる', () => {
+    render(<ProgressRing value={0} max={100} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('value=maxの場合にプログレスが100%になる', () => {
+    render(<ProgressRing value={100} max={100} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+});


### PR DESCRIPTION
## 概要
SVGベースの円形プログレスインジケーターコンポーネントを追加

## 変更内容
- `ProgressRing.tsx`: 円形SVGプログレス表示（新規）
  - 値に応じた色変化（80%以上:緑, 60-80%:黄, 60%未満:赤）
  - 中央ラベル表示
  - サイズカスタマイズ可能
  - role=progressbar/aria-valuenow/aria-valuemax対応
- `ProgressRing.test.tsx`: 10テスト（新規）

## テスト
- 全1216テスト合格