### PR TITLE
refactor: Cardコンポーネント適用バッチ5

### DIFF
--- a/frontend/src/components/FavoriteStatsCard.tsx
+++ b/frontend/src/components/FavoriteStatsCard.tsx
@@ -1,4 +1,5 @@
 import type { FavoritePhrase } from '../types';
+import Card from './Card';
 
 interface FavoriteStatsCardProps {
   phrases: FavoritePhrase[];
@@ -24,7 +25,7 @@ export default function FavoriteStatsCard({ phrases }: FavoriteStatsCardProps) {
   const maxCount = Math.max(...Object.values(patternCounts));
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">お気に入り統計</p>
         <div className="flex items-baseline gap-1">
@@ -51,6 +52,6 @@ export default function FavoriteStatsCard({ phrases }: FavoriteStatsCardProps) {
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/LearningInsightsCard.tsx
+++ b/frontend/src/components/LearningInsightsCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface LearningInsightsCardProps {
   totalSessions: number;
   averageScore: number;
@@ -16,7 +18,7 @@ export default function LearningInsightsCard({
   ];
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">学習インサイト</p>
       <div className="grid grid-cols-3 gap-3">
         {stats.map((stat) => (
@@ -29,6 +31,6 @@ export default function LearningInsightsCard({
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/NextStepCard.tsx
+++ b/frontend/src/components/NextStepCard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowTrendingUpIcon,
   StarIcon,
 } from '@heroicons/react/24/outline';
+import Card from './Card';
 
 interface NextStepCardProps {
   totalSessions: number;
@@ -54,7 +55,7 @@ export default function NextStepCard({ totalSessions, averageScore }: NextStepCa
   const Icon = step.icon;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-2">次のステップ</p>
       <div className="flex items-start gap-3">
         <Icon className="w-6 h-6 text-primary-400 flex-shrink-0" />
@@ -63,6 +64,6 @@ export default function NextStepCard({ totalSessions, averageScore }: NextStepCa
           <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{step.description}</p>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/PracticeFrequencyCard.tsx
+++ b/frontend/src/components/PracticeFrequencyCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import Card from './Card';
 
 interface PracticeFrequencyCardProps {
   dates: string[];
@@ -44,7 +45,7 @@ export default function PracticeFrequencyCard({ dates }: PracticeFrequencyCardPr
   const delta = currentWeek.count - lastWeek.count;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <div className="flex items-center justify-between mb-3">
         <p className="text-xs font-medium text-[var(--color-text-secondary)]">週別練習頻度</p>
         <div className="flex items-center gap-2">
@@ -81,6 +82,6 @@ export default function PracticeFrequencyCard({ dates }: PracticeFrequencyCardPr
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/PracticeLevelCard.tsx
+++ b/frontend/src/components/PracticeLevelCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface PracticeLevelCardProps {
   totalSessions: number;
 }
@@ -42,7 +44,7 @@ export default function PracticeLevelCard({ totalSessions }: PracticeLevelCardPr
   const remaining = next ? next.threshold - totalSessions : 0;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-2">練習レベル</p>
 
       <div className="flex items-baseline gap-2 mb-2">
@@ -61,6 +63,6 @@ export default function PracticeLevelCard({ totalSessions }: PracticeLevelCardPr
       <p className="text-xs text-[var(--color-text-muted)]">
         {next ? `次のレベルまであと${remaining}回` : '最高レベル到達！'}
       </p>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
- 共通Cardコンポーネントを追加5コンポーネントに適用
  - FavoriteStatsCard, LearningInsightsCard, NextStepCard, PracticeFrequencyCard, PracticeLevelCard
- 合計25コンポーネントでCard使用

## テスト結果
- 全1233テスト合格

Closes #602