### PR TITLE
feat: Badgeコンポーネント追加（再利用可能なバッジ/チップ）

### DIFF
--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -1,0 +1,32 @@
+import { ReactNode } from 'react';
+
+type BadgeVariant = 'success' | 'warning' | 'danger' | 'info' | 'neutral';
+type BadgeSize = 'sm' | 'md';
+
+interface BadgeProps {
+  children: ReactNode;
+  variant?: BadgeVariant;
+  size?: BadgeSize;
+  className?: string;
+}
+
+const VARIANT_STYLES: Record<BadgeVariant, string> = {
+  success: 'bg-emerald-900/30 text-emerald-400',
+  warning: 'bg-amber-900/30 text-amber-400',
+  danger: 'bg-rose-900/30 text-rose-400',
+  info: 'bg-blue-900/30 text-blue-400',
+  neutral: 'bg-surface-3 text-[var(--color-text-muted)]',
+};
+
+const SIZE_STYLES: Record<BadgeSize, string> = {
+  sm: 'text-[10px] px-2 py-0.5',
+  md: 'text-xs px-2.5 py-1',
+};
+
+export default function Badge({ children, variant = 'neutral', size = 'sm', className = '' }: BadgeProps) {
+  return (
+    <span className={`inline-flex items-center font-medium rounded-full ${VARIANT_STYLES[variant]} ${SIZE_STYLES[size]} ${className}`}>
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/__tests__/Badge.test.tsx
+++ b/frontend/src/components/__tests__/Badge.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Badge from '../Badge';
+
+describe('Badge', () => {
+  it('テキストが表示される', () => {
+    render(<Badge>初級</Badge>);
+    expect(screen.getByText('初級')).toBeInTheDocument();
+  });
+
+  it('デフォルトでneutralバリアントが適用される', () => {
+    render(<Badge>テスト</Badge>);
+    const badge = screen.getByText('テスト');
+    expect(badge.className).toContain('bg-surface-3');
+  });
+
+  it('successバリアントが適用される', () => {
+    render(<Badge variant="success">成功</Badge>);
+    const badge = screen.getByText('成功');
+    expect(badge.className).toContain('bg-emerald-900/30');
+    expect(badge.className).toContain('text-emerald-400');
+  });
+
+  it('warningバリアントが適用される', () => {
+    render(<Badge variant="warning">警告</Badge>);
+    const badge = screen.getByText('警告');
+    expect(badge.className).toContain('bg-amber-900/30');
+    expect(badge.className).toContain('text-amber-400');
+  });
+
+  it('dangerバリアントが適用される', () => {
+    render(<Badge variant="danger">危険</Badge>);
+    const badge = screen.getByText('危険');
+    expect(badge.className).toContain('bg-rose-900/30');
+    expect(badge.className).toContain('text-rose-400');
+  });
+
+  it('infoバリアントが適用される', () => {
+    render(<Badge variant="info">情報</Badge>);
+    const badge = screen.getByText('情報');
+    expect(badge.className).toContain('bg-blue-900/30');
+    expect(badge.className).toContain('text-blue-400');
+  });
+
+  it('デフォルトでsmサイズが適用される', () => {
+    render(<Badge>小</Badge>);
+    const badge = screen.getByText('小');
+    expect(badge.className).toContain('text-[10px]');
+    expect(badge.className).toContain('px-2');
+    expect(badge.className).toContain('py-0.5');
+  });
+
+  it('mdサイズが適用される', () => {
+    render(<Badge size="md">中</Badge>);
+    const badge = screen.getByText('中');
+    expect(badge.className).toContain('text-xs');
+    expect(badge.className).toContain('px-2.5');
+    expect(badge.className).toContain('py-1');
+  });
+
+  it('rounded-fullクラスが適用される', () => {
+    render(<Badge>丸</Badge>);
+    const badge = screen.getByText('丸');
+    expect(badge.className).toContain('rounded-full');
+  });
+
+  it('追加のclassNameが適用される', () => {
+    render(<Badge className="ml-2">追加</Badge>);
+    const badge = screen.getByText('追加');
+    expect(badge.className).toContain('ml-2');
+  });
+});


### PR DESCRIPTION
## 概要
- 5つのカラーバリアント（success/warning/danger/info/neutral）
- 2サイズ対応（sm/md）・ピル形状・追加className対応
- 散在するインラインバッジスタイルを統一する基盤コンポーネント

## テスト結果
- 全1256テスト合格（+10件）

Closes #616