### PR TITLE
ノートエディタにライン数表示を追加

### DIFF
--- a/frontend/src/components/LineCount.tsx
+++ b/frontend/src/components/LineCount.tsx
@@ -1,0 +1,11 @@
+interface LineCountProps {
+  lineCount: number;
+}
+
+export default function LineCount({ lineCount }: LineCountProps) {
+  return (
+    <span className="text-[10px] text-[var(--color-text-faint)]">
+      {lineCount}行
+    </span>
+  );
+}

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -5,6 +5,7 @@ import BlockEditor from './BlockEditor';
 import TableOfContents from './TableOfContents';
 import WordCount from './WordCount';
 import ReadingTime from './ReadingTime';
+import LineCount from './LineCount';
 
 interface NoteEditorProps {
   title: string;
@@ -66,6 +67,7 @@ export default function NoteEditor({
 
       <div className="flex items-center gap-3 pt-3 border-t border-surface-3" aria-label="ノート統計">
         <WordCount charCount={stats.charCount} />
+        <LineCount lineCount={stats.lineCount} />
         <ReadingTime charCount={stats.charCount} />
       </div>
     </div>

--- a/frontend/src/components/__tests__/LineCount.test.tsx
+++ b/frontend/src/components/__tests__/LineCount.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LineCount from '../LineCount';
+
+describe('LineCount', () => {
+  it('行数が表示される', () => {
+    render(<LineCount lineCount={10} />);
+    expect(screen.getByText('10行')).toBeInTheDocument();
+  });
+
+  it('0行が正しく表示される', () => {
+    render(<LineCount lineCount={0} />);
+    expect(screen.getByText('0行')).toBeInTheDocument();
+  });
+
+  it('正しいスタイルクラスが適用される', () => {
+    render(<LineCount lineCount={5} />);
+    const element = screen.getByText('5行');
+    expect(element.className).toContain('text-[10px]');
+  });
+});

--- a/frontend/src/utils/noteStats.ts
+++ b/frontend/src/utils/noteStats.ts
@@ -2,12 +2,14 @@ import { tiptapToPlainText } from './tiptapToPlainText';
 
 export interface NoteStats {
   charCount: number;
+  lineCount: number;
 }
 
 export function getNoteStats(content: string): NoteStats {
   const plainText = tiptapToPlainText(content);
   const cleaned = plainText.replace(/[\s\n]/g, '');
   const charCount = cleaned.length;
+  const lineCount = plainText === '' ? 0 : plainText.split('\n').length;
 
-  return { charCount };
+  return { charCount, lineCount };
 }


### PR DESCRIPTION
## 概要
- LineCountコンポーネントをTDDで実装（3テスト）
- noteStatsにlineCountフィールド追加
- NoteEditorの統計バーに行数表示を追加（文字数・行数・読了時間）

## テスト結果
- フロントエンド: 1693テスト全パス

closes #916