### PR TITLE
feat: インデント制御ボタンをツールバーに追加

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -90,6 +90,8 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onUndo={handleUndo}
         onRedo={handleRedo}
         onClearFormatting={handleClearFormatting}
+        onIndent={handleIndent}
+        onOutdent={handleOutdent}
       />
       {linkBubble && (
         <div

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -3,6 +3,7 @@ import ColorPicker from './ColorPicker';
 import HighlightPicker from './HighlightPicker';
 import TextAlignButtons from './TextAlignButtons';
 import UndoRedoButtons from './UndoRedoButtons';
+import IndentButtons from './IndentButtons';
 import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 
@@ -19,6 +20,8 @@ interface EditorToolbarProps {
   onUndo: () => void;
   onRedo: () => void;
   onClearFormatting: () => void;
+  onIndent: () => void;
+  onOutdent: () => void;
 }
 
 export default function EditorToolbar({
@@ -34,6 +37,8 @@ export default function EditorToolbar({
   onUndo,
   onRedo,
   onClearFormatting,
+  onIndent,
+  onOutdent,
 }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
@@ -44,6 +49,8 @@ export default function EditorToolbar({
       <HighlightPicker onSelectHighlight={onHighlight} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <TextAlignButtons onAlign={onAlign} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <IndentButtons onIndent={onIndent} onOutdent={onOutdent} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <UndoRedoButtons onUndo={onUndo} onRedo={onRedo} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />

--- a/frontend/src/components/IndentButtons.tsx
+++ b/frontend/src/components/IndentButtons.tsx
@@ -1,0 +1,29 @@
+import { ArrowRightIcon, ArrowLeftIcon } from '@heroicons/react/24/outline';
+
+interface IndentButtonsProps {
+  onIndent: () => void;
+  onOutdent: () => void;
+}
+
+export default function IndentButtons({ onIndent, onOutdent }: IndentButtonsProps) {
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        aria-label="インデント減少"
+        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+        onClick={onOutdent}
+      >
+        <ArrowLeftIcon className="w-4 h-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="インデント増加"
+        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+        onClick={onIndent}
+      >
+        <ArrowRightIcon className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -16,6 +16,8 @@ describe('EditorToolbar', () => {
     onUndo: vi.fn(),
     onRedo: vi.fn(),
     onClearFormatting: vi.fn(),
+    onIndent: vi.fn(),
+    onOutdent: vi.fn(),
   };
 
   it('書式ボタンが表示される', () => {

--- a/frontend/src/components/__tests__/IndentButtons.test.tsx
+++ b/frontend/src/components/__tests__/IndentButtons.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import IndentButtons from '../IndentButtons';
+
+describe('IndentButtons', () => {
+  it('2つのボタンが表示される', () => {
+    render(<IndentButtons onIndent={vi.fn()} onOutdent={vi.fn()} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('インデント増加ボタンにaria-labelがある', () => {
+    render(<IndentButtons onIndent={vi.fn()} onOutdent={vi.fn()} />);
+    expect(screen.getByLabelText('インデント増加')).toBeInTheDocument();
+  });
+
+  it('インデント減少ボタンにaria-labelがある', () => {
+    render(<IndentButtons onIndent={vi.fn()} onOutdent={vi.fn()} />);
+    expect(screen.getByLabelText('インデント減少')).toBeInTheDocument();
+  });
+
+  it('インデント増加クリックでonIndentが呼ばれる', () => {
+    const onIndent = vi.fn();
+    render(<IndentButtons onIndent={onIndent} onOutdent={vi.fn()} />);
+    fireEvent.click(screen.getByLabelText('インデント増加'));
+    expect(onIndent).toHaveBeenCalledOnce();
+  });
+
+  it('インデント減少クリックでonOutdentが呼ばれる', () => {
+    const onOutdent = vi.fn();
+    render(<IndentButtons onIndent={vi.fn()} onOutdent={onOutdent} />);
+    fireEvent.click(screen.getByLabelText('インデント減少'));
+    expect(onOutdent).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -61,5 +61,23 @@ export function useEditorFormat(editor: Editor | null) {
     editor?.chain().focus().unsetAllMarks().clearNodes().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting };
+  const handleIndent = useCallback(() => {
+    if (!editor) return;
+    if (editor.can().sinkListItem('listItem')) {
+      editor.chain().focus().sinkListItem('listItem').run();
+    } else if (editor.can().sinkListItem('taskItem')) {
+      editor.chain().focus().sinkListItem('taskItem').run();
+    }
+  }, [editor]);
+
+  const handleOutdent = useCallback(() => {
+    if (!editor) return;
+    if (editor.can().liftListItem('listItem')) {
+      editor.chain().focus().liftListItem('listItem').run();
+    } else if (editor.can().liftListItem('taskItem')) {
+      editor.chain().focus().liftListItem('taskItem').run();
+    }
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent };
 }


### PR DESCRIPTION
## 概要
- リスト項目のネストレベルを増減するIndentButtonsコンポーネントを追加
- sinkListItem/liftListItemでlistItemとtaskItemの両方に対応
- EditorToolbarに統合（TextAlignButtonsとUndoRedoButtonsの間に配置）

## テスト計画
- [x] IndentButtons: 5テストパス
- [x] EditorToolbar: 5テストパス
- [x] 全1627テストパス

closes #856