### PR TITLE
refactor: PracticeCalendarのヘルパー関数をcalendarHelpersに分離

### DIFF
--- a/frontend/src/components/PracticeCalendar.tsx
+++ b/frontend/src/components/PracticeCalendar.tsx
@@ -1,42 +1,8 @@
 import { useMemo } from 'react';
+import { toLocalDateKey, getCalendarDays, getIntensityClass } from '../utils/calendarHelpers';
 
 interface PracticeCalendarProps {
   practiceDates: string[];
-}
-
-function toLocalDateKey(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-}
-
-function getCalendarDays(weeks: number): Date[] {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
-  const dayOfWeek = today.getDay();
-  const endOfWeek = new Date(today);
-  endOfWeek.setDate(today.getDate() + (6 - dayOfWeek));
-
-  const startDate = new Date(endOfWeek);
-  startDate.setDate(endOfWeek.getDate() - weeks * 7 + 1);
-
-  const days: Date[] = [];
-  const current = new Date(startDate);
-  while (current <= endOfWeek) {
-    days.push(new Date(current));
-    current.setDate(current.getDate() + 1);
-  }
-
-  return days;
-}
-
-function getIntensityClass(count: number): string {
-  if (count === 0) return 'bg-surface-3';
-  if (count === 1) return 'bg-emerald-200';
-  if (count === 2) return 'bg-emerald-400';
-  return 'bg-emerald-600';
 }
 
 export default function PracticeCalendar({ practiceDates }: PracticeCalendarProps) {

--- a/frontend/src/utils/__tests__/calendarHelpers.test.ts
+++ b/frontend/src/utils/__tests__/calendarHelpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { toLocalDateKey, getCalendarDays, getIntensityClass } from '../calendarHelpers';
+
+describe('calendarHelpers', () => {
+  describe('toLocalDateKey', () => {
+    it('日付をYYYY-MM-DD形式に変換する', () => {
+      const date = new Date(2026, 0, 5); // 2026-01-05
+      expect(toLocalDateKey(date)).toBe('2026-01-05');
+    });
+
+    it('月と日を0埋めする', () => {
+      const date = new Date(2026, 2, 3); // 2026-03-03
+      expect(toLocalDateKey(date)).toBe('2026-03-03');
+    });
+  });
+
+  describe('getCalendarDays', () => {
+    it('指定された週数分の日付を返す', () => {
+      const days = getCalendarDays(1);
+      expect(days).toHaveLength(7);
+    });
+
+    it('2週間分で14日を返す', () => {
+      const days = getCalendarDays(2);
+      expect(days).toHaveLength(14);
+    });
+
+    it('日付が昇順に並ぶ', () => {
+      const days = getCalendarDays(2);
+      for (let i = 1; i < days.length; i++) {
+        expect(days[i].getTime()).toBeGreaterThan(days[i - 1].getTime());
+      }
+    });
+  });
+
+  describe('getIntensityClass', () => {
+    it('0回でbg-surface-3を返す', () => {
+      expect(getIntensityClass(0)).toBe('bg-surface-3');
+    });
+
+    it('1回でbg-emerald-200を返す', () => {
+      expect(getIntensityClass(1)).toBe('bg-emerald-200');
+    });
+
+    it('2回でbg-emerald-400を返す', () => {
+      expect(getIntensityClass(2)).toBe('bg-emerald-400');
+    });
+
+    it('3回以上でbg-emerald-600を返す', () => {
+      expect(getIntensityClass(3)).toBe('bg-emerald-600');
+      expect(getIntensityClass(5)).toBe('bg-emerald-600');
+    });
+  });
+});

--- a/frontend/src/utils/calendarHelpers.ts
+++ b/frontend/src/utils/calendarHelpers.ts
@@ -1,0 +1,34 @@
+export function toLocalDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function getCalendarDays(weeks: number): Date[] {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const dayOfWeek = today.getDay();
+  const endOfWeek = new Date(today);
+  endOfWeek.setDate(today.getDate() + (6 - dayOfWeek));
+
+  const startDate = new Date(endOfWeek);
+  startDate.setDate(endOfWeek.getDate() - weeks * 7 + 1);
+
+  const days: Date[] = [];
+  const current = new Date(startDate);
+  while (current <= endOfWeek) {
+    days.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return days;
+}
+
+export function getIntensityClass(count: number): string {
+  if (count === 0) return 'bg-surface-3';
+  if (count === 1) return 'bg-emerald-200';
+  if (count === 2) return 'bg-emerald-400';
+  return 'bg-emerald-600';
+}


### PR DESCRIPTION
## 概要
closes #810

- PracticeCalendarコンポーネント内のヘルパー関数（toLocalDateKey, getCalendarDays, getIntensityClass）を`utils/calendarHelpers.ts`に抽出
- 各関数のユニットテスト9件を追加
- コンポーネントの責務を明確化し、テスタビリティ向上

## テスト
- 全1580テスト合格