### PR TITLE
テーブル挿入ボタンをエディタツールバーに追加

### DIFF
--- a/frontend/src/components/EditorToolbar.tsx
+++ b/frontend/src/components/EditorToolbar.tsx
@@ -12,6 +12,7 @@ import CodeBlockButton from './CodeBlockButton';
 import InlineCodeButton from './InlineCodeButton';
 import ListButtons from './ListButtons';
 import TaskListButton from './TaskListButton';
+import TableInsertButton from './TableInsertButton';
 import ClearFormattingButton from './ClearFormattingButton';
 import KeyboardShortcutsHelp from './KeyboardShortcutsHelp';
 import ToolbarDivider from './ToolbarDivider';
@@ -42,6 +43,8 @@ export default function EditorToolbar({ handlers }: EditorToolbarProps) {
       <ToolbarDivider />
       <ListButtons onBulletList={handlers.handleBulletList} onOrderedList={handlers.handleOrderedList} />
       <TaskListButton onTaskList={handlers.handleTaskList} />
+      <ToolbarDivider />
+      <TableInsertButton onInsertTable={handlers.handleInsertTable} />
       <ToolbarDivider />
       <UndoRedoButtons onUndo={handlers.handleUndo} onRedo={handlers.handleRedo} />
       <ToolbarDivider />

--- a/frontend/src/components/TableInsertButton.tsx
+++ b/frontend/src/components/TableInsertButton.tsx
@@ -1,0 +1,10 @@
+import { TableCellsIcon } from '@heroicons/react/24/outline';
+import ToolbarIconButton from './ToolbarIconButton';
+
+interface TableInsertButtonProps {
+  onInsertTable: () => void;
+}
+
+export default function TableInsertButton({ onInsertTable }: TableInsertButtonProps) {
+  return <ToolbarIconButton icon={TableCellsIcon} label="テーブル挿入" onClick={onInsertTable} />;
+}

--- a/frontend/src/components/__tests__/EditorToolbar.test.tsx
+++ b/frontend/src/components/__tests__/EditorToolbar.test.tsx
@@ -27,6 +27,7 @@ describe('EditorToolbar', () => {
     handleInlineCode: vi.fn(),
     handleHeading: vi.fn(),
     handleTaskList: vi.fn(),
+    handleInsertTable: vi.fn(),
     ...overrides,
   });
 

--- a/frontend/src/components/__tests__/TableInsertButton.test.tsx
+++ b/frontend/src/components/__tests__/TableInsertButton.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TableInsertButton from '../TableInsertButton';
+
+describe('TableInsertButton', () => {
+  it('テーブル挿入ボタンが表示される', () => {
+    render(<TableInsertButton onInsertTable={vi.fn()} />);
+    expect(screen.getByLabelText('テーブル挿入')).toBeInTheDocument();
+  });
+
+  it('クリックでonInsertTableが呼ばれる', () => {
+    const onInsertTable = vi.fn();
+    render(<TableInsertButton onInsertTable={onInsertTable} />);
+    fireEvent.click(screen.getByLabelText('テーブル挿入'));
+    expect(onInsertTable).toHaveBeenCalledTimes(1);
+  });
+
+  it('ToolbarIconButtonを使用している', () => {
+    render(<TableInsertButton onInsertTable={vi.fn()} />);
+    const button = screen.getByLabelText('テーブル挿入');
+    expect(button.tagName).toBe('BUTTON');
+  });
+});

--- a/frontend/src/hooks/useEditorFormat.ts
+++ b/frontend/src/hooks/useEditorFormat.ts
@@ -24,6 +24,7 @@ export interface EditorFormatHandlers {
   handleInlineCode: () => void;
   handleHeading: (level: number) => void;
   handleTaskList: () => void;
+  handleInsertTable: () => void;
 }
 
 export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
@@ -132,6 +133,10 @@ export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
     editor?.chain().focus().toggleTaskList().run();
   }, [editor]);
 
+  const handleInsertTable = useCallback(() => {
+    editor?.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
+  }, [editor]);
+
   const handleHeading = useCallback((level: number) => {
     if (!editor) return;
     if (level === 0) {
@@ -141,5 +146,5 @@ export function useEditorFormat(editor: Editor | null): EditorFormatHandlers {
     }
   }, [editor]);
 
-  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock, handleBulletList, handleOrderedList, handleInlineCode, handleHeading, handleTaskList };
+  return { handleBold, handleItalic, handleUnderline, handleStrike, handleAlign, handleSelectColor, handleHighlight, handleSuperscript, handleSubscript, handleUndo, handleRedo, handleClearFormatting, handleIndent, handleOutdent, handleBlockquote, handleHorizontalRule, handleCodeBlock, handleBulletList, handleOrderedList, handleInlineCode, handleHeading, handleTaskList, handleInsertTable };
 }


### PR DESCRIPTION
## 概要
- TableInsertButtonコンポーネントをTDDで実装（TableCellsIcon使用）
- useEditorFormatにhandleInsertTable（3x3テーブル、ヘッダー行付き）を追加
- EditorToolbarのリストボタン群の後にTableInsertButton追加

## テスト結果
- フロントエンド: 1687テスト全パス

closes #910