### PR TITLE
refactor: Cardコンポーネント適用バッチ6

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,14 @@
+import { ReactNode, HTMLAttributes } from 'react';
+
+interface CardProps extends Omit<HTMLAttributes<HTMLDivElement>, 'className'> {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function Card({ children, className = '', ...props }: CardProps) {
+  return (
+    <div className={`bg-surface-1 rounded-lg border border-surface-3 p-4 ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/PracticeReminderCard.tsx
+++ b/frontend/src/components/PracticeReminderCard.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import Card from './Card';
 
 interface PracticeReminderCardProps {
   lastPracticeDate: string | null;
@@ -19,7 +20,7 @@ export default function PracticeReminderCard({ lastPracticeDate }: PracticeRemin
   const daysAgo = getDaysAgo(lastPracticeDate);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex items-center justify-between">
+    <Card className="flex items-center justify-between">
       <div>
         {daysAgo === 0 ? (
           <p className="text-sm font-medium text-emerald-400">今日も練習済み！</p>
@@ -40,6 +41,6 @@ export default function PracticeReminderCard({ lastPracticeDate }: PracticeRemin
           練習する
         </button>
       )}
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -1,4 +1,5 @@
 import type { PracticeScenario } from '../types';
+import Card from './Card';
 
 interface ScenarioCardProps {
   scenario: PracticeScenario;
@@ -38,9 +39,9 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
   };
 
   return (
-    <div
+    <Card
       onClick={() => onSelect(scenario)}
-      className="bg-surface-1 rounded-lg border border-surface-3 p-4 cursor-pointer hover:bg-surface-2 transition-colors"
+      className="cursor-pointer hover:bg-surface-2 transition-colors"
     >
       <div className="flex items-center justify-between mb-2">
         <span className="text-xs text-[var(--color-text-muted)]">{categoryLabel[scenario.category] || scenario.category}</span>
@@ -72,6 +73,6 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
         </svg>
         <span>相手役: {scenario.roleName}</span>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/ScoreHistorySessionCard.tsx
+++ b/frontend/src/components/ScoreHistorySessionCard.tsx
@@ -1,4 +1,5 @@
 import type { ScoreHistoryItem } from '../hooks/useScoreHistory';
+import Card from './Card';
 
 interface ScoreHistorySessionCardProps {
   item: ScoreHistoryItem;
@@ -8,8 +9,8 @@ interface ScoreHistorySessionCardProps {
 
 export default function ScoreHistorySessionCard({ item, delta, onClick }: ScoreHistorySessionCardProps) {
   return (
-    <div
-      className="bg-surface-1 rounded-lg border border-surface-3 p-4 cursor-pointer hover:border-[var(--color-border-hover)] transition-colors"
+    <Card
+      className="cursor-pointer hover:border-[var(--color-border-hover)] transition-colors"
       onClick={onClick}
     >
       <div className="flex items-center justify-between mb-3">
@@ -59,6 +60,6 @@ export default function ScoreHistorySessionCard({ item, delta, onClick }: ScoreH
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SessionCompleteCard.tsx
+++ b/frontend/src/components/SessionCompleteCard.tsx
@@ -1,4 +1,5 @@
 import { CheckCircleIcon } from '@heroicons/react/24/solid';
+import Card from './Card';
 
 interface SessionCompleteCardProps {
   duration: number;
@@ -20,7 +21,7 @@ export default function SessionCompleteCard({
   onPracticeAgain,
 }: SessionCompleteCardProps) {
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-6 text-center">
+    <Card className="p-6 text-center">
       <CheckCircleIcon className="w-10 h-10 text-emerald-400 mx-auto mb-3" />
       <h3 className="text-sm font-bold text-[var(--color-text-primary)] mb-4">セッション完了</h3>
 
@@ -49,6 +50,6 @@ export default function SessionCompleteCard({
           もう一度練習
         </button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SkillGapAnalysisCard.tsx
+++ b/frontend/src/components/SkillGapAnalysisCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface AxisScore {
   axis: string;
   score: number;
@@ -23,7 +25,7 @@ export default function SkillGapAnalysisCard({ scores, goal }: SkillGapAnalysisC
   const allAchieved = gaps.every((g) => g.achieved);
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキルギャップ分析</p>
 
       {allAchieved && (
@@ -58,6 +60,6 @@ export default function SkillGapAnalysisCard({ scores, goal }: SkillGapAnalysisC
           </div>
         ))}
       </div>
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
- 共通Cardコンポーネントを追加5コンポーネントに適用
  - PracticeReminderCard, ScenarioCard, ScoreHistorySessionCard, SessionCompleteCard, SkillGapAnalysisCard
- CardにHTMLAttributes拡張（onClick等のイベントハンドラ対応）
- 合計30コンポーネントでCard使用

## テスト結果
- 全1243テスト合格

Closes #610