### PR TITLE
refactor: useChatからメッセージ選択ロジックをuseMessageSelectionに分離

### DIFF
--- a/frontend/src/hooks/__tests__/useMessageSelection.test.ts
+++ b/frontend/src/hooks/__tests__/useMessageSelection.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMessageSelection } from '../useMessageSelection';
+import type { ChatMessage } from '../../types';
+
+const makeMessages = (count: number): ChatMessage[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    roomId: 1,
+    senderId: i % 2 === 0 ? 1 : 2,
+    senderName: `User${i % 2}`,
+    content: `msg${i + 1}`,
+    createdAt: '2025-01-01T00:00:00',
+    isSender: i % 2 === 0,
+  }));
+
+describe('useMessageSelection', () => {
+  it('初期状態はselectionMode=false', () => {
+    const { result } = renderHook(() => useMessageSelection(makeMessages(5)));
+    expect(result.current.selectionMode).toBe(false);
+    expect(result.current.selectedMessages.size).toBe(0);
+  });
+
+  it('enterSelectionModeで選択モードに入る', () => {
+    const { result } = renderHook(() => useMessageSelection(makeMessages(5)));
+    act(() => result.current.enterSelectionMode());
+    expect(result.current.selectionMode).toBe(true);
+  });
+
+  it('cancelSelectionで選択モードを終了する', () => {
+    const { result } = renderHook(() => useMessageSelection(makeMessages(5)));
+    act(() => result.current.enterSelectionMode());
+    act(() => result.current.cancelSelection());
+    expect(result.current.selectionMode).toBe(false);
+    expect(result.current.selectedMessages.size).toBe(0);
+  });
+
+  it('handleRangeClickで開始・終了を指定して範囲選択する', () => {
+    const messages = makeMessages(5);
+    const { result } = renderHook(() => useMessageSelection(messages));
+    act(() => result.current.enterSelectionMode());
+    // 1番目をクリック（開始）
+    act(() => result.current.handleRangeClick(1));
+    expect(result.current.selectedMessages.size).toBe(1);
+    // 3番目をクリック（終了）
+    act(() => result.current.handleRangeClick(3));
+    expect(result.current.selectedMessages.size).toBe(3);
+    expect(result.current.selectedMessages.has(1)).toBe(true);
+    expect(result.current.selectedMessages.has(2)).toBe(true);
+    expect(result.current.selectedMessages.has(3)).toBe(true);
+  });
+
+  it('handleQuickSelectで直近N件を選択する', () => {
+    const messages = makeMessages(10);
+    const { result } = renderHook(() => useMessageSelection(messages));
+    act(() => result.current.handleQuickSelect(3));
+    expect(result.current.selectedMessages.size).toBe(3);
+    expect(result.current.selectedMessages.has(8)).toBe(true);
+    expect(result.current.selectedMessages.has(9)).toBe(true);
+    expect(result.current.selectedMessages.has(10)).toBe(true);
+  });
+
+  it('handleSelectAllで全件選択する', () => {
+    const messages = makeMessages(5);
+    const { result } = renderHook(() => useMessageSelection(messages));
+    act(() => result.current.handleSelectAll());
+    expect(result.current.selectedMessages.size).toBe(5);
+  });
+
+  it('handleDeselectAllで全件選択解除する', () => {
+    const messages = makeMessages(5);
+    const { result } = renderHook(() => useMessageSelection(messages));
+    act(() => result.current.handleSelectAll());
+    act(() => result.current.handleDeselectAll());
+    expect(result.current.selectedMessages.size).toBe(0);
+  });
+
+  it('isInRangeが範囲内のインデックスを判定する', () => {
+    const messages = makeMessages(5);
+    const { result } = renderHook(() => useMessageSelection(messages));
+    act(() => result.current.handleRangeClick(1));
+    act(() => result.current.handleRangeClick(3));
+    expect(result.current.isInRange(0)).toBe(true);
+    expect(result.current.isInRange(1)).toBe(true);
+    expect(result.current.isInRange(2)).toBe(true);
+    expect(result.current.isInRange(3)).toBe(false);
+  });
+
+  it('getRangeLabelが開始・終了ラベルを返す', () => {
+    const messages = makeMessages(5);
+    const { result } = renderHook(() => useMessageSelection(messages));
+    act(() => result.current.handleRangeClick(1));
+    act(() => result.current.handleRangeClick(3));
+    expect(result.current.getRangeLabel(0)).toBe('開始');
+    expect(result.current.getRangeLabel(2)).toBe('終了');
+    expect(result.current.getRangeLabel(1)).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useMessageSelection.ts
+++ b/frontend/src/hooks/useMessageSelection.ts
@@ -1,0 +1,96 @@
+import { useState, useCallback } from 'react';
+import type { ChatMessage } from '../types';
+
+export function useMessageSelection(messages: ChatMessage[]) {
+  const [selectionMode, setSelectionMode] = useState(false);
+  const [selectedMessages, setSelectedMessages] = useState<Set<number>>(new Set());
+  const [rangeStart, setRangeStart] = useState<number | null>(null);
+  const [rangeEnd, setRangeEnd] = useState<number | null>(null);
+
+  const enterSelectionMode = useCallback(() => {
+    setSelectionMode(true);
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+  }, []);
+
+  const cancelSelection = useCallback(() => {
+    setSelectionMode(false);
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+  }, []);
+
+  const handleRangeClick = useCallback((messageId: number) => {
+    const messageIndex = messages.findIndex((msg) => msg.id === messageId);
+    if (rangeStart === null) {
+      setRangeStart(messageIndex);
+      setRangeEnd(null);
+      setSelectedMessages(new Set([messageId]));
+    } else if (rangeEnd === null) {
+      setRangeEnd(messageIndex);
+      const start = Math.min(rangeStart, messageIndex);
+      const end = Math.max(rangeStart, messageIndex);
+      const rangeIds = new Set(messages.slice(start, end + 1).map((msg) => msg.id));
+      setSelectedMessages(rangeIds);
+    } else {
+      setRangeStart(messageIndex);
+      setRangeEnd(null);
+      setSelectedMessages(new Set([messageId]));
+    }
+  }, [messages, rangeStart, rangeEnd]);
+
+  const handleQuickSelect = useCallback((count: number) => {
+    const recentMessages = messages.slice(-count);
+    const recentIds = new Set(recentMessages.map((msg) => msg.id));
+    setSelectedMessages(recentIds);
+    if (recentMessages.length > 0) {
+      setRangeStart(messages.length - count);
+      setRangeEnd(messages.length - 1);
+    }
+  }, [messages]);
+
+  const handleSelectAll = useCallback(() => {
+    const allIds = new Set(messages.map((msg) => msg.id));
+    setSelectedMessages(allIds);
+    setRangeStart(0);
+    setRangeEnd(messages.length - 1);
+  }, [messages]);
+
+  const handleDeselectAll = useCallback(() => {
+    setSelectedMessages(new Set());
+    setRangeStart(null);
+    setRangeEnd(null);
+  }, []);
+
+  const isInRange = useCallback((index: number): boolean => {
+    if (rangeStart === null) return false;
+    if (rangeEnd === null) return index === rangeStart;
+    const start = Math.min(rangeStart, rangeEnd);
+    const end = Math.max(rangeStart, rangeEnd);
+    return index >= start && index <= end;
+  }, [rangeStart, rangeEnd]);
+
+  const getRangeLabel = useCallback((index: number): string | null => {
+    if (rangeStart === index && rangeEnd === null) return '開始';
+    if (rangeEnd === null) return null;
+    const start = Math.min(rangeStart!, rangeEnd);
+    const end = Math.max(rangeStart!, rangeEnd);
+    if (index === start) return '開始';
+    if (index === end) return '終了';
+    return null;
+  }, [rangeStart, rangeEnd]);
+
+  return {
+    selectionMode,
+    selectedMessages,
+    enterSelectionMode,
+    cancelSelection,
+    handleRangeClick,
+    handleQuickSelect,
+    handleSelectAll,
+    handleDeselectAll,
+    isInRange,
+    getRangeLabel,
+  };
+}


### PR DESCRIPTION
## 概要
closes #816

- useChat.ts（306行→236行、70行削減）からAI選択モード関連ロジックを分離
- useMessageSelectionフック新規作成（範囲選択・全選択・クイック選択・ユーティリティ）
- useMessageSelection.test.ts: 9テスト追加
- useChatのreturn APIは変更なし（後方互換性維持）

## テスト
- 全1593テスト合格