### PR TITLE
feat: ScrollToTopボタン追加（長ページのUX向上）

### DIFF
--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ChevronUpIcon } from '@heroicons/react/24/solid';
+
+interface ScrollToTopProps {
+  targetId: string;
+  threshold?: number;
+}
+
+export default function ScrollToTop({ targetId, threshold = 200 }: ScrollToTopProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const target = document.getElementById(targetId);
+    if (!target) return;
+
+    const handleScroll = () => {
+      setVisible(target.scrollTop >= threshold);
+    };
+
+    target.addEventListener('scroll', handleScroll);
+    return () => target.removeEventListener('scroll', handleScroll);
+  }, [targetId, threshold]);
+
+  const handleClick = useCallback(() => {
+    const target = document.getElementById(targetId);
+    if (target) {
+      target.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }, [targetId]);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={handleClick}
+      aria-label="ページ上部に戻る"
+      className="fixed bottom-6 right-6 z-40 w-10 h-10 bg-primary-500 hover:bg-primary-600 text-white rounded-full shadow-lg flex items-center justify-center transition-colors duration-150 animate-fade-in"
+    >
+      <ChevronUpIcon className="w-5 h-5" />
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/ScrollToTop.test.tsx
+++ b/frontend/src/components/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ScrollToTop from '../ScrollToTop';
+
+describe('ScrollToTop', () => {
+  let scrollContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    scrollContainer = document.createElement('div');
+    scrollContainer.id = 'scroll-target';
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 0, writable: true });
+    scrollContainer.scrollTo = vi.fn();
+    document.body.appendChild(scrollContainer);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(scrollContainer);
+  });
+
+  it('初期状態ではボタンが非表示', () => {
+    render(<ScrollToTop targetId="scroll-target" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('スクロール後にボタンが表示される', () => {
+    render(<ScrollToTop targetId="scroll-target" threshold={100} />);
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 150 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('ボタンクリックでscrollToが呼ばれる', () => {
+    render(<ScrollToTop targetId="scroll-target" threshold={100} />);
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 200 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    fireEvent.click(screen.getByRole('button'));
+    expect(scrollContainer.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('aria-labelが設定される', () => {
+    render(<ScrollToTop targetId="scroll-target" threshold={0} />);
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 10 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'ページ上部に戻る');
+  });
+
+  it('閾値以下にスクロールするとボタンが非表示になる', () => {
+    render(<ScrollToTop targetId="scroll-target" threshold={100} />);
+    // スクロールして表示
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 200 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    expect(screen.getByRole('button')).toBeInTheDocument();
+
+    // 上に戻って非表示
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 50 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('デフォルトのthresholdが200である', () => {
+    render(<ScrollToTop targetId="scroll-target" />);
+    // 199ではまだ表示されない
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 199 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    // 200で表示される
+    Object.defineProperty(scrollContainer, 'scrollTop', { value: 200 });
+    act(() => {
+      fireEvent.scroll(scrollContainer);
+    });
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('ターゲット要素が存在しない場合エラーにならない', () => {
+    expect(() => render(<ScrollToTop targetId="nonexistent" />)).not.toThrow();
+  });
+});

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import SkipLink from '../SkipLink';
+import ScrollToTop from '../ScrollToTop';
 
 const pageTitles: Record<string, string> = {
   '/': 'ホーム',
@@ -65,6 +66,7 @@ export default function AppShell() {
         <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto outline-none">
           <Outlet />
         </main>
+        <ScrollToTop targetId="main-content" />
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
- スクロール位置が200px以上で表示されるフローティングボタン
- クリックでスムーズスクロールにより上部に移動
- AppShellに組み込み済み（全認証ページで利用可能）

## テスト結果
- 全1243テスト合格（+7件）

Closes #608