### PR TITLE
feat: SkipLinkコンポーネント追加（キーボードアクセシビリティ向上）

### DIFF
--- a/frontend/src/components/SkipLink.tsx
+++ b/frontend/src/components/SkipLink.tsx
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+
+interface SkipLinkProps {
+  targetId: string;
+  label?: string;
+}
+
+export default function SkipLink({ targetId, label = 'メインコンテンツへスキップ' }: SkipLinkProps) {
+  const handleClick = useCallback((e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const target = document.getElementById(targetId);
+    if (target) {
+      target.focus();
+    }
+  }, [targetId]);
+
+  return (
+    <a
+      href={`#${targetId}`}
+      onClick={handleClick}
+      className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary-500 focus:text-white focus:rounded-lg focus:font-medium focus:shadow-lg z-50"
+    >
+      {label}
+    </a>
+  );
+}

--- a/frontend/src/components/__tests__/SkipLink.test.tsx
+++ b/frontend/src/components/__tests__/SkipLink.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SkipLink from '../SkipLink';
+
+describe('SkipLink', () => {
+  it('リンクがレンダリングされる', () => {
+    render(<SkipLink targetId="main-content" />);
+    expect(screen.getByText('メインコンテンツへスキップ')).toBeInTheDocument();
+  });
+
+  it('デフォルトでは視覚的に非表示', () => {
+    render(<SkipLink targetId="main-content" />);
+    const link = screen.getByText('メインコンテンツへスキップ');
+    expect(link.className).toContain('sr-only');
+  });
+
+  it('フォーカス時に表示される', () => {
+    render(<SkipLink targetId="main-content" />);
+    const link = screen.getByText('メインコンテンツへスキップ');
+    fireEvent.focus(link);
+    expect(link.className).toContain('focus:not-sr-only');
+  });
+
+  it('href属性がターゲットIDを参照する', () => {
+    render(<SkipLink targetId="main-content" />);
+    const link = screen.getByText('メインコンテンツへスキップ');
+    expect(link).toHaveAttribute('href', '#main-content');
+  });
+
+  it('カスタムラベルが表示される', () => {
+    render(<SkipLink targetId="main-content" label="ナビゲーションをスキップ" />);
+    expect(screen.getByText('ナビゲーションをスキップ')).toBeInTheDocument();
+  });
+
+  it('クリック時にターゲット要素にフォーカスが移動する', () => {
+    const target = document.createElement('div');
+    target.id = 'main-content';
+    target.tabIndex = -1;
+    document.body.appendChild(target);
+
+    render(<SkipLink targetId="main-content" />);
+    const link = screen.getByText('メインコンテンツへスキップ');
+    fireEvent.click(link);
+    expect(document.activeElement).toBe(target);
+
+    document.body.removeChild(target);
+  });
+
+  it('z-50クラスでナビゲーション上に表示される', () => {
+    render(<SkipLink targetId="main-content" />);
+    const link = screen.getByText('メインコンテンツへスキップ');
+    expect(link.className).toContain('z-50');
+  });
+
+  it('role=linkが暗黙的に設定される（aタグ）', () => {
+    render(<SkipLink targetId="main-content" />);
+    const link = screen.getByText('メインコンテンツへスキップ');
+    expect(link.tagName).toBe('A');
+  });
+});

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
+import SkipLink from '../SkipLink';
 
 const pageTitles: Record<string, string> = {
   '/': 'ホーム',
@@ -32,6 +33,7 @@ export default function AppShell() {
 
   return (
     <div className="h-screen flex bg-surface">
+      <SkipLink targetId="main-content" />
       {/* デスクトップサイドバー */}
       <div className="hidden md:block">
         <Sidebar />
@@ -60,7 +62,7 @@ export default function AppShell() {
           title={title}
           onMenuToggle={() => setMobileMenuOpen(!mobileMenuOpen)}
         />
-        <main className="flex-1 overflow-auto">
+        <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto outline-none">
           <Outlet />
         </main>
       </div>


### PR DESCRIPTION
## 概要
- キーボードユーザー向けの「メインコンテンツへスキップ」リンクを追加
- フォーカス時のみ画面上部に表示され、クリック/Enterでメインコンテンツエリアにジャンプ
- AppShellに組み込み済み

## テスト結果
- 全1233テスト合格（+8件）

Closes #600