### PR TITLE
refactor: ScoreHistoryItem型の重複解消

### DIFF
--- a/frontend/src/components/CommunicationStyleCard.tsx
+++ b/frontend/src/components/CommunicationStyleCard.tsx
@@ -1,12 +1,8 @@
-import type { AxisScore } from '../types';
+import type { ScoreHistoryItem } from '../types';
 import Card from './Card';
 
-interface Session {
-  scores: AxisScore[];
-}
-
 interface Props {
-  sessions: Session[];
+  sessions: ScoreHistoryItem[];
 }
 
 const STYLE_MAP: Record<string, { label: string; description: string; color: string }> = {
@@ -37,7 +33,7 @@ const STYLE_MAP: Record<string, { label: string; description: string; color: str
   },
 };
 
-function getAverageScores(sessions: Session[]): Map<string, number> {
+function getAverageScores(sessions: ScoreHistoryItem[]): Map<string, number> {
   const totals = new Map<string, { sum: number; count: number }>();
 
   for (const session of sessions) {

--- a/frontend/src/components/RecentSessionsCard.tsx
+++ b/frontend/src/components/RecentSessionsCard.tsx
@@ -1,17 +1,11 @@
 import { useNavigate } from 'react-router-dom';
+import type { ScoreHistoryItem } from '../types';
 import { getScoreTextColor } from '../utils/scoreColor';
 import Card from './Card';
 import { formatDate } from '../utils/formatters';
 
-interface Session {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  createdAt: string;
-}
-
 interface RecentSessionsCardProps {
-  sessions: Session[];
+  sessions: ScoreHistoryItem[];
 }
 
 export default function RecentSessionsCard({ sessions }: RecentSessionsCardProps) {

--- a/frontend/src/components/ScoreHistorySessionCard.tsx
+++ b/frontend/src/components/ScoreHistorySessionCard.tsx
@@ -1,4 +1,4 @@
-import type { ScoreHistoryItem } from '../hooks/useScoreHistory';
+import type { ScoreHistoryItem } from '../types';
 import Card from './Card';
 
 interface ScoreHistorySessionCardProps {

--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -1,15 +1,7 @@
-import type { AxisScore } from '../types';
-
-interface Session {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  scores: AxisScore[];
-  createdAt: string;
-}
+import type { ScoreHistoryItem } from '../types';
 
 interface SessionDetailModalProps {
-  session: Session;
+  session: ScoreHistoryItem;
   onClose: () => void;
 }
 

--- a/frontend/src/components/WeeklyComparisonCard.tsx
+++ b/frontend/src/components/WeeklyComparisonCard.tsx
@@ -1,12 +1,8 @@
+import type { ScoreHistoryItem } from '../types';
 import Card from './Card';
 
-interface Session {
-  overallScore: number;
-  createdAt: string;
-}
-
 interface WeeklyComparisonCardProps {
-  sessions: Session[];
+  sessions: ScoreHistoryItem[];
 }
 
 function getMonday(date: Date): Date {

--- a/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
+++ b/frontend/src/components/__tests__/CommunicationStyleCard.test.tsx
@@ -1,11 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import type { AxisScore } from '../../types';
+import type { AxisScore, ScoreHistoryItem } from '../../types';
 import CommunicationStyleCard from '../CommunicationStyleCard';
-
-interface Session {
-  scores: AxisScore[];
-}
 
 describe('CommunicationStyleCard', () => {
   it('セッションがない場合は未判定メッセージを表示する', () => {
@@ -14,7 +10,7 @@ describe('CommunicationStyleCard', () => {
   });
 
   it('論理的構成力が最高の場合は論理型を表示する', () => {
-    const sessions: Session[] = [{
+    const sessions: ScoreHistoryItem[] = [{
       scores: [
         { axis: '論理的構成力', score: 9, comment: '' },
         { axis: '配慮表現', score: 5, comment: '' },
@@ -28,7 +24,7 @@ describe('CommunicationStyleCard', () => {
   });
 
   it('配慮表現が最高の場合は共感型を表示する', () => {
-    const sessions: Session[] = [{
+    const sessions: ScoreHistoryItem[] = [{
       scores: [
         { axis: '論理的構成力', score: 5, comment: '' },
         { axis: '配慮表現', score: 9, comment: '' },
@@ -42,7 +38,7 @@ describe('CommunicationStyleCard', () => {
   });
 
   it('要約力が最高の場合は簡潔型を表示する', () => {
-    const sessions: Session[] = [{
+    const sessions: ScoreHistoryItem[] = [{
       scores: [
         { axis: '論理的構成力', score: 5, comment: '' },
         { axis: '配慮表現', score: 5, comment: '' },
@@ -56,7 +52,7 @@ describe('CommunicationStyleCard', () => {
   });
 
   it('提案力が最高の場合は提案型を表示する', () => {
-    const sessions: Session[] = [{
+    const sessions: ScoreHistoryItem[] = [{
       scores: [
         { axis: '論理的構成力', score: 5, comment: '' },
         { axis: '配慮表現', score: 5, comment: '' },
@@ -70,7 +66,7 @@ describe('CommunicationStyleCard', () => {
   });
 
   it('質問・傾聴力が最高の場合は傾聴型を表示する', () => {
-    const sessions: Session[] = [{
+    const sessions: ScoreHistoryItem[] = [{
       scores: [
         { axis: '論理的構成力', score: 5, comment: '' },
         { axis: '配慮表現', score: 5, comment: '' },
@@ -92,7 +88,7 @@ describe('CommunicationStyleCard', () => {
   });
 
   it('複数セッションの平均からスタイルを判定する', () => {
-    const sessions: Session[] = [
+    const sessions: ScoreHistoryItem[] = [
       {
         scores: [
           { axis: '論理的構成力', score: 8, comment: '' },

--- a/frontend/src/components/__tests__/ScoreHistorySessionCard.test.tsx
+++ b/frontend/src/components/__tests__/ScoreHistorySessionCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ScoreHistorySessionCard from '../ScoreHistorySessionCard';
-import type { ScoreHistoryItem } from '../../hooks/useScoreHistory';
+import type { ScoreHistoryItem } from '../../types';
 
 const baseItem: ScoreHistoryItem = {
   sessionId: 1,

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -1,14 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
-import type { AxisScore } from '../types';
+import type { ScoreHistoryItem } from '../types';
 import { useAiChat } from './useAiChat';
-
-export interface ScoreHistoryItem {
-  sessionId: number;
-  sessionTitle: string;
-  overallScore: number;
-  scores: AxisScore[];
-  createdAt: string;
-}
 
 const FILTERS = ['すべて', '練習', 'フリー'] as const;
 export type FilterType = (typeof FILTERS)[number];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -165,3 +165,12 @@ export interface ScoreHistory {
   overallScore: number;
   createdAt: string;
 }
+
+/** スコア履歴アイテム（スコア詳細付き） */
+export interface ScoreHistoryItem {
+  sessionId: number;
+  sessionTitle: string;
+  overallScore: number;
+  scores: AxisScore[];
+  createdAt: string;
+}


### PR DESCRIPTION
## 概要
- 4つのコンポーネントに定義されたローカル`Session` interfaceを共通の`ScoreHistoryItem`型に統一
- `ScoreHistoryItem`を`useScoreHistory.ts`から`types/index.ts`に移動
- 9ファイル変更、53行削除・28行追加（-25行）

## 対象
- RecentSessionsCard / CommunicationStyleCard / WeeklyComparisonCard / SessionDetailModal
- useScoreHistory.ts / ScoreHistorySessionCard + テスト2件

## テスト計画
- [x] 全1622テストパス

closes #852