### PR TITLE
refactor: ResultCountコンポーネントの分離

### DIFF
--- a/frontend/src/components/ResultCount.tsx
+++ b/frontend/src/components/ResultCount.tsx
@@ -1,0 +1,13 @@
+interface ResultCountProps {
+  filteredCount: number;
+  totalCount: number;
+  isFilterActive: boolean;
+}
+
+export default function ResultCount({ filteredCount, totalCount, isFilterActive }: ResultCountProps) {
+  return (
+    <p className="text-[10px] text-[var(--color-text-muted)] mb-2">
+      {isFilterActive ? `${filteredCount} / ${totalCount}件` : `${totalCount}件`}
+    </p>
+  );
+}

--- a/frontend/src/components/__tests__/ResultCount.test.tsx
+++ b/frontend/src/components/__tests__/ResultCount.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ResultCount from '../ResultCount';
+
+describe('ResultCount', () => {
+  it('フィルター未適用時に全件数のみ表示する', () => {
+    render(<ResultCount filteredCount={5} totalCount={5} isFilterActive={false} />);
+    expect(screen.getByText('5件')).toBeInTheDocument();
+  });
+
+  it('フィルター適用時にフィルタ後件数と全件数を表示する', () => {
+    render(<ResultCount filteredCount={2} totalCount={5} isFilterActive={true} />);
+    expect(screen.getByText('2 / 5件')).toBeInTheDocument();
+  });
+
+  it('フィルタ後件数が0の場合も表示する', () => {
+    render(<ResultCount filteredCount={0} totalCount={5} isFilterActive={true} />);
+    expect(screen.getByText('0 / 5件')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -4,6 +4,7 @@ import FilterTabs from '../components/FilterTabs';
 import DifficultyFilter from '../components/DifficultyFilter';
 import SortSelector from '../components/SortSelector';
 import FilterResetButton from '../components/FilterResetButton';
+import ResultCount from '../components/ResultCount';
 import SearchBox from '../components/SearchBox';
 import { usePracticePage } from '../hooks/usePracticePage';
 import { PRACTICE_CATEGORY_TABS } from '../constants/scenarioLabels';
@@ -63,9 +64,7 @@ export default function PracticePage() {
 
       {/* 結果件数 */}
       {!loading && (
-        <p className="text-[10px] text-[var(--color-text-muted)] mb-2">
-          {isFilterActive ? `${filteredCount} / ${totalCount}件` : `${totalCount}件`}
-        </p>
+        <ResultCount filteredCount={filteredCount} totalCount={totalCount} isFilterActive={isFilterActive} />
       )}
 
       {/* シナリオ一覧 */}


### PR DESCRIPTION
## 概要
PracticePageの結果件数表示ロジックをResultCountコンポーネントに分離。

## 変更内容
- ResultCountコンポーネント新規作成（フィルタ適用時: X / Y件、未適用時: Y件）
- PracticePageからインラインの件数表示を削除しResultCountに置換

## テスト
- ResultCountテスト3件追加
- 全1369テストパス

Closes #729