### PR TITLE
feat: ノートUX向上 - 自動保存インジケーター・トースト通知・キーボードショートカット

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -4,6 +4,7 @@ import { getNoteStats } from '../utils/noteStats';
 import { useTableOfContents } from '../hooks/useTableOfContents';
 import { useMarkdownExport } from '../hooks/useMarkdownExport';
 import { useToast } from '../hooks/useToast';
+import type { SaveStatus } from '../hooks/useNoteEditor';
 import BlockEditor from './BlockEditor';
 import TableOfContents from './TableOfContents';
 import WordCount from './WordCount';
@@ -14,14 +15,22 @@ interface NoteEditorProps {
   title: string;
   content: string;
   noteId: string | null;
+  saveStatus: SaveStatus;
   onTitleChange: (title: string) => void;
   onContentChange: (content: string) => void;
 }
+
+const SAVE_STATUS_CONFIG: Record<Exclude<SaveStatus, 'idle'>, { label: string; color: string }> = {
+  unsaved: { label: '未保存', color: 'text-amber-500' },
+  saving: { label: '保存中...', color: 'text-[var(--color-text-muted)]' },
+  saved: { label: '保存済み', color: 'text-emerald-500' },
+};
 
 export default function NoteEditor({
   title,
   content,
   noteId,
+  saveStatus,
   onTitleChange,
   onContentChange,
 }: NoteEditorProps) {
@@ -95,6 +104,11 @@ export default function NoteEditor({
         <WordCount charCount={stats.charCount} />
         <LineCount lineCount={stats.lineCount} />
         <ReadingTime charCount={stats.charCount} />
+        {saveStatus !== 'idle' && (
+          <span className={`text-xs ${SAVE_STATUS_CONFIG[saveStatus].color}`} aria-label="保存状態">
+            {SAVE_STATUS_CONFIG[saveStatus].label}
+          </span>
+        )}
         <div className="ml-auto flex items-center gap-1">
           <button
             type="button"

--- a/frontend/src/components/__tests__/NoteEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteEditor.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import NoteEditor from '../NoteEditor';
+import type { SaveStatus } from '../../hooks/useNoteEditor';
 
 vi.mock('../../hooks/useBlockEditor', () => ({
   useBlockEditor: () => ({ editor: null }),
@@ -14,6 +15,7 @@ const defaultProps = {
   title: 'テストノート',
   content: '',
   noteId: 'note-1',
+  saveStatus: 'idle' as SaveStatus,
   onTitleChange: vi.fn(),
   onContentChange: vi.fn(),
 };
@@ -50,5 +52,25 @@ describe('NoteEditor', () => {
   it('ノート統計が表示される', () => {
     render(<NoteEditor {...defaultProps} />);
     expect(screen.getByLabelText('ノート統計')).toBeInTheDocument();
+  });
+
+  it('saveStatusがidleのとき保存インジケーターが表示されない', () => {
+    render(<NoteEditor {...defaultProps} saveStatus="idle" />);
+    expect(screen.queryByLabelText('保存状態')).not.toBeInTheDocument();
+  });
+
+  it('saveStatusがunsavedのとき「未保存」が表示される', () => {
+    render(<NoteEditor {...defaultProps} saveStatus="unsaved" />);
+    expect(screen.getByText('未保存')).toBeInTheDocument();
+  });
+
+  it('saveStatusがsavingのとき「保存中...」が表示される', () => {
+    render(<NoteEditor {...defaultProps} saveStatus="saving" />);
+    expect(screen.getByText('保存中...')).toBeInTheDocument();
+  });
+
+  it('saveStatusがsavedのとき「保存済み」が表示される', () => {
+    render(<NoteEditor {...defaultProps} saveStatus="saved" />);
+    expect(screen.getByText('保存済み')).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/__tests__/useNoteKeyboardShortcuts.test.ts
+++ b/frontend/src/hooks/__tests__/useNoteKeyboardShortcuts.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useNoteKeyboardShortcuts } from '../useNoteKeyboardShortcuts';
+
+describe('useNoteKeyboardShortcuts', () => {
+  const mockOnCreateNote = vi.fn();
+  const mockOnForceSave = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('Ctrl+Nでノート作成が呼ばれる', () => {
+    renderHook(() => useNoteKeyboardShortcuts({ onCreateNote: mockOnCreateNote, onForceSave: mockOnForceSave }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n', ctrlKey: true }));
+
+    expect(mockOnCreateNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('Meta+Nでノート作成が呼ばれる（Mac）', () => {
+    renderHook(() => useNoteKeyboardShortcuts({ onCreateNote: mockOnCreateNote, onForceSave: mockOnForceSave }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n', metaKey: true }));
+
+    expect(mockOnCreateNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+Sで即時保存が呼ばれる', () => {
+    renderHook(() => useNoteKeyboardShortcuts({ onCreateNote: mockOnCreateNote, onForceSave: mockOnForceSave }));
+
+    const event = new KeyboardEvent('keydown', { key: 's', ctrlKey: true, cancelable: true });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+
+    expect(mockOnForceSave).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('Meta+Sで即時保存が呼ばれる（Mac）', () => {
+    renderHook(() => useNoteKeyboardShortcuts({ onCreateNote: mockOnCreateNote, onForceSave: mockOnForceSave }));
+
+    const event = new KeyboardEvent('keydown', { key: 's', metaKey: true, cancelable: true });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+
+    expect(mockOnForceSave).toHaveBeenCalledTimes(1);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('修飾キーなしのNキーではノート作成が呼ばれない', () => {
+    renderHook(() => useNoteKeyboardShortcuts({ onCreateNote: mockOnCreateNote, onForceSave: mockOnForceSave }));
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n' }));
+
+    expect(mockOnCreateNote).not.toHaveBeenCalled();
+  });
+
+  it('アンマウント時にイベントリスナーが解除される', () => {
+    const { unmount } = renderHook(() => useNoteKeyboardShortcuts({ onCreateNote: mockOnCreateNote, onForceSave: mockOnForceSave }));
+
+    unmount();
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'n', ctrlKey: true }));
+
+    expect(mockOnCreateNote).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useNoteKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useNoteKeyboardShortcuts.ts
@@ -1,0 +1,29 @@
+import { useEffect, useCallback } from 'react';
+
+interface UseNoteKeyboardShortcutsOptions {
+  onCreateNote: () => void;
+  onForceSave: () => void;
+}
+
+export function useNoteKeyboardShortcuts({ onCreateNote, onForceSave }: UseNoteKeyboardShortcutsOptions) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+
+      if (e.key === 'n') {
+        e.preventDefault();
+        onCreateNote();
+      } else if (e.key === 's') {
+        e.preventDefault();
+        onForceSave();
+      }
+    },
+    [onCreateNote, onForceSave]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+}


### PR DESCRIPTION
## 概要
ノートページのUXを3つの機能で向上させる。

### 自動保存インジケーター (#944)
- フッターバーに保存状態（未保存 / 保存中... / 保存済み）を表示
- `useNoteEditor` に `SaveStatus` 型と状態管理を追加

### トースト通知 (#945)
- ノート作成成功/失敗時にトースト通知を表示
- ノート削除成功時にトースト通知を表示

### キーボードショートカット (#946)
- `Ctrl+N` / `⌘+N`: 新規ノート作成
- `Ctrl+S` / `⌘+S`: デバウンスをスキップして即時保存
- `useNoteKeyboardShortcuts` フックを新規作成

## テスト
- 新規テスト: 19件（saveStatus 6件、forceSave 2件、トースト 3件、ショートカット 6件、UI 4件）
- 全1830テスト パス

Closes #944, Closes #945, Closes #946