### PR TITLE
GetAiChatSessionsByRelatedRoomIdUseCaseテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatSessionsByRelatedRoomIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatSessionsByRelatedRoomIdUseCaseTest.java
@@ -1,0 +1,71 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.AiChatSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.mapper.AiChatSessionMapper;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAiChatSessionsByRelatedRoomIdUseCase")
+class GetAiChatSessionsByRelatedRoomIdUseCaseTest {
+
+    @Mock private AiChatSessionRepository repository;
+    @Mock private AiChatSessionMapper mapper;
+    @InjectMocks private GetAiChatSessionsByRelatedRoomIdUseCase useCase;
+
+    private AiChatSession createSession(Integer id) {
+        AiChatSession session = new AiChatSession();
+        session.setId(id);
+        User user = new User();
+        user.setId(1);
+        session.setUser(user);
+        session.setTitle("セッション" + id);
+        return session;
+    }
+
+    @Test
+    @DisplayName("ルームIDでセッション一覧を正常に取得できる")
+    void returnsSessions() {
+        AiChatSession s1 = createSession(1);
+        AiChatSession s2 = createSession(2);
+        AiChatSessionDto dto1 = new AiChatSessionDto();
+        dto1.setId(1);
+        AiChatSessionDto dto2 = new AiChatSessionDto();
+        dto2.setId(2);
+
+        when(repository.findByRelatedRoomId(10)).thenReturn(List.of(s1, s2));
+        when(mapper.toDto(s1)).thenReturn(dto1);
+        when(mapper.toDto(s2)).thenReturn(dto2);
+
+        List<AiChatSessionDto> result = useCase.execute(10);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getId()).isEqualTo(1);
+        assertThat(result.get(1).getId()).isEqualTo(2);
+        verify(repository).findByRelatedRoomId(10);
+    }
+
+    @Test
+    @DisplayName("セッションが0件の場合は空リストを返す")
+    void returnsEmptyList() {
+        when(repository.findByRelatedRoomId(99)).thenReturn(Collections.emptyList());
+
+        List<AiChatSessionDto> result = useCase.execute(99);
+
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## 概要
- GetAiChatSessionsByRelatedRoomIdUseCaseTest（2テスト）: セッション一覧取得・空リスト
- 全UseCaseクラスのテストカバレッジ100%達成

## テスト結果
- バックエンド: 291テスト（290パス、contextLoads 1件は既知の事前既存問題）

closes #920