### PR TITLE
fix: 不正なTailwind opacity値(900/300)を修正・README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@
 - **Loadingコンポーネント統一**：ChatListPage/NotesPage/ProfilePageのインラインスピナーをLoadingコンポーネントに置換・role="status"自動適用
 
 ### テスト品質
-- **フロントエンド1291テスト**：Vitest + React Testing Library
+- **フロントエンド1297テスト**：Vitest + React Testing Library
   - Repository層テスト（13リポジトリ・62テスト）
   - Hooks層テスト（33フック・332テスト）
   - Store層テスト（1スライス・5テスト）

--- a/frontend/src/components/DailyGoalCard.tsx
+++ b/frontend/src/components/DailyGoalCard.tsx
@@ -25,7 +25,7 @@ export default function DailyGoalCard() {
       >
         <div
           className={`h-2 rounded-full transition-all duration-300 ${
-            isAchieved ? 'bg-emerald-900/300' : 'bg-primary-500'
+            isAchieved ? 'bg-emerald-500' : 'bg-primary-500'
           }`}
           style={{ width: `${Math.min(progress, 100)}%` }}
         />

--- a/frontend/src/components/FavoriteStatsCard.tsx
+++ b/frontend/src/components/FavoriteStatsCard.tsx
@@ -6,11 +6,11 @@ interface FavoriteStatsCardProps {
 }
 
 const PATTERN_COLORS: Record<string, string> = {
-  'フォーマル': 'bg-blue-900/300',
-  'ソフト': 'bg-emerald-900/300',
-  '簡潔': 'bg-amber-900/300',
+  'フォーマル': 'bg-blue-500',
+  'ソフト': 'bg-emerald-500',
+  '簡潔': 'bg-amber-500',
   '質問型': 'bg-purple-500',
-  '提案型': 'bg-rose-900/300',
+  '提案型': 'bg-rose-500',
 };
 
 export default function FavoriteStatsCard({ phrases }: FavoriteStatsCardProps) {

--- a/frontend/src/components/ScoreDistributionCard.tsx
+++ b/frontend/src/components/ScoreDistributionCard.tsx
@@ -12,10 +12,10 @@ const RANGES = [
 ] as const;
 
 const RANGE_COLORS = [
-  'bg-emerald-900/300',
-  'bg-blue-900/300',
-  'bg-amber-900/300',
-  'bg-rose-900/300',
+  'bg-emerald-500',
+  'bg-blue-500',
+  'bg-amber-500',
+  'bg-rose-500',
 ];
 
 function getMessage(topRangeIndex: number): string {

--- a/frontend/src/components/ScoreGoalCard.tsx
+++ b/frontend/src/components/ScoreGoalCard.tsx
@@ -48,7 +48,7 @@ export default function ScoreGoalCard({ averageScore }: Props) {
 
       <div className="w-full bg-surface-3 rounded-full h-2 mb-2">
         <div
-          className={`h-2 rounded-full transition-all ${achieved ? 'bg-emerald-900/300' : 'bg-primary-500'}`}
+          className={`h-2 rounded-full transition-all ${achieved ? 'bg-emerald-500' : 'bg-primary-500'}`}
           style={{ width: `${progress}%` }}
         />
       </div>

--- a/frontend/src/components/WeeklyGoalProgressCard.tsx
+++ b/frontend/src/components/WeeklyGoalProgressCard.tsx
@@ -33,7 +33,7 @@ export default function WeeklyGoalProgressCard({
       <div className="w-full bg-surface-3 rounded-full h-2 mb-2">
         <div
           data-testid="progress-bar"
-          className={`h-2 rounded-full transition-all ${isCompleted ? 'bg-emerald-900/300' : 'bg-primary-500'}`}
+          className={`h-2 rounded-full transition-all ${isCompleted ? 'bg-emerald-500' : 'bg-primary-500'}`}
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -105,7 +105,7 @@ export default function AskAiPage() {
               <PracticeTimer />
               <button
                 onClick={() => handleSend('練習を終了して、今回の会話全体に対するフィードバックとスコアカードをお願いします。')}
-                className="bg-rose-900/300 text-white text-xs px-3 py-1.5 rounded-lg hover:bg-rose-600 transition-colors"
+                className="bg-rose-500 text-white text-xs px-3 py-1.5 rounded-lg hover:bg-rose-600 transition-colors"
               >
                 練習終了
               </button>

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -59,7 +59,7 @@ export default function ChatListPage() {
                       : `あなた: ${truncateMessage(user.lastMessage)}`}
                   </p>
                   {user.unreadCount > 0 && (
-                    <span className="bg-rose-900/300 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full flex-shrink-0">
+                    <span className="bg-rose-500 text-white text-[10px] font-bold px-1.5 py-0.5 rounded-full flex-shrink-0">
                       {user.unreadCount > 99 ? '99+' : user.unreadCount}
                     </span>
                   )}

--- a/frontend/src/utils/scoreColor.ts
+++ b/frontend/src/utils/scoreColor.ts
@@ -5,9 +5,9 @@ export function getScoreTextColor(score: number): string {
 }
 
 export function getScoreBarColor(score: number): string {
-  if (score >= 8) return 'bg-emerald-900/300';
-  if (score >= 6) return 'bg-amber-900/300';
-  return 'bg-rose-900/300';
+  if (score >= 8) return 'bg-emerald-500';
+  if (score >= 6) return 'bg-amber-500';
+  return 'bg-rose-500';
 }
 
 export function getScoreLevel(score: number): { label: string; color: string } {


### PR DESCRIPTION
## 概要
Copilotレビューで発見された不正なTailwind CSSクラスを修正。

## 問題
- `bg-*-900/300` はopacity 300%で無効（Tailwindは0-100のみ対応）
- プログレスバー・未読バッジ・ボタンの背景色が表示されていなかった

## 修正内容
- `bg-*-900/300` → `bg-*-500` に統一（8ファイル15箇所）
- 対象: scoreColor.ts, ScoreDistributionCard, ScoreGoalCard, WeeklyGoalProgressCard, DailyGoalCard, FavoriteStatsCard, ChatListPage, AskAiPage
- README: テスト数1297に更新
- S3デプロイ・CloudFrontキャッシュ削除済み

## テスト
- 全1297テスト合格

Close #650