### PR TITLE
feat: スコアスパークラインをメニューページに追加 (#679)

### DIFF
--- a/frontend/src/components/ScoreSparkline.tsx
+++ b/frontend/src/components/ScoreSparkline.tsx
@@ -1,0 +1,82 @@
+import { ArrowTrendingUpIcon, ArrowTrendingDownIcon } from '@heroicons/react/24/solid';
+import Card from './Card';
+
+interface ScoreSparklineProps {
+  scores: number[];
+}
+
+export default function ScoreSparkline({ scores }: ScoreSparklineProps) {
+  if (scores.length < 2) {
+    return (
+      <Card>
+        <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-1">スコア推移</p>
+        <p className="text-xs text-[var(--color-text-muted)]">データ不足</p>
+      </Card>
+    );
+  }
+
+  const recent = scores.slice(-5);
+  const latest = recent[recent.length - 1];
+  const previous = recent[recent.length - 2];
+  const isUp = latest > previous;
+  const isDown = latest < previous;
+
+  const min = Math.min(...recent);
+  const max = Math.max(...recent);
+  const range = max - min || 1;
+
+  const width = 120;
+  const height = 32;
+  const padding = 2;
+
+  const points = recent.map((score, i) => {
+    const x = padding + (i / (recent.length - 1)) * (width - padding * 2);
+    const y = padding + (1 - (score - min) / range) * (height - padding * 2);
+    return `${x},${y}`;
+  }).join(' ');
+
+  const strokeColor = isUp ? '#34d399' : isDown ? '#f87171' : '#9ba4b5';
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-medium text-[var(--color-text-secondary)]">スコア推移</p>
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-bold text-[var(--color-text-primary)]">{latest}</span>
+          {isUp && (
+            <ArrowTrendingUpIcon data-testid="trend-up" className="w-4 h-4 text-emerald-400" />
+          )}
+          {isDown && (
+            <ArrowTrendingDownIcon data-testid="trend-down" className="w-4 h-4 text-rose-400" />
+          )}
+        </div>
+      </div>
+
+      <svg width={width} height={height} className="w-full" viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
+        <polyline
+          points={points}
+          fill="none"
+          stroke={strokeColor}
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {recent.map((score, i) => {
+          const x = padding + (i / (recent.length - 1)) * (width - padding * 2);
+          const y = padding + (1 - (score - min) / range) * (height - padding * 2);
+          return (
+            <circle
+              key={i}
+              cx={x}
+              cy={y}
+              r={i === recent.length - 1 ? 3 : 2}
+              fill={i === recent.length - 1 ? strokeColor : 'var(--color-surface-3)'}
+              stroke={strokeColor}
+              strokeWidth="1"
+            />
+          );
+        })}
+      </svg>
+    </Card>
+  );
+}

--- a/frontend/src/components/__tests__/ScoreSparkline.test.tsx
+++ b/frontend/src/components/__tests__/ScoreSparkline.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ScoreSparkline from '../ScoreSparkline';
+
+describe('ScoreSparkline', () => {
+  it('スコアが2件以上の場合にSVGグラフが描画される', () => {
+    const { container } = render(<ScoreSparkline scores={[6.0, 7.0, 8.0]} />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+  });
+
+  it('スコアが1件以下の場合はグラフが描画されない', () => {
+    const { container } = render(<ScoreSparkline scores={[7.0]} />);
+
+    const svg = container.querySelector('svg');
+    expect(svg).toBeNull();
+    expect(screen.getByText('データ不足')).toBeInTheDocument();
+  });
+
+  it('最新スコアの数値が表示される', () => {
+    render(<ScoreSparkline scores={[5.0, 6.5, 8.2]} />);
+
+    expect(screen.getByText('8.2')).toBeInTheDocument();
+  });
+
+  it('上昇トレンドの場合に上向きインジケーターが表示される', () => {
+    const { container } = render(<ScoreSparkline scores={[5.0, 6.0, 7.0, 8.0]} />);
+
+    const trendIndicator = container.querySelector('[data-testid="trend-up"]');
+    expect(trendIndicator).toBeTruthy();
+  });
+
+  it('下降トレンドの場合に下向きインジケーターが表示される', () => {
+    const { container } = render(<ScoreSparkline scores={[8.0, 7.0, 6.0, 5.0]} />);
+
+    const trendIndicator = container.querySelector('[data-testid="trend-down"]');
+    expect(trendIndicator).toBeTruthy();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -18,6 +18,7 @@ import ScoreGrowthTrendCard from '../components/ScoreGrowthTrendCard';
 import PracticeFrequencyCard from '../components/PracticeFrequencyCard';
 import MenuNavigationCard from '../components/MenuNavigationCard';
 import SessionCountMilestoneCard from '../components/SessionCountMilestoneCard';
+import ScoreSparkline from '../components/ScoreSparkline';
 import { useMenuData } from '../hooks/useMenuData';
 
 export default function MenuPage() {
@@ -35,6 +36,13 @@ export default function MenuPage() {
             averageScore={averageScore}
             streakDays={uniqueDays}
           />
+        </div>
+      )}
+
+      {/* スコアスパークライン */}
+      {allScores.length >= 2 && (
+        <div className="mb-6">
+          <ScoreSparkline scores={allScores.map(s => s.overallScore)} />
         </div>
       )}
 


### PR DESCRIPTION
## 概要
MenuPageにスコア推移のミニグラフ（スパークライン）を追加。

## 変更内容
- `ScoreSparkline`コンポーネント新規作成
  - 直近5件のスコアをSVGポリラインで描画
  - 最新スコア数値表示
  - 上昇トレンド：緑矢印（ArrowTrendingUpIcon）
  - 下降トレンド：赤矢印（ArrowTrendingDownIcon）
- MenuPageの成長トレンドカードの上に配置

## テスト
- ScoreSparklineのユニットテスト5件追加
- 全1316テストパス（168ファイル）

Closes #679