### PR TITLE
fix: +ボタンのホバー遅延修正・スラッシュコマンド画像選択修正

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { EditorContent } from '@tiptap/react';
 import 'tippy.js/dist/tippy.css';
 import { executeCommand } from '../extensions/SlashCommandExtension';
@@ -29,7 +29,32 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
   const formatHandlers = useEditorFormat(editor);
 
+  // スラッシュコマンドから画像アップロードを呼べるようにする
+  useEffect(() => {
+    if (!editor) return;
+    editor.storage.slashCommand.onImageUpload = openFileDialog;
+    return () => { editor.storage.slashCommand.onImageUpload = null; };
+  }, [editor, openFileDialog]);
+
   const lastMoveTime = useRef(0);
+  const hideTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHideTimeout = useCallback(() => {
+    if (hideTimeout.current) {
+      clearTimeout(hideTimeout.current);
+      hideTimeout.current = null;
+    }
+  }, []);
+
+  const scheduleHide = useCallback(() => {
+    clearHideTimeout();
+    hideTimeout.current = setTimeout(() => {
+      if (!inserterMenuOpen.current) {
+        setInserterVisible(false);
+      }
+    }, 200);
+  }, [clearHideTimeout]);
+
   const handleMouseMove = useCallback((e: React.MouseEvent) => {
     const now = Date.now();
     if (now - lastMoveTime.current < 50) return;
@@ -42,25 +67,29 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
     const target = e.target as HTMLElement;
 
     // +ボタン上にマウスがある場合は表示状態を維持
-    if (target.closest('[data-block-inserter]')) return;
-
-    const block = target.closest('p, h1, h2, h3, ul, ol, li, blockquote');
-    if (!block || !editorEl.contains(block)) {
-      setInserterVisible(false);
+    if (target.closest('[data-block-inserter]')) {
+      clearHideTimeout();
       return;
     }
 
+    const block = target.closest('p, h1, h2, h3, ul, ol, li, blockquote');
+    if (!block || !editorEl.contains(block)) {
+      scheduleHide();
+      return;
+    }
+
+    clearHideTimeout();
     const containerRect = containerRef.current.getBoundingClientRect();
     const blockRect = block.getBoundingClientRect();
     setInserterTop(blockRect.top - containerRect.top);
     setInserterVisible(true);
-  }, []);
+  }, [clearHideTimeout, scheduleHide]);
 
   const handleMouseLeave = useCallback(() => {
     if (!inserterMenuOpen.current) {
-      setInserterVisible(false);
+      scheduleHide();
     }
-  }, []);
+  }, [scheduleHide]);
 
   const handleInserterMenuOpenChange = useCallback((open: boolean) => {
     inserterMenuOpen.current = open;

--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -33,9 +33,13 @@ function executeCommand(editor: Editor, command: SlashCommand) {
       }
       break;
     }
-    case 'image':
-      // image action is handled externally via onImageUpload callback
+    case 'image': {
+      const onImageUpload = editor.storage.slashCommand?.onImageUpload;
+      if (typeof onImageUpload === 'function') {
+        onImageUpload();
+      }
       break;
+    }
     case 'taskList':
       chain.toggleTaskList().run();
       break;
@@ -87,6 +91,12 @@ export type SlashCommandSuggestionOptions = Omit<SuggestionOptions<SlashCommand>
 
 export const SlashCommandExtension = Extension.create({
   name: 'slashCommand',
+
+  addStorage() {
+    return {
+      onImageUpload: null as (() => void) | null,
+    };
+  },
 
   addOptions() {
     return {

--- a/frontend/src/extensions/__tests__/SlashCommandExtension.test.ts
+++ b/frontend/src/extensions/__tests__/SlashCommandExtension.test.ts
@@ -63,8 +63,15 @@ describe('SlashCommandExtension', () => {
     expect(setToggleList).toHaveBeenCalled();
   });
 
-  it('imageコマンドはエラーなく実行される（外部で処理）', () => {
-    const editor = createMockEditor();
+  it('imageコマンドでstorage.onImageUploadが呼ばれる', () => {
+    const onImageUpload = vi.fn();
+    const editor = { ...createMockEditor(), storage: { slashCommand: { onImageUpload } } };
+    executeCommand(editor as never, findCommand('image'));
+    expect(onImageUpload).toHaveBeenCalled();
+  });
+
+  it('imageコマンドでonImageUploadが未設定でもエラーにならない', () => {
+    const editor = { ...createMockEditor(), storage: { slashCommand: { onImageUpload: null } } };
     expect(() => executeCommand(editor as never, findCommand('image'))).not.toThrow();
   });
 


### PR DESCRIPTION
## 概要
Notionエディタの2つの問題を修正 #924

## 修正内容

### 1. +ボタンのホバー消失バグ（再修正）
前回の修正（data-block-inserter属性チェック）では、コンテンツ（pl-8）とボタン（left-0）の間のギャップを通過する際にまだ消える問題があった。

**修正**: `setInserterVisible(false)`を即時実行ではなく200msの`setTimeout`で遅延実行に変更。ボタンやブロック要素にマウスが到達した時点でタイマーをクリアし、Notionと同様のスムーズなホバー体験を実現。

### 2. スラッシュコマンド（/）での画像選択
`/`入力→十字キーで「画像」を選択→Enterでファイルダイアログが開かない問題。

**原因**: `executeCommand`の`image`ケースが`break`のみで何も実行していなかった。

**修正**: `editor.storage.slashCommand.onImageUpload`を通じて`openFileDialog`を呼び出すように変更。`BlockEditor`で`useEffect`によりstorageにコールバックを登録。

## テスト
- フロントエンド: 1702テスト全通過（+1テスト追加）