### PR TITLE
feat: 見出しレベルセレクターをツールバーに追加 #898

### DIFF
--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -1,4 +1,5 @@
 import type { EditorFormatHandlers } from '../hooks/useEditorFormat';
+import HeadingSelect from './HeadingSelect';
 import FormatButtons from './FormatButtons';
 import ColorPicker from './ColorPicker';
 import HighlightPicker from './HighlightPicker';
@@ -20,6 +21,8 @@ interface EditorToolbarProps {
 export default function EditorToolbar({ handlers }: EditorToolbarProps) {
   return (
     <div className="px-8 py-1 border-b border-[var(--color-surface-3)] flex items-center gap-3">
+      <HeadingSelect onHeading={handlers.handleHeading} />
+      <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <FormatButtons onBold={handlers.handleBold} onItalic={handlers.handleItalic} onUnderline={handlers.handleUnderline} onStrike={handlers.handleStrike} onSuperscript={handlers.handleSuperscript} onSubscript={handlers.handleSubscript} />
       <div className="w-px h-4 bg-[var(--color-surface-3)]" />
       <ColorPicker onSelectColor={handlers.handleSelectColor} />

--- a/frontend/src/components/HeadingSelect.tsx
+++ b/frontend/src/components/HeadingSelect.tsx
@@ -1,0 +1,19 @@
+interface HeadingSelectProps {
+  onHeading: (level: number) => void;
+}
+
+export default function HeadingSelect({ onHeading }: HeadingSelectProps) {
+  return (
+    <select
+      aria-label="見出し"
+      className="text-xs bg-transparent text-[var(--color-text-faint)] border border-[var(--color-surface-3)] rounded px-1 py-0.5 focus:outline-none focus:border-primary-500"
+      defaultValue="0"
+      onChange={(e) => onHeading(Number(e.target.value))}
+    >
+      <option value="0">標準</option>
+      <option value="1">見出し1</option>
+      <option value="2">見出し2</option>
+      <option value="3">見出し3</option>
+    </select>
+  );
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -25,6 +25,7 @@ describe('EditorToolbar', () => {
     handleBulletList: vi.fn(),
     handleOrderedList: vi.fn(),
     handleInlineCode: vi.fn(),
+    handleHeading: vi.fn(),
     ...overrides,
   });
 

--- a/frontend/src/components/__tests__/HeadingSelect.test.tsx
+++ b/frontend/src/components/__tests__/HeadingSelect.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HeadingSelect from '../HeadingSelect';
+
+describe('HeadingSelect', () => {
+  it('見出しセレクトが表示される', () => {
+    render(<HeadingSelect onHeading={vi.fn()} />);
+    expect(screen.getByLabelText('見出し')).toBeInTheDocument();
+  });
+
+  it('セレクトにオプションが含まれる', () => {
+    render(<HeadingSelect onHeading={vi.fn()} />);
+    const select = screen.getByLabelText('見出し') as HTMLSelectElement;
+    expect(select.options.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('見出しレベル選択でonHeadingが呼ばれる', () => {
+    const onHeading = vi.fn();
+    render(<HeadingSelect onHeading={onHeading} />);
+    fireEvent.change(screen.getByLabelText('見出し'), { target: { value: '2' } });
+    expect(onHeading).toHaveBeenCalledWith(2);
+  });
+
+  it('標準テキスト選択でonHeadingが0で呼ばれる', () => {
+    const onHeading = vi.fn();
+    render(<HeadingSelect onHeading={onHeading} />);
+    fireEvent.change(screen.getByLabelText('見出し'), { target: { value: '0' } });
+    expect(onHeading).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -22,6 +22,7 @@ export interface EditorFormatHandlers {
   handleBulletList: () => void;
   handleOrderedList: () => void;
   handleInlineCode: () => void;
+  handleHeading: (level: number) => void;
 }
 
 export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
@@ -126,5 +127,14 @@ export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
     editor?.chain().focus().toggleCode().run();
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock, handleBulletList, handleOrderedList, handleInlineCode };
+  const handleHeading = useCallback((level: number) => {
+    if (!editor) return;
+    if (level === 0) {
+      editor.chain().focus().setParagraph().run();
+    } else {
+      editor.chain().focus().toggleHeading({ level: level as 1 | 2 | 3 }).run();
+    }
+  }, [editor]);
+
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock, handleBulletList, handleOrderedList, handleInlineCode, handleHeading };
 }


### PR DESCRIPTION
## 概要
エディタツールバーに見出しレベルセレクターを追加。

## 変更内容
- `HeadingSelect.tsx`: 標準/H1/H2/H3のドロップダウンセレクター
- `useEditorFormat.ts`: handleHeadingハンドラー追加（level=0でparagraph、1-3でtoggleHeading）
- `EditorToolbar.tsx`: HeadingSelectをツールバー先頭に配置
- テスト4件追加

closes #898