### PR TITLE
feat: Notionライクデザイン調整（ライトテーマ・コードブロック行番号）

### DIFF
--- a/frontend/src/components/CodeBlockNodeView.tsx
+++ b/frontend/src/components/CodeBlockNodeView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { NodeViewWrapper, NodeViewContent } from '@tiptap/react';
 import { ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
 
@@ -36,6 +36,12 @@ export default function CodeBlockNodeView({ node, updateAttributes }: CodeBlockN
   const [copied, setCopied] = useState(false);
   const language = node.attrs.language || '';
 
+  const lineCount = useMemo(() => {
+    const text = node.textContent;
+    if (!text) return 1;
+    return text.split('\n').length;
+  }, [node.textContent]);
+
   const handleCopy = () => {
     navigator.clipboard.writeText(node.textContent);
     setCopied(true);
@@ -68,9 +74,16 @@ export default function CodeBlockNodeView({ node, updateAttributes }: CodeBlockN
           )}
         </button>
       </div>
-      <pre>
-        <NodeViewContent as="code" />
-      </pre>
+      <div className="code-block-body">
+        <div className="code-block-line-numbers" contentEditable={false} aria-hidden="true">
+          {Array.from({ length: lineCount }, (_, i) => (
+            <span key={i}>{i + 1}</span>
+          ))}
+        </div>
+        <pre>
+          <NodeViewContent as="code" />
+        </pre>
+      </div>
     </NodeViewWrapper>
   );
 }

--- a/frontend/src/components/__tests__/CodeBlockNodeView.test.tsx
+++ b/frontend/src/components/__tests__/CodeBlockNodeView.test.tsx
@@ -67,4 +67,30 @@ describe('CodeBlockNodeView', () => {
     render(<CodeBlockNodeView {...defaultProps} />);
     expect(screen.getByText('コピー')).toBeInTheDocument();
   });
+
+  it('行番号が表示される（1行のコード）', () => {
+    render(<CodeBlockNodeView {...defaultProps} />);
+    const lineNumbers = screen.getByText('1');
+    expect(lineNumbers).toBeInTheDocument();
+  });
+
+  it('複数行のコードで正しい行番号が表示される', () => {
+    const props = {
+      ...defaultProps,
+      node: { ...defaultProps.node, textContent: 'line1\nline2\nline3' },
+    };
+    render(<CodeBlockNodeView {...props} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('空のコードブロックでも行番号1が表示される', () => {
+    const props = {
+      ...defaultProps,
+      node: { ...defaultProps.node, textContent: '' },
+    };
+    render(<CodeBlockNodeView {...props} />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,20 +22,20 @@
 }
 
 .light {
-  --color-surface: #F7F6F3;
+  --color-surface: #FFFFFF;
   --color-surface-1: #FFFFFF;
-  --color-surface-2: #F1F0ED;
-  --color-surface-3: #E8E7E4;
-  --color-text-primary: #1A1A1A;
-  --color-text-secondary: #374151;
-  --color-text-tertiary: #6B7280;
-  --color-text-muted: #9CA3AF;
-  --color-text-faint: #D1D5DB;
-  --color-text-subtle: #E5E7EB;
-  --color-border-hover: #D1D5DB;
-  --scrollbar-track: #F1F5F9;
-  --scrollbar-thumb: #CBD5E1;
-  --scrollbar-thumb-hover: #94A3B8;
+  --color-surface-2: #F7F7F5;
+  --color-surface-3: #E8E8E6;
+  --color-text-primary: #191919;
+  --color-text-secondary: #37352F;
+  --color-text-tertiary: #787774;
+  --color-text-muted: #A4A4A0;
+  --color-text-faint: #D3D3D0;
+  --color-text-subtle: #E8E8E6;
+  --color-border-hover: #D3D3D0;
+  --scrollbar-track: #FFFFFF;
+  --scrollbar-thumb: #D3D3D0;
+  --scrollbar-thumb-hover: #A4A4A0;
 }
 
 @layer base {
@@ -180,10 +180,34 @@
   background: var(--color-surface-3);
   color: var(--color-text-secondary);
 }
+.code-block-body {
+  display: flex;
+  overflow-x: auto;
+}
+.code-block-line-numbers {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  padding: 0.75rem 0;
+  padding-left: 0.75rem;
+  padding-right: 0.5rem;
+  text-align: right;
+  user-select: none;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-text-muted);
+  border-right: 1px solid var(--color-surface-3);
+}
+.code-block-line-numbers span {
+  min-width: 1.5rem;
+}
 .code-block-wrapper pre {
   margin: 0;
   padding: 0.75rem 1rem;
   overflow-x: auto;
+  flex: 1;
+  min-width: 0;
   font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
   font-size: 0.8125rem;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- ライトテーマの配色をNotion風のクリーンな白/グレーに変更（クリーム色→ホワイトベース）
- コードブロックに行番号ガターを追加（Notionライクな表示）
- 行番号は`useMemo`でテキスト内容から動的に計算

## 対応Issue
- Close #980
- Close #981
- Close #982

## テスト
- [x] CodeBlockNodeViewテスト: 行番号表示（1行・複数行・空）の3テスト追加
- [x] 全1903テストパス