### PR TITLE
fix: Notionエディタ改善（+ボタン・コードスニペット・画像アップロード）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ COGNITO_JWK_SET_URI=https://cognito-idp.ap-northeast-1.amazonaws.com/your-user-p
 AWS_ACCESS_KEY=your-aws-access-key
 AWS_SECRET_KEY=your-aws-secret-key
 AWS_REGION=ap-northeast-1
+
+# S3 ノート画像
+NOTE_IMAGES_BUCKET=your-note-images-bucket-name
+NOTE_IMAGES_CDN_URL=https://your-cloudfront-domain.cloudfront.net

--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -93,6 +93,8 @@ jobs:
             COGNITO_JWK_SET_URI=${{ secrets.COGNITO_JWK_SET_URI }}
             DYNAMODB_AI_CHAT_TABLE=${{ secrets.DYNAMODB_AI_CHAT_TABLE }}
             DYNAMODB_CHAT_TABLE=${{ secrets.DYNAMODB_CHAT_TABLE }}
+            NOTE_IMAGES_BUCKET=${{ secrets.NOTE_IMAGES_BUCKET }}
+            NOTE_IMAGES_CDN_URL=${{ secrets.NOTE_IMAGES_CDN_URL }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -23,6 +23,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
   const containerRef = useRef<HTMLDivElement>(null);
   const [inserterVisible, setInserterVisible] = useState(false);
   const [inserterTop, setInserterTop] = useState(0);
+  const inserterMenuOpen = useRef(false);
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
@@ -39,6 +40,10 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
     if (!editorEl) return;
 
     const target = e.target as HTMLElement;
+
+    // +ボタン上にマウスがある場合は表示状態を維持
+    if (target.closest('[data-block-inserter]')) return;
+
     const block = target.closest('p, h1, h2, h3, ul, ol, li, blockquote');
     if (!block || !editorEl.contains(block)) {
       setInserterVisible(false);
@@ -52,7 +57,16 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
   }, []);
 
   const handleMouseLeave = useCallback(() => {
-    setInserterVisible(false);
+    if (!inserterMenuOpen.current) {
+      setInserterVisible(false);
+    }
+  }, []);
+
+  const handleInserterMenuOpenChange = useCallback((open: boolean) => {
+    inserterMenuOpen.current = open;
+    if (!open) {
+      setInserterVisible(false);
+    }
   }, []);
 
   const handleCommand = useCallback((command: SlashCommand) => {
@@ -94,6 +108,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         visible={inserterVisible}
         top={inserterTop}
         onCommand={handleCommand}
+        onMenuOpenChange={handleInserterMenuOpenChange}
       />
       <div className="pl-8">
         <EditorContent editor={editor} aria-label="ノートの内容" />

--- a/frontend/src/components/BlockInserterButton.tsx
+++ b/frontend/src/components/BlockInserterButton.tsx
@@ -7,10 +7,16 @@ interface BlockInserterButtonProps {
   visible: boolean;
   top: number;
   onCommand: (command: SlashCommand) => void;
+  onMenuOpenChange?: (open: boolean) => void;
 }
 
-export default function BlockInserterButton({ visible, top, onCommand }: BlockInserterButtonProps) {
-  const [menuOpen, setMenuOpen] = useState(false);
+export default function BlockInserterButton({ visible, top, onCommand, onMenuOpenChange }: BlockInserterButtonProps) {
+  const [menuOpen, setMenuOpenInternal] = useState(false);
+
+  const setMenuOpen = (open: boolean) => {
+    setMenuOpenInternal(open);
+    onMenuOpenChange?.(open);
+  };
   const [selectedIndex, setSelectedIndex] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -57,6 +63,7 @@ export default function BlockInserterButton({ visible, top, onCommand }: BlockIn
 
   return (
     <div
+      data-block-inserter
       className="absolute left-0 z-10 transition-all duration-150"
       style={{ top: `${top}px` }}
     >

--- a/frontend/src/components/CodeBlockNodeView.tsx
+++ b/frontend/src/components/CodeBlockNodeView.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { NodeViewWrapper, NodeViewContent } from '@tiptap/react';
+import { ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
+
+const LANGUAGES = [
+  { value: '', label: 'プレーンテキスト' },
+  { value: 'javascript', label: 'JavaScript' },
+  { value: 'typescript', label: 'TypeScript' },
+  { value: 'python', label: 'Python' },
+  { value: 'java', label: 'Java' },
+  { value: 'css', label: 'CSS' },
+  { value: 'html', label: 'HTML' },
+  { value: 'json', label: 'JSON' },
+  { value: 'bash', label: 'Bash' },
+  { value: 'sql', label: 'SQL' },
+  { value: 'xml', label: 'XML' },
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'yaml', label: 'YAML' },
+  { value: 'rust', label: 'Rust' },
+  { value: 'go', label: 'Go' },
+  { value: 'c', label: 'C' },
+  { value: 'cpp', label: 'C++' },
+  { value: 'csharp', label: 'C#' },
+  { value: 'php', label: 'PHP' },
+  { value: 'ruby', label: 'Ruby' },
+  { value: 'swift', label: 'Swift' },
+  { value: 'kotlin', label: 'Kotlin' },
+];
+
+interface CodeBlockNodeViewProps {
+  node: { attrs: { language: string | null }; textContent: string };
+  updateAttributes: (attrs: { language: string }) => void;
+}
+
+export default function CodeBlockNodeView({ node, updateAttributes }: CodeBlockNodeViewProps) {
+  const [copied, setCopied] = useState(false);
+  const language = node.attrs.language || '';
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(node.textContent);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <NodeViewWrapper className="code-block-wrapper">
+      <div className="code-block-header" contentEditable={false}>
+        <select
+          value={language}
+          onChange={(e) => updateAttributes({ language: e.target.value })}
+          className="code-block-language"
+          aria-label="プログラミング言語"
+        >
+          {LANGUAGES.map(lang => (
+            <option key={lang.value} value={lang.value}>{lang.label}</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="code-block-copy"
+          aria-label="コードをコピー"
+        >
+          {copied ? (
+            <><CheckIcon className="w-3.5 h-3.5" /><span>コピーしました</span></>
+          ) : (
+            <><ClipboardIcon className="w-3.5 h-3.5" /><span>コピー</span></>
+          )}
+        </button>
+      </div>
+      <pre>
+        <NodeViewContent as="code" />
+      </pre>
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/components/__tests__/BlockInserterButton.test.tsx
+++ b/frontend/src/components/__tests__/BlockInserterButton.test.tsx
@@ -5,6 +5,7 @@ import { SLASH_COMMANDS } from '../../constants/slashCommands';
 
 describe('BlockInserterButton', () => {
   const mockOnCommand = vi.fn();
+  const mockOnMenuOpenChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,5 +60,19 @@ describe('BlockInserterButton', () => {
     expect(screen.getByRole('menu')).toBeInTheDocument();
     fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('メニュー開閉時にonMenuOpenChangeが呼ばれる', () => {
+    render(<BlockInserterButton visible={true} top={100} onCommand={mockOnCommand} onMenuOpenChange={mockOnMenuOpenChange} />);
+    fireEvent.click(screen.getByLabelText('ブロックを追加'));
+    expect(mockOnMenuOpenChange).toHaveBeenCalledWith(true);
+    fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+    expect(mockOnMenuOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('data-block-inserter属性がルート要素に設定される', () => {
+    render(<BlockInserterButton visible={true} top={100} onCommand={mockOnCommand} />);
+    const button = screen.getByLabelText('ブロックを追加');
+    expect(button.closest('[data-block-inserter]')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/CodeBlockNodeView.test.tsx
+++ b/frontend/src/components/__tests__/CodeBlockNodeView.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import CodeBlockNodeView from '../CodeBlockNodeView';
+
+vi.mock('@tiptap/react', () => ({
+  NodeViewWrapper: ({ children, className }: { children: React.ReactNode; className: string }) => (
+    <div data-testid="node-view-wrapper" className={className}>{children}</div>
+  ),
+  NodeViewContent: ({ as }: { as: string }) => {
+    const Tag = as as keyof JSX.IntrinsicElements;
+    return <Tag data-testid="node-view-content">console.log("test")</Tag>;
+  },
+}));
+
+describe('CodeBlockNodeView', () => {
+  const mockUpdateAttributes = vi.fn();
+  const defaultProps = {
+    node: { attrs: { language: 'javascript' }, textContent: 'console.log("hello")' },
+    updateAttributes: mockUpdateAttributes,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it('コードブロックが表示される', () => {
+    render(<CodeBlockNodeView {...defaultProps} />);
+    expect(screen.getByTestId('node-view-wrapper')).toHaveClass('code-block-wrapper');
+    expect(screen.getByTestId('node-view-content')).toBeInTheDocument();
+  });
+
+  it('言語セレクターが選択された言語を表示する', () => {
+    render(<CodeBlockNodeView {...defaultProps} />);
+    const select = screen.getByLabelText('プログラミング言語') as HTMLSelectElement;
+    expect(select.value).toBe('javascript');
+  });
+
+  it('言語を変更するとupdateAttributesが呼ばれる', () => {
+    render(<CodeBlockNodeView {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('プログラミング言語'), { target: { value: 'python' } });
+    expect(mockUpdateAttributes).toHaveBeenCalledWith({ language: 'python' });
+  });
+
+  it('コピーボタンをクリックするとクリップボードにコピーされる', async () => {
+    render(<CodeBlockNodeView {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText('コードをコピー'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('console.log("hello")');
+    await waitFor(() => {
+      expect(screen.getByText('コピーしました')).toBeInTheDocument();
+    });
+  });
+
+  it('言語がnullの場合はプレーンテキストが選択される', () => {
+    const props = {
+      ...defaultProps,
+      node: { ...defaultProps.node, attrs: { language: null } },
+    };
+    render(<CodeBlockNodeView {...props} />);
+    const select = screen.getByLabelText('プログラミング言語') as HTMLSelectElement;
+    expect(select.value).toBe('');
+  });
+
+  it('コピーボタンにテキストが表示される', () => {
+    render(<CodeBlockNodeView {...defaultProps} />);
+    expect(screen.getByText('コピー')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/extensions/CodeBlockExtension.ts
+++ b/frontend/src/extensions/CodeBlockExtension.ts
@@ -1,0 +1,9 @@
+import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
+import { ReactNodeViewRenderer } from '@tiptap/react';
+import CodeBlockNodeView from '../components/CodeBlockNodeView';
+
+export const CodeBlock = CodeBlockLowlight.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(CodeBlockNodeView);
+  },
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,36 +127,84 @@
   margin: 1rem 0;
 }
 
-/* Code block */
-.ProseMirror pre {
+/* Code block (Notion-style) */
+.code-block-wrapper {
   background: var(--color-surface-2);
   border: 1px solid var(--color-surface-3);
   border-radius: 0.5rem;
-  padding: 0.75rem 1rem;
   margin: 0.5rem 0;
+  overflow: hidden;
+}
+.code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.375rem 0.75rem;
+  border-bottom: 1px solid var(--color-surface-3);
+  background: var(--color-surface-1);
+}
+.code-block-language {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.code-block-language:hover {
+  border-color: var(--color-surface-3);
+  color: var(--color-text-secondary);
+}
+.code-block-language:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+.code-block-copy {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: 0.25rem;
+  background: transparent;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.code-block-copy:hover {
+  background: var(--color-surface-3);
+  color: var(--color-text-secondary);
+}
+.code-block-wrapper pre {
+  margin: 0;
+  padding: 0.75rem 1rem;
   overflow-x: auto;
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
   font-size: 0.8125rem;
   line-height: 1.5;
 }
-.ProseMirror pre code {
+.code-block-wrapper pre code {
   color: var(--color-text-primary);
   background: none;
   padding: 0;
 }
 /* Lowlight syntax colors */
-.ProseMirror pre .hljs-keyword { color: #c678dd; }
-.ProseMirror pre .hljs-string { color: #98c379; }
-.ProseMirror pre .hljs-number { color: #d19a66; }
-.ProseMirror pre .hljs-comment { color: var(--color-text-muted); font-style: italic; }
-.ProseMirror pre .hljs-function { color: #61afef; }
-.ProseMirror pre .hljs-title { color: #61afef; }
-.ProseMirror pre .hljs-params { color: var(--color-text-secondary); }
-.ProseMirror pre .hljs-built_in { color: #e5c07b; }
-.ProseMirror pre .hljs-attr { color: #d19a66; }
-.ProseMirror pre .hljs-tag { color: #e06c75; }
-.ProseMirror pre .hljs-name { color: #e06c75; }
-.ProseMirror pre .hljs-selector-class { color: #d19a66; }
+.code-block-wrapper pre .hljs-keyword { color: #c678dd; }
+.code-block-wrapper pre .hljs-string { color: #98c379; }
+.code-block-wrapper pre .hljs-number { color: #d19a66; }
+.code-block-wrapper pre .hljs-comment { color: var(--color-text-muted); font-style: italic; }
+.code-block-wrapper pre .hljs-function { color: #61afef; }
+.code-block-wrapper pre .hljs-title { color: #61afef; }
+.code-block-wrapper pre .hljs-params { color: var(--color-text-secondary); }
+.code-block-wrapper pre .hljs-built_in { color: #e5c07b; }
+.code-block-wrapper pre .hljs-attr { color: #d19a66; }
+.code-block-wrapper pre .hljs-tag { color: #e06c75; }
+.code-block-wrapper pre .hljs-name { color: #e06c75; }
+.code-block-wrapper pre .hljs-selector-class { color: #d19a66; }
 
 /* Inline code */
 .ProseMirror code {

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -27,6 +27,9 @@ vi.mock('../../extensions/ToggleListExtension', () => ({
 vi.mock('../../extensions/CalloutExtension', () => ({
   Callout: 'Callout',
 }));
+vi.mock('../../extensions/CodeBlockExtension', () => ({
+  CodeBlock: { configure: vi.fn(() => 'CodeBlock') },
+}));
 vi.mock('@tiptap/extension-link', () => ({ default: { configure: vi.fn(() => 'Link') } }));
 vi.mock('@tiptap/extension-text-style', () => ({ default: 'TextStyle' }));
 vi.mock('@tiptap/extension-color', () => ({ default: 'Color' }));

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -3,7 +3,6 @@ import Placeholder from '@tiptap/extension-placeholder';
 import Image from '@tiptap/extension-image';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
-import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import Highlight from '@tiptap/extension-highlight';
 import Table from '@tiptap/extension-table';
 import TableRow from '@tiptap/extension-table-row';
@@ -14,6 +13,7 @@ import { SlashCommandExtension } from '../extensions/SlashCommandExtension';
 import { slashCommandRenderer } from '../extensions/slashCommandRenderer';
 import { ToggleList, ToggleSummary, ToggleContent } from '../extensions/ToggleListExtension';
 import { Callout } from '../extensions/CalloutExtension';
+import { CodeBlock } from '../extensions/CodeBlockExtension';
 import Link from '@tiptap/extension-link';
 import TextStyle from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
@@ -29,7 +29,7 @@ export function createEditorExtensions() {
       heading: { levels: [1, 2, 3] },
       codeBlock: false,
     }),
-    CodeBlockLowlight.configure({
+    CodeBlock.configure({
       lowlight: createLowlight(common),
     }),
     Placeholder.configure({


### PR DESCRIPTION
## 概要
Notionエディタの3つの問題を修正 #922

## 修正内容

### 1. +ボタンのホバー消失バグ修正
- `data-block-inserter`属性でボタン上のマウス検知を追加
- メニュー開閉状態を親コンポーネントに通知する`onMenuOpenChange`コールバック追加
- メニュー表示中は`handleMouseLeave`で非表示にしないように修正

### 2. コードブロック → Notion風コードスニペット
- `CodeBlockNodeView` React NodeView（言語セレクター22言語 + コピーボタン）
- `CodeBlockExtension`でCodeBlockLowlightをReact NodeView付きで拡張
- Notion風のヘッダー・スタイリング適用

### 3. 画像アップロード500エラー修正
- ECSデプロイ設定に`NOTE_IMAGES_BUCKET`/`NOTE_IMAGES_CDN_URL`環境変数追加
- `NoteImageController`にtry-catch追加（IllegalArgumentException→400、その他→500+ログ）
- `.env.example`にS3設定テンプレート追加
- S3バケット・CloudFront・GitHub Secrets設定済み

## テスト
- フロントエンド: 1701テスト全通過
- バックエンド: NoteImageControllerTest 4テスト全通過（新規2テスト追加）