### PR TITLE
test: EmptyStateエッジケーステスト+3追加

### DIFF
--- a/frontend/src/components/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/__tests__/EmptyState.test.tsx
@@ -62,4 +62,31 @@ describe('EmptyState', () => {
     expect(screen.getByText('質問や相談を何でも聞いてください')).toBeDefined();
     expect(container.querySelector('svg')).toBeTruthy();
   });
+
+  it('タイトルがh3要素で表示される', () => {
+    render(<EmptyState icon={ChatBubbleLeftRightIcon} title="見出しテスト" />);
+    const heading = screen.getByText('見出しテスト');
+    expect(heading.tagName).toBe('H3');
+  });
+
+  it('アクションボタンに説明文とともに表示できる', () => {
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        icon={ChatBubbleLeftRightIcon}
+        title="テスト"
+        description="説明テキスト"
+        action={{ label: '操作', onClick }}
+      />
+    );
+    expect(screen.getByText('説明テキスト')).toBeDefined();
+    expect(screen.getByText('操作')).toBeDefined();
+  });
+
+  it('アイコンがbg-surface-3の丸い背景内に表示される', () => {
+    const { container } = render(<EmptyState icon={ChatBubbleLeftRightIcon} title="テスト" />);
+    const iconWrapper = container.querySelector('.bg-surface-3.rounded-full');
+    expect(iconWrapper).toBeTruthy();
+    expect(iconWrapper?.querySelector('svg')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## 概要
EmptyStateコンポーネントに3つのエッジケーステストを追加。

## 追加テスト
- タイトルがh3要素で表示される確認
- アクションボタン+説明文の同時表示確認
- アイコンがbg-surface-3の丸背景内に表示される確認

## テスト結果
- 全1301テスト合格（+3）

Close #656