### PR TITLE
feat: ConfirmModalにフォーカストラップと自動フォーカス追加 #592

### DIFF
--- a/frontend/src/components/__tests__/ConfirmModal.test.tsx
+++ b/frontend/src/components/__tests__/ConfirmModal.test.tsx
@@ -96,4 +96,31 @@ describe('ConfirmModal', () => {
     if (overlay) fireEvent.click(overlay);
     expect(mockOnCancel).toHaveBeenCalled();
   });
+
+  it('モーダル表示時にキャンセルボタンが自動フォーカスされる', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+    expect(document.activeElement).toBe(screen.getByText('キャンセル'));
+  });
+
+  it('Tabキーで確認ボタンからキャンセルボタンへ循環移動する', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+    const confirmBtn = screen.getByText('削除');
+    confirmBtn.focus();
+    fireEvent.keyDown(confirmBtn, { key: 'Tab' });
+    expect(document.activeElement).toBe(screen.getByText('キャンセル'));
+  });
+
+  it('Shift+Tabでキャンセルボタンから確認ボタンへ循環移動する', () => {
+    render(
+      <ConfirmModal isOpen={true} message="削除しますか？" onConfirm={mockOnConfirm} onCancel={mockOnCancel} />
+    );
+    const cancelBtn = screen.getByText('キャンセル');
+    cancelBtn.focus();
+    fireEvent.keyDown(cancelBtn, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByText('削除'));
+  });
 });


### PR DESCRIPTION
## 概要
ConfirmModalにWCAG 2.1準拠のフォーカストラップと自動フォーカスを追加

## 変更内容
- モーダル表示時にキャンセルボタンへ自動フォーカス（安全側の操作にフォーカス）
- Tab/Shift+Tabでモーダル内の2つのボタン間でフォーカスを循環
- モーダル外へのフォーカス漏れ防止

## テスト
- ConfirmModalテスト: 9→12（+3テスト）
- 全1222テスト合格