### PR TITLE
fix: useLocalStorageエラーハンドリング強化・README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,12 @@
 - **ScrollToTopボタン**：長ページでスクロール位置200px以上で表示されるフローティングボタン・スムーズスクロールで上部に移動・AppShellに組み込み済み
 - **Badgeコンポーネント**：5カラーバリアント（success/warning/danger/info/neutral）・2サイズ対応のインラインバッジ
 - **Avatarコンポーネント**：プロフィール画像+イニシャルフォールバック統一・4サイズ対応（sm/md/lg/xl）・MemberItem/ChatListPage/ProfilePageに適用
+- **useLocalStorageフック**：localStorage読み書きの型安全な統一フック・JSON直列化自動処理・エラーハンドリング・関数型setValue対応・ScoreGoalCard/ScoreHistoryPageに適用
 
 ### テスト品質
-- **フロントエンド1272テスト**：Vitest + React Testing Library
+- **フロントエンド1285テスト**：Vitest + React Testing Library
   - Repository層テスト（13リポジトリ・62テスト）
-  - Hooks層テスト（32フック・319テスト）
+  - Hooks層テスト（33フック・332テスト）
   - Store層テスト（1スライス・5テスト）
   - UIコンポーネントテスト（82コンポーネント・514テスト）
   - ページコンポーネントテスト（17ページ・110テスト）

--- a/frontend/src/hooks/useLocalStorage.ts
+++ b/frontend/src/hooks/useLocalStorage.ts
@@ -15,13 +15,21 @@ export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: Se
   const setValue = useCallback((value: SetValue<T>) => {
     setStoredValue((prev) => {
       const newValue = value instanceof Function ? value(prev) : value;
-      localStorage.setItem(key, JSON.stringify(newValue));
+      try {
+        localStorage.setItem(key, JSON.stringify(newValue));
+      } catch {
+        // QuotaExceededError等 - stateは更新する
+      }
       return newValue;
     });
   }, [key]);
 
   const removeValue = useCallback(() => {
-    localStorage.removeItem(key);
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // localStorage unavailable
+    }
     setStoredValue(defaultValue);
   }, [key, defaultValue]);
 


### PR DESCRIPTION
## 概要
Copilotレビュー指摘の修正とREADME更新。

## 変更内容
- **useLocalStorage**: setValue/removeValueにtry-catch追加（QuotaExceededError等の防御）
- **README**: useLocalStorageフック記載追加、テスト数1285に更新、Hooks層33フック332テストに更新

## デプロイ
- S3デプロイ済み、CloudFrontキャッシュ削除済み

## テスト
- 1285テスト全パス