### PR TITLE
refactor: ToolbarIconButtonコンポーネントを抽出してツールバーボタンの重複を解消

### DIFF
--- a/frontend/src/components/BlockquoteButton.tsx
+++ b/frontend/src/components/BlockquoteButton.tsx
@@ -1,18 +1,10 @@
 import { ChatBubbleBottomCenterTextIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
 
 interface BlockquoteButtonProps {
   onBlockquote: () => void;
 }
 
 export default function BlockquoteButton({ onBlockquote }: BlockquoteButtonProps) {
-  return (
-    <button
-      type="button"
-      aria-label="引用"
-      className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-      onClick={onBlockquote}
-    >
-      <ChatBubbleBottomCenterTextIcon className="w-4 h-4" />
-    </button>
-  );
+  return <ToolbarIconButton icon={ChatBubbleBottomCenterTextIcon} label="引用" onClick={onBlockquote} />;
 }

--- a/frontend/src/components/ClearFormattingButton.tsx
+++ b/frontend/src/components/ClearFormattingButton.tsx
@@ -1,18 +1,10 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
 
 interface ClearFormattingButtonProps {
   onClearFormatting: () => void;
 }
 
 export default function ClearFormattingButton({ onClearFormatting }: ClearFormattingButtonProps) {
-  return (
-    <button
-      type="button"
-      aria-label="書式クリア"
-      className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-      onClick={onClearFormatting}
-    >
-      <XMarkIcon className="w-4 h-4" />
-    </button>
-  );
+  return <ToolbarIconButton icon={XMarkIcon} label="書式クリア" onClick={onClearFormatting} />;
 }

--- a/frontend/src/components/FormatButtons.tsx
+++ b/frontend/src/components/FormatButtons.tsx
@@ -1,5 +1,6 @@
 import { BoldIcon, ItalicIcon, UnderlineIcon, StrikethroughIcon } from '@heroicons/react/24/solid';
 import { ArrowUpIcon, ArrowDownIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
 
 interface FormatButtonsProps {
   onBold: () => void;
@@ -25,15 +26,7 @@ export default function FormatButtons({ onBold, onItalic, onUnderline, onStrike,
   return (
     <div className="flex items-center gap-0.5">
       {BUTTONS.map(({ label, Icon, key }) => (
-        <button
-          key={key}
-          type="button"
-          aria-label={label}
-          className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-          onClick={handlers[key]}
-        >
-          <Icon className="w-4 h-4" />
-        </button>
+        <ToolbarIconButton key={key} icon={Icon} label={label} onClick={handlers[key]} />
       ))}
     </div>
   );

--- a/frontend/src/components/IndentButtons.tsx
+++ b/frontend/src/components/IndentButtons.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightIcon, ArrowLeftIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
 
 interface IndentButtonsProps {
   onIndent: () => void;
@@ -8,22 +9,8 @@ interface IndentButtonsProps {
 export default function IndentButtons({ onIndent, onOutdent }: IndentButtonsProps) {
   return (
     <div className="flex items-center gap-0.5">
-      <button
-        type="button"
-        aria-label="インデント減少"
-        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-        onClick={onOutdent}
-      >
-        <ArrowLeftIcon className="w-4 h-4" />
-      </button>
-      <button
-        type="button"
-        aria-label="インデント増加"
-        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-        onClick={onIndent}
-      >
-        <ArrowRightIcon className="w-4 h-4" />
-      </button>
+      <ToolbarIconButton icon={ArrowLeftIcon} label="インデント減少" onClick={onOutdent} />
+      <ToolbarIconButton icon={ArrowRightIcon} label="インデント増加" onClick={onIndent} />
     </div>
   );
 }

--- a/frontend/src/components/TextAlignButtons.tsx
+++ b/frontend/src/components/TextAlignButtons.tsx
@@ -1,4 +1,5 @@
 import { Bars3BottomLeftIcon, Bars3Icon, Bars3BottomRightIcon } from '@heroicons/react/24/solid';
+import ToolbarIconButton from './ToolbarIconButton';
 
 type Alignment = 'left' | 'center' | 'right';
 
@@ -17,17 +18,13 @@ export default function TextAlignButtons({ onAlign, activeAlign }: TextAlignButt
   return (
     <div className="flex items-center gap-0.5">
       {ALIGNMENTS.map(({ alignment, label, Icon }) => (
-        <button
+        <ToolbarIconButton
           key={alignment}
-          type="button"
-          aria-label={label}
-          className={`w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] transition-colors ${
-            activeAlign === alignment ? 'text-primary-500' : 'text-[var(--color-text-faint)]'
-          }`}
+          icon={Icon}
+          label={label}
           onClick={() => onAlign(alignment)}
-        >
-          <Icon className="w-4 h-4" />
-        </button>
+          isActive={activeAlign === alignment}
+        />
       ))}
     </div>
   );

--- a/frontend/src/components/ToolbarIconButton.tsx
+++ b/frontend/src/components/ToolbarIconButton.tsx
@@ -1,0 +1,23 @@
+import type { ComponentType, SVGProps } from 'react';
+
+interface ToolbarIconButtonProps {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  label: string;
+  onClick: () => void;
+  isActive?: boolean;
+}
+
+export default function ToolbarIconButton({ icon: Icon, label, onClick, isActive = false }: ToolbarIconButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className={`w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] transition-colors ${
+        isActive ? 'text-primary-500' : 'text-[var(--color-text-faint)]'
+      }`}
+      onClick={onClick}
+    >
+      <Icon className="w-4 h-4" />
+    </button>
+  );
+}

--- a/frontend/src/components/UndoRedoButtons.tsx
+++ b/frontend/src/components/UndoRedoButtons.tsx
@@ -1,4 +1,5 @@
 import { ArrowUturnLeftIcon, ArrowUturnRightIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
 
 interface UndoRedoButtonsProps {
   onUndo: () => void;
@@ -8,22 +9,8 @@ interface UndoRedoButtonsProps {
 export default function UndoRedoButtons({ onUndo, onRedo }: UndoRedoButtonsProps) {
   return (
     <div className="flex items-center gap-0.5">
-      <button
-        type="button"
-        aria-label="元に戻す"
-        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-        onClick={onUndo}
-      >
-        <ArrowUturnLeftIcon className="w-4 h-4" />
-      </button>
-      <button
-        type="button"
-        aria-label="やり直す"
-        className="w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-faint)] transition-colors"
-        onClick={onRedo}
-      >
-        <ArrowUturnRightIcon className="w-4 h-4" />
-      </button>
+      <ToolbarIconButton icon={ArrowUturnLeftIcon} label="元に戻す" onClick={onUndo} />
+      <ToolbarIconButton icon={ArrowUturnRightIcon} label="やり直す" onClick={onRedo} />
     </div>
   );
 }

--- a/frontend/src/components/__tests__/ToolbarIconButton.test.tsx
+++ b/frontend/src/components/__tests__/ToolbarIconButton.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ToolbarIconButton from '../ToolbarIconButton';
+
+const MockIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg data-testid="mock-icon" {...props} />
+);
+
+describe('ToolbarIconButton', () => {
+  it('ボタンとアイコンが表示される', () => {
+    render(<ToolbarIconButton icon={MockIcon} label="テスト" onClick={vi.fn()} />);
+    expect(screen.getByLabelText('テスト')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-icon')).toBeInTheDocument();
+  });
+
+  it('クリックでonClickが呼ばれる', () => {
+    const onClick = vi.fn();
+    render(<ToolbarIconButton icon={MockIcon} label="テスト" onClick={onClick} />);
+    fireEvent.click(screen.getByLabelText('テスト'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('button type="button"である', () => {
+    render(<ToolbarIconButton icon={MockIcon} label="テスト" onClick={vi.fn()} />);
+    const button = screen.getByLabelText('テスト');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('isActive=trueでtext-primary-500クラスが適用される', () => {
+    render(<ToolbarIconButton icon={MockIcon} label="テスト" onClick={vi.fn()} isActive />);
+    const button = screen.getByLabelText('テスト');
+    expect(button.className).toContain('text-primary-500');
+  });
+
+  it('isActive=falseでtext-faintクラスが適用される', () => {
+    render(<ToolbarIconButton icon={MockIcon} label="テスト" onClick={vi.fn()} />);
+    const button = screen.getByLabelText('テスト');
+    expect(button.className).toContain('text-[var(--color-text-faint)]');
+  });
+});


### PR DESCRIPTION
## 概要
ツールバーの各ボタンコンポーネントで重複していた同一CSSクラス文字列を、共通の`ToolbarIconButton`コンポーネントに抽出。

## 変更内容
- `ToolbarIconButton.tsx` 新規作成（`icon`, `label`, `onClick`, `isActive`プロパティ）
- 6つのコンポーネントを`ToolbarIconButton`利用に書き換え
  - FormatButtons, UndoRedoButtons, ClearFormattingButton, IndentButtons, TextAlignButtons, BlockquoteButton
- テスト追加（5件）
- +82行 / -70行（重複削減）

## テスト結果
- フロントエンド: 1641テスト全通過

closes #870