### PR TITLE
test: ChatRoomService・RoomMemberServiceのユニットテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/ChatRoomServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ChatRoomServiceTest.java
@@ -1,0 +1,48 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.repository.ChatRoomRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @InjectMocks
+    private ChatRoomService chatRoomService;
+
+    @Test
+    @DisplayName("findChatRoomById: 存在するルームを返す")
+    void findChatRoomById_returnsRoom() {
+        ChatRoom room = new ChatRoom();
+        room.setId(1);
+        when(chatRoomRepository.findById(1)).thenReturn(Optional.of(room));
+
+        ChatRoom result = chatRoomService.findChatRoomById(1);
+
+        assertEquals(1, result.getId());
+        verify(chatRoomRepository).findById(1);
+    }
+
+    @Test
+    @DisplayName("findChatRoomById: 存在しないルームで例外")
+    void findChatRoomById_throwsWhenNotFound() {
+        when(chatRoomRepository.findById(999)).thenReturn(Optional.empty());
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> chatRoomService.findChatRoomById(999));
+        assertEquals("ルームが存在しません。", ex.getMessage());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/RoomMemberServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/RoomMemberServiceTest.java
@@ -1,0 +1,83 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.RoomMemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RoomMemberServiceTest {
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
+
+    @InjectMocks
+    private RoomMemberService roomMemberService;
+
+    @Test
+    @DisplayName("existsRoom: ルームにユーザーが存在する場合true")
+    void existsRoom_returnsTrue() {
+        when(roomMemberRepository.existsByRoom_IdAndUser_Id(10, 1)).thenReturn(true);
+
+        assertTrue(roomMemberService.existsRoom(10, 1));
+        verify(roomMemberRepository).existsByRoom_IdAndUser_Id(10, 1);
+    }
+
+    @Test
+    @DisplayName("existsRoom: ルームにユーザーが存在しない場合false")
+    void existsRoom_returnsFalse() {
+        when(roomMemberRepository.existsByRoom_IdAndUser_Id(10, 1)).thenReturn(false);
+
+        assertFalse(roomMemberService.existsRoom(10, 1));
+    }
+
+    @Test
+    @DisplayName("findRoomId: ユーザーが所属するルームIDリストを返す")
+    void findRoomId_returnsRoomIds() {
+        when(roomMemberRepository.findRoomIdByUserId(1)).thenReturn(List.of(10, 20, 30));
+
+        List<Integer> result = roomMemberService.findRoomId(1);
+
+        assertEquals(3, result.size());
+        assertEquals(List.of(10, 20, 30), result);
+    }
+
+    @Test
+    @DisplayName("findUsers: 会話相手のユーザーリストを返す")
+    void findUsers_returnsUsers() {
+        User user1 = new User();
+        user1.setId(2);
+        user1.setName("ユーザー2");
+        User user2 = new User();
+        user2.setId(3);
+        user2.setName("ユーザー3");
+
+        when(roomMemberRepository.findUsersByUserId(1)).thenReturn(List.of(user1, user2));
+
+        List<User> result = roomMemberService.findUsers(1);
+
+        assertEquals(2, result.size());
+        assertEquals("ユーザー2", result.get(0).getName());
+        assertEquals("ユーザー3", result.get(1).getName());
+    }
+
+    @Test
+    @DisplayName("countChatPartners: 会話相手の数を返す")
+    void countChatPartners_returnsCount() {
+        when(roomMemberRepository.countDistinctPartnersByUserId(1)).thenReturn(5L);
+
+        Long result = roomMemberService.countChatPartners(1);
+
+        assertEquals(5L, result);
+        verify(roomMemberRepository).countDistinctPartnersByUserId(1);
+    }
+}


### PR DESCRIPTION
## 概要
closes #812

- ChatRoomServiceのユニットテスト2件追加（正常系・存在しないルームの例外）
- RoomMemberServiceのユニットテスト5件追加（existsRoom, findRoomId, findUsers, countChatPartners）
- JUnit 5 + Mockito、既存パターンに準拠

## テスト
- 新規7テスト全て合格