### PR TITLE
refactor: UIタイミング定数集約・window.promptをインラインUIに置換

### DIFF
--- a/frontend/src/components/CodeBlockNodeView.tsx
+++ b/frontend/src/components/CodeBlockNodeView.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { NodeViewWrapper, NodeViewContent } from '@tiptap/react';
 import { ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { UI_TIMINGS } from '../constants/uiTimings';
 
 const LANGUAGES = [
   { value: '', label: 'プレーンテキスト' },
@@ -46,7 +47,7 @@ export default function CodeBlockNodeView({ node, updateAttributes }: CodeBlockN
     try {
       await navigator.clipboard.writeText(node.textContent);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopied(false), UI_TIMINGS.COPY_FEEDBACK_DURATION);
     } catch {
       // Clipboard API非対応・権限なし時は無視
     }

--- a/frontend/src/components/ExportSessionButton.tsx
+++ b/frontend/src/components/ExportSessionButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { CheckIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
+import { UI_TIMINGS } from '../constants/uiTimings';
 
 interface Message {
   id: number;
@@ -22,7 +23,7 @@ export default function ExportSessionButton({ messages }: ExportSessionButtonPro
     try {
       await navigator.clipboard.writeText(text);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopied(false), UI_TIMINGS.COPY_FEEDBACK_DURATION);
     } catch {
       // Clipboard API非対応・権限なし時は無視
     }

--- a/frontend/src/components/RephraseModal.tsx
+++ b/frontend/src/components/RephraseModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
 import { StarIcon as StarOutlineIcon } from '@heroicons/react/24/outline';
 import { StarIcon as StarSolidIcon } from '@heroicons/react/24/solid';
+import { UI_TIMINGS } from '../constants/uiTimings';
 
 interface RephraseResult {
   formal: string;
@@ -42,7 +43,7 @@ export default function RephraseModal({ result, onClose, originalText = '' }: Re
   const handleCopy = async (text: string, key: string) => {
     await navigator.clipboard.writeText(text);
     setCopiedKey(key);
-    setTimeout(() => setCopiedKey(null), 2000);
+    setTimeout(() => setCopiedKey(null), UI_TIMINGS.COPY_FEEDBACK_DURATION);
   };
 
   const handleFavorite = (text: string, label: string, key: string) => {

--- a/frontend/src/components/SessionNoteEditor.tsx
+++ b/frontend/src/components/SessionNoteEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useSessionNote } from '../hooks/useSessionNote';
+import { UI_TIMINGS } from '../constants/uiTimings';
 
 interface SessionNoteEditorProps {
   sessionId: number;
@@ -17,7 +18,7 @@ export default function SessionNoteEditor({ sessionId }: SessionNoteEditorProps)
   const handleSave = () => {
     saveNote(text);
     setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
+    setTimeout(() => setSaved(false), UI_TIMINGS.COPY_FEEDBACK_DURATION);
   };
 
   return (

--- a/frontend/src/constants/__tests__/uiTimings.test.ts
+++ b/frontend/src/constants/__tests__/uiTimings.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { UI_TIMINGS, UI_DIMENSIONS } from '../uiTimings';
+
+describe('UI_TIMINGS', () => {
+  it('コピーフィードバック時間が定義されている', () => {
+    expect(UI_TIMINGS.COPY_FEEDBACK_DURATION).toBe(2000);
+  });
+
+  it('ツールバー非表示遅延が定義されている', () => {
+    expect(UI_TIMINGS.TOOLBAR_HIDE_DELAY).toBe(150);
+  });
+
+  it('ブロック挿入ボタン非表示遅延が定義されている', () => {
+    expect(UI_TIMINGS.INSERTER_HIDE_DELAY).toBe(200);
+  });
+
+  it('マウス移動スロットルが定義されている', () => {
+    expect(UI_TIMINGS.MOUSE_MOVE_THROTTLE).toBe(50);
+  });
+});
+
+describe('UI_DIMENSIONS', () => {
+  it('選択ツールバーオフセットが定義されている', () => {
+    expect(UI_DIMENSIONS.SELECTION_TOOLBAR_OFFSET_TOP).toBe(48);
+  });
+});

--- a/frontend/src/constants/uiTimings.ts
+++ b/frontend/src/constants/uiTimings.ts
@@ -1,0 +1,17 @@
+/** UI共通のタイミング・ディメンション定数 */
+
+export const UI_TIMINGS = {
+  /** コピー完了フィードバックの表示時間 (ms) */
+  COPY_FEEDBACK_DURATION: 2000,
+  /** ツールバーのblur非表示遅延 (ms) */
+  TOOLBAR_HIDE_DELAY: 150,
+  /** ブロック挿入ボタンの非表示遅延 (ms) */
+  INSERTER_HIDE_DELAY: 200,
+  /** マウス移動のスロットル間隔 (ms) */
+  MOUSE_MOVE_THROTTLE: 50,
+} as const;
+
+export const UI_DIMENSIONS = {
+  /** 選択ツールバーの上オフセット (px) */
+  SELECTION_TOOLBAR_OFFSET_TOP: 48,
+} as const;

--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -70,12 +70,9 @@ function executeCommand(editor: Editor, command: SlashCommand) {
       break;
     }
     case 'youtube': {
-      const url = window.prompt('YouTubeのURLを入力してください');
-      if (url) {
-        const setYoutubeVideo = (editor.commands as { setYoutubeVideo?: (opts: { src: string }) => boolean }).setYoutubeVideo;
-        if (typeof setYoutubeVideo === 'function') {
-          setYoutubeVideo({ src: url });
-        }
+      const onYoutubeUrl = editor.storage.slashCommand?.onYoutubeUrl;
+      if (typeof onYoutubeUrl === 'function') {
+        onYoutubeUrl();
       }
       break;
     }
@@ -103,6 +100,7 @@ export const SlashCommandExtension = Extension.create({
     return {
       onImageUpload: null as (() => void) | null,
       onEmojiPicker: null as (() => void) | null,
+      onYoutubeUrl: null as (() => void) | null,
     };
   },
 


### PR DESCRIPTION
## Summary
- UIタイミング定数（COPY_FEEDBACK_DURATION等）をuiTimings.tsに集約し6コンポーネントに適用
- SelectionToolbarのリンク追加をwindow.promptからインラインURL入力に置換
- SlashCommandのYouTube URL入力をBlockEditor内インラインUIに置換

## 対応Issue
- Close #988
- Close #989

## テスト
- [x] uiTimings定数テスト5件追加
- [x] 全1912テストパス