### PR TITLE
feat: 書式クリアボタンをツールバーに追加

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -89,6 +89,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onAlign={handleAlign}
         onUndo={handleUndo}
         onRedo={handleRedo}
+        onClearFormatting={handleClearFormatting}
       />
       {linkBubble && (
         <div

--- a/frontend/src/components/ClearFormattingButton.tsx
+++ b/frontend/src/components/ClearFormattingButton.tsx
@@ -1,0 +1,18 @@
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+interface ClearFormattingButtonProps {
+  onClearFormatting: () => void;
+}
+
+export default function ClearFormattingButton({ onClearFormatting }: ClearFormattingButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label="書式クリア"
+      className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+      onClick={onClearFormatting}
+    >
+      <XMarkIcon className="w-4 h-4" />
+    </button>
+  );
+}

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -3,6 +3,7 @@ import ColorPicker from './ColorPicker';
 import HighlightPicker from './HighlightPicker';
 import TextAlignButtons from './TextAlignButtons';
 import UndoRedoButtons from './UndoRedoButtons';
+import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 
 interface EditorToolbarProps {
@@ -17,6 +18,7 @@ interface EditorToolbarProps {
   onAlign: (alignment: 'left' | 'center' | 'right') => void;
   onUndo: () => void;
   onRedo: () => void;
+  onClearFormatting: () => void;
 }
 
 export default function EditorToolbar({
@@ -31,6 +33,7 @@ export default function EditorToolbar({
   onAlign,
   onUndo,
   onRedo,
+  onClearFormatting,
 }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
@@ -43,6 +46,8 @@ export default function EditorToolbar({
       <TextAlignButtons onAlign={onAlign} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <UndoRedoButtons onUndo={onUndo} onRedo={onRedo} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <ClearFormattingButton onClearFormatting={onClearFormatting} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <KeyboardShortcutsHelp />
     </div>

--- a/frontend/src/components/__tests__/ClearFormattingButton.test.tsx
+++ b/frontend/src/components/__tests__/ClearFormattingButton.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ClearFormattingButton from '../ClearFormattingButton';
+
+describe('ClearFormattingButton', () => {
+  it('ボタンが表示される', () => {
+    render(<ClearFormattingButton onClearFormatting={vi.fn()} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('aria-labelが設定されている', () => {
+    render(<ClearFormattingButton onClearFormatting={vi.fn()} />);
+    expect(screen.getByLabelText('書式クリア')).toBeInTheDocument();
+  });
+
+  it('クリックでonClearFormattingが呼ばれる', () => {
+    const onClearFormatting = vi.fn();
+    render(<ClearFormattingButton onClearFormatting={onClearFormatting} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClearFormatting).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -15,6 +15,7 @@ describe('EditorToolbar', () => {
     onAlign: vi.fn(),
     onUndo: vi.fn(),
     onRedo: vi.fn(),
+    onClearFormatting: vi.fn(),
   };
 
   it('書式ボタンが表示される', () => {

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -57,5 +57,9 @@ export function useEditorFormat(editor: Editor | null) {
     editor?.chain().focus().redo().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo };
+  const handleClearFormatting = useCallback(() => {
+    editor?.chain().focus().unsetAllMarks().clearNodes().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting };
 }


### PR DESCRIPTION
## 概要
- 選択テキストの全書式をワンクリックで解除するClearFormattingButtonを追加
- unsetAllMarks + clearNodesで太字・斜体・色・ハイライト等を一括クリア
- EditorToolbarに統合（UndoRedo横に配置）

## テスト計画
- [x] ClearFormattingButton: 3テストパス
- [x] EditorToolbar: 5テストパス
- [x] 全1622テストパス

closes #850