### PR TITLE
test: ブロックエディタ関連のテストカバレッジ拡充

### DIFF
--- a/frontend/src/extensions/__tests__/SlashCommandExtension.test.ts
+++ b/frontend/src/extensions/__tests__/SlashCommandExtension.test.ts
@@ -63,6 +63,59 @@ describe('SlashCommandExtension', () => {
     expect(setToggleList).toHaveBeenCalled();
   });
 
+  it('imageコマンドはエラーなく実行される（外部で処理）', () => {
+    const editor = createMockEditor();
+    expect(() => executeCommand(editor as never, findCommand('image'))).not.toThrow();
+  });
+
+  it('taskListコマンドでtoggleTaskListが呼ばれる', () => {
+    const chain = {
+      focus: vi.fn().mockReturnThis(),
+      toggleTaskList: vi.fn().mockReturnThis(),
+      run: vi.fn(),
+    };
+    const editor = { chain: vi.fn(() => chain) };
+    executeCommand(editor as never, findCommand('taskList'));
+    expect(chain.toggleTaskList).toHaveBeenCalled();
+    expect(chain.run).toHaveBeenCalled();
+  });
+
+  it('codeBlockコマンドでtoggleCodeBlockが呼ばれる', () => {
+    const chain = {
+      focus: vi.fn().mockReturnThis(),
+      toggleCodeBlock: vi.fn().mockReturnThis(),
+      run: vi.fn(),
+    };
+    const editor = { chain: vi.fn(() => chain) };
+    executeCommand(editor as never, findCommand('codeBlock'));
+    expect(chain.toggleCodeBlock).toHaveBeenCalled();
+    expect(chain.run).toHaveBeenCalled();
+  });
+
+  it('blockquoteコマンドでtoggleBlockquoteが呼ばれる', () => {
+    const chain = {
+      focus: vi.fn().mockReturnThis(),
+      toggleBlockquote: vi.fn().mockReturnThis(),
+      run: vi.fn(),
+    };
+    const editor = { chain: vi.fn(() => chain) };
+    executeCommand(editor as never, findCommand('blockquote'));
+    expect(chain.toggleBlockquote).toHaveBeenCalled();
+    expect(chain.run).toHaveBeenCalled();
+  });
+
+  it('horizontalRuleコマンドでsetHorizontalRuleが呼ばれる', () => {
+    const chain = {
+      focus: vi.fn().mockReturnThis(),
+      setHorizontalRule: vi.fn().mockReturnThis(),
+      run: vi.fn(),
+    };
+    const editor = { chain: vi.fn(() => chain) };
+    executeCommand(editor as never, findCommand('horizontalRule'));
+    expect(chain.setHorizontalRule).toHaveBeenCalled();
+    expect(chain.run).toHaveBeenCalled();
+  });
+
   it('SLASH_COMMANDSのフィルタリングが正しく動作する', () => {
     const filtered = SLASH_COMMANDS.filter(item =>
       item.label.toLowerCase().includes('見出し')

--- a/frontend/src/extensions/__tests__/slashCommandRenderer.test.tsx
+++ b/frontend/src/extensions/__tests__/slashCommandRenderer.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { slashCommandRenderer } from '../slashCommandRenderer';
+import type { SlashCommand } from '../../constants/slashCommands';
+
+vi.mock('react-dom/client', () => ({
+  createRoot: vi.fn(() => ({
+    render: vi.fn(),
+    unmount: vi.fn(),
+  })),
+}));
+
+vi.mock('tippy.js', () => ({
+  default: vi.fn(() => ({
+    destroy: vi.fn(),
+    hide: vi.fn(),
+    setProps: vi.fn(),
+  })),
+}));
+
+const mockItems: SlashCommand[] = [
+  { label: 'テキスト', description: '通常の段落', icon: 'Bars3BottomLeftIcon', action: 'paragraph' },
+  { label: '見出し1', description: '大見出し', icon: 'H1Icon', action: 'heading1' },
+  { label: '見出し2', description: '中見出し', icon: 'H2Icon', action: 'heading2' },
+];
+
+function createMockProps(items = mockItems) {
+  return {
+    items,
+    command: vi.fn(),
+    clientRect: () => new DOMRect(0, 0, 100, 20),
+    editor: {} as any,
+    range: { from: 0, to: 0 },
+    query: '',
+    text: '',
+    decorationNode: null,
+  };
+}
+
+describe('slashCommandRenderer', () => {
+  let renderer: ReturnType<typeof slashCommandRenderer>;
+
+  beforeEach(() => {
+    renderer = slashCommandRenderer();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('onStartでTippyポップアップを作成する', async () => {
+    const tippy = (await import('tippy.js')).default;
+    const props = createMockProps();
+    renderer.onStart(props as any);
+
+    expect(tippy).toHaveBeenCalledWith(
+      document.body,
+      expect.objectContaining({
+        showOnCreate: true,
+        interactive: true,
+        trigger: 'manual',
+        placement: 'bottom-start',
+        theme: 'slash-command',
+      })
+    );
+  });
+
+  it('onStartでReactルートを作成してレンダリングする', async () => {
+    const { createRoot } = await import('react-dom/client');
+    const props = createMockProps();
+    renderer.onStart(props as any);
+
+    expect(createRoot).toHaveBeenCalled();
+  });
+
+  it('onUpdateでアイテムとポップアップ位置を更新する', async () => {
+    const tippy = (await import('tippy.js')).default;
+    const props = createMockProps();
+    renderer.onStart(props as any);
+
+    const mockPopup = vi.mocked(tippy).mock.results[0]!.value;
+    const newProps = createMockProps([mockItems[0]!]);
+    renderer.onUpdate(newProps as any);
+
+    expect(mockPopup.setProps).toHaveBeenCalled();
+  });
+
+  it('ArrowDownキーでselectedIndexがインクリメントされる', () => {
+    renderer.onStart(createMockProps() as any);
+
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+    } as any);
+
+    expect(result).toBe(true);
+  });
+
+  it('ArrowUpキーでselectedIndexがデクリメントされる', () => {
+    renderer.onStart(createMockProps() as any);
+
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+    } as any);
+
+    expect(result).toBe(true);
+  });
+
+  it('Enterキーで選択中のコマンドが実行される', () => {
+    const props = createMockProps();
+    renderer.onStart(props as any);
+
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'Enter' }),
+    } as any);
+
+    expect(result).toBe(true);
+    expect(props.command).toHaveBeenCalledWith(mockItems[0]);
+  });
+
+  it('Escapeキーでポップアップが非表示になる', async () => {
+    const tippy = (await import('tippy.js')).default;
+    renderer.onStart(createMockProps() as any);
+
+    const mockPopup = vi.mocked(tippy).mock.results[0]!.value;
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'Escape' }),
+    } as any);
+
+    expect(result).toBe(true);
+    expect(mockPopup.hide).toHaveBeenCalled();
+  });
+
+  it('未対応キーはfalseを返す', () => {
+    renderer.onStart(createMockProps() as any);
+
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'Tab' }),
+    } as any);
+
+    expect(result).toBe(false);
+  });
+
+  it('onExitでポップアップとルートをクリーンアップする', async () => {
+    const tippy = (await import('tippy.js')).default;
+    const { createRoot } = await import('react-dom/client');
+    renderer.onStart(createMockProps() as any);
+
+    const mockPopup = vi.mocked(tippy).mock.results[0]!.value;
+    const mockRoot = vi.mocked(createRoot).mock.results[0]!.value;
+
+    renderer.onExit();
+
+    expect(mockPopup.destroy).toHaveBeenCalled();
+    expect(mockRoot.unmount).toHaveBeenCalled();
+  });
+
+  it('空アイテムでArrowDownを押してもfalseを返す', () => {
+    renderer.onStart(createMockProps([]) as any);
+
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'ArrowDown' }),
+    } as any);
+
+    expect(result).toBe(false);
+  });
+
+  it('空アイテムでArrowUpを押してもfalseを返す', () => {
+    renderer.onStart(createMockProps([]) as any);
+
+    const result = renderer.onKeyDown({
+      event: new KeyboardEvent('keydown', { key: 'ArrowUp' }),
+    } as any);
+
+    expect(result).toBe(false);
+  });
+});

--- a/frontend/src/utils/__tests__/auth.test.ts
+++ b/frontend/src/utils/__tests__/auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getCognitoAuthUrl } from '../auth';
+
+const mockEnv = {
+  VITE_COGNITO_DOMAIN: 'test.auth.ap-northeast-1.amazoncognito.com',
+  VITE_CLIENT_ID: 'test-client-id',
+  VITE_REDIRECT_URI: 'http://localhost:5173/callback',
+  VITE_RESPONSE_TYPE: 'code',
+  VITE_SCOPE: 'openid email profile',
+};
+
+beforeEach(() => {
+  vi.stubEnv('VITE_COGNITO_DOMAIN', mockEnv.VITE_COGNITO_DOMAIN);
+  vi.stubEnv('VITE_CLIENT_ID', mockEnv.VITE_CLIENT_ID);
+  vi.stubEnv('VITE_REDIRECT_URI', mockEnv.VITE_REDIRECT_URI);
+  vi.stubEnv('VITE_RESPONSE_TYPE', mockEnv.VITE_RESPONSE_TYPE);
+  vi.stubEnv('VITE_SCOPE', mockEnv.VITE_SCOPE);
+});
+
+describe('getCognitoAuthUrl', () => {
+  it('正しいCognitoドメインのURLを生成する', () => {
+    const url = getCognitoAuthUrl('Google');
+    expect(url).toContain(`https://${mockEnv.VITE_COGNITO_DOMAIN}/oauth2/authorize`);
+  });
+
+  it('client_idパラメータが設定される', () => {
+    const url = new URL(getCognitoAuthUrl('Google'));
+    expect(url.searchParams.get('client_id')).toBe(mockEnv.VITE_CLIENT_ID);
+  });
+
+  it('redirect_uriパラメータが設定される', () => {
+    const url = new URL(getCognitoAuthUrl('Google'));
+    expect(url.searchParams.get('redirect_uri')).toBe(mockEnv.VITE_REDIRECT_URI);
+  });
+
+  it('response_typeパラメータが設定される', () => {
+    const url = new URL(getCognitoAuthUrl('Google'));
+    expect(url.searchParams.get('response_type')).toBe(mockEnv.VITE_RESPONSE_TYPE);
+  });
+
+  it('scopeパラメータが設定される', () => {
+    const url = new URL(getCognitoAuthUrl('Google'));
+    expect(url.searchParams.get('scope')).toBe(mockEnv.VITE_SCOPE);
+  });
+
+  it('identity_providerにprovider引数が設定される', () => {
+    const url = new URL(getCognitoAuthUrl('Google'));
+    expect(url.searchParams.get('identity_provider')).toBe('Google');
+  });
+
+  it('stateパラメータがランダムな16進文字列として生成される', () => {
+    const url = new URL(getCognitoAuthUrl('Google'));
+    const state = url.searchParams.get('state');
+    expect(state).toBeTruthy();
+    expect(state).toMatch(/^[0-9a-f]+$/);
+    expect(state!.length).toBe(64); // 32 bytes * 2 hex chars
+  });
+
+  it('呼び出すたびに異なるstateが生成される', () => {
+    const url1 = new URL(getCognitoAuthUrl('Google'));
+    const url2 = new URL(getCognitoAuthUrl('Google'));
+    expect(url1.searchParams.get('state')).not.toBe(url2.searchParams.get('state'));
+  });
+
+  it('異なるプロバイダを渡せる', () => {
+    const url = new URL(getCognitoAuthUrl('LoginWithAmazon'));
+    expect(url.searchParams.get('identity_provider')).toBe('LoginWithAmazon');
+  });
+});


### PR DESCRIPTION
## 概要
ブロックエディタ関連のコンポーネント・ユーティリティのテストカバレッジを拡充

## 追加テスト
- **SlashCommandExtension** (+5テスト): taskList/codeBlock/blockquote/horizontalRule/imageコマンド
- **slashCommandRenderer** (+11テスト): キーボードナビゲーション、Tippyポップアップ管理、クリーンアップ
- **auth.ts** (+9テスト): CognitoAuthURL生成、パラメータ検証、state乱数生成
- **useBlockEditor** (+4テスト): レガシーMarkdown変換、不正JSON処理、拡張数検証

## テスト結果
- 1446 → 1475テスト（+29テスト追加）
- 185テストファイル全パス

Closes #768