### PR TITLE
feat: 練習フィルターリセットボタン

### DIFF
--- a/frontend/src/components/FilterResetButton.tsx
+++ b/frontend/src/components/FilterResetButton.tsx
@@ -1,0 +1,20 @@
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
+
+interface FilterResetButtonProps {
+  isActive: boolean;
+  onReset: () => void;
+}
+
+export default function FilterResetButton({ isActive, onReset }: FilterResetButtonProps) {
+  if (!isActive) return null;
+
+  return (
+    <button
+      onClick={onReset}
+      className="flex items-center gap-1 text-[10px] font-medium text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+    >
+      <ArrowPathIcon className="w-3 h-3" />
+      リセット
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/FilterResetButton.test.tsx
+++ b/frontend/src/components/__tests__/FilterResetButton.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FilterResetButton from '../FilterResetButton';
+
+describe('FilterResetButton', () => {
+  const mockOnReset = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('フィルターが適用されている場合にボタンが表示される', () => {
+    render(<FilterResetButton isActive={true} onReset={mockOnReset} />);
+    expect(screen.getByText('リセット')).toBeInTheDocument();
+  });
+
+  it('フィルターが適用されていない場合にボタンが非表示', () => {
+    render(<FilterResetButton isActive={false} onReset={mockOnReset} />);
+    expect(screen.queryByText('リセット')).not.toBeInTheDocument();
+  });
+
+  it('クリックするとonResetが呼ばれる', () => {
+    render(<FilterResetButton isActive={true} onReset={mockOnReset} />);
+    fireEvent.click(screen.getByText('リセット'));
+    expect(mockOnReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('ArrowPathアイコンが表示される', () => {
+    render(<FilterResetButton isActive={true} onReset={mockOnReset} />);
+    const button = screen.getByText('リセット').closest('button');
+    expect(button).toBeDefined();
+    expect(button?.querySelector('svg')).toBeDefined();
+  });
+});

--- a/frontend/src/hooks/__tests__/usePracticePage.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticePage.test.ts
@@ -151,4 +151,35 @@ describe('usePracticePage', () => {
     const names = result.current.filteredScenarios.map((s) => s.name);
     expect(names).toEqual(['シナリオA', 'シナリオB', 'シナリオC']);
   });
+
+  it('初期状態ではisFilterActiveがfalse', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.isFilterActive).toBe(false);
+  });
+
+  it('フィルター変更でisFilterActiveがtrueになる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedDifficulty('初級');
+    });
+    expect(result.current.isFilterActive).toBe(true);
+  });
+
+  it('resetFiltersで全フィルターが初期状態に戻る', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedCategory('顧客折衝');
+      result.current.setSelectedDifficulty('初級');
+      result.current.setSelectedSort('name');
+    });
+    expect(result.current.isFilterActive).toBe(true);
+
+    act(() => {
+      result.current.resetFilters();
+    });
+    expect(result.current.selectedCategory).toBe('すべて');
+    expect(result.current.selectedDifficulty).toBeNull();
+    expect(result.current.selectedSort).toBe('default');
+    expect(result.current.isFilterActive).toBe(false);
+  });
 });

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -48,6 +48,14 @@ export function usePracticePage() {
     return result;
   }, [scenarios, selectedCategory, selectedDifficulty, selectedSort, bookmarkedIds]);
 
+  const isFilterActive = selectedCategory !== 'すべて' || selectedDifficulty !== null || selectedSort !== 'default';
+
+  const resetFilters = useCallback(() => {
+    setSelectedCategory('すべて');
+    setSelectedDifficulty(null);
+    setSelectedSort('default');
+  }, []);
+
   const handleSelectScenario = useCallback(async (scenario: PracticeScenario) => {
     const session = await createPracticeSession({ scenarioId: scenario.id });
     if (session) {
@@ -69,6 +77,8 @@ export function usePracticePage() {
     setSelectedDifficulty,
     selectedSort,
     setSelectedSort,
+    isFilterActive,
+    resetFilters,
     filteredScenarios,
     loading,
     handleSelectScenario,

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -3,6 +3,7 @@ import { SkeletonCard } from '../components/Skeleton';
 import FilterTabs from '../components/FilterTabs';
 import DifficultyFilter from '../components/DifficultyFilter';
 import SortSelector from '../components/SortSelector';
+import FilterResetButton from '../components/FilterResetButton';
 import { usePracticePage } from '../hooks/usePracticePage';
 
 const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
@@ -15,6 +16,8 @@ export default function PracticePage() {
     setSelectedDifficulty,
     selectedSort,
     setSelectedSort,
+    isFilterActive,
+    resetFilters,
     filteredScenarios,
     loading,
     handleSelectScenario,
@@ -40,9 +43,12 @@ export default function PracticePage() {
         className="mb-3"
       />
 
-      {/* 難易度フィルター・ソート */}
+      {/* 難易度フィルター・ソート・リセット */}
       <div className="flex items-center justify-between mb-5">
-        <DifficultyFilter selected={selectedDifficulty} onChange={setSelectedDifficulty} />
+        <div className="flex items-center gap-3">
+          <DifficultyFilter selected={selectedDifficulty} onChange={setSelectedDifficulty} />
+          <FilterResetButton isActive={isFilterActive} onReset={resetFilters} />
+        </div>
         <SortSelector selected={selectedSort} onChange={setSelectedSort} />
       </div>
 


### PR DESCRIPTION
## 概要
練習ページにフィルターリセットボタンを追加。カテゴリ・難易度・ソートをワンクリックで初期状態に戻す。

## 変更内容
- `FilterResetButton`コンポーネント新規作成（ArrowPathIcon付き・フィルター適用時のみ表示）
- `usePracticePage`にisFilterActive・resetFiltersロジック追加
- `PracticePage`に配置（DifficultyFilterの横）

## テスト結果
全1350テスト通過（171ファイル）

closes #711