### PR TITLE
refactor: ScoreHistoryPage分割・定数重複解消

### DIFF
--- a/frontend/src/components/ScoreOverviewSection.tsx
+++ b/frontend/src/components/ScoreOverviewSection.tsx
@@ -1,0 +1,91 @@
+import SkillRadarChart from './SkillRadarChart';
+import ScoreRankBadge from './ScoreRankBadge';
+import ScoreStatsSummary from './ScoreStatsSummary';
+import ScoreComparisonCard from './ScoreComparisonCard';
+import ScoreImprovementAdvice from './ScoreImprovementAdvice';
+import SkillSummaryCard from './SkillSummaryCard';
+import CommunicationStyleCard from './CommunicationStyleCard';
+import ScoreGoalCard from './ScoreGoalCard';
+import SkillGapAnalysisCard from './SkillGapAnalysisCard';
+import WeeklyComparisonCard from './WeeklyComparisonCard';
+import SkillRadarOverlayCard from './SkillRadarOverlayCard';
+import SessionFeedbackSummary from './SessionFeedbackSummary';
+import WeakAxisAdviceCard from './WeakAxisAdviceCard';
+import PersonalBestCard from './PersonalBestCard';
+import type { ScoreHistoryItem, AxisScore } from '../types';
+
+interface ScoreOverviewSectionProps {
+  history: ScoreHistoryItem[];
+  latestSession: ScoreHistoryItem;
+  averageScore: number;
+  weakestAxis: AxisScore | null;
+  scoreGoal: number;
+}
+
+export default function ScoreOverviewSection({
+  history,
+  latestSession,
+  averageScore,
+  weakestAxis,
+  scoreGoal,
+}: ScoreOverviewSectionProps) {
+  const hasScores = latestSession.scores.length > 0;
+
+  return (
+    <>
+      <CommunicationStyleCard sessions={history} />
+
+      <ScoreGoalCard averageScore={averageScore} />
+
+      {hasScores && (
+        <SkillGapAnalysisCard scores={latestSession.scores} goal={scoreGoal} />
+      )}
+
+      <ScoreStatsSummary history={history} />
+
+      <PersonalBestCard history={history} />
+
+      <WeeklyComparisonCard sessions={history} />
+
+      <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex items-center justify-between">
+        <div>
+          <p className="text-xs text-[var(--color-text-muted)] mb-1">最新スコア</p>
+          <p className="text-2xl font-bold text-[var(--color-text-primary)]">{latestSession.overallScore.toFixed(1)}</p>
+        </div>
+        <ScoreRankBadge score={latestSession.overallScore} />
+      </div>
+
+      {hasScores && (
+        <SessionFeedbackSummary scores={latestSession.scores} overallScore={latestSession.overallScore} />
+      )}
+
+      {weakestAxis && <WeakAxisAdviceCard axis={weakestAxis.axis} />}
+
+      {hasScores && (
+        <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex justify-center">
+          <SkillRadarChart scores={latestSession.scores} title="最新のスキルバランス" />
+        </div>
+      )}
+
+      {history.length >= 2 && (
+        <SkillRadarOverlayCard
+          previousScores={history[history.length - 2].scores}
+          currentScores={latestSession.scores}
+        />
+      )}
+
+      {history.length >= 2 && history[0].scores.length > 0 && (
+        <ScoreComparisonCard
+          firstScores={history[0].scores}
+          latestScores={latestSession.scores}
+          firstOverall={history[0].overallScore}
+          latestOverall={latestSession.overallScore}
+        />
+      )}
+
+      {hasScores && <SkillSummaryCard scores={latestSession.scores} />}
+
+      {hasScores && <ScoreImprovementAdvice scores={latestSession.scores} />}
+    </>
+  );
+}

--- a/frontend/src/components/SessionListSection.tsx
+++ b/frontend/src/components/SessionListSection.tsx
@@ -1,0 +1,85 @@
+import ScoreDistributionCard from './ScoreDistributionCard';
+import SessionTimeCard from './SessionTimeCard';
+import SkillTrendChart from './SkillTrendChart';
+import SkillMilestoneCard from './SkillMilestoneCard';
+import PracticeCalendar from './PracticeCalendar';
+import SessionDetailModal from './SessionDetailModal';
+import ScoreHistorySessionCard from './ScoreHistorySessionCard';
+import ScoreFilterSummary from './ScoreFilterSummary';
+import ScoreTrendIndicator from './ScoreTrendIndicator';
+import FilterTabs from './FilterTabs';
+import { FILTERS } from '../hooks/useScoreHistory';
+import type { ScoreHistoryItem } from '../types';
+import type { ScoreHistoryItemWithDelta } from '../hooks/useScoreHistory';
+
+interface SessionListSectionProps {
+  history: ScoreHistoryItem[];
+  filteredHistoryWithDelta: ScoreHistoryItemWithDelta[];
+  filter: string;
+  setFilter: (filter: string) => void;
+  selectedSession: ScoreHistoryItem | null;
+  setSelectedSession: (session: ScoreHistoryItem | null) => void;
+}
+
+export default function SessionListSection({
+  history,
+  filteredHistoryWithDelta,
+  filter,
+  setFilter,
+  selectedSession,
+  setSelectedSession,
+}: SessionListSectionProps) {
+  const latestSession = history[history.length - 1];
+  const hasScores = latestSession && latestSession.scores.length > 0;
+
+  return (
+    <>
+      <ScoreDistributionCard scores={history.map(h => h.overallScore)} />
+
+      <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+        <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スコア推移</p>
+        <div className="flex items-end gap-1 h-16">
+          {history.map((item) => (
+            <div
+              key={item.sessionId}
+              data-testid="trend-bar"
+              className="flex-1 bg-primary-500 rounded-t"
+              style={{ height: `${item.overallScore * 10}%` }}
+              title={`${item.sessionTitle}: ${item.overallScore}`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {hasScores && <SkillMilestoneCard scores={latestSession.scores} />}
+
+      <SkillTrendChart history={history} />
+
+      <SessionTimeCard dates={history.map(h => h.createdAt)} />
+
+      <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />
+
+      <FilterTabs tabs={[...FILTERS]} selected={filter} onSelect={setFilter} />
+
+      <ScoreFilterSummary scores={filteredHistoryWithDelta.map(h => h.overallScore)} />
+
+      <ScoreTrendIndicator scores={filteredHistoryWithDelta.map(h => h.overallScore)} />
+
+      {filteredHistoryWithDelta.map((item) => (
+        <ScoreHistorySessionCard
+          key={item.sessionId}
+          item={item}
+          delta={item.delta}
+          onClick={() => setSelectedSession(item)}
+        />
+      ))}
+
+      {selectedSession && (
+        <SessionDetailModal
+          session={selectedSession}
+          onClose={() => setSelectedSession(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/WeakAxisAdviceCard.tsx
+++ b/frontend/src/components/WeakAxisAdviceCard.tsx
@@ -4,14 +4,6 @@ interface WeakAxisAdviceCardProps {
   axis: string;
 }
 
-const AXIS_ADVICE: Record<string, string> = {
-  '論理的構成力': '論理的構成力を伸ばすシナリオで練習しましょう',
-  '配慮表現': '配慮表現を伸ばすシナリオで練習しましょう',
-  '要約力': '要約力を伸ばすシナリオで練習しましょう',
-  '提案力': '提案力を伸ばすシナリオで練習しましょう',
-  '質問・傾聴力': '質問・傾聴力を伸ばすシナリオで練習しましょう',
-};
-
 export default function WeakAxisAdviceCard({ axis }: WeakAxisAdviceCardProps) {
   const navigate = useNavigate();
 
@@ -19,7 +11,7 @@ export default function WeakAxisAdviceCard({ axis }: WeakAxisAdviceCardProps) {
     <div className="bg-surface-2 rounded-lg border border-[var(--color-border-hover)] p-4">
       <p className="text-xs font-semibold text-primary-300 mb-1">おすすめ練習</p>
       <p className="text-xs text-primary-400 mb-2">
-        {AXIS_ADVICE[axis] || `${axis}を伸ばすシナリオで練習しましょう`}
+        {`${axis}を伸ばすシナリオで練習しましょう`}
       </p>
       <button
         onClick={() => navigate('/practice')}

--- a/frontend/src/components/__tests__/ScoreOverviewSection.test.tsx
+++ b/frontend/src/components/__tests__/ScoreOverviewSection.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ScoreOverviewSection from '../ScoreOverviewSection';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../ScoreGoalCard', () => ({
+  default: ({ averageScore }: { averageScore: number }) => (
+    <div data-testid="score-goal-card">目標: {averageScore}</div>
+  ),
+}));
+
+const mockHistory = [
+  {
+    sessionId: 1,
+    sessionTitle: 'テスト',
+    overallScore: 7.5,
+    scores: [{ axis: '論理的構成力', score: 8, comment: '良い' }],
+    createdAt: '2026-01-15T10:00:00Z',
+  },
+];
+
+const latestSession = mockHistory[0];
+
+describe('ScoreOverviewSection', () => {
+  it('最新スコアが表示される', () => {
+    render(
+      <ScoreOverviewSection
+        history={mockHistory}
+        latestSession={latestSession}
+        averageScore={7.5}
+        weakestAxis={{ axis: '論理的構成力', score: 8, comment: '良い' }}
+        scoreGoal={8.0}
+      />
+    );
+    expect(screen.getAllByText('7.5').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('統計サマリーが表示される', () => {
+    render(
+      <ScoreOverviewSection
+        history={mockHistory}
+        latestSession={latestSession}
+        averageScore={7.5}
+        weakestAxis={null}
+        scoreGoal={8.0}
+      />
+    );
+    expect(screen.getByText('総セッション')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/SessionListSection.test.tsx
+++ b/frontend/src/components/__tests__/SessionListSection.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SessionListSection from '../SessionListSection';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockHistory = [
+  {
+    sessionId: 1,
+    sessionTitle: '会議フィードバック',
+    overallScore: 7.4,
+    scores: [{ axis: '論理的構成力', score: 8, comment: '良い' }],
+    createdAt: '2026-01-15T10:00:00Z',
+    delta: null,
+  },
+  {
+    sessionId: 2,
+    sessionTitle: '練習: テスト',
+    overallScore: 8.0,
+    scores: [{ axis: '論理的構成力', score: 9, comment: '素晴らしい' }],
+    createdAt: '2026-01-16T10:00:00Z',
+    delta: 0.6,
+  },
+];
+
+describe('SessionListSection', () => {
+  it('セッション一覧が表示される', () => {
+    render(
+      <SessionListSection
+        history={mockHistory}
+        filteredHistoryWithDelta={mockHistory}
+        filter="すべて"
+        setFilter={vi.fn()}
+        selectedSession={null}
+        setSelectedSession={vi.fn()}
+      />
+    );
+    expect(screen.getByText('会議フィードバック')).toBeInTheDocument();
+    expect(screen.getByText('練習: テスト')).toBeInTheDocument();
+  });
+
+  it('フィルタタブが表示される', () => {
+    render(
+      <SessionListSection
+        history={mockHistory}
+        filteredHistoryWithDelta={mockHistory}
+        filter="すべて"
+        setFilter={vi.fn()}
+        selectedSession={null}
+        setSelectedSession={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('tab', { name: 'すべて' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -2,31 +2,9 @@ import { useNavigate } from 'react-router-dom';
 import { SparklesIcon } from '@heroicons/react/24/outline';
 import { SkeletonCard } from '../components/Skeleton';
 import EmptyState from '../components/EmptyState';
-import SkillRadarChart from '../components/SkillRadarChart';
-import PracticeCalendar from '../components/PracticeCalendar';
-import ScoreRankBadge from '../components/ScoreRankBadge';
-import ScoreStatsSummary from '../components/ScoreStatsSummary';
-import SkillMilestoneCard from '../components/SkillMilestoneCard';
-import ScoreComparisonCard from '../components/ScoreComparisonCard';
-import ScoreImprovementAdvice from '../components/ScoreImprovementAdvice';
-import SkillSummaryCard from '../components/SkillSummaryCard';
-import CommunicationStyleCard from '../components/CommunicationStyleCard';
-import ScoreGoalCard from '../components/ScoreGoalCard';
-import ScoreDistributionCard from '../components/ScoreDistributionCard';
-import SessionTimeCard from '../components/SessionTimeCard';
-import SkillGapAnalysisCard from '../components/SkillGapAnalysisCard';
-import WeeklyComparisonCard from '../components/WeeklyComparisonCard';
-import SkillTrendChart from '../components/SkillTrendChart';
-import SkillRadarOverlayCard from '../components/SkillRadarOverlayCard';
-import SessionDetailModal from '../components/SessionDetailModal';
-import ScoreHistorySessionCard from '../components/ScoreHistorySessionCard';
-import ScoreFilterSummary from '../components/ScoreFilterSummary';
-import ScoreTrendIndicator from '../components/ScoreTrendIndicator';
-import SessionFeedbackSummary from '../components/SessionFeedbackSummary';
-import WeakAxisAdviceCard from '../components/WeakAxisAdviceCard';
-import PersonalBestCard from '../components/PersonalBestCard';
-import FilterTabs from '../components/FilterTabs';
-import { useScoreHistory, FILTERS } from '../hooks/useScoreHistory';
+import ScoreOverviewSection from '../components/ScoreOverviewSection';
+import SessionListSection from '../components/SessionListSection';
+import { useScoreHistory } from '../hooks/useScoreHistory';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 export default function ScoreHistoryPage() {
@@ -61,142 +39,22 @@ export default function ScoreHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
-      {/* コミュニケーションスタイル */}
-      <CommunicationStyleCard sessions={history} />
-
-      {/* 目標スコア */}
-      <ScoreGoalCard
+      <ScoreOverviewSection
+        history={history}
+        latestSession={latestSession!}
         averageScore={averageScore}
+        weakestAxis={weakestAxis}
+        scoreGoal={scoreGoal}
       />
 
-      {/* スキルギャップ分析 */}
-      {latestSession && latestSession.scores.length > 0 && (
-        <SkillGapAnalysisCard
-          scores={latestSession.scores}
-          goal={scoreGoal}
-        />
-      )}
-
-      {/* 統計サマリー */}
-      <ScoreStatsSummary history={history} />
-
-      {/* 自己ベスト */}
-      <PersonalBestCard history={history} />
-
-      {/* 週間比較 */}
-      <WeeklyComparisonCard sessions={history} />
-
-      {/* 最新スコアとランクバッジ */}
-      {latestSession && (
-        <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex items-center justify-between">
-          <div>
-            <p className="text-xs text-[var(--color-text-muted)] mb-1">最新スコア</p>
-            <p className="text-2xl font-bold text-[var(--color-text-primary)]">{latestSession.overallScore.toFixed(1)}</p>
-          </div>
-          <ScoreRankBadge score={latestSession.overallScore} />
-        </div>
-      )}
-
-      {/* セッションフィードバックサマリー */}
-      {latestSession && latestSession.scores.length > 0 && (
-        <SessionFeedbackSummary scores={latestSession.scores} overallScore={latestSession.overallScore} />
-      )}
-
-      {/* 弱点ベースのおすすめ練習 */}
-      {weakestAxis && <WeakAxisAdviceCard axis={weakestAxis.axis} />}
-
-      {/* スキルレーダーチャート */}
-      {latestSession && latestSession.scores.length > 0 && (
-        <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex justify-center">
-          <SkillRadarChart scores={latestSession.scores} title="最新のスキルバランス" />
-        </div>
-      )}
-
-      {/* スキル変化レーダー（前回vs今回） */}
-      {history.length >= 2 && latestSession && (
-        <SkillRadarOverlayCard
-          previousScores={history[history.length - 2].scores}
-          currentScores={latestSession.scores}
-        />
-      )}
-
-      {/* 初回vs最新スコア比較 */}
-      {history.length >= 2 && latestSession && history[0].scores.length > 0 && (
-        <ScoreComparisonCard
-          firstScores={history[0].scores}
-          latestScores={latestSession.scores}
-          firstOverall={history[0].overallScore}
-          latestOverall={latestSession.overallScore}
-        />
-      )}
-
-      {/* スキル強弱サマリー */}
-      {latestSession && latestSession.scores.length > 0 && (
-        <SkillSummaryCard scores={latestSession.scores} />
-      )}
-
-      {/* 改善アドバイス */}
-      {latestSession && latestSession.scores.length > 0 && (
-        <ScoreImprovementAdvice scores={latestSession.scores} />
-      )}
-
-      {/* スコア分布 */}
-      <ScoreDistributionCard scores={history.map(h => h.overallScore)} />
-
-      {/* スコア推移グラフ */}
-      <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
-        <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-3">スコア推移</p>
-        <div className="flex items-end gap-1 h-16">
-          {history.map((item) => (
-            <div
-              key={item.sessionId}
-              data-testid="trend-bar"
-              className="flex-1 bg-primary-500 rounded-t"
-              style={{ height: `${item.overallScore * 10}%` }}
-              title={`${item.sessionTitle}: ${item.overallScore}`}
-            />
-          ))}
-        </div>
-      </div>
-
-      {/* スキル別マイルストーン */}
-      {latestSession && latestSession.scores.length > 0 && (
-        <SkillMilestoneCard scores={latestSession.scores} />
-      )}
-
-      {/* スキル別推移 */}
-      <SkillTrendChart history={history} />
-
-      {/* セッション時間帯 */}
-      <SessionTimeCard dates={history.map(h => h.createdAt)} />
-
-      {/* 練習カレンダー */}
-      <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />
-
-      {/* フィルタタブ */}
-      <FilterTabs tabs={[...FILTERS]} selected={filter} onSelect={setFilter} />
-
-      {/* フィルタサマリー */}
-      <ScoreFilterSummary scores={filteredHistoryWithDelta.map(h => h.overallScore)} />
-
-      {/* トレンドインジケーター */}
-      <ScoreTrendIndicator scores={filteredHistoryWithDelta.map(h => h.overallScore)} />
-
-      {filteredHistoryWithDelta.map((item) => (
-        <ScoreHistorySessionCard
-          key={item.sessionId}
-          item={item}
-          delta={item.delta}
-          onClick={() => setSelectedSession(item)}
-        />
-      ))}
-
-      {selectedSession && (
-        <SessionDetailModal
-          session={selectedSession}
-          onClose={() => setSelectedSession(null)}
-        />
-      )}
+      <SessionListSection
+        history={history}
+        filteredHistoryWithDelta={filteredHistoryWithDelta}
+        filter={filter}
+        setFilter={setFilter}
+        selectedSession={selectedSession}
+        setSelectedSession={setSelectedSession}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
ScoreHistoryPageの可読性と保守性を向上させるリファクタリング。

### ScoreHistoryPage分割 (#952)
- 202行 → 60行に削減（70%減）
- `ScoreOverviewSection`: スコア概要・統計・スキル分析を担当
- `SessionListSection`: セッション一覧・フィルタ・推移グラフを担当
- 各セクションに個別テストを追加

### 定数重複解消 (#953)
- `WeakAxisAdviceCard` の `AXIS_ADVICE` 定数マップを削除
- 全エントリが同一パターンのため、テンプレートリテラルに簡素化

## テスト
- 新規テスト: 4件（セクションコンポーネント）
- 全1840テスト パス

Closes #952, Closes #953