### PR TITLE
refactor: EditorToolbarコンポーネント分離

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -7,8 +7,7 @@ import { useImageUpload } from '../hooks/useImageUpload';
 import { useLinkEditor } from '../hooks/useLinkEditor';
 import BlockInserterButton from './BlockInserterButton';
 import LinkBubbleMenu from './LinkBubbleMenu';
-import ColorPicker from './ColorPicker';
-import TextAlignButtons from './TextAlignButtons';
+import EditorToolbar from './EditorToolbar';
 import type { SlashCommand } from '../constants/slashCommands';
 
 interface BlockEditorProps {
@@ -90,11 +89,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
       onDragOver={(e) => e.preventDefault()}
       onClick={handleEditorClick}
     >
-      <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
-        <ColorPicker onSelectColor={handleSelectColor} />
-        <div className="w-px h-4 bg-[var(--color-surface-3)]" />
-        <TextAlignButtons onAlign={handleAlign} />
-      </div>
+      <EditorToolbar onSelectColor={handleSelectColor} onAlign={handleAlign} />
       {linkBubble && (
         <div
           className="absolute z-50"

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -1,0 +1,17 @@
+import ColorPicker from './ColorPicker';
+import TextAlignButtons from './TextAlignButtons';
+
+interface EditorToolbarProps {
+  onSelectColor: (color: string) => void;
+  onAlign: (alignment: 'left' | 'center' | 'right') => void;
+}
+
+export default function EditorToolbar({ onSelectColor, onAlign }: EditorToolbarProps) {
+  return (
+    <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
+      <ColorPicker onSelectColor={onSelectColor} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <TextAlignButtons onAlign={onAlign} />
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditorToolbar from '../EditorToolbar';
+
+describe('EditorToolbar', () => {
+  const defaultProps = {
+    onSelectColor: vi.fn(),
+    onAlign: vi.fn(),
+  };
+
+  it('カラーピッカーが表示される', () => {
+    render(<EditorToolbar {...defaultProps} />);
+    expect(screen.getByLabelText('赤')).toBeInTheDocument();
+  });
+
+  it('配置ボタンが表示される', () => {
+    render(<EditorToolbar {...defaultProps} />);
+    expect(screen.getByLabelText('左寄せ')).toBeInTheDocument();
+    expect(screen.getByLabelText('中央寄せ')).toBeInTheDocument();
+    expect(screen.getByLabelText('右寄せ')).toBeInTheDocument();
+  });
+
+  it('色選択でonSelectColorが呼ばれる', () => {
+    const onSelectColor = vi.fn();
+    render(<EditorToolbar {...defaultProps} onSelectColor={onSelectColor} />);
+    fireEvent.click(screen.getByLabelText('赤'));
+    expect(onSelectColor).toHaveBeenCalled();
+  });
+
+  it('配置ボタンクリックでonAlignが呼ばれる', () => {
+    const onAlign = vi.fn();
+    render(<EditorToolbar {...defaultProps} onAlign={onAlign} />);
+    fireEvent.click(screen.getByLabelText('中央寄せ'));
+    expect(onAlign).toHaveBeenCalledWith('center');
+  });
+});


### PR DESCRIPTION
## 概要
- BlockEditorからツールバー（ColorPicker + TextAlignButtons）をEditorToolbarに分離
- 今後のツールバー機能追加が容易に

## 変更内容
- `EditorToolbar.tsx` 新規作成（18行）
- `EditorToolbar.test.tsx` 新規作成（4テスト）
- `BlockEditor.tsx` 簡素化（ツールバー部分をEditorToolbarに委譲）

## テスト
- 全1555テスト合格

closes #798