### PR TITLE
fix: TypeScript any型排除とReact.memo最適化

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { PencilSquareIcon, TrashIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { formatDate } from '../utils/formatters';
 
@@ -16,7 +17,7 @@ interface AiSessionListItemProps {
   onEditingTitleChange: (title: string) => void;
 }
 
-export default function AiSessionListItem({
+export default memo(function AiSessionListItem({
   id,
   title,
   createdAt,
@@ -96,4 +97,4 @@ export default function AiSessionListItem({
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon, TrashIcon } from '@heroicons/react/24/outline';
 import { formatHourMinute } from '../utils/formatters';
 
@@ -16,7 +16,7 @@ interface MessageBubbleProps {
   isDeleted?: boolean;
 }
 
-export default function MessageBubble({
+export default memo(function MessageBubble({
   isSender,
   type = 'text',
   content,
@@ -121,4 +121,4 @@ export default function MessageBubble({
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import { MapPinIcon as MapPinOutline } from '@heroicons/react/24/outline';
 import { MapPinIcon as MapPinSolid } from '@heroicons/react/24/solid';
@@ -16,7 +17,7 @@ interface NoteListItemProps {
   onTogglePin: (noteId: string) => void;
 }
 
-export default function NoteListItem({
+export default memo(function NoteListItem({
   noteId,
   title,
   content,
@@ -91,4 +92,4 @@ export default function NoteListItem({
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -62,7 +62,7 @@ export function useChat() {
     try {
       const data = await ChatRepository.fetchHistory(roomId!);
       if (!Array.isArray(data)) return;
-      const formatted = data.map((msg: any) => ({
+      const formatted = data.map((msg: ChatMessage) => ({
         id: msg.id,
         roomId: msg.roomId,
         senderId: msg.senderId,

--- a/frontend/src/hooks/usePractice.ts
+++ b/frontend/src/hooks/usePractice.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import PracticeRepository, {
   PracticeScenario,
+  PracticeSession,
   CreatePracticeSessionRequest,
 } from '../repositories/PracticeRepository';
 
@@ -69,7 +70,7 @@ export const usePractice = () => {
    * 練習セッションを作成
    */
   const createPracticeSession = useCallback(
-    async (request: CreatePracticeSessionRequest): Promise<any | null> => {
+    async (request: CreatePracticeSessionRequest): Promise<PracticeSession | null> => {
       setLoading(true);
       setError(null);
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import SockJS from 'sockjs-client';
-import { Client, IMessage } from '@stomp/stompjs';
+import { Client, IFrame, IMessage } from '@stomp/stompjs';
 
 /**
  * WebSocketフック
@@ -23,7 +23,7 @@ interface UseWebSocketOptions {
   userId: number | null;
   onConnect?: () => void;
   onDisconnect?: () => void;
-  onError?: (error: any) => void;
+  onError?: (error: IFrame) => void;
 }
 
 interface Subscription {
@@ -104,7 +104,7 @@ export const useWebSocket = ({ url, userId, onConnect, onDisconnect, onError }: 
   /**
    * メッセージ送信
    */
-  const publish = useCallback((destination: string, body: any) => {
+  const publish = useCallback((destination: string, body: Record<string, unknown>) => {
     if (clientRef.current?.connected) {
       clientRef.current.publish({
         destination,

--- a/frontend/src/repositories/PracticeRepository.ts
+++ b/frontend/src/repositories/PracticeRepository.ts
@@ -24,6 +24,12 @@ export interface PracticeScenario {
   systemPrompt: string;
 }
 
+export interface PracticeSession {
+  id: number;
+  title?: string;
+  scenarioId?: number;
+}
+
 export interface CreatePracticeSessionRequest {
   scenarioId: number;
 }
@@ -48,7 +54,7 @@ class PracticeRepository {
   /**
    * 練習セッションを作成
    */
-  async createPracticeSession(request: CreatePracticeSessionRequest): Promise<any> {
+  async createPracticeSession(request: CreatePracticeSessionRequest): Promise<PracticeSession> {
     const response = await apiClient.post('/api/practice/sessions', request);
     return response.data;
   }


### PR DESCRIPTION
## 概要
### TypeScript any型排除
- `useWebSocket.ts`: `onError`型を`IFrame`に、`publish`の`body`を`Record<string, unknown>`に変更
- `useChat.ts`: `msg: any`を`msg: ChatMessage`に変更
- `PracticeRepository.ts`: `PracticeSession`型を定義し`Promise<any>`を排除
- `usePractice.ts`: `Promise<any | null>`を`Promise<PracticeSession | null>`に変更

### React.memo最適化
- `NoteListItem`: リスト内で頻繁にレンダリングされる純粋コンポーネント
- `AiSessionListItem`: 同上
- `MessageBubble`: チャットリストで大量レンダリングされるコンポーネント

## テスト
- 全1892テストパス

Closes #973, Closes #974