### PR TITLE
refactor: ScoreHistoryインターフェースの重複排除

### DIFF
--- a/frontend/src/components/WeeklyReportCard.tsx
+++ b/frontend/src/components/WeeklyReportCard.tsx
@@ -1,12 +1,6 @@
 import { useMemo } from 'react';
 import Card from './Card';
-
-interface ScoreHistory {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  createdAt: string;
-}
+import type { ScoreHistory } from '../types';
 
 interface WeeklyReportCardProps {
   allScores: ScoreHistory[];

--- a/frontend/src/components/__tests__/PracticeCalendar.test.tsx
+++ b/frontend/src/components/__tests__/PracticeCalendar.test.tsx
@@ -1,13 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import PracticeCalendar from '../PracticeCalendar';
-
-interface ScoreHistory {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  createdAt: string;
-}
+import type { ScoreHistory } from '../../types';
 
 describe('PracticeCalendar', () => {
   it('タイトルが表示される', () => {

--- a/frontend/src/components/__tests__/WeeklyReportCard.test.tsx
+++ b/frontend/src/components/__tests__/WeeklyReportCard.test.tsx
@@ -1,13 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import WeeklyReportCard from '../WeeklyReportCard';
-
-interface ScoreHistory {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  createdAt: string;
-}
+import type { ScoreHistory } from '../../types';
 
 describe('WeeklyReportCard', () => {
   it('今週の練習回数を表示する', () => {

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -1,15 +1,9 @@
 import { useState, useEffect, useMemo } from 'react';
 import { MenuRepository } from '../repositories/MenuRepository';
+import type { ScoreHistory } from '../types';
 
 interface ChatStats {
   chatPartnerCount: number;
-}
-
-interface ScoreHistory {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  createdAt: string;
 }
 
 export function useMenuData() {

--- a/frontend/src/repositories/MenuRepository.ts
+++ b/frontend/src/repositories/MenuRepository.ts
@@ -1,4 +1,5 @@
 import apiClient from '../lib/axios';
+import type { ScoreHistory } from '../types';
 
 interface ChatStats {
   chatPartnerCount: number;
@@ -6,13 +7,6 @@ interface ChatStats {
 
 interface ChatRoomsResponse {
   chatUsers: Array<{ roomId: number; unreadCount: number }>;
-}
-
-interface ScoreHistory {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  createdAt: string;
 }
 
 export const MenuRepository = {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -157,3 +157,11 @@ export interface Note {
   createdAt: number;
   updatedAt: number;
 }
+
+/** スコア履歴 */
+export interface ScoreHistory {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  createdAt: string;
+}


### PR DESCRIPTION
## 概要
- 5ファイルで重複定義されていたScoreHistoryインターフェースをtypes/index.tsに統一
- 対象: MenuRepository, useMenuData, WeeklyReportCard, WeeklyReportCard.test, PracticeCalendar.test
- 35行削除、13行追加（-22行）

closes #846