### PR TITLE
feat: ExportSessionButton・ErrorBoundary・SecondaryPanelのインラインSVGをHeroiconsに統一

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ReactNode } from 'react';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -28,9 +29,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
       return (
         <div className="flex flex-col items-center justify-center h-full min-h-[300px] text-center px-4">
           <div className="bg-rose-900/30 rounded-full p-4 mb-4">
-            <svg className="w-8 h-8 text-rose-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
-            </svg>
+            <ExclamationTriangleIcon className="w-8 h-8 text-rose-400" />
           </div>
           <h2 className="text-base font-semibold text-[var(--color-text-primary)] mb-1">エラーが発生しました</h2>
           <p className="text-sm text-[var(--color-text-muted)] mb-4 max-w-sm">

--- a/frontend/src/components/ExportSessionButton.tsx
+++ b/frontend/src/components/ExportSessionButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { CheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 
 interface Message {
   id: number;
@@ -31,13 +32,9 @@ export default function ExportSessionButton({ messages }: ExportSessionButtonPro
       className="p-1.5 rounded-lg hover:bg-surface-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
     >
       {copied ? (
-        <svg className="w-4 h-4 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-        </svg>
+        <CheckIcon className="w-4 h-4 text-emerald-500" />
       ) : (
-        <svg className="w-4 h-4 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-        </svg>
+        <ClipboardDocumentIcon className="w-4 h-4 text-[var(--color-text-muted)]" />
       )}
     </button>
   );

--- a/frontend/src/components/layout/SecondaryPanel.tsx
+++ b/frontend/src/components/layout/SecondaryPanel.tsx
@@ -1,3 +1,5 @@
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
 interface SecondaryPanelProps {
   title: string;
   headerContent?: React.ReactNode;
@@ -30,9 +32,7 @@ export default function SecondaryPanel({ title, headerContent, children, mobileO
             className="p-1 hover:bg-surface-2 rounded transition-colors"
             aria-label="パネルを閉じる"
           >
-            <svg className="w-4 h-4 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <XMarkIcon className="w-4 h-4 text-[var(--color-text-muted)]" />
           </button>
         </div>
         {headerContent && <div className="px-4 py-2 border-b border-surface-3">{headerContent}</div>}


### PR DESCRIPTION
## 概要
3コンポーネントのインラインSVGをHeroiconsコンポーネントに置換。

## 変更内容
- ExportSessionButton: CheckIcon + ClipboardDocumentIcon
- ErrorBoundary: ExclamationTriangleIcon
- SecondaryPanel: XMarkIcon

## テスト
- 全1301テスト合格

Close #660