### PR TITLE
refactor: PRACTICE_CATEGORY_TABSをconstantsに分離

### DIFF
--- a/frontend/src/constants/scenarioLabels.ts
+++ b/frontend/src/constants/scenarioLabels.ts
@@ -21,6 +21,9 @@ export const CATEGORY_LABEL_TO_DB: Record<string, string> = Object.fromEntries(
   Object.entries(CATEGORY_LABEL).map(([k, v]) => [v, k])
 );
 
+/** PracticePageのカテゴリタブ一覧 */
+export const PRACTICE_CATEGORY_TABS = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
+
 export const DIFFICULTY_DESCRIPTION: Record<string, string> = {
   beginner: '基本的な報連相',
   intermediate: '利害関係の調整',

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -6,8 +6,7 @@ import SortSelector from '../components/SortSelector';
 import FilterResetButton from '../components/FilterResetButton';
 import SearchBox from '../components/SearchBox';
 import { usePracticePage } from '../hooks/usePracticePage';
-
-const CATEGORIES = ['すべて', 'ブックマーク', '顧客折衝', 'シニア・上司', 'チーム内'] as const;
+import { PRACTICE_CATEGORY_TABS } from '../constants/scenarioLabels';
 
 export default function PracticePage() {
   const {
@@ -45,7 +44,7 @@ export default function PracticePage() {
 
       {/* カテゴリタブ */}
       <FilterTabs
-        tabs={[...CATEGORIES]}
+        tabs={[...PRACTICE_CATEGORY_TABS]}
         selected={selectedCategory}
         onSelect={setSelectedCategory}
         className="mb-3"


### PR DESCRIPTION
## 概要
PracticePageのローカルCATEGORIES定数をconstants/scenarioLabels.tsに移動。

## 変更内容
- scenarioLabels.tsにPRACTICE_CATEGORY_TABSを追加
- PracticePageからローカルCATEGORIES定数を削除しimportに変更

## テスト
- 全1359テストパス

Closes #721