### PR TITLE
feat: キーボードショートカットヘルプダイアログ

### DIFF
--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -3,6 +3,7 @@ import ColorPicker from './ColorPicker';
 import HighlightPicker from './HighlightPicker';
 import TextAlignButtons from './TextAlignButtons';
 import UndoRedoButtons from './UndoRedoButtons';
+import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 
 interface EditorToolbarProps {
   onBold: () => void;
@@ -42,6 +43,8 @@ export default function EditorToolbar({
       <TextAlignButtons onAlign={onAlign} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <UndoRedoButtons onUndo={onUndo} onRedo={onRedo} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <KeyboardShortcutsHelp />
     </div>
   );
 }

--- a/frontend/src/components/KeyboardShortcutsHelp.tsx
+++ b/frontend/src/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { QuestionMarkCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+const SHORTCUTS = [
+  { keys: 'Ctrl+B', label: '太字' },
+  { keys: 'Ctrl+I', label: '斜体' },
+  { keys: 'Ctrl+U', label: '下線' },
+  { keys: 'Ctrl+Shift+S', label: '取り消し線' },
+  { keys: 'Ctrl+Z', label: '元に戻す' },
+  { keys: 'Ctrl+Shift+Z', label: 'やり直す' },
+  { keys: 'Ctrl+Shift+7', label: '番号付きリスト' },
+  { keys: 'Ctrl+Shift+8', label: '箇条書き' },
+  { keys: '/', label: 'スラッシュコマンド' },
+];
+
+export default function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="ショートカット一覧"
+        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+        onClick={() => setOpen(true)}
+      >
+        <QuestionMarkCircleIcon className="w-4 h-4" />
+      </button>
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-[var(--color-surface-1)] rounded-lg shadow-xl p-5 w-80 max-h-[80vh] overflow-y-auto">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">キーボードショートカット</h3>
+              <button
+                type="button"
+                aria-label="閉じる"
+                className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)]"
+                onClick={() => setOpen(false)}
+              >
+                <XMarkIcon className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="space-y-2">
+              {SHORTCUTS.map((shortcut) => (
+                <div key={shortcut.keys} className="flex items-center justify-between py-1">
+                  <span className="text-xs text-[var(--color-text-secondary)]">{shortcut.label}</span>
+                  <kbd className="text-[10px] bg-[var(--color-surface-3)] text-[var(--color-text-faint)] px-1.5 py-0.5 rounded font-mono">
+                    {shortcut.keys}
+                  </kbd>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/__tests__/KeyboardShortcutsHelp.test.tsx
+++ b/frontend/src/components/__tests__/KeyboardShortcutsHelp.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import KeyboardShortcutsHelp from '../KeyboardShortcutsHelp';
+
+describe('KeyboardShortcutsHelp', () => {
+  it('ボタンが表示される', () => {
+    render(<KeyboardShortcutsHelp />);
+    expect(screen.getByLabelText('ショートカット一覧')).toBeInTheDocument();
+  });
+
+  it('ボタンクリックでダイアログが表示される', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByLabelText('ショートカット一覧'));
+    expect(screen.getByText('キーボードショートカット')).toBeInTheDocument();
+  });
+
+  it('ショートカット一覧に太字が含まれる', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByLabelText('ショートカット一覧'));
+    expect(screen.getByText('太字')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンでダイアログが閉じる', () => {
+    render(<KeyboardShortcutsHelp />);
+    fireEvent.click(screen.getByLabelText('ショートカット一覧'));
+    expect(screen.getByText('キーボードショートカット')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('閉じる'));
+    expect(screen.queryByText('キーボードショートカット')).not.toBeInTheDocument();
+  });
+
+  it('初期状態ではダイアログが非表示', () => {
+    render(<KeyboardShortcutsHelp />);
+    expect(screen.queryByText('キーボードショートカット')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- EditorToolbarにショートカットヘルプボタン（QuestionMarkCircleIcon）を追加
- クリックでモーダルが開き、TipTapの主要ショートカット9種を一覧表示
- 閉じるボタンでモーダルを閉じる
- KeyboardShortcutsHelpコンポーネントを新規作成（5テスト付き）

closes #838