### PR TITLE
fix: scores配列がnull/undefinedの場合のTypeError修正

### DIFF
--- a/frontend/src/components/CommunicationStyleCard.tsx
+++ b/frontend/src/components/CommunicationStyleCard.tsx
@@ -46,7 +46,8 @@ function getAverageScores(sessions: Session[]): Map<string, number> {
   const totals = new Map<string, { sum: number; count: number }>();
 
   for (const session of sessions) {
-    for (const score of session.scores) {
+    const scores = Array.isArray(session.scores) ? session.scores : [];
+    for (const score of scores) {
       const current = totals.get(score.axis) || { sum: 0, count: 0 };
       current.sum += score.score;
       current.count += 1;

--- a/frontend/src/components/SkillTrendChart.tsx
+++ b/frontend/src/components/SkillTrendChart.tsx
@@ -17,9 +17,13 @@ export default function SkillTrendChart({ history }: SkillTrendChartProps) {
 
   const latest = history[history.length - 1];
   const previous = history.length > 1 ? history[history.length - 2] : null;
+  const latestScores = Array.isArray(latest.scores) ? latest.scores : [];
+  const previousScores = Array.isArray(previous?.scores) ? previous.scores : [];
 
-  const skills = latest.scores.map((s) => {
-    const prevScore = previous?.scores.find((p) => p.axis === s.axis)?.score;
+  if (latestScores.length === 0) return null;
+
+  const skills = latestScores.map((s) => {
+    const prevScore = previousScores.find((p) => p.axis === s.axis)?.score;
     const delta = prevScore !== undefined ? s.score - prevScore : null;
 
     return {

--- a/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
+++ b/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
@@ -88,6 +88,14 @@ describe('CommunicationStyleCard', () => {
     expect(screen.getByText('傾聴型コミュニケーター')).toBeInTheDocument();
   });
 
+  it('scoresがnullのセッションでもエラーにならない', () => {
+    const sessions = [
+      { scores: null as unknown as AxisScore[] },
+    ];
+    render(<CommunicationStyleCard sessions={sessions} />);
+    expect(document.body).toBeTruthy();
+  });
+
   it('複数セッションの平均からスタイルを判定する', () => {
     const sessions: Session[] = [
       {

--- a/frontend/src/components/__tests__/SkillTrendChart.test.tsx
+++ b/frontend/src/components/__tests__/SkillTrendChart.test.tsx
@@ -57,6 +57,28 @@ describe('SkillTrendChart', () => {
     expect(screen.getByText('+2')).toBeInTheDocument();
   });
 
+  it('scoresがnullのセッションでもエラーにならない', () => {
+    const history = [
+      { sessionId: 1, scores: null as unknown as { axis: string; score: number }[] },
+    ];
+    const { container } = render(<SkillTrendChart history={history} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('前回セッションのscoresがnullでもエラーにならない', () => {
+    const history = [
+      { sessionId: 1, scores: null as unknown as { axis: string; score: number }[] },
+      {
+        sessionId: 2,
+        scores: [
+          { axis: '論理的構成力', score: 8 },
+        ],
+      },
+    ];
+    render(<SkillTrendChart history={history} />);
+    expect(screen.getByText('論理的構成力')).toBeInTheDocument();
+  });
+
   it('履歴が空の場合は何も表示しない', () => {
     const { container } = render(<SkillTrendChart history={[]} />);
 

--- a/frontend/src/hooks/__tests__/useScoreHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreHistory.test.ts
@@ -186,6 +186,38 @@ describe('useScoreHistory', () => {
     expect(result.current.selectedSession).toBeNull();
   });
 
+  it('scoresがnullのセッションでもエラーにならない', async () => {
+    const mockData = [
+      { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.0, scores: null, createdAt: '2026-02-10' },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(1);
+    });
+
+    expect(result.current.history[0].scores).toEqual([]);
+    expect(result.current.weakestAxis).toBeNull();
+  });
+
+  it('scoresがundefinedのセッションでもエラーにならない', async () => {
+    const mockData = [
+      { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.0, createdAt: '2026-02-10' },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(1);
+    });
+
+    expect(result.current.history[0].scores).toEqual([]);
+    expect(result.current.weakestAxis).toBeNull();
+  });
+
   it('最新セッションのスコアが空の場合にweakestAxisがnullになる', async () => {
     const mockData = [
       { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.0, scores: [], createdAt: '2026-02-10' },

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -32,7 +32,11 @@ export function useScoreHistory() {
   useEffect(() => {
     const loadHistory = async () => {
       const data = await fetchScoreHistory();
-      setHistory(Array.isArray(data) ? data : []);
+      const items = Array.isArray(data) ? data : [];
+      setHistory(items.map((item: ScoreHistoryItem) => ({
+        ...item,
+        scores: Array.isArray(item.scores) ? item.scores : [],
+      })));
     };
     loadHistory();
   }, [fetchScoreHistory]);


### PR DESCRIPTION
## 概要
- APIレスポンスの`scores`フィールドが`null`/`undefined`の場合に`.find()`等の配列操作で`TypeError: s.find is not a function`が発生する問題を修正

## 変更内容
- `useScoreHistory`: データ取得時に各アイテムの`scores`を`Array.isArray`で正規化
- `SkillTrendChart`: `latest.scores`と`previous?.scores`に防御ガード追加
- `CommunicationStyleCard`: `session.scores`に防御ガード追加
- テスト+5件（scoresがnull/undefinedの場合の防御テスト）

## テスト
- [x] 全1377テストパス（+5件）

Closes #735