### PR TITLE
test: ResultCountのエッジケーステスト追加

### DIFF
--- a/frontend/src/components/__tests__/ResultCount.test.tsx
+++ b/frontend/src/components/__tests__/ResultCount.test.tsx
@@ -17,4 +17,22 @@ describe('ResultCount', () => {
     render(<ResultCount filteredCount={0} totalCount={5} isFilterActive={true} />);
     expect(screen.getByText('0 / 5件')).toBeInTheDocument();
   });
+
+  it('totalCountが0の場合も表示する', () => {
+    render(<ResultCount filteredCount={0} totalCount={0} isFilterActive={false} />);
+    expect(screen.getByText('0件')).toBeInTheDocument();
+  });
+
+  it('全件一致時にフィルター適用でもX / Y形式で表示する', () => {
+    render(<ResultCount filteredCount={5} totalCount={5} isFilterActive={true} />);
+    expect(screen.getByText('5 / 5件')).toBeInTheDocument();
+  });
+
+  it('rerenderで件数が更新される', () => {
+    const { rerender } = render(<ResultCount filteredCount={3} totalCount={10} isFilterActive={true} />);
+    expect(screen.getByText('3 / 10件')).toBeInTheDocument();
+
+    rerender(<ResultCount filteredCount={7} totalCount={10} isFilterActive={true} />);
+    expect(screen.getByText('7 / 10件')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
ResultCountコンポーネントのエッジケーステスト3件追加。

## テスト内容
1. totalCountが0の場合の表示
2. 全件一致時のフィルター適用表示
3. rerenderで件数が更新される

## テスト
- 全1372テストパス

Closes #731