### PR TITLE
refactor: FormMessageインターフェースの重複排除

### DIFF
--- a/frontend/src/hooks/useConfirmForgotPassword.ts
+++ b/frontend/src/hooks/useConfirmForgotPassword.ts
@@ -2,11 +2,7 @@ import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import authRepository from '../repositories/AuthRepository';
 import { AxiosError } from 'axios';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import type { FormMessage } from '../types';
 
 export function useConfirmForgotPassword() {
   const location = useLocation();

--- a/frontend/src/hooks/useConfirmSignup.ts
+++ b/frontend/src/hooks/useConfirmSignup.ts
@@ -2,11 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import authRepository from '../repositories/AuthRepository';
 import { AxiosError } from 'axios';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import type { FormMessage } from '../types';
 
 export function useConfirmSignup() {
   const navigate = useNavigate();

--- a/frontend/src/hooks/useForgotPassword.ts
+++ b/frontend/src/hooks/useForgotPassword.ts
@@ -2,11 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import authRepository from '../repositories/AuthRepository';
 import { AxiosError } from 'axios';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import type { FormMessage } from '../types';
 
 export function useForgotPassword() {
   const [email, setEmail] = useState('');

--- a/frontend/src/hooks/useProfileEdit.ts
+++ b/frontend/src/hooks/useProfileEdit.ts
@@ -1,10 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import ProfileRepository from '../repositories/ProfileRepository';
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import type { FormMessage } from '../types';
 
 export function useProfileEdit() {
   const [form, setForm] = useState({ name: '', bio: '' });

--- a/frontend/src/hooks/useSignupPage.ts
+++ b/frontend/src/hooks/useSignupPage.ts
@@ -1,16 +1,12 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from './useAuth';
+import type { FormMessage } from '../types';
 
 interface SignupForm {
   email: string;
   password: string;
   name: string;
-}
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
 }
 
 export function useSignupPage() {

--- a/frontend/src/hooks/useUserProfilePage.ts
+++ b/frontend/src/hooks/useUserProfilePage.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useUserProfile } from './useUserProfile';
+import type { FormMessage } from '../types';
 
 interface UserProfileForm {
   displayName: string;
@@ -9,11 +10,6 @@ interface UserProfileForm {
   goals: string;
   concerns: string;
   preferredFeedbackStyle: string;
-}
-
-interface FormMessage {
-  type: 'success' | 'error';
-  text: string;
 }
 
 export const COMMUNICATION_STYLES = [

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -75,6 +75,12 @@ export interface FlashMessage {
   text: string;
 }
 
+/** フォームメッセージ */
+export interface FormMessage {
+  type: 'success' | 'error';
+  text: string;
+}
+
 /** ユーザープロフィール（パーソナリティ設定） */
 export interface UserProfile {
   displayName: string;


### PR DESCRIPTION
## 概要
- 6ファイルで重複定義されていたFormMessageインターフェースをtypes/index.tsに統一
- useForgotPassword, useSignupPage, useConfirmSignup, useUserProfilePage, useConfirmForgotPassword, useProfileEditの各hookからローカル定義を削除しimportに変更
- 30行削除、12行追加（-18行）

closes #834