### PR TITLE
feat: 練習シナリオ難易度フィルター機能 (#687)

### DIFF
--- a/frontend/src/components/DifficultyFilter.tsx
+++ b/frontend/src/components/DifficultyFilter.tsx
@@ -1,0 +1,34 @@
+interface DifficultyFilterProps {
+  selected: string | null;
+  onChange: (difficulty: string | null) => void;
+}
+
+const DIFFICULTIES = [
+  { value: null, label: '全レベル', style: 'text-[var(--color-text-secondary)] bg-surface-2' },
+  { value: '初級', label: '初級', style: 'text-emerald-400 bg-emerald-900/30' },
+  { value: '中級', label: '中級', style: 'text-amber-400 bg-amber-900/30' },
+  { value: '上級', label: '上級', style: 'text-rose-400 bg-rose-900/30' },
+] as const;
+
+export default function DifficultyFilter({ selected, onChange }: DifficultyFilterProps) {
+  return (
+    <div className="flex gap-1.5">
+      {DIFFICULTIES.map(({ value, label, style }) => {
+        const isActive = selected === value;
+        return (
+          <button
+            key={label}
+            onClick={() => onChange(value)}
+            className={`text-[10px] font-medium px-2.5 py-1 rounded-full transition-colors ${
+              isActive
+                ? style
+                : 'text-[var(--color-text-muted)] bg-transparent hover:bg-surface-2'
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/DifficultyFilter.test.tsx
+++ b/frontend/src/components/__tests__/DifficultyFilter.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DifficultyFilter from '../DifficultyFilter';
+
+describe('DifficultyFilter', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('全ての難易度ボタンが表示される', () => {
+    render(<DifficultyFilter selected={null} onChange={mockOnChange} />);
+
+    expect(screen.getByText('全レベル')).toBeInTheDocument();
+    expect(screen.getByText('初級')).toBeInTheDocument();
+    expect(screen.getByText('中級')).toBeInTheDocument();
+    expect(screen.getByText('上級')).toBeInTheDocument();
+  });
+
+  it('難易度ボタンをクリックするとonChangeが呼ばれる', () => {
+    render(<DifficultyFilter selected={null} onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByText('初級'));
+    expect(mockOnChange).toHaveBeenCalledWith('初級');
+  });
+
+  it('全レベルをクリックするとnullが渡される', () => {
+    render(<DifficultyFilter selected="初級" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByText('全レベル'));
+    expect(mockOnChange).toHaveBeenCalledWith(null);
+  });
+
+  it('選択中の難易度がハイライトされる', () => {
+    render(<DifficultyFilter selected="中級" onChange={mockOnChange} />);
+
+    const selectedButton = screen.getByText('中級');
+    expect(selectedButton.className).toContain('text-amber-400');
+  });
+});

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -13,6 +13,7 @@ const CATEGORY_LABEL_TO_DB: Record<string, string> = {
 export function usePracticePage() {
   const navigate = useNavigate();
   const [selectedCategory, setSelectedCategory] = useState<string>('すべて');
+  const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
   const { scenarios, loading, fetchScenarios, createPracticeSession } = usePractice();
   const { bookmarkedIds, toggleBookmark, isBookmarked } = useBookmark();
 
@@ -21,12 +22,20 @@ export function usePracticePage() {
   }, [fetchScenarios]);
 
   const filteredScenarios = useMemo(() => {
-    if (selectedCategory === 'すべて') return scenarios;
+    let result = scenarios;
+
     if (selectedCategory === 'ブックマーク') {
-      return scenarios.filter((s) => bookmarkedIds.includes(s.id));
+      result = result.filter((s) => bookmarkedIds.includes(s.id));
+    } else if (selectedCategory !== 'すべて') {
+      result = result.filter((s) => s.category === CATEGORY_LABEL_TO_DB[selectedCategory]);
     }
-    return scenarios.filter((s) => s.category === CATEGORY_LABEL_TO_DB[selectedCategory]);
-  }, [scenarios, selectedCategory, bookmarkedIds]);
+
+    if (selectedDifficulty) {
+      result = result.filter((s) => s.difficulty === selectedDifficulty);
+    }
+
+    return result;
+  }, [scenarios, selectedCategory, selectedDifficulty, bookmarkedIds]);
 
   const handleSelectScenario = useCallback(async (scenario: PracticeScenario) => {
     const session = await createPracticeSession({ scenarioId: scenario.id });
@@ -45,6 +54,8 @@ export function usePracticePage() {
   return {
     selectedCategory,
     setSelectedCategory,
+    selectedDifficulty,
+    setSelectedDifficulty,
     filteredScenarios,
     loading,
     handleSelectScenario,

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -1,6 +1,7 @@
 import ScenarioCard from '../components/ScenarioCard';
 import { SkeletonCard } from '../components/Skeleton';
 import FilterTabs from '../components/FilterTabs';
+import DifficultyFilter from '../components/DifficultyFilter';
 import { usePracticePage } from '../hooks/usePracticePage';
 
 const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
@@ -9,6 +10,8 @@ export default function PracticePage() {
   const {
     selectedCategory,
     setSelectedCategory,
+    selectedDifficulty,
+    setSelectedDifficulty,
     filteredScenarios,
     loading,
     handleSelectScenario,
@@ -31,8 +34,13 @@ export default function PracticePage() {
         tabs={[...CATEGORIES]}
         selected={selectedCategory}
         onSelect={setSelectedCategory}
-        className="mb-5"
+        className="mb-3"
       />
+
+      {/* 難易度フィルター */}
+      <div className="mb-5">
+        <DifficultyFilter selected={selectedDifficulty} onChange={setSelectedDifficulty} />
+      </div>
 
       {/* シナリオ一覧 */}
       {loading ? (


### PR DESCRIPTION
## 概要
PracticePageに難易度フィルター（全レベル/初級/中級/上級）を追加。

## 変更内容
- `DifficultyFilter`コンポーネント新規作成（色分けボタン：初級=緑/中級=黄/上級=赤）
- `usePracticePage`フックに`selectedDifficulty`ステート追加
- カテゴリと難易度の複合フィルタリングに対応
- PracticePageのカテゴリタブの下に難易度フィルターを配置

## テスト
- DifficultyFilterのユニットテスト4件追加
- 全1323テストパス（169ファイル）

Closes #687