### PR TITLE
feat: Empty State改善・モーダルアニメーション統一

### DIFF
--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -74,7 +74,7 @@ export default function ConfirmModal({
       />
 
       {/* モーダル */}
-      <div role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title" onKeyDown={handleKeyDown} className="relative bg-surface-1 rounded-2xl shadow-md p-6 mx-4 max-w-sm w-full animate-fade-in">
+      <div role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title" onKeyDown={handleKeyDown} className="relative bg-surface-1 rounded-2xl shadow-md p-6 mx-4 max-w-sm w-full animate-scale-in">
         {/* アイコン */}
         <div className="flex justify-center mb-4">
           <div

--- a/frontend/src/components/RephraseModal.tsx
+++ b/frontend/src/components/RephraseModal.tsx
@@ -54,8 +54,8 @@ export default function RephraseModal({ result, onClose, originalText = '' }: Re
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-surface-1 rounded-lg shadow-lg max-w-lg w-full mx-4 p-5">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-fade-in">
+      <div className="bg-surface-1 rounded-lg shadow-lg max-w-lg w-full mx-4 p-5 animate-scale-in">
         <h3 className="text-sm font-semibold text-[var(--color-text-primary)] mb-4">言い換え提案</h3>
 
         {result === null ? (

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -31,8 +31,12 @@ export default function ChatListPage() {
         {loading ? (
           <Loading className="py-8" />
         ) : chatUsers.length === 0 ? (
-          <div className="p-4 text-center text-sm text-[var(--color-text-muted)]">
-            チャット履歴がありません
+          <div className="py-12">
+            <EmptyState
+              icon={ChatBubbleLeftRightIcon}
+              title={searchQuery ? '該当するユーザーがいません' : 'チャット履歴がありません'}
+              description={searchQuery ? '検索条件を変更してみてください' : 'メンバーとのチャットを始めましょう'}
+            />
           </div>
         ) : (
           chatUsers.map((user) => (

--- a/frontend/src/pages/FavoritesPage.tsx
+++ b/frontend/src/pages/FavoritesPage.tsx
@@ -1,6 +1,7 @@
 import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
 import SearchBox from '../components/SearchBox';
 import FavoriteStatsCard from '../components/FavoriteStatsCard';
+import EmptyState from '../components/EmptyState';
 import { StarIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 const PATTERN_FILTERS = ['すべて', 'フォーマル', 'ソフト', '簡潔'] as const;
@@ -43,14 +44,17 @@ export default function FavoritesPage() {
       )}
 
       {phrases.length === 0 ? (
-        <div className="flex flex-col items-center justify-center h-64 text-[var(--color-text-muted)]">
-          <p className="text-sm font-medium">お気に入りフレーズがありません</p>
-          <p className="text-xs mt-1 flex items-center gap-1">言い換え提案で<StarIcon className="w-3 h-3 inline-block" />をタップするとここに保存されます</p>
-        </div>
+        <EmptyState
+          icon={StarIcon}
+          title="お気に入りフレーズがありません"
+          description="言い換え提案で★をタップするとここに保存されます"
+        />
       ) : filteredPhrases.length === 0 ? (
-        <div className="text-center py-8">
-          <p className="text-sm text-[var(--color-text-muted)]">該当するフレーズがありません</p>
-        </div>
+        <EmptyState
+          icon={StarIcon}
+          title="該当するフレーズがありません"
+          description="検索条件やフィルターを変更してみてください"
+        />
       ) : (
         <div className="space-y-2">
           {filteredPhrases.map((phrase) => (

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -99,8 +99,13 @@ export default function NotesPage() {
           {loading && notes.length === 0 ? (
             <Loading className="py-8" />
           ) : filteredNotes.length === 0 ? (
-            <div className="p-4 text-center text-xs text-[var(--color-text-muted)]">
-              ノートがありません
+            <div className="py-12">
+              <EmptyState
+                icon={DocumentTextIcon}
+                title={searchQuery ? '該当するノートがありません' : 'ノートがありません'}
+                description={searchQuery ? '検索条件を変更してみてください' : '新しいノートを作成しましょう'}
+                action={!searchQuery ? { label: '新しいノート', onClick: handleCreateNote } : undefined}
+              />
             </div>
           ) : (
             filteredNotes.map((note) => (

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -6,6 +6,8 @@ import SortSelector from '../components/SortSelector';
 import FilterResetButton from '../components/FilterResetButton';
 import ResultCount from '../components/ResultCount';
 import SearchBox from '../components/SearchBox';
+import EmptyState from '../components/EmptyState';
+import { AcademicCapIcon } from '@heroicons/react/24/outline';
 import { usePracticePage } from '../hooks/usePracticePage';
 import { PRACTICE_CATEGORY_TABS } from '../constants/scenarioLabels';
 
@@ -75,8 +77,13 @@ export default function PracticePage() {
           <SkeletonCard />
         </div>
       ) : filteredScenarios.length === 0 ? (
-        <div className="text-center py-12 text-xs text-[var(--color-text-muted)]">
-          シナリオがありません
+        <div className="py-12">
+          <EmptyState
+            icon={AcademicCapIcon}
+            title={isFilterActive ? '該当するシナリオがありません' : 'シナリオがありません'}
+            description={isFilterActive ? 'フィルター条件を変更してみてください' : 'シナリオが読み込まれていません'}
+            action={isFilterActive ? { label: 'フィルターをリセット', onClick: resetFilters } : undefined}
+          />
         </div>
       ) : (
         <div className="grid gap-3">

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -27,12 +27,17 @@ export default {
       },
       animation: {
         'fade-in': 'fadeIn 0.15s ease-in',
+        'scale-in': 'scaleIn 0.2s ease-out',
         'skeleton': 'skeleton 1.5s ease-in-out infinite',
       },
       keyframes: {
         fadeIn: {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },
+        },
+        scaleIn: {
+          '0%': { opacity: '0', transform: 'scale(0.95)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
         },
         skeleton: {
           '0%': { backgroundPosition: '200% 0' },


### PR DESCRIPTION
## Summary
- PracticePage/ChatListPage/NotesPage/FavoritesPageの空状態をEmptyStateコンポーネントに統一
- フィルター適用時と初期状態で異なるメッセージ・CTAを表示
- RephraseModal/ConfirmModalにscale-inアニメーション追加

## 対応Issue
- Close #991
- Close #992

## テスト
- [x] 全1912テストパス