### PR TITLE
feat: ツールバーに引用ブロックボタンを追加

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -92,6 +92,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onClearFormatting={handleClearFormatting}
         onIndent={handleIndent}
         onOutdent={handleOutdent}
+        onBlockquote={handleBlockquote}
       />
       {linkBubble && (
         <div

--- a/frontend/src/components/BlockquoteButton.tsx
+++ b/frontend/src/components/BlockquoteButton.tsx
@@ -1,0 +1,18 @@
+import { ChatBubbleBottomCenterTextIcon } from '@heroicons/react/24/outline';
+
+interface BlockquoteButtonProps {
+  onBlockquote: () => void;
+}
+
+export default function BlockquoteButton({ onBlockquote }: BlockquoteButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label="引用"
+      className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
+      onClick={onBlockquote}
+    >
+      <ChatBubbleBottomCenterTextIcon className="w-4 h-4" />
+    </button>
+  );
+}

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -4,6 +4,7 @@ import HighlightPicker from './HighlightPicker';
 import TextAlignButtons from './TextAlignButtons';
 import UndoRedoButtons from './UndoRedoButtons';
 import IndentButtons from './IndentButtons';
+import BlockquoteButton from './BlockquoteButton';
 import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 
@@ -22,6 +23,7 @@ interface EditorToolbarProps {
   onClearFormatting: () => void;
   onIndent: () => void;
   onOutdent: () => void;
+  onBlockquote: () => void;
 }
 
 export default function EditorToolbar({
@@ -39,6 +41,7 @@ export default function EditorToolbar({
   onClearFormatting,
   onIndent,
   onOutdent,
+  onBlockquote,
 }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
@@ -51,6 +54,8 @@ export default function EditorToolbar({
       <TextAlignButtons onAlign={onAlign} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <IndentButtons onIndent={onIndent} onOutdent={onOutdent} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
+      <BlockquoteButton onBlockquote={onBlockquote} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <UndoRedoButtons onUndo={onUndo} onRedo={onRedo} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />

--- a/frontend/src/components/__tests__/BlockquoteButton.test.tsx
+++ b/frontend/src/components/__tests__/BlockquoteButton.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BlockquoteButton from '../BlockquoteButton';
+
+describe('BlockquoteButton', () => {
+  it('引用ボタンが表示される', () => {
+    render(<BlockquoteButton onBlockquote={vi.fn()} />);
+    expect(screen.getByLabelText('引用')).toBeInTheDocument();
+  });
+
+  it('クリックでonBlockquoteが呼ばれる', () => {
+    const onBlockquote = vi.fn();
+    render(<BlockquoteButton onBlockquote={onBlockquote} />);
+    fireEvent.click(screen.getByLabelText('引用'));
+    expect(onBlockquote).toHaveBeenCalledTimes(1);
+  });
+
+  it('ボタンがbutton要素である', () => {
+    render(<BlockquoteButton onBlockquote={vi.fn()} />);
+    const button = screen.getByLabelText('引用');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+});

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -18,6 +18,7 @@ describe('EditorToolbar', () => {
     onClearFormatting: vi.fn(),
     onIndent: vi.fn(),
     onOutdent: vi.fn(),
+    onBlockquote: vi.fn(),
   };
 
   it('書式ボタンが表示される', () => {

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -79,5 +79,9 @@ export function useEditorFormat(editor: Editor | null) {
     }
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent };
+  const handleBlockquote = useCallback(() => {
+    editor?.chain().focus().toggleBlockquote().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote };
 }


### PR DESCRIPTION
## 概要
エディタのツールバーにBlockquoteButton（引用ブロック）ボタンを追加。

## 変更内容
- `BlockquoteButton.tsx` 新規作成（ChatBubbleBottomCenterTextIconアイコン使用）
- `useEditorFormat.ts` に `handleBlockquote` 追加（`toggleBlockquote()`）
- `EditorToolbar.tsx` に `BlockquoteButton` 統合
- `BlockEditor.tsx` に `handleBlockquote` 連携
- テスト追加（3件）、既存テスト更新

## テスト結果
- フロントエンド: 1636テスト全通過

closes #868