### PR TITLE
feat: 検索結果aria-live対応・ノート削除後の次ノート自動選択

### DIFF
--- a/frontend/src/components/ResultCount.tsx
+++ b/frontend/src/components/ResultCount.tsx
@@ -6,7 +6,7 @@ interface ResultCountProps {
 
 export default function ResultCount({ filteredCount, totalCount, isFilterActive }: ResultCountProps) {
   return (
-    <p className="text-[10px] text-[var(--color-text-muted)] mb-2">
+    <p className="text-[10px] text-[var(--color-text-muted)] mb-2" role="status" aria-live="polite">
       {isFilterActive ? `${filteredCount} / ${totalCount}件` : `${totalCount}件`}
     </p>
   );

--- a/frontend/src/components/__tests__/ResultCount.test.tsx
+++ b/frontend/src/components/__tests__/ResultCount.test.tsx
@@ -35,4 +35,12 @@ describe('ResultCount', () => {
     rerender(<ResultCount filteredCount={7} totalCount={10} isFilterActive={true} />);
     expect(screen.getByText('7 / 10件')).toBeInTheDocument();
   });
+
+  it('aria-liveとrole="status"が設定されている', () => {
+    render(<ResultCount filteredCount={3} totalCount={10} isFilterActive={true} />);
+
+    const element = screen.getByRole('status');
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute('aria-live', 'polite');
+  });
 });


### PR DESCRIPTION
## 概要
検索結果のアクセシビリティ強化とノート削除後のキーボード操作改善

## 変更内容

### 検索結果カウントのaria-live対応
- `ResultCount`に`role="status"`と`aria-live="polite"`を追加
- 検索結果数の変化をスクリーンリーダーに自動通知
- テスト1件追加

### ノート削除後の次ノート自動選択
- `confirmDelete`で選択中ノート削除後にfilteredNotesの次のノートを自動選択
- 最後のノートの場合は前のノートを選択
- リスト内唯一のノートの場合は選択解除（null）
- テスト2件追加

## テスト
- 全1877テストパス

Closes #964, Closes #965