### PR TITLE
feat: ツールバーに水平線ボタンを追加

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -26,7 +26,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
-  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote } = useEditorFormat(editor);
+  const { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule } = useEditorFormat(editor);
 
   const lastMoveTime = useRef(0);
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
@@ -93,6 +93,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         onIndent={handleIndent}
         onOutdent={handleOutdent}
         onBlockquote={handleBlockquote}
+        onHorizontalRule={handleHorizontalRule}
       />
       {linkBubble && (
         <div

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -5,6 +5,7 @@ import TextAlignButtons from './TextAlignButtons';
 import UndoRedoButtons from './UndoRedoButtons';
 import IndentButtons from './IndentButtons';
 import BlockquoteButton from './BlockquoteButton';
+import HorizontalRuleButton from './HorizontalRuleButton';
 import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 
@@ -24,6 +25,7 @@ interface EditorToolbarProps {
   onIndent: () => void;
   onOutdent: () => void;
   onBlockquote: () => void;
+  onHorizontalRule: () => void;
 }
 
 export default function EditorToolbar({
@@ -42,6 +44,7 @@ export default function EditorToolbar({
   onIndent,
   onOutdent,
   onBlockquote,
+  onHorizontalRule,
 }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
@@ -56,6 +59,7 @@ export default function EditorToolbar({
       <IndentButtons onIndent={onIndent} onOutdent={onOutdent} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <BlockquoteButton onBlockquote={onBlockquote} />
+      <HorizontalRuleButton onHorizontalRule={onHorizontalRule} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <UndoRedoButtons onUndo={onUndo} onRedo={onRedo} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />

--- a/frontend/src/components/HorizontalRuleButton.tsx
+++ b/frontend/src/components/HorizontalRuleButton.tsx
@@ -1,0 +1,10 @@
+import { MinusIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
+
+interface HorizontalRuleButtonProps {
+  onHorizontalRule: () => void;
+}
+
+export default function HorizontalRuleButton({ onHorizontalRule }: HorizontalRuleButtonProps) {
+  return <ToolbarIconButton icon={MinusIcon} label="水平線" onClick={onHorizontalRule} />;
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -19,6 +19,7 @@ describe('EditorToolbar', () => {
     onIndent: vi.fn(),
     onOutdent: vi.fn(),
     onBlockquote: vi.fn(),
+    onHorizontalRule: vi.fn(),
   };
 
   it('書式ボタンが表示される', () => {

--- a/frontend/src/components/__tests__/HorizontalRuleButton.test.tsx
+++ b/frontend/src/components/__tests__/HorizontalRuleButton.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HorizontalRuleButton from '../HorizontalRuleButton';
+
+describe('HorizontalRuleButton', () => {
+  it('水平線ボタンが表示される', () => {
+    render(<HorizontalRuleButton onHorizontalRule={vi.fn()} />);
+    expect(screen.getByLabelText('水平線')).toBeInTheDocument();
+  });
+
+  it('クリックでonHorizontalRuleが呼ばれる', () => {
+    const onHorizontalRule = vi.fn();
+    render(<HorizontalRuleButton onHorizontalRule={onHorizontalRule} />);
+    fireEvent.click(screen.getByLabelText('水平線'));
+    expect(onHorizontalRule).toHaveBeenCalledTimes(1);
+  });
+
+  it('ボタンがbutton要素である', () => {
+    render(<HorizontalRuleButton onHorizontalRule={vi.fn()} />);
+    const button = screen.getByLabelText('水平線');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -83,5 +83,9 @@ export function useEditorFormat(editor: Editor | null) {
     editor?.chain().focus().toggleBlockquote().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote };
+  const handleHorizontalRule = useCallback(() => {
+    editor?.chain().focus().setHorizontalRule().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule };
 }


### PR DESCRIPTION
## 概要
エディタのツールバーにHorizontalRuleButton（水平線）ボタンを追加。

## 変更内容
- `HorizontalRuleButton.tsx` 新規作成（MinusIconアイコン、ToolbarIconButton利用）
- `useEditorFormat.ts` に `handleHorizontalRule` 追加（`setHorizontalRule()`）
- `EditorToolbar.tsx` に `HorizontalRuleButton` 統合
- `BlockEditor.tsx` に `handleHorizontalRule` 連携
- テスト追加（3件）、既存テスト更新

## テスト結果
- フロントエンド: 1644テスト全通過

closes #874