### PR TITLE
feat: 画像アップロード機能（フロントエンド）

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -5,6 +5,7 @@ import BlockEditor from './BlockEditor';
 interface NoteEditorProps {
   title: string;
   content: string;
+  noteId: string | null;
   onTitleChange: (title: string) => void;
   onContentChange: (content: string) => void;
 }
@@ -12,6 +13,7 @@ interface NoteEditorProps {
 export default function NoteEditor({
   title,
   content,
+  noteId,
   onTitleChange,
   onContentChange,
 }: NoteEditorProps) {
@@ -28,7 +30,7 @@ export default function NoteEditor({
         className="text-xl font-bold text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full mb-4 placeholder:text-[var(--color-text-faint)]"
       />
 
-      <BlockEditor content={content} onChange={onContentChange} />
+      <BlockEditor content={content} onChange={onContentChange} noteId={noteId} />
 
       <div className="flex items-center gap-3 pt-3 border-t border-surface-3 text-[11px] text-[var(--color-text-faint)]" aria-label="ノート統計">
         <span>{stats.charCount}文字</span>

--- a/frontend/src/components/__tests__/NoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteEditor.test.tsx
@@ -5,6 +5,7 @@ import NoteEditor from '../NoteEditor';
 const defaultProps = {
   title: 'テストノート',
   content: '',
+  noteId: 'note-1',
   onTitleChange: vi.fn(),
   onContentChange: vi.fn(),
 };

--- a/frontend/src/constants/__tests__/slashCommands.test.ts
+++ b/frontend/src/constants/__tests__/slashCommands.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { SLASH_COMMANDS } from '../slashCommands';
 
 describe('SLASH_COMMANDS', () => {
-  it('7つのコマンドが定義されている', () => {
-    expect(SLASH_COMMANDS).toHaveLength(7);
+  it('8つのコマンドが定義されている', () => {
+    expect(SLASH_COMMANDS).toHaveLength(8);
   });
 
   it('各コマンドに必要なプロパティがある', () => {

--- a/frontend/src/constants/slashCommands.ts
+++ b/frontend/src/constants/slashCommands.ts
@@ -5,7 +5,8 @@ export type SlashCommandAction =
   | 'heading3'
   | 'bulletList'
   | 'orderedList'
-  | 'toggleList';
+  | 'toggleList'
+  | 'image';
 
 export interface SlashCommand {
   label: string;
@@ -22,4 +23,5 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { label: '箇条書き', description: '箇条書きリスト', icon: '•', action: 'bulletList' },
   { label: '番号付きリスト', description: '順序付きリスト', icon: '1.', action: 'orderedList' },
   { label: 'トグル', description: '開閉可能なブロック', icon: '▶', action: 'toggleList' },
+  { label: '画像', description: '画像をアップロード', icon: '🖼', action: 'image' },
 ];

--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -33,6 +33,9 @@ function executeCommand(editor: Editor, command: SlashCommand) {
       }
       break;
     }
+    case 'image':
+      // image action is handled externally via onImageUpload callback
+      break;
     default: {
       const _exhaustive: never = command.action;
       console.error('Unknown slash command action:', _exhaustive);

--- a/frontend/src/hooks/__tests__/useImageUpload.test.ts
+++ b/frontend/src/hooks/__tests__/useImageUpload.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useImageUpload } from '../useImageUpload';
+import NoteImageRepository from '../../repositories/NoteImageRepository';
+
+vi.mock('../../repositories/NoteImageRepository', () => ({
+  default: {
+    getPresignedUrl: vi.fn(),
+    uploadToS3: vi.fn(),
+  },
+}));
+
+function createMockEditor() {
+  const run = vi.fn();
+  const setImage = vi.fn(() => ({ run }));
+  const focus = vi.fn(() => ({ setImage }));
+  const chain = vi.fn(() => ({ focus }));
+  return { chain, focus, setImage, run } as unknown as ReturnType<typeof createMockEditor> & {
+    chain: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
+    setImage: ReturnType<typeof vi.fn>;
+    run: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('useImageUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('画像ファイルをアップロードしてエディタに挿入する', async () => {
+    const editor = createMockEditor();
+    vi.mocked(NoteImageRepository.getPresignedUrl).mockResolvedValue({
+      uploadUrl: 'https://s3.example.com/upload',
+      imageUrl: 'https://cdn.example.com/image.png',
+    });
+    vi.mocked(NoteImageRepository.uploadToS3).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useImageUpload('note1', editor as any));
+
+    const file = new File(['test'], 'photo.png', { type: 'image/png' });
+    await act(async () => {
+      await result.current.uploadAndInsert(file);
+    });
+
+    expect(NoteImageRepository.getPresignedUrl).toHaveBeenCalledWith('note1', 'photo.png', 'image/png');
+    expect(NoteImageRepository.uploadToS3).toHaveBeenCalledWith('https://s3.example.com/upload', file);
+    expect(editor.chain).toHaveBeenCalled();
+  });
+
+  it('noteIdがnullの場合はアップロードしない', async () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useImageUpload(null, editor as any));
+
+    const file = new File(['test'], 'photo.png', { type: 'image/png' });
+    await act(async () => {
+      await result.current.uploadAndInsert(file);
+    });
+
+    expect(NoteImageRepository.getPresignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('許可されていないファイル形式はアップロードしない', async () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useImageUpload('note1', editor as any));
+
+    const file = new File(['test'], 'file.pdf', { type: 'application/pdf' });
+    await act(async () => {
+      await result.current.uploadAndInsert(file);
+    });
+
+    expect(NoteImageRepository.getPresignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('エラー時にコンソールエラーを出力する', async () => {
+    const editor = createMockEditor();
+    vi.mocked(NoteImageRepository.getPresignedUrl).mockRejectedValue(new Error('network error'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useImageUpload('note1', editor as any));
+
+    const file = new File(['test'], 'photo.png', { type: 'image/png' });
+    await act(async () => {
+      await result.current.uploadAndInsert(file);
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith('画像アップロードに失敗しました:', expect.any(Error));
+    consoleSpy.mockRestore();
+  });
+});

--- a/frontend/src/hooks/useImageUpload.ts
+++ b/frontend/src/hooks/useImageUpload.ts
@@ -1,0 +1,74 @@
+import { useCallback, useRef } from 'react';
+import type { Editor } from '@tiptap/core';
+import NoteImageRepository from '../repositories/NoteImageRepository';
+
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
+
+export function useImageUpload(noteId: string | null, editor: Editor | null) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const uploadAndInsert = useCallback(async (file: File) => {
+    if (!noteId || !editor) return;
+    if (!ALLOWED_TYPES.includes(file.type)) return;
+
+    try {
+      const { uploadUrl, imageUrl } = await NoteImageRepository.getPresignedUrl(
+        noteId, file.name, file.type
+      );
+      await NoteImageRepository.uploadToS3(uploadUrl, file);
+      editor.chain().focus().setImage({ src: imageUrl, alt: file.name }).run();
+    } catch (error) {
+      console.error('画像アップロードに失敗しました:', error);
+    }
+  }, [noteId, editor]);
+
+  const handleFilesFromInput = useCallback((files: FileList | null) => {
+    if (!files) return;
+    Array.from(files).forEach(file => uploadAndInsert(file));
+  }, [uploadAndInsert]);
+
+  const openFileDialog = useCallback(() => {
+    if (!fileInputRef.current) {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = 'image/*';
+      input.style.display = 'none';
+      input.addEventListener('change', () => {
+        handleFilesFromInput(input.files);
+        input.value = '';
+      });
+      document.body.appendChild(input);
+      fileInputRef.current = input;
+    }
+    fileInputRef.current.click();
+  }, [handleFilesFromInput]);
+
+  const handleDrop = useCallback((event: React.DragEvent) => {
+    const files = event.dataTransfer?.files;
+    if (!files || files.length === 0) return;
+
+    const imageFiles = Array.from(files).filter(f => ALLOWED_TYPES.includes(f.type));
+    if (imageFiles.length === 0) return;
+
+    event.preventDefault();
+    imageFiles.forEach(file => uploadAndInsert(file));
+  }, [uploadAndInsert]);
+
+  const handlePaste = useCallback((event: React.ClipboardEvent) => {
+    const items = event.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) {
+          event.preventDefault();
+          uploadAndInsert(file);
+          return;
+        }
+      }
+    }
+  }, [uploadAndInsert]);
+
+  return { uploadAndInsert, openFileDialog, handleDrop, handlePaste };
+}

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -131,6 +131,7 @@ export default function NotesPage() {
           <NoteEditor
             title={editTitle}
             content={editContent}
+            noteId={selectedNoteId}
             onTitleChange={handleTitleChange}
             onContentChange={handleContentChange}
           />

--- a/frontend/src/repositories/NoteImageRepository.ts
+++ b/frontend/src/repositories/NoteImageRepository.ts
@@ -1,0 +1,25 @@
+import apiClient from '../lib/axios';
+import axios from 'axios';
+
+interface PresignedUrlResponse {
+  uploadUrl: string;
+  imageUrl: string;
+}
+
+const NoteImageRepository = {
+  async getPresignedUrl(noteId: string, fileName: string, contentType: string): Promise<PresignedUrlResponse> {
+    const res = await apiClient.post(`/api/notes/${noteId}/images/presigned-url`, {
+      fileName,
+      contentType,
+    });
+    return res.data;
+  },
+
+  async uploadToS3(uploadUrl: string, file: File): Promise<void> {
+    await axios.put(uploadUrl, file, {
+      headers: { 'Content-Type': file.type },
+    });
+  },
+};
+
+export default NoteImageRepository;

--- a/frontend/src/repositories/__tests__/NoteImageRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteImageRepository.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NoteImageRepository from '../NoteImageRepository';
+import apiClient from '../../lib/axios';
+import axios from 'axios';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    put: vi.fn(),
+  },
+}));
+
+describe('NoteImageRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPresignedUrl', () => {
+    it('presigned URLを取得する', async () => {
+      const mockResponse = {
+        data: {
+          uploadUrl: 'https://s3.example.com/upload',
+          imageUrl: 'https://cdn.example.com/notes/1/note1/abc_image.png',
+        },
+      };
+      vi.mocked(apiClient.post).mockResolvedValue(mockResponse);
+
+      const result = await NoteImageRepository.getPresignedUrl('note1', 'image.png', 'image/png');
+
+      expect(apiClient.post).toHaveBeenCalledWith('/api/notes/note1/images/presigned-url', {
+        fileName: 'image.png',
+        contentType: 'image/png',
+      });
+      expect(result.uploadUrl).toBe('https://s3.example.com/upload');
+      expect(result.imageUrl).toBe('https://cdn.example.com/notes/1/note1/abc_image.png');
+    });
+  });
+
+  describe('uploadToS3', () => {
+    it('S3にファイルをアップロードする', async () => {
+      vi.mocked(axios.put).mockResolvedValue({ status: 200 });
+      const file = new File(['test'], 'image.png', { type: 'image/png' });
+
+      await NoteImageRepository.uploadToS3('https://s3.example.com/upload', file);
+
+      expect(axios.put).toHaveBeenCalledWith('https://s3.example.com/upload', file, {
+        headers: { 'Content-Type': 'image/png' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 概要
ブロックエディタに画像アップロード機能を追加（フロントエンド部分）。

## 変更内容
- `NoteImageRepository` — presigned URL取得 + S3直接アップロード
- `useImageUpload` — ドラッグ&ドロップ・ペースト・ファイル選択ダイアログ対応
- スラッシュコマンドに「画像」コマンド追加（`/画像`で呼び出し）
- `BlockEditor` — noteId prop追加、onDrop/onPaste/onDragOverイベント対応
- `NoteEditor` / `NotesPage` — noteIdの伝搬

## 対応操作
- `/画像` スラッシュコマンド → ファイル選択ダイアログ
- 「+」ボタン → 画像メニュー → ファイル選択ダイアログ
- ドラッグ&ドロップで画像挿入
- クリップボードからのペースト

## テスト
- `NoteImageRepository.test.ts` — 2テスト（presigned URL取得、S3アップロード）
- `useImageUpload.test.ts` — 4テスト（正常系、null noteId、不正形式、エラーハンドリング）

closes #754