### PR TITLE
feat: チャットアクセシビリティ改善 - フォーカス復帰・aria属性追加

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -42,6 +42,8 @@ export default function MessageBubble({
     ? 'self-end bg-surface-3 text-[var(--color-text-muted)] italic rounded-br-sm'
     : 'self-start bg-surface-3 text-[var(--color-text-muted)] italic rounded-bl-sm';
 
+  const ariaLabel = isSender ? '自分のメッセージ' : senderName ? `${senderName}のメッセージ` : 'メッセージ';
+
   return (
     <div
       className={`flex ${
@@ -50,7 +52,7 @@ export default function MessageBubble({
       onMouseEnter={() => isSender && !isDeleted && setShowDelete(true)}
       onMouseLeave={() => setShowDelete(false)}
     >
-      <div className="flex flex-col w-full">
+      <div className="flex flex-col w-full" role="article" aria-label={ariaLabel}>
         {!isSender && senderName && (
           <span className="text-xs text-[var(--color-text-muted)] mb-1 ml-1">{senderName}</span>
         )}
@@ -77,6 +79,7 @@ export default function MessageBubble({
               onClick={() => onDelete(id)}
               className="absolute -top-2 -right-2 bg-red-500 hover:bg-red-600 text-white rounded-full p-1 transition-colors duration-150"
               title="削除"
+              aria-label="メッセージを削除"
             >
               <TrashIcon className="w-3 h-3" />
             </button>
@@ -95,7 +98,7 @@ export default function MessageBubble({
                 onClick={() => onCopy(id, content)}
                 title={isCopied ? 'コピー済み' : 'コピー'}
                 aria-label={isCopied ? 'コピー済み' : 'メッセージをコピー'}
-                className="text-[var(--color-text-faint)] hover:text-[var(--color-text-secondary)] transition-colors opacity-0 group-hover:opacity-100"
+                className="text-[var(--color-text-faint)] hover:text-[var(--color-text-secondary)] transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
               >
                 {isCopied ? (
                   <ClipboardDocumentCheckIcon className="w-3.5 h-3.5 text-green-500" />
@@ -107,7 +110,8 @@ export default function MessageBubble({
             {isSender && onRephrase && (
               <button
                 onClick={() => onRephrase(content)}
-                className="text-[10px] text-primary-500 hover:text-primary-300 transition-colors opacity-0 group-hover:opacity-100"
+                className="text-[10px] text-primary-500 hover:text-primary-300 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+                aria-label="メッセージを言い換え"
               >
                 言い換え
               </button>

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -13,6 +13,14 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
   const minRows = 1;
   const maxRows = 8;
 
+  const prevIsSendingRef = useRef(isSending);
+  useEffect(() => {
+    if (prevIsSendingRef.current && !isSending) {
+      textareaRef.current?.focus();
+    }
+    prevIsSendingRef.current = isSending;
+  }, [isSending]);
+
   useEffect(() => {
     const textarea = textareaRef.current;
     if (textarea) {

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -102,4 +102,33 @@ describe('MessageBubble', () => {
 
     expect(screen.getByText('10:30')).toBeInTheDocument();
   });
+
+  it('メッセージにarticleロールとaria-labelがある', () => {
+    render(<MessageBubble isSender={false} content="こんにちは" id={1} senderName="田中太郎" />);
+
+    const article = screen.getByRole('article');
+    expect(article).toBeInTheDocument();
+    expect(article).toHaveAttribute('aria-label', '田中太郎のメッセージ');
+  });
+
+  it('送信者メッセージにaria-labelがある', () => {
+    render(<MessageBubble isSender={true} content="テスト" id={1} />);
+
+    expect(screen.getByRole('article')).toHaveAttribute('aria-label', '自分のメッセージ');
+  });
+
+  it('削除ボタンにaria-labelがある', () => {
+    const mockDelete = vi.fn();
+    render(<MessageBubble isSender={true} content="テスト" id={1} onDelete={mockDelete} />);
+
+    // ホバーで削除ボタン表示
+    fireEvent.mouseEnter(screen.getByRole('article').parentElement!);
+    expect(screen.getByLabelText('メッセージを削除')).toBeInTheDocument();
+  });
+
+  it('言い換えボタンにaria-labelがある', () => {
+    render(<MessageBubble isSender={true} content="テスト" id={1} onRephrase={vi.fn()} />);
+
+    expect(screen.getByLabelText('メッセージを言い換え')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/MessageInput.test.tsx
+++ b/frontend/src/components/__tests__/MessageInput.test.tsx
@@ -48,4 +48,12 @@ describe('MessageInput', () => {
 
     expect(screen.getByLabelText('送信')).toBeDisabled();
   });
+
+  it('送信完了後に入力欄にフォーカスが戻る', () => {
+    const { rerender } = render(<MessageInput onSend={mockOnSend} isSending={true} />);
+
+    rerender(<MessageInput onSend={mockOnSend} isSending={false} />);
+
+    expect(screen.getByPlaceholderText('メッセージを入力...')).toHaveFocus();
+  });
 });


### PR DESCRIPTION
## 概要
チャット機能のアクセシビリティとユーザビリティを改善

## 変更内容
- **MessageInput**: 送信完了後（`isSending`がtrue→false）にテキスト入力欄へ自動フォーカス復帰
- **MessageBubble**: `role="article"`と`aria-label`追加（送信者「自分のメッセージ」/受信者「{name}のメッセージ」）
- 削除ボタンに`aria-label="メッセージを削除"`追加
- 言い換えボタンに`aria-label="メッセージを言い換え"`追加
- コピー・言い換えボタンのキーボードフォーカス時にも表示（`focus:opacity-100`）

## テスト
- MessageInput: 7テスト（+1追加）
- MessageBubble: 19テスト（+4追加）
- 全1845テストパス

Closes #955, Closes #956