### PR TITLE
test: ProgressRingのエッジケーステスト追加 #588

### DIFF
--- a/frontend/src/components/__tests__/ProgressRing.test.tsx
+++ b/frontend/src/components/__tests__/ProgressRing.test.tsx
@@ -58,4 +58,21 @@ describe('ProgressRing', () => {
     render(<ProgressRing value={100} max={100} />);
     expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
   });
+
+  it('ラベルが未指定の場合にテキストが表示されない', () => {
+    const { container } = render(<ProgressRing value={50} max={100} />);
+    const span = container.querySelector('span');
+    expect(span).toBeNull();
+  });
+
+  it('aria-valueminが0に設定される', () => {
+    render(<ProgressRing value={50} max={100} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuemin', '0');
+  });
+
+  it('背景円と進捗円の2つのcircle要素がレンダリングされる', () => {
+    const { container } = render(<ProgressRing value={50} max={100} />);
+    const circles = container.querySelectorAll('circle');
+    expect(circles).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## 概要
ProgressRingコンポーネントのエッジケーステストを追加

## 変更内容
- ラベル未指定時にspan要素が表示されないことを確認
- aria-valueminが0に設定されることを確認
- 背景円と進捗円の2つのcircle要素確認

## テスト
- ProgressRingテスト: 10→13（+3テスト）
- 全1219テスト合格