### PR TITLE
feat: テキストハイライト（背景色マーカー）機能追加

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -83,6 +83,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onUnderline={handleUnderline}
         onStrike={handleStrike}
         onSelectColor={handleSelectColor}
+        onHighlight={handleHighlight}
         onAlign={handleAlign}
       />
       {linkBubble && (

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -1,5 +1,6 @@
 import FormatButtons from './FormatButtons';
 import ColorPicker from './ColorPicker';
+import HighlightPicker from './HighlightPicker';
 import TextAlignButtons from './TextAlignButtons';
 
 interface EditorToolbarProps {
@@ -8,6 +9,7 @@ interface EditorToolbarProps {
   onUnderline: () => void;
   onStrike: () => void;
   onSelectColor: (color: string) => void;
+  onHighlight: (color: string) => void;
   onAlign: (alignment: 'left' | 'center' | 'right') => void;
 }
 
@@ -17,6 +19,7 @@ export default function EditorToolbar({
   onUnderline,
   onStrike,
   onSelectColor,
+  onHighlight,
   onAlign,
 }: EditorToolbarProps) {
   return (
@@ -24,6 +27,8 @@ export default function EditorToolbar({
       <FormatButtons onBold={onBold} onItalic={onItalic} onUnderline={onUnderline} onStrike={onStrike} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <ColorPicker onSelectColor={onSelectColor} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <HighlightPicker onSelectHighlight={onHighlight} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <TextAlignButtons onAlign={onAlign} />
     </div>

--- a/frontend/src/components/HighlightPicker.tsx
+++ b/frontend/src/components/HighlightPicker.tsx
@@ -1,0 +1,40 @@
+interface HighlightPickerProps {
+  onSelectHighlight: (color: string) => void;
+}
+
+const HIGHLIGHTS = [
+  { color: '#fecaca', label: '赤ハイライト' },
+  { color: '#fed7aa', label: 'オレンジハイライト' },
+  { color: '#fef08a', label: '黄ハイライト' },
+  { color: '#bbf7d0', label: '緑ハイライト' },
+  { color: '#bfdbfe', label: '青ハイライト' },
+  { color: '#e9d5ff', label: '紫ハイライト' },
+];
+
+export default function HighlightPicker({ onSelectHighlight }: HighlightPickerProps) {
+  return (
+    <div className="flex items-center gap-1">
+      {HIGHLIGHTS.map(({ color, label }) => (
+        <button
+          key={color}
+          type="button"
+          aria-label={label}
+          className="w-5 h-5 rounded border border-[var(--color-surface-3)] hover:scale-110 transition-transform"
+          style={{ backgroundColor: color }}
+          onClick={() => onSelectHighlight(color)}
+        />
+      ))}
+      <button
+        type="button"
+        aria-label="ハイライトをリセット"
+        className="w-5 h-5 rounded border border-[var(--color-surface-3)] hover:scale-110 transition-transform flex items-center justify-center bg-[var(--color-surface-1)]"
+        onClick={() => onSelectHighlight('')}
+      >
+        <svg width="10" height="10" viewBox="0 0 10 10" className="text-[var(--color-text-secondary)]">
+          <line x1="2" y1="2" x2="8" y2="8" stroke="currentColor" strokeWidth="1.5" />
+          <line x1="8" y1="2" x2="2" y2="8" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -9,6 +9,7 @@ describe('EditorToolbar', () => {
     onUnderline: vi.fn(),
     onStrike: vi.fn(),
     onSelectColor: vi.fn(),
+    onHighlight: vi.fn(),
     onAlign: vi.fn(),
   };
 

--- a/frontend/src/components/__tests__/HighlightPicker.test.tsx
+++ b/frontend/src/components/__tests__/HighlightPicker.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HighlightPicker from '../HighlightPicker';
+
+describe('HighlightPicker', () => {
+  it('6色のハイライトボタンが表示される', () => {
+    render(<HighlightPicker onSelectHighlight={vi.fn()} />);
+    const buttons = screen.getAllByRole('button');
+    // 6色 + リセットボタン = 7
+    expect(buttons).toHaveLength(7);
+  });
+
+  it('色ボタンをクリックすると色コードが渡される', () => {
+    const handler = vi.fn();
+    render(<HighlightPicker onSelectHighlight={handler} />);
+    fireEvent.click(screen.getByLabelText('赤ハイライト'));
+    expect(handler).toHaveBeenCalledWith('#fecaca');
+  });
+
+  it('リセットボタンをクリックすると空文字が渡される', () => {
+    const handler = vi.fn();
+    render(<HighlightPicker onSelectHighlight={handler} />);
+    fireEvent.click(screen.getByLabelText('ハイライトをリセット'));
+    expect(handler).toHaveBeenCalledWith('');
+  });
+
+  it('各ボタンにaria-labelがある', () => {
+    render(<HighlightPicker onSelectHighlight={vi.fn()} />);
+    expect(screen.getByLabelText('赤ハイライト')).toBeInTheDocument();
+    expect(screen.getByLabelText('オレンジハイライト')).toBeInTheDocument();
+    expect(screen.getByLabelText('黄ハイライト')).toBeInTheDocument();
+    expect(screen.getByLabelText('緑ハイライト')).toBeInTheDocument();
+    expect(screen.getByLabelText('青ハイライト')).toBeInTheDocument();
+    expect(screen.getByLabelText('紫ハイライト')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -32,5 +32,14 @@ export function useEditorFormat(editor: Editor | null) {
     }
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor };
+  const handleHighlight = useCallback((color: string) => {
+    if (!editor) return;
+    if (color) {
+      editor.chain().focus().setHighlight({ color }).run();
+    } else {
+      editor.chain().focus().unsetHighlight().run();
+    }
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight };
 }


### PR DESCRIPTION
## 概要
closes #814

- HighlightPickerコンポーネント追加（6色 + リセットボタン）
- EditorToolbarにハイライトピッカーを統合
- useEditorFormatにhandleHighlightハンドラー追加
- TipTapのHighlight拡張（multicolor: true）を活用

## テスト
- HighlightPicker.test.tsx: 4テスト追加
- EditorToolbar.test.tsx: 既存テスト更新
- 全1584テスト合格