### PR TITLE
refactor: MessageBubbleAiの重複コード統合

### DIFF
--- a/frontend/src/components/MessageBubbleAi.tsx
+++ b/frontend/src/components/MessageBubbleAi.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon, TrashIcon } from '@heroicons/react/24/outline';
+import MessageBubble from './MessageBubble';
 
 interface MessageBubbleAiProps {
   isSender: boolean;
@@ -12,79 +11,6 @@ interface MessageBubbleAiProps {
   isDeleted?: boolean;
 }
 
-export default function MessageBubbleAi({
-  isSender,
-  type = 'text',
-  content,
-  id,
-  onDelete,
-  onCopy,
-  isCopied = false,
-  isDeleted = false,
-}: MessageBubbleAiProps) {
-  const [showDelete, setShowDelete] = useState(false);
-
-  const baseStyle =
-    'max-w-[85%] px-4 py-2.5 rounded-2xl text-sm whitespace-pre-wrap break-words relative';
-
-  const alignment = isSender
-    ? 'self-end bg-primary-500 text-white rounded-br-sm'
-    : 'self-start bg-surface-3 text-[var(--color-text-primary)] rounded-bl-sm';
-
-  const deletedStyle = 'bg-surface-3 text-[var(--color-text-muted)] italic';
-
-  return (
-    <div
-      className={`flex ${
-        isSender ? 'justify-end' : 'justify-start'
-      } my-3 group`}
-      onMouseEnter={() => isSender && !isDeleted && setShowDelete(true)}
-      onMouseLeave={() => setShowDelete(false)}
-    >
-      <div className={`${baseStyle} ${isDeleted ? deletedStyle : alignment}`}>
-        {isDeleted ? (
-          <p>メッセージを削除しました</p>
-        ) : (
-          <>
-            {type === 'text' && <p>{content}</p>}
-            {type === 'image' && (
-              <img
-                src={content}
-                alt="画像"
-                className="max-w-full rounded-lg shadow-md"
-              />
-            )}
-            {type === 'bot' && <p className="italic opacity-80">{content}</p>}
-          </>
-        )}
-
-        {isSender && showDelete && onDelete && !isDeleted && (
-          <button
-            onClick={() => onDelete(id)}
-            className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 transition-colors duration-150"
-            title="削除"
-          >
-            <TrashIcon className="w-3 h-3" />
-          </button>
-        )}
-      </div>
-
-      {!isDeleted && onCopy && (
-        <div className={`flex items-center mt-1 ${isSender ? 'justify-end' : 'justify-start'}`}>
-          <button
-            onClick={() => onCopy(id, content)}
-            title={isCopied ? 'コピー済み' : 'コピー'}
-            aria-label={isCopied ? 'コピー済み' : 'メッセージをコピー'}
-            className="text-[var(--color-text-faint)] hover:text-[var(--color-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
-          >
-            {isCopied ? (
-              <ClipboardDocumentCheckIcon className="w-3.5 h-3.5 text-green-500" />
-            ) : (
-              <ClipboardDocumentIcon className="w-3.5 h-3.5" />
-            )}
-          </button>
-        </div>
-      )}
-    </div>
-  );
+export default function MessageBubbleAi(props: MessageBubbleAiProps) {
+  return <MessageBubble {...props} />;
 }


### PR DESCRIPTION
## 概要
- MessageBubbleAi（90行）をMessageBubbleへの委譲コンポーネント（17行）に統合
- 73行の重複コード削減
- 既存のimportパスは維持し後方互換性を保持

## 変更内容
- `MessageBubbleAi.tsx`: 90行の独立実装 → MessageBubbleへの委譲（17行）

## テスト
- 全1534テスト合格（既存29件のMessageBubble/MessageBubbleAiテスト含む）

closes #792