### PR TITLE
CardHeadingコンポーネント抽出

### DIFF
--- a/frontend/src/components/CardHeading.tsx
+++ b/frontend/src/components/CardHeading.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+interface CardHeadingProps {
+  children: ReactNode;
+}
+
+export default function CardHeading({ children }: CardHeadingProps) {
+  return (
+    <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">
+      {children}
+    </p>
+  );
+}

--- a/frontend/src/components/LearningInsightsCard.tsx
+++ b/frontend/src/components/LearningInsightsCard.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import CardHeading from './CardHeading';
 
 interface LearningInsightsCardProps {
   totalSessions: number;
@@ -19,7 +20,7 @@ export default function LearningInsightsCard({
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">学習インサイト</p>
+      <CardHeading>学習インサイト</CardHeading>
       <div className="grid grid-cols-3 gap-3">
         {stats.map((stat) => (
           <div key={stat.label} className="text-center">

--- a/frontend/src/components/PracticeCalendar.tsx
+++ b/frontend/src/components/PracticeCalendar.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import CardHeading from './CardHeading';
 import { toLocalDateKey, getCalendarDays, getIntensityClass } from '../utils/calendarHelpers';
 
 interface PracticeCalendarProps {
@@ -29,7 +30,7 @@ export default function PracticeCalendar({ practiceDates }: PracticeCalendarProp
 
   return (
     <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">練習カレンダー</p>
+      <CardHeading>練習カレンダー</CardHeading>
 
       <div className="flex gap-0.5">
         {/* 曜日ラベル */}

--- a/frontend/src/components/ScoreComparisonCard.tsx
+++ b/frontend/src/components/ScoreComparisonCard.tsx
@@ -1,6 +1,7 @@
 import type { AxisScore } from '../types';
 import { getDeltaColor, formatDelta } from '../utils/scoreColor';
 import Card from './Card';
+import CardHeading from './CardHeading';
 
 interface ScoreComparisonCardProps {
   firstScores: AxisScore[];
@@ -19,7 +20,7 @@ export default function ScoreComparisonCard({
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">成長の記録</p>
+      <CardHeading>成長の記録</CardHeading>
 
       <div className="flex items-center justify-between mb-4">
         <div className="text-center">

--- a/frontend/src/components/ScoreDistributionCard.tsx
+++ b/frontend/src/components/ScoreDistributionCard.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import CardHeading from './CardHeading';
 
 interface ScoreDistributionCardProps {
   scores: number[];
@@ -43,7 +44,7 @@ export default function ScoreDistributionCard({ scores }: ScoreDistributionCardP
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スコア分布</p>
+      <CardHeading>スコア分布</CardHeading>
 
       <div className="space-y-2">
         {RANGES.map((range, i) => (

--- a/frontend/src/components/ScoreImprovementAdvice.tsx
+++ b/frontend/src/components/ScoreImprovementAdvice.tsx
@@ -1,5 +1,6 @@
 import type { AxisScore } from '../types';
 import Card from './Card';
+import CardHeading from './CardHeading';
 import { IMPROVEMENT_ADVICE, SCORE_THRESHOLD } from '../constants/axisAdvice';
 
 interface ScoreImprovementAdviceProps {
@@ -11,7 +12,7 @@ export default function ScoreImprovementAdvice({ scores }: ScoreImprovementAdvic
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">改善アドバイス</p>
+      <CardHeading>改善アドバイス</CardHeading>
 
       {weakAxes.length === 0 ? (
         <p className="text-xs text-emerald-400 font-medium">

--- a/frontend/src/components/SessionTimeCard.tsx
+++ b/frontend/src/components/SessionTimeCard.tsx
@@ -1,3 +1,5 @@
+import CardHeading from './CardHeading';
+
 interface SessionTimeCardProps {
   dates: string[];
 }
@@ -50,7 +52,7 @@ export default function SessionTimeCard({ dates }: SessionTimeCardProps) {
 
   return (
     <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">練習時間帯</p>
+      <CardHeading>練習時間帯</CardHeading>
 
       <div className="space-y-2">
         {TIME_SLOTS.map((slot, i) => (

--- a/frontend/src/components/SkillGapAnalysisCard.tsx
+++ b/frontend/src/components/SkillGapAnalysisCard.tsx
@@ -1,5 +1,6 @@
 import type { AxisScore } from '../types';
 import Card from './Card';
+import CardHeading from './CardHeading';
 
 interface SkillGapAnalysisCardProps {
   scores: AxisScore[];
@@ -22,7 +23,7 @@ export default function SkillGapAnalysisCard({ scores, goal }: SkillGapAnalysisC
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキルギャップ分析</p>
+      <CardHeading>スキルギャップ分析</CardHeading>
 
       {allAchieved && (
         <p className="text-xs text-emerald-400 font-medium mb-3">

--- a/frontend/src/components/SkillRadarOverlayCard.tsx
+++ b/frontend/src/components/SkillRadarOverlayCard.tsx
@@ -1,4 +1,5 @@
 import Card from './Card';
+import CardHeading from './CardHeading';
 import type { AxisScore } from '../types';
 import {
   polarToCartesian,
@@ -22,7 +23,7 @@ export default function SkillRadarOverlayCard({ previousScores, currentScores }:
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキル変化レーダー</p>
+      <CardHeading>スキル変化レーダー</CardHeading>
 
       <div className="flex justify-center">
         <svg viewBox={`0 0 ${RADAR_SIZE} ${RADAR_SIZE}`} width={RADAR_SIZE} height={RADAR_SIZE}>

--- a/frontend/src/components/SkillSummaryCard.tsx
+++ b/frontend/src/components/SkillSummaryCard.tsx
@@ -1,5 +1,6 @@
 import type { AxisScore } from '../types';
 import Card from './Card';
+import CardHeading from './CardHeading';
 
 interface SkillSummaryCardProps {
   scores: AxisScore[];
@@ -14,7 +15,7 @@ export default function SkillSummaryCard({ scores }: SkillSummaryCardProps) {
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキル強弱サマリー</p>
+      <CardHeading>スキル強弱サマリー</CardHeading>
 
       <div className="grid grid-cols-2 gap-3">
         <div data-testid="strengths">

--- a/frontend/src/components/SkillTrendChart.tsx
+++ b/frontend/src/components/SkillTrendChart.tsx
@@ -1,3 +1,4 @@
+import CardHeading from './CardHeading';
 import type { AxisScore } from '../types';
 
 interface HistoryItem {
@@ -32,7 +33,7 @@ export default function SkillTrendChart({ history }: SkillTrendChartProps) {
 
   return (
     <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スキル別推移</p>
+      <CardHeading>スキル別推移</CardHeading>
       <div className="space-y-2">
         {skills.map((skill) => (
           <div key={skill.axis} className="flex items-center gap-2">

--- a/frontend/src/components/WeeklyComparisonCard.tsx
+++ b/frontend/src/components/WeeklyComparisonCard.tsx
@@ -1,6 +1,7 @@
 import type { ScoreHistoryItem } from '../types';
 import { getWeekRange } from '../utils/weekUtils';
 import Card from './Card';
+import CardHeading from './CardHeading';
 
 interface WeeklyComparisonCardProps {
   sessions: ScoreHistoryItem[];
@@ -30,7 +31,7 @@ export default function WeeklyComparisonCard({ sessions }: WeeklyComparisonCardP
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">週間比較</p>
+      <CardHeading>週間比較</CardHeading>
 
       <div className="grid grid-cols-2 gap-4">
         <div>

--- a/frontend/src/components/WeeklyReportCard.tsx
+++ b/frontend/src/components/WeeklyReportCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import Card from './Card';
+import CardHeading from './CardHeading';
 import type { ScoreHistory } from '../types';
 import { getWeekRange } from '../utils/weekUtils';
 
@@ -43,7 +44,7 @@ export default function WeeklyReportCard({ allScores }: WeeklyReportCardProps) {
 
   return (
     <Card>
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">今週のレポート</p>
+      <CardHeading>今週のレポート</CardHeading>
 
       <div className="grid grid-cols-2 gap-4 mb-3">
         <div>

--- a/frontend/src/components/__tests__/CardHeading.test.tsx
+++ b/frontend/src/components/__tests__/CardHeading.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CardHeading from '../CardHeading';
+
+describe('CardHeading', () => {
+  it('テキストが表示される', () => {
+    render(<CardHeading>テストタイトル</CardHeading>);
+    expect(screen.getByText('テストタイトル')).toBeInTheDocument();
+  });
+
+  it('正しいスタイルクラスが適用される', () => {
+    render(<CardHeading>タイトル</CardHeading>);
+    const heading = screen.getByText('タイトル');
+    expect(heading.className).toContain('text-xs');
+    expect(heading.className).toContain('font-medium');
+  });
+
+  it('p要素としてレンダリングされる', () => {
+    render(<CardHeading>タイトル</CardHeading>);
+    const heading = screen.getByText('タイトル');
+    expect(heading.tagName).toBe('P');
+  });
+});


### PR DESCRIPTION
## 概要
- CardHeadingコンポーネントをTDDで新規作成（3テスト）
- 12のカードコンポーネントの重複見出しパターンを共通化

## 対象ファイル
WeeklyReportCard, LearningInsightsCard, ScoreComparisonCard, ScoreImprovementAdvice, WeeklyComparisonCard, SkillSummaryCard, PracticeCalendar, ScoreDistributionCard, SkillGapAnalysisCard, SkillRadarOverlayCard, SkillTrendChart, SessionTimeCard

## テスト結果
- フロントエンド: 1690テスト全パス

closes #912