### PR TITLE
refactor: Cardコンポーネント適用バッチ7

### DIFF
--- a/frontend/src/components/CommunicationStyleCard.tsx
+++ b/frontend/src/components/CommunicationStyleCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface AxisScore {
   axis: string;
   score: number;
@@ -62,11 +64,11 @@ function getAverageScores(sessions: Session[]): Map<string, number> {
 export default function CommunicationStyleCard({ sessions }: Props) {
   if (sessions.length === 0) {
     return (
-      <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <Card>
         <p className="text-xs font-medium text-[var(--color-text-muted)] mb-1">あなたのスタイル</p>
         <p className="text-sm text-[var(--color-text-faint)]">まだスタイルが判定できません</p>
         <p className="text-xs text-[var(--color-text-faint)] mt-1">練習セッションを完了するとスタイルが判定されます</p>
-      </div>
+      </Card>
     );
   }
 
@@ -88,10 +90,10 @@ export default function CommunicationStyleCard({ sessions }: Props) {
   }
 
   return (
-    <div className={`rounded-lg border p-4 ${style.color}`}>
+    <Card className={style.color}>
       <p className="text-xs font-medium opacity-75 mb-1">あなたのスタイル</p>
       <p className="text-base font-bold">{style.label}</p>
       <p className="text-xs mt-1 opacity-75">{style.description}</p>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -5,6 +5,7 @@ import {
   AcademicCapIcon,
   ChartBarIcon,
 } from '@heroicons/react/24/outline';
+import Card from './Card';
 
 interface MenuNavigationCardProps {
   totalUnread: number;
@@ -56,10 +57,12 @@ export default function MenuNavigationCard({ totalUnread, latestScore }: MenuNav
       {MENU_ITEMS.map((item) => {
         const badge = getBadge(item.badgeKey);
         return (
-          <button
+          <Card
             key={item.to}
+            role="button"
+            tabIndex={0}
             onClick={() => navigate(item.to)}
-            className="w-full flex items-center gap-4 bg-surface-1 rounded-lg border border-surface-3 p-4 text-left hover:bg-surface-2 transition-colors"
+            className="w-full flex items-center gap-4 text-left hover:bg-surface-2 transition-colors cursor-pointer"
           >
             <item.icon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
             <div className="flex-1 min-w-0">
@@ -73,7 +76,7 @@ export default function MenuNavigationCard({ totalUnread, latestScore }: MenuNav
               </div>
               <p className="text-xs text-[var(--color-text-muted)]">{item.description}</p>
             </div>
-          </button>
+          </Card>
         );
       })}
     </div>

--- a/frontend/src/components/SkillMilestoneCard.tsx
+++ b/frontend/src/components/SkillMilestoneCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface AxisScore {
   axis: string;
   score: number;
@@ -41,7 +43,7 @@ export default function SkillMilestoneCard({ scores }: SkillMilestoneCardProps) 
   if (scores.length === 0) return null;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <h3 className="text-xs font-semibold text-[var(--color-text-primary)] mb-3">スキル到達レベル</h3>
       <div className="space-y-3">
         {scores.map((s) => {
@@ -75,6 +77,6 @@ export default function SkillMilestoneCard({ scores }: SkillMilestoneCardProps) 
           );
         })}
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/SkillRadarOverlayCard.tsx
+++ b/frontend/src/components/SkillRadarOverlayCard.tsx
@@ -1,3 +1,4 @@
+import Card from './Card';
 import type { AxisScore } from '../types';
 
 interface SkillRadarOverlayCardProps {
@@ -48,7 +49,7 @@ export default function SkillRadarOverlayCard({ previousScores, currentScores }:
   const labels = currentScores.length > 0 ? currentScores : previousScores;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキル変化レーダー</p>
 
       <div className="flex justify-center">
@@ -134,6 +135,6 @@ export default function SkillRadarOverlayCard({ previousScores, currentScores }:
           <span className="text-[10px] text-[var(--color-text-muted)]">今回</span>
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/components/WeeklyComparisonCard.tsx
+++ b/frontend/src/components/WeeklyComparisonCard.tsx
@@ -1,3 +1,5 @@
+import Card from './Card';
+
 interface Session {
   overallScore: number;
   createdAt: string;
@@ -40,7 +42,7 @@ export default function WeeklyComparisonCard({ sessions }: WeeklyComparisonCardP
   const delta = showDelta ? Math.round((thisAvg - lastAvg) * 10) / 10 : 0;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+    <Card>
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">週間比較</p>
 
       <div className="grid grid-cols-2 gap-4">
@@ -77,6 +79,6 @@ export default function WeeklyComparisonCard({ sessions }: WeeklyComparisonCardP
           <span className="text-xs text-[var(--color-text-faint)] ml-1">先週比</span>
         </div>
       )}
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## 概要
- 共通Cardコンポーネントを追加5コンポーネントに適用
  - SkillMilestoneCard, SkillRadarOverlayCard, WeeklyComparisonCard, MenuNavigationCard, CommunicationStyleCard
- 合計35コンポーネントでCard使用

## テスト結果
- 全1256テスト合格

Closes #618