### PR TITLE
refactor: noteStatsからreadingTimeMinを削除

### DIFF
--- a/frontend/src/utils/__tests__/noteStats.test.ts
+++ b/frontend/src/utils/__tests__/noteStats.test.ts
@@ -2,10 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { getNoteStats } from '../noteStats';
 
 describe('getNoteStats', () => {
-  it('空文字で0文字・0分を返す', () => {
+  it('空文字で0文字を返す', () => {
     const stats = getNoteStats('');
     expect(stats.charCount).toBe(0);
-    expect(stats.readingTimeMin).toBe(0);
   });
 
   it('文字数を正しくカウントする', () => {
@@ -18,43 +17,19 @@ describe('getNoteStats', () => {
     expect(stats.charCount).toBe(7);
   });
 
-  it('読了時間を日本語400文字/分で計算する', () => {
-    const text = 'あ'.repeat(400);
-    const stats = getNoteStats(text);
-    expect(stats.readingTimeMin).toBe(1);
-  });
-
-  it('800文字で2分の読了時間を返す', () => {
-    const text = 'あ'.repeat(800);
-    const stats = getNoteStats(text);
-    expect(stats.readingTimeMin).toBe(2);
-  });
-
-  it('1文字でも最低1分の読了時間を返す', () => {
-    const stats = getNoteStats('あ');
-    expect(stats.readingTimeMin).toBe(1);
-  });
-
   it('スペースを除外して文字数をカウントする', () => {
     const stats = getNoteStats('hello world');
     expect(stats.charCount).toBe(10);
   });
 
-  it('全スペースの場合0文字・0分を返す', () => {
+  it('全スペースの場合0文字を返す', () => {
     const stats = getNoteStats('   \n\n  \t  ');
     expect(stats.charCount).toBe(0);
-    expect(stats.readingTimeMin).toBe(0);
   });
 
   it('日本語と英語の混合文字をカウントする', () => {
     const stats = getNoteStats('Hello世界');
     expect(stats.charCount).toBe(7);
-  });
-
-  it('長文で正しい読了時間を計算する', () => {
-    const text = 'あ'.repeat(1200);
-    const stats = getNoteStats(text);
-    expect(stats.readingTimeMin).toBe(3);
   });
 
   it('タブ文字を除外してカウントする', () => {

--- a/frontend/src/utils/noteStats.ts
+++ b/frontend/src/utils/noteStats.ts
@@ -1,17 +1,13 @@
 import { tiptapToPlainText } from './tiptapToPlainText';
 
-const CHARS_PER_MINUTE = 400;
-
 export interface NoteStats {
   charCount: number;
-  readingTimeMin: number;
 }
 
 export function getNoteStats(content: string): NoteStats {
   const plainText = tiptapToPlainText(content);
   const cleaned = plainText.replace(/[\s\n]/g, '');
   const charCount = cleaned.length;
-  const readingTimeMin = charCount === 0 ? 0 : Math.max(1, Math.round(charCount / CHARS_PER_MINUTE));
 
-  return { charCount, readingTimeMin };
+  return { charCount };
 }


### PR DESCRIPTION
## 概要
- ReadingTimeコンポーネント導入により不要になったnoteStatsのreadingTimeMinを削除
- CHARS_PER_MINUTE定数も削除（ReadingTimeコンポーネント内に移動済み）
- 32行削除、3行追加（-29行）

## テスト計画
- [x] 全1633テストパス

closes #864