### PR TITLE
AiChatMessage UseCaseテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CountAiChatMessagesBySessionIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CountAiChatMessagesBySessionIdUseCaseTest.java
@@ -1,0 +1,42 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.repository.AiChatMessageRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CountAiChatMessagesBySessionIdUseCase")
+class CountAiChatMessagesBySessionIdUseCaseTest {
+
+    @Mock private AiChatMessageRepository repository;
+    @InjectMocks private CountAiChatMessagesBySessionIdUseCase useCase;
+
+    @Test
+    @DisplayName("セッションのメッセージ数を正常に取得できる")
+    void returnsCount() {
+        when(repository.countBySessionId(5)).thenReturn(10L);
+
+        Long result = useCase.execute(5);
+
+        assertThat(result).isEqualTo(10L);
+        verify(repository).countBySessionId(5);
+    }
+
+    @Test
+    @DisplayName("メッセージが0件の場合は0を返す")
+    void returnsZero() {
+        when(repository.countBySessionId(99)).thenReturn(0L);
+
+        Long result = useCase.execute(99);
+
+        assertThat(result).isEqualTo(0L);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatMessagesByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatMessagesByUserIdUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.AiChatMessageResponseDto;
+import com.example.FreStyle.entity.AiChatMessage;
+import com.example.FreStyle.mapper.AiChatMessageMapper;
+import com.example.FreStyle.repository.AiChatMessageRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAiChatMessagesByUserIdUseCase")
+class GetAiChatMessagesByUserIdUseCaseTest {
+
+    @Mock private AiChatMessageRepository repository;
+    @Mock private AiChatMessageMapper mapper;
+    @InjectMocks private GetAiChatMessagesByUserIdUseCase useCase;
+
+    @Test
+    @DisplayName("ユーザーのメッセージ一覧を正常に取得できる")
+    void returnsMessages() {
+        AiChatMessage msg1 = new AiChatMessage();
+        msg1.setId(1);
+        AiChatMessage msg2 = new AiChatMessage();
+        msg2.setId(2);
+        AiChatMessageResponseDto dto1 = new AiChatMessageResponseDto();
+        dto1.setId(1);
+        AiChatMessageResponseDto dto2 = new AiChatMessageResponseDto();
+        dto2.setId(2);
+
+        when(repository.findByUserIdOrderByCreatedAtAsc(10)).thenReturn(List.of(msg1, msg2));
+        when(mapper.toDto(msg1)).thenReturn(dto1);
+        when(mapper.toDto(msg2)).thenReturn(dto2);
+
+        List<AiChatMessageResponseDto> result = useCase.execute(10);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1);
+        assertThat(result.get(1).getId()).isEqualTo(2);
+        verify(repository).findByUserIdOrderByCreatedAtAsc(10);
+    }
+
+    @Test
+    @DisplayName("メッセージが0件の場合は空リストを返す")
+    void returnsEmptyList() {
+        when(repository.findByUserIdOrderByCreatedAtAsc(99)).thenReturn(Collections.emptyList());
+
+        List<AiChatMessageResponseDto> result = useCase.execute(99);
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 概要
- GetAiChatMessagesByUserIdUseCaseTest（2テスト）: メッセージ一覧取得・空リスト
- CountAiChatMessagesBySessionIdUseCaseTest（2テスト）: メッセージ数取得・0件

## テスト結果
- バックエンド: 282テスト（281パス、contextLoads 1件は既知の事前既存問題）

closes #908