### PR TITLE
refactor: FormFieldErrorとgetFieldBorderClassを抽出 #894

### DIFF
--- a/frontend/src/components/FormFieldError.tsx
+++ b/frontend/src/components/FormFieldError.tsx
@@ -1,0 +1,13 @@
+interface FormFieldErrorProps {
+  name: string;
+  error?: string;
+}
+
+export default function FormFieldError({ name, error }: FormFieldErrorProps) {
+  if (!error) return null;
+  return (
+    <p id={`${name}-error`} role="alert" className="text-xs text-rose-400 mt-1">
+      {error}
+    </p>
+  );
+}

--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -1,5 +1,7 @@
 import { ChangeEvent, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/solid';
+import FormFieldError from './FormFieldError';
+import { getFieldBorderClass } from '../utils/fieldStyles';
 
 interface InputFieldProps {
   label: string;
@@ -46,11 +48,7 @@ export default function InputField({
           }}
           aria-invalid={!!error}
           aria-describedby={error ? `${name}-error` : undefined}
-          className={`w-full border rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:ring-1 transition-colors duration-150 ${
-            error
-              ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
-              : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500'
-          }`}
+          className={`w-full border rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:ring-1 transition-colors duration-150 ${getFieldBorderClass(!!error)}`}
         />
         {inputValue && (
           <button
@@ -62,11 +60,7 @@ export default function InputField({
           </button>
         )}
       </div>
-      {error && (
-        <p id={`${name}-error`} role="alert" className="text-xs text-rose-400 mt-1">
-          {error}
-        </p>
-      )}
+      <FormFieldError name={name} error={error} />
     </div>
   );
 }

--- a/frontend/src/components/SelectField.tsx
+++ b/frontend/src/components/SelectField.tsx
@@ -1,4 +1,6 @@
 import { ChangeEvent } from 'react';
+import FormFieldError from './FormFieldError';
+import { getFieldBorderClass } from '../utils/fieldStyles';
 
 interface SelectOption {
   value: string;
@@ -27,21 +29,13 @@ export default function SelectField({ label, name, value, onChange, options, err
         onChange={onChange}
         aria-invalid={!!error}
         aria-describedby={error ? `${name}-error` : undefined}
-        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-1 transition-colors ${
-          error
-            ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
-            : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500'
-        }`}
+        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-1 transition-colors ${getFieldBorderClass(!!error)}`}
       >
         {options.map((opt) => (
           <option key={opt.value} value={opt.value}>{opt.label}</option>
         ))}
       </select>
-      {error && (
-        <p id={`${name}-error`} role="alert" className="text-xs text-rose-400 mt-1">
-          {error}
-        </p>
-      )}
+      <FormFieldError name={name} error={error} />
     </div>
   );
 }

--- a/frontend/src/components/TextareaField.tsx
+++ b/frontend/src/components/TextareaField.tsx
@@ -1,4 +1,6 @@
 import { ChangeEvent } from 'react';
+import FormFieldError from './FormFieldError';
+import { getFieldBorderClass } from '../utils/fieldStyles';
 
 interface TextareaFieldProps {
   label: string;
@@ -27,17 +29,9 @@ export default function TextareaField({ label, name, value, onChange, placeholde
         maxLength={maxLength}
         aria-invalid={!!error}
         aria-describedby={error ? `${name}-error` : undefined}
-        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-1 transition-colors resize-none ${
-          error
-            ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
-            : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500'
-        }`}
+        className={`w-full border rounded-lg px-3 py-2 text-sm focus:ring-1 transition-colors resize-none ${getFieldBorderClass(!!error)}`}
       />
-      {error && (
-        <p id={`${name}-error`} role="alert" className="text-xs text-rose-400 mt-1">
-          {error}
-        </p>
-      )}
+      <FormFieldError name={name} error={error} />
       {maxLength && (
         <p className={`text-xs text-right mt-1 ${
           value.length >= maxLength

--- a/frontend/src/components/__tests__/FormFieldError.test.tsx
+++ b/frontend/src/components/__tests__/FormFieldError.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import FormFieldError from '../FormFieldError';
+
+describe('FormFieldError', () => {
+  it('エラーメッセージが表示される', () => {
+    render(<FormFieldError name="email" error="メールアドレスが無効です" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('メールアドレスが無効です');
+  });
+
+  it('errorがundefinedの場合は何も表示しない', () => {
+    const { container } = render(<FormFieldError name="email" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('errorが空文字の場合は何も表示しない', () => {
+    const { container } = render(<FormFieldError name="email" error="" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('正しいid属性が設定される', () => {
+    render(<FormFieldError name="password" error="必須です" />);
+    expect(screen.getByRole('alert')).toHaveAttribute('id', 'password-error');
+  });
+});

--- a/frontend/src/utils/__tests__/fieldStyles.test.ts
+++ b/frontend/src/utils/__tests__/fieldStyles.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { getFieldBorderClass } from '../fieldStyles';
+
+describe('getFieldBorderClass', () => {
+  it('エラーありの場合はrose系のクラスを返す', () => {
+    const result = getFieldBorderClass(true);
+    expect(result).toContain('border-rose-500');
+    expect(result).toContain('focus:border-rose-500');
+  });
+
+  it('エラーなしの場合はprimary系のクラスを返す', () => {
+    const result = getFieldBorderClass(false);
+    expect(result).toContain('border-surface-3');
+    expect(result).toContain('focus:border-primary-500');
+  });
+});

--- a/frontend/src/utils/fieldStyles.ts
+++ b/frontend/src/utils/fieldStyles.ts
@@ -1,0 +1,5 @@
+export function getFieldBorderClass(hasError: boolean): string {
+  return hasError
+    ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
+    : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500';
+}


### PR DESCRIPTION
## 概要
フォームフィールドコンポーネントで重複していたエラー表示とボーダースタイルを共通化。

## 変更内容
- `FormFieldError.tsx`: エラーメッセージ表示コンポーネント（role="alert"、id属性付き）
- `fieldStyles.ts`: `getFieldBorderClass(hasError)` ユーティリティ
- `InputField.tsx`: FormFieldError + getFieldBorderClass適用
- `SelectField.tsx`: 同上
- `TextareaField.tsx`: 同上
- テスト6件追加（FormFieldError 4件、fieldStyles 2件）

closes #894