### PR TITLE
refactor: ハンバーガーメニュー・PlusアイコンのインラインSVGをHeroiconsに統一

### DIFF
--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -8,6 +8,7 @@ import PracticeTimer from '../components/PracticeTimer';
 import SessionNoteEditor from '../components/SessionNoteEditor';
 import ExportSessionButton from '../components/ExportSessionButton';
 import AiSessionListItem from '../components/AiSessionListItem';
+import { PlusIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import { useAskAi } from '../hooks/useAskAi';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
@@ -51,9 +52,7 @@ export default function AskAiPage() {
             onClick={handleNewSession}
             className="w-full bg-primary-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-            </svg>
+            <PlusIcon className="w-4 h-4" />
             新しいチャット
           </button>
         }
@@ -88,9 +87,7 @@ export default function AskAiPage() {
             className="p-1.5 hover:bg-surface-2 rounded transition-colors"
             aria-label="セッション一覧を開く"
           >
-            <svg className="w-5 h-5 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
+            <Bars3Icon className="w-5 h-5 text-[var(--color-text-muted)]" />
           </button>
           <span className="ml-2 text-xs text-[var(--color-text-muted)]">セッション一覧</span>
         </div>

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import EmptyState from '../components/EmptyState';
 import SearchBox from '../components/SearchBox';
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import { ChatBubbleLeftRightIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import Avatar from '../components/Avatar';
 import Loading from '../components/Loading';
 import { useChatList } from '../hooks/useChatList';
@@ -78,9 +78,7 @@ export default function ChatListPage() {
             className="p-1.5 hover:bg-surface-2 rounded transition-colors"
             aria-label="チャット一覧を開く"
           >
-            <svg className="w-5 h-5 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
+            <Bars3Icon className="w-5 h-5 text-[var(--color-text-muted)]" />
           </button>
           <span className="ml-2 text-xs text-[var(--color-text-muted)]">チャット一覧</span>
         </div>


### PR DESCRIPTION
## 概要
- ChatListPage・AskAiPageのインラインSVGをHeroiconsコンポーネントに置換
- ハンバーガーメニュー → `Bars3Icon`（NotesPageと統一）
- プラスアイコン → `PlusIcon`（NotesPageと統一）

## 変更ファイル
- `frontend/src/pages/ChatListPage.tsx` - Bars3Icon置換
- `frontend/src/pages/AskAiPage.tsx` - Bars3Icon・PlusIcon置換

## テスト
- 全1294テスト合格

Close #646