### PR TITLE
feat: SearchBoxアクセシビリティ改善

### DIFF
--- a/frontend/src/components/SearchBox.tsx
+++ b/frontend/src/components/SearchBox.tsx
@@ -8,13 +8,14 @@ interface SearchBoxProps {
 
 export default function SearchBox({ value, onChange, placeholder = '検索' }: SearchBoxProps) {
   return (
-    <div className="relative">
+    <div className="relative" role="search">
       <MagnifyingGlassIcon className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-[var(--color-text-faint)]" />
       <input
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        aria-label={placeholder}
         className="w-full rounded-lg border border-surface-3 py-2.5 pl-12 pr-9 focus:border-primary-500 focus:ring-1 focus:ring-primary-500 focus:outline-none transition-colors duration-150 placeholder-slate-400"
       />
       {value && (

--- a/frontend/src/components/__tests__/SearchBox.test.tsx
+++ b/frontend/src/components/__tests__/SearchBox.test.tsx
@@ -77,4 +77,22 @@ describe('SearchBox', () => {
     const clearButton = screen.getByLabelText('検索をクリア');
     expect(clearButton.tagName).toBe('BUTTON');
   });
+
+  it('role="search"が外側のdivに適用される', () => {
+    render(<SearchBox value="" onChange={vi.fn()} />);
+    expect(screen.getByRole('search')).toBeInTheDocument();
+  });
+
+  it('aria-labelがinputに適用される', () => {
+    render(<SearchBox value="" onChange={vi.fn()} placeholder="名前で検索" />);
+    const input = screen.getByLabelText('名前で検索');
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('デフォルトplaceholderがaria-labelに使用される', () => {
+    render(<SearchBox value="" onChange={vi.fn()} />);
+    const input = screen.getByLabelText('検索');
+    expect(input).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
SearchBoxコンポーネントのスクリーンリーダー対応を改善。

## 変更内容
- コンテナdivに `role="search"` 追加（検索ランドマーク）
- inputに `aria-label` 追加（placeholder値をデフォルト使用）

## テスト
- 3テスト追加（1288テスト全パス）

Closes #639