### PR TITLE
feat: MessageSearchBarアクセシビリティ改善

### DIFF
--- a/frontend/src/components/MessageSearchBar.tsx
+++ b/frontend/src/components/MessageSearchBar.tsx
@@ -1,3 +1,5 @@
+import { XMarkIcon } from '@heroicons/react/24/solid';
+
 interface MessageSearchBarProps {
   onSearch: (query: string) => void;
   onClear: () => void;
@@ -6,24 +8,23 @@ interface MessageSearchBarProps {
 
 export default function MessageSearchBar({ onSearch, onClear, matchCount }: MessageSearchBarProps) {
   return (
-    <div className="flex items-center gap-2 px-4 py-2 bg-surface-2 border-b border-surface-3">
+    <div className="flex items-center gap-2 px-4 py-2 bg-surface-2 border-b border-surface-3" role="search">
       <input
         type="text"
         placeholder="メッセージを検索..."
+        aria-label="メッセージを検索"
         onChange={(e) => onSearch(e.target.value)}
         className="flex-1 text-sm bg-surface-1 border border-surface-3 rounded-lg px-3 py-1.5 outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"
       />
       {matchCount > 0 && (
-        <span className="text-xs text-[var(--color-text-muted)] flex-shrink-0">{matchCount}件</span>
+        <span className="text-xs text-[var(--color-text-muted)] flex-shrink-0" aria-live="polite">{matchCount}件</span>
       )}
       <button
         onClick={onClear}
         aria-label="検索をクリア"
         className="text-xs text-[var(--color-text-faint)] hover:text-[var(--color-text-tertiary)] p-1 rounded hover:bg-surface-3 transition-colors"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-        </svg>
+        <XMarkIcon className="w-4 h-4" />
       </button>
     </div>
   );

--- a/frontend/src/components/__tests__/MessageSearchBar.test.tsx
+++ b/frontend/src/components/__tests__/MessageSearchBar.test.tsx
@@ -44,4 +44,21 @@ describe('MessageSearchBar', () => {
 
     expect(screen.queryByText('0件')).not.toBeInTheDocument();
   });
+
+  it('role="search"がコンテナに適用される', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+    expect(screen.getByRole('search')).toBeInTheDocument();
+  });
+
+  it('aria-labelがinputに適用される', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+    const input = screen.getByLabelText('メッセージを検索');
+    expect(input.tagName).toBe('INPUT');
+  });
+
+  it('マッチ件数がaria-liveで通知される', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={5} />);
+    const liveRegion = screen.getByText('5件');
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+  });
 });


### PR DESCRIPTION
## 概要
MessageSearchBarのスクリーンリーダー対応を改善。

## 変更内容
- コンテナに `role="search"` 追加
- inputに `aria-label="メッセージを検索"` 追加
- マッチ件数に `aria-live="polite"` 追加（スクリーンリーダー通知）
- インラインSVGをHeroicons `XMarkIcon` に置換

## テスト
- 3テスト追加（1294テスト全パス）

Closes #644