### PR TITLE
test: AIチャットUseCase層のユニットテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/AddAiChatMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/AddAiChatMessageUseCaseTest.java
@@ -1,0 +1,131 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.AiChatMessageResponseDto;
+import com.example.FreStyle.entity.AiChatMessage;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.mapper.AiChatMessageMapper;
+import com.example.FreStyle.repository.AiChatMessageRepository;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+import com.example.FreStyle.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AddAiChatMessageUseCase")
+class AddAiChatMessageUseCaseTest {
+
+    @Mock
+    private AiChatMessageRepository aiChatMessageRepository;
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AiChatMessageMapper mapper;
+
+    @InjectMocks
+    private AddAiChatMessageUseCase useCase;
+
+    @Nested
+    @DisplayName("正常系")
+    class Success {
+
+        @Test
+        @DisplayName("ユーザーメッセージを追加してDTOを返す")
+        void shouldAddUserMessage() {
+            AiChatSession session = new AiChatSession();
+            session.setId(1);
+            when(aiChatSessionRepository.findById(1)).thenReturn(Optional.of(session));
+
+            User user = new User();
+            user.setId(1);
+            when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+            AiChatMessage savedMessage = new AiChatMessage();
+            savedMessage.setId(10);
+            when(aiChatMessageRepository.save(any(AiChatMessage.class))).thenReturn(savedMessage);
+
+            AiChatMessageResponseDto expectedDto = new AiChatMessageResponseDto();
+            expectedDto.setId(10);
+            expectedDto.setRole("user");
+            when(mapper.toDto(savedMessage)).thenReturn(expectedDto);
+
+            AiChatMessageResponseDto result = useCase.executeUserMessage(1, 1, "こんにちは");
+
+            assertThat(result.getId()).isEqualTo(10);
+            assertThat(result.getRole()).isEqualTo("user");
+            verify(aiChatMessageRepository).save(any(AiChatMessage.class));
+        }
+
+        @Test
+        @DisplayName("アシスタントメッセージを追加してDTOを返す")
+        void shouldAddAssistantMessage() {
+            AiChatSession session = new AiChatSession();
+            session.setId(1);
+            when(aiChatSessionRepository.findById(1)).thenReturn(Optional.of(session));
+
+            User user = new User();
+            user.setId(1);
+            when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+            AiChatMessage savedMessage = new AiChatMessage();
+            savedMessage.setId(11);
+            when(aiChatMessageRepository.save(any(AiChatMessage.class))).thenReturn(savedMessage);
+
+            AiChatMessageResponseDto expectedDto = new AiChatMessageResponseDto();
+            expectedDto.setId(11);
+            expectedDto.setRole("assistant");
+            when(mapper.toDto(savedMessage)).thenReturn(expectedDto);
+
+            AiChatMessageResponseDto result = useCase.executeAssistantMessage(1, 1, "応答です");
+
+            assertThat(result.getId()).isEqualTo(11);
+            assertThat(result.getRole()).isEqualTo("assistant");
+        }
+    }
+
+    @Nested
+    @DisplayName("異常系")
+    class Error {
+
+        @Test
+        @DisplayName("セッションが見つからない場合はResourceNotFoundExceptionをスローする")
+        void shouldThrowWhenSessionNotFound() {
+            when(aiChatSessionRepository.findById(999)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.executeUserMessage(999, 1, "テスト"))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("ユーザーが見つからない場合はResourceNotFoundExceptionをスローする")
+        void shouldThrowWhenUserNotFound() {
+            AiChatSession session = new AiChatSession();
+            session.setId(1);
+            when(aiChatSessionRepository.findById(1)).thenReturn(Optional.of(session));
+            when(userRepository.findById(999)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.executeUserMessage(1, 999, "テスト"))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateAiChatSessionUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateAiChatSessionUseCaseTest.java
@@ -1,0 +1,132 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.AiChatSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.mapper.AiChatSessionMapper;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+import com.example.FreStyle.repository.ChatRoomRepository;
+import com.example.FreStyle.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateAiChatSessionUseCase")
+class CreateAiChatSessionUseCaseTest {
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private AiChatSessionMapper mapper;
+
+    @InjectMocks
+    private CreateAiChatSessionUseCase useCase;
+
+    @Nested
+    @DisplayName("正常系")
+    class Success {
+
+        @Test
+        @DisplayName("セッションを作成してDTOを返す")
+        void shouldCreateSessionAndReturnDto() {
+            User user = new User();
+            user.setId(1);
+            when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+            AiChatSession savedSession = new AiChatSession();
+            savedSession.setId(10);
+            when(aiChatSessionRepository.save(any(AiChatSession.class))).thenReturn(savedSession);
+
+            AiChatSessionDto expectedDto = new AiChatSessionDto();
+            expectedDto.setId(10);
+            when(mapper.toDto(savedSession)).thenReturn(expectedDto);
+
+            AiChatSessionDto result = useCase.execute(1, "テストセッション", null);
+
+            assertThat(result.getId()).isEqualTo(10);
+            verify(aiChatSessionRepository).save(any(AiChatSession.class));
+        }
+
+        @Test
+        @DisplayName("関連ルーム指定でセッションを作成する")
+        void shouldCreateSessionWithRelatedRoom() {
+            User user = new User();
+            user.setId(1);
+            when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+            ChatRoom room = new ChatRoom();
+            room.setId(5);
+            when(chatRoomRepository.findById(5)).thenReturn(Optional.of(room));
+
+            AiChatSession savedSession = new AiChatSession();
+            savedSession.setId(10);
+            when(aiChatSessionRepository.save(any(AiChatSession.class))).thenReturn(savedSession);
+
+            AiChatSessionDto expectedDto = new AiChatSessionDto();
+            expectedDto.setId(10);
+            when(mapper.toDto(savedSession)).thenReturn(expectedDto);
+
+            AiChatSessionDto result = useCase.execute(1, "テスト", 5);
+
+            assertThat(result.getId()).isEqualTo(10);
+            verify(chatRoomRepository).findById(5);
+        }
+
+        @Test
+        @DisplayName("シーンとセッションタイプ指定でセッションを作成する")
+        void shouldCreateSessionWithSceneAndType() {
+            User user = new User();
+            user.setId(1);
+            when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+            AiChatSession savedSession = new AiChatSession();
+            savedSession.setId(10);
+            when(aiChatSessionRepository.save(any(AiChatSession.class))).thenReturn(savedSession);
+
+            AiChatSessionDto expectedDto = new AiChatSessionDto();
+            expectedDto.setId(10);
+            when(mapper.toDto(savedSession)).thenReturn(expectedDto);
+
+            AiChatSessionDto result = useCase.execute(1, "練習", null, "meeting", "practice", 3);
+
+            assertThat(result.getId()).isEqualTo(10);
+        }
+    }
+
+    @Nested
+    @DisplayName("異常系")
+    class Error {
+
+        @Test
+        @DisplayName("ユーザーが見つからない場合はResourceNotFoundExceptionをスローする")
+        void shouldThrowWhenUserNotFound() {
+            when(userRepository.findById(999)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.execute(999, "テスト", null))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteAiChatSessionUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteAiChatSessionUseCaseTest.java
@@ -1,0 +1,77 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteAiChatSessionUseCase")
+class DeleteAiChatSessionUseCaseTest {
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @InjectMocks
+    private DeleteAiChatSessionUseCase useCase;
+
+    @Nested
+    @DisplayName("正常系")
+    class Success {
+
+        @Test
+        @DisplayName("セッションを削除する")
+        void shouldDeleteSession() {
+            User user = new User();
+            user.setId(1);
+            AiChatSession session = new AiChatSession();
+            session.setId(10);
+            session.setUser(user);
+            when(aiChatSessionRepository.findByIdAndUserId(10, 1))
+                    .thenReturn(Optional.of(session));
+
+            useCase.execute(10, 1);
+
+            verify(aiChatSessionRepository).delete(session);
+        }
+    }
+
+    @Nested
+    @DisplayName("異常系")
+    class Error {
+
+        @Test
+        @DisplayName("セッションが見つからない場合はResourceNotFoundExceptionをスローする")
+        void shouldThrowWhenSessionNotFound() {
+            when(aiChatSessionRepository.findByIdAndUserId(999, 1))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.execute(999, 1))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("他ユーザーのセッションは削除できない")
+        void shouldThrowWhenDifferentUser() {
+            when(aiChatSessionRepository.findByIdAndUserId(10, 2))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> useCase.execute(10, 2))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatMessagesBySessionIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatMessagesBySessionIdUseCaseTest.java
@@ -1,0 +1,68 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.AiChatMessageResponseDto;
+import com.example.FreStyle.entity.AiChatMessage;
+import com.example.FreStyle.mapper.AiChatMessageMapper;
+import com.example.FreStyle.repository.AiChatMessageRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAiChatMessagesBySessionIdUseCase")
+class GetAiChatMessagesBySessionIdUseCaseTest {
+
+    @Mock
+    private AiChatMessageRepository aiChatMessageRepository;
+
+    @Mock
+    private AiChatMessageMapper mapper;
+
+    @InjectMocks
+    private GetAiChatMessagesBySessionIdUseCase useCase;
+
+    @Test
+    @DisplayName("セッションIDでメッセージ一覧を取得する")
+    void shouldReturnMessagesBySessionId() {
+        AiChatMessage msg1 = new AiChatMessage();
+        msg1.setId(1);
+        AiChatMessage msg2 = new AiChatMessage();
+        msg2.setId(2);
+        when(aiChatMessageRepository.findBySessionIdOrderByCreatedAtAsc(1))
+                .thenReturn(List.of(msg1, msg2));
+
+        AiChatMessageResponseDto dto1 = new AiChatMessageResponseDto();
+        dto1.setId(1);
+        AiChatMessageResponseDto dto2 = new AiChatMessageResponseDto();
+        dto2.setId(2);
+        when(mapper.toDto(msg1)).thenReturn(dto1);
+        when(mapper.toDto(msg2)).thenReturn(dto2);
+
+        List<AiChatMessageResponseDto> result = useCase.execute(1);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1);
+        assertThat(result.get(1).getId()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("メッセージがない場合は空リストを返す")
+    void shouldReturnEmptyListWhenNoMessages() {
+        when(aiChatMessageRepository.findBySessionIdOrderByCreatedAtAsc(999))
+                .thenReturn(Collections.emptyList());
+
+        List<AiChatMessageResponseDto> result = useCase.execute(999);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatSessionsByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatSessionsByUserIdUseCaseTest.java
@@ -1,0 +1,68 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.AiChatSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.mapper.AiChatSessionMapper;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAiChatSessionsByUserIdUseCase")
+class GetAiChatSessionsByUserIdUseCaseTest {
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private AiChatSessionMapper mapper;
+
+    @InjectMocks
+    private GetAiChatSessionsByUserIdUseCase useCase;
+
+    @Test
+    @DisplayName("ユーザーIDでセッション一覧を取得する")
+    void shouldReturnSessionsByUserId() {
+        AiChatSession session1 = new AiChatSession();
+        session1.setId(1);
+        AiChatSession session2 = new AiChatSession();
+        session2.setId(2);
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(1))
+                .thenReturn(List.of(session1, session2));
+
+        AiChatSessionDto dto1 = new AiChatSessionDto();
+        dto1.setId(1);
+        AiChatSessionDto dto2 = new AiChatSessionDto();
+        dto2.setId(2);
+        when(mapper.toDto(session1)).thenReturn(dto1);
+        when(mapper.toDto(session2)).thenReturn(dto2);
+
+        List<AiChatSessionDto> result = useCase.execute(1);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1);
+        assertThat(result.get(1).getId()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("セッションがない場合は空リストを返す")
+    void shouldReturnEmptyListWhenNoSessions() {
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(999))
+                .thenReturn(Collections.emptyList());
+
+        List<AiChatSessionDto> result = useCase.execute(999);
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 概要
AIチャット機能のUseCase層に対するユニットテストを追加（15テスト）

## 追加テスト
| テストクラス | テスト数 | 対象 |
|---|---|---|
| CreateAiChatSessionUseCaseTest | 4 | セッション作成（正常系3件・異常系1件） |
| GetAiChatSessionsByUserIdUseCaseTest | 2 | セッション一覧取得 |
| AddAiChatMessageUseCaseTest | 4 | メッセージ追加（正常系2件・異常系2件） |
| GetAiChatMessagesBySessionIdUseCaseTest | 2 | メッセージ一覧取得 |
| DeleteAiChatSessionUseCaseTest | 3 | セッション削除（正常系1件・異常系2件） |

## テスト結果
- バックエンド: BUILD SUCCESSFUL

closes #776