### PR TITLE
refactor: AxisScoreBarコンポーネントを抽出してスコアバー表示の重複を解消 #888

### DIFF
--- a/frontend/src/components/AxisScoreBar.tsx
+++ b/frontend/src/components/AxisScoreBar.tsx
@@ -1,0 +1,15 @@
+interface AxisScoreBarProps {
+  score: number;
+  barColorClass?: string;
+}
+
+export default function AxisScoreBar({ score, barColorClass = 'bg-primary-500' }: AxisScoreBarProps) {
+  return (
+    <div role="progressbar" className="w-full bg-surface-3 rounded-full h-1.5">
+      <div
+        className={`h-1.5 rounded-full ${barColorClass}`}
+        style={{ width: `${score * 10}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ScoreCard.tsx
+++ b/frontend/src/components/ScoreCard.tsx
@@ -2,6 +2,7 @@ import type { ScoreCard as ScoreCardType } from '../types';
 import { LightBulbIcon } from '@heroicons/react/24/outline';
 import { getScoreLevel, getScoreBarColor } from '../utils/scoreColor';
 import Card from './Card';
+import AxisScoreBar from './AxisScoreBar';
 
 interface ScoreCardProps {
   scoreCard: ScoreCardType;
@@ -35,12 +36,7 @@ export default function ScoreCard({ scoreCard }: ScoreCardProps) {
               <span className="text-xs text-[var(--color-text-muted)]">{axisScore.axis}</span>
               <span className="text-xs font-medium text-[var(--color-text-tertiary)]">{axisScore.score}</span>
             </div>
-            <div className="w-full bg-surface-3 rounded-full h-1.5">
-              <div
-                className={`h-1.5 rounded-full ${getScoreBarColor(axisScore.score)}`}
-                style={{ width: `${axisScore.score * 10}%` }}
-              />
-            </div>
+            <AxisScoreBar score={axisScore.score} barColorClass={getScoreBarColor(axisScore.score)} />
             <p className="text-[10px] text-[var(--color-text-faint)] mt-0.5">{axisScore.comment}</p>
             {axisScore.score <= 5 && (
               <p className="text-[10px] text-amber-400 mt-0.5 flex items-center gap-0.5">

--- a/frontend/src/components/ScoreHistorySessionCard.tsx
+++ b/frontend/src/components/ScoreHistorySessionCard.tsx
@@ -1,5 +1,6 @@
 import type { ScoreHistoryItem } from '../types';
 import Card from './Card';
+import AxisScoreBar from './AxisScoreBar';
 
 interface ScoreHistorySessionCardProps {
   item: ScoreHistoryItem;
@@ -48,11 +49,8 @@ export default function ScoreHistorySessionCard({ item, delta, onClick }: ScoreH
             <span className="text-xs text-[var(--color-text-muted)] w-24 flex-shrink-0 truncate">
               {axisScore.axis}
             </span>
-            <div className="flex-1 bg-surface-3 rounded-full h-1.5">
-              <div
-                className="h-1.5 rounded-full bg-primary-500"
-                style={{ width: `${axisScore.score * 10}%` }}
-              />
+            <div className="flex-1">
+              <AxisScoreBar score={axisScore.score} />
             </div>
             <span className="text-xs text-[var(--color-text-tertiary)] w-5 text-right">
               {axisScore.score}

--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -1,4 +1,5 @@
 import type { ScoreHistoryItem } from '../types';
+import AxisScoreBar from './AxisScoreBar';
 
 interface SessionDetailModalProps {
   session: ScoreHistoryItem;
@@ -49,11 +50,8 @@ export default function SessionDetailModal({ session, onClose }: SessionDetailMo
                     {axisScore.score.toFixed(1)}
                   </span>
                 </div>
-                <div className="w-full bg-surface-3 rounded-full h-1.5 mb-2">
-                  <div
-                    className="h-1.5 rounded-full bg-primary-500"
-                    style={{ width: `${axisScore.score * 10}%` }}
-                  />
+                <div className="mb-2">
+                  <AxisScoreBar score={axisScore.score} />
                 </div>
                 {axisScore.comment && (
                   <p className="text-xs text-[var(--color-text-muted)]">{axisScore.comment}</p>

--- a/frontend/src/components/__tests__/AxisScoreBar.test.tsx
+++ b/frontend/src/components/__tests__/AxisScoreBar.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AxisScoreBar from '../AxisScoreBar';
+
+describe('AxisScoreBar', () => {
+  it('プログレスバーが表示される', () => {
+    render(<AxisScoreBar score={7} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toBeInTheDocument();
+  });
+
+  it('スコアに応じた幅が設定される', () => {
+    render(<AxisScoreBar score={8} />);
+    const bar = screen.getByRole('progressbar');
+    const inner = bar.firstChild as HTMLElement;
+    expect(inner.style.width).toBe('80%');
+  });
+
+  it('スコア0で幅が0%になる', () => {
+    render(<AxisScoreBar score={0} />);
+    const bar = screen.getByRole('progressbar');
+    const inner = bar.firstChild as HTMLElement;
+    expect(inner.style.width).toBe('0%');
+  });
+
+  it('カスタムバー色クラスを適用できる', () => {
+    render(<AxisScoreBar score={5} barColorClass="bg-emerald-500" />);
+    const bar = screen.getByRole('progressbar');
+    const inner = bar.firstChild as HTMLElement;
+    expect(inner.className).toContain('bg-emerald-500');
+  });
+
+  it('デフォルトでbg-primary-500が適用される', () => {
+    render(<AxisScoreBar score={5} />);
+    const bar = screen.getByRole('progressbar');
+    const inner = bar.firstChild as HTMLElement;
+    expect(inner.className).toContain('bg-primary-500');
+  });
+});


### PR DESCRIPTION
## 概要
3つのコンポーネントで重複していたプログレスバー表示をAxisScoreBarに抽出。

## 変更内容
- `AxisScoreBar.tsx`: score, barColorClassプロパティを持つ共通プログレスバーコンポーネント
- `ScoreCard.tsx`: getScoreBarColor付きでAxisScoreBarを使用
- `ScoreHistorySessionCard.tsx`: デフォルト色でAxisScoreBarを使用
- `SessionDetailModal.tsx`: デフォルト色でAxisScoreBarを使用
- テスト5件追加

closes #888