### PR TITLE
test: AskAiPage・ChatPageのページテスト追加

### DIFF
--- a/frontend/src/pages/__tests__/AskAiPage.test.tsx
+++ b/frontend/src/pages/__tests__/AskAiPage.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import AskAiPage from '../AskAiPage';
+import { useAskAi } from '../../hooks/useAskAi';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+
+vi.mock('../../hooks/useAskAi');
+vi.mock('../../hooks/useCopyToClipboard');
+vi.mock('../../hooks/useBlockEditor', () => ({
+  useBlockEditor: () => ({ editor: null }),
+}));
+
+const mockUseAskAi = {
+  sessions: [],
+  messages: [],
+  scoreCard: null,
+  messagesEndRef: { current: null },
+  isPracticeMode: false,
+  scenarioName: null,
+  currentSessionId: null,
+  deleteModal: { isOpen: false, sessionId: null },
+  editingSessionId: null,
+  editingTitle: '',
+  setEditingTitle: vi.fn(),
+  handleNewSession: vi.fn(),
+  handleSelectSession: vi.fn(),
+  handleDeleteSession: vi.fn(),
+  confirmDeleteSession: vi.fn(),
+  cancelDeleteSession: vi.fn(),
+  handleStartEditTitle: vi.fn(),
+  handleSaveTitle: vi.fn(),
+  handleCancelEditTitle: vi.fn(),
+  handleSend: vi.fn(),
+  handleDeleteMessage: vi.fn(),
+};
+
+describe('AskAiPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useAskAi).mockReturnValue({ ...mockUseAskAi });
+    vi.mocked(useCopyToClipboard).mockReturnValue({ copiedId: null, copyToClipboard: vi.fn() });
+  });
+
+  it('メッセージが空の場合にEmptyStateが表示される', () => {
+    render(<AskAiPage />);
+    expect(screen.getByText('AIアシスタントへようこそ')).toBeInTheDocument();
+  });
+
+  it('新しいチャットボタンが表示される', () => {
+    render(<AskAiPage />);
+    expect(screen.getAllByText('新しいチャット').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('新しいチャットボタンクリックでhandleNewSessionが呼ばれる', () => {
+    render(<AskAiPage />);
+    fireEvent.click(screen.getAllByText('新しいチャット')[0]);
+    expect(mockUseAskAi.handleNewSession).toHaveBeenCalled();
+  });
+
+  it('セッション一覧が表示される', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      sessions: [
+        { id: 1, title: 'セッション1', createdAt: '2026-02-10T10:00:00Z' },
+        { id: 2, title: 'セッション2', createdAt: '2026-02-11T10:00:00Z' },
+      ] as any,
+    });
+    render(<AskAiPage />);
+    expect(screen.getAllByText('セッション1').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('セッション2').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('メッセージが表示される', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      messages: [
+        { id: 1, content: 'こんにちは', isSender: true, createdAt: '2026-02-10' },
+        { id: 2, content: 'お手伝いします', isSender: false, createdAt: '2026-02-10' },
+      ] as any,
+    });
+    render(<AskAiPage />);
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+    expect(screen.getByText('お手伝いします')).toBeInTheDocument();
+  });
+
+  it('練習モード時に練習ヘッダーが表示される', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      isPracticeMode: true,
+      scenarioName: 'テストシナリオ',
+    });
+    render(<AskAiPage />);
+    expect(screen.getByText('テストシナリオ')).toBeInTheDocument();
+    expect(screen.getByText('AIが相手役を演じます')).toBeInTheDocument();
+    expect(screen.getByText('練習終了')).toBeInTheDocument();
+  });
+
+  it('練習終了ボタンクリックでhandleSendが呼ばれる', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      isPracticeMode: true,
+      scenarioName: 'テストシナリオ',
+    });
+    render(<AskAiPage />);
+    fireEvent.click(screen.getByText('練習終了'));
+    expect(mockUseAskAi.handleSend).toHaveBeenCalledWith(
+      expect.stringContaining('練習を終了')
+    );
+  });
+
+  it('セッション削除確認モーダルが表示される', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      deleteModal: { isOpen: true, sessionId: 1 },
+    });
+    render(<AskAiPage />);
+    expect(screen.getByText('このセッションを削除しますか？チャット履歴もすべて削除されます。この操作は取り消せません。')).toBeInTheDocument();
+  });
+
+  it('削除確認でconfirmDeleteSessionが呼ばれる', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      deleteModal: { isOpen: true, sessionId: 1 },
+    });
+    render(<AskAiPage />);
+    fireEvent.click(screen.getByText('削除する'));
+    expect(mockUseAskAi.confirmDeleteSession).toHaveBeenCalled();
+  });
+
+  it('削除キャンセルでcancelDeleteSessionが呼ばれる', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      deleteModal: { isOpen: true, sessionId: 1 },
+    });
+    render(<AskAiPage />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(mockUseAskAi.cancelDeleteSession).toHaveBeenCalled();
+  });
+
+  it('モバイルヘッダーにセッション一覧を開くボタンが表示される', () => {
+    render(<AskAiPage />);
+    expect(screen.getByLabelText('セッション一覧を開く')).toBeInTheDocument();
+  });
+
+  it('スコアカードが表示される', () => {
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      scoreCard: {
+        overallScore: 8.5,
+        scores: [
+          { axis: '論理的構成力', score: 9, comment: '素晴らしい' },
+        ],
+      } as any,
+    });
+    render(<AskAiPage />);
+    expect(screen.getByText('8.5')).toBeInTheDocument();
+  });
+
+  it('練習モードでないときは練習ヘッダーが表示されない', () => {
+    render(<AskAiPage />);
+    expect(screen.queryByText('AIが相手役を演じます')).not.toBeInTheDocument();
+    expect(screen.queryByText('練習終了')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/ChatPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatPage.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ChatPage from '../ChatPage';
+import { useChat } from '../../hooks/useChat';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+
+vi.mock('../../hooks/useChat');
+vi.mock('../../hooks/useCopyToClipboard');
+
+const mockUseChat = {
+  messages: [],
+  deleteModal: { isOpen: false, messageId: null },
+  selectionMode: false,
+  selectedMessages: new Set<number>(),
+  showSceneSelector: false,
+  showRephraseModal: false,
+  rephraseResult: null,
+  rephraseOriginalText: '',
+  messagesEndRef: { current: null },
+  handleSend: vi.fn(),
+  handleDeleteMessage: vi.fn(),
+  confirmDelete: vi.fn(),
+  cancelDelete: vi.fn(),
+  handleAiFeedback: vi.fn(),
+  handleRangeClick: vi.fn(),
+  handleQuickSelect: vi.fn(),
+  handleSelectAll: vi.fn(),
+  handleDeselectAll: vi.fn(),
+  handleCancelSelection: vi.fn(),
+  handleSendToAi: vi.fn(),
+  handleSceneSelect: vi.fn(),
+  handleRephrase: vi.fn(),
+  setShowRephraseModal: vi.fn(),
+  isInRange: vi.fn().mockReturnValue(false),
+  getRangeLabel: vi.fn().mockReturnValue(null),
+};
+
+describe('ChatPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useChat).mockReturnValue({ ...mockUseChat });
+    vi.mocked(useCopyToClipboard).mockReturnValue({ copiedId: null, copyToClipboard: vi.fn() });
+  });
+
+  it('メッセージが空の場合にEmptyStateが表示される', () => {
+    render(<ChatPage />);
+    expect(screen.getByText('チャットへようこそ')).toBeInTheDocument();
+  });
+
+  it('メッセージが表示される', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      messages: [
+        { id: 1, roomId: 1, senderId: 1, senderName: 'テスト', content: 'メッセージ1', createdAt: '2026-02-10', isSender: true },
+        { id: 2, roomId: 1, senderId: 2, senderName: '相手', content: 'メッセージ2', createdAt: '2026-02-10', isSender: false },
+      ] as any,
+    });
+    render(<ChatPage />);
+    expect(screen.getByText('メッセージ1')).toBeInTheDocument();
+    expect(screen.getByText('メッセージ2')).toBeInTheDocument();
+  });
+
+  it('メッセージがある場合にAIフィードバックボタンが表示される', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      messages: [
+        { id: 1, roomId: 1, senderId: 1, senderName: 'テスト', content: 'テスト', createdAt: '2026-02-10', isSender: true },
+      ] as any,
+    });
+    render(<ChatPage />);
+    expect(screen.getByText('AIにフィードバックしてもらう')).toBeInTheDocument();
+  });
+
+  it('AIフィードバックボタンクリックでhandleAiFeedbackが呼ばれる', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      messages: [
+        { id: 1, roomId: 1, senderId: 1, senderName: 'テスト', content: 'テスト', createdAt: '2026-02-10', isSender: true },
+      ] as any,
+    });
+    render(<ChatPage />);
+    fireEvent.click(screen.getByText('AIにフィードバックしてもらう'));
+    expect(mockUseChat.handleAiFeedback).toHaveBeenCalled();
+  });
+
+  it('選択モード時にMessageSelectionPanelが表示される', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      selectionMode: true,
+      selectedMessages: new Set([1]),
+    });
+    render(<ChatPage />);
+    expect(screen.queryByText('AIにフィードバックしてもらう')).not.toBeInTheDocument();
+  });
+
+  it('メッセージが空の場合にAIフィードバックボタンが非表示', () => {
+    render(<ChatPage />);
+    expect(screen.queryByText('AIにフィードバックしてもらう')).not.toBeInTheDocument();
+  });
+
+  it('削除確認モーダルが表示される', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      deleteModal: { isOpen: true, messageId: 1 },
+    });
+    render(<ChatPage />);
+    expect(screen.getByText('このメッセージを削除しますか？この操作は取り消せません。')).toBeInTheDocument();
+  });
+
+  it('削除確認でconfirmDeleteが呼ばれる', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      deleteModal: { isOpen: true, messageId: 1 },
+    });
+    render(<ChatPage />);
+    fireEvent.click(screen.getByText('削除する'));
+    expect(mockUseChat.confirmDelete).toHaveBeenCalled();
+  });
+
+  it('削除キャンセルでcancelDeleteが呼ばれる', () => {
+    vi.mocked(useChat).mockReturnValue({
+      ...mockUseChat,
+      deleteModal: { isOpen: true, messageId: 1 },
+    });
+    render(<ChatPage />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(mockUseChat.cancelDelete).toHaveBeenCalled();
+  });
+
+  it('削除モーダルが閉じている場合はメッセージが表示されない', () => {
+    render(<ChatPage />);
+    expect(screen.queryByText('このメッセージを削除しますか？この操作は取り消せません。')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
テストが存在しなかった2つのメインページにテストを追加し、全ページコンポーネントのテストカバレッジ100%を達成。

## 追加テスト
- **AskAiPage.test.tsx** (13テスト): EmptyState表示・セッション一覧・メッセージ表示・練習モード・スコアカード・削除確認等
- **ChatPage.test.tsx** (10テスト): EmptyState表示・メッセージ表示・AIフィードバック・選択モード・削除確認等

## テスト
- 全1811テスト通過（+23テスト）

Closes #941, Closes #942