### PR TITLE
refactor: ScoreHistoryPage・NotesPageのロジックをHooksに完全分離

### DIFF
--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -7,6 +7,7 @@ export function useNotes() {
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const notesRef = useRef<Note[]>(notes);
   notesRef.current = notes;
 
@@ -76,6 +77,25 @@ export function useNotes() {
     setSelectedNoteId(noteId);
   }, []);
 
+  const selectedNote = useMemo(() => {
+    return notes.find((n) => n.noteId === selectedNoteId) || null;
+  }, [notes, selectedNoteId]);
+
+  const requestDelete = useCallback((noteId: string) => {
+    setDeleteTargetId(noteId);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (deleteTargetId) {
+      await deleteNote(deleteTargetId);
+      setDeleteTargetId(null);
+    }
+  }, [deleteTargetId, deleteNote]);
+
+  const cancelDelete = useCallback(() => {
+    setDeleteTargetId(null);
+  }, []);
+
   const filteredNotes = useMemo(() => {
     const query = searchQuery.toLowerCase();
     const filtered = query
@@ -91,6 +111,7 @@ export function useNotes() {
     notes,
     filteredNotes,
     selectedNoteId,
+    selectedNote,
     loading,
     searchQuery,
     setSearchQuery,
@@ -100,5 +121,9 @@ export function useNotes() {
     deleteNote,
     selectNote,
     togglePin,
+    deleteTargetId,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
   };
 }

--- a/frontend/src/hooks/useScoreHistory.ts
+++ b/frontend/src/hooks/useScoreHistory.ts
@@ -2,6 +2,10 @@ import { useEffect, useState, useMemo } from 'react';
 import type { ScoreHistoryItem } from '../types';
 import { useAiChat } from './useAiChat';
 
+export interface ScoreHistoryItemWithDelta extends ScoreHistoryItem {
+  delta: number | null;
+}
+
 const FILTERS = ['すべて', '練習', 'フリー'] as const;
 export type FilterType = (typeof FILTERS)[number];
 export { FILTERS };
@@ -48,9 +52,21 @@ export function useScoreHistory() {
     return [...latestSession.scores].sort((a, b) => a.score - b.score)[0] ?? null;
   }, [latestSession]);
 
+  const filteredHistoryWithDelta = useMemo((): ScoreHistoryItemWithDelta[] => {
+    return filteredHistory.map((item) => {
+      const originalIndex = history.indexOf(item);
+      const prevItem = originalIndex > 0 ? history[originalIndex - 1] : null;
+      const delta = prevItem
+        ? Math.round((item.overallScore - prevItem.overallScore) * 10) / 10
+        : null;
+      return { ...item, delta };
+    });
+  }, [filteredHistory, history]);
+
   return {
     history,
     filteredHistory,
+    filteredHistoryWithDelta,
     filter,
     setFilter,
     loading,

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import NoteListItem from '../components/NoteListItem';
 import NoteEditor from '../components/NoteEditor';
@@ -16,22 +16,24 @@ export default function NotesPage() {
     notes,
     filteredNotes,
     selectedNoteId,
+    selectedNote,
     loading,
     searchQuery,
     setSearchQuery,
     fetchNotes,
     createNote,
     updateNote,
-    deleteNote,
     selectNote,
     togglePin,
+    deleteTargetId,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
   } = useNotes();
 
   useEffect(() => {
     fetchNotes();
   }, [fetchNotes]);
-
-  const selectedNote = notes.find((n) => n.noteId === selectedNoteId) || null;
 
   const { editTitle, editContent, handleTitleChange, handleContentChange } =
     useNoteEditor(selectedNoteId, selectedNote, updateNote);
@@ -44,19 +46,6 @@ export default function NotesPage() {
   const handleSelectNote = (noteId: string) => {
     selectNote(noteId);
     closeMobilePanel();
-  };
-
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
-
-  const handleDeleteNote = (noteId: string) => {
-    setDeleteTargetId(noteId);
-  };
-
-  const confirmDelete = async () => {
-    if (deleteTargetId) {
-      await deleteNote(deleteTargetId);
-      setDeleteTargetId(null);
-    }
   };
 
   return (
@@ -106,7 +95,7 @@ export default function NotesPage() {
                 isPinned={note.isPinned}
                 isActive={selectedNoteId === note.noteId}
                 onSelect={handleSelectNote}
-                onDelete={handleDeleteNote}
+                onDelete={requestDelete}
                 onTogglePin={togglePin}
               />
             ))
@@ -149,7 +138,7 @@ export default function NotesPage() {
         isOpen={deleteTargetId !== null}
         message="このノートを削除しますか？"
         onConfirm={confirmDelete}
-        onCancel={() => setDeleteTargetId(null)}
+        onCancel={cancelDelete}
       />
     </div>
   );

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -27,7 +27,7 @@ import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 export default function ScoreHistoryPage() {
-  const { history, filteredHistory, filter, setFilter, loading, latestSession, averageScore, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
+  const { history, filteredHistoryWithDelta, filter, setFilter, loading, latestSession, averageScore, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
   const [scoreGoal] = useLocalStorage('scoreGoal', 8.0);
 
   if (loading) {
@@ -168,27 +168,19 @@ export default function ScoreHistoryPage() {
       <FilterTabs tabs={[...FILTERS]} selected={filter} onSelect={setFilter} />
 
       {/* フィルタサマリー */}
-      <ScoreFilterSummary scores={filteredHistory.map(h => h.overallScore)} />
+      <ScoreFilterSummary scores={filteredHistoryWithDelta.map(h => h.overallScore)} />
 
       {/* トレンドインジケーター */}
-      <ScoreTrendIndicator scores={filteredHistory.map(h => h.overallScore)} />
+      <ScoreTrendIndicator scores={filteredHistoryWithDelta.map(h => h.overallScore)} />
 
-      {filteredHistory.map((item) => {
-        const originalIndex = history.indexOf(item);
-        const prevItem = originalIndex > 0 ? history[originalIndex - 1] : null;
-        const delta = prevItem
-          ? Math.round((item.overallScore - prevItem.overallScore) * 10) / 10
-          : null;
-
-        return (
-          <ScoreHistorySessionCard
-            key={item.sessionId}
-            item={item}
-            delta={delta}
-            onClick={() => setSelectedSession(item)}
-          />
-        );
-      })}
+      {filteredHistoryWithDelta.map((item) => (
+        <ScoreHistorySessionCard
+          key={item.sessionId}
+          item={item}
+          delta={item.delta}
+          onClick={() => setSelectedSession(item)}
+        />
+      ))}
 
       {selectedSession && (
         <SessionDetailModal


### PR DESCRIPTION
## 概要
- ScoreHistoryPageのインライン計算ロジックをuseScoreHistoryフックに集約
- NotesPageの削除確認状態管理をuseNotesフックに移動
- ChatPage (#938) は調査の結果、既にリファクタリング済みのためクローズ

## 変更内容
- `useScoreHistory`: `filteredHistoryWithDelta`プロパティ追加（デルタ計算のカプセル化）
- `useNotes`: `selectedNote`派生値、`requestDelete`/`confirmDelete`/`cancelDelete`追加
- `NotesPage`: `useState(deleteTargetId)` 削除、フック経由に変更（156行→145行）
- `ScoreHistoryPage`: インライン計算ロジック削除（201行→193行）

## テスト
- 全1788テスト通過
- useScoreHistory: +2テスト（filteredHistoryWithDelta）
- useNotes: +7テスト（selectedNote・削除確認フロー）
- NotesPageテスト: モックを新API構造に更新

Closes #937, Closes #939