### PR TITLE
refactor: BlockEditorのエディタ設定をuseBlockEditorフックに分離

### DIFF
--- a/frontend/src/hooks/useBlockEditor.ts
+++ b/frontend/src/hooks/useBlockEditor.ts
@@ -1,0 +1,97 @@
+import { useEffect, useMemo } from 'react';
+import { useEditor } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+import Placeholder from '@tiptap/extension-placeholder';
+import Image from '@tiptap/extension-image';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import Highlight from '@tiptap/extension-highlight';
+import { common, createLowlight } from 'lowlight';
+import { SlashCommandExtension } from '../extensions/SlashCommandExtension';
+import { slashCommandRenderer } from '../extensions/slashCommandRenderer';
+import { ToggleList, ToggleSummary, ToggleContent } from '../extensions/ToggleListExtension';
+import { isLegacyMarkdown } from '../utils/isLegacyMarkdown';
+import { markdownToTiptap } from '../utils/markdownToTiptap';
+
+interface UseBlockEditorOptions {
+  content: string;
+  onChange: (jsonString: string) => void;
+}
+
+export function useBlockEditor({ content, onChange }: UseBlockEditorOptions) {
+  const initialContent = useMemo(() => {
+    if (!content) return undefined;
+    if (isLegacyMarkdown(content)) {
+      return markdownToTiptap(content);
+    }
+    try {
+      return JSON.parse(content);
+    } catch {
+      return undefined;
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [1, 2, 3] },
+        codeBlock: false,
+      }),
+      CodeBlockLowlight.configure({
+        lowlight: createLowlight(common),
+      }),
+      Placeholder.configure({
+        placeholder: 'ここに入力...',
+      }),
+      Image.configure({
+        allowBase64: false,
+        HTMLAttributes: { class: 'note-image' },
+      }),
+      SlashCommandExtension.configure({
+        suggestion: {
+          render: slashCommandRenderer,
+        },
+      }),
+      Highlight.configure({ multicolor: true }),
+      TaskList,
+      TaskItem.configure({ nested: true }),
+      ToggleList,
+      ToggleSummary,
+      ToggleContent,
+    ],
+    content: initialContent,
+    onUpdate: ({ editor }) => {
+      onChange(JSON.stringify(editor.getJSON()));
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    const currentJson = JSON.stringify(editor.getJSON());
+    if (content === currentJson) return;
+
+    if (!content) {
+      editor.commands.clearContent();
+      return;
+    }
+
+    let newContent;
+    if (isLegacyMarkdown(content)) {
+      newContent = markdownToTiptap(content);
+    } else {
+      try {
+        newContent = JSON.parse(content);
+      } catch {
+        return;
+      }
+    }
+
+    const newJson = JSON.stringify(newContent);
+    if (newJson === currentJson) return;
+
+    editor.commands.setContent(newContent);
+  }, [content, editor]);
+
+  return { editor };
+}


### PR DESCRIPTION
## 概要
- BlockEditorコンポーネントからTipTap関連のロジックを`useBlockEditor`カスタムフックに分離
- BlockEditorはUI描画とイベントハンドリングに集中

## 変更内容
- `useBlockEditor.ts`: TipTap拡張設定・エディタ初期化・コンテンツ同期を管理するカスタムフック
- `useBlockEditor.test.ts`: フックのユニットテスト（4テスト）
- `BlockEditor.tsx`: useBlockEditorフックを利用するよう簡素化（166行 → 83行）

## テスト
- 全1446テストパス