### PR TITLE
feat: 練習シナリオのソート機能

### DIFF
--- a/frontend/src/components/SortSelector.tsx
+++ b/frontend/src/components/SortSelector.tsx
@@ -1,0 +1,36 @@
+export type SortOption = 'default' | 'difficulty-asc' | 'difficulty-desc' | 'name';
+
+interface SortSelectorProps {
+  selected: SortOption;
+  onChange: (sort: SortOption) => void;
+}
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'default', label: 'デフォルト' },
+  { value: 'difficulty-asc', label: '難易度↑' },
+  { value: 'difficulty-desc', label: '難易度↓' },
+  { value: 'name', label: '名前順' },
+];
+
+export default function SortSelector({ selected, onChange }: SortSelectorProps) {
+  return (
+    <div className="flex gap-1.5">
+      {SORT_OPTIONS.map(({ value, label }) => {
+        const isActive = selected === value;
+        return (
+          <button
+            key={value}
+            onClick={() => onChange(value)}
+            className={`text-[10px] font-medium px-2.5 py-1 rounded-full transition-colors ${
+              isActive
+                ? 'text-[var(--color-text-secondary)] bg-surface-2'
+                : 'text-[var(--color-text-muted)] bg-transparent hover:bg-surface-2'
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SortSelector.test.tsx
+++ b/frontend/src/components/__tests__/SortSelector.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SortSelector from '../SortSelector';
+
+describe('SortSelector', () => {
+  const mockOnChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('全てのソートオプションが表示される', () => {
+    render(<SortSelector selected="default" onChange={mockOnChange} />);
+
+    expect(screen.getByText('デフォルト')).toBeInTheDocument();
+    expect(screen.getByText('難易度↑')).toBeInTheDocument();
+    expect(screen.getByText('難易度↓')).toBeInTheDocument();
+    expect(screen.getByText('名前順')).toBeInTheDocument();
+  });
+
+  it('ソートオプションをクリックするとonChangeが呼ばれる', () => {
+    render(<SortSelector selected="default" onChange={mockOnChange} />);
+
+    fireEvent.click(screen.getByText('難易度↑'));
+    expect(mockOnChange).toHaveBeenCalledWith('difficulty-asc');
+  });
+
+  it('選択中のオプションがハイライトされる', () => {
+    render(<SortSelector selected="name" onChange={mockOnChange} />);
+
+    const selectedButton = screen.getByText('名前順');
+    expect(selectedButton.className).toContain('text-[var(--color-text-secondary)]');
+  });
+
+  it('非選択のオプションはmutedスタイルが適用される', () => {
+    render(<SortSelector selected="default" onChange={mockOnChange} />);
+
+    const unselectedButton = screen.getByText('名前順');
+    expect(unselectedButton.className).toContain('text-[var(--color-text-muted)]');
+  });
+});

--- a/frontend/src/hooks/__tests__/usePracticePage.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticePage.test.ts
@@ -12,9 +12,9 @@ const mockCreatePracticeSession = vi.fn();
 vi.mock('../usePractice', () => ({
   usePractice: () => ({
     scenarios: [
-      { id: 1, name: 'シナリオ1', category: 'customer' },
-      { id: 2, name: 'シナリオ2', category: 'senior' },
-      { id: 3, name: 'シナリオ3', category: 'team' },
+      { id: 1, name: 'シナリオC', category: 'customer', difficulty: 'advanced' },
+      { id: 2, name: 'シナリオA', category: 'senior', difficulty: 'beginner' },
+      { id: 3, name: 'シナリオB', category: 'team', difficulty: 'intermediate' },
     ],
     loading: false,
     fetchScenarios: mockFetchScenarios,
@@ -118,5 +118,37 @@ describe('usePracticePage', () => {
     const { result } = renderHook(() => usePracticePage());
     expect(result.current.isBookmarked).toBeDefined();
     expect(result.current.toggleBookmark).toBeDefined();
+  });
+
+  it('初期ソートはdefault', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.selectedSort).toBe('default');
+  });
+
+  it('難易度昇順でソートできる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedSort('difficulty-asc');
+    });
+    const names = result.current.filteredScenarios.map((s) => s.name);
+    expect(names).toEqual(['シナリオA', 'シナリオB', 'シナリオC']);
+  });
+
+  it('難易度降順でソートできる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedSort('difficulty-desc');
+    });
+    const names = result.current.filteredScenarios.map((s) => s.name);
+    expect(names).toEqual(['シナリオC', 'シナリオB', 'シナリオA']);
+  });
+
+  it('名前順でソートできる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedSort('name');
+    });
+    const names = result.current.filteredScenarios.map((s) => s.name);
+    expect(names).toEqual(['シナリオA', 'シナリオB', 'シナリオC']);
   });
 });

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import type { PracticeScenario } from '../types';
 import { usePractice } from './usePractice';
 import { useBookmark } from './useBookmark';
+import type { SortOption } from '../components/SortSelector';
 
 const CATEGORY_LABEL_TO_DB: Record<string, string> = {
   '顧客折衝': 'customer',
@@ -10,10 +11,17 @@ const CATEGORY_LABEL_TO_DB: Record<string, string> = {
   'チーム内': 'team',
 };
 
+const DIFFICULTY_ORDER: Record<string, number> = {
+  beginner: 1,
+  intermediate: 2,
+  advanced: 3,
+};
+
 export function usePracticePage() {
   const navigate = useNavigate();
   const [selectedCategory, setSelectedCategory] = useState<string>('すべて');
   const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
+  const [selectedSort, setSelectedSort] = useState<SortOption>('default');
   const { scenarios, loading, fetchScenarios, createPracticeSession } = usePractice();
   const { bookmarkedIds, toggleBookmark, isBookmarked } = useBookmark();
 
@@ -34,8 +42,16 @@ export function usePracticePage() {
       result = result.filter((s) => s.difficulty === selectedDifficulty);
     }
 
+    if (selectedSort === 'difficulty-asc') {
+      result = [...result].sort((a, b) => (DIFFICULTY_ORDER[a.difficulty] ?? 0) - (DIFFICULTY_ORDER[b.difficulty] ?? 0));
+    } else if (selectedSort === 'difficulty-desc') {
+      result = [...result].sort((a, b) => (DIFFICULTY_ORDER[b.difficulty] ?? 0) - (DIFFICULTY_ORDER[a.difficulty] ?? 0));
+    } else if (selectedSort === 'name') {
+      result = [...result].sort((a, b) => a.name.localeCompare(b.name, 'ja'));
+    }
+
     return result;
-  }, [scenarios, selectedCategory, selectedDifficulty, bookmarkedIds]);
+  }, [scenarios, selectedCategory, selectedDifficulty, selectedSort, bookmarkedIds]);
 
   const handleSelectScenario = useCallback(async (scenario: PracticeScenario) => {
     const session = await createPracticeSession({ scenarioId: scenario.id });
@@ -56,6 +72,8 @@ export function usePracticePage() {
     setSelectedCategory,
     selectedDifficulty,
     setSelectedDifficulty,
+    selectedSort,
+    setSelectedSort,
     filteredScenarios,
     loading,
     handleSelectScenario,

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -2,6 +2,7 @@ import ScenarioCard from '../components/ScenarioCard';
 import { SkeletonCard } from '../components/Skeleton';
 import FilterTabs from '../components/FilterTabs';
 import DifficultyFilter from '../components/DifficultyFilter';
+import SortSelector from '../components/SortSelector';
 import { usePracticePage } from '../hooks/usePracticePage';
 
 const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
@@ -12,6 +13,8 @@ export default function PracticePage() {
     setSelectedCategory,
     selectedDifficulty,
     setSelectedDifficulty,
+    selectedSort,
+    setSelectedSort,
     filteredScenarios,
     loading,
     handleSelectScenario,
@@ -37,9 +40,10 @@ export default function PracticePage() {
         className="mb-3"
       />
 
-      {/* 難易度フィルター */}
-      <div className="mb-5">
+      {/* 難易度フィルター・ソート */}
+      <div className="flex items-center justify-between mb-5">
         <DifficultyFilter selected={selectedDifficulty} onChange={setSelectedDifficulty} />
+        <SortSelector selected={selectedSort} onChange={setSelectedSort} />
       </div>
 
       {/* シナリオ一覧 */}


### PR DESCRIPTION
## 概要
練習ページにソート機能を追加。カテゴリ・難易度フィルターとの複合利用に対応。

## 変更内容
- `SortSelector`コンポーネント新規作成（デフォルト/難易度↑/難易度↓/名前順）
- `usePracticePage`フックにソートロジック追加（DIFFICULTY_ORDER定数でbeginner→advanced順）
- `PracticePage`に配置（DifficultyFilterの横）

## テスト結果
全1334テスト通過（170ファイル）
- SortSelector: 4テスト追加
- usePracticePage: 4テスト追加

closes #695