### PR TITLE
ProgressBarコンポーネント抽出

### DIFF
--- a/frontend/src/components/DailyGoalCard.tsx
+++ b/frontend/src/components/DailyGoalCard.tsx
@@ -1,5 +1,6 @@
 import { useDailyGoal } from '../hooks/useDailyGoal';
 import Card from './Card';
+import ProgressBar from './ProgressBar';
 
 export default function DailyGoalCard() {
   const { goal, isAchieved, progress } = useDailyGoal();
@@ -16,20 +17,10 @@ export default function DailyGoalCard() {
         </span>
       </div>
 
-      <div
-        role="progressbar"
-        aria-valuenow={progress}
-        aria-valuemin={0}
-        aria-valuemax={100}
-        className="w-full bg-surface-3 rounded-full h-2"
-      >
-        <div
-          className={`h-2 rounded-full transition-all duration-300 ${
-            isAchieved ? 'bg-emerald-500' : 'bg-primary-500'
-          }`}
-          style={{ width: `${Math.min(progress, 100)}%` }}
-        />
-      </div>
+      <ProgressBar
+        percentage={Math.min(progress, 100)}
+        barColorClass={isAchieved ? 'bg-emerald-500' : 'bg-primary-500'}
+      />
 
       {isAchieved && (
         <p className="text-xs text-emerald-400 font-medium mt-2">

--- a/frontend/src/components/PracticeLevelCard.tsx
+++ b/frontend/src/components/PracticeLevelCard.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import ProgressBar from './ProgressBar';
 
 interface PracticeLevelCardProps {
   totalSessions: number;
@@ -52,12 +53,8 @@ export default function PracticeLevelCard({ totalSessions }: PracticeLevelCardPr
         <span className="text-sm font-medium text-[var(--color-text-tertiary)]">{current.title}</span>
       </div>
 
-      <div className="w-full bg-surface-3 rounded-full h-2 mb-2">
-        <div
-          data-testid="level-progress"
-          className="h-2 rounded-full bg-primary-500 transition-all"
-          style={{ width: `${Math.min(progress, 100)}%` }}
-        />
+      <div className="mb-2">
+        <ProgressBar percentage={Math.min(progress, 100)} />
       </div>
 
       <p className="text-xs text-[var(--color-text-muted)]">

--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,0 +1,21 @@
+interface ProgressBarProps {
+  percentage: number;
+  barColorClass?: string;
+}
+
+export default function ProgressBar({ percentage, barColorClass = 'bg-primary-500' }: ProgressBarProps) {
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={percentage}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      className="w-full bg-surface-3 rounded-full h-2"
+    >
+      <div
+        className={`h-2 rounded-full transition-all ${barColorClass}`}
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ScoreGoalCard.tsx
+++ b/frontend/src/components/ScoreGoalCard.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import ProgressBar from './ProgressBar';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 interface Props {
@@ -46,10 +47,10 @@ export default function ScoreGoalCard({ averageScore }: Props) {
         </div>
       </div>
 
-      <div className="w-full bg-surface-3 rounded-full h-2 mb-2">
-        <div
-          className={`h-2 rounded-full transition-all ${achieved ? 'bg-emerald-500' : 'bg-primary-500'}`}
-          style={{ width: `${progress}%` }}
+      <div className="mb-2">
+        <ProgressBar
+          percentage={progress}
+          barColorClass={achieved ? 'bg-emerald-500' : 'bg-primary-500'}
         />
       </div>
 

--- a/frontend/src/components/WeeklyGoalProgressCard.tsx
+++ b/frontend/src/components/WeeklyGoalProgressCard.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import ProgressBar from './ProgressBar';
 
 interface WeeklyGoalProgressCardProps {
   sessionsThisWeek: number;
@@ -30,11 +31,10 @@ export default function WeeklyGoalProgressCard({
         <span className="text-sm text-[var(--color-text-muted)]">/ {weeklyGoal} 回</span>
       </div>
 
-      <div className="w-full bg-surface-3 rounded-full h-2 mb-2">
-        <div
-          data-testid="progress-bar"
-          className={`h-2 rounded-full transition-all ${isCompleted ? 'bg-emerald-500' : 'bg-primary-500'}`}
-          style={{ width: `${percentage}%` }}
+      <div className="mb-2">
+        <ProgressBar
+          percentage={percentage}
+          barColorClass={isCompleted ? 'bg-emerald-500' : 'bg-primary-500'}
         />
       </div>
 

--- a/frontend/src/components/__tests__/PracticeLevelCard.test.tsx
+++ b/frontend/src/components/__tests__/PracticeLevelCard.test.tsx
@@ -37,7 +37,8 @@ describe('PracticeLevelCard', () => {
   it('プログレスバーが表示される', () => {
     render(<PracticeLevelCard totalSessions={3} />);
 
-    const bar = document.querySelector('[data-testid="level-progress"]');
+    const progressbar = screen.getByRole('progressbar');
+    const bar = progressbar.firstElementChild;
     expect(bar).toHaveStyle({ width: '60%' });
   });
 });

--- a/frontend/src/components/__tests__/ProgressBar.test.tsx
+++ b/frontend/src/components/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProgressBar from '../ProgressBar';
+
+describe('ProgressBar', () => {
+  it('progressbarロールが表示される', () => {
+    render(<ProgressBar percentage={50} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('パーセンテージに応じた幅が設定される', () => {
+    render(<ProgressBar percentage={75} />);
+    const bar = screen.getByRole('progressbar').firstElementChild as HTMLElement;
+    expect(bar.style.width).toBe('75%');
+  });
+
+  it('デフォルトでprimary色が適用される', () => {
+    render(<ProgressBar percentage={50} />);
+    const bar = screen.getByRole('progressbar').firstElementChild as HTMLElement;
+    expect(bar.className).toContain('bg-primary-500');
+  });
+
+  it('カスタム色クラスを指定できる', () => {
+    render(<ProgressBar percentage={50} barColorClass="bg-emerald-500" />);
+    const bar = screen.getByRole('progressbar').firstElementChild as HTMLElement;
+    expect(bar.className).toContain('bg-emerald-500');
+  });
+
+  it('aria属性が正しく設定される', () => {
+    render(<ProgressBar percentage={60} />);
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '60');
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '100');
+  });
+});

--- a/frontend/src/components/__tests__/WeeklyGoalProgressCard.test.tsx
+++ b/frontend/src/components/__tests__/WeeklyGoalProgressCard.test.tsx
@@ -37,7 +37,8 @@ describe('WeeklyGoalProgressCard', () => {
   it('プログレスバーが正しい幅で表示される', () => {
     render(<WeeklyGoalProgressCard sessionsThisWeek={3} weeklyGoal={5} />);
 
-    const bar = document.querySelector('[data-testid="progress-bar"]');
+    const progressbar = screen.getByRole('progressbar');
+    const bar = progressbar.firstElementChild;
     expect(bar).toHaveStyle({ width: '60%' });
   });
 });


### PR DESCRIPTION
## 概要
- ProgressBarコンポーネントをTDDで新規作成（5テスト）
- DailyGoalCard、PracticeLevelCard、ScoreGoalCard、WeeklyGoalProgressCardの重複プログレスバーを共通化
- テストセレクターをrole="progressbar"ベースに更新

## テスト結果
- フロントエンド: 1684テスト全パス

closes #906