### PR TITLE
AddUserPage・MemberPageのエラー表示をFormMessageに統一

### DIFF
--- a/frontend/src/pages/AddUserPage.tsx
+++ b/frontend/src/pages/AddUserPage.tsx
@@ -1,5 +1,6 @@
 import MemberList from '../components/MemberList';
 import SearchBox from '../components/SearchBox';
+import FormMessage from '../components/FormMessage';
 import {
   MagnifyingGlassIcon,
   UserPlusIcon,
@@ -21,11 +22,7 @@ export default function AddUserPage() {
       </div>
 
       {/* エラー表示 */}
-      {error && (
-        <div className="mb-4 p-3 bg-rose-900/30 border border-rose-800 rounded-lg">
-          <p className="text-sm text-rose-400">{error}</p>
-        </div>
-      )}
+      <FormMessage message={error ? { type: 'error', text: error } : null} />
 
       {/* 検索前の状態 */}
       {users.length === 0 && !debounceQuery && (

--- a/frontend/src/pages/MemberPage.tsx
+++ b/frontend/src/pages/MemberPage.tsx
@@ -1,5 +1,6 @@
 import MemberList from '../components/MemberList';
 import SearchBox from '../components/SearchBox';
+import FormMessage from '../components/FormMessage';
 import { useUserSearch } from '../hooks/useUserSearch';
 
 export default function MemberPage() {
@@ -23,11 +24,7 @@ export default function MemberPage() {
       </div>
 
       {/* エラー表示 */}
-      {error && (
-        <div className="mb-4 p-3 bg-rose-900/30 border border-rose-800 rounded-lg">
-          <p className="text-sm text-rose-400">{error}</p>
-        </div>
-      )}
+      <FormMessage message={error ? { type: 'error', text: error } : null} />
 
       {/* メンバーリスト */}
       {users.length === 0 && !error && (


### PR DESCRIPTION
## 概要
- AddUserPageのインラインエラーdiv → FormMessageコンポーネントに置換
- MemberPageのインラインエラーdiv → FormMessageコンポーネントに置換
- role=alertやアイコン表示によるアクセシビリティ向上

## テスト結果
- フロントエンド: 1693テスト全パス

closes #918