### PR TITLE
feat: タスクリスト（チェックリスト）機能

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,8 @@
         "@tiptap/extension-dropcursor": "^3.19.0",
         "@tiptap/extension-image": "^3.19.0",
         "@tiptap/extension-placeholder": "^3.19.0",
+        "@tiptap/extension-task-item": "^3.19.0",
+        "@tiptap/extension-task-list": "^3.19.0",
         "@tiptap/pm": "^3.19.0",
         "@tiptap/react": "^3.19.0",
         "@tiptap/starter-kit": "^3.19.0",
@@ -2221,6 +2223,32 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^3.19.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-item": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-item/-/extension-task-item-3.19.0.tgz",
+      "integrity": "sha512-1il70SoaoEA5jKr2QS30CpZoB7EzdSLugROMBPRUPc0feIBKAf6yUPhxlFyU4ez/uT4Pazsf1HAgHI3AOr+MtQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.19.0"
+      }
+    },
+    "node_modules/@tiptap/extension-task-list": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-task-list/-/extension-task-list-3.19.0.tgz",
+      "integrity": "sha512-Slb6YZi7XpVT966oAJhqzZu4LVuHtUeZgMxA0bdc8FSZBxntcr8OQWmPbqvR437RAR/Xd7b5quXS3JmSeksyvA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.19.0"
       }
     },
     "node_modules/@tiptap/extension-text": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,8 @@
     "@tiptap/extension-dropcursor": "^3.19.0",
     "@tiptap/extension-image": "^3.19.0",
     "@tiptap/extension-placeholder": "^3.19.0",
+    "@tiptap/extension-task-item": "^3.19.0",
+    "@tiptap/extension-task-list": "^3.19.0",
     "@tiptap/pm": "^3.19.0",
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",

--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -3,6 +3,8 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Placeholder from '@tiptap/extension-placeholder';
 import Image from '@tiptap/extension-image';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
 import 'tippy.js/dist/tippy.css';
 import { SlashCommandExtension, executeCommand } from '../extensions/SlashCommandExtension';
 import { slashCommandRenderer } from '../extensions/slashCommandRenderer';
@@ -53,6 +55,8 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
           render: slashCommandRenderer,
         },
       }),
+      TaskList,
+      TaskItem.configure({ nested: true }),
       ToggleList,
       ToggleSummary,
       ToggleContent,

--- a/frontend/src/constants/__tests__/slashCommands.test.ts
+++ b/frontend/src/constants/__tests__/slashCommands.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { SLASH_COMMANDS } from '../slashCommands';
 
 describe('SLASH_COMMANDS', () => {
-  it('8つのコマンドが定義されている', () => {
-    expect(SLASH_COMMANDS).toHaveLength(8);
+  it('9つのコマンドが定義されている', () => {
+    expect(SLASH_COMMANDS).toHaveLength(9);
   });
 
   it('各コマンドに必要なプロパティがある', () => {

--- a/frontend/src/constants/slashCommands.ts
+++ b/frontend/src/constants/slashCommands.ts
@@ -6,7 +6,8 @@ export type SlashCommandAction =
   | 'bulletList'
   | 'orderedList'
   | 'toggleList'
-  | 'image';
+  | 'image'
+  | 'taskList';
 
 export interface SlashCommand {
   label: string;
@@ -24,4 +25,5 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { label: '番号付きリスト', description: '順序付きリスト', icon: '1.', action: 'orderedList' },
   { label: 'トグル', description: '開閉可能なブロック', icon: '▶', action: 'toggleList' },
   { label: '画像', description: '画像をアップロード', icon: '🖼', action: 'image' },
+  { label: 'タスクリスト', description: 'チェックリスト', icon: '☑', action: 'taskList' },
 ];

--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -36,6 +36,9 @@ function executeCommand(editor: Editor, command: SlashCommand) {
     case 'image':
       // image action is handled externally via onImageUpload callback
       break;
+    case 'taskList':
+      chain.toggleTaskList().run();
+      break;
     default: {
       const _exhaustive: never = command.action;
       console.error('Unknown slash command action:', _exhaustive);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,6 +105,41 @@
 .ProseMirror strong { font-weight: 700; }
 .ProseMirror em { font-style: italic; }
 
+/* Task list (checkbox) */
+.ProseMirror ul[data-type="taskList"] {
+  list-style: none;
+  padding-left: 0;
+}
+.ProseMirror ul[data-type="taskList"] li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+.ProseMirror ul[data-type="taskList"] li label {
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+.ProseMirror ul[data-type="taskList"] li label input[type="checkbox"] {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border: 2px solid var(--color-text-muted);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  display: block;
+}
+.ProseMirror ul[data-type="taskList"] li label input[type="checkbox"]:checked {
+  background-color: #6366f1;
+  border-color: #6366f1;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E");
+  background-size: 100%;
+  background-position: center;
+}
+.ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div > p {
+  text-decoration: line-through;
+  color: var(--color-text-muted);
+}
+
 /* Toggle list */
 .toggle-closed [data-toggle-content] {
   display: none;

--- a/frontend/src/utils/__tests__/tiptapToPlainText.test.ts
+++ b/frontend/src/utils/__tests__/tiptapToPlainText.test.ts
@@ -87,6 +87,22 @@ describe('tiptapToPlainText', () => {
     expect(tiptapToPlainText(json)).toBe('これは太字です');
   });
 
+  it('タスクリストのテキストを抽出する', () => {
+    const json = JSON.stringify({
+      type: 'doc',
+      content: [
+        {
+          type: 'taskList',
+          content: [
+            { type: 'taskItem', attrs: { checked: false }, content: [{ type: 'paragraph', content: [{ type: 'text', text: 'TODO1' }] }] },
+            { type: 'taskItem', attrs: { checked: true }, content: [{ type: 'paragraph', content: [{ type: 'text', text: 'TODO2' }] }] },
+          ],
+        },
+      ],
+    });
+    expect(tiptapToPlainText(json)).toBe('TODO1 TODO2');
+  });
+
   it('トグルリストのテキストを抽出する', () => {
     const json = JSON.stringify({
       type: 'doc',

--- a/frontend/src/utils/tiptapToPlainText.ts
+++ b/frontend/src/utils/tiptapToPlainText.ts
@@ -8,7 +8,7 @@ interface TiptapNode {
 
 const CONTAINER_BLOCK_TYPES = new Set([
   'doc', 'blockquote', 'bulletList', 'orderedList', 'listItem',
-  'toggleList', 'toggleContent',
+  'taskList', 'taskItem', 'toggleList', 'toggleContent',
 ]);
 
 function extractText(node: TiptapNode): string {


### PR DESCRIPTION
## 概要
ノートエディタにNotionライクなタスクリスト（チェックリスト）機能を追加。

## 変更内容
- `@tiptap/extension-task-list` / `@tiptap/extension-task-item` パッケージ導入
- スラッシュコマンドに「タスクリスト」追加（`/タスクリスト`）
- Notionライクなチェックボックスデザイン（ダーク/ライト対応）
- チェック済みアイテムに取り消し線
- ネストされたタスクリスト対応
- tiptapToPlainText にtaskList/taskItem対応

## テスト
- slashCommands テスト更新（9コマンド）
- tiptapToPlainText テスト追加（タスクリスト抽出）

closes #758