### PR TITLE
feat: S3画像アップロード用バックエンドAPI

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/config/S3Config.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.example.FreStyle.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.access-key}")
+    private String accessKey;
+
+    @Value("${aws.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/NoteImageController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/NoteImageController.java
@@ -1,0 +1,42 @@
+package com.example.FreStyle.controller;
+
+import com.example.FreStyle.dto.PresignedUrlRequest;
+import com.example.FreStyle.dto.PresignedUrlResponse;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.NoteImageService;
+import com.example.FreStyle.service.UserIdentityService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notes")
+public class NoteImageController {
+
+    private static final Logger logger = LoggerFactory.getLogger(NoteImageController.class);
+    private final NoteImageService noteImageService;
+    private final UserIdentityService userIdentityService;
+
+    @PostMapping("/{noteId}/images/presigned-url")
+    public ResponseEntity<PresignedUrlResponse> getPresignedUrl(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable String noteId,
+            @Valid @RequestBody PresignedUrlRequest request
+    ) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+
+        PresignedUrlResponse response = noteImageService.generatePresignedUrl(
+                user.getId(), noteId, request.fileName(), request.contentType()
+        );
+        logger.info("Presigned URL生成成功 - noteId: {}, fileName: {}", noteId, request.fileName());
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/PresignedUrlRequest.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/PresignedUrlRequest.java
@@ -1,0 +1,8 @@
+package com.example.FreStyle.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PresignedUrlRequest(
+    @NotBlank String fileName,
+    @NotBlank String contentType
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/PresignedUrlResponse.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/PresignedUrlResponse.java
@@ -1,0 +1,6 @@
+package com.example.FreStyle.dto;
+
+public record PresignedUrlResponse(
+    String uploadUrl,
+    String imageUrl
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/service/NoteImageService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/NoteImageService.java
@@ -1,0 +1,65 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.dto.PresignedUrlResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class NoteImageService {
+
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml"
+    );
+
+    private final S3Presigner s3Presigner;
+    private final String bucketName;
+    private final String cdnBaseUrl;
+
+    public NoteImageService(
+            S3Presigner s3Presigner,
+            @Value("${aws.s3.note-images-bucket}") String bucketName,
+            @Value("${aws.s3.note-images-cdn-url}") String cdnBaseUrl) {
+        this.s3Presigner = s3Presigner;
+        this.bucketName = bucketName;
+        this.cdnBaseUrl = cdnBaseUrl;
+    }
+
+    public PresignedUrlResponse generatePresignedUrl(Integer userId, String noteId, String fileName, String contentType) {
+        if (!ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new IllegalArgumentException("許可されていないファイル形式です: " + contentType);
+        }
+
+        String key = buildKey(userId, noteId, fileName);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+
+        String uploadUrl = presignedRequest.url().toString();
+        String imageUrl = cdnBaseUrl + "/" + key;
+
+        return new PresignedUrlResponse(uploadUrl, imageUrl);
+    }
+
+    private String buildKey(Integer userId, String noteId, String fileName) {
+        String uuid = UUID.randomUUID().toString().substring(0, 8);
+        return "notes/" + userId + "/" + noteId + "/" + uuid + "_" + fileName;
+    }
+}

--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -40,6 +40,10 @@ aws.dynamodb.table-name.ai-chat=fre_style_ai_chat
 aws.dynamodb.table-name.chat=fre_style_chat
 aws.dynamodb.table-name.notes=fre_style_notes
 
+# S3 ノート画像
+aws.s3.note-images-bucket=${NOTE_IMAGES_BUCKET}
+aws.s3.note-images-cdn-url=${NOTE_IMAGES_CDN_URL}
+
 # ========== ロギング設定 ==========
 # Spring Security
 logging.level.org.springframework.security=DEBUG

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/NoteImageControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/NoteImageControllerTest.java
@@ -1,0 +1,96 @@
+package com.example.FreStyle.controller;
+
+import com.example.FreStyle.dto.PresignedUrlRequest;
+import com.example.FreStyle.dto.PresignedUrlResponse;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.NoteImageService;
+import com.example.FreStyle.service.UserIdentityService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NoteImageControllerTest {
+
+    @Mock
+    private NoteImageService noteImageService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private NoteImageController noteImageController;
+
+    private Jwt jwt;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("test-sub");
+
+        user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+    }
+
+    @Test
+    @DisplayName("Presigned URLを生成して返す")
+    void shouldReturnPresignedUrl() {
+        PresignedUrlResponse expected = new PresignedUrlResponse(
+                "https://s3.example.com/upload", "https://cdn.example.com/notes/1/note1/abc_image.png"
+        );
+        when(noteImageService.generatePresignedUrl(1, "note1", "image.png", "image/png"))
+                .thenReturn(expected);
+
+        ResponseEntity<PresignedUrlResponse> response = noteImageController.getPresignedUrl(
+                jwt, "note1", new PresignedUrlRequest("image.png", "image/png")
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().uploadUrl()).isEqualTo("https://s3.example.com/upload");
+        assertThat(response.getBody().imageUrl()).startsWith("https://cdn.example.com/notes/1/note1/");
+        verify(noteImageService).generatePresignedUrl(1, "note1", "image.png", "image/png");
+    }
+
+    @Test
+    @DisplayName("NoteImageServiceにユーザーIDを渡す")
+    void shouldPassUserIdToService() {
+        user.setId(42);
+        PresignedUrlResponse expected = new PresignedUrlResponse(
+                "https://s3.example.com/upload", "https://cdn.example.com/notes/42/noteXYZ/abc_photo.jpg"
+        );
+        when(noteImageService.generatePresignedUrl(42, "noteXYZ", "photo.jpg", "image/jpeg"))
+                .thenReturn(expected);
+
+        noteImageController.getPresignedUrl(
+                jwt, "noteXYZ", new PresignedUrlRequest("photo.jpg", "image/jpeg")
+        );
+
+        verify(noteImageService).generatePresignedUrl(42, "noteXYZ", "photo.jpg", "image/jpeg");
+    }
+
+    @Test
+    @DisplayName("不正なcontentTypeはサービス層でエラーになる")
+    void shouldPropagateServiceException() {
+        when(noteImageService.generatePresignedUrl(1, "note1", "file.exe", "application/octet-stream"))
+                .thenThrow(new IllegalArgumentException("許可されていないファイル形式です: application/octet-stream"));
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () ->
+                noteImageController.getPresignedUrl(
+                        jwt, "note1", new PresignedUrlRequest("file.exe", "application/octet-stream")
+                )
+        );
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/NoteImageServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/NoteImageServiceTest.java
@@ -1,0 +1,87 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.dto.PresignedUrlResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NoteImageServiceTest {
+
+    @Mock
+    private S3Presigner s3Presigner;
+
+    @Mock
+    private PresignedPutObjectRequest presignedPutObjectRequest;
+
+    private NoteImageService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new NoteImageService(s3Presigner, "test-bucket", "https://cdn.example.com");
+    }
+
+    @Test
+    void presigned_URLを生成できる() throws Exception {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenReturn(presignedPutObjectRequest);
+        when(presignedPutObjectRequest.url()).thenReturn(new URL("https://s3.example.com/upload"));
+
+        PresignedUrlResponse response = service.generatePresignedUrl(1, "note1", "image.png", "image/png");
+
+        assertThat(response.uploadUrl()).startsWith("https://s3.example.com/");
+        assertThat(response.imageUrl()).startsWith("https://cdn.example.com/notes/1/note1/");
+        assertThat(response.imageUrl()).endsWith("_image.png");
+    }
+
+    @Test
+    void S3キーにユーザーIDとノートIDが含まれる() throws Exception {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenReturn(presignedPutObjectRequest);
+        when(presignedPutObjectRequest.url()).thenReturn(new URL("https://s3.example.com/upload"));
+
+        service.generatePresignedUrl(42, "noteXYZ", "photo.jpg", "image/jpeg");
+
+        ArgumentCaptor<PutObjectPresignRequest> captor = ArgumentCaptor.forClass(PutObjectPresignRequest.class);
+        verify(s3Presigner).presignPutObject(captor.capture());
+
+        String key = captor.getValue().putObjectRequest().key();
+        assertThat(key).startsWith("notes/42/noteXYZ/");
+        assertThat(key).endsWith("_photo.jpg");
+    }
+
+    @Test
+    void contentTypeがS3リクエストに含まれる() throws Exception {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenReturn(presignedPutObjectRequest);
+        when(presignedPutObjectRequest.url()).thenReturn(new URL("https://s3.example.com/upload"));
+
+        service.generatePresignedUrl(1, "note1", "image.png", "image/png");
+
+        ArgumentCaptor<PutObjectPresignRequest> captor = ArgumentCaptor.forClass(PutObjectPresignRequest.class);
+        verify(s3Presigner).presignPutObject(captor.capture());
+
+        assertThat(captor.getValue().putObjectRequest().contentType()).isEqualTo("image/png");
+    }
+
+    @Test
+    void 画像以外のcontentTypeはエラー() {
+        assertThatThrownBy(() ->
+                service.generatePresignedUrl(1, "note1", "file.exe", "application/octet-stream")
+        ).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## 概要
ノートエディタへの画像挿入機能のバックエンド部分を実装。
S3 Presigned URLを生成するAPIエンドポイントを追加。

## 変更内容
- `S3Config` — S3Presigner Spring Bean設定
- `NoteImageService` — Presigned URL生成ロジック（contentTypeバリデーション付き）
- `NoteImageController` — `POST /api/notes/{noteId}/images/presigned-url` エンドポイント
- `PresignedUrlRequest` / `PresignedUrlResponse` — DTOレコード
- `application.properties` — S3バケット名・CDN URL設定追加

## S3パス構成
`notes/{userId}/{noteId}/{uuid}_{fileName}`

## フロー
1. フロントエンド → Presigned URL取得（このPR）
2. フロントエンド → S3に直接PUT（PR6）
3. CDN URL経由でエディタに画像挿入（PR6）

## テスト
- `NoteImageServiceTest` — 4テストケース（URL生成、S3キー検証、contentType検証、不正ファイル形式エラー）
- `NoteImageControllerTest` — 3テストケース（正常系、ユーザーID連携、エラー伝播）

closes #752