### PR TITLE
feat: ツールバーにコードブロックボタンを追加

### DIFF
--- a/frontend/src/components/CodeBlockButton.tsx
+++ b/frontend/src/components/CodeBlockButton.tsx
@@ -1,0 +1,10 @@
+import { CodeBracketIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
+
+interface CodeBlockButtonProps {
+  onCodeBlock: () => void;
+}
+
+export default function CodeBlockButton({ onCodeBlock }: CodeBlockButtonProps) {
+  return <ToolbarIconButton icon={CodeBracketIcon} label="コードブロック" onClick={onCodeBlock} />;
+}

--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -7,6 +7,7 @@ import UndoRedoButtons from './UndoRedoButtons';
 import IndentButtons from './IndentButtons';
 import BlockquoteButton from './BlockquoteButton';
 import HorizontalRuleButton from './HorizontalRuleButton';
+import CodeBlockButton from './CodeBlockButton';
 import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 
@@ -29,6 +30,7 @@ export default function EditorToolbar({ handlers }: EditorToolbarProps) {
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <BlockquoteButton onBlockquote={handlers.handleBlockquote} />
       <HorizontalRuleButton onHorizontalRule={handlers.handleHorizontalRule} />
+      <CodeBlockButton onCodeBlock={handlers.handleCodeBlock} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <UndoRedoButtons onUndo={handlers.handleUndo} onRedo={handlers.handleRedo} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />

--- a/frontend/src/components/__tests__/CodeBlockButton.test.tsx
+++ b/frontend/src/components/__tests__/CodeBlockButton.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CodeBlockButton from '../CodeBlockButton';
+
+describe('CodeBlockButton', () => {
+  it('コードブロックボタンが表示される', () => {
+    render(<CodeBlockButton onCodeBlock={vi.fn()} />);
+    expect(screen.getByLabelText('コードブロック')).toBeInTheDocument();
+  });
+
+  it('クリックでonCodeBlockが呼ばれる', () => {
+    const onCodeBlock = vi.fn();
+    render(<CodeBlockButton onCodeBlock={onCodeBlock} />);
+    fireEvent.click(screen.getByLabelText('コードブロック'));
+    expect(onCodeBlock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ボタンがbutton要素である', () => {
+    render(<CodeBlockButton onCodeBlock={vi.fn()} />);
+    const button = screen.getByLabelText('コードブロック');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+});

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -21,6 +21,7 @@ describe('EditorToolbar', () => {
     handleOutdent: vi.fn(),
     handleBlockquote: vi.fn(),
     handleHorizontalRule: vi.fn(),
+    handleCodeBlock: vi.fn(),
     ...overrides,
   });
 

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -18,6 +18,7 @@ export interface EditorFormatHandlers {
   handleOutdent: () => void;
   handleBlockquote: () => void;
   handleHorizontalRule: () => void;
+  handleCodeBlock: () => void;
 }
 
 export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
@@ -106,5 +107,9 @@ export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
     editor?.chain().focus().setHorizontalRule().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule };
+  const handleCodeBlock = useCallback(() => {
+    editor?.chain().focus().toggleCodeBlock().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock };
 }


### PR DESCRIPTION
## 概要
エディタのツールバーにCodeBlockButton（コードブロック）ボタンを追加。

## 変更内容
- `CodeBlockButton.tsx` 新規作成（CodeBracketIconアイコン、ToolbarIconButton利用）
- `useEditorFormat.ts` に `handleCodeBlock` 追加（`toggleCodeBlock()`）
- `EditorFormatHandlers` 型に `handleCodeBlock` 追加
- `EditorToolbar.tsx` に `CodeBlockButton` 統合
- テスト追加（3件）、既存テスト更新

## テスト結果
- フロントエンド: 1647テスト全通過

closes #880