### PR TITLE
feat: 練習シナリオ結果件数表示の追加

### DIFF
--- a/frontend/src/hooks/__tests__/usePracticePage.test.ts
+++ b/frontend/src/hooks/__tests__/usePracticePage.test.ts
@@ -244,4 +244,18 @@ describe('usePracticePage', () => {
     expect(result.current.filteredScenarios).toHaveLength(1);
     expect(result.current.filteredScenarios[0].name).toBe('シナリオA');
   });
+
+  it('totalCountは全シナリオ数を返す', () => {
+    const { result } = renderHook(() => usePracticePage());
+    expect(result.current.totalCount).toBe(3);
+  });
+
+  it('filteredCountはフィルタ後のシナリオ数を返す', () => {
+    const { result } = renderHook(() => usePracticePage());
+    act(() => {
+      result.current.setSelectedCategory('顧客折衝');
+    });
+    expect(result.current.filteredCount).toBe(1);
+    expect(result.current.totalCount).toBe(3);
+  });
 });

--- a/frontend/src/hooks/usePracticePage.ts
+++ b/frontend/src/hooks/usePracticePage.ts
@@ -72,6 +72,9 @@ export function usePracticePage() {
     }
   }, [createPracticeSession, navigate]);
 
+  const totalCount = scenarios.length;
+  const filteredCount = filteredScenarios.length;
+
   return {
     selectedCategory,
     setSelectedCategory,
@@ -84,6 +87,8 @@ export function usePracticePage() {
     isFilterActive,
     resetFilters,
     filteredScenarios,
+    totalCount,
+    filteredCount,
     loading,
     handleSelectScenario,
     isBookmarked,

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -21,6 +21,8 @@ export default function PracticePage() {
     isFilterActive,
     resetFilters,
     filteredScenarios,
+    totalCount,
+    filteredCount,
     loading,
     handleSelectScenario,
     isBookmarked,
@@ -58,6 +60,13 @@ export default function PracticePage() {
         </div>
         <SortSelector selected={selectedSort} onChange={setSelectedSort} />
       </div>
+
+      {/* 結果件数 */}
+      {!loading && (
+        <p className="text-[10px] text-[var(--color-text-muted)] mb-2">
+          {isFilterActive ? `${filteredCount} / ${totalCount}件` : `${totalCount}件`}
+        </p>
+      )}
 
       {/* シナリオ一覧 */}
       {loading ? (

--- a/frontend/src/pages/__tests__/PracticePage.test.tsx
+++ b/frontend/src/pages/__tests__/PracticePage.test.tsx
@@ -121,6 +121,30 @@ describe('PracticePage', () => {
     });
   });
 
+  describe('結果件数表示', () => {
+    it('初期状態で全件数が表示される', () => {
+      render(
+        <BrowserRouter>
+          <PracticePage />
+        </BrowserRouter>
+      );
+
+      expect(screen.getByText('3件')).toBeInTheDocument();
+    });
+
+    it('フィルター適用時にフィルタ後件数と全件数が表示される', () => {
+      render(
+        <BrowserRouter>
+          <PracticePage />
+        </BrowserRouter>
+      );
+
+      fireEvent.click(screen.getByRole('tab', { name: '顧客折衝' }));
+
+      expect(screen.getByText('1 / 3件')).toBeInTheDocument();
+    });
+  });
+
   describe('シナリオ検索', () => {
     it('検索ボックスが表示される', () => {
       render(


### PR DESCRIPTION
## 概要
PracticePageにフィルター・検索結果の件数を表示する。

## 変更内容
- usePracticePageにtotalCount・filteredCountを追加
- PracticePageにフィルター結果件数を表示（適用時: X / Y件、未適用時: Y件）

## テスト
- usePracticePageテスト2件追加（totalCount、filteredCount）
- PracticePageテスト2件追加（初期件数、フィルタ後件数）
- 全1366テストパス

Closes #727