### PR TITLE
fix: scoreCard.scoresとsession.scoresの配列null防御追加

### DIFF
--- a/frontend/src/components/PracticeResultSummary.tsx
+++ b/frontend/src/components/PracticeResultSummary.tsx
@@ -10,7 +10,10 @@ interface PracticeResultSummaryProps {
 export default function PracticeResultSummary({ scoreCard, scenarioName }: PracticeResultSummaryProps) {
   const navigate = useNavigate();
 
-  const sorted = [...scoreCard.scores].sort((a, b) => b.score - a.score);
+  const scores = Array.isArray(scoreCard.scores) ? scoreCard.scores : [];
+  if (scores.length === 0) return null;
+
+  const sorted = [...scores].sort((a, b) => b.score - a.score);
   const strongest = sorted[0];
   const weakest = sorted[sorted.length - 1];
 

--- a/frontend/src/components/ScoreCard.tsx
+++ b/frontend/src/components/ScoreCard.tsx
@@ -29,7 +29,7 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
       </div>
 
       <div className="space-y-2">
-        {scoreCard.scores.map((axisScore) => (
+        {(Array.isArray(scoreCard.scores) ? scoreCard.scores : []).map((axisScore) => (
           <div key={axisScore.axis}>
             <div className="flex items-center justify-between mb-0.5">
               <span className="text-xs text-[var(--color-text-muted)]">{axisScore.axis}</span>

--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -51,7 +51,7 @@ export default function SessionDetailModal({ session, onClose }: SessionDetailMo
           </div>
 
           <div className="space-y-3">
-            {session.scores.map((axisScore) => (
+            {(Array.isArray(session.scores) ? session.scores : []).map((axisScore) => (
               <div key={axisScore.axis} className="bg-surface-2 rounded-lg p-3">
                 <div className="flex items-center justify-between mb-1.5">
                   <span className="text-xs font-medium text-[var(--color-text-secondary)]">

--- a/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
+++ b/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
@@ -64,6 +64,16 @@ describe('PracticeResultSummary', () => {
     expect(screen.getByText(/障害報告/)).toBeInTheDocument();
   });
 
+  it('scoresがnullでもエラーにならない', () => {
+    const nullCard: ScoreCard = {
+      sessionId: 1,
+      overallScore: 7.0,
+      scores: null as unknown as ScoreCard['scores'],
+    };
+    render(<PracticeResultSummary scoreCard={nullCard} scenarioName="テスト" />);
+    expect(document.body).toBeTruthy();
+  });
+
   it('全軸のスコアが同じ場合でも正しく表示される', () => {
     const equalScores: ScoreCard = {
       sessionId: 2,

--- a/frontend/src/components/__tests__/ScoreCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreCard.test.tsx
@@ -95,6 +95,16 @@ describe('ScoreCard', () => {
     expect(screen.queryByText(/この項目を重点的に練習しましょう/)).not.toBeInTheDocument();
   });
 
+  it('scoresがnullでもエラーにならない', () => {
+    const nullScoresCard: ScoreCardType = {
+      sessionId: 1,
+      scores: null as unknown as ScoreCardType['scores'],
+      overallScore: 7.0,
+    };
+    render(<ScoreCard scoreCard={nullScoresCard} />);
+    expect(screen.getByText('スコアカード')).toBeInTheDocument();
+  });
+
   it('スコアに応じたプログレスバーの色分けがされる', () => {
     render(<ScoreCard scoreCard={scoreCard} />);
 

--- a/frontend/src/components/__tests__/SessionDetailModal.test.tsx
+++ b/frontend/src/components/__tests__/SessionDetailModal.test.tsx
@@ -44,6 +44,15 @@ describe('SessionDetailModal', () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  it('scoresがnullでもエラーにならない', () => {
+    const nullSession = {
+      ...session,
+      scores: null as unknown as typeof session.scores,
+    };
+    render(<SessionDetailModal session={nullSession} onClose={vi.fn()} />);
+    expect(screen.getByText('障害報告の練習')).toBeInTheDocument();
+  });
+
   it('オーバーレイクリックでonCloseが呼ばれる', () => {
     const onClose = vi.fn();
     render(<SessionDetailModal session={session} onClose={onClose} />);

--- a/frontend/src/hooks/useAiChat.ts
+++ b/frontend/src/hooks/useAiChat.ts
@@ -221,7 +221,10 @@ export const useAiChat = () => {
 
     try {
       const data = await AiChatRepository.getScoreCard(sessionId);
-      setScoreCard(data);
+      setScoreCard({
+        ...data,
+        scores: Array.isArray(data.scores) ? data.scores : [],
+      });
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'スコアカードの取得に失敗しました。';


### PR DESCRIPTION
## 概要
- #735 の追加修正。`useAiChat`経由で取得される`scoreCard.scores`と`SessionDetailModal`の`session.scores`にも配列null防御を追加

## 変更内容
- `useAiChat.ts`: scoreCard取得時にscoresを`Array.isArray`で正規化
- `ScoreCard.tsx`: `scoreCard.scores.map()`に防御ガード追加
- `PracticeResultSummary.tsx`: `scoreCard.scores`に防御ガード、空配列時はnull返却
- `SessionDetailModal.tsx`: `session.scores.map()`に防御ガード追加
- テスト+3件（各コンポーネントのscores null防御テスト）

## テスト
- [x] 全1380テストパス（+3件）

Closes #737