### PR TITLE
feat: AIアシスタント会話テンプレート機能 (#671)

### DIFF
--- a/frontend/src/components/ConversationTemplates.tsx
+++ b/frontend/src/components/ConversationTemplates.tsx
@@ -1,0 +1,65 @@
+import { ChatBubbleLeftRightIcon, EnvelopeIcon, AcademicCapIcon, PresentationChartBarIcon } from '@heroicons/react/24/outline';
+
+interface Template {
+  title: string;
+  prompt: string;
+  category: string;
+}
+
+interface ConversationTemplatesProps {
+  onSelect: (prompt: string) => void;
+}
+
+const CATEGORIES = [
+  { name: 'メール添削', icon: EnvelopeIcon },
+  { name: '敬語・表現', icon: AcademicCapIcon },
+  { name: '報連相', icon: ChatBubbleLeftRightIcon },
+  { name: '会議・発表', icon: PresentationChartBarIcon },
+];
+
+const TEMPLATES: Template[] = [
+  { category: 'メール添削', title: 'メールの添削をお願い', prompt: '以下のメールをビジネスメールとして添削してください。改善点とその理由も教えてください。' },
+  { category: 'メール添削', title: '件名の改善提案', prompt: 'メールの件名を効果的にするコツを教えてください。具体的な良い例・悪い例も挙げてください。' },
+  { category: '敬語・表現', title: '敬語の使い分け', prompt: '尊敬語・謙譲語・丁寧語の使い分けについて、よくある間違いと正しい使い方を教えてください。' },
+  { category: '敬語・表現', title: 'クッション言葉の練習', prompt: 'ビジネスシーンで使えるクッション言葉を状況別に教えてください。依頼・断り・質問それぞれの場面で使える表現をお願いします。' },
+  { category: '報連相', title: '報告の構成方法', prompt: '上司への報告を分かりやすく伝えるための構成方法を教えてください。「結論→理由→詳細」の型で練習したいです。' },
+  { category: '報連相', title: '悪い報告の伝え方', prompt: '問題やトラブルが発生した場合の報告の仕方を教えてください。相手を不安にさせずに正確に伝えるコツを知りたいです。' },
+  { category: '会議・発表', title: '会議での発言の仕方', prompt: '会議で自分の意見を効果的に伝える方法を教えてください。発言のタイミングや話し方のコツもお願いします。' },
+  { category: '会議・発表', title: '質疑応答の対処法', prompt: 'プレゼンテーション後の質疑応答で、うまく答えられない質問が来た場合の対処法を教えてください。' },
+];
+
+export default function ConversationTemplates({ onSelect }: ConversationTemplatesProps) {
+  return (
+    <div className="max-w-2xl mx-auto w-full space-y-6">
+      <p className="text-sm font-medium text-[var(--color-text-secondary)] text-center">
+        テンプレートから始める
+      </p>
+
+      <div className="flex flex-wrap justify-center gap-2 mb-2">
+        {CATEGORIES.map(({ name, icon: Icon }) => (
+          <span key={name} className="inline-flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] bg-surface-2 px-2.5 py-1 rounded-full">
+            <Icon className="w-3.5 h-3.5" />
+            {name}
+          </span>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {TEMPLATES.map((template) => (
+          <button
+            key={template.title}
+            onClick={() => onSelect(template.prompt)}
+            className="text-left p-3 rounded-lg border border-surface-3 hover:border-[var(--color-text-muted)] hover:bg-surface-2 transition-colors group"
+          >
+            <p className="text-xs font-medium text-[var(--color-text-primary)] group-hover:text-primary-400 transition-colors">
+              {template.title}
+            </p>
+            <p className="text-[10px] text-[var(--color-text-tertiary)] mt-0.5 line-clamp-2">
+              {template.prompt}
+            </p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/ConversationTemplates.test.tsx
+++ b/frontend/src/components/__tests__/ConversationTemplates.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ConversationTemplates from '../ConversationTemplates';
+
+describe('ConversationTemplates', () => {
+  const mockOnSelect = vi.fn();
+
+  it('テンプレートカテゴリが全て表示される', () => {
+    render(<ConversationTemplates onSelect={mockOnSelect} />);
+
+    expect(screen.getByText('メール添削')).toBeInTheDocument();
+    expect(screen.getByText('敬語・表現')).toBeInTheDocument();
+    expect(screen.getByText('報連相')).toBeInTheDocument();
+    expect(screen.getByText('会議・発表')).toBeInTheDocument();
+  });
+
+  it('テンプレートをクリックするとonSelectが呼ばれる', () => {
+    render(<ConversationTemplates onSelect={mockOnSelect} />);
+
+    const firstTemplate = screen.getAllByRole('button')[0];
+    fireEvent.click(firstTemplate);
+
+    expect(mockOnSelect).toHaveBeenCalledTimes(1);
+    expect(mockOnSelect).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('各テンプレートにタイトルと説明が表示される', () => {
+    render(<ConversationTemplates onSelect={mockOnSelect} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.length).toBeGreaterThanOrEqual(8);
+
+    buttons.forEach((button) => {
+      expect(button.textContent).toBeTruthy();
+    });
+  });
+
+  it('見出しテキストが表示される', () => {
+    render(<ConversationTemplates onSelect={mockOnSelect} />);
+
+    expect(screen.getByText('テンプレートから始める')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -9,6 +9,7 @@ import SessionNoteEditor from '../components/SessionNoteEditor';
 import ExportSessionButton from '../components/ExportSessionButton';
 import AiSessionListItem from '../components/AiSessionListItem';
 import EmptyState from '../components/EmptyState';
+import ConversationTemplates from '../components/ConversationTemplates';
 import { PlusIcon, Bars3Icon, SparklesIcon } from '@heroicons/react/24/outline';
 import { useAskAi } from '../hooks/useAskAi';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
@@ -117,11 +118,14 @@ export default function AskAiPage() {
         {/* メッセージエリア */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
           {messages.length === 0 && (
-            <EmptyState
-              icon={SparklesIcon}
-              title="AIアシスタントへようこそ"
-              description="質問や相談を何でも聞いてください"
-            />
+            <div className="flex flex-col items-center justify-center h-full gap-6">
+              <EmptyState
+                icon={SparklesIcon}
+                title="AIアシスタントへようこそ"
+                description="質問や相談を何でも聞いてください"
+              />
+              <ConversationTemplates onSelect={handleSend} />
+            </div>
           )}
           {messages.map((msg) => (
             <div key={msg.id} className="max-w-3xl mx-auto w-full">


### PR DESCRIPTION
## 概要
AIアシスタントページの空状態に会話テンプレート機能を追加。

## 変更内容
- `ConversationTemplates`コンポーネントを新規作成
- 4カテゴリ（メール添削、敬語・表現、報連相、会議・発表）×2 = 8テンプレート
- テンプレートクリックでAIチャットが即座に開始
- AskAiPageの空状態にEmptyStateと共に表示

## テスト
- ConversationTemplatesのユニットテスト4件追加
- 全1308テストパス（167ファイル）

Closes #671