### PR TITLE
refactor: ChatServiceのObject[]をDTO化して型安全性向上

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/dto/PartnerRoomProjection.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/PartnerRoomProjection.java
@@ -1,0 +1,9 @@
+package com.example.FreStyle.dto;
+
+/**
+ * 相手ユーザーIDとルームIDのペアを型安全に受け取るためのプロジェクション
+ */
+public interface PartnerRoomProjection {
+    Integer getUserId();
+    Integer getRoomId();
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/RoomMemberRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/RoomMemberRepository.java
@@ -1,5 +1,6 @@
 package com.example.FreStyle.repository;
 
+import com.example.FreStyle.dto.PartnerRoomProjection;
 import com.example.FreStyle.entity.RoomMember;
 import com.example.FreStyle.entity.User;
 
@@ -40,17 +41,16 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Integer>
 
     /**
      * 自分が参加しているルームで、相手ユーザーとルームIDのペアを取得
-     * 結果: [userId, roomId] のリスト
      */
     @Query("""
-            SELECT rm2.user.id, rm2.room.id
+            SELECT rm2.user.id AS userId, rm2.room.id AS roomId
             FROM RoomMember rm2
             WHERE rm2.room.id IN (
                 SELECT rm.room.id FROM RoomMember rm WHERE rm.user.id = :userId
             )
             AND rm2.user.id <> :userId
             """)
-    List<Object[]> findPartnerUserIdAndRoomIdByUserId(@Param("userId") Integer userId);
+    List<PartnerRoomProjection> findPartnerUserIdAndRoomIdByUserId(@Param("userId") Integer userId);
 
     /**
      * 指定ルームで自分以外のユーザーを取得

--- a/FreStyle/src/main/java/com/example/FreStyle/service/ChatService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ChatService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.FreStyle.dto.ChatUserDto;
+import com.example.FreStyle.dto.PartnerRoomProjection;
 import com.example.FreStyle.entity.ChatMessage;
 import com.example.FreStyle.entity.ChatRoom;
 import com.example.FreStyle.entity.RoomMember;
@@ -69,21 +70,21 @@ public class ChatService {
         System.out.println("🔍 findChatUsers 開始 - myUserId: " + myUserId + ", query: " + query);
         
         // 1. 自分が参加しているルームと相手ユーザーIDのペアを取得
-        List<Object[]> partnerData = roomMemberRepository.findPartnerUserIdAndRoomIdByUserId(myUserId);
+        List<PartnerRoomProjection> partnerData = roomMemberRepository.findPartnerUserIdAndRoomIdByUserId(myUserId);
         System.out.println("📊 取得したルーム数: " + partnerData.size());
-        
+
         if (partnerData.isEmpty()) {
             return new ArrayList<>();
         }
-        
+
         // 2. 相手ユーザーIDとルームIDのマップを作成
         Map<Integer, Integer> userIdToRoomId = new HashMap<>();
         List<Integer> roomIds = new ArrayList<>();
         List<Integer> partnerUserIds = new ArrayList<>();
-        
-        for (Object[] row : partnerData) {
-            Integer partnerId = (Integer) row[0];
-            Integer roomId = (Integer) row[1];
+
+        for (PartnerRoomProjection row : partnerData) {
+            Integer partnerId = row.getUserId();
+            Integer roomId = row.getRoomId();
             userIdToRoomId.put(partnerId, roomId);
             roomIds.add(roomId);
             partnerUserIds.add(partnerId);

--- a/FreStyle/src/test/java/com/example/FreStyle/service/ChatServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ChatServiceTest.java
@@ -1,6 +1,7 @@
 package com.example.FreStyle.service;
 
 import com.example.FreStyle.dto.ChatUserDto;
+import com.example.FreStyle.dto.PartnerRoomProjection;
 import com.example.FreStyle.entity.ChatMessage;
 import com.example.FreStyle.entity.ChatRoom;
 import com.example.FreStyle.entity.User;
@@ -73,13 +74,20 @@ class ChatServiceTest {
         latestMessage.setCreatedAt(new Timestamp(System.currentTimeMillis()));
     }
 
+    private PartnerRoomProjection createProjection(Integer userId, Integer roomId) {
+        PartnerRoomProjection projection = mock(PartnerRoomProjection.class);
+        when(projection.getUserId()).thenReturn(userId);
+        when(projection.getRoomId()).thenReturn(roomId);
+        return projection;
+    }
+
     @Test
     @DisplayName("findChatUsers: 未読数が正しくDTOに設定される")
     void findChatUsers_setsCorrectUnreadCount() {
         // Arrange
         // partnerId=2, roomId=10 のペアを返す
-        List<Object[]> partnerDataList = new ArrayList<>();
-        partnerDataList.add(new Object[]{2, 10});
+        List<PartnerRoomProjection> partnerDataList = new ArrayList<>();
+        partnerDataList.add(createProjection(2, 10));
         when(roomMemberRepository.findPartnerUserIdAndRoomIdByUserId(1))
                 .thenReturn(partnerDataList);
         when(userRepository.findAllById(List.of(2)))
@@ -106,8 +114,8 @@ class ChatServiceTest {
     @DisplayName("findChatUsers: 未読レコードなしのルームはカウント0")
     void findChatUsers_noUnreadRecord_defaultsToZero() {
         // Arrange
-        List<Object[]> partnerDataList = new ArrayList<>();
-        partnerDataList.add(new Object[]{2, 10});
+        List<PartnerRoomProjection> partnerDataList = new ArrayList<>();
+        partnerDataList.add(createProjection(2, 10));
         when(roomMemberRepository.findPartnerUserIdAndRoomIdByUserId(1))
                 .thenReturn(partnerDataList);
         when(userRepository.findAllById(List.of(2)))


### PR DESCRIPTION
## 概要
- `RoomMemberRepository.findPartnerUserIdAndRoomIdByUserId` の戻り値を `List<Object[]>` から `List<PartnerRoomProjection>` に変更
- `ChatService.findChatUsers` での `(Integer) row[0]` のようなキャストを `row.getUserId()` に置換
- テストも `PartnerRoomProjection` のモックを使用するように更新

## 変更内容
- `PartnerRoomProjection` インターフェース新規作成（Spring Data JPAインターフェースプロジェクション）
- `RoomMemberRepository` のJPQLにエイリアス追加 (`AS userId`, `AS roomId`)
- `ChatService` の `Object[]` ループを型安全なプロジェクションに置換
- `ChatServiceTest` のモックデータを `Object[]` から `PartnerRoomProjection` モックに変更

## テスト
- [x] `./gradlew test` — 292テスト中291パス（1件はDB接続の既存問題）
- [x] `ChatServiceTest` — 全件パス

closes #996