### PR TITLE
refactor: Cardコンポーネントの追加適用（第4弾・累計20件） #594

### DIFF
--- a/frontend/src/components/RecentNotesCard.tsx
+++ b/frontend/src/components/RecentNotesCard.tsx
@@ -1,4 +1,5 @@
 import { SessionNoteRepository } from '../repositories/SessionNoteRepository';
+import Card from './Card';
 
 export default function RecentNotesCard() {
   const allNotes = SessionNoteRepository.getAll();
@@ -11,7 +12,7 @@ export default function RecentNotesCard() {
     .slice(0, 3);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">最近のメモ</p>
         <span className="text-[10px] text-[var(--color-text-faint)]">{noteEntries.length}件</span>
@@ -30,6 +31,6 @@ export default function RecentNotesCard() {
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreDistributionCard.tsx
+++ b/frontend/src/components/ScoreDistributionCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface ScoreDistributionCardProps {
   scores: number[];
 }
@@ -40,7 +42,7 @@ export default function ScoreDistributionCard({ scores }: ScoreDistributionCardP
   const topRangeIndex = counts.indexOf(maxCount);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スコア分布</p>
 
       <div className="space-y-2">
@@ -63,6 +65,6 @@ export default function ScoreDistributionCard({ scores }: ScoreDistributionCardP
       </div>
 
       <p className="text-xs text-[var(--color-text-muted)] mt-3">{getMessage(topRangeIndex)}</p>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreGoalCard.tsx
+++ b/frontend/src/components/ScoreGoalCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Card from './Card';
 
 interface Props {
   averageScore: number;
@@ -30,7 +31,7 @@ export default function ScoreGoalCard({ averageScore }: Props) {
   const progress = Math.min((averageScore / goal) * 100, 100);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">目標スコア</p>
         <select
@@ -69,6 +70,6 @@ export default function ScoreGoalCard({ averageScore }: Props) {
           ? '目標達成！素晴らしいです！'
           : `あと ${gap.toFixed(1)} ポイントで目標達成です`}
       </p>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreImprovementAdvice.tsx
+++ b/frontend/src/components/ScoreImprovementAdvice.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface AxisScore {
   axis: string;
   score: number;
@@ -22,7 +24,7 @@ export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdvic
   const weakAxes = scores.filter((s) => s.score < THRESHOLD);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">改善アドバイス</p>
 
       {weakAxes.length === 0 ? (
@@ -48,6 +50,6 @@ export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdvic
           ))}
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/StreakCalendarCard.tsx
+++ b/frontend/src/components/StreakCalendarCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface StreakCalendarCardProps {
   practiceDates: string[];
 }
@@ -47,7 +49,7 @@ export default function StreakCalendarCard({ practiceDates }: StreakCalendarCard
   const streak = calculateStreak(practiceDates);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">練習カレンダー</p>
         <div className="flex items-baseline gap-1">
@@ -84,6 +86,6 @@ export default function StreakCalendarCard({ practiceDates }: StreakCalendarCard
           );
         })}
       </div>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
Cardコンポーネントをさらに5つに適用（累計20コンポーネント）

## 変更内容
- `StreakCalendarCard.tsx`: Card適用
- `ScoreDistributionCard.tsx`: Card適用
- `ScoreGoalCard.tsx`: Card適用
- `ScoreImprovementAdvice.tsx`: Card適用
- `RecentNotesCard.tsx`: Card適用

## テスト
- 全1222テスト合格