### PR TITLE
refactor: useAutoResizeTextareaフック抽出・RephraseModal ESCキー対応

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, KeyboardEvent } from 'react';
 import { PaperAirplaneIcon, PlusIcon } from '@heroicons/react/24/solid';
+import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 
 interface MessageInputProps {
   onSend: (text: string) => void;
@@ -9,9 +10,7 @@ interface MessageInputProps {
 export default function MessageInput({ onSend, isSending = false }: MessageInputProps) {
   const [text, setText] = useState('');
   const [isComposing, setIsComposing] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const minRows = 1;
-  const maxRows = 8;
+  const textareaRef = useAutoResizeTextarea({ text });
 
   const prevIsSendingRef = useRef(isSending);
   useEffect(() => {
@@ -19,34 +18,7 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
       textareaRef.current?.focus();
     }
     prevIsSendingRef.current = isSending;
-  }, [isSending]);
-
-  useEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea) {
-      textarea.style.height = 'auto';
-      const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight);
-      const paddingTop = parseFloat(getComputedStyle(textarea).paddingTop);
-      const paddingBottom = parseFloat(
-        getComputedStyle(textarea).paddingBottom
-      );
-
-      const maxHeight = maxRows * lineHeight + paddingTop + paddingBottom;
-      const newScrollHeight = textarea.scrollHeight;
-      const newHeight = Math.min(newScrollHeight, maxHeight);
-
-      if (newHeight > 0) {
-        textarea.style.height = `${newHeight}px`;
-      } else {
-        textarea.style.height = `${
-          minRows * lineHeight + paddingTop + paddingBottom
-        }px`;
-      }
-
-      textarea.style.overflowY =
-        newScrollHeight > maxHeight ? 'scroll' : 'hidden';
-    }
-  }, [text]);
+  }, [isSending, textareaRef]);
 
   const handleSend = () => {
     if (!text.trim() || isSending) return;
@@ -73,7 +45,7 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
       <div className="flex-1 min-w-0">
         <textarea
           ref={textareaRef}
-          rows={minRows}
+          rows={1}
           className="w-full bg-transparent text-[var(--color-text-primary)] outline-none resize-none px-3 py-2 placeholder-slate-400 leading-6"
           placeholder="メッセージを入力..."
           value={text}

--- a/frontend/src/components/RephraseModal.tsx
+++ b/frontend/src/components/RephraseModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
 import { StarIcon as StarOutlineIcon } from '@heroicons/react/24/outline';
 import { StarIcon as StarSolidIcon } from '@heroicons/react/24/solid';
@@ -29,6 +29,15 @@ export default function RephraseModal({ result, onClose, originalText = '' }: Re
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const { saveFavorite, isFavorite } = useFavoritePhrase();
   const [savedKeys, setSavedKeys] = useState<Set<string>>(new Set());
+
+  const handleEsc = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+  }, [onClose]);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [handleEsc]);
 
   const handleCopy = async (text: string, key: string) => {
     await navigator.clipboard.writeText(text);

--- a/frontend/src/components/__tests__/RephraseModal.test.tsx
+++ b/frontend/src/components/__tests__/RephraseModal.test.tsx
@@ -92,6 +92,13 @@ describe('RephraseModal', () => {
     expect(favButtons).toHaveLength(5);
   });
 
+  it('ESCキーでonCloseが呼ばれる', () => {
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
   it('コピーボタンクリックでフィードバックが表示される', async () => {
     // clipboard mockを設定
     Object.assign(navigator, {

--- a/frontend/src/hooks/__tests__/useAutoResizeTextarea.test.ts
+++ b/frontend/src/hooks/__tests__/useAutoResizeTextarea.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAutoResizeTextarea } from '../useAutoResizeTextarea';
+
+describe('useAutoResizeTextarea', () => {
+  let mockTextarea: HTMLTextAreaElement;
+
+  beforeEach(() => {
+    mockTextarea = document.createElement('textarea');
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      lineHeight: '24px',
+      paddingTop: '8px',
+      paddingBottom: '8px',
+    } as CSSStyleDeclaration);
+  });
+
+  it('refオブジェクトを返す', () => {
+    const { result } = renderHook(() => useAutoResizeTextarea({ text: '' }));
+
+    expect(result.current).toHaveProperty('current');
+  });
+
+  it('テキスト変更時にtextareaの高さが更新される', () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useAutoResizeTextarea({ text }),
+      { initialProps: { text: '' } }
+    );
+
+    // refにテキストエリアを設定
+    Object.defineProperty(result.current, 'current', {
+      value: mockTextarea,
+      writable: true,
+    });
+    Object.defineProperty(mockTextarea, 'scrollHeight', { value: 40, configurable: true });
+
+    rerender({ text: 'テスト' });
+
+    expect(mockTextarea.style.height).not.toBe('');
+  });
+
+  it('maxRowsを超えた場合overflowYがscrollになる', () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useAutoResizeTextarea({ text, maxRows: 2 }),
+      { initialProps: { text: '' } }
+    );
+
+    Object.defineProperty(result.current, 'current', {
+      value: mockTextarea,
+      writable: true,
+    });
+    // lineHeight=24, padding=16, maxHeight = 2*24+16 = 64
+    // scrollHeight > maxHeight → scroll
+    Object.defineProperty(mockTextarea, 'scrollHeight', { value: 100, configurable: true });
+
+    rerender({ text: '長いテキスト\n複数行' });
+
+    expect(mockTextarea.style.overflowY).toBe('scroll');
+  });
+
+  it('maxRows以内の場合overflowYがhiddenになる', () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useAutoResizeTextarea({ text, maxRows: 8 }),
+      { initialProps: { text: '' } }
+    );
+
+    Object.defineProperty(result.current, 'current', {
+      value: mockTextarea,
+      writable: true,
+    });
+    Object.defineProperty(mockTextarea, 'scrollHeight', { value: 40, configurable: true });
+
+    rerender({ text: 'テスト' });
+
+    expect(mockTextarea.style.overflowY).toBe('hidden');
+  });
+
+  it('デフォルトのminRowsは1、maxRowsは8', () => {
+    const { result, rerender } = renderHook(
+      ({ text }) => useAutoResizeTextarea({ text }),
+      { initialProps: { text: '' } }
+    );
+
+    Object.defineProperty(result.current, 'current', {
+      value: mockTextarea,
+      writable: true,
+    });
+    Object.defineProperty(mockTextarea, 'scrollHeight', { value: 40, configurable: true });
+
+    rerender({ text: 'テスト' });
+
+    // maxRows=8, lineHeight=24, padding=16 → maxHeight=208
+    // scrollHeight(40) < maxHeight(208) → height=40px
+    expect(mockTextarea.style.height).toBe('40px');
+  });
+});

--- a/frontend/src/hooks/useAutoResizeTextarea.ts
+++ b/frontend/src/hooks/useAutoResizeTextarea.ts
@@ -1,0 +1,35 @@
+import { useRef, useEffect } from 'react';
+
+interface UseAutoResizeTextareaOptions {
+  text: string;
+  minRows?: number;
+  maxRows?: number;
+}
+
+export function useAutoResizeTextarea({ text, minRows = 1, maxRows = 8 }: UseAutoResizeTextareaOptions) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = ref.current;
+    if (!textarea) return;
+
+    textarea.style.height = 'auto';
+    const lineHeight = parseFloat(getComputedStyle(textarea).lineHeight);
+    const paddingTop = parseFloat(getComputedStyle(textarea).paddingTop);
+    const paddingBottom = parseFloat(getComputedStyle(textarea).paddingBottom);
+
+    const maxHeight = maxRows * lineHeight + paddingTop + paddingBottom;
+    const newScrollHeight = textarea.scrollHeight;
+    const newHeight = Math.min(newScrollHeight, maxHeight);
+
+    if (newHeight > 0) {
+      textarea.style.height = `${newHeight}px`;
+    } else {
+      textarea.style.height = `${minRows * lineHeight + paddingTop + paddingBottom}px`;
+    }
+
+    textarea.style.overflowY = newScrollHeight > maxHeight ? 'scroll' : 'hidden';
+  }, [text, minRows, maxRows]);
+
+  return ref;
+}


### PR DESCRIPTION
## 概要
テキストエリア自動リサイズロジックのフック化とモーダルのESCキー操作統一

## 変更内容

### useAutoResizeTextareaフック抽出
- MessageInput内の25行の自動リサイズロジックを`useAutoResizeTextarea`カスタムフックに抽出
- minRows/maxRowsをパラメータ化し再利用可能に
- MessageInput: 102行 → 74行に削減
- フックテスト5件追加

### RephraseModal ESCキー対応
- ESCキーで閉じる処理を追加（ConfirmModalと動作統一）
- useEffect + useCallbackでイベントリスナー管理
- ESCキーテスト1件追加

## テスト
- 全1874テストパス

Closes #961, Closes #962