### PR TITLE
refactor: ScoreHistoryPageの平均スコア計算をuseScoreHistoryに移動

### DIFF
--- a/frontend/src/hooks/__tests__/useScoreHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreHistory.test.ts
@@ -218,6 +218,36 @@ describe('useScoreHistory', () => {
     expect(result.current.weakestAxis).toBeNull();
   });
 
+  it('averageScoreが全セッションの平均を返す', async () => {
+    const mockData = [
+      { sessionId: 1, sessionTitle: 'テスト1', overallScore: 7.0, scores: [], createdAt: '2026-02-10' },
+      { sessionId: 2, sessionTitle: 'テスト2', overallScore: 8.5, scores: [], createdAt: '2026-02-11' },
+      { sessionId: 3, sessionTitle: 'テスト3', overallScore: 9.0, scores: [], createdAt: '2026-02-12' },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(3);
+    });
+
+    // (7.0 + 8.5 + 9.0) / 3 = 8.166... → 8.2
+    expect(result.current.averageScore).toBe(8.2);
+  });
+
+  it('空の履歴でaverageScoreが0を返す', async () => {
+    mockFetchScoreHistory.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(mockFetchScoreHistory).toHaveBeenCalled();
+    });
+
+    expect(result.current.averageScore).toBe(0);
+  });
+
   it('最新セッションのスコアが空の場合にweakestAxisがnullになる', async () => {
     const mockData = [
       { sessionId: 1, sessionTitle: 'テスト', overallScore: 7.0, scores: [], createdAt: '2026-02-10' },

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -51,6 +51,11 @@ export function useScoreHistory() {
 
   const latestSession = history.length > 0 ? history[history.length - 1] : null;
 
+  const averageScore = useMemo(() => {
+    if (history.length === 0) return 0;
+    return Math.round((history.reduce((sum, h) => sum + h.overallScore, 0) / history.length) * 10) / 10;
+  }, [history]);
+
   const weakestAxis = useMemo(() => {
     if (!latestSession) return null;
     return [...latestSession.scores].sort((a, b) => a.score - b.score)[0] ?? null;
@@ -63,6 +68,7 @@ export function useScoreHistory() {
     setFilter,
     loading,
     latestSession,
+    averageScore,
     weakestAxis,
     selectedSession,
     setSelectedSession,

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -27,7 +27,7 @@ import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 export default function ScoreHistoryPage() {
-  const { history, filteredHistory, filter, setFilter, loading, latestSession, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
+  const { history, filteredHistory, filter, setFilter, loading, latestSession, averageScore, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
   const [scoreGoal] = useLocalStorage('scoreGoal', 8.0);
 
   if (loading) {
@@ -57,7 +57,7 @@ export default function ScoreHistoryPage() {
 
       {/* 目標スコア */}
       <ScoreGoalCard
-        averageScore={Math.round((history.reduce((sum, h) => sum + h.overallScore, 0) / history.length) * 10) / 10}
+        averageScore={averageScore}
       />
 
       {/* スキルギャップ分析 */}


### PR DESCRIPTION
## 概要
ScoreHistoryPage内のインライン計算をuseScoreHistoryフックに移動

## 変更内容
- `useScoreHistory` に `averageScore` メモ化プロパティを追加（history変更時に再計算）
- `ScoreHistoryPage` からインライン `Math.round(...)` を除去し、`averageScore` を直接使用

## テスト
- averageScoreのテスト2件追加（平均計算・空履歴）
- 全1492テストパス

Closes #774