### PR TITLE
refactor: インラインスピナーをLoadingコンポーネントに統一

### DIFF
--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -4,6 +4,7 @@ import EmptyState from '../components/EmptyState';
 import SearchBox from '../components/SearchBox';
 import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import Avatar from '../components/Avatar';
+import Loading from '../components/Loading';
 import { useChatList } from '../hooks/useChatList';
 import { formatTime, truncateMessage } from '../utils/formatters';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
@@ -28,9 +29,7 @@ export default function ChatListPage() {
         }
       >
         {loading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-500" />
-          </div>
+          <Loading className="py-8" />
         ) : chatUsers.length === 0 ? (
           <div className="p-4 text-center text-sm text-[var(--color-text-muted)]">
             チャット履歴がありません

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -4,6 +4,7 @@ import NoteListItem from '../components/NoteListItem';
 import NoteEditor from '../components/NoteEditor';
 import EmptyState from '../components/EmptyState';
 import ConfirmModal from '../components/ConfirmModal';
+import Loading from '../components/Loading';
 import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import { useNotes } from '../hooks/useNotes';
 import { useNoteEditor } from '../hooks/useNoteEditor';
@@ -89,9 +90,7 @@ export default function NotesPage() {
       >
         <div className="p-2 space-y-0.5">
           {loading && notes.length === 0 ? (
-            <div className="flex items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-500" />
-            </div>
+            <Loading className="py-8" />
           ) : filteredNotes.length === 0 ? (
             <div className="p-4 text-center text-xs text-[var(--color-text-muted)]">
               ノートがありません

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
 import FormMessage from '../components/FormMessage';
 import Avatar from '../components/Avatar';
+import Loading from '../components/Loading';
 import { useProfileEdit } from '../hooks/useProfileEdit';
 
 export default function ProfilePage() {
@@ -10,9 +11,7 @@ export default function ProfilePage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-full">
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-500" />
-      </div>
+      <Loading className="h-full" />
     );
   }
 


### PR DESCRIPTION
## 概要
3ページのハードコードされたローディングスピナーをLoadingコンポーネントに置換。

## 変更内容
- **ChatListPage**: インラインスピナー → `<Loading className="py-8" />`
- **NotesPage**: インラインスピナー → `<Loading className="py-8" />`
- **ProfilePage**: インラインスピナー → `<Loading className="h-full" />`

## 効果
- `role="status"` と `aria-label="読み込み中"` が自動適用（アクセシビリティ向上）
- スピナースタイルの統一（border-t + primary-500テーマカラー）
- コード3行削減

## テスト
- 1288テスト全パス（変更なし）