### PR TITLE
refactor: ソートオプション定数をconstantsファイルに分離

### DIFF
--- a/frontend/src/components/SortSelector.tsx
+++ b/frontend/src/components/SortSelector.tsx
@@ -1,16 +1,12 @@
-export type SortOption = 'default' | 'difficulty-asc' | 'difficulty-desc' | 'name';
+import { SORT_OPTIONS } from '../constants/sortOptions';
+import type { SortOption } from '../constants/sortOptions';
 
 interface SortSelectorProps {
   selected: SortOption;
   onChange: (sort: SortOption) => void;
 }
 
-const SORT_OPTIONS: { value: SortOption; label: string }[] = [
-  { value: 'default', label: 'デフォルト' },
-  { value: 'difficulty-asc', label: '難易度↑' },
-  { value: 'difficulty-desc', label: '難易度↓' },
-  { value: 'name', label: '名前順' },
-];
+export type { SortOption };
 
 export default function SortSelector({ selected, onChange }: SortSelectorProps) {
   return (

--- a/frontend/src/constants/sortOptions.ts
+++ b/frontend/src/constants/sortOptions.ts
@@ -1,0 +1,25 @@
+/**
+ * ソートオプション定数
+ *
+ * SortSelector と usePracticePage で共有
+ */
+
+export type SortOption = 'default' | 'difficulty-asc' | 'difficulty-desc' | 'name';
+
+export interface SortOptionItem {
+  value: SortOption;
+  label: string;
+}
+
+export const SORT_OPTIONS: SortOptionItem[] = [
+  { value: 'default', label: 'デフォルト' },
+  { value: 'difficulty-asc', label: '難易度↑' },
+  { value: 'difficulty-desc', label: '難易度↓' },
+  { value: 'name', label: '名前順' },
+];
+
+export const DIFFICULTY_ORDER: Record<string, number> = {
+  beginner: 1,
+  intermediate: 2,
+  advanced: 3,
+};

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -3,18 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import type { PracticeScenario } from '../types';
 import { usePractice } from './usePractice';
 import { useBookmark } from './useBookmark';
-import type { SortOption } from '../components/SortSelector';
+import { DIFFICULTY_ORDER } from '../constants/sortOptions';
+import type { SortOption } from '../constants/sortOptions';
 
 const CATEGORY_LABEL_TO_DB: Record<string, string> = {
   '顧客折衝': 'customer',
   'シニア・上司': 'senior',
   'チーム内': 'team',
-};
-
-const DIFFICULTY_ORDER: Record<string, number> = {
-  beginner: 1,
-  intermediate: 2,
-  advanced: 3,
 };
 
 export function usePracticePage() {


### PR DESCRIPTION
## 概要
ソート関連定数を`constants/sortOptions.ts`に統合。

## 変更内容
- `frontend/src/constants/sortOptions.ts` 新規作成（SortOption型, SORT_OPTIONS, DIFFICULTY_ORDER）
- `SortSelector.tsx` からローカル定数削除→constantsインポート
- `usePracticePage.ts` からDIFFICULTY_ORDER削除→constantsインポート

## テスト結果
全1334テスト通過（170ファイル）

closes #697