### PR TITLE
fix: ダークテーマをネイビーブルー系に変更・クリーム色バッジ修正

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -72,7 +72,7 @@ export default function AiSessionListItem({
         <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
           <button
             onClick={(e) => { e.stopPropagation(); onStartEdit({ id, title }); }}
-            className="p-1 hover:bg-blue-100 rounded"
+            className="p-1 hover:bg-blue-900/30 rounded"
             title="タイトルを編集"
           >
             <PencilSquareIcon className="w-3.5 h-3.5 text-blue-500" />
@@ -82,7 +82,7 @@ export default function AiSessionListItem({
               e.stopPropagation();
               onDelete(id);
             }}
-            className="p-1 hover:bg-rose-100 rounded"
+            className="p-1 hover:bg-rose-900/30 rounded"
             title="削除"
           >
             <TrashIcon className="w-3.5 h-3.5 text-rose-500" />

--- a/frontend/src/components/DailyChallengeCard.tsx
+++ b/frontend/src/components/DailyChallengeCard.tsx
@@ -22,9 +22,9 @@ const CHALLENGES: Challenge[] = [
 ];
 
 const DIFFICULTY_STYLES: Record<string, string> = {
-  '初級': 'bg-emerald-100 text-emerald-400',
-  '中級': 'bg-amber-100 text-amber-400',
-  '上級': 'bg-rose-100 text-rose-400',
+  '初級': 'bg-emerald-900/30 text-emerald-400',
+  '中級': 'bg-amber-900/30 text-amber-400',
+  '上級': 'bg-rose-900/30 text-rose-400',
 };
 
 export default function DailyChallengeCard() {

--- a/frontend/src/components/ScoreImprovementAdvice.tsx
+++ b/frontend/src/components/ScoreImprovementAdvice.tsx
@@ -35,7 +35,7 @@ export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdvic
         <div className="space-y-3">
           {weakAxes.map((axis) => (
             <div key={axis.axis} data-testid="advice-item" className="flex gap-3">
-              <div className="flex-shrink-0 w-5 h-5 rounded-full bg-amber-100 flex items-center justify-center mt-0.5">
+              <div className="flex-shrink-0 w-5 h-5 rounded-full bg-amber-900/30 flex items-center justify-center mt-0.5">
                 <span className="text-amber-400 text-[10px] font-bold">!</span>
               </div>
               <div>

--- a/frontend/src/components/ScoreRankBadge.tsx
+++ b/frontend/src/components/ScoreRankBadge.tsx
@@ -10,10 +10,10 @@ interface Rank {
 }
 
 function getRank(score: number): Rank {
-  if (score >= 9.0) return { letter: 'S', label: 'エキスパート', bgColor: 'bg-amber-100', textColor: 'text-amber-400' };
+  if (score >= 9.0) return { letter: 'S', label: 'エキスパート', bgColor: 'bg-amber-900/30', textColor: 'text-amber-400' };
   if (score >= 8.0) return { letter: 'A', label: '上級', bgColor: 'bg-surface-3', textColor: 'text-[var(--color-text-secondary)]' };
-  if (score >= 7.0) return { letter: 'B', label: '中級', bgColor: 'bg-orange-100', textColor: 'text-orange-700' };
-  if (score >= 6.0) return { letter: 'C', label: '初級', bgColor: 'bg-emerald-100', textColor: 'text-emerald-400' };
+  if (score >= 7.0) return { letter: 'B', label: '中級', bgColor: 'bg-orange-900/30', textColor: 'text-orange-400' };
+  if (score >= 6.0) return { letter: 'C', label: '初級', bgColor: 'bg-emerald-900/30', textColor: 'text-emerald-400' };
   return { letter: 'D', label: '入門', bgColor: 'bg-surface-3', textColor: 'text-[var(--color-text-muted)]' };
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,22 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Dark theme (default) */
+/* Dark theme (default) - Navy blue base like Zenn */
 :root {
-  --color-surface: #0a0a0a;
-  --color-surface-1: #111827;
-  --color-surface-2: #1f2937;
-  --color-surface-3: #374151;
-  --color-text-primary: #ffffff;
-  --color-text-secondary: #9ca3af;
-  --color-text-tertiary: #6b7280;
-  --color-text-muted: #4b5563;
-  --color-text-faint: #374151;
-  --color-text-subtle: #1f2937;
-  --color-border-hover: #374151;
-  --scrollbar-track: #0a0a0a;
-  --scrollbar-thumb: #374151;
-  --scrollbar-thumb-hover: #4b5563;
+  --color-surface: #0f1219;
+  --color-surface-1: #171c28;
+  --color-surface-2: #1e2535;
+  --color-surface-3: #2a3245;
+  --color-text-primary: #e3e8f0;
+  --color-text-secondary: #9ba4b5;
+  --color-text-tertiary: #6b7690;
+  --color-text-muted: #4a5368;
+  --color-text-faint: #353d50;
+  --color-text-subtle: #1e2535;
+  --color-border-hover: #2a3245;
+  --scrollbar-track: #0f1219;
+  --scrollbar-thumb: #2a3245;
+  --scrollbar-thumb-hover: #4a5368;
   color-scheme: dark;
 }
 

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -31,6 +31,14 @@ vi.mock('../../components/RecentNotesCard', () => ({
   default: () => <div data-testid="recent-notes">RecentNotesCard</div>,
 }));
 
+vi.mock('../../components/CommunicationTipCard', () => ({
+  default: () => <div data-testid="communication-tip">CommunicationTipCard</div>,
+}));
+
+vi.mock('../../components/DailyChallengeCard', () => ({
+  default: () => <div data-testid="daily-challenge">DailyChallengeCard</div>,
+}));
+
 const mockUseMenuData = vi.fn();
 vi.mock('../../hooks/useMenuData', () => ({
   useMenuData: () => mockUseMenuData(),


### PR DESCRIPTION
## 概要
ユーザーフィードバックに基づくダークテーマの大幅改善。

## 変更内容

### 1. 背景色をネイビーブルー系に変更
現在の灰色系からZennのダークモードのような濃紺ベースに変更：
- `surface`: #0a0a0a → **#0f1219**（濃紺ベース）
- `surface-1`: #111827 → **#171c28**（カード背景）
- `surface-2`: #1f2937 → **#1e2535**（ホバー背景）
- `surface-3`: #374151 → **#2a3245**（ボーダー）
- テキスト色も青味がかったグレーに統一

### 2. クリーム色バッジをダークモード対応に修正
`bg-*-100`（クリーム/ライト色）→ `bg-*-900/30`（半透明ダーク色）に変更：
- DailyChallengeCard（初級/中級/上級バッジ）
- ScoreRankBadge（S/B/Cランクバッジ）
- ScoreImprovementAdvice（改善アドバイスアイコン）
- AiSessionListItem（編集/削除ボタンホバー）

### 3. テスト修正
- MenuPageテストのフレーキー修正（CommunicationTipCard/DailyChallengeCardモック追加）

## テスト
- 全1304テスト合格
- S3デプロイ・CloudFrontキャッシュ削除済み

Close #668