### PR TITLE
refactor: CATEGORY_LABEL_TO_DBをscenarioLabels定数に統合

### DIFF
--- a/frontend/src/constants/scenarioLabels.ts
+++ b/frontend/src/constants/scenarioLabels.ts
@@ -1,7 +1,7 @@
 /**
  * シナリオラベル定数
  *
- * ScenarioCard で使用するDB値→日本語の変換マッピング
+ * ScenarioCard・usePracticePage で使用するDB値⇔日本語の変換マッピング
  */
 
 export const DIFFICULTY_LABEL: Record<string, string> = {
@@ -15,6 +15,11 @@ export const CATEGORY_LABEL: Record<string, string> = {
   senior: 'シニア・上司',
   team: 'チーム内',
 };
+
+/** 日本語カテゴリ→DB値の逆引き（usePracticePageのフィルタリングで使用） */
+export const CATEGORY_LABEL_TO_DB: Record<string, string> = Object.fromEntries(
+  Object.entries(CATEGORY_LABEL).map(([k, v]) => [v, k])
+);
 
 export const DIFFICULTY_DESCRIPTION: Record<string, string> = {
   beginner: '基本的な報連相',

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -5,12 +5,7 @@ import { usePractice } from './usePractice';
 import { useBookmark } from './useBookmark';
 import { DIFFICULTY_ORDER } from '../constants/sortOptions';
 import type { SortOption } from '../constants/sortOptions';
-
-const CATEGORY_LABEL_TO_DB: Record<string, string> = {
-  '顧客折衝': 'customer',
-  'シニア・上司': 'senior',
-  'チーム内': 'team',
-};
+import { CATEGORY_LABEL_TO_DB } from '../constants/scenarioLabels';
 
 export function usePracticePage() {
   const navigate = useNavigate();


### PR DESCRIPTION
## 概要
CATEGORY_LABEL_TO_DB定数を`constants/scenarioLabels.ts`に統合。

## 変更内容
- `constants/scenarioLabels.ts`にCATEGORY_LABEL_TO_DB追加（CATEGORY_LABELの逆引き自動生成）
- `usePracticePage.ts`からローカル定数削除→constantsインポート

## テスト結果
全1350テスト通過（171ファイル）

closes #713