### PR TITLE
refactor: SkillRadarヘルパー関数をutilsに共通化

### DIFF
--- a/frontend/src/components/SkillRadarChart.tsx
+++ b/frontend/src/components/SkillRadarChart.tsx
@@ -1,46 +1,17 @@
 import type { AxisScore } from '../types';
+import {
+  polarToCartesian,
+  getPolygonPoints,
+  getGridPoints,
+  RADAR_SIZE,
+  RADAR_CENTER,
+  RADAR_RADIUS,
+  RADAR_GRID_LEVELS,
+} from '../utils/skillRadarHelpers';
 
 interface SkillRadarChartProps {
   scores: AxisScore[];
   title?: string;
-}
-
-const SIZE = 200;
-const CENTER = SIZE / 2;
-const RADIUS = 70;
-const GRID_LEVELS = [2, 4, 6, 8, 10];
-
-function polarToCartesian(angle: number, radius: number): { x: number; y: number } {
-  // Start from top (-90 degrees)
-  const rad = ((angle - 90) * Math.PI) / 180;
-  return {
-    x: CENTER + radius * Math.cos(rad),
-    y: CENTER + radius * Math.sin(rad),
-  };
-}
-
-function getPolygonPoints(values: number[], maxValue: number): string {
-  if (values.length === 0) return '';
-  const angleStep = 360 / values.length;
-  return values
-    .map((value, i) => {
-      const ratio = value / maxValue;
-      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
-      return `${point.x},${point.y}`;
-    })
-    .join(' ');
-}
-
-function getGridPoints(level: number, count: number): string {
-  if (count === 0) return '';
-  const angleStep = 360 / count;
-  const ratio = level / 10;
-  return Array.from({ length: count })
-    .map((_, i) => {
-      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
-      return `${point.x},${point.y}`;
-    })
-    .join(' ');
 }
 
 export default function SkillRadarChart({ scores, title }: SkillRadarChartProps) {
@@ -52,9 +23,9 @@ export default function SkillRadarChart({ scores, title }: SkillRadarChartProps)
       {title && (
         <h4 className="text-xs font-semibold text-[var(--color-text-secondary)] mb-2">{title}</h4>
       )}
-      <svg viewBox={`0 0 ${SIZE} ${SIZE}`} width={SIZE} height={SIZE}>
+      <svg viewBox={`0 0 ${RADAR_SIZE} ${RADAR_SIZE}`} width={RADAR_SIZE} height={RADAR_SIZE}>
         {/* グリッド線 */}
-        {GRID_LEVELS.map((level) => (
+        {RADAR_GRID_LEVELS.map((level) => (
           <polygon
             key={level}
             className="grid"
@@ -67,12 +38,12 @@ export default function SkillRadarChart({ scores, title }: SkillRadarChartProps)
 
         {/* 軸線 */}
         {scores.map((_, i) => {
-          const point = polarToCartesian(i * angleStep, RADIUS);
+          const point = polarToCartesian(i * angleStep, RADAR_RADIUS);
           return (
             <line
               key={i}
-              x1={CENTER}
-              y1={CENTER}
+              x1={RADAR_CENTER}
+              y1={RADAR_CENTER}
               x2={point.x}
               y2={point.y}
               stroke="var(--color-surface-3)"
@@ -97,7 +68,7 @@ export default function SkillRadarChart({ scores, title }: SkillRadarChartProps)
         {/* スコアドット */}
         {scores.map((s, i) => {
           const ratio = s.score / 10;
-          const point = polarToCartesian(i * angleStep, RADIUS * ratio);
+          const point = polarToCartesian(i * angleStep, RADAR_RADIUS * ratio);
           return (
             <circle
               key={i}
@@ -111,7 +82,7 @@ export default function SkillRadarChart({ scores, title }: SkillRadarChartProps)
 
         {/* ラベル */}
         {scores.map((s, i) => {
-          const point = polarToCartesian(i * angleStep, RADIUS + 18);
+          const point = polarToCartesian(i * angleStep, RADAR_RADIUS + 18);
           return (
             <text
               key={i}

--- a/frontend/src/components/SkillRadarOverlayCard.tsx
+++ b/frontend/src/components/SkillRadarOverlayCard.tsx
@@ -1,46 +1,18 @@
 import Card from './Card';
 import type { AxisScore } from '../types';
+import {
+  polarToCartesian,
+  getPolygonPoints,
+  getGridPoints,
+  RADAR_SIZE,
+  RADAR_CENTER,
+  RADAR_RADIUS,
+  RADAR_GRID_LEVELS,
+} from '../utils/skillRadarHelpers';
 
 interface SkillRadarOverlayCardProps {
   previousScores: AxisScore[];
   currentScores: AxisScore[];
-}
-
-const SIZE = 200;
-const CENTER = SIZE / 2;
-const RADIUS = 70;
-const GRID_LEVELS = [2, 4, 6, 8, 10];
-
-function polarToCartesian(angle: number, radius: number): { x: number; y: number } {
-  const rad = ((angle - 90) * Math.PI) / 180;
-  return {
-    x: CENTER + radius * Math.cos(rad),
-    y: CENTER + radius * Math.sin(rad),
-  };
-}
-
-function getPolygonPoints(values: number[], maxValue: number): string {
-  if (values.length === 0) return '';
-  const angleStep = 360 / values.length;
-  return values
-    .map((value, i) => {
-      const ratio = value / maxValue;
-      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
-      return `${point.x},${point.y}`;
-    })
-    .join(' ');
-}
-
-function getGridPoints(level: number, count: number): string {
-  if (count === 0) return '';
-  const angleStep = 360 / count;
-  const ratio = level / 10;
-  return Array.from({ length: count })
-    .map((_, i) => {
-      const point = polarToCartesian(i * angleStep, RADIUS * ratio);
-      return `${point.x},${point.y}`;
-    })
-    .join(' ');
 }
 
 export default function SkillRadarOverlayCard({ previousScores, currentScores }: SkillRadarOverlayCardProps) {
@@ -53,9 +25,9 @@ export default function SkillRadarOverlayCard({ previousScores, currentScores }:
       <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキル変化レーダー</p>
 
       <div className="flex justify-center">
-        <svg viewBox={`0 0 ${SIZE} ${SIZE}`} width={SIZE} height={SIZE}>
+        <svg viewBox={`0 0 ${RADAR_SIZE} ${RADAR_SIZE}`} width={RADAR_SIZE} height={RADAR_SIZE}>
           {/* グリッド線 */}
-          {GRID_LEVELS.map((level) => (
+          {RADAR_GRID_LEVELS.map((level) => (
             <polygon
               key={level}
               points={getGridPoints(level, axisCount)}
@@ -67,12 +39,12 @@ export default function SkillRadarOverlayCard({ previousScores, currentScores }:
 
           {/* 軸線 */}
           {labels.map((_, i) => {
-            const point = polarToCartesian(i * angleStep, RADIUS);
+            const point = polarToCartesian(i * angleStep, RADAR_RADIUS);
             return (
               <line
                 key={i}
-                x1={CENTER}
-                y1={CENTER}
+                x1={RADAR_CENTER}
+                y1={RADAR_CENTER}
                 x2={point.x}
                 y2={point.y}
                 stroke="var(--color-surface-3)"
@@ -106,7 +78,7 @@ export default function SkillRadarOverlayCard({ previousScores, currentScores }:
 
           {/* ラベル */}
           {labels.map((s, i) => {
-            const point = polarToCartesian(i * angleStep, RADIUS + 18);
+            const point = polarToCartesian(i * angleStep, RADAR_RADIUS + 18);
             return (
               <text
                 key={i}

--- a/frontend/src/utils/__tests__/skillRadarHelpers.test.ts
+++ b/frontend/src/utils/__tests__/skillRadarHelpers.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  polarToCartesian,
+  getPolygonPoints,
+  getGridPoints,
+  RADAR_SIZE,
+  RADAR_CENTER,
+  RADAR_RADIUS,
+  RADAR_GRID_LEVELS,
+} from '../skillRadarHelpers';
+
+describe('skillRadarHelpers', () => {
+  describe('定数', () => {
+    it('RADAR_SIZEは200', () => {
+      expect(RADAR_SIZE).toBe(200);
+    });
+
+    it('RADAR_CENTERはSIZE/2', () => {
+      expect(RADAR_CENTER).toBe(RADAR_SIZE / 2);
+    });
+
+    it('RADAR_RADIUSは70', () => {
+      expect(RADAR_RADIUS).toBe(70);
+    });
+
+    it('RADAR_GRID_LEVELSは[2,4,6,8,10]', () => {
+      expect(RADAR_GRID_LEVELS).toEqual([2, 4, 6, 8, 10]);
+    });
+  });
+
+  describe('polarToCartesian', () => {
+    it('角度0で上方向（y=CENTER-radius）を返す', () => {
+      const point = polarToCartesian(0, RADAR_RADIUS);
+      expect(point.x).toBeCloseTo(RADAR_CENTER, 5);
+      expect(point.y).toBeCloseTo(RADAR_CENTER - RADAR_RADIUS, 5);
+    });
+
+    it('角度90で右方向（x=CENTER+radius）を返す', () => {
+      const point = polarToCartesian(90, RADAR_RADIUS);
+      expect(point.x).toBeCloseTo(RADAR_CENTER + RADAR_RADIUS, 5);
+      expect(point.y).toBeCloseTo(RADAR_CENTER, 5);
+    });
+
+    it('半径0で中心を返す', () => {
+      const point = polarToCartesian(45, 0);
+      expect(point.x).toBeCloseTo(RADAR_CENTER, 5);
+      expect(point.y).toBeCloseTo(RADAR_CENTER, 5);
+    });
+  });
+
+  describe('getPolygonPoints', () => {
+    it('空配列で空文字を返す', () => {
+      expect(getPolygonPoints([], 10)).toBe('');
+    });
+
+    it('全て最大値で外周のポイントを返す', () => {
+      const result = getPolygonPoints([10, 10, 10, 10, 10], 10);
+      expect(result).toBeTruthy();
+      const points = result.split(' ');
+      expect(points).toHaveLength(5);
+    });
+
+    it('値0で全て中心を返す', () => {
+      const result = getPolygonPoints([0, 0, 0], 10);
+      const points = result.split(' ');
+      points.forEach((point) => {
+        const [x, y] = point.split(',').map(Number);
+        expect(x).toBeCloseTo(RADAR_CENTER, 5);
+        expect(y).toBeCloseTo(RADAR_CENTER, 5);
+      });
+    });
+  });
+
+  describe('getGridPoints', () => {
+    it('count=0で空文字を返す', () => {
+      expect(getGridPoints(5, 0)).toBe('');
+    });
+
+    it('レベル10で外周のポイントを返す', () => {
+      const result = getGridPoints(10, 5);
+      expect(result).toBeTruthy();
+      const points = result.split(' ');
+      expect(points).toHaveLength(5);
+    });
+
+    it('レベル5で半径50%のポイントを返す', () => {
+      const result = getGridPoints(5, 5);
+      const points = result.split(' ');
+      // 最初のポイント（角度0=上方向）
+      const [x, y] = points[0].split(',').map(Number);
+      expect(x).toBeCloseTo(RADAR_CENTER, 5);
+      expect(y).toBeCloseTo(RADAR_CENTER - RADAR_RADIUS * 0.5, 5);
+    });
+  });
+});

--- a/frontend/src/utils/skillRadarHelpers.ts
+++ b/frontend/src/utils/skillRadarHelpers.ts
@@ -1,0 +1,36 @@
+export const RADAR_SIZE = 200;
+export const RADAR_CENTER = RADAR_SIZE / 2;
+export const RADAR_RADIUS = 70;
+export const RADAR_GRID_LEVELS = [2, 4, 6, 8, 10];
+
+export function polarToCartesian(angle: number, radius: number): { x: number; y: number } {
+  const rad = ((angle - 90) * Math.PI) / 180;
+  return {
+    x: RADAR_CENTER + radius * Math.cos(rad),
+    y: RADAR_CENTER + radius * Math.sin(rad),
+  };
+}
+
+export function getPolygonPoints(values: number[], maxValue: number): string {
+  if (values.length === 0) return '';
+  const angleStep = 360 / values.length;
+  return values
+    .map((value, i) => {
+      const ratio = value / maxValue;
+      const point = polarToCartesian(i * angleStep, RADAR_RADIUS * ratio);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+}
+
+export function getGridPoints(level: number, count: number): string {
+  if (count === 0) return '';
+  const angleStep = 360 / count;
+  const ratio = level / 10;
+  return Array.from({ length: count })
+    .map((_, i) => {
+      const point = polarToCartesian(i * angleStep, RADAR_RADIUS * ratio);
+      return `${point.x},${point.y}`;
+    })
+    .join(' ');
+}


### PR DESCRIPTION
## 概要
SkillRadarChart.tsx と SkillRadarOverlayCard.tsx で重複していたSVG描画ヘルパー関数を `utils/skillRadarHelpers.ts` に抽出。

## 変更内容
- `polarToCartesian` / `getPolygonPoints` / `getGridPoints` / 定数4つを共通モジュールに抽出
- 両コンポーネントからローカル関数を削除し、共通importに変更
- 合計-88行の重複削除

## テスト結果
- フロントエンド: 1511テスト全パス（+13テスト）

closes #780