### PR TITLE
fix: Clipboard APIエラーハンドリング・アクセシビリティ・memo最適化

### DIFF
--- a/frontend/src/components/CodeBlockNodeView.tsx
+++ b/frontend/src/components/CodeBlockNodeView.tsx
@@ -42,10 +42,14 @@ export default function CodeBlockNodeView({ node, updateAttributes }: CodeBlockN
     return text.split('\n').length;
   }, [node.textContent]);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(node.textContent);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(node.textContent);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API非対応・権限なし時は無視
+    }
   };
 
   return (

--- a/frontend/src/components/ExportSessionButton.tsx
+++ b/frontend/src/components/ExportSessionButton.tsx
@@ -19,9 +19,13 @@ export default function ExportSessionButton({ messages }: ExportSessionButtonPro
       .map((msg) => `${msg.role === 'user' ? 'あなた' : 'AI'}: ${msg.content}`)
       .join('\n\n');
 
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API非対応・権限なし時は無視
+    }
   };
 
   return (

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -62,6 +62,13 @@ export default function MenuNavigationCard({ totalUnread, latestScore }: MenuNav
             role="button"
             tabIndex={0}
             onClick={() => navigate(item.to)}
+            onKeyDown={(e: React.KeyboardEvent) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                navigate(item.to);
+              }
+            }}
+            aria-label={item.label}
             className="w-full flex items-center gap-4 text-left hover:bg-surface-2 transition-colors cursor-pointer"
           >
             <item.icon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />

--- a/frontend/src/components/RoomListItem.tsx
+++ b/frontend/src/components/RoomListItem.tsx
@@ -1,10 +1,12 @@
+import { memo } from 'react';
+
 interface RoomListItemProps {
   name: string;
   lastMessage: string;
   unreadCount: number;
 }
 
-export default function RoomListItem({ name, lastMessage, unreadCount }: RoomListItemProps) {
+export default memo(function RoomListItem({ name, lastMessage, unreadCount }: RoomListItemProps) {
   return (
     <div className="p-4 rounded-xl hover:bg-surface-2 cursor-pointer flex justify-between items-center transition-colors duration-150 border border-surface-3">
       <div className="flex-1 min-w-0">
@@ -18,4 +20,4 @@ export default function RoomListItem({ name, lastMessage, unreadCount }: RoomLis
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/__tests__/ExportSessionButton.test.tsx
+++ b/frontend/src/components/__tests__/ExportSessionButton.test.tsx
@@ -97,4 +97,19 @@ describe('ExportSessionButton', () => {
     fireEvent.click(button);
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
   });
+
+  it('Clipboard APIがエラーを返してもクラッシュしない', async () => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockRejectedValue(new Error('Permission denied')),
+      },
+    });
+    render(<ExportSessionButton messages={mockMessages} />);
+    fireEvent.click(screen.getByTitle('会話をコピー'));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    });
+    expect(screen.getByTitle('会話をコピー')).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/MenuNavigationCard.test.tsx
+++ b/frontend/src/components/__tests__/MenuNavigationCard.test.tsx
@@ -65,4 +65,26 @@ describe('MenuNavigationCard', () => {
     const buttons = screen.getAllByRole('button');
     expect(buttons).toHaveLength(4);
   });
+
+  it('Enterキーで画面遷移する', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    const chatButton = screen.getByRole('button', { name: 'チャット' });
+    fireEvent.keyDown(chatButton, { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith('/chat');
+  });
+
+  it('Spaceキーで画面遷移する', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    const practiceButton = screen.getByRole('button', { name: '練習モード' });
+    fireEvent.keyDown(practiceButton, { key: ' ' });
+    expect(mockNavigate).toHaveBeenCalledWith('/practice');
+  });
+
+  it('aria-labelが各メニュー項目に設定されている', () => {
+    render(<MenuNavigationCard totalUnread={0} latestScore={null} />);
+    expect(screen.getByRole('button', { name: 'チャット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'AI アシスタント' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '練習モード' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'スコア履歴' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- ExportSessionButton/CodeBlockNodeViewのClipboard APIにtry-catch追加
- MenuNavigationCardにEnter/Spaceキーハンドラとaria-label追加
- RoomListItemにReact.memo適用

## 対応Issue
- Close #984
- Close #985
- Close #986

## テスト
- [x] ExportSessionButton: Clipboard失敗時のテスト追加
- [x] MenuNavigationCard: Enter/Spaceキー遷移テスト・aria-labelテスト追加
- [x] 全1907テストパス