### PR TITLE
refactor: BlockEditorのリンク管理ロジックをuseLinkEditorフックに分離

### DIFF
--- a/frontend/src/hooks/__tests__/useLinkEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useLinkEditor.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLinkEditor } from '../useLinkEditor';
+import type { Editor } from '@tiptap/core';
+
+function createMockEditor(): Editor {
+  const chain = {
+    focus: vi.fn().mockReturnThis(),
+    extendMarkRange: vi.fn().mockReturnThis(),
+    setLink: vi.fn().mockReturnThis(),
+    unsetLink: vi.fn().mockReturnThis(),
+    run: vi.fn(),
+  };
+  return {
+    getAttributes: vi.fn(() => ({ href: '' })),
+    chain: vi.fn(() => chain),
+    view: {
+      dom: document.createElement('div'),
+    },
+    _chain: chain,
+  } as unknown as Editor & { _chain: typeof chain };
+}
+
+describe('useLinkEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態でlinkBubbleがnull', () => {
+    const editor = createMockEditor();
+    const containerRef = { current: document.createElement('div') };
+    const { result } = renderHook(() => useLinkEditor(editor, containerRef));
+
+    expect(result.current.linkBubble).toBeNull();
+  });
+
+  it('handleEditorClickでリンクがないときlinkBubbleがnull', () => {
+    const editor = createMockEditor();
+    const container = document.createElement('div');
+    const containerRef = { current: container };
+    const { result } = renderHook(() => useLinkEditor(editor, containerRef));
+
+    const event = { target: document.createElement('p') } as unknown as React.MouseEvent;
+    act(() => {
+      result.current.handleEditorClick(event);
+    });
+
+    expect(result.current.linkBubble).toBeNull();
+  });
+
+  it('dismissLinkBubbleでlinkBubbleをnullにする', () => {
+    const editor = createMockEditor();
+    const containerRef = { current: document.createElement('div') };
+    const { result } = renderHook(() => useLinkEditor(editor, containerRef));
+
+    act(() => {
+      result.current.dismissLinkBubble();
+    });
+
+    expect(result.current.linkBubble).toBeNull();
+  });
+
+  it('handleRemoveLinkでunsetLinkが呼ばれる', () => {
+    const editor = createMockEditor();
+    const containerRef = { current: document.createElement('div') };
+    const { result } = renderHook(() => useLinkEditor(editor, containerRef));
+
+    act(() => {
+      result.current.handleRemoveLink();
+    });
+
+    const chain = (editor as unknown as { _chain: { unsetLink: ReturnType<typeof vi.fn> } })._chain;
+    expect(chain.unsetLink).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useLinkEditor.ts
+++ b/frontend/src/hooks/useLinkEditor.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Editor } from '@tiptap/core';
+
+export interface LinkBubbleState {
+  url: string;
+  top: number;
+  left: number;
+}
+
+export function useLinkEditor(
+  editor: Editor | null,
+  containerRef: React.RefObject<HTMLDivElement | null>,
+) {
+  const [linkBubble, setLinkBubble] = useState<LinkBubbleState | null>(null);
+
+  // Ctrl+K / Cmd+K でリンク挿入
+  useEffect(() => {
+    if (!editor) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        const previousUrl = editor.getAttributes('link').href || '';
+        const url = window.prompt('URLを入力', previousUrl);
+        if (url === null) return;
+        if (url === '') {
+          editor.chain().focus().extendMarkRange('link').unsetLink().run();
+        } else {
+          editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+        }
+      }
+    };
+    const editorEl = editor.view.dom;
+    editorEl.addEventListener('keydown', handleKeyDown);
+    return () => editorEl.removeEventListener('keydown', handleKeyDown);
+  }, [editor]);
+
+  // リンククリック検知
+  const handleEditorClick = useCallback((e: React.MouseEvent) => {
+    if (!editor || !containerRef.current) return;
+    const target = e.target as HTMLElement;
+    const linkEl = target.closest('a.note-link');
+    if (linkEl) {
+      const href = linkEl.getAttribute('href') || '';
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const linkRect = linkEl.getBoundingClientRect();
+      setLinkBubble({
+        url: href,
+        top: linkRect.bottom - containerRect.top + 4,
+        left: linkRect.left - containerRect.left,
+      });
+    } else {
+      setLinkBubble(null);
+    }
+  }, [editor, containerRef]);
+
+  // リンク編集
+  const handleEditLink = useCallback(() => {
+    if (!editor || !linkBubble) return;
+    const url = window.prompt('URLを入力', linkBubble.url);
+    if (url === null) return;
+    if (url === '') {
+      editor.chain().focus().extendMarkRange('link').unsetLink().run();
+    } else {
+      editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+    }
+    setLinkBubble(null);
+  }, [editor, linkBubble]);
+
+  // リンク削除
+  const handleRemoveLink = useCallback(() => {
+    if (!editor) return;
+    editor.chain().focus().extendMarkRange('link').unsetLink().run();
+    setLinkBubble(null);
+  }, [editor]);
+
+  const dismissLinkBubble = useCallback(() => {
+    setLinkBubble(null);
+  }, []);
+
+  return {
+    linkBubble,
+    handleEditorClick,
+    handleEditLink,
+    handleRemoveLink,
+    dismissLinkBubble,
+  };
+}


### PR DESCRIPTION
## 概要
BlockEditor.tsx（154行）からリンク関連ロジックをuseLinkEditorフックに抽出し、100行にスリム化。

## 変更内容
- `useLinkEditor.ts`: Ctrl+K/Cmd+Kショートカット、リンクバブル状態管理、編集・削除ハンドラを集約
- `BlockEditor.tsx`: 154行→100行（-54行）
- `useLinkEditor.test.ts`: 4テスト追加

## テスト結果
- フロントエンド: 1521テスト全パス（+4テスト）

closes #786