### PR TITLE
feat: エディタにUndo/Redoボタンを追加

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -87,6 +87,8 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onSelectColor={handleSelectColor}
         onHighlight={handleHighlight}
         onAlign={handleAlign}
+        onUndo={handleUndo}
+        onRedo={handleRedo}
       />
       {linkBubble && (
         <div

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -2,6 +2,7 @@ import FormatButtons from './FormatButtons';
 import ColorPicker from './ColorPicker';
 import HighlightPicker from './HighlightPicker';
 import TextAlignButtons from './TextAlignButtons';
+import UndoRedoButtons from './UndoRedoButtons';
 
 interface EditorToolbarProps {
   onBold: () => void;
@@ -13,6 +14,8 @@ interface EditorToolbarProps {
   onSelectColor: (color: string) => void;
   onHighlight: (color: string) => void;
   onAlign: (alignment: 'left' | 'center' | 'right') => void;
+  onUndo: () => void;
+  onRedo: () => void;
 }
 
 export default function EditorToolbar({
@@ -25,6 +28,8 @@ export default function EditorToolbar({
   onSelectColor,
   onHighlight,
   onAlign,
+  onUndo,
+  onRedo,
 }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
@@ -35,6 +40,8 @@ export default function EditorToolbar({
       <HighlightPicker onSelectHighlight={onHighlight} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <TextAlignButtons onAlign={onAlign} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <UndoRedoButtons onUndo={onUndo} onRedo={onRedo} />
     </div>
   );
 }

--- a/frontend/src/components/UndoRedoButtons.tsx
+++ b/frontend/src/components/UndoRedoButtons.tsx
@@ -1,0 +1,29 @@
+import { ArrowUturnLeftIcon, ArrowUturnRightIcon } from '@heroicons/react/24/outline';
+
+interface UndoRedoButtonsProps {
+  onUndo: () => void;
+  onRedo: () => void;
+}
+
+export default function UndoRedoButtons({ onUndo, onRedo }: UndoRedoButtonsProps) {
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        aria-label="元に戻す"
+        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+        onClick={onUndo}
+      >
+        <ArrowUturnLeftIcon className="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="やり直す"
+        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+        onClick={onRedo}
+      >
+        <ArrowUturnRightIcon className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -13,6 +13,8 @@ describe('EditorToolbar', () => {
     onSelectColor: vi.fn(),
     onHighlight: vi.fn(),
     onAlign: vi.fn(),
+    onUndo: vi.fn(),
+    onRedo: vi.fn(),
   };
 
   it('書式ボタンが表示される', () => {

--- a/frontend/src/components/__tests__/UndoRedoButtons.test.tsx
+++ b/frontend/src/components/__tests__/UndoRedoButtons.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import UndoRedoButtons from '../UndoRedoButtons';
+
+describe('UndoRedoButtons', () => {
+  it('2つのボタンが表示される', () => {
+    render(<UndoRedoButtons onUndo={vi.fn()} onRedo={vi.fn()} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('元に戻すボタンにaria-labelがある', () => {
+    render(<UndoRedoButtons onUndo={vi.fn()} onRedo={vi.fn()} />);
+    expect(screen.getByLabelText('元に戻す')).toBeInTheDocument();
+  });
+
+  it('やり直すボタンにaria-labelがある', () => {
+    render(<UndoRedoButtons onUndo={vi.fn()} onRedo={vi.fn()} />);
+    expect(screen.getByLabelText('やり直す')).toBeInTheDocument();
+  });
+
+  it('元に戻すクリックでonUndoが呼ばれる', () => {
+    const onUndo = vi.fn();
+    render(<UndoRedoButtons onUndo={onUndo} onRedo={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText('元に戻す'));
+    expect(onUndo).toHaveBeenCalled();
+  });
+
+  it('やり直すクリックでonRedoが呼ばれる', () => {
+    const onRedo = vi.fn();
+    render(<UndoRedoButtons onUndo={vi.fn()} onRedo={onRedo} />);
+    fireEvent.click(screen.getByLabelText('やり直す'));
+    expect(onRedo).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -49,5 +49,13 @@ export function useEditorFormat(editor: Editor | null) {
     editor?.chain().focus().toggleSubscript().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript };
+  const handleUndo = useCallback(() => {
+    editor?.chain().focus().undo().run();
+  }, [editor]);
+
+  const handleRedo = useCallback(() => {
+    editor?.chain().focus().redo().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo };
 }


### PR DESCRIPTION
## 概要
- EditorToolbarにUndo/Redoボタン（ArrowUturnLeftIcon/ArrowUturnRightIcon）を追加
- useEditorFormatにhandleUndo/handleRedoハンドラーを実装
- UndoRedoButtonsコンポーネントを新規作成（5テスト付き）

closes #826