### PR TITLE
feat: インラインコードボタンをツールバーに追加 #892

### DIFF
--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -8,6 +8,7 @@ import IndentButtons from './IndentButtons';
 import BlockquoteButton from './BlockquoteButton';
 import HorizontalRuleButton from './HorizontalRuleButton';
 import CodeBlockButton from './CodeBlockButton';
+import InlineCodeButton from './InlineCodeButton';
 import ListButtons from './ListButtons';
 import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
@@ -31,6 +32,7 @@ export default function EditorToolbar({ handlers }: EditorToolbarProps) {
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <BlockquoteButton onBlockquote={handlers.handleBlockquote} />
       <HorizontalRuleButton onHorizontalRule={handlers.handleHorizontalRule} />
+      <InlineCodeButton onInlineCode={handlers.handleInlineCode} />
       <CodeBlockButton onCodeBlock={handlers.handleCodeBlock} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <ListButtons onBulletList={handlers.handleBulletList} onOrderedList={handlers.handleOrderedList} />

--- a/frontend/src/components/InlineCodeButton.tsx
+++ b/frontend/src/components/InlineCodeButton.tsx
@@ -1,0 +1,10 @@
+import { CommandLineIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
+
+interface InlineCodeButtonProps {
+  onInlineCode: () => void;
+}
+
+export default function InlineCodeButton({ onInlineCode }: InlineCodeButtonProps) {
+  return <ToolbarIconButton icon={CommandLineIcon} label="インラインコード" onClick={onInlineCode} />;
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -24,6 +24,7 @@ describe('EditorToolbar', () => {
     handleCodeBlock: vi.fn(),
     handleBulletList: vi.fn(),
     handleOrderedList: vi.fn(),
+    handleInlineCode: vi.fn(),
     ...overrides,
   });
 

--- a/frontend/src/components/__tests__/InlineCodeButton.test.tsx
+++ b/frontend/src/components/__tests__/InlineCodeButton.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InlineCodeButton from '../InlineCodeButton';
+
+describe('InlineCodeButton', () => {
+  it('インラインコードボタンが表示される', () => {
+    render(<InlineCodeButton onInlineCode={vi.fn()} />);
+    expect(screen.getByLabelText('インラインコード')).toBeInTheDocument();
+  });
+
+  it('クリックでonInlineCodeが呼ばれる', () => {
+    const onInlineCode = vi.fn();
+    render(<InlineCodeButton onInlineCode={onInlineCode} />);
+    fireEvent.click(screen.getByLabelText('インラインコード'));
+    expect(onInlineCode).toHaveBeenCalledTimes(1);
+  });
+
+  it('ボタンがbutton要素である', () => {
+    render(<InlineCodeButton onInlineCode={vi.fn()} />);
+    const button = screen.getByLabelText('インラインコード');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -21,6 +21,7 @@ export interface EditorFormatHandlers {
   handleCodeBlock: () => void;
   handleBulletList: () => void;
   handleOrderedList: () => void;
+  handleInlineCode: () => void;
 }
 
 export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
@@ -121,5 +122,9 @@ export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
     editor?.chain().focus().toggleOrderedList().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock, handleBulletList, handleOrderedList };
+  const handleInlineCode = useCallback(() => {
+    editor?.chain().focus().toggleCode().run();
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock, handleBulletList, handleOrderedList, handleInlineCode };
 }


### PR DESCRIPTION
## 概要
エディタツールバーにインラインコードのトグルボタンを追加。

## 変更内容
- `InlineCodeButton.tsx`: CommandLineIconを使用したインラインコードトグルボタン
- `useEditorFormat.ts`: handleInlineCodeハンドラー追加（toggleCode）
- `EditorToolbar.tsx`: InlineCodeButtonを統合
- テスト3件追加

closes #892