### PR TITLE
refactor: 週計算ロジックをweekUtilsに統一

### DIFF
--- a/frontend/src/components/WeeklyComparisonCard.tsx
+++ b/frontend/src/components/WeeklyComparisonCard.tsx
@@ -1,23 +1,14 @@
 import type { ScoreHistoryItem } from '../types';
+import { getWeekRange } from '../utils/weekUtils';
 import Card from './Card';
 
 interface WeeklyComparisonCardProps {
   sessions: ScoreHistoryItem[];
 }
 
-function getMonday(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
-  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1));
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
 export default function WeeklyComparisonCard({ sessions }: WeeklyComparisonCardProps) {
-  const now = new Date();
-  const thisMonday = getMonday(now);
-  const lastMonday = new Date(thisMonday);
-  lastMonday.setDate(thisMonday.getDate() - 7);
+  const { start: thisMonday } = getWeekRange(0);
+  const { start: lastMonday } = getWeekRange(1);
 
   const thisWeek = sessions.filter((s) => new Date(s.createdAt) >= thisMonday);
   const lastWeek = sessions.filter((s) => {

--- a/frontend/src/components/WeeklyReportCard.tsx
+++ b/frontend/src/components/WeeklyReportCard.tsx
@@ -1,24 +1,10 @@
 import { useMemo } from 'react';
 import Card from './Card';
 import type { ScoreHistory } from '../types';
+import { getWeekRange } from '../utils/weekUtils';
 
 interface WeeklyReportCardProps {
   allScores: ScoreHistory[];
-}
-
-function getWeekRange(weeksAgo: number): { start: Date; end: Date } {
-  const now = new Date();
-  const dayOfWeek = now.getDay();
-  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
-
-  const start = new Date(now);
-  start.setDate(now.getDate() + mondayOffset - weeksAgo * 7);
-  start.setHours(0, 0, 0, 0);
-
-  const end = new Date(start);
-  end.setDate(start.getDate() + 7);
-
-  return { start, end };
 }
 
 export default function WeeklyReportCard({ allScores }: WeeklyReportCardProps) {

--- a/frontend/src/hooks/useMenuData.ts
+++ b/frontend/src/hooks/useMenuData.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { MenuRepository } from '../repositories/MenuRepository';
 import type { ScoreHistory } from '../types';
+import { getMonday } from '../utils/weekUtils';
 
 interface ChatStats {
   chatPartnerCount: number;
@@ -54,11 +55,7 @@ export function useMenuData() {
   const uniqueDays = practiceDates.length;
 
   const sessionsThisWeek = useMemo(() => {
-    const now = new Date();
-    const day = now.getDay();
-    const monday = new Date(now);
-    monday.setDate(now.getDate() - (day === 0 ? 6 : day - 1));
-    monday.setHours(0, 0, 0, 0);
+    const monday = getMonday(new Date());
     return allScores.filter(s => new Date(s.createdAt) >= monday).length;
   }, [allScores]);
 

--- a/frontend/src/utils/__tests__/weekUtils.test.ts
+++ b/frontend/src/utils/__tests__/weekUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { getMonday, getWeekRange } from '../weekUtils';
+
+describe('weekUtils', () => {
+  describe('getMonday', () => {
+    it('水曜日の月曜日を返す', () => {
+      const wed = new Date(2025, 0, 8); // 2025-01-08 水曜
+      const monday = getMonday(wed);
+      expect(monday.getDay()).toBe(1);
+      expect(monday.getDate()).toBe(6);
+    });
+
+    it('月曜日なら同日を返す', () => {
+      const mon = new Date(2025, 0, 6); // 2025-01-06 月曜
+      const monday = getMonday(mon);
+      expect(monday.getDate()).toBe(6);
+    });
+
+    it('日曜日なら前週の月曜を返す', () => {
+      const sun = new Date(2025, 0, 12); // 2025-01-12 日曜
+      const monday = getMonday(sun);
+      expect(monday.getDate()).toBe(6);
+    });
+
+    it('時刻が00:00:00にリセットされる', () => {
+      const date = new Date(2025, 0, 8, 15, 30, 45);
+      const monday = getMonday(date);
+      expect(monday.getHours()).toBe(0);
+      expect(monday.getMinutes()).toBe(0);
+      expect(monday.getSeconds()).toBe(0);
+    });
+  });
+
+  describe('getWeekRange', () => {
+    it('今週の範囲を返す', () => {
+      const { start, end } = getWeekRange(0);
+      expect(start.getDay()).toBe(1);
+      expect(end.getTime() - start.getTime()).toBe(7 * 24 * 60 * 60 * 1000);
+    });
+
+    it('先週の範囲を返す', () => {
+      const thisWeek = getWeekRange(0);
+      const lastWeek = getWeekRange(1);
+      expect(lastWeek.end.getTime()).toBe(thisWeek.start.getTime());
+    });
+  });
+});

--- a/frontend/src/utils/weekUtils.ts
+++ b/frontend/src/utils/weekUtils.ts
@@ -1,0 +1,19 @@
+/** 指定日が属する週の月曜日（00:00:00）を返す */
+export function getMonday(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1));
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** N週前の月曜〜翌月曜の範囲を返す */
+export function getWeekRange(weeksAgo: number): { start: Date; end: Date } {
+  const start = getMonday(new Date());
+  start.setDate(start.getDate() - weeksAgo * 7);
+
+  const end = new Date(start);
+  end.setDate(start.getDate() + 7);
+
+  return { start, end };
+}


### PR DESCRIPTION
## 概要
- 3箇所に重複していた週計算ロジック（getMonday/getWeekRange）を`utils/weekUtils.ts`に抽出
- WeeklyComparisonCard（ローカルgetMonday削除）
- WeeklyReportCard（ローカルgetWeekRange削除）
- useMenuData（インライン月曜計算→getMonday利用）
- weekUtils用テスト6件追加

## テスト計画
- [x] weekUtils: 6テストパス
- [x] 全1633テストパス

closes #858