### PR TITLE
feat: Cmd+K/Ctrl+Kコマンドパレット実装

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { useCommandPalette } from '../hooks/useCommandPalette';
+import { useTheme } from '../hooks/useTheme';
+import type { CommandItem } from '../constants/commandPaletteItems';
+
+interface CommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreateNote?: () => void;
+}
+
+export default function CommandPalette({ isOpen, onClose, onCreateNote }: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const { toggleTheme } = useTheme();
+  const { query, selectedIndex, filteredItems, setQuery, selectNext, selectPrev, close } = useCommandPalette();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [isOpen, setQuery]);
+
+  const executeCommand = useCallback((item: CommandItem) => {
+    if (item.action.type === 'navigate') {
+      navigate(item.action.path);
+    } else if (item.action.type === 'action') {
+      switch (item.action.id) {
+        case 'toggle-theme':
+          toggleTheme();
+          break;
+        case 'new-note':
+          if (onCreateNote) {
+            onCreateNote();
+          } else {
+            navigate('/notes');
+          }
+          break;
+      }
+    }
+    close();
+    onClose();
+  }, [navigate, toggleTheme, onCreateNote, close, onClose]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      onClose();
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      selectNext();
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      selectPrev();
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (filteredItems[selectedIndex]) {
+        executeCommand(filteredItems[selectedIndex]);
+      }
+    }
+  }, [close, onClose, selectNext, selectPrev, filteredItems, selectedIndex, executeCommand]);
+
+  useEffect(() => {
+    if (!listRef.current) return;
+    const selected = listRef.current.querySelector('[aria-selected="true"]');
+    if (selected && typeof selected.scrollIntoView === 'function') {
+      selected.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedIndex]);
+
+  if (!isOpen) return null;
+
+  // カテゴリ別にグループ化
+  const categories = new Map<string, { items: CommandItem[]; startIndex: number }>();
+  let idx = 0;
+  for (const item of filteredItems) {
+    if (!categories.has(item.category)) {
+      categories.set(item.category, { items: [], startIndex: idx });
+    }
+    categories.get(item.category)!.items.push(item);
+    idx++;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-[20vh]">
+      <div
+        data-testid="command-palette-overlay"
+        className="absolute inset-0 bg-black/50"
+        onClick={() => { close(); onClose(); }}
+      />
+      <div className="relative w-full max-w-lg bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-xl shadow-2xl overflow-hidden">
+        {/* 検索入力 */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
+          <MagnifyingGlassIcon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="コマンドを検索..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex-1 bg-transparent text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none text-sm"
+          />
+          <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono text-[var(--color-text-muted)] bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded">
+            ESC
+          </kbd>
+        </div>
+
+        {/* コマンドリスト */}
+        <div ref={listRef} role="listbox" className="max-h-80 overflow-y-auto p-2">
+          {filteredItems.length === 0 ? (
+            <div className="px-3 py-8 text-center text-sm text-[var(--color-text-muted)]">
+              該当するコマンドがありません
+            </div>
+          ) : (
+            Array.from(categories.entries()).map(([category, { items, startIndex }]) => (
+              <div key={category}>
+                <div className="px-3 py-1.5 text-[11px] font-medium text-[var(--color-text-muted)] uppercase tracking-wider">
+                  {category}
+                </div>
+                {items.map((item, i) => {
+                  const globalIndex = startIndex + i;
+                  const isSelected = globalIndex === selectedIndex;
+                  const Icon = item.icon;
+                  return (
+                    <div
+                      key={item.id}
+                      role="option"
+                      aria-selected={isSelected}
+                      className={`flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer transition-colors ${
+                        isSelected
+                          ? 'bg-[var(--color-surface-3)] text-[var(--color-text-primary)]'
+                          : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-2)]'
+                      }`}
+                      onClick={() => executeCommand(item)}
+                      onMouseEnter={() => {
+                        // マウスホバーで選択を変更するならここで
+                      }}
+                    >
+                      <Icon className="w-4 h-4 flex-shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-sm font-medium truncate">{item.label}</div>
+                        {item.description && (
+                          <div className="text-xs text-[var(--color-text-muted)] truncate">
+                            {item.description}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* フッター */}
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-[var(--color-border)] text-[10px] text-[var(--color-text-muted)]">
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded font-mono">↑↓</kbd>
+            移動
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded font-mono">↵</kbd>
+            実行
+          </span>
+          <span className="flex items-center gap-1">
+            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded font-mono">esc</kbd>
+            閉じる
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+import CommandPalette from '../CommandPalette';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockToggleTheme = vi.fn();
+vi.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark', toggleTheme: mockToggleTheme }),
+}));
+
+describe('CommandPalette', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderPalette(props = {}) {
+    return render(
+      <BrowserRouter>
+        <CommandPalette {...defaultProps} {...props} />
+      </BrowserRouter>
+    );
+  }
+
+  it('isOpen=falseのとき何も表示しない', () => {
+    renderPalette({ isOpen: false });
+    expect(screen.queryByPlaceholderText('コマンドを検索...')).not.toBeInTheDocument();
+  });
+
+  it('isOpen=trueのとき検索入力が表示される', () => {
+    renderPalette();
+    expect(screen.getByPlaceholderText('コマンドを検索...')).toBeInTheDocument();
+  });
+
+  it('全コマンドがデフォルトで表示される', () => {
+    renderPalette();
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('チャット')).toBeInTheDocument();
+    expect(screen.getByText('テーマ切替')).toBeInTheDocument();
+    expect(screen.getByText('新規ノート作成')).toBeInTheDocument();
+  });
+
+  it('カテゴリヘッダーが表示される', () => {
+    renderPalette();
+    expect(screen.getByText('ページ移動')).toBeInTheDocument();
+    expect(screen.getByText('アクション')).toBeInTheDocument();
+  });
+
+  it('検索入力で絞り込みができる', () => {
+    renderPalette();
+    fireEvent.change(screen.getByPlaceholderText('コマンドを検索...'), {
+      target: { value: 'ノート' },
+    });
+    expect(screen.getByText('ノート')).toBeInTheDocument();
+    expect(screen.getByText('新規ノート作成')).toBeInTheDocument();
+    expect(screen.queryByText('ホーム')).not.toBeInTheDocument();
+  });
+
+  it('ナビゲーションコマンドをクリックするとページ移動する', () => {
+    renderPalette();
+    fireEvent.click(screen.getByText('ノート'));
+    expect(mockNavigate).toHaveBeenCalledWith('/notes');
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('テーマ切替コマンドをクリックするとテーマが切り替わる', () => {
+    renderPalette();
+    fireEvent.click(screen.getByText('テーマ切替'));
+    expect(mockToggleTheme).toHaveBeenCalled();
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('背景オーバーレイをクリックするとパレットが閉じる', () => {
+    renderPalette();
+    fireEvent.click(screen.getByTestId('command-palette-overlay'));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('Escapeキーでパレットが閉じる', () => {
+    renderPalette();
+    fireEvent.keyDown(screen.getByPlaceholderText('コマンドを検索...'), {
+      key: 'Escape',
+    });
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('ArrowDownで選択が移動する', () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText('コマンドを検索...');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    // 2番目のアイテムが選択状態になっているか確認
+    const items = screen.getAllByRole('option');
+    expect(items[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowUpで選択が戻る', () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText('コマンドを検索...');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    const items = screen.getAllByRole('option');
+    expect(items[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('Enterで選択中のコマンドが実行される', () => {
+    renderPalette();
+    const input = screen.getByPlaceholderText('コマンドを検索...');
+    // 最初のアイテム（ホーム）が選択されている状態でEnter
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('検索結果が空のとき「該当するコマンドがありません」と表示', () => {
+    renderPalette();
+    fireEvent.change(screen.getByPlaceholderText('コマンドを検索...'), {
+      target: { value: 'xxxxxxxxx' },
+    });
+    expect(screen.getByText('該当するコマンドがありません')).toBeInTheDocument();
+  });
+
+  it('新規ノート作成コマンドをクリックするとノートページに移動する', () => {
+    renderPalette();
+    fireEvent.click(screen.getByText('新規ノート作成'));
+    expect(mockNavigate).toHaveBeenCalledWith('/notes');
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import SkipLink from '../SkipLink';
 import ScrollToTop from '../ScrollToTop';
+import CommandPalette from '../CommandPalette';
 
 const pageTitles: Record<string, string> = {
   '/': 'ホーム',
@@ -29,8 +30,21 @@ function getPageTitle(pathname: string): string {
 
 export default function AppShell() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const location = useLocation();
   const title = getPageTitle(location.pathname);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault();
+      setCommandPaletteOpen(prev => !prev);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
 
   return (
     <div className="h-screen flex bg-surface">
@@ -68,6 +82,10 @@ export default function AppShell() {
         </main>
         <ScrollToTop targetId="main-content" />
       </div>
+      <CommandPalette
+        isOpen={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -45,5 +45,18 @@ describe('AppShell', () => {
     // TopBarにはモバイルメニューボタンがある
     const menuButton = screen.getByRole('button', { name: /メニュー/i });
     expect(menuButton).toBeDefined();
+  });
+
+  it('Cmd+Kでコマンドパレットが開く', () => {
+    renderAppShell();
+    expect(screen.queryByPlaceholderText('コマンドを検索...')).not.toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    expect(screen.getByPlaceholderText('コマンドを検索...')).toBeInTheDocument();
+  });
+
+  it('Ctrl+Kでコマンドパレットが開く', () => {
+    renderAppShell();
+    fireEvent.keyDown(document, { key: 'k', ctrlKey: true });
+    expect(screen.getByPlaceholderText('コマンドを検索...')).toBeInTheDocument();
   });
 });

--- a/frontend/src/constants/commandPaletteItems.ts
+++ b/frontend/src/constants/commandPaletteItems.ts
@@ -1,0 +1,142 @@
+import {
+  HomeIcon,
+  ChatBubbleLeftRightIcon,
+  SparklesIcon,
+  AcademicCapIcon,
+  MagnifyingGlassIcon,
+  ChartBarIcon,
+  StarIcon,
+  DocumentTextIcon,
+  UserCircleIcon,
+  LightBulbIcon,
+  SunIcon,
+  DocumentPlusIcon,
+} from '@heroicons/react/24/outline';
+import type { ComponentType, SVGProps } from 'react';
+
+export type CommandAction =
+  | { type: 'navigate'; path: string }
+  | { type: 'action'; id: string };
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  description?: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  category: 'ページ移動' | 'アクション';
+  action: CommandAction;
+  keywords?: string[];
+}
+
+export const COMMAND_ITEMS: CommandItem[] = [
+  // ページ移動
+  {
+    id: 'nav-home',
+    label: 'ホーム',
+    description: 'ホーム画面に移動',
+    icon: HomeIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/' },
+    keywords: ['home', 'メニュー', 'トップ'],
+  },
+  {
+    id: 'nav-chat',
+    label: 'チャット',
+    description: 'チャット一覧に移動',
+    icon: ChatBubbleLeftRightIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/chat' },
+    keywords: ['chat', 'メッセージ', '会話'],
+  },
+  {
+    id: 'nav-ai',
+    label: 'AI アシスタント',
+    description: 'AIアシスタントに移動',
+    icon: SparklesIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/chat/ask-ai' },
+    keywords: ['ai', '人工知能', 'アシスタント'],
+  },
+  {
+    id: 'nav-practice',
+    label: '練習モード',
+    description: '練習モードに移動',
+    icon: AcademicCapIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/practice' },
+    keywords: ['practice', '練習', 'トレーニング'],
+  },
+  {
+    id: 'nav-user-search',
+    label: 'ユーザー検索',
+    description: 'ユーザー検索に移動',
+    icon: MagnifyingGlassIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/chat/users' },
+    keywords: ['search', 'user', '検索', 'ユーザー'],
+  },
+  {
+    id: 'nav-scores',
+    label: 'スコア履歴',
+    description: 'スコア履歴に移動',
+    icon: ChartBarIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/scores' },
+    keywords: ['score', 'history', '履歴', '成績'],
+  },
+  {
+    id: 'nav-favorites',
+    label: 'お気に入り',
+    description: 'お気に入りフレーズに移動',
+    icon: StarIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/favorites' },
+    keywords: ['favorite', 'star', 'お気に入り', 'フレーズ'],
+  },
+  {
+    id: 'nav-notes',
+    label: 'ノート',
+    description: 'ノートに移動',
+    icon: DocumentTextIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/notes' },
+    keywords: ['note', 'メモ', 'ノート'],
+  },
+  {
+    id: 'nav-profile',
+    label: 'プロフィール',
+    description: 'プロフィールに移動',
+    icon: UserCircleIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/profile/me' },
+    keywords: ['profile', 'プロフィール', '設定'],
+  },
+  {
+    id: 'nav-personality',
+    label: 'パーソナリティ設定',
+    description: 'パーソナリティ設定に移動',
+    icon: LightBulbIcon,
+    category: 'ページ移動',
+    action: { type: 'navigate', path: '/profile/personality' },
+    keywords: ['personality', 'パーソナリティ', '性格'],
+  },
+  // アクション
+  {
+    id: 'action-toggle-theme',
+    label: 'テーマ切替',
+    description: 'ダークモード / ライトモードを切り替え',
+    icon: SunIcon,
+    category: 'アクション',
+    action: { type: 'action', id: 'toggle-theme' },
+    keywords: ['theme', 'dark', 'light', 'テーマ', 'ダーク', 'ライト'],
+  },
+  {
+    id: 'action-new-note',
+    label: '新規ノート作成',
+    description: '新しいノートを作成',
+    icon: DocumentPlusIcon,
+    category: 'アクション',
+    action: { type: 'action', id: 'new-note' },
+    keywords: ['new', 'note', 'create', '新規', '作成', 'ノート'],
+  },
+];

--- a/frontend/src/hooks/__tests__/useCommandPalette.test.ts
+++ b/frontend/src/hooks/__tests__/useCommandPalette.test.ts
@@ -1,0 +1,146 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useCommandPalette } from '../useCommandPalette';
+import { COMMAND_ITEMS } from '../../constants/commandPaletteItems';
+
+describe('useCommandPalette', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態ではパレットが閉じている', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe('');
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('openでパレットが開く', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('closeでパレットが閉じてクエリがリセットされる', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.setQuery('テスト');
+    });
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe('');
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('クエリが空のとき全コマンドを返す', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.filteredItems).toEqual(COMMAND_ITEMS);
+  });
+
+  it('クエリでラベルをフィルタリングできる', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.setQuery('ノート');
+    });
+    const labels = result.current.filteredItems.map(i => i.label);
+    expect(labels).toContain('ノート');
+    expect(labels).toContain('新規ノート作成');
+    expect(labels).not.toContain('ホーム');
+  });
+
+  it('キーワードでもフィルタリングできる', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.setQuery('dark');
+    });
+    const labels = result.current.filteredItems.map(i => i.label);
+    expect(labels).toContain('テーマ切替');
+  });
+
+  it('descriptionでもフィルタリングできる', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.setQuery('ダークモード');
+    });
+    const labels = result.current.filteredItems.map(i => i.label);
+    expect(labels).toContain('テーマ切替');
+  });
+
+  it('フィルタリングは大文字小文字を区別しない', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.setQuery('AI');
+    });
+    const labels = result.current.filteredItems.map(i => i.label);
+    expect(labels).toContain('AI アシスタント');
+  });
+
+  it('クエリ変更時にselectedIndexが0にリセットされる', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.selectNext();
+      result.current.selectNext();
+    });
+    expect(result.current.selectedIndex).toBe(2);
+    act(() => {
+      result.current.setQuery('ノート');
+    });
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('selectNextでインデックスが進む', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.selectNext();
+    });
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it('selectNextは最後のアイテムでループする', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+    });
+    const count = result.current.filteredItems.length;
+    for (let i = 0; i < count; i++) {
+      act(() => {
+        result.current.selectNext();
+      });
+    }
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('selectPrevでインデックスが戻る', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.selectNext();
+      result.current.selectNext();
+      result.current.selectPrev();
+    });
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it('selectPrevは最初のアイテムで最後にループする', () => {
+    const { result } = renderHook(() => useCommandPalette());
+    act(() => {
+      result.current.open();
+      result.current.selectPrev();
+    });
+    expect(result.current.selectedIndex).toBe(result.current.filteredItems.length - 1);
+  });
+});

--- a/frontend/src/hooks/useCommandPalette.ts
+++ b/frontend/src/hooks/useCommandPalette.ts
@@ -1,0 +1,62 @@
+import { useState, useMemo, useCallback } from 'react';
+import { COMMAND_ITEMS, type CommandItem } from '../constants/commandPaletteItems';
+
+function filterItems(items: CommandItem[], query: string): CommandItem[] {
+  if (!query.trim()) return items;
+  const lower = query.toLowerCase();
+  return items.filter(item => {
+    if (item.label.toLowerCase().includes(lower)) return true;
+    if (item.description?.toLowerCase().includes(lower)) return true;
+    if (item.keywords?.some(k => k.toLowerCase().includes(lower))) return true;
+    return false;
+  });
+}
+
+export function useCommandPalette() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQueryState] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const filteredItems = useMemo(() => filterItems(COMMAND_ITEMS, query), [query]);
+
+  const setQuery = useCallback((q: string) => {
+    setQueryState(q);
+    setSelectedIndex(0);
+  }, []);
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQueryState('');
+    setSelectedIndex(0);
+  }, []);
+
+  const selectNext = useCallback(() => {
+    setSelectedIndex(prev => {
+      const items = filterItems(COMMAND_ITEMS, query);
+      return (prev + 1) % items.length;
+    });
+  }, [query]);
+
+  const selectPrev = useCallback(() => {
+    setSelectedIndex(prev => {
+      const items = filterItems(COMMAND_ITEMS, query);
+      return (prev - 1 + items.length) % items.length;
+    });
+  }, [query]);
+
+  return {
+    isOpen,
+    query,
+    selectedIndex,
+    filteredItems,
+    open,
+    close,
+    setQuery,
+    selectNext,
+    selectPrev,
+  };
+}


### PR DESCRIPTION
## 概要
- `Cmd+K`（Mac）/ `Ctrl+K`（Windows/Linux）でコマンドパレットを開く機能を実装
- ページ移動（10ページ対応）とアクション（テーマ切替、新規ノート作成）をキーボードから素早く実行可能

## 変更内容
- `CommandPalette` コンポーネント: 検索入力、キーボード操作（↑↓/Enter/Esc）、カテゴリ別表示
- `useCommandPalette` フック: 状態管理、ラベル/キーワード/説明文によるフィルタリング
- `commandPaletteItems.ts`: コマンド定義（ページ移動10件 + アクション2件）
- `AppShell` に `Cmd+K`/`Ctrl+K` キーボードショートカット統合

## テスト
- `useCommandPalette.test.ts`: 13件（フィルタリング、選択操作、状態管理）
- `CommandPalette.test.tsx`: 14件（表示、検索、キーボード操作、コマンド実行）
- `AppShell.test.tsx`: 2件追加（Cmd+K、Ctrl+Kショートカット）
- 全1733テスト通過

## テスト手順
- [x] `Cmd+K`/`Ctrl+K` でパレットが開閉する
- [x] テキスト入力でコマンドが絞り込まれる
- [x] ↑↓キーで選択移動、Enterで実行
- [x] ページ移動コマンドで正しいページに遷移
- [x] テーマ切替コマンドでダーク/ライト切替
- [x] Escキー・背景クリックでパレットが閉じる

Closes #928