### PR TITLE
feat: 「+」ブロック挿入ボタン

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -85,7 +85,12 @@ export default function BlockEditor({ content, onChange }: BlockEditorProps) {
     editor.commands.setContent(newContent);
   }, [content, editor]);
 
+  const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    const now = Date.now();
+    if (now - lastMoveTime.current < 50) return;
+    lastMoveTime.current = now;
+
     if (!containerRef.current) return;
     const editorEl = containerRef.current.querySelector('.ProseMirror');
     if (!editorEl) return;

--- a/frontend/src/components/BlockInserterButton.tsx
+++ b/frontend/src/components/BlockInserterButton.tsx
@@ -17,7 +17,14 @@ export default function BlockInserterButton({ visible, top, onCommand }: BlockIn
   useEffect(() => {
     if (!menuOpen) return;
     setSelectedIndex(0);
+    menuRef.current?.focus();
   }, [menuOpen]);
+
+  useEffect(() => {
+    if (!visible) {
+      setMenuOpen(false);
+    }
+  }, [visible]);
 
   function handleSelect(index: number) {
     const cmd = SLASH_COMMANDS[index];
@@ -66,7 +73,8 @@ export default function BlockInserterButton({ visible, top, onCommand }: BlockIn
       {menuOpen && (
         <div
           ref={menuRef}
-          className="absolute left-8 top-0 z-20"
+          tabIndex={0}
+          className="absolute left-8 top-0 z-20 outline-none"
           onKeyDown={handleKeyDown}
         >
           <SlashCommandMenu

--- a/frontend/src/components/__tests__/BlockInserterButton.test.tsx
+++ b/frontend/src/components/__tests__/BlockInserterButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import BlockInserterButton from '../BlockInserterButton';
 import { SLASH_COMMANDS } from '../../constants/slashCommands';
@@ -43,6 +43,14 @@ describe('BlockInserterButton', () => {
     render(<BlockInserterButton visible={true} top={200} onCommand={mockOnCommand} />);
     const button = screen.getByLabelText('ブロックを追加');
     expect(button.parentElement).toHaveStyle({ top: '200px' });
+  });
+
+  it('visible=falseになるとメニューが閉じる', () => {
+    const { rerender } = render(<BlockInserterButton visible={true} top={100} onCommand={mockOnCommand} />);
+    fireEvent.click(screen.getByLabelText('ブロックを追加'));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    rerender(<BlockInserterButton visible={false} top={100} onCommand={mockOnCommand} />);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 
   it('メニュー表示中にEscで閉じる', () => {


### PR DESCRIPTION
## 概要
ブロック左側にマウスホバーで「+」ボタンを表示し、クリックでスラッシュコマンドメニューと同じメニューを開く機能を追加。

## 変更内容
- `BlockInserterButton` コンポーネント追加（PlusIcon + メニュー表示）
- `BlockEditor` にホバー検知ロジック統合（closest で最寄りブロック要素を検出）
- Esc キーでメニューを閉じる対応
- エディタ領域に `pl-8` パディング追加（「+」ボタンスペース確保）

## 新規ファイル
- `BlockInserterButton.tsx` — 「+」ボタン + メニューUI
- `BlockInserterButton.test.tsx` — テスト7件

## テスト
- 7件追加（合計1438テスト全パス）

Closes #748