### PR TITLE
refactor: ScenarioCardのインラインSVGをHeroiconsに統一

### DIFF
--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -1,5 +1,7 @@
 import type { PracticeScenario } from '../types';
 import Card from './Card';
+import { BookmarkIcon as BookmarkOutlineIcon, UserIcon } from '@heroicons/react/24/outline';
+import { BookmarkIcon as BookmarkSolidIcon } from '@heroicons/react/24/solid';
 
 interface ScenarioCardProps {
   scenario: PracticeScenario;
@@ -52,9 +54,11 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
               title={isBookmarked ? 'ブックマーク解除' : 'ブックマーク'}
               className="p-0.5 hover:bg-surface-2 rounded transition-colors"
             >
-              <svg className="w-4 h-4" fill={isBookmarked ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-              </svg>
+              {isBookmarked ? (
+                <BookmarkSolidIcon className="w-4 h-4" />
+              ) : (
+                <BookmarkOutlineIcon className="w-4 h-4" />
+              )}
             </button>
           )}
           <span className={`text-xs px-2 py-0.5 rounded border ${difficultyColor[scenario.difficulty] || 'bg-surface-2 text-[var(--color-text-muted)] border-surface-3'}`}>
@@ -68,9 +72,7 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
         {difficultyDescription[scenario.difficulty] || ''} ・ 約5〜10分
       </p>
       <div className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
-        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-        </svg>
+        <UserIcon className="w-3.5 h-3.5" />
         <span>相手役: {scenario.roleName}</span>
       </div>
     </Card>


### PR DESCRIPTION
## 概要
- ブックマークアイコン: BookmarkIcon (solid/outline切り替え)
- ユーザーアイコン: UserIcon

## テスト
- 全1301テスト合格

Close #662