### PR TITLE
test: SearchBoxエッジケーステスト3件追加

### DIFF
--- a/frontend/src/components/__tests__/SearchBox.test.tsx
+++ b/frontend/src/components/__tests__/SearchBox.test.tsx
@@ -95,4 +95,24 @@ describe('SearchBox', () => {
     const input = screen.getByLabelText('検索');
     expect(input).toBeInTheDocument();
   });
+
+  it('searchロール内にinputが含まれる', () => {
+    render(<SearchBox value="" onChange={vi.fn()} />);
+    const searchRegion = screen.getByRole('search');
+    const input = searchRegion.querySelector('input');
+    expect(input).toBeTruthy();
+  });
+
+  it('クリアボタンがsearchロール内に含まれる', () => {
+    render(<SearchBox value="テスト" onChange={vi.fn()} />);
+    const searchRegion = screen.getByRole('search');
+    const clearButton = searchRegion.querySelector('button');
+    expect(clearButton).toBeTruthy();
+  });
+
+  it('カスタムplaceholderがaria-labelとplaceholder両方に反映される', () => {
+    render(<SearchBox value="" onChange={vi.fn()} placeholder="メールで検索" />);
+    const input = screen.getByLabelText('メールで検索');
+    expect(input).toHaveAttribute('placeholder', 'メールで検索');
+  });
 });


### PR DESCRIPTION
## 概要
SearchBoxコンポーネントのエッジケーステストを3件追加。

## 追加テスト
- **searchロール内のinput**: `role="search"` 内にinput要素が含まれることを確認
- **searchロール内のクリアボタン**: `role="search"` 内にbutton要素が含まれることを確認
- **placeholder+aria-label一致**: カスタムplaceholderがaria-labelとplaceholder両方に反映されることを確認

## テスト
- 1291テスト全パス（+3）