### PR TITLE
test: MessageSearchBarエッジケーステスト+3追加

### DIFF
--- a/frontend/src/components/__tests__/MessageSearchBar.test.tsx
+++ b/frontend/src/components/__tests__/MessageSearchBar.test.tsx
@@ -61,4 +61,26 @@ describe('MessageSearchBar', () => {
     const liveRegion = screen.getByText('5件');
     expect(liveRegion).toHaveAttribute('aria-live', 'polite');
   });
+
+  it('入力をクリアするとonSearchが空文字で呼ばれる', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+    const input = screen.getByPlaceholderText('メッセージを検索...');
+
+    fireEvent.change(input, { target: { value: 'テスト' } });
+    mockOnSearch.mockClear();
+    fireEvent.change(input, { target: { value: '' } });
+    expect(mockOnSearch).toHaveBeenCalledWith('');
+  });
+
+  it('クリアボタンがsearchロール内にある', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={0} />);
+    const searchContainer = screen.getByRole('search');
+    const clearButton = screen.getByLabelText('検索をクリア');
+    expect(searchContainer).toContainElement(clearButton);
+  });
+
+  it('大きなマッチ件数が正しく表示される', () => {
+    render(<MessageSearchBar onSearch={mockOnSearch} onClear={mockOnClear} matchCount={999} />);
+    expect(screen.getByText('999件')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
MessageSearchBarに3つのエッジケーステストを追加。

## 追加テスト
- 入力クリア時のonSearch空文字呼び出し確認
- クリアボタンがsearchロール内に存在する確認
- 大きなマッチ件数（999件）の表示確認

## テスト結果
- 全1297テスト合格（+3）

Close #648