### PR TITLE
feat: 練習シナリオ検索機能の追加

### DIFF
--- a/frontend/src/hooks/__tests__/usePracticePage.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticePage.test.ts
@@ -182,4 +182,39 @@ describe('usePracticePage', () => {
     expect(result.current.selectedSort).toBe('default');
     expect(result.current.isFilterActive).toBe(false);
   });
+
+  it('初期searchQueryは空文字', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.searchQuery).toBe('');
+  });
+
+  it('searchQueryでシナリオ名を絞り込める', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSearchQuery('シナリオA');
+    });
+    expect(result.current.filteredScenarios).toHaveLength(1);
+    expect(result.current.filteredScenarios[0].name).toBe('シナリオA');
+  });
+
+  it('searchQueryが設定されるとisFilterActiveがtrueになる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSearchQuery('テスト');
+    });
+    expect(result.current.isFilterActive).toBe(true);
+  });
+
+  it('resetFiltersでsearchQueryもクリアされる', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSearchQuery('シナリオ');
+    });
+    expect(result.current.searchQuery).toBe('シナリオ');
+
+    act(() => {
+      result.current.resetFilters();
+    });
+    expect(result.current.searchQuery).toBe('');
+  });
 });

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -12,6 +12,7 @@ export function usePracticePage() {
   const [selectedCategory, setSelectedCategory] = useState<string>('すべて');
   const [selectedDifficulty, setSelectedDifficulty] = useState<string | null>(null);
   const [selectedSort, setSelectedSort] = useState<SortOption>('default');
+  const [searchQuery, setSearchQuery] = useState<string>('');
   const { scenarios, loading, fetchScenarios, createPracticeSession } = usePractice();
   const { bookmarkedIds, toggleBookmark, isBookmarked } = useBookmark();
 
@@ -28,6 +29,11 @@ export function usePracticePage() {
       result = result.filter((s) => s.category === CATEGORY_LABEL_TO_DB[selectedCategory]);
     }
 
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter((s) => s.name.toLowerCase().includes(q));
+    }
+
     if (selectedDifficulty) {
       result = result.filter((s) => s.difficulty === selectedDifficulty);
     }
@@ -41,14 +47,15 @@ export function usePracticePage() {
     }
 
     return result;
-  }, [scenarios, selectedCategory, selectedDifficulty, selectedSort, bookmarkedIds]);
+  }, [scenarios, selectedCategory, selectedDifficulty, selectedSort, searchQuery, bookmarkedIds]);
 
-  const isFilterActive = selectedCategory !== 'すべて' || selectedDifficulty !== null || selectedSort !== 'default';
+  const isFilterActive = selectedCategory !== 'すべて' || selectedDifficulty !== null || selectedSort !== 'default' || searchQuery !== '';
 
   const resetFilters = useCallback(() => {
     setSelectedCategory('すべて');
     setSelectedDifficulty(null);
     setSelectedSort('default');
+    setSearchQuery('');
   }, []);
 
   const handleSelectScenario = useCallback(async (scenario: PracticeScenario) => {
@@ -72,6 +79,8 @@ export function usePracticePage() {
     setSelectedDifficulty,
     selectedSort,
     setSelectedSort,
+    searchQuery,
+    setSearchQuery,
     isFilterActive,
     resetFilters,
     filteredScenarios,

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -4,6 +4,7 @@ import FilterTabs from '../components/FilterTabs';
 import DifficultyFilter from '../components/DifficultyFilter';
 import SortSelector from '../components/SortSelector';
 import FilterResetButton from '../components/FilterResetButton';
+import SearchBox from '../components/SearchBox';
 import { usePracticePage } from '../hooks/usePracticePage';
 
 const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
@@ -16,6 +17,8 @@ export default function PracticePage() {
     setSelectedDifficulty,
     selectedSort,
     setSelectedSort,
+    searchQuery,
+    setSearchQuery,
     isFilterActive,
     resetFilters,
     filteredScenarios,
@@ -33,6 +36,11 @@ export default function PracticePage() {
         <p className="text-xs text-[var(--color-text-muted)]">
           AIが相手役を演じます。実践的なビジネスシーンでコミュニケーションスキルを磨きましょう。
         </p>
+      </div>
+
+      {/* 検索ボックス */}
+      <div className="mb-3">
+        <SearchBox value={searchQuery} onChange={setSearchQuery} placeholder="シナリオを検索" />
       </div>
 
       {/* カテゴリタブ */}

--- a/frontend/src/pages/__tests__/PracticePage.test.tsx
+++ b/frontend/src/pages/__tests__/PracticePage.test.tsx
@@ -121,6 +121,34 @@ describe('PracticePage', () => {
     });
   });
 
+  describe('シナリオ検索', () => {
+    it('検索ボックスが表示される', () => {
+      render(
+        <BrowserRouter>
+          <PracticePage />
+        </BrowserRouter>
+      );
+
+      expect(screen.getByPlaceholderText('シナリオを検索')).toBeInTheDocument();
+    });
+
+    it('検索キーワードでシナリオを絞り込める', () => {
+      render(
+        <BrowserRouter>
+          <PracticePage />
+        </BrowserRouter>
+      );
+
+      fireEvent.change(screen.getByPlaceholderText('シナリオを検索'), {
+        target: { value: '障害' },
+      });
+
+      expect(screen.getByText('本番障害の緊急報告')).toBeInTheDocument();
+      expect(screen.queryByText('設計方針の意見対立')).not.toBeInTheDocument();
+      expect(screen.queryByText('チーム内の進捗共有')).not.toBeInTheDocument();
+    });
+  });
+
   describe('シナリオカードクリック時の動作', () => {
     it('シナリオカードクリック時にinitialPromptを含むstateでnavigateする', async () => {
       render(


### PR DESCRIPTION
## 概要
PracticePageにSearchBoxを追加し、シナリオ名でリアルタイム検索できるようにする。

## 変更内容
- usePracticePageにsearchQuery/setSearchQueryステートを追加
- filteredScenariosにシナリオ名の検索フィルタリングを追加
- isFilterActive・resetFiltersにsearchQueryを統合
- PracticePageにSearchBoxを配置

## テスト
- usePracticePageテスト4件追加（searchQuery初期値、絞り込み、isFilterActive、resetFilters）
- PracticePageテスト2件追加（検索ボックス表示、キーワード絞り込み）
- 全1359テストパス

Closes #719