### PR TITLE
test: ScenarioCardのエッジケーステスト3件追加

### DIFF
--- a/frontend/src/components/__tests__/ScenarioCard.test.tsx
+++ b/frontend/src/components/__tests__/ScenarioCard.test.tsx
@@ -115,4 +115,23 @@ describe('ScenarioCard', () => {
     const badge = screen.getByText('上級');
     expect(badge.className).toContain('text-rose-400');
   });
+
+  it('未知のdifficulty値はそのまま表示される', () => {
+    const unknownScenario = { ...mockScenario, difficulty: 'expert' };
+    render(<ScenarioCard scenario={unknownScenario} onSelect={vi.fn()} />);
+    expect(screen.getByText('expert')).toBeDefined();
+  });
+
+  it('未知のcategory値はそのまま表示される', () => {
+    const unknownScenario = { ...mockScenario, category: 'other' };
+    render(<ScenarioCard scenario={unknownScenario} onSelect={vi.fn()} />);
+    expect(screen.getByText('other')).toBeDefined();
+  });
+
+  it('ブックマークボタンクリックでonToggleBookmarkが正しいidで呼ばれる', () => {
+    const onToggleBookmark = vi.fn();
+    render(<ScenarioCard scenario={mockScenario} onSelect={vi.fn()} isBookmarked={false} onToggleBookmark={onToggleBookmark} />);
+    screen.getByTitle('ブックマーク').click();
+    expect(onToggleBookmark).toHaveBeenCalledWith(1);
+  });
 });


### PR DESCRIPTION
## 概要
ScenarioCardコンポーネントのエッジケーステストを3件追加。

## 追加テスト
1. 未知のdifficulty値のフォールバック表示
2. 未知のcategory値のフォールバック表示
3. ブックマーククリック時のonToggleBookmark引数

## テスト結果
全1343テスト通過（170ファイル）

closes #707