### PR TITLE
test: FilterResetButtonのエッジケーステスト3件追加

### DIFF
--- a/frontend/src/components/__tests__/FilterResetButton.test.tsx
+++ b/frontend/src/components/__tests__/FilterResetButton.test.tsx
@@ -31,4 +31,29 @@ describe('FilterResetButton', () => {
     expect(button).toBeDefined();
     expect(button?.querySelector('svg')).toBeDefined();
   });
+
+  it('isActiveがfalseからtrueに変わるとボタンが出現する', () => {
+    const { rerender } = render(<FilterResetButton isActive={false} onReset={mockOnReset} />);
+    expect(screen.queryByText('リセット')).not.toBeInTheDocument();
+
+    rerender(<FilterResetButton isActive={true} onReset={mockOnReset} />);
+    expect(screen.getByText('リセット')).toBeInTheDocument();
+  });
+
+  it('isActiveがtrueからfalseに変わるとボタンが消える', () => {
+    const { rerender } = render(<FilterResetButton isActive={true} onReset={mockOnReset} />);
+    expect(screen.getByText('リセット')).toBeInTheDocument();
+
+    rerender(<FilterResetButton isActive={false} onReset={mockOnReset} />);
+    expect(screen.queryByText('リセット')).not.toBeInTheDocument();
+  });
+
+  it('連続クリックでonResetが複数回呼ばれる', () => {
+    render(<FilterResetButton isActive={true} onReset={mockOnReset} />);
+    const button = screen.getByText('リセット');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(mockOnReset).toHaveBeenCalledTimes(3);
+  });
 });


### PR DESCRIPTION
## 概要
FilterResetButtonコンポーネントのエッジケーステストを3件追加。

## 追加テスト
1. isActive false→trueでボタン出現
2. isActive true→falseでボタン消失
3. 連続クリックでonResetが複数回呼ばれる

## テスト結果
全1353テスト通過（171ファイル）

closes #715