### PR TITLE
feat: コールアウトのカラーバリエーション対応

### DIFF
--- a/frontend/src/constants/__tests__/slashCommands.test.ts
+++ b/frontend/src/constants/__tests__/slashCommands.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { SLASH_COMMANDS } from '../slashCommands';
 
 describe('SLASH_COMMANDS', () => {
-  it('15のコマンドが定義されている', () => {
-    expect(SLASH_COMMANDS).toHaveLength(15);
+  it('18のコマンドが定義されている', () => {
+    expect(SLASH_COMMANDS).toHaveLength(18);
   });
 
   it('各コマンドに必要なプロパティがある', () => {
@@ -15,8 +15,14 @@ describe('SLASH_COMMANDS', () => {
     }
   });
 
-  it('全アクションがユニーク', () => {
-    const actions = SLASH_COMMANDS.map(c => c.action);
-    expect(new Set(actions).size).toBe(actions.length);
+  it('全ラベルがユニーク', () => {
+    const labels = SLASH_COMMANDS.map(c => c.label);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it('コールアウトが4種類ある', () => {
+    const callouts = SLASH_COMMANDS.filter(c => c.action === 'callout');
+    expect(callouts).toHaveLength(4);
+    expect(callouts.map(c => c.attrs?.calloutType)).toEqual(['info', 'warning', 'success', 'error']);
   });
 });

--- a/frontend/src/constants/slashCommands.ts
+++ b/frontend/src/constants/slashCommands.ts
@@ -20,6 +20,7 @@ export interface SlashCommand {
   description: string;
   icon: string;
   action: SlashCommandAction;
+  attrs?: { calloutType: string; emoji: string };
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
@@ -36,6 +37,9 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { label: '引用', description: '引用ブロック', icon: '❝', action: 'blockquote' },
   { label: '区切り線', description: '水平線で区切る', icon: '—', action: 'horizontalRule' },
   { label: 'テーブル', description: '表を挿入', icon: '▦', action: 'table' },
-  { label: 'コールアウト', description: '強調ブロック', icon: '💡', action: 'callout' },
+  { label: 'コールアウト（情報）', description: '情報の強調', icon: '💡', action: 'callout', attrs: { calloutType: 'info', emoji: '💡' } },
+  { label: 'コールアウト（警告）', description: '注意喚起', icon: '⚠️', action: 'callout', attrs: { calloutType: 'warning', emoji: '⚠️' } },
+  { label: 'コールアウト（成功）', description: '成功・完了', icon: '✅', action: 'callout', attrs: { calloutType: 'success', emoji: '✅' } },
+  { label: 'コールアウト（エラー）', description: 'エラー・危険', icon: '❌', action: 'callout', attrs: { calloutType: 'error', emoji: '❌' } },
   { label: 'YouTube', description: 'YouTube動画を埋め込み', icon: '▶', action: 'youtube' },
 ];

--- a/frontend/src/extensions/CalloutExtension.ts
+++ b/frontend/src/extensions/CalloutExtension.ts
@@ -46,6 +46,13 @@ export const Callout = Node.create({
           content: [{ type: 'paragraph' }],
         });
       },
+      setCalloutWithType: (calloutType: CalloutType, emoji: string) => ({ commands }) => {
+        return commands.insertContent({
+          type: 'callout',
+          attrs: { type: calloutType, emoji },
+          content: [{ type: 'paragraph' }],
+        });
+      },
     };
   },
 });

--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -52,9 +52,16 @@ function executeCommand(editor: Editor, command: SlashCommand) {
       chain.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
       break;
     case 'callout': {
-      const setCallout = (editor.commands as { setCallout?: () => boolean }).setCallout;
-      if (typeof setCallout === 'function') {
-        setCallout();
+      if (command.attrs) {
+        const setCalloutWithType = (editor.commands as { setCalloutWithType?: (type: string, emoji: string) => boolean }).setCalloutWithType;
+        if (typeof setCalloutWithType === 'function') {
+          setCalloutWithType(command.attrs.calloutType, command.attrs.emoji);
+        }
+      } else {
+        const setCallout = (editor.commands as { setCallout?: () => boolean }).setCallout;
+        if (typeof setCallout === 'function') {
+          setCallout();
+        }
       }
       break;
     }

--- a/frontend/src/extensions/__tests__/SlashCommandExtension.test.ts
+++ b/frontend/src/extensions/__tests__/SlashCommandExtension.test.ts
@@ -128,11 +128,20 @@ describe('SlashCommandExtension', () => {
     expect(chain.run).toHaveBeenCalled();
   });
 
-  it('calloutコマンドでsetCalloutが呼ばれる', () => {
-    const setCallout = vi.fn();
-    const editor = { chain: vi.fn(() => ({ focus: vi.fn().mockReturnThis(), run: vi.fn() })), commands: { setCallout } };
-    executeCommand(editor as never, findCommand('callout'));
-    expect(setCallout).toHaveBeenCalled();
+  it('情報コールアウトでsetCalloutWithTypeが呼ばれる', () => {
+    const setCalloutWithType = vi.fn();
+    const editor = { chain: vi.fn(() => ({ focus: vi.fn().mockReturnThis(), run: vi.fn() })), commands: { setCalloutWithType } };
+    const infoCallout = SLASH_COMMANDS.find(c => c.action === 'callout' && c.attrs?.calloutType === 'info')!;
+    executeCommand(editor as never, infoCallout);
+    expect(setCalloutWithType).toHaveBeenCalledWith('info', '💡');
+  });
+
+  it('警告コールアウトでsetCalloutWithTypeが呼ばれる', () => {
+    const setCalloutWithType = vi.fn();
+    const editor = { chain: vi.fn(() => ({ focus: vi.fn().mockReturnThis(), run: vi.fn() })), commands: { setCalloutWithType } };
+    const warningCallout = SLASH_COMMANDS.find(c => c.action === 'callout' && c.attrs?.calloutType === 'warning')!;
+    executeCommand(editor as never, warningCallout);
+    expect(setCalloutWithType).toHaveBeenCalledWith('warning', '⚠️');
   });
 
   it('SLASH_COMMANDSのフィルタリングが正しく動作する', () => {


### PR DESCRIPTION
## 概要
- スラッシュコマンドにコールアウト4種（情報/警告/成功/エラー）を追加（15→18コマンド）
- SlashCommandインターフェースにoptionalなattrs（calloutType, emoji）を追加
- CalloutExtensionにsetCalloutWithTypeコマンドを追加
- executeCommandでattrs付きコールアウトをsetCalloutWithTypeで処理

closes #832