### PR TITLE
feat: WordCountコンポーネントを追加

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -3,6 +3,7 @@ import { getNoteStats } from '../utils/noteStats';
 import { useTableOfContents } from '../hooks/useTableOfContents';
 import BlockEditor from './BlockEditor';
 import TableOfContents from './TableOfContents';
+import WordCount from './WordCount';
 
 interface NoteEditorProps {
   title: string;
@@ -62,9 +63,9 @@ export default function NoteEditor({
 
       <BlockEditor content={content} onChange={onContentChange} noteId={noteId} />
 
-      <div className="flex items-center gap-3 pt-3 border-t border-surface-3 text-[11px] text-[var(--color-text-faint)]" aria-label="ノート統計">
-        <span>{stats.charCount}文字</span>
-        {stats.readingTimeMin > 0 && <span>約{stats.readingTimeMin}分</span>}
+      <div className="flex items-center gap-3 pt-3 border-t border-surface-3" aria-label="ノート統計">
+        <WordCount charCount={stats.charCount} />
+        {stats.readingTimeMin > 0 && <span className="text-[11px] text-[var(--color-text-faint)]">約{stats.readingTimeMin}分</span>}
       </div>
     </div>
   );

--- a/frontend/src/components/WordCount.tsx
+++ b/frontend/src/components/WordCount.tsx
@@ -1,0 +1,11 @@
+interface WordCountProps {
+  charCount: number;
+}
+
+export default function WordCount({ charCount }: WordCountProps) {
+  return (
+    <div className="px-8 py-1 text-[10px] text-[var(--color-text-faint)] text-right">
+      {charCount}文字
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/WordCount.test.tsx
+++ b/frontend/src/components/__tests__/WordCount.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import WordCount from '../WordCount';
+
+describe('WordCount', () => {
+  it('文字数が表示される', () => {
+    render(<WordCount charCount={42} />);
+    expect(screen.getByText('42文字')).toBeInTheDocument();
+  });
+
+  it('0文字の場合も表示される', () => {
+    render(<WordCount charCount={0} />);
+    expect(screen.getByText('0文字')).toBeInTheDocument();
+  });
+
+  it('大きな数値も表示される', () => {
+    render(<WordCount charCount={1500} />);
+    expect(screen.getByText('1500文字')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 文字数表示をWordCountコンポーネントとして新規作成（3テスト付き）
- NoteEditorのインライン文字数表示をWordCountコンポーネントに置換
- 再利用可能なコンポーネントとして分離

closes #844