### PR TITLE
refactor: useBlockEditorのエクステンション設定を分離

### DIFF
--- a/frontend/src/hooks/__tests__/useBlockEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useBlockEditor.test.ts
@@ -6,41 +6,10 @@ vi.mock('@tiptap/react', () => ({
   useEditor: vi.fn(() => mockEditor),
 }));
 
-vi.mock('@tiptap/starter-kit', () => ({ default: { configure: vi.fn(() => 'StarterKit') } }));
-vi.mock('@tiptap/extension-placeholder', () => ({ default: { configure: vi.fn(() => 'Placeholder') } }));
-vi.mock('@tiptap/extension-image', () => ({ default: { configure: vi.fn(() => 'Image') } }));
-vi.mock('@tiptap/extension-task-list', () => ({ default: 'TaskList' }));
-vi.mock('@tiptap/extension-task-item', () => ({ default: { configure: vi.fn(() => 'TaskItem') } }));
-vi.mock('@tiptap/extension-code-block-lowlight', () => ({ default: { configure: vi.fn(() => 'CodeBlockLowlight') } }));
-vi.mock('@tiptap/extension-highlight', () => ({ default: { configure: vi.fn(() => 'Highlight') } }));
-vi.mock('@tiptap/extension-table', () => ({ default: { configure: vi.fn(() => 'Table') } }));
-vi.mock('@tiptap/extension-table-row', () => ({ default: 'TableRow' }));
-vi.mock('@tiptap/extension-table-cell', () => ({ default: 'TableCell' }));
-vi.mock('@tiptap/extension-table-header', () => ({ default: 'TableHeader' }));
-vi.mock('lowlight', () => ({ common: {}, createLowlight: vi.fn(() => 'lowlight') }));
-vi.mock('../../extensions/SlashCommandExtension', () => ({
-  SlashCommandExtension: { configure: vi.fn(() => 'SlashCommand') },
-  executeCommand: vi.fn(),
+const mockExtensions = ['ext1', 'ext2'];
+vi.mock('../../utils/editorExtensions', () => ({
+  createEditorExtensions: vi.fn(() => mockExtensions),
 }));
-vi.mock('../../extensions/slashCommandRenderer', () => ({
-  slashCommandRenderer: vi.fn(),
-}));
-vi.mock('../../extensions/ToggleListExtension', () => ({
-  ToggleList: 'ToggleList',
-  ToggleSummary: 'ToggleSummary',
-  ToggleContent: 'ToggleContent',
-}));
-vi.mock('../../extensions/CalloutExtension', () => ({
-  Callout: 'Callout',
-}));
-vi.mock('@tiptap/extension-link', () => ({ default: { configure: vi.fn(() => 'Link') } }));
-vi.mock('@tiptap/extension-text-style', () => ({ default: 'TextStyle' }));
-vi.mock('@tiptap/extension-color', () => ({ default: 'Color' }));
-vi.mock('@tiptap/extension-text-align', () => ({ default: { configure: vi.fn(() => 'TextAlign') } }));
-vi.mock('@tiptap/extension-underline', () => ({ default: 'Underline' }));
-vi.mock('@tiptap/extension-superscript', () => ({ default: 'Superscript' }));
-vi.mock('@tiptap/extension-subscript', () => ({ default: 'Subscript' }));
-vi.mock('@tiptap/extension-youtube', () => ({ default: { configure: vi.fn(() => 'Youtube') } }));
 vi.mock('../../utils/isLegacyMarkdown', () => ({
   isLegacyMarkdown: vi.fn(() => false),
 }));
@@ -68,26 +37,14 @@ describe('useBlockEditor', () => {
     expect(result.current.editor).toBe(mockEditor);
   });
 
-  it('useEditorにextensionsを渡して呼び出す', async () => {
+  it('createEditorExtensionsの結果をuseEditorに渡す', async () => {
     const { useEditor } = await import('@tiptap/react');
     const onChange = vi.fn();
     renderHook(() => useBlockEditor({ content: '', onChange }));
 
     expect(useEditor).toHaveBeenCalledWith(
       expect.objectContaining({
-        extensions: expect.arrayContaining([
-          'StarterKit',
-          'CodeBlockLowlight',
-          'Placeholder',
-          'Image',
-          'SlashCommand',
-          'Highlight',
-          'TaskList',
-          'TaskItem',
-          'ToggleList',
-          'ToggleSummary',
-          'ToggleContent',
-        ]),
+        extensions: mockExtensions,
       })
     );
   });
@@ -156,14 +113,5 @@ describe('useBlockEditor', () => {
 
     const call = vi.mocked(useEditor).mock.calls[0]!;
     expect(call[0]).toHaveProperty('onUpdate');
-  });
-
-  it('22個の拡張が設定される', async () => {
-    const { useEditor } = await import('@tiptap/react');
-    const onChange = vi.fn();
-    renderHook(() => useBlockEditor({ content: '', onChange }));
-
-    const call = vi.mocked(useEditor).mock.calls[0]!;
-    expect(call[0]!.extensions).toHaveLength(24);
   });
 });

--- a/frontend/src/hooks/useBlockEditor.ts
+++ b/frontend/src/hooks/useBlockEditor.ts
@@ -1,29 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useEditor } from '@tiptap/react';
-import StarterKit from '@tiptap/starter-kit';
-import Placeholder from '@tiptap/extension-placeholder';
-import Image from '@tiptap/extension-image';
-import TaskList from '@tiptap/extension-task-list';
-import TaskItem from '@tiptap/extension-task-item';
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
-import Highlight from '@tiptap/extension-highlight';
-import Table from '@tiptap/extension-table';
-import TableRow from '@tiptap/extension-table-row';
-import TableCell from '@tiptap/extension-table-cell';
-import TableHeader from '@tiptap/extension-table-header';
-import { common, createLowlight } from 'lowlight';
-import { SlashCommandExtension } from '../extensions/SlashCommandExtension';
-import { slashCommandRenderer } from '../extensions/slashCommandRenderer';
-import { ToggleList, ToggleSummary, ToggleContent } from '../extensions/ToggleListExtension';
-import { Callout } from '../extensions/CalloutExtension';
-import Link from '@tiptap/extension-link';
-import TextStyle from '@tiptap/extension-text-style';
-import Color from '@tiptap/extension-color';
-import TextAlign from '@tiptap/extension-text-align';
-import Underline from '@tiptap/extension-underline';
-import Superscript from '@tiptap/extension-superscript';
-import Subscript from '@tiptap/extension-subscript';
-import Youtube from '@tiptap/extension-youtube';
+import { createEditorExtensions } from '../utils/editorExtensions';
 import { isLegacyMarkdown } from '../utils/isLegacyMarkdown';
 import { markdownToTiptap } from '../utils/markdownToTiptap';
 
@@ -46,54 +23,7 @@ export function useBlockEditor({ content, onChange }: UseBlockEditorOptions) {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({
-        heading: { levels: [1, 2, 3] },
-        codeBlock: false,
-      }),
-      CodeBlockLowlight.configure({
-        lowlight: createLowlight(common),
-      }),
-      Placeholder.configure({
-        placeholder: 'ここに入力...',
-      }),
-      Image.configure({
-        allowBase64: false,
-        HTMLAttributes: { class: 'note-image' },
-      }),
-      SlashCommandExtension.configure({
-        suggestion: {
-          render: slashCommandRenderer,
-        },
-      }),
-      Highlight.configure({ multicolor: true }),
-      TaskList,
-      TaskItem.configure({ nested: true }),
-      ToggleList,
-      ToggleSummary,
-      ToggleContent,
-      Table.configure({ resizable: true }),
-      TableRow,
-      TableCell,
-      TableHeader,
-      Callout,
-      Link.configure({
-        openOnClick: false,
-        HTMLAttributes: { class: 'note-link' },
-      }),
-      TextStyle,
-      Color,
-      TextAlign.configure({
-        types: ['heading', 'paragraph'],
-      }),
-      Underline,
-      Superscript,
-      Subscript,
-      Youtube.configure({
-        allowFullscreen: true,
-        HTMLAttributes: { class: 'note-youtube' },
-      }),
-    ],
+    extensions: createEditorExtensions(),
     content: initialContent,
     onUpdate: ({ editor }) => {
       onChange(JSON.stringify(editor.getJSON()));

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@tiptap/starter-kit', () => ({ default: { configure: vi.fn(() => 'StarterKit') } }));
+vi.mock('@tiptap/extension-placeholder', () => ({ default: { configure: vi.fn(() => 'Placeholder') } }));
+vi.mock('@tiptap/extension-image', () => ({ default: { configure: vi.fn(() => 'Image') } }));
+vi.mock('@tiptap/extension-task-list', () => ({ default: 'TaskList' }));
+vi.mock('@tiptap/extension-task-item', () => ({ default: { configure: vi.fn(() => 'TaskItem') } }));
+vi.mock('@tiptap/extension-code-block-lowlight', () => ({ default: { configure: vi.fn(() => 'CodeBlockLowlight') } }));
+vi.mock('@tiptap/extension-highlight', () => ({ default: { configure: vi.fn(() => 'Highlight') } }));
+vi.mock('@tiptap/extension-table', () => ({ default: { configure: vi.fn(() => 'Table') } }));
+vi.mock('@tiptap/extension-table-row', () => ({ default: 'TableRow' }));
+vi.mock('@tiptap/extension-table-cell', () => ({ default: 'TableCell' }));
+vi.mock('@tiptap/extension-table-header', () => ({ default: 'TableHeader' }));
+vi.mock('lowlight', () => ({ common: {}, createLowlight: vi.fn(() => 'lowlight') }));
+vi.mock('../../extensions/SlashCommandExtension', () => ({
+  SlashCommandExtension: { configure: vi.fn(() => 'SlashCommand') },
+  executeCommand: vi.fn(),
+}));
+vi.mock('../../extensions/slashCommandRenderer', () => ({
+  slashCommandRenderer: vi.fn(),
+}));
+vi.mock('../../extensions/ToggleListExtension', () => ({
+  ToggleList: 'ToggleList',
+  ToggleSummary: 'ToggleSummary',
+  ToggleContent: 'ToggleContent',
+}));
+vi.mock('../../extensions/CalloutExtension', () => ({
+  Callout: 'Callout',
+}));
+vi.mock('@tiptap/extension-link', () => ({ default: { configure: vi.fn(() => 'Link') } }));
+vi.mock('@tiptap/extension-text-style', () => ({ default: 'TextStyle' }));
+vi.mock('@tiptap/extension-color', () => ({ default: 'Color' }));
+vi.mock('@tiptap/extension-text-align', () => ({ default: { configure: vi.fn(() => 'TextAlign') } }));
+vi.mock('@tiptap/extension-underline', () => ({ default: 'Underline' }));
+vi.mock('@tiptap/extension-superscript', () => ({ default: 'Superscript' }));
+vi.mock('@tiptap/extension-subscript', () => ({ default: 'Subscript' }));
+vi.mock('@tiptap/extension-youtube', () => ({ default: { configure: vi.fn(() => 'Youtube') } }));
+
+import { createEditorExtensions } from '../editorExtensions';
+
+describe('createEditorExtensions', () => {
+  it('24個のエクステンションを返す', () => {
+    const extensions = createEditorExtensions();
+    expect(extensions).toHaveLength(24);
+  });
+
+  it('主要なエクステンションが含まれる', () => {
+    const extensions = createEditorExtensions();
+    expect(extensions).toContain('StarterKit');
+    expect(extensions).toContain('Placeholder');
+    expect(extensions).toContain('Image');
+    expect(extensions).toContain('TaskList');
+    expect(extensions).toContain('ToggleList');
+    expect(extensions).toContain('Callout');
+    expect(extensions).toContain('Underline');
+    expect(extensions).toContain('Superscript');
+    expect(extensions).toContain('Subscript');
+  });
+
+  it('毎回新しい配列を返す', () => {
+    const a = createEditorExtensions();
+    const b = createEditorExtensions();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -1,0 +1,75 @@
+import StarterKit from '@tiptap/starter-kit';
+import Placeholder from '@tiptap/extension-placeholder';
+import Image from '@tiptap/extension-image';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import Highlight from '@tiptap/extension-highlight';
+import Table from '@tiptap/extension-table';
+import TableRow from '@tiptap/extension-table-row';
+import TableCell from '@tiptap/extension-table-cell';
+import TableHeader from '@tiptap/extension-table-header';
+import { common, createLowlight } from 'lowlight';
+import { SlashCommandExtension } from '../extensions/SlashCommandExtension';
+import { slashCommandRenderer } from '../extensions/slashCommandRenderer';
+import { ToggleList, ToggleSummary, ToggleContent } from '../extensions/ToggleListExtension';
+import { Callout } from '../extensions/CalloutExtension';
+import Link from '@tiptap/extension-link';
+import TextStyle from '@tiptap/extension-text-style';
+import Color from '@tiptap/extension-color';
+import TextAlign from '@tiptap/extension-text-align';
+import Underline from '@tiptap/extension-underline';
+import Superscript from '@tiptap/extension-superscript';
+import Subscript from '@tiptap/extension-subscript';
+import Youtube from '@tiptap/extension-youtube';
+
+export function createEditorExtensions() {
+  return [
+    StarterKit.configure({
+      heading: { levels: [1, 2, 3] },
+      codeBlock: false,
+    }),
+    CodeBlockLowlight.configure({
+      lowlight: createLowlight(common),
+    }),
+    Placeholder.configure({
+      placeholder: 'ここに入力...',
+    }),
+    Image.configure({
+      allowBase64: false,
+      HTMLAttributes: { class: 'note-image' },
+    }),
+    SlashCommandExtension.configure({
+      suggestion: {
+        render: slashCommandRenderer,
+      },
+    }),
+    Highlight.configure({ multicolor: true }),
+    TaskList,
+    TaskItem.configure({ nested: true }),
+    ToggleList,
+    ToggleSummary,
+    ToggleContent,
+    Table.configure({ resizable: true }),
+    TableRow,
+    TableCell,
+    TableHeader,
+    Callout,
+    Link.configure({
+      openOnClick: false,
+      HTMLAttributes: { class: 'note-link' },
+    }),
+    TextStyle,
+    Color,
+    TextAlign.configure({
+      types: ['heading', 'paragraph'],
+    }),
+    Underline,
+    Superscript,
+    Subscript,
+    Youtube.configure({
+      allowFullscreen: true,
+      HTMLAttributes: { class: 'note-youtube' },
+    }),
+  ];
+}


### PR DESCRIPTION
## 概要
- 24個のTipTapエクステンション設定をeditorExtensions.tsのcreateEditorExtensions()に抽出
- useBlockEditor.tsを131行→62行に削減
- エクステンション設定のテストを独立ファイルに分離（3テスト）
- useBlockEditorテストを簡素化（エクステンション個別モック→createEditorExtensionsモック）

closes #828