### PR TITLE
feat: Avatarコンポーネント追加（画像+イニシャルフォールバック統一）

### DIFF
--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,0 +1,35 @@
+type AvatarSize = 'sm' | 'md' | 'lg' | 'xl';
+
+interface AvatarProps {
+  name: string;
+  src?: string;
+  size?: AvatarSize;
+}
+
+const SIZE_STYLES: Record<AvatarSize, { container: string; text: string }> = {
+  sm: { container: 'w-8 h-8', text: 'text-xs' },
+  md: { container: 'w-10 h-10', text: 'text-sm' },
+  lg: { container: 'w-14 h-14', text: 'text-xl' },
+  xl: { container: 'w-16 h-16', text: 'text-2xl' },
+};
+
+export default function Avatar({ name, src, size = 'md' }: AvatarProps) {
+  const initial = name ? name.charAt(0).toUpperCase() : '?';
+  const styles = SIZE_STYLES[size];
+
+  if (src) {
+    return (
+      <div className={`${styles.container} rounded-full flex-shrink-0 overflow-hidden`}>
+        <img src={src} alt={name} className="w-full h-full object-cover rounded-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`${styles.container} rounded-full bg-primary-500 flex items-center justify-center flex-shrink-0`}
+    >
+      <span className={`text-white ${styles.text} font-bold`}>{initial}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/Avatar.test.tsx
+++ b/frontend/src/components/__tests__/Avatar.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Avatar from '../Avatar';
+
+describe('Avatar', () => {
+  it('名前のイニシャルが表示される', () => {
+    render(<Avatar name="田中太郎" />);
+    expect(screen.getByText('田')).toBeInTheDocument();
+  });
+
+  it('画像URLが指定された場合imgタグが表示される', () => {
+    render(<Avatar name="田中" src="https://example.com/photo.jpg" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg');
+    expect(img).toHaveAttribute('alt', '田中');
+  });
+
+  it('画像URLがない場合イニシャルフォールバックが表示される', () => {
+    render(<Avatar name="Taro" />);
+    expect(screen.getByText('T')).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('名前が空文字の場合?が表示される', () => {
+    render(<Avatar name="" />);
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+
+  it('デフォルトでmdサイズが適用される', () => {
+    const { container } = render(<Avatar name="A" />);
+    const avatar = container.firstChild as HTMLElement;
+    expect(avatar.className).toContain('w-10');
+    expect(avatar.className).toContain('h-10');
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<Avatar name="A" size="sm" />);
+    const avatar = container.firstChild as HTMLElement;
+    expect(avatar.className).toContain('w-8');
+    expect(avatar.className).toContain('h-8');
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<Avatar name="A" size="lg" />);
+    const avatar = container.firstChild as HTMLElement;
+    expect(avatar.className).toContain('w-14');
+    expect(avatar.className).toContain('h-14');
+  });
+
+  it('xlサイズが適用される', () => {
+    const { container } = render(<Avatar name="A" size="xl" />);
+    const avatar = container.firstChild as HTMLElement;
+    expect(avatar.className).toContain('w-16');
+    expect(avatar.className).toContain('h-16');
+  });
+
+  it('rounded-fullクラスが適用される', () => {
+    const { container } = render(<Avatar name="A" />);
+    const avatar = container.firstChild as HTMLElement;
+    expect(avatar.className).toContain('rounded-full');
+  });
+
+  it('画像にobject-coverクラスが適用される', () => {
+    render(<Avatar name="A" src="https://example.com/photo.jpg" />);
+    const img = screen.getByRole('img');
+    expect(img.className).toContain('object-cover');
+  });
+});


### PR DESCRIPTION
## 概要
- プロフィール画像表示 + イニシャルフォールバック統一コンポーネント
- 4サイズ対応（sm/md/lg/xl）
- ChatListPage/MemberItem/ProfilePage等のインライン実装を置換可能

## テスト結果
- 全1269テスト合格（+10件）

Closes #624