### PR TITLE
refactor: 日付フォーマットをformatters.tsに統一

### DIFF
--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -2,6 +2,7 @@ import { TrashIcon } from '@heroicons/react/24/outline';
 import { MapPinIcon as MapPinOutline } from '@heroicons/react/24/outline';
 import { MapPinIcon as MapPinSolid } from '@heroicons/react/24/solid';
 import { tiptapToPlainText } from '../utils/tiptapToPlainText';
+import { formatMonthDay } from '../utils/formatters';
 
 interface NoteListItemProps {
   noteId: string;
@@ -28,8 +29,7 @@ export default function NoteListItem({
 }: NoteListItemProps) {
   const displayTitle = title || '無題';
   const preview = tiptapToPlainText(content).replace(/\n/g, ' ').slice(0, 60);
-  const date = new Date(updatedAt);
-  const dateStr = `${date.getMonth() + 1}/${date.getDate()}`;
+  const dateStr = formatMonthDay(updatedAt);
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/frontend/src/components/ScoreHistorySessionCard.tsx
+++ b/frontend/src/components/ScoreHistorySessionCard.tsx
@@ -1,6 +1,7 @@
 import type { ScoreHistoryItem } from '../types';
 import Card from './Card';
 import AxisScoreBar from './AxisScoreBar';
+import { formatLongDate } from '../utils/formatters';
 
 interface ScoreHistorySessionCardProps {
   item: ScoreHistoryItem;
@@ -20,11 +21,7 @@ export default function ScoreHistorySessionCard({ item, delta, onClick }: ScoreH
             {item.sessionTitle || `セッション #${item.sessionId}`}
           </h3>
           <p className="text-xs text-[var(--color-text-faint)] mt-0.5">
-            {new Date(item.createdAt).toLocaleDateString('ja-JP', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric',
-            })}
+            {formatLongDate(item.createdAt)}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/frontend/src/utils/__tests__/formatters.test.ts
+++ b/frontend/src/utils/__tests__/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { formatTime, formatDate, formatHourMinute, truncateMessage } from '../formatters';
+import { formatTime, formatDate, formatHourMinute, formatMonthDay, formatLongDate, truncateMessage } from '../formatters';
 
 describe('formatTime', () => {
   beforeEach(() => {
@@ -61,6 +61,37 @@ describe('formatHourMinute', () => {
   it('時刻をHH:mm形式で返す', () => {
     const result = formatHourMinute('2025-06-15T10:30:00');
     expect(result).toMatch(/10:30/);
+  });
+});
+
+describe('formatMonthDay', () => {
+  it('タイムスタンプからM/D形式を返す', () => {
+    // 2025-06-15 のタイムスタンプ
+    const timestamp = new Date('2025-06-15T10:00:00').getTime();
+    expect(formatMonthDay(timestamp)).toBe('6/15');
+  });
+
+  it('1月1日のタイムスタンプを正しくフォーマットする', () => {
+    const timestamp = new Date('2025-01-01T00:00:00').getTime();
+    expect(formatMonthDay(timestamp)).toBe('1/1');
+  });
+
+  it('12月31日のタイムスタンプを正しくフォーマットする', () => {
+    const timestamp = new Date('2025-12-31T23:59:59').getTime();
+    expect(formatMonthDay(timestamp)).toBe('12/31');
+  });
+});
+
+describe('formatLongDate', () => {
+  it('ISO日付文字列からY年M月D日形式を返す', () => {
+    const result = formatLongDate('2025-06-15T10:00:00');
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/6/);
+    expect(result).toMatch(/15/);
+  });
+
+  it('空文字の場合は空文字を返す', () => {
+    expect(formatLongDate('')).toBe('');
   });
 });
 

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -28,6 +28,20 @@ export function formatHourMinute(dateString?: string): string {
   return new Date(dateString).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
 }
 
+export function formatMonthDay(timestamp: number): string {
+  const date = new Date(timestamp);
+  return `${date.getMonth() + 1}/${date.getDate()}`;
+}
+
+export function formatLongDate(dateString: string): string {
+  if (!dateString) return '';
+  return new Date(dateString).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
 export function truncateMessage(message: string | undefined, maxLength = 30): string {
   if (!message) return 'メッセージはありません';
   if (message.length <= maxLength) return message;


### PR DESCRIPTION
## 概要
- NoteListItemのインライン日付計算を`formatMonthDay`ユーティリティに統一
- ScoreHistorySessionCardの`toLocaleDateString`を`formatLongDate`ユーティリティに統一
- `formatMonthDay`・`formatLongDate`のユニットテスト追加（5テスト）

## 変更ファイル
- `frontend/src/utils/formatters.ts` — formatMonthDay・formatLongDate追加
- `frontend/src/utils/__tests__/formatters.test.ts` — テスト追加
- `frontend/src/components/NoteListItem.tsx` — formatMonthDay使用
- `frontend/src/components/ScoreHistorySessionCard.tsx` — formatLongDate使用

## テスト
- 全1882テストパス

Closes #967, Closes #968