### PR TITLE
refactor: AxisScoreインターフェースの重複排除

### DIFF
--- a/frontend/src/components/CommunicationStyleCard.tsx
+++ b/frontend/src/components/CommunicationStyleCard.tsx
@@ -1,10 +1,5 @@
+import type { AxisScore } from '../types';
 import Card from './Card';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface Session {
   scores: AxisScore[];

--- a/frontend/src/components/ScoreComparisonCard.tsx
+++ b/frontend/src/components/ScoreComparisonCard.tsx
@@ -1,11 +1,6 @@
+import type { AxisScore } from '../types';
 import { getDeltaColor, formatDelta } from '../utils/scoreColor';
 import Card from './Card';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface ScoreComparisonCardProps {
   firstScores: AxisScore[];

--- a/frontend/src/components/ScoreImprovementAdvice.tsx
+++ b/frontend/src/components/ScoreImprovementAdvice.tsx
@@ -1,11 +1,6 @@
+import type { AxisScore } from '../types';
 import Card from './Card';
 import { IMPROVEMENT_ADVICE, SCORE_THRESHOLD } from '../constants/axisAdvice';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface ScoreImprovementAdviceProps {
   scores: AxisScore[];

--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -1,8 +1,4 @@
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
+import type { AxisScore } from '../types';
 
 interface Session {
   sessionId: number;

--- a/frontend/src/components/SessionFeedbackSummary.tsx
+++ b/frontend/src/components/SessionFeedbackSummary.tsx
@@ -1,10 +1,5 @@
+import type { AxisScore } from '../types';
 import Card from './Card';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface SessionFeedbackSummaryProps {
   scores: AxisScore[];

--- a/frontend/src/components/SkillGapAnalysisCard.tsx
+++ b/frontend/src/components/SkillGapAnalysisCard.tsx
@@ -1,9 +1,5 @@
+import type { AxisScore } from '../types';
 import Card from './Card';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-}
 
 interface SkillGapAnalysisCardProps {
   scores: AxisScore[];

--- a/frontend/src/components/SkillMilestoneCard.tsx
+++ b/frontend/src/components/SkillMilestoneCard.tsx
@@ -1,10 +1,5 @@
+import type { AxisScore } from '../types';
 import Card from './Card';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface SkillMilestoneCardProps {
   scores: AxisScore[];

--- a/frontend/src/components/SkillSummaryCard.tsx
+++ b/frontend/src/components/SkillSummaryCard.tsx
@@ -1,10 +1,5 @@
+import type { AxisScore } from '../types';
 import Card from './Card';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface SkillSummaryCardProps {
   scores: AxisScore[];

--- a/frontend/src/components/SkillTrendChart.tsx
+++ b/frontend/src/components/SkillTrendChart.tsx
@@ -1,7 +1,4 @@
-interface AxisScore {
-  axis: string;
-  score: number;
-}
+import type { AxisScore } from '../types';
 
 interface HistoryItem {
   sessionId: number;

--- a/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
+++ b/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
@@ -1,12 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import type { AxisScore } from '../../types';
 import CommunicationStyleCard from '../CommunicationStyleCard';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 interface Session {
   scores: AxisScore[];

--- a/frontend/src/components/__tests__/SkillGapAnalysisCard.test.tsx
+++ b/frontend/src/components/__tests__/SkillGapAnalysisCard.test.tsx
@@ -4,11 +4,11 @@ import SkillGapAnalysisCard from '../SkillGapAnalysisCard';
 
 describe('SkillGapAnalysisCard', () => {
   const defaultScores = [
-    { axis: '論理的構成力', score: 6.0 },
-    { axis: '配慮表現', score: 8.0 },
-    { axis: '要約力', score: 5.0 },
-    { axis: '提案力', score: 7.0 },
-    { axis: '質問・傾聴力', score: 9.0 },
+    { axis: '論理的構成力', score: 6.0, comment: '' },
+    { axis: '配慮表現', score: 8.0, comment: '' },
+    { axis: '要約力', score: 5.0, comment: '' },
+    { axis: '提案力', score: 7.0, comment: '' },
+    { axis: '質問・傾聴力', score: 9.0, comment: '' },
   ];
 
   it('タイトルが表示される', () => {
@@ -50,11 +50,11 @@ describe('SkillGapAnalysisCard', () => {
 
   it('全軸達成時に祝福メッセージが表示される', () => {
     const highScores = [
-      { axis: '論理的構成力', score: 9.0 },
-      { axis: '配慮表現', score: 8.5 },
-      { axis: '要約力', score: 8.0 },
-      { axis: '提案力', score: 9.5 },
-      { axis: '質問・傾聴力', score: 8.0 },
+      { axis: '論理的構成力', score: 9.0, comment: '' },
+      { axis: '配慮表現', score: 8.5, comment: '' },
+      { axis: '要約力', score: 8.0, comment: '' },
+      { axis: '提案力', score: 9.5, comment: '' },
+      { axis: '質問・傾聴力', score: 8.0, comment: '' },
     ];
     render(<SkillGapAnalysisCard scores={highScores} goal={8.0} />);
     expect(screen.getByText(/全スキル目標達成/)).toBeInTheDocument();

--- a/frontend/src/components/__tests__/SkillTrendChart.test.tsx
+++ b/frontend/src/components/__tests__/SkillTrendChart.test.tsx
@@ -6,21 +6,21 @@ const mockHistory = [
   {
     sessionId: 1,
     scores: [
-      { axis: '論理的構成力', score: 6 },
-      { axis: '配慮表現', score: 7 },
-      { axis: '要約力', score: 5 },
-      { axis: '提案力', score: 4 },
-      { axis: '質問・傾聴力', score: 8 },
+      { axis: '論理的構成力', score: 6, comment: '' },
+      { axis: '配慮表現', score: 7, comment: '' },
+      { axis: '要約力', score: 5, comment: '' },
+      { axis: '提案力', score: 4, comment: '' },
+      { axis: '質問・傾聴力', score: 8, comment: '' },
     ],
   },
   {
     sessionId: 2,
     scores: [
-      { axis: '論理的構成力', score: 8 },
-      { axis: '配慮表現', score: 7 },
-      { axis: '要約力', score: 6 },
-      { axis: '提案力', score: 5 },
-      { axis: '質問・傾聴力', score: 9 },
+      { axis: '論理的構成力', score: 8, comment: '' },
+      { axis: '配慮表現', score: 7, comment: '' },
+      { axis: '要約力', score: 6, comment: '' },
+      { axis: '提案力', score: 5, comment: '' },
+      { axis: '質問・傾聴力', score: 9, comment: '' },
     ],
   },
 ];
@@ -59,7 +59,7 @@ describe('SkillTrendChart', () => {
 
   it('scoresがnullのセッションでもエラーにならない', () => {
     const history = [
-      { sessionId: 1, scores: null as unknown as { axis: string; score: number }[] },
+      { sessionId: 1, scores: null as unknown as { axis: string; score: number; comment: string }[] },
     ];
     const { container } = render(<SkillTrendChart history={history} />);
     expect(container.firstChild).toBeNull();
@@ -67,11 +67,11 @@ describe('SkillTrendChart', () => {
 
   it('前回セッションのscoresがnullでもエラーにならない', () => {
     const history = [
-      { sessionId: 1, scores: null as unknown as { axis: string; score: number }[] },
+      { sessionId: 1, scores: null as unknown as { axis: string; score: number; comment: string }[] },
       {
         sessionId: 2,
         scores: [
-          { axis: '論理的構成力', score: 8 },
+          { axis: '論理的構成力', score: 8, comment: '' },
         ],
       },
     ];

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -1,11 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
+import type { AxisScore } from '../types';
 import { useAiChat } from './useAiChat';
-
-interface AxisScore {
-  axis: string;
-  score: number;
-  comment: string;
-}
 
 export interface ScoreHistoryItem {
   sessionId: number;


### PR DESCRIPTION
## 概要
- 11ファイルで重複定義されていたAxisScoreインターフェースをtypes/index.tsからのimportに統一
- 対象: ScoreComparisonCard, SkillGapAnalysisCard, CommunicationStyleCard, SessionFeedbackSummary, SkillSummaryCard, SkillTrendChart, SessionDetailModal, useScoreHistory, CommunicationStyleCard.test, SkillMilestoneCard, ScoreImprovementAdvice
- 85行削除、34行追加（-51行）

closes #840