### PR TITLE
refactor: スキル軸アドバイスデータを定数ファイルに統合 (#681)

### DIFF
--- a/frontend/src/components/PracticeResultSummary.tsx
+++ b/frontend/src/components/PracticeResultSummary.tsx
@@ -1,18 +1,11 @@
 import { useNavigate } from 'react-router-dom';
+import { getAdviceForAxis } from '../constants/axisAdvice';
 import type { ScoreCard } from '../types';
 
 interface PracticeResultSummaryProps {
   scoreCard: ScoreCard;
   scenarioName: string;
 }
-
-const IMPROVEMENT_ADVICE: Record<string, string> = {
-  '論理的構成力': '論理的構成力を伸ばすために、結論→理由→具体例の構成を意識して練習しましょう。',
-  '配慮表現': '配慮表現を伸ばすために、クッション言葉や敬語のバリエーションを増やしましょう。',
-  '要約力': '要約力を伸ばすために、要点を3つに絞って伝える練習をしましょう。',
-  '提案力': '提案力を伸ばすために、代替案を複数用意してから発言する習慣をつけましょう。',
-  '質問・傾聴力': '質問・傾聴力を伸ばすために、相手の発言を復唱してから質問する練習をしましょう。',
-};
 
 export default function PracticeResultSummary({ scoreCard, scenarioName }: PracticeResultSummaryProps) {
   const navigate = useNavigate();
@@ -21,7 +14,7 @@ export default function PracticeResultSummary({ scoreCard, scenarioName }: Pract
   const strongest = sorted[0];
   const weakest = sorted[sorted.length - 1];
 
-  const advice = IMPROVEMENT_ADVICE[weakest.axis] || `${weakest.axis}を伸ばすために、繰り返し練習しましょう。`;
+  const advice = getAdviceForAxis(weakest.axis);
 
   return (
     <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 my-3 max-w-[85%] self-start">

--- a/frontend/src/components/ScoreImprovementAdvice.tsx
+++ b/frontend/src/components/ScoreImprovementAdvice.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import { IMPROVEMENT_ADVICE, SCORE_THRESHOLD } from '../constants/axisAdvice';
 
 interface AxisScore {
   axis: string;
@@ -10,18 +11,8 @@ interface ScoreImprovementAdviceProps {
   scores: AxisScore[];
 }
 
-const AXIS_ADVICE: Record<string, string> = {
-  '論理的構成力': '結論→理由→具体例の順で話す練習をしましょう。報連相の構造化を意識してみてください。',
-  '配慮表現': 'クッション言葉や敬語のバリエーションを増やしましょう。相手の立場に立った表現を心がけてください。',
-  '要約力': '話す前に要点を3つに絞る練習をしましょう。技術的な内容を非エンジニアにも分かるように説明する訓練が効果的です。',
-  '提案力': '課題だけでなく解決策をセットで伝える習慣をつけましょう。代替案を複数用意するとさらに効果的です。',
-  '質問・傾聴力': '5W1Hを意識した質問を心がけましょう。相手の発言を要約して確認する「オウム返し」も有効です。',
-};
-
-const THRESHOLD = 7;
-
 export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdviceProps) {
-  const weakAxes = scores.filter((s) => s.score < THRESHOLD);
+  const weakAxes = scores.filter((s) => s.score < SCORE_THRESHOLD);
 
   return (
     <Card>
@@ -43,7 +34,7 @@ export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdvic
                   {axis.axis}（{axis.score.toFixed(1)}）
                 </p>
                 <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
-                  {AXIS_ADVICE[axis.axis] || `${axis.axis}を伸ばすための練習を続けましょう。`}
+                  {IMPROVEMENT_ADVICE[axis.axis] || `${axis.axis}を伸ばすための練習を続けましょう。`}
                 </p>
               </div>
             </div>

--- a/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
+++ b/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
@@ -48,7 +48,7 @@ describe('PracticeResultSummary', () => {
   it('改善アドバイスが表示される', () => {
     render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
 
-    expect(screen.getByText(/提案力を伸ばすために/)).toBeInTheDocument();
+    expect(screen.getByText(/課題だけでなく解決策をセットで伝える/)).toBeInTheDocument();
   });
 
   it('次の練習へボタンをクリックすると練習ページに遷移する', () => {

--- a/frontend/src/constants/axisAdvice.ts
+++ b/frontend/src/constants/axisAdvice.ts
@@ -1,0 +1,19 @@
+/**
+ * スキル軸別の改善アドバイス定数
+ *
+ * PracticeResultSummary と ScoreImprovementAdvice で共有
+ */
+
+export const IMPROVEMENT_ADVICE: Record<string, string> = {
+  '論理的構成力': '結論→理由→具体例の順で話す練習をしましょう。報連相の構造化を意識してみてください。',
+  '配慮表現': 'クッション言葉や敬語のバリエーションを増やしましょう。相手の立場に立った表現を心がけてください。',
+  '要約力': '話す前に要点を3つに絞る練習をしましょう。技術的な内容を非エンジニアにも分かるように説明する訓練が効果的です。',
+  '提案力': '課題だけでなく解決策をセットで伝える習慣をつけましょう。代替案を複数用意するとさらに効果的です。',
+  '質問・傾聴力': '5W1Hを意識した質問を心がけましょう。相手の発言を要約して確認する「オウム返し」も有効です。',
+};
+
+export const SCORE_THRESHOLD = 7;
+
+export function getAdviceForAxis(axis: string): string {
+  return IMPROVEMENT_ADVICE[axis] || `${axis}を伸ばすための練習を続けましょう。`;
+}


### PR DESCRIPTION
## 概要
重複していたスキル軸アドバイスデータを共通定数ファイルに統合。

## 変更内容
- `src/constants/axisAdvice.ts` 新規作成
  - `IMPROVEMENT_ADVICE`: 5軸アドバイスデータ
  - `SCORE_THRESHOLD`: 改善閾値（7）
  - `getAdviceForAxis()`: 軸名からアドバイスを取得するヘルパー関数
- `PracticeResultSummary.tsx`: ローカルのIMPROVEMENT_ADVICEを削除、`getAdviceForAxis`を使用
- `ScoreImprovementAdvice.tsx`: ローカルのAXIS_ADVICE/THRESHOLDを削除、共通定数をインポート

## テスト
- 全1316テストパス（168ファイル）

Closes #681