### PR TITLE
feat: 読了時間コンポーネントを追加

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -4,6 +4,7 @@ import { useTableOfContents } from '../hooks/useTableOfContents';
 import BlockEditor from './BlockEditor';
 import TableOfContents from './TableOfContents';
 import WordCount from './WordCount';
+import ReadingTime from './ReadingTime';
 
 interface NoteEditorProps {
   title: string;
@@ -65,7 +66,7 @@ export default function NoteEditor({
 
       <div className="flex items-center gap-3 pt-3 border-t border-surface-3" aria-label="ノート統計">
         <WordCount charCount={stats.charCount} />
-        {stats.readingTimeMin > 0 && <span className="text-[11px] text-[var(--color-text-faint)]">約{stats.readingTimeMin}分</span>}
+        <ReadingTime charCount={stats.charCount} />
       </div>
     </div>
   );

--- a/frontend/src/components/ReadingTime.tsx
+++ b/frontend/src/components/ReadingTime.tsx
@@ -1,0 +1,15 @@
+interface ReadingTimeProps {
+  charCount: number;
+}
+
+const CHARS_PER_MINUTE = 500;
+
+export default function ReadingTime({ charCount }: ReadingTimeProps) {
+  const minutes = charCount === 0 ? 0 : Math.max(1, Math.ceil(charCount / CHARS_PER_MINUTE));
+
+  return (
+    <span className="text-[10px] text-[var(--color-text-faint)]">
+      約{minutes}分
+    </span>
+  );
+}

--- a/frontend/src/components/__tests__/ReadingTime.test.tsx
+++ b/frontend/src/components/__tests__/ReadingTime.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ReadingTime from '../ReadingTime';
+
+describe('ReadingTime', () => {
+  it('0文字の場合「約0分」を表示する', () => {
+    render(<ReadingTime charCount={0} />);
+    expect(screen.getByText('約0分')).toBeInTheDocument();
+  });
+
+  it('400文字の場合「約1分」を表示する', () => {
+    render(<ReadingTime charCount={400} />);
+    expect(screen.getByText('約1分')).toBeInTheDocument();
+  });
+
+  it('2000文字の場合「約4分」を表示する', () => {
+    render(<ReadingTime charCount={2000} />);
+    expect(screen.getByText('約4分')).toBeInTheDocument();
+  });
+
+  it('200文字の場合「約1分」（切り上げ）を表示する', () => {
+    render(<ReadingTime charCount={200} />);
+    expect(screen.getByText('約1分')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 文字数から推定読了時間を計算するReadingTimeコンポーネントを追加
- 500文字/分で計算、1分未満は切り上げ
- NoteEditorのインライン表示をReadingTimeに置換

## テスト計画
- [x] ReadingTime: 4テストパス
- [x] 全1637テストパス

closes #862