### PR TITLE
fix: テキスト輝度改善・.claude gitignore・Tipsカテゴリバッジ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+.claude/

--- a/frontend/src/components/CommunicationTipCard.tsx
+++ b/frontend/src/components/CommunicationTipCard.tsx
@@ -32,7 +32,7 @@ export default function CommunicationTipCard() {
         <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">今日のTips</h3>
         <span
           data-testid="tip-category"
-          className="text-[10px] font-medium text-amber-400 bg-amber-900/30 px-2 py-0.5 rounded"
+          className="text-[10px] font-medium text-[var(--color-text-primary)] border border-[var(--color-text-muted)] px-2 py-0.5 rounded"
         >
           {tip.category}
         </span>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,11 +8,11 @@
   --color-surface-1: #171c28;
   --color-surface-2: #1e2535;
   --color-surface-3: #2a3245;
-  --color-text-primary: #e3e8f0;
-  --color-text-secondary: #9ba4b5;
-  --color-text-tertiary: #6b7690;
-  --color-text-muted: #4a5368;
-  --color-text-faint: #353d50;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #b0bcd0;
+  --color-text-tertiary: #7e8ca4;
+  --color-text-muted: #546178;
+  --color-text-faint: #3a4560;
   --color-text-subtle: #1e2535;
   --color-border-hover: #2a3245;
   --scrollbar-track: #0f1219;


### PR DESCRIPTION
## 概要
- ダークモードのテキスト色を明るく調整（白色輝度向上）
- `.claude/` ディレクトリを `.gitignore` に追加
- CommunicationTipCardのカテゴリバッジを灰色枠・白文字に変更

## 変更内容
- `--color-text-primary`: #e3e8f0 → #f1f5f9（より明るい白色）
- `--color-text-secondary`: #9ba4b5 → #b0bcd0
- `--color-text-tertiary`: #6b7690 → #7e8ca4
- `--color-text-muted`: #4a5368 → #546178
- `--color-text-faint`: #353d50 → #3a4560
- Tipsカテゴリバッジ: amber色 → テーマ変数の白文字・灰色枠

## テスト
- 全1304テストパス（166ファイル）