### PR TITLE
refactor: ScoreGoalCard・ScoreHistoryPageにuseLocalStorage適用

### DIFF
--- a/frontend/src/components/ScoreGoalCard.tsx
+++ b/frontend/src/components/ScoreGoalCard.tsx
@@ -1,29 +1,17 @@
-import { useState } from 'react';
 import Card from './Card';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 
 interface Props {
   averageScore: number;
 }
 
 const GOAL_OPTIONS = [6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0];
-const STORAGE_KEY = 'scoreGoal';
-
-function getStoredGoal(): number {
-  const stored = localStorage.getItem(STORAGE_KEY);
-  if (stored) {
-    const parsed = parseFloat(stored);
-    if (!isNaN(parsed)) return parsed;
-  }
-  return 8.0;
-}
 
 export default function ScoreGoalCard({ averageScore }: Props) {
-  const [goal, setGoal] = useState(getStoredGoal);
+  const [goal, setGoal] = useLocalStorage('scoreGoal', 8.0);
 
   const handleGoalChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newGoal = parseFloat(e.target.value);
-    setGoal(newGoal);
-    localStorage.setItem(STORAGE_KEY, String(newGoal));
+    setGoal(parseFloat(e.target.value));
   };
 
   const achieved = averageScore >= goal;

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -24,9 +24,11 @@ import WeakAxisAdviceCard from '../components/WeakAxisAdviceCard';
 import PersonalBestCard from '../components/PersonalBestCard';
 import FilterTabs from '../components/FilterTabs';
 import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 
 export default function ScoreHistoryPage() {
   const { history, filteredHistory, filter, setFilter, loading, latestSession, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
+  const [scoreGoal] = useLocalStorage('scoreGoal', 8.0);
 
   if (loading) {
     return (
@@ -62,14 +64,7 @@ export default function ScoreHistoryPage() {
       {latestSession && latestSession.scores.length > 0 && (
         <SkillGapAnalysisCard
           scores={latestSession.scores}
-          goal={(() => {
-            try {
-              const stored = localStorage.getItem('scoreGoal');
-              return stored ? parseFloat(stored) : 8.0;
-            } catch {
-              return 8.0;
-            }
-          })()}
+          goal={scoreGoal}
         />
       )}
 


### PR DESCRIPTION
## 概要
直接のlocalStorage操作をuseLocalStorageフックに置換するリファクタリング。

## 変更内容
- **ScoreGoalCard**: `getStoredGoal()`関数+`useState`+手動`setItem` → `useLocalStorage`に統一（9行削減）
- **ScoreHistoryPage**: インラインIIFE `(() => { localStorage.getItem... })()` → `useLocalStorage`に置換

## テスト
- 1282テスト全パス（変更なし）