### PR TITLE
fix: ノートエディタの3つの不具合修正

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -140,7 +140,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
   return (
     <div
       ref={containerRef}
-      className="block-editor flex-1 overflow-y-auto relative"
+      className="block-editor flex-1 overflow-y-auto relative pl-10"
       data-testid="block-editor"
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}

--- a/frontend/src/components/BlockInserterButton.tsx
+++ b/frontend/src/components/BlockInserterButton.tsx
@@ -64,7 +64,7 @@ export default function BlockInserterButton({ visible, top, onCommand, onMenuOpe
   return (
     <div
       data-block-inserter
-      className="absolute -left-8 z-10 transition-all duration-150"
+      className="absolute left-0 z-10 transition-all duration-150"
       style={{ top: `${top}px` }}
     >
       <div className="group relative">
@@ -80,7 +80,7 @@ export default function BlockInserterButton({ visible, top, onCommand, onMenuOpe
         </button>
         {!menuOpen && (
           <div className="absolute left-8 top-1/2 -translate-y-1/2 hidden group-hover:block z-30 pointer-events-none">
-            <div className="bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-lg shadow-lg px-3 py-2 whitespace-nowrap">
+            <div className="bg-[var(--color-surface-1)] border border-surface-3 rounded-lg shadow-lg px-3 py-2 whitespace-nowrap">
               <p className="text-xs font-medium text-[var(--color-text-primary)]">クリックして下に追加</p>
               <p className="text-[11px] text-[var(--color-text-muted)]">Opt+クリック/Alt+クリックで上に追加</p>
             </div>

--- a/frontend/src/components/CalloutNodeView.tsx
+++ b/frontend/src/components/CalloutNodeView.tsx
@@ -54,7 +54,7 @@ export default function CalloutNodeView({ node, updateAttributes }: CalloutNodeV
           {showMenu && (
             <div
               ref={menuRef}
-              className="absolute left-0 top-8 z-50 bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-lg shadow-lg p-1 min-w-[120px]"
+              className="absolute left-0 top-8 z-50 bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-lg shadow-lg p-1 min-w-[120px]"
             >
               {CALLOUT_TYPES.map((ct) => (
                 <button

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -99,9 +99,9 @@ export default function CommandPalette({ isOpen, onClose, onCreateNote }: Comman
         className="absolute inset-0 bg-black/50"
         onClick={() => { close(); onClose(); }}
       />
-      <div className="relative w-full max-w-lg bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-xl shadow-2xl overflow-hidden">
+      <div className="relative w-full max-w-lg bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-xl shadow-2xl overflow-hidden">
         {/* 検索入力 */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border)]">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-surface-3)]">
           <MagnifyingGlassIcon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
           <input
             ref={inputRef}
@@ -112,7 +112,7 @@ export default function CommandPalette({ isOpen, onClose, onCreateNote }: Comman
             onKeyDown={handleKeyDown}
             className="flex-1 bg-transparent text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none text-sm"
           />
-          <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono text-[var(--color-text-muted)] bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded">
+          <kbd className="hidden sm:inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono text-[var(--color-text-muted)] bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded">
             ESC
           </kbd>
         </div>
@@ -166,17 +166,17 @@ export default function CommandPalette({ isOpen, onClose, onCreateNote }: Comman
         </div>
 
         {/* フッター */}
-        <div className="flex items-center gap-4 px-4 py-2 border-t border-[var(--color-border)] text-[10px] text-[var(--color-text-muted)]">
+        <div className="flex items-center gap-4 px-4 py-2 border-t border-[var(--color-surface-3)] text-[10px] text-[var(--color-text-muted)]">
           <span className="flex items-center gap-1">
-            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded font-mono">↑↓</kbd>
+            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded font-mono">↑↓</kbd>
             移動
           </span>
           <span className="flex items-center gap-1">
-            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded font-mono">↵</kbd>
+            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded font-mono">↵</kbd>
             実行
           </span>
           <span className="flex items-center gap-1">
-            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded font-mono">esc</kbd>
+            <kbd className="px-1 py-0.5 bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded font-mono">esc</kbd>
             閉じる
           </span>
         </div>

--- a/frontend/src/components/EmojiPicker.tsx
+++ b/frontend/src/components/EmojiPicker.tsx
@@ -47,7 +47,7 @@ export default function EmojiPicker({ isOpen, onSelect, onClose }: EmojiPickerPr
   return (
     <div
       data-testid="emoji-picker"
-      className="w-72 bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-xl shadow-2xl overflow-hidden"
+      className="w-72 bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-xl shadow-2xl overflow-hidden"
     >
       {/* 検索 */}
       <div className="px-3 pt-3 pb-2">
@@ -58,7 +58,7 @@ export default function EmojiPicker({ isOpen, onSelect, onClose }: EmojiPickerPr
           value={search}
           onChange={e => setSearch(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="w-full px-3 py-1.5 text-xs bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+          className="w-full px-3 py-1.5 text-xs bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded-lg text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
         />
       </div>
 

--- a/frontend/src/components/LinkBubbleMenu.tsx
+++ b/frontend/src/components/LinkBubbleMenu.tsx
@@ -8,7 +8,7 @@ interface LinkBubbleMenuProps {
 
 export default function LinkBubbleMenu({ url, onEdit, onRemove }: LinkBubbleMenuProps) {
   return (
-    <div className="flex items-center gap-1 bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-lg shadow-lg px-2 py-1.5 text-sm">
+    <div className="flex items-center gap-1 bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-lg shadow-lg px-2 py-1.5 text-sm">
       <a
         href={url}
         target="_blank"

--- a/frontend/src/components/SearchReplaceBar.tsx
+++ b/frontend/src/components/SearchReplaceBar.tsx
@@ -98,7 +98,7 @@ export default function SearchReplaceBar({ editor, isOpen, onClose }: SearchRepl
 
   return (
     <div
-      className="absolute top-0 right-0 z-30 bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-bl-lg shadow-lg"
+      className="absolute top-0 right-0 z-30 bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-bl-lg shadow-lg"
       data-testid="search-replace-bar"
     >
       {/* 検索行 */}
@@ -120,7 +120,7 @@ export default function SearchReplaceBar({ editor, isOpen, onClose }: SearchRepl
             value={searchTerm}
             onChange={e => handleSearchChange(e.target.value)}
             onKeyDown={handleSearchKeyDown}
-            className="w-48 pl-7 pr-2 py-1 text-xs bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+            className="w-48 pl-7 pr-2 py-1 text-xs bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
           />
         </div>
         <span className="text-[10px] text-[var(--color-text-muted)] min-w-[3.5rem] text-center">
@@ -156,7 +156,7 @@ export default function SearchReplaceBar({ editor, isOpen, onClose }: SearchRepl
 
       {/* 置換行 */}
       {showReplace && (
-        <div className="flex items-center gap-1.5 px-3 py-2 border-t border-[var(--color-border)]">
+        <div className="flex items-center gap-1.5 px-3 py-2 border-t border-[var(--color-surface-3)]">
           <div className="w-5" /> {/* スペーサー（アイコン幅に合わせる） */}
           <input
             type="text"
@@ -164,7 +164,7 @@ export default function SearchReplaceBar({ editor, isOpen, onClose }: SearchRepl
             value={replaceTerm}
             onChange={e => handleReplaceChange(e.target.value)}
             onKeyDown={handleReplaceKeyDown}
-            className="w-48 px-2 py-1 text-xs bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
+            className="w-48 px-2 py-1 text-xs bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] rounded text-[var(--color-text-primary)] placeholder-[var(--color-text-muted)] outline-none focus:border-[var(--color-accent)]"
           />
           <button
             type="button"

--- a/frontend/src/components/SlashCommandMenu.tsx
+++ b/frontend/src/components/SlashCommandMenu.tsx
@@ -39,7 +39,7 @@ export default function SlashCommandMenu({ items, selectedIndex, onSelect }: Sla
       role="menu"
       aria-activedescendant={activeId}
       aria-label="スラッシュコマンド"
-      className="slash-command-menu bg-[var(--color-surface-1)] border border-[var(--color-border)] rounded-xl shadow-2xl overflow-y-auto max-h-80 min-w-[280px]"
+      className="slash-command-menu bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-xl shadow-2xl overflow-y-auto max-h-80 min-w-[280px]"
     >
       {[...categories.entries()].map(([category, { items: catItems, startIndex }]) => (
         <div key={category}>
@@ -64,7 +64,7 @@ export default function SlashCommandMenu({ items, selectedIndex, onSelect }: Sla
                 onClick={() => onSelect(globalIndex)}
                 type="button"
               >
-                <span className="w-7 h-7 flex items-center justify-center rounded bg-[var(--color-surface-2)] border border-[var(--color-border)] text-xs font-semibold shrink-0">
+                <span className="w-7 h-7 flex items-center justify-center rounded bg-[var(--color-surface-2)] border border-[var(--color-surface-3)] text-xs font-semibold shrink-0">
                   {item.icon}
                 </span>
                 <span className="flex-1 text-sm font-medium truncate">{item.label}</span>
@@ -78,9 +78,9 @@ export default function SlashCommandMenu({ items, selectedIndex, onSelect }: Sla
           })}
         </div>
       ))}
-      <div className="flex items-center justify-between px-3 py-2 border-t border-[var(--color-border)] mt-1">
+      <div className="flex items-center justify-between px-3 py-2 border-t border-[var(--color-surface-3)] mt-1">
         <span className="text-[11px] text-[var(--color-text-faint)]">メニューを閉じる</span>
-        <kbd className="text-[11px] text-[var(--color-text-faint)] bg-[var(--color-surface-2)] px-1.5 py-0.5 rounded border border-[var(--color-border)]">
+        <kbd className="text-[11px] text-[var(--color-text-faint)] bg-[var(--color-surface-2)] px-1.5 py-0.5 rounded border border-[var(--color-surface-3)]">
           esc
         </kbd>
       </div>

--- a/frontend/src/extensions/__tests__/FullWidthHeadingInputRule.test.ts
+++ b/frontend/src/extensions/__tests__/FullWidthHeadingInputRule.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * 全角＃見出し変換の正規表現テスト
+ *
+ * TipTapのInputRuleで使用する正規表現が
+ * 半角 # と全角 ＃ の両方にマッチすることを検証する。
+ */
+
+const HEADING_REGEX_1 = /^([#＃]{1})\s$/;
+const HEADING_REGEX_2 = /^([#＃]{1,2})\s$/;
+const HEADING_REGEX_3 = /^([#＃]{1,3})\s$/;
+
+describe('全角＃見出し変換の正規表現', () => {
+  it('半角 # + スペースでH1にマッチする', () => {
+    expect(HEADING_REGEX_1.test('# ')).toBe(true);
+  });
+
+  it('全角 ＃ + スペースでH1にマッチする', () => {
+    expect(HEADING_REGEX_1.test('＃ ')).toBe(true);
+  });
+
+  it('半角 ## + スペースでH2にマッチする', () => {
+    expect(HEADING_REGEX_2.test('## ')).toBe(true);
+  });
+
+  it('全角 ＃＃ + スペースでH2にマッチする', () => {
+    expect(HEADING_REGEX_2.test('＃＃ ')).toBe(true);
+  });
+
+  it('半角と全角混在 #＃ + スペースでH2にマッチする', () => {
+    expect(HEADING_REGEX_2.test('#＃ ')).toBe(true);
+  });
+
+  it('半角 ### + スペースでH3にマッチする', () => {
+    expect(HEADING_REGEX_3.test('### ')).toBe(true);
+  });
+
+  it('全角 ＃＃＃ + スペースでH3にマッチする', () => {
+    expect(HEADING_REGEX_3.test('＃＃＃ ')).toBe(true);
+  });
+
+  it('4つ以上のハッシュにはH3がマッチしない', () => {
+    expect(HEADING_REGEX_3.test('#### ')).toBe(false);
+    expect(HEADING_REGEX_3.test('＃＃＃＃ ')).toBe(false);
+  });
+});

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('@tiptap/starter-kit', () => ({ default: { configure: vi.fn(() => 'StarterKit') } }));
+vi.mock('@tiptap/extension-heading', () => ({
+  default: { configure: vi.fn(() => ({ extend: vi.fn(() => 'Heading') })) },
+}));
+vi.mock('@tiptap/core', () => ({
+  textblockTypeInputRule: vi.fn(),
+}));
 vi.mock('@tiptap/extension-placeholder', () => ({ default: { configure: vi.fn(() => 'Placeholder') } }));
 vi.mock('@tiptap/extension-image', () => ({ default: { configure: vi.fn(() => 'Image') } }));
 vi.mock('@tiptap/extension-task-list', () => ({ default: 'TaskList' }));
@@ -45,9 +51,9 @@ vi.mock('../../extensions/SearchReplaceExtension', () => ({
 import { createEditorExtensions } from '../editorExtensions';
 
 describe('createEditorExtensions', () => {
-  it('25個のエクステンションを返す', () => {
+  it('26個のエクステンションを返す', () => {
     const extensions = createEditorExtensions();
-    expect(extensions).toHaveLength(25);
+    expect(extensions).toHaveLength(26);
   });
 
   it('主要なエクステンションが含まれる', () => {

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -1,4 +1,6 @@
 import StarterKit from '@tiptap/starter-kit';
+import Heading from '@tiptap/extension-heading';
+import { textblockTypeInputRule } from '@tiptap/core';
 import Placeholder from '@tiptap/extension-placeholder';
 import Image from '@tiptap/extension-image';
 import TaskList from '@tiptap/extension-task-list';
@@ -27,8 +29,19 @@ import { SearchReplaceExtension } from '../extensions/SearchReplaceExtension';
 export function createEditorExtensions() {
   return [
     StarterKit.configure({
-      heading: { levels: [1, 2, 3] },
+      heading: false,
       codeBlock: false,
+    }),
+    Heading.configure({ levels: [1, 2, 3] }).extend({
+      addInputRules() {
+        return (this.options.levels as number[]).map((level) => {
+          return textblockTypeInputRule({
+            find: new RegExp(`^([#＃]{${Math.min(...(this.options.levels as number[]))},${level}})\\s$`),
+            type: this.type,
+            getAttributes: { level },
+          });
+        });
+      },
     }),
     CodeBlock.configure({
       lowlight: createLowlight(common),


### PR DESCRIPTION
## 概要

### 1. 全角＃で見出し変換対応
- TipTap HeadingのInputRuleを拡張し、全角`＃`（U+FF03）でも見出しに変換可能に
- `＃ ` → H1、`＃＃ ` → H2、`＃＃＃ ` → H3
- 半角`#`との混在も対応

### 2. +ブロック挿入ボタン修復
- CSS仕様により`overflow-y: auto`を設定すると`overflow-x`も`auto`になり、`-left-8`配置のボタンがクリップされていた
- コンテナに`pl-10`パディングを追加し、ボタンを`left-0`に配置変更
- 未定義CSS変数`--color-border`を全19箇所で`--color-surface-3`に修正

### 3. コードブロック削除問題修正
- `useBlockEditor`の`onUpdate`コールバックがstaleクロージャ（古いonChange参照）を使用していた問題をrefパターンで解決
- `lastEmittedJson`で自身が発行したコンテンツの同期ループを防止
- これにより編集中の不意な`setContent`呼び出しを排除

## テスト
- 全角＃正規表現テスト追加（8テスト）
- エクステンション数テスト更新（25→26）
- 全1900テストパス

Closes #976, Closes #977, Closes #978