### PR TITLE
feat: AskAiPageの空状態UIをEmptyStateコンポーネントに統一

### DIFF
--- a/frontend/src/components/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/__tests__/EmptyState.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import EmptyState from '../EmptyState';
-import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
+import { ChatBubbleLeftRightIcon, SparklesIcon } from '@heroicons/react/24/outline';
 
 describe('EmptyState', () => {
   it('タイトルを表示する', () => {
@@ -52,5 +52,14 @@ describe('EmptyState', () => {
     // タイトルのみ
     const texts = Array.from(paragraphs).map(p => p.textContent);
     expect(texts).not.toContain('詳しい説明テキスト');
+  });
+
+  it('異なるアイコンでも正しく表示される', () => {
+    const { container } = render(
+      <EmptyState icon={SparklesIcon} title="AIアシスタントへようこそ" description="質問や相談を何でも聞いてください" />
+    );
+    expect(screen.getByText('AIアシスタントへようこそ')).toBeDefined();
+    expect(screen.getByText('質問や相談を何でも聞いてください')).toBeDefined();
+    expect(container.querySelector('svg')).toBeTruthy();
   });
 });

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -8,7 +8,8 @@ import PracticeTimer from '../components/PracticeTimer';
 import SessionNoteEditor from '../components/SessionNoteEditor';
 import ExportSessionButton from '../components/ExportSessionButton';
 import AiSessionListItem from '../components/AiSessionListItem';
-import { PlusIcon, Bars3Icon } from '@heroicons/react/24/outline';
+import EmptyState from '../components/EmptyState';
+import { PlusIcon, Bars3Icon, SparklesIcon } from '@heroicons/react/24/outline';
 import { useAskAi } from '../hooks/useAskAi';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
@@ -116,19 +117,11 @@ export default function AskAiPage() {
         {/* メッセージエリア */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
           {messages.length === 0 && (
-            <div className="flex flex-col items-center justify-center h-full text-center">
-              <div className="bg-surface-3 rounded-full p-4 mb-4">
-                <svg className="w-8 h-8 text-[var(--color-text-faint)]" fill="currentColor" viewBox="0 0 20 20">
-                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                </svg>
-              </div>
-              <h3 className="text-base font-semibold text-[var(--color-text-secondary)] mb-1">
-                AIアシスタントへようこそ
-              </h3>
-              <p className="text-sm text-[var(--color-text-muted)] max-w-xs">
-                質問や相談を何でも聞いてください
-              </p>
-            </div>
+            <EmptyState
+              icon={SparklesIcon}
+              title="AIアシスタントへようこそ"
+              description="質問や相談を何でも聞いてください"
+            />
           )}
           {messages.map((msg) => (
             <div key={msg.id} className="max-w-3xl mx-auto w-full">


### PR DESCRIPTION
## 概要
- AskAiPageのインラインSVG空状態UIをEmptyState+SparklesIconに置換
- 他ページ（ChatListPage, NotesPage等）と同じEmptyStateパターンに統一

## テスト
- EmptyStateテスト+1追加（SparklesIconでの表示確認）
- 全1298テスト合格

Close #652