### PR TITLE
fix: p.reduce is not a functionエラーの防御チェック追加

### DIFF
--- a/frontend/src/components/ScoreFilterSummary.tsx
+++ b/frontend/src/components/ScoreFilterSummary.tsx
@@ -3,7 +3,7 @@ interface ScoreFilterSummaryProps {
 }
 
 export default function ScoreFilterSummary({ scores }: ScoreFilterSummaryProps) {
-  if (scores.length === 0) return null;
+  if (!Array.isArray(scores) || scores.length === 0) return null;
 
   const avg = Math.round((scores.reduce((s, v) => s + v, 0) / scores.length) * 10) / 10;
   const max = Math.max(...scores);

--- a/frontend/src/components/ScoreGrowthTrendCard.tsx
+++ b/frontend/src/components/ScoreGrowthTrendCard.tsx
@@ -31,7 +31,7 @@ interface Props {
 
 export default function ScoreGrowthTrendCard({ scores }: Props) {
   const analysis = useMemo(() => {
-    if (scores.length < 2) return null;
+    if (!Array.isArray(scores) || scores.length < 2) return null;
 
     const mid = Math.floor(scores.length / 2);
     const firstHalf = scores.slice(0, mid);

--- a/frontend/src/components/ScoreTrendIndicator.tsx
+++ b/frontend/src/components/ScoreTrendIndicator.tsx
@@ -39,7 +39,7 @@ const TREND_CONFIG = {
 } as const;
 
 export default function ScoreTrendIndicator({ scores }: ScoreTrendIndicatorProps) {
-  if (scores.length < 2) return null;
+  if (!Array.isArray(scores) || scores.length < 2) return null;
 
   const trend = calculateTrend(scores);
   const config = TREND_CONFIG[trend];

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -31,14 +31,14 @@ export function useMenuData() {
           setStats(statsData.value);
         }
 
-        if (roomsData.status === 'fulfilled' && roomsData.value?.chatUsers) {
+        if (roomsData.status === 'fulfilled' && Array.isArray(roomsData.value?.chatUsers)) {
           const unread = roomsData.value.chatUsers.reduce(
             (sum, u) => sum + u.unreadCount, 0
           );
           setTotalUnread(unread);
         }
 
-        if (scoresData.status === 'fulfilled' && scoresData.value.length > 0) {
+        if (scoresData.status === 'fulfilled' && Array.isArray(scoresData.value) && scoresData.value.length > 0) {
           setLatestScore(scoresData.value[0]);
           setAllScores(scoresData.value);
         }

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -32,7 +32,7 @@ export function useScoreHistory() {
   useEffect(() => {
     const loadHistory = async () => {
       const data = await fetchScoreHistory();
-      setHistory(data);
+      setHistory(Array.isArray(data) ? data : []);
     };
     loadHistory();
   }, [fetchScoreHistory]);


### PR DESCRIPTION
## 概要
本番環境で発生した `TypeError: p.reduce is not a function` エラーを修正。

## 原因
APIレスポンスが配列でない場合（ネットワークエラー、レスポンス形式変更等）に、`.reduce()` 呼び出しでクラッシュ。

## 修正内容
- **useMenuData**: `scoresData.value` と `chatUsers` に `Array.isArray()` チェック追加
- **useScoreHistory**: `fetchScoreHistory` の戻り値に `Array.isArray()` ガード追加
- **ScoreGrowthTrendCard**: `scores` propsの配列チェック追加
- **ScoreTrendIndicator**: `scores` propsの配列チェック追加
- **ScoreFilterSummary**: `scores` propsの配列チェック追加

## デプロイ
- S3デプロイ済み、CloudFrontキャッシュ削除済み

## テスト
- 1285テスト全パス