### PR TITLE
refactor: 日付フォーマットをformatters.tsに集約

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -1,4 +1,5 @@
 import { PencilSquareIcon, TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { formatDate } from '../utils/formatters';
 
 interface AiSessionListItemProps {
   id: number;
@@ -63,7 +64,7 @@ export default function AiSessionListItem({
           <>
             <p className="text-sm font-medium truncate">{title || '新しいチャット'}</p>
             <p className="text-[11px] text-[var(--color-text-muted)]">
-              {createdAt ? new Date(createdAt).toLocaleDateString('ja-JP') : ''}
+              {createdAt ? formatDate(createdAt) : ''}
             </p>
           </>
         )}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { formatHourMinute } from '../utils/formatters';
 
 interface MessageBubbleProps {
   isSender: boolean;
@@ -40,15 +41,6 @@ export default function MessageBubble({
   const deletedAlignment = isSender
     ? 'self-end bg-surface-3 text-[var(--color-text-muted)] italic rounded-br-sm'
     : 'self-start bg-surface-3 text-[var(--color-text-muted)] italic rounded-bl-sm';
-
-  const formatTime = (dateString?: string) => {
-    if (!dateString) return '';
-    const date = new Date(dateString);
-    return date.toLocaleTimeString('ja-JP', {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
 
   return (
     <div
@@ -95,7 +87,7 @@ export default function MessageBubble({
           <div className={`flex items-center gap-2 mt-1 ${isSender ? 'justify-end' : 'justify-start'}`}>
             {createdAt && (
               <span className={`text-[10px] ${isSender ? 'mr-1 text-[var(--color-text-faint)]' : 'ml-1 text-[var(--color-text-faint)]'}`}>
-                {formatTime(createdAt)}
+                {formatHourMinute(createdAt)}
               </span>
             )}
             {onCopy && (

--- a/frontend/src/components/PersonalBestCard.tsx
+++ b/frontend/src/components/PersonalBestCard.tsx
@@ -1,5 +1,6 @@
 import { TrophyIcon } from '@heroicons/react/24/solid';
 import Card from './Card';
+import { formatDate } from '../utils/formatters';
 
 interface PersonalBestCardProps {
   history: { sessionId: number; overallScore: number; createdAt: string }[];
@@ -23,7 +24,7 @@ export default function PersonalBestCard({ history }: PersonalBestCardProps) {
         <div className="mt-1">
           <p className="text-[10px] text-[var(--color-text-muted)]">達成日</p>
           <p className="text-xs text-[var(--color-text-secondary)]">
-            {new Date(best.createdAt).toLocaleDateString('ja-JP')}
+            {formatDate(best.createdAt)}
           </p>
         </div>
       </div>

--- a/frontend/src/components/RecentNotesCard.tsx
+++ b/frontend/src/components/RecentNotesCard.tsx
@@ -1,5 +1,6 @@
 import { SessionNoteRepository } from '../repositories/SessionNoteRepository';
 import Card from './Card';
+import { formatDate } from '../utils/formatters';
 
 export default function RecentNotesCard() {
   const allNotes = SessionNoteRepository.getAll();
@@ -26,7 +27,7 @@ export default function RecentNotesCard() {
           >
             <p className="text-xs text-[var(--color-text-secondary)] line-clamp-2">{entry.note}</p>
             <p className="text-[10px] text-[var(--color-text-faint)] mt-1">
-              {new Date(entry.updatedAt).toLocaleDateString('ja-JP')}
+              {formatDate(entry.updatedAt)}
             </p>
           </div>
         ))}

--- a/frontend/src/components/RecentSessionsCard.tsx
+++ b/frontend/src/components/RecentSessionsCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { getScoreTextColor } from '../utils/scoreColor';
 import Card from './Card';
+import { formatDate } from '../utils/formatters';
 
 interface Session {
   sessionId: number;
@@ -39,7 +40,7 @@ export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps
             <div className="flex-1 min-w-0 mr-3">
               <p className="text-sm text-[var(--color-text-secondary)] truncate">{session.sessionTitle}</p>
               <p className="text-[10px] text-[var(--color-text-faint)]">
-                {new Date(session.createdAt).toLocaleDateString('ja-JP')}
+                {formatDate(session.createdAt)}
               </p>
             </div>
             <span className={`text-sm font-semibold ${getScoreTextColor(session.overallScore)}`}>

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { formatTime, truncateMessage } from '../formatters';
+import { formatTime, formatDate, formatHourMinute, truncateMessage } from '../formatters';
 
 describe('formatTime', () => {
   beforeEach(() => {
@@ -33,6 +33,34 @@ describe('formatTime', () => {
   it('1週間以上前の場合は月日で返す', () => {
     const result = formatTime('2025-05-01T10:30:00');
     expect(result).toMatch(/5/);
+  });
+});
+
+describe('formatDate', () => {
+  it('空文字の場合は空文字を返す', () => {
+    expect(formatDate('')).toBe('');
+  });
+
+  it('日付文字列をja-JP形式に変換する', () => {
+    const result = formatDate('2025-06-15T10:30:00');
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/6/);
+    expect(result).toMatch(/15/);
+  });
+});
+
+describe('formatHourMinute', () => {
+  it('undefinedの場合は空文字を返す', () => {
+    expect(formatHourMinute(undefined)).toBe('');
+  });
+
+  it('空文字の場合は空文字を返す', () => {
+    expect(formatHourMinute('')).toBe('');
+  });
+
+  it('時刻をHH:mm形式で返す', () => {
+    const result = formatHourMinute('2025-06-15T10:30:00');
+    expect(result).toMatch(/10:30/);
   });
 });
 

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -18,6 +18,16 @@ export function formatTime(dateString: string): string {
   }
 }
 
+export function formatDate(dateString: string): string {
+  if (!dateString) return '';
+  return new Date(dateString).toLocaleDateString('ja-JP');
+}
+
+export function formatHourMinute(dateString?: string): string {
+  if (!dateString) return '';
+  return new Date(dateString).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
+}
+
 export function truncateMessage(message: string | undefined, maxLength = 30): string {
   if (!message) return 'メッセージはありません';
   if (message.length <= maxLength) return message;


### PR DESCRIPTION
## 概要
closes #822

- formatDate, formatHourMinuteをformatters.tsに追加（テスト5件追加）
- MessageBubble.tsx: ローカルformatTime関数を削除し、formatHourMinuteに置換
- PersonalBestCard, RecentNotesCard, AiSessionListItem, RecentSessionsCard: インラインのtoLocaleDateStringをformatDateに置換
- 日付フォーマットの一元管理により保守性向上

## テスト
- formatters.test.ts: 5テスト追加
- 全1602テスト合格