### PR TITLE
feat: ユーザーフィードバック改善 - 検索ローディング・送信状態・EmptyState CTA

### DIFF
--- a/frontend/src/hooks/__tests__/useProfileEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileEdit.test.ts
@@ -116,6 +116,35 @@ describe('useProfileEdit', () => {
     expect(result.current.form.name).toBe('テスト太郎');
   });
 
+  it('handleUpdate中はsubmittingがtrueになる', async () => {
+    let resolveUpdate: (value: any) => void;
+    mockUpdateProfile.mockImplementation(
+      () => new Promise((resolve) => { resolveUpdate = resolve; })
+    );
+
+    const { result } = renderHook(() => useProfileEdit());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.submitting).toBe(false);
+
+    let updatePromise: Promise<void>;
+    act(() => {
+      updatePromise = result.current.handleUpdate();
+    });
+
+    expect(result.current.submitting).toBe(true);
+
+    await act(async () => {
+      resolveUpdate!({ success: 'OK' });
+      await updatePromise!;
+    });
+
+    expect(result.current.submitting).toBe(false);
+  });
+
   it('handleUpdate時にupdateProfileにフォーム値が渡される', async () => {
     const { result } = renderHook(() => useProfileEdit());
 

--- a/frontend/src/hooks/__tests__/useUserSearch.test.ts
+++ b/frontend/src/hooks/__tests__/useUserSearch.test.ts
@@ -18,6 +18,23 @@ describe('useUserSearch', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('検索中はloadingがtrueになる', async () => {
+    let resolveSearch: (value: any) => void;
+    vi.mocked(UserSearchRepository.searchUsers).mockImplementation(
+      () => new Promise((resolve) => { resolveSearch = resolve; })
+    );
+
+    const { result } = renderHook(() => useUserSearch());
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveSearch!([]);
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
   it('初回マウント時にユーザー検索が実行される', async () => {
     const mockUsers = [{ id: 1, name: 'テスト', email: 'test@example.com' }];
     vi.mocked(UserSearchRepository.searchUsers).mockResolvedValue(mockUsers);

--- a/frontend/src/hooks/useProfileEdit.ts
+++ b/frontend/src/hooks/useProfileEdit.ts
@@ -6,6 +6,7 @@ export function useProfileEdit() {
   const [form, setForm] = useState({ name: '', bio: '' });
   const [message, setMessage] = useState<FormMessage | null>(null);
   const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     const loadProfile = async () => {
@@ -26,11 +27,14 @@ export function useProfileEdit() {
   }, []);
 
   const handleUpdate = useCallback(async () => {
+    setSubmitting(true);
     try {
       const data = await ProfileRepository.updateProfile(form);
       setMessage({ type: 'success', text: data.success || 'プロフィールを更新しました。' });
     } catch {
       setMessage({ type: 'error', text: '通信エラーが発生しました。' });
+    } finally {
+      setSubmitting(false);
     }
   }, [form]);
 
@@ -38,6 +42,7 @@ export function useProfileEdit() {
     form,
     message,
     loading,
+    submitting,
     updateField,
     handleUpdate,
   };

--- a/frontend/src/hooks/useUserSearch.ts
+++ b/frontend/src/hooks/useUserSearch.ts
@@ -6,6 +6,7 @@ import type { MemberUser } from '../types';
 export function useUserSearch() {
   const [users, setUsers] = useState<MemberUser[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [debounceQuery, setDebounceQuery] = useState('');
 
@@ -23,6 +24,7 @@ export function useUserSearch() {
     let cancelled = false;
 
     const search = async () => {
+      setLoading(true);
       try {
         const result = await UserSearchRepository.searchUsers(debounceQuery || undefined);
         if (!cancelled) {
@@ -32,6 +34,10 @@ export function useUserSearch() {
       } catch (err) {
         if (!cancelled) {
           setError((err as Error).message);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
         }
       }
     };
@@ -46,6 +52,7 @@ export function useUserSearch() {
   return {
     users,
     error,
+    loading,
     searchQuery,
     setSearchQuery,
     debounceQuery,

--- a/frontend/src/pages/MemberPage.tsx
+++ b/frontend/src/pages/MemberPage.tsx
@@ -1,10 +1,11 @@
 import MemberList from '../components/MemberList';
 import SearchBox from '../components/SearchBox';
 import FormMessage from '../components/FormMessage';
+import Loading from '../components/Loading';
 import { useUserSearch } from '../hooks/useUserSearch';
 
 export default function MemberPage() {
-  const { users, error, searchQuery, setSearchQuery } = useUserSearch();
+  const { users, error, loading, searchQuery, setSearchQuery } = useUserSearch();
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
@@ -27,11 +28,13 @@ export default function MemberPage() {
       <FormMessage message={error ? { type: 'error', text: error } : null} />
 
       {/* メンバーリスト */}
-      {users.length === 0 && !error && (
+      {loading ? (
+        <Loading className="py-12" />
+      ) : users.length === 0 && !error ? (
         <div className="text-center py-12">
           <p className="text-sm text-[var(--color-text-muted)]">メンバーがまだいません</p>
         </div>
-      )}
+      ) : null}
       <MemberList users={users} />
     </div>
   );

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -7,7 +7,7 @@ import Loading from '../components/Loading';
 import { useProfileEdit } from '../hooks/useProfileEdit';
 
 export default function ProfilePage() {
-  const { form, message, loading, updateField, handleUpdate } = useProfileEdit();
+  const { form, message, loading, submitting, updateField, handleUpdate } = useProfileEdit();
 
   if (loading) {
     return (
@@ -54,7 +54,9 @@ export default function ProfilePage() {
             rows={4}
             maxLength={200}
           />
-          <PrimaryButton type="submit">プロフィールを更新</PrimaryButton>
+          <PrimaryButton type="submit" disabled={submitting}>
+            {submitting ? '更新中...' : 'プロフィールを更新'}
+          </PrimaryButton>
         </form>
       </div>
     </div>

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -1,4 +1,7 @@
+import { useNavigate } from 'react-router-dom';
+import { SparklesIcon } from '@heroicons/react/24/outline';
 import { SkeletonCard } from '../components/Skeleton';
+import EmptyState from '../components/EmptyState';
 import SkillRadarChart from '../components/SkillRadarChart';
 import PracticeCalendar from '../components/PracticeCalendar';
 import ScoreRankBadge from '../components/ScoreRankBadge';
@@ -27,6 +30,7 @@ import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 export default function ScoreHistoryPage() {
+  const navigate = useNavigate();
   const { history, filteredHistoryWithDelta, filter, setFilter, loading, latestSession, averageScore, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
   const [scoreGoal] = useLocalStorage('scoreGoal', 8.0);
 
@@ -43,10 +47,15 @@ export default function ScoreHistoryPage() {
 
   if (history.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 text-[var(--color-text-muted)]">
-        <p className="text-sm font-medium">スコア履歴がありません</p>
-        <p className="text-xs mt-1">AIアシスタントでフィードバックを受けるとスコアが記録されます</p>
-      </div>
+      <EmptyState
+        icon={SparklesIcon}
+        title="スコア履歴がありません"
+        description="AIアシスタントでフィードバックを受けるとスコアが記録されます"
+        action={{
+          label: 'AIアシスタントで練習を開始',
+          onClick: () => navigate('/chat/ask-ai'),
+        }}
+      />
     );
   }
 

--- a/frontend/src/pages/__tests__/MemberPage.test.tsx
+++ b/frontend/src/pages/__tests__/MemberPage.test.tsx
@@ -12,6 +12,7 @@ function defaultData() {
   return {
     users: [],
     error: null,
+    loading: false,
     searchQuery: '',
     setSearchQuery: vi.fn(),
     debounceQuery: '',
@@ -65,6 +66,28 @@ describe('MemberPage', () => {
     render(<BrowserRouter><MemberPage /></BrowserRouter>);
 
     expect(screen.getByText('ネットワークエラー')).toBeInTheDocument();
+  });
+
+  it('ローディング中はスピナーが表示される', () => {
+    mockUseUserSearch.mockReturnValue({
+      ...defaultData(),
+      loading: true,
+    });
+
+    const { container } = render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('ローディング中はメンバーなしメッセージが非表示', () => {
+    mockUseUserSearch.mockReturnValue({
+      ...defaultData(),
+      loading: true,
+    });
+
+    render(<BrowserRouter><MemberPage /></BrowserRouter>);
+
+    expect(screen.queryByText('メンバーがまだいません')).not.toBeInTheDocument();
   });
 
   it('エラー時にメンバーなしメッセージは表示しない', () => {

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProfilePage from '../ProfilePage';
 import ProfileRepository from '../../repositories/ProfileRepository';
 
@@ -57,6 +57,24 @@ describe('ProfilePage', () => {
 
     await waitFor(() => {
       expect(screen.getByDisplayValue('テスト自己紹介')).toBeInTheDocument();
+    });
+  });
+
+  it('送信中はボタンが「更新中...」になり無効化される', async () => {
+    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '' });
+    mockedRepo.updateProfile.mockReturnValue(new Promise(() => {}));
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('プロフィールを更新')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('プロフィールを更新'));
+
+    await waitFor(() => {
+      expect(screen.getByText('更新中...')).toBeInTheDocument();
+      expect(screen.getByText('更新中...').closest('button')).toBeDisabled();
     });
   });
 

--- a/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
+++ b/frontend/src/pages/__tests__/ScoreHistoryPage.test.tsx
@@ -99,7 +99,7 @@ describe('ScoreHistoryPage', () => {
     }, { timeout: 3000 });
   });
 
-  it('履歴が空の場合メッセージが表示される', async () => {
+  it('履歴が空の場合EmptyStateが表示される', async () => {
     mockFetchScoreHistory.mockResolvedValue([]);
     const ScoreHistoryPage = await importScoreHistoryPage();
 
@@ -107,7 +107,22 @@ describe('ScoreHistoryPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('スコア履歴がありません')).toBeInTheDocument();
+      expect(screen.getByText('AIアシスタントで練習を開始')).toBeInTheDocument();
     }, { timeout: 3000 });
+  });
+
+  it('EmptyStateのCTAボタンでAIアシスタントに遷移する', async () => {
+    mockFetchScoreHistory.mockResolvedValue([]);
+    const ScoreHistoryPage = await importScoreHistoryPage();
+
+    render(<ScoreHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('AIアシスタントで練習を開始')).toBeInTheDocument();
+    }, { timeout: 3000 });
+
+    fireEvent.click(screen.getByText('AIアシスタントで練習を開始'));
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai');
   });
 
   it('ローディング中はスケルトンが表示される', async () => {


### PR DESCRIPTION
## 概要
3ページにわたるユーザーフィードバック改善を実施。

### メンバー検索ローディング (#948)
- `useUserSearch` に `loading` 状態を追加
- `MemberPage` で検索中にスピナーを表示
- ローディング中は「メンバーがまだいません」を非表示

### プロフィール更新送信状態 (#949)
- `useProfileEdit` に `submitting` 状態を追加
- 送信中はボタンを「更新中...」に変更し無効化
- 二重送信を防止

### スコア履歴EmptyState CTA (#950)
- 空状態を `EmptyState` コンポーネントに置換
- 「AIアシスタントで練習を開始」CTAボタンを追加
- 初期ユーザーのオンボーディング改善

## テスト
- 新規テスト: 5件
- 全1836テスト パス

Closes #948, Closes #949, Closes #950