### PR TITLE
AiChatMessage/SessionMapperテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/mapper/AiChatMessageMapperTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/mapper/AiChatMessageMapperTest.java
@@ -1,0 +1,72 @@
+package com.example.FreStyle.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.FreStyle.dto.AiChatMessageResponseDto;
+import com.example.FreStyle.entity.AiChatMessage;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.User;
+
+@DisplayName("AiChatMessageMapper")
+class AiChatMessageMapperTest {
+
+    private final AiChatMessageMapper mapper = new AiChatMessageMapper();
+
+    private AiChatMessage createMessage() {
+        AiChatMessage message = new AiChatMessage();
+        message.setId(1);
+
+        AiChatSession session = new AiChatSession();
+        session.setId(10);
+        message.setSession(session);
+
+        User user = new User();
+        user.setId(5);
+        message.setUser(user);
+
+        message.setRole(AiChatMessage.Role.user);
+        message.setContent("テストメッセージ");
+        message.setCreatedAt(Timestamp.valueOf("2025-01-01 12:00:00"));
+        return message;
+    }
+
+    @Test
+    @DisplayName("エンティティからDTOに正しく変換できる")
+    void toDtoConvertsCorrectly() {
+        AiChatMessage message = createMessage();
+
+        AiChatMessageResponseDto dto = mapper.toDto(message);
+
+        assertThat(dto.getId()).isEqualTo(1);
+        assertThat(dto.getSessionId()).isEqualTo(10);
+        assertThat(dto.getUserId()).isEqualTo(5);
+        assertThat(dto.getRole()).isEqualTo("user");
+        assertThat(dto.getContent()).isEqualTo("テストメッセージ");
+        assertThat(dto.getCreatedAt()).isEqualTo(Timestamp.valueOf("2025-01-01 12:00:00"));
+    }
+
+    @Test
+    @DisplayName("assistantロールが正しく変換される")
+    void toDtoWithAssistantRole() {
+        AiChatMessage message = createMessage();
+        message.setRole(AiChatMessage.Role.assistant);
+
+        AiChatMessageResponseDto dto = mapper.toDto(message);
+
+        assertThat(dto.getRole()).isEqualTo("assistant");
+    }
+
+    @Test
+    @DisplayName("nullを渡すとIllegalArgumentExceptionを投げる")
+    void toDtoThrowsOnNull() {
+        assertThatThrownBy(() -> mapper.toDto(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("null");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/mapper/AiChatSessionMapperTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/mapper/AiChatSessionMapperTest.java
@@ -1,0 +1,84 @@
+package com.example.FreStyle.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Timestamp;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.example.FreStyle.dto.AiChatSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.entity.User;
+
+@DisplayName("AiChatSessionMapper")
+class AiChatSessionMapperTest {
+
+    private final AiChatSessionMapper mapper = new AiChatSessionMapper();
+
+    private AiChatSession createSession() {
+        AiChatSession session = new AiChatSession();
+        session.setId(1);
+
+        User user = new User();
+        user.setId(10);
+        session.setUser(user);
+
+        session.setTitle("テストセッション");
+        session.setScene("meeting");
+        session.setSessionType("normal");
+        session.setScenarioId(null);
+        session.setCreatedAt(Timestamp.valueOf("2025-01-01 12:00:00"));
+        session.setUpdatedAt(Timestamp.valueOf("2025-01-01 13:00:00"));
+        return session;
+    }
+
+    @Test
+    @DisplayName("エンティティからDTOに正しく変換できる")
+    void toDtoConvertsCorrectly() {
+        AiChatSession session = createSession();
+
+        AiChatSessionDto dto = mapper.toDto(session);
+
+        assertThat(dto.getId()).isEqualTo(1);
+        assertThat(dto.getUserId()).isEqualTo(10);
+        assertThat(dto.getTitle()).isEqualTo("テストセッション");
+        assertThat(dto.getScene()).isEqualTo("meeting");
+        assertThat(dto.getSessionType()).isEqualTo("normal");
+        assertThat(dto.getRelatedRoomId()).isNull();
+    }
+
+    @Test
+    @DisplayName("relatedRoomがある場合はIDが設定される")
+    void toDtoWithRelatedRoom() {
+        AiChatSession session = createSession();
+        ChatRoom room = new ChatRoom();
+        room.setId(99);
+        session.setRelatedRoom(room);
+
+        AiChatSessionDto dto = mapper.toDto(session);
+
+        assertThat(dto.getRelatedRoomId()).isEqualTo(99);
+    }
+
+    @Test
+    @DisplayName("relatedRoomがnullの場合はrelatedRoomIdがnull")
+    void toDtoWithoutRelatedRoom() {
+        AiChatSession session = createSession();
+        session.setRelatedRoom(null);
+
+        AiChatSessionDto dto = mapper.toDto(session);
+
+        assertThat(dto.getRelatedRoomId()).isNull();
+    }
+
+    @Test
+    @DisplayName("nullを渡すとIllegalArgumentExceptionを投げる")
+    void toDtoThrowsOnNull() {
+        assertThatThrownBy(() -> mapper.toDto(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("null");
+    }
+}


### PR DESCRIPTION
## 概要
- AiChatMessageMapperTest（3テスト）: DTO変換・assistantロール・null例外
- AiChatSessionMapperTest（4テスト）: DTO変換・relatedRoom有無・null例外

## テスト結果
- バックエンド: 289テスト（288パス、contextLoads 1件は既知の事前既存問題）

closes #914