### PR TITLE
refactor: ConversationTemplatesのデータ層分離 (#673)

### DIFF
--- a/frontend/src/components/ConversationTemplates.tsx
+++ b/frontend/src/components/ConversationTemplates.tsx
@@ -1,32 +1,17 @@
 import { ChatBubbleLeftRightIcon, EnvelopeIcon, AcademicCapIcon, PresentationChartBarIcon } from '@heroicons/react/24/outline';
-
-interface Template {
-  title: string;
-  prompt: string;
-  category: string;
-}
+import { TEMPLATE_CATEGORIES, CONVERSATION_TEMPLATES } from '../constants/conversationTemplates';
+import type { TemplateCategory } from '../constants/conversationTemplates';
 
 interface ConversationTemplatesProps {
   onSelect: (prompt: string) => void;
 }
 
-const CATEGORIES = [
-  { name: 'メール添削', icon: EnvelopeIcon },
-  { name: '敬語・表現', icon: AcademicCapIcon },
-  { name: '報連相', icon: ChatBubbleLeftRightIcon },
-  { name: '会議・発表', icon: PresentationChartBarIcon },
-];
-
-const TEMPLATES: Template[] = [
-  { category: 'メール添削', title: 'メールの添削をお願い', prompt: '以下のメールをビジネスメールとして添削してください。改善点とその理由も教えてください。' },
-  { category: 'メール添削', title: '件名の改善提案', prompt: 'メールの件名を効果的にするコツを教えてください。具体的な良い例・悪い例も挙げてください。' },
-  { category: '敬語・表現', title: '敬語の使い分け', prompt: '尊敬語・謙譲語・丁寧語の使い分けについて、よくある間違いと正しい使い方を教えてください。' },
-  { category: '敬語・表現', title: 'クッション言葉の練習', prompt: 'ビジネスシーンで使えるクッション言葉を状況別に教えてください。依頼・断り・質問それぞれの場面で使える表現をお願いします。' },
-  { category: '報連相', title: '報告の構成方法', prompt: '上司への報告を分かりやすく伝えるための構成方法を教えてください。「結論→理由→詳細」の型で練習したいです。' },
-  { category: '報連相', title: '悪い報告の伝え方', prompt: '問題やトラブルが発生した場合の報告の仕方を教えてください。相手を不安にさせずに正確に伝えるコツを知りたいです。' },
-  { category: '会議・発表', title: '会議での発言の仕方', prompt: '会議で自分の意見を効果的に伝える方法を教えてください。発言のタイミングや話し方のコツもお願いします。' },
-  { category: '会議・発表', title: '質疑応答の対処法', prompt: 'プレゼンテーション後の質疑応答で、うまく答えられない質問が来た場合の対処法を教えてください。' },
-];
+const CATEGORY_ICONS: Record<TemplateCategory['iconName'], React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
+  'envelope': EnvelopeIcon,
+  'academic-cap': AcademicCapIcon,
+  'chat-bubble': ChatBubbleLeftRightIcon,
+  'presentation': PresentationChartBarIcon,
+};
 
 export default function ConversationTemplates({ onSelect }: ConversationTemplatesProps) {
   return (
@@ -36,16 +21,19 @@ export default function ConversationTemplates({ onSelect }: ConversationTemplate
       </p>
 
       <div className="flex flex-wrap justify-center gap-2 mb-2">
-        {CATEGORIES.map(({ name, icon: Icon }) => (
-          <span key={name} className="inline-flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] bg-surface-2 px-2.5 py-1 rounded-full">
-            <Icon className="w-3.5 h-3.5" />
-            {name}
-          </span>
-        ))}
+        {TEMPLATE_CATEGORIES.map(({ name, iconName }) => {
+          const Icon = CATEGORY_ICONS[iconName];
+          return (
+            <span key={name} className="inline-flex items-center gap-1 text-xs text-[var(--color-text-tertiary)] bg-surface-2 px-2.5 py-1 rounded-full">
+              <Icon className="w-3.5 h-3.5" />
+              {name}
+            </span>
+          );
+        })}
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-        {TEMPLATES.map((template) => (
+        {CONVERSATION_TEMPLATES.map((template) => (
           <button
             key={template.title}
             onClick={() => onSelect(template.prompt)}

--- a/frontend/src/constants/conversationTemplates.ts
+++ b/frontend/src/constants/conversationTemplates.ts
@@ -1,0 +1,28 @@
+export interface ConversationTemplate {
+  title: string;
+  prompt: string;
+  category: string;
+}
+
+export interface TemplateCategory {
+  name: string;
+  iconName: 'envelope' | 'academic-cap' | 'chat-bubble' | 'presentation';
+}
+
+export const TEMPLATE_CATEGORIES: TemplateCategory[] = [
+  { name: 'メール添削', iconName: 'envelope' },
+  { name: '敬語・表現', iconName: 'academic-cap' },
+  { name: '報連相', iconName: 'chat-bubble' },
+  { name: '会議・発表', iconName: 'presentation' },
+];
+
+export const CONVERSATION_TEMPLATES: ConversationTemplate[] = [
+  { category: 'メール添削', title: 'メールの添削をお願い', prompt: '以下のメールをビジネスメールとして添削してください。改善点とその理由も教えてください。' },
+  { category: 'メール添削', title: '件名の改善提案', prompt: 'メールの件名を効果的にするコツを教えてください。具体的な良い例・悪い例も挙げてください。' },
+  { category: '敬語・表現', title: '敬語の使い分け', prompt: '尊敬語・謙譲語・丁寧語の使い分けについて、よくある間違いと正しい使い方を教えてください。' },
+  { category: '敬語・表現', title: 'クッション言葉の練習', prompt: 'ビジネスシーンで使えるクッション言葉を状況別に教えてください。依頼・断り・質問それぞれの場面で使える表現をお願いします。' },
+  { category: '報連相', title: '報告の構成方法', prompt: '上司への報告を分かりやすく伝えるための構成方法を教えてください。「結論→理由→詳細」の型で練習したいです。' },
+  { category: '報連相', title: '悪い報告の伝え方', prompt: '問題やトラブルが発生した場合の報告の仕方を教えてください。相手を不安にさせずに正確に伝えるコツを知りたいです。' },
+  { category: '会議・発表', title: '会議での発言の仕方', prompt: '会議で自分の意見を効果的に伝える方法を教えてください。発言のタイミングや話し方のコツもお願いします。' },
+  { category: '会議・発表', title: '質疑応答の対処法', prompt: 'プレゼンテーション後の質疑応答で、うまく答えられない質問が来た場合の対処法を教えてください。' },
+];


### PR DESCRIPTION
## 概要
ConversationTemplatesコンポーネントのデータ層をクリーンアーキテクチャに基づいて分離。

## 変更内容
- `src/constants/conversationTemplates.ts` 新規作成
  - `ConversationTemplate` / `TemplateCategory` 型定義をエクスポート
  - `TEMPLATE_CATEGORIES` / `CONVERSATION_TEMPLATES` 定数をエクスポート
- `ConversationTemplates.tsx` を表示層のみに簡素化
  - アイコンマッピングを `CATEGORY_ICONS` として分離

## テスト
- 全1308テストパス（167ファイル）

Closes #673