### PR TITLE
feat: 上付き文字・下付き文字（Superscript/Subscript）機能追加

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,8 @@
         "@tiptap/extension-image": "^3.19.0",
         "@tiptap/extension-link": "^3.19.0",
         "@tiptap/extension-placeholder": "^3.19.0",
+        "@tiptap/extension-subscript": "^3.19.0",
+        "@tiptap/extension-superscript": "^3.19.0",
         "@tiptap/extension-table": "^3.19.0",
         "@tiptap/extension-table-cell": "^3.19.0",
         "@tiptap/extension-table-header": "^3.19.0",
@@ -2279,6 +2281,34 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^3.19.0"
+      }
+    },
+    "node_modules/@tiptap/extension-subscript": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-subscript/-/extension-subscript-3.19.0.tgz",
+      "integrity": "sha512-RchUOSIDprlnuzmA/znZIBKMONIlCAXHuR6XkoNX2jFJ/9OHk/si+jEeY8jJfpPDpVqZ3KrwS/zJrqhU/pT+hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.19.0",
+        "@tiptap/pm": "^3.19.0"
+      }
+    },
+    "node_modules/@tiptap/extension-superscript": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-superscript/-/extension-superscript-3.19.0.tgz",
+      "integrity": "sha512-PjLUGjM23/7hqFP5HS1DbdywRm63GhjJ5SD6KqNgyZQwcwDZeJTAW2b/LYTHAP+k07OxOLPdj/k4ntQKtgKNow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.19.0",
+        "@tiptap/pm": "^3.19.0"
       }
     },
     "node_modules/@tiptap/extension-table": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,8 @@
     "@tiptap/extension-image": "^3.19.0",
     "@tiptap/extension-link": "^3.19.0",
     "@tiptap/extension-placeholder": "^3.19.0",
+    "@tiptap/extension-subscript": "^3.19.0",
+    "@tiptap/extension-superscript": "^3.19.0",
     "@tiptap/extension-table": "^3.19.0",
     "@tiptap/extension-table-cell": "^3.19.0",
     "@tiptap/extension-table-header": "^3.19.0",

--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -82,6 +82,8 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onItalic={handleItalic}
         onUnderline={handleUnderline}
         onStrike={handleStrike}
+        onSuperscript={handleSuperscript}
+        onSubscript={handleSubscript}
         onSelectColor={handleSelectColor}
         onHighlight={handleHighlight}
         onAlign={handleAlign}

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -8,6 +8,8 @@ interface EditorToolbarProps {
   onItalic: () => void;
   onUnderline: () => void;
   onStrike: () => void;
+  onSuperscript: () => void;
+  onSubscript: () => void;
   onSelectColor: (color: string) => void;
   onHighlight: (color: string) => void;
   onAlign: (alignment: 'left' | 'center' | 'right') => void;
@@ -18,13 +20,15 @@ export default function EditorToolbar({
   onItalic,
   onUnderline,
   onStrike,
+  onSuperscript,
+  onSubscript,
   onSelectColor,
   onHighlight,
   onAlign,
 }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
-      <FormatButtons onBold={onBold} onItalic={onItalic} onUnderline={onUnderline} onStrike={onStrike} />
+      <FormatButtons onBold={onBold} onItalic={onItalic} onUnderline={onUnderline} onStrike={onStrike} onSuperscript={onSuperscript} onSubscript={onSubscript} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <ColorPicker onSelectColor={onSelectColor} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />

--- a/frontend/src/components/FormatButtons.tsx
+++ b/frontend/src/components/FormatButtons.tsx
@@ -1,10 +1,13 @@
 import { BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon } from '@heroicons/react/24/solid';
+import { ArrowUpIcon, ArrowDownIcon } from '@heroicons/react/24/outline';
 
 interface FormatButtonsProps {
   onBold: () => void;
   onItalic: () => void;
   onUnderline: () => void;
   onStrike: () => void;
+  onSuperscript: () => void;
+  onSubscript: () => void;
 }
 
 const BUTTONS = [
@@ -12,10 +15,12 @@ const BUTTONS = [
   { label: '斜体', Icon: ItalicIcon, key: 'italic' as const },
   { label: '下線', Icon: UnderlineIcon, key: 'underline' as const },
   { label: '取り消し線', Icon: StrikethroughIcon, key: 'strike' as const },
+  { label: '上付き文字', Icon: ArrowUpIcon, key: 'superscript' as const },
+  { label: '下付き文字', Icon: ArrowDownIcon, key: 'subscript' as const },
 ];
 
-export default function FormatButtons({ onBold, onItalic, onUnderline, onStrike }: FormatButtonsProps) {
-  const handlers = { bold: onBold, italic: onItalic, underline: onUnderline, strike: onStrike };
+export default function FormatButtons({ onBold, onItalic, onUnderline, onStrike, onSuperscript, onSubscript }: FormatButtonsProps) {
+  const handlers = { bold: onBold, italic: onItalic, underline: onUnderline, strike: onStrike, superscript: onSuperscript, subscript: onSubscript };
 
   return (
     <div className="flex items-center gap-0.5">

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -8,6 +8,8 @@ describe('EditorToolbar', () => {
     onItalic: vi.fn(),
     onUnderline: vi.fn(),
     onStrike: vi.fn(),
+    onSuperscript: vi.fn(),
+    onSubscript: vi.fn(),
     onSelectColor: vi.fn(),
     onHighlight: vi.fn(),
     onAlign: vi.fn(),

--- a/frontend/src/components/__tests__/FormatButtons.test.tsx
+++ b/frontend/src/components/__tests__/FormatButtons.test.tsx
@@ -8,12 +8,14 @@ describe('FormatButtons', () => {
     onItalic: vi.fn(),
     onUnderline: vi.fn(),
     onStrike: vi.fn(),
+    onSuperscript: vi.fn(),
+    onSubscript: vi.fn(),
   };
 
-  it('4つの書式ボタンが表示される', () => {
+  it('6つの書式ボタンが表示される', () => {
     render(<FormatButtons {...defaultProps} />);
     const buttons = screen.getAllByRole('button');
-    expect(buttons).toHaveLength(4);
+    expect(buttons).toHaveLength(6);
   });
 
   it('太字ボタンにaria-labelがある', () => {
@@ -36,6 +38,16 @@ describe('FormatButtons', () => {
     expect(screen.getByLabelText('取り消し線')).toBeInTheDocument();
   });
 
+  it('上付き文字ボタンにaria-labelがある', () => {
+    render(<FormatButtons {...defaultProps} />);
+    expect(screen.getByLabelText('上付き文字')).toBeInTheDocument();
+  });
+
+  it('下付き文字ボタンにaria-labelがある', () => {
+    render(<FormatButtons {...defaultProps} />);
+    expect(screen.getByLabelText('下付き文字')).toBeInTheDocument();
+  });
+
   it('太字クリックでonBoldが呼ばれる', () => {
     const onBold = vi.fn();
     render(<FormatButtons {...defaultProps} onBold={onBold} />);
@@ -55,5 +67,19 @@ describe('FormatButtons', () => {
     render(<FormatButtons {...defaultProps} onStrike={onStrike} />);
     fireEvent.click(screen.getByLabelText('取り消し線'));
     expect(onStrike).toHaveBeenCalled();
+  });
+
+  it('上付き文字クリックでonSuperscriptが呼ばれる', () => {
+    const onSuperscript = vi.fn();
+    render(<FormatButtons {...defaultProps} onSuperscript={onSuperscript} />);
+    fireEvent.click(screen.getByLabelText('上付き文字'));
+    expect(onSuperscript).toHaveBeenCalled();
+  });
+
+  it('下付き文字クリックでonSubscriptが呼ばれる', () => {
+    const onSubscript = vi.fn();
+    render(<FormatButtons {...defaultProps} onSubscript={onSubscript} />);
+    fireEvent.click(screen.getByLabelText('下付き文字'));
+    expect(onSubscript).toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/__tests__/useBlockEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useBlockEditor.test.ts
@@ -38,6 +38,8 @@ vi.mock('@tiptap/extension-text-style', () => ({ default: 'TextStyle' }));
 vi.mock('@tiptap/extension-color', () => ({ default: 'Color' }));
 vi.mock('@tiptap/extension-text-align', () => ({ default: { configure: vi.fn(() => 'TextAlign') } }));
 vi.mock('@tiptap/extension-underline', () => ({ default: 'Underline' }));
+vi.mock('@tiptap/extension-superscript', () => ({ default: 'Superscript' }));
+vi.mock('@tiptap/extension-subscript', () => ({ default: 'Subscript' }));
 vi.mock('@tiptap/extension-youtube', () => ({ default: { configure: vi.fn(() => 'Youtube') } }));
 vi.mock('../../utils/isLegacyMarkdown', () => ({
   isLegacyMarkdown: vi.fn(() => false),
@@ -162,6 +164,6 @@ describe('useBlockEditor', () => {
     renderHook(() => useBlockEditor({ content: '', onChange }));
 
     const call = vi.mocked(useEditor).mock.calls[0]!;
-    expect(call[0]!.extensions).toHaveLength(22);
+    expect(call[0]!.extensions).toHaveLength(24);
   });
 });

--- a/frontend/src/hooks/useBlockEditor.ts
+++ b/frontend/src/hooks/useBlockEditor.ts
@@ -21,6 +21,8 @@ import TextStyle from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
 import TextAlign from '@tiptap/extension-text-align';
 import Underline from '@tiptap/extension-underline';
+import Superscript from '@tiptap/extension-superscript';
+import Subscript from '@tiptap/extension-subscript';
 import Youtube from '@tiptap/extension-youtube';
 import { isLegacyMarkdown } from '../utils/isLegacyMarkdown';
 import { markdownToTiptap } from '../utils/markdownToTiptap';
@@ -85,6 +87,8 @@ export function useBlockEditor({ content, onChange }: UseBlockEditorOptions) {
         types: ['heading', 'paragraph'],
       }),
       Underline,
+      Superscript,
+      Subscript,
       Youtube.configure({
         allowFullscreen: true,
         HTMLAttributes: { class: 'note-youtube' },

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -41,5 +41,13 @@ export function useEditorFormat(editor: Editor | null) {
     }
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight };
+  const handleSuperscript = useCallback(() => {
+    editor?.chain().focus().toggleSuperscript().run();
+  }, [editor]);
+
+  const handleSubscript = useCallback(() => {
+    editor?.chain().focus().toggleSubscript().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript };
 }


### PR DESCRIPTION
## 概要
closes #820

- FormatButtonsに上付き文字・下付き文字ボタン追加（4→6ボタン）
- @tiptap/extension-superscript, @tiptap/extension-subscript インストール
- useBlockEditorに拡張追加（22→24拡張）
- useEditorFormatにハンドラー追加
- EditorToolbar・BlockEditorに統合

## テスト
- FormatButtons.test.tsx: 8→12テスト
- 全1597テスト合格