### PR TITLE
refactor: Avatarコンポーネント適用（MemberItem・ChatListPage・ProfilePage）

### DIFF
--- a/frontend/src/components/MemberItem.tsx
+++ b/frontend/src/components/MemberItem.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { ChatBubbleLeftIcon, UserPlusIcon } from '@heroicons/react/24/solid';
 import ChatRepository from '../repositories/ChatRepository';
+import Avatar from './Avatar';
 
 interface MemberItemProps {
   id: number;
@@ -34,9 +35,7 @@ export default function MemberItem({ id, name, roomId, email }: MemberItemProps)
       className="bg-surface-1 rounded-2xl cursor-pointer overflow-hidden group border border-surface-3 hover:bg-surface-2 transition-colors duration-150 mb-3"
     >
       <div className="flex items-center p-4">
-        <div className="w-14 h-14 bg-primary-500 rounded-full flex items-center justify-center text-white font-bold text-xl flex-shrink-0">
-          {name?.charAt(0)?.toUpperCase() || '?'}
-        </div>
+        <Avatar name={name} size="lg" />
 
         <div className="flex-1 ml-4 min-w-0">
           <p className="text-base font-bold text-[var(--color-text-primary)] truncate">

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -3,6 +3,7 @@ import SecondaryPanel from '../components/layout/SecondaryPanel';
 import EmptyState from '../components/EmptyState';
 import SearchBox from '../components/SearchBox';
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import Avatar from '../components/Avatar';
 import { useChatList } from '../hooks/useChatList';
 import { formatTime, truncateMessage } from '../utils/formatters';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
@@ -41,21 +42,7 @@ export default function ChatListPage() {
               onClick={() => { navigate(`/chat/users/${user.roomId}`); closeMobilePanel(); }}
               className="w-full px-4 py-3 flex items-center gap-3 hover:bg-surface-2 transition-colors border-b border-surface-3 text-left"
             >
-              <div className="flex-shrink-0">
-                {user.profileImage ? (
-                  <img
-                    src={user.profileImage}
-                    alt={user.name}
-                    className="w-10 h-10 rounded-full object-cover"
-                  />
-                ) : (
-                  <div className="w-10 h-10 rounded-full bg-primary-500 flex items-center justify-center">
-                    <span className="text-white text-sm font-bold">
-                      {user.name?.charAt(0)?.toUpperCase() || '?'}
-                    </span>
-                  </div>
-                )}
-              </div>
+              <Avatar name={user.name} src={user.profileImage} />
 
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import InputField from '../components/InputField';
 import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
 import FormMessage from '../components/FormMessage';
+import Avatar from '../components/Avatar';
 import { useProfileEdit } from '../hooks/useProfileEdit';
 
 export default function ProfilePage() {
@@ -21,11 +22,7 @@ export default function ProfilePage() {
 
       <div className="bg-surface-1 rounded-lg border border-surface-3 p-6">
         <div className="flex items-center gap-4 mb-6">
-          <div className="w-16 h-16 bg-primary-500 rounded-full flex items-center justify-center">
-            <span className="text-white text-2xl font-bold">
-              {form.name?.charAt(0)?.toUpperCase() || 'U'}
-            </span>
-          </div>
+          <Avatar name={form.name || 'U'} size="xl" />
           <div>
             <h2 className="text-lg font-bold text-[var(--color-text-primary)]">プロフィールを編集</h2>
             <p className="text-sm text-[var(--color-text-muted)]">あなたの情報を更新してください</p>


### PR DESCRIPTION
## 概要
- MemberItem: インラインアバターをAvatar(lg)に置換
- ChatListPage: 画像+フォールバックをAvatar(md)に置換
- ProfilePage: インラインアバターをAvatar(xl)に置換
- コード-17行削減

## テスト結果
- 全1269テスト合格

Closes #626