### PR TITLE
feat: 引用ブロック・区切り線

### DIFF
--- a/frontend/src/constants/__tests__/slashCommands.test.ts
+++ b/frontend/src/constants/__tests__/slashCommands.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { SLASH_COMMANDS } from '../slashCommands';
 
 describe('SLASH_COMMANDS', () => {
-  it('10のコマンドが定義されている', () => {
-    expect(SLASH_COMMANDS).toHaveLength(10);
+  it('12のコマンドが定義されている', () => {
+    expect(SLASH_COMMANDS).toHaveLength(12);
   });
 
   it('各コマンドに必要なプロパティがある', () => {

--- a/frontend/src/constants/slashCommands.ts
+++ b/frontend/src/constants/slashCommands.ts
@@ -8,7 +8,9 @@ export type SlashCommandAction =
   | 'toggleList'
   | 'image'
   | 'taskList'
-  | 'codeBlock';
+  | 'codeBlock'
+  | 'blockquote'
+  | 'horizontalRule';
 
 export interface SlashCommand {
   label: string;
@@ -28,4 +30,6 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { label: '画像', description: '画像をアップロード', icon: '🖼', action: 'image' },
   { label: 'タスクリスト', description: 'チェックリスト', icon: '☑', action: 'taskList' },
   { label: 'コード', description: 'コードブロック', icon: '</>', action: 'codeBlock' },
+  { label: '引用', description: '引用ブロック', icon: '❝', action: 'blockquote' },
+  { label: '区切り線', description: '水平線で区切る', icon: '—', action: 'horizontalRule' },
 ];

--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -42,6 +42,12 @@ function executeCommand(editor: Editor, command: SlashCommand) {
     case 'codeBlock':
       chain.toggleCodeBlock().run();
       break;
+    case 'blockquote':
+      chain.toggleBlockquote().run();
+      break;
+    case 'horizontalRule':
+      chain.setHorizontalRule().run();
+      break;
     default: {
       const _exhaustive: never = command.action;
       console.error('Unknown slash command action:', _exhaustive);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -105,6 +105,21 @@
 .ProseMirror strong { font-weight: 700; }
 .ProseMirror em { font-style: italic; }
 
+/* Blockquote */
+.ProseMirror blockquote {
+  border-left: 3px solid #6366f1;
+  padding-left: 1rem;
+  margin: 0.5rem 0;
+  color: var(--color-text-secondary);
+}
+
+/* Horizontal rule */
+.ProseMirror hr {
+  border: none;
+  border-top: 1px solid var(--color-surface-3);
+  margin: 1rem 0;
+}
+
 /* Code block */
 .ProseMirror pre {
   background: var(--color-surface-2);


### PR DESCRIPTION
## 概要
ノートエディタにNotionライクな引用ブロックと区切り線を追加。

## 変更内容
- スラッシュコマンドに「引用」「区切り線」追加（`/引用` `/区切り線`）
- 引用ブロック: インディゴ左ボーダースタイル
- 区切り線: テーマ対応の水平線
- SlashCommandAction union型に `blockquote` / `horizontalRule` 追加

## テスト
- slashCommands テスト更新（12コマンド）

closes #762