### PR TITLE
feat: ScenarioCardの難易度バッジを色分け表示

### DIFF
--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -2,6 +2,7 @@ import type { PracticeScenario } from '../types';
 import Card from './Card';
 import { BookmarkIcon as BookmarkOutlineIcon, UserIcon } from '@heroicons/react/24/outline';
 import { BookmarkIcon as BookmarkSolidIcon } from '@heroicons/react/24/solid';
+import { DIFFICULTY_STYLES } from '../constants/difficultyStyles';
 
 interface ScenarioCardProps {
   scenario: PracticeScenario;
@@ -28,11 +29,12 @@ const difficultyDescription: Record<string, string> = {
   advanced: '複雑な交渉・説得',
 };
 
-const difficultyColor: Record<string, string> = {
-  beginner: 'bg-surface-3 text-[var(--color-text-secondary)] border-surface-3',
-  intermediate: 'bg-surface-3 text-[var(--color-text-secondary)] border-surface-3',
-  advanced: 'bg-surface-3 text-[var(--color-text-secondary)] border-surface-3',
-};
+function getDifficultyColor(difficulty: string): string {
+  const label = difficultyLabel[difficulty];
+  return label && DIFFICULTY_STYLES[label]
+    ? DIFFICULTY_STYLES[label]
+    : 'bg-surface-2 text-[var(--color-text-muted)]';
+}
 
 export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggleBookmark }: ScenarioCardProps) {
   const handleBookmarkClick = (e: React.MouseEvent) => {
@@ -61,7 +63,7 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
               )}
             </button>
           )}
-          <span className={`text-xs px-2 py-0.5 rounded border ${difficultyColor[scenario.difficulty] || 'bg-surface-2 text-[var(--color-text-muted)] border-surface-3'}`}>
+          <span className={`text-xs px-2 py-0.5 rounded-full ${getDifficultyColor(scenario.difficulty)}`}>
             {difficultyLabel[scenario.difficulty] || scenario.difficulty}
           </span>
         </div>

--- a/frontend/src/components/__tests__/ScenarioCard.test.tsx
+++ b/frontend/src/components/__tests__/ScenarioCard.test.tsx
@@ -95,4 +95,24 @@ describe('ScenarioCard', () => {
     render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} isBookmarked={true} onToggleBookmark={vi.fn()} />);
     expect(screen.getByTitle('ブックマーク解除')).toBeDefined();
   });
+
+  it('初級バッジにemeraldの色が適用される', () => {
+    const beginnerScenario = { ...mockScenario, difficulty: 'beginner' };
+    render(<ScenarioCard scenario={beginnerScenario} onSelect={vi.fn()} />);
+    const badge = screen.getByText('初級');
+    expect(badge.className).toContain('text-emerald-400');
+  });
+
+  it('中級バッジにamberの色が適用される', () => {
+    render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} />);
+    const badge = screen.getByText('中級');
+    expect(badge.className).toContain('text-amber-400');
+  });
+
+  it('上級バッジにroseの色が適用される', () => {
+    const advancedScenario = { ...mockScenario, difficulty: 'advanced' };
+    render(<ScenarioCard scenario={advancedScenario} onSelect={vi.fn()} />);
+    const badge = screen.getByText('上級');
+    expect(badge.className).toContain('text-rose-400');
+  });
 });


### PR DESCRIPTION
## 概要
ScenarioCardの難易度バッジを色分け表示に変更。

## 変更内容
- 全レベル同色（surface-3）→ DIFFICULTY_STYLES定数の色分け適用
  - 初級: emerald（緑）
  - 中級: amber（黄）
  - 上級: rose（赤）
- `getDifficultyColor()`関数で英語キー→日本語キー→スタイルを変換
- バッジをrounded-fullに統一

## テスト結果
全1340テスト通過（170ファイル）

closes #703