### PR TITLE
refactor: useEditorFormatフック分離

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -5,6 +5,7 @@ import { executeCommand } from '../extensions/SlashCommandExtension';
 import { useBlockEditor } from '../hooks/useBlockEditor';
 import { useImageUpload } from '../hooks/useImageUpload';
 import { useLinkEditor } from '../hooks/useLinkEditor';
+import { useEditorFormat } from '../hooks/useEditorFormat';
 import BlockInserterButton from './BlockInserterButton';
 import LinkBubbleMenu from './LinkBubbleMenu';
 import EditorToolbar from './EditorToolbar';
@@ -25,6 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -62,36 +64,6 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
     editor.chain().focus().run();
     executeCommand(editor, command);
   }, [editor, openFileDialog]);
-
-  const handleBold = useCallback(() => {
-    editor?.chain().focus().toggleBold().run();
-  }, [editor]);
-
-  const handleItalic = useCallback(() => {
-    editor?.chain().focus().toggleItalic().run();
-  }, [editor]);
-
-  const handleUnderline = useCallback(() => {
-    editor?.chain().focus().toggleUnderline().run();
-  }, [editor]);
-
-  const handleStrike = useCallback(() => {
-    editor?.chain().focus().toggleStrike().run();
-  }, [editor]);
-
-  const handleAlign = useCallback((alignment: 'left' | 'center' | 'right') => {
-    if (!editor) return;
-    editor.chain().focus().setTextAlign(alignment).run();
-  }, [editor]);
-
-  const handleSelectColor = useCallback((color: string) => {
-    if (!editor) return;
-    if (color) {
-      editor.chain().focus().setColor(color).run();
-    } else {
-      editor.chain().focus().unsetColor().run();
-    }
-  }, [editor]);
 
   return (
     <div

--- a/frontend/src/hooks/__tests__/useEditorFormat.test.ts
+++ b/frontend/src/hooks/__tests__/useEditorFormat.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEditorFormat } from '../useEditorFormat';
+
+describe('useEditorFormat', () => {
+  const createMockEditor = () => ({
+    chain: vi.fn(() => ({
+      focus: vi.fn(() => ({
+        toggleBold: vi.fn(() => ({ run: vi.fn() })),
+        toggleItalic: vi.fn(() => ({ run: vi.fn() })),
+        toggleUnderline: vi.fn(() => ({ run: vi.fn() })),
+        toggleStrike: vi.fn(() => ({ run: vi.fn() })),
+        setTextAlign: vi.fn(() => ({ run: vi.fn() })),
+        setColor: vi.fn(() => ({ run: vi.fn() })),
+        unsetColor: vi.fn(() => ({ run: vi.fn() })),
+      })),
+    })),
+  });
+
+  it('全てのハンドラーを返す', () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorFormat(editor as never));
+
+    expect(result.current.handleBold).toBeDefined();
+    expect(result.current.handleItalic).toBeDefined();
+    expect(result.current.handleUnderline).toBeDefined();
+    expect(result.current.handleStrike).toBeDefined();
+    expect(result.current.handleAlign).toBeDefined();
+    expect(result.current.handleSelectColor).toBeDefined();
+  });
+
+  it('handleBoldがeditor.chain()を呼ぶ', () => {
+    const editor = createMockEditor();
+    const { result } = renderHook(() => useEditorFormat(editor as never));
+
+    act(() => result.current.handleBold());
+    expect(editor.chain).toHaveBeenCalled();
+  });
+
+  it('editorがnullでもエラーにならない', () => {
+    const { result } = renderHook(() => useEditorFormat(null));
+
+    expect(() => act(() => result.current.handleBold())).not.toThrow();
+    expect(() => act(() => result.current.handleAlign('center'))).not.toThrow();
+    expect(() => act(() => result.current.handleSelectColor('#ff0000'))).not.toThrow();
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import type { Editor } from '@tiptap/react';
+
+export function useEditorFormat(editor: Editor | null) {
+  const handleBold = useCallback(() => {
+    editor?.chain().focus().toggleBold().run();
+  }, [editor]);
+
+  const handleItalic = useCallback(() => {
+    editor?.chain().focus().toggleItalic().run();
+  }, [editor]);
+
+  const handleUnderline = useCallback(() => {
+    editor?.chain().focus().toggleUnderline().run();
+  }, [editor]);
+
+  const handleStrike = useCallback(() => {
+    editor?.chain().focus().toggleStrike().run();
+  }, [editor]);
+
+  const handleAlign = useCallback((alignment: 'left' | 'center' | 'right') => {
+    if (!editor) return;
+    editor.chain().focus().setTextAlign(alignment).run();
+  }, [editor]);
+
+  const handleSelectColor = useCallback((color: string) => {
+    if (!editor) return;
+    if (color) {
+      editor.chain().focus().setColor(color).run();
+    } else {
+      editor.chain().focus().unsetColor().run();
+    }
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor };
+}


### PR DESCRIPTION
## 概要
- BlockEditorから書式関連ハンドラー6個をuseEditorFormatフックに分離
- BlockEditor 139行→109行に削減（30行削減）

## 変更内容
- `useEditorFormat.ts` 新規作成（handleBold/Italic/Underline/Strike/Align/SelectColor）
- `useEditorFormat.test.ts` 新規作成（3テスト）
- `BlockEditor.tsx` 簡素化

## テスト
- 全1567テスト合格

closes #804