### PR TITLE
refactor: System.out.println/e.printStackTrace()をSLF4Jロガーに統一

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -111,9 +111,7 @@ public class CognitoAuthController {
             return ResponseEntity.badRequest().body(Map.of("error", "パスワードポリシーに違反しています。"));
 
         } catch (RuntimeException e) {
-            log.info("❌ エラー: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
-            log.info("========== /signup 処理完了(INTERNAL_SERVER_ERROR) ==========\n");
+            log.error("/signup エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
@@ -158,9 +156,7 @@ public class CognitoAuthController {
                     .body(Map.of("error", "ユーザーが存在しません。"));
 
         } catch (RuntimeException e) {
-            log.info("❌ エラー: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
-            log.info("========== /confirm 処理完了(INTERNAL_SERVER_ERROR) ==========\n");
+            log.error("/confirm エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
@@ -226,9 +222,7 @@ public class CognitoAuthController {
             return ResponseEntity.ok(Map.of("succes", "ログインできました。"));
 
         } catch (RuntimeException e) {
-            log.info("❌ エラー: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
-            log.info("========== /login 処理完了(BAD_REQUEST) ==========\n");
+            log.error("/login エラー: {}", e.getMessage(), e);
             return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
         }
     }
@@ -264,7 +258,7 @@ public class CognitoAuthController {
                 .block();
 
         if (tokenResponse == null) {
-            System.err.println("[CognitoAuthController /callback] ERROR: tokenResponse is null");
+            log.error("/callback トークンレスポンスがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "トークン取得に失敗しました。"));
         }
@@ -281,7 +275,7 @@ public class CognitoAuthController {
 
         Optional<JWTClaimsSet> claimsOpt = JwtUtils.decode(idToken);
         if (claimsOpt.isEmpty()) {
-            System.err.println("[CognitoAuthController /callback] ERROR: Failed to decode idToken");
+            log.error("/callback IDトークンのデコード失敗");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "無効なリクエストです。"));
         }
@@ -310,8 +304,7 @@ public class CognitoAuthController {
             return ResponseEntity.ok(Map .of("success","ログインできました"));
 
         } catch (Exception e) {
-            log.info("[CognitoAuthController /callback] ERROR: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
+            log.error("/callback エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", "server error: " + e.getMessage()));
         }
@@ -376,9 +369,7 @@ public class CognitoAuthController {
                     .body(Map.of("error", "ユーザーが存在しません。"));
 
         } catch (RuntimeException e) {
-            log.info("❌ エラー: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
-            log.info("========== /forgot-password 処理完了(INTERNAL_SERVER_ERROR) ==========\n");
+            log.error("/forgot-password エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
         }
     }
@@ -414,14 +405,11 @@ public class CognitoAuthController {
                     tokens.get("accessToken")
             );
 
-            User user = accessTokenEntity.getUser();
-            
             setAuthCookies(response, tokens.get("accessToken"), refreshToken, email);
             return ResponseEntity.ok(Map.of("success","更新完了"));
 
         } catch (RuntimeException e) {
-            log.info("[CognitoAuthController /refresh-token] ERROR: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
+            log.error("/refresh-token エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", e.getMessage()));
         }
@@ -475,9 +463,7 @@ public class CognitoAuthController {
                     .body(Map.of("error", "パスワードポリシーに違反しています。"));
 
         } catch (RuntimeException e) {
-            log.info("❌ エラー: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
-            log.info("========== /confirm-forgot-password 処理完了(INTERNAL_SERVER_ERROR) ==========\n");
+            log.error("/confirm-forgot-password エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", e.getMessage()));
         }
@@ -517,8 +503,7 @@ public class CognitoAuthController {
             return ResponseEntity.ok(Map.of("id",id));
 
         } catch (RuntimeException e) {
-            log.info("[CognitoAuthController /me] ERROR: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
+            log.error("/me エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError()
                     .body(Map.of("error", e.getMessage()));
         }
@@ -558,7 +543,7 @@ public class CognitoAuthController {
             .sameSite("None") // 開発環境: Lax、本番環境: None
             .build();
 
-    System.out.println("[setAuthCookies] Setting cookies - ACCESS_TOKEN and REFRESH_TOKEN");
+    log.debug("Cookie設定: ACCESS_TOKEN, REFRESH_TOKEN, EMAIL");
     response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
     response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
     response.addHeader(HttpHeaders.SET_COOKIE, emailCookie.toString());

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/HelloController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/HelloController.java
@@ -3,18 +3,17 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import lombok.extern.slf4j.Slf4j;
+
 @RestController
 @RequestMapping("/api")
+@Slf4j
 public class HelloController {
-  
+
   @GetMapping("/hello")
   public String hello() {
-    System.out.println("========== Hello Endpoint Called ==========");
-    System.out.println("Hello health check endpoint called.");
-    System.out.println("This is a test endpoint to verify the backend is running.");
-
-
+    log.debug("Hello health check endpoint called");
     return "hello";
   }
-  
+
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/service/BedrockService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/BedrockService.java
@@ -119,8 +119,7 @@ public class BedrockService {
             return aiReply;
 
         } catch (Exception e) {
-            log.error("❌ Bedrock 呼び出しエラー: {}", e.getMessage());
-            e.printStackTrace();
+            log.error("Bedrock 呼び出しエラー: {}", e.getMessage(), e);
             throw new RuntimeException("AI応答の取得に失敗しました: " + e.getMessage(), e);
         }
     }
@@ -184,8 +183,7 @@ public class BedrockService {
             return aiReply;
 
         } catch (Exception e) {
-            log.error("❌ Bedrock 呼び出しエラー（履歴付き）: {}", e.getMessage());
-            e.printStackTrace();
+            log.error("Bedrock 呼び出しエラー（履歴付き）: {}", e.getMessage(), e);
             throw new RuntimeException("AI応答の取得に失敗しました: " + e.getMessage(), e);
         }
     }
@@ -290,8 +288,7 @@ public class BedrockService {
             return aiReply;
 
         } catch (Exception e) {
-            log.error("❌ Bedrock 呼び出しエラー（UserProfile付き）: {}", e.getMessage());
-            e.printStackTrace();
+            log.error("Bedrock 呼び出しエラー（UserProfile付き）: {}", e.getMessage(), e);
             throw new RuntimeException("AI応答の取得に失敗しました: " + e.getMessage(), e);
         }
     }
@@ -349,8 +346,7 @@ public class BedrockService {
             return aiReply;
 
         } catch (Exception e) {
-            log.error("❌ Bedrock 練習モードエラー: {}", e.getMessage());
-            e.printStackTrace();
+            log.error("Bedrock 練習モードエラー: {}", e.getMessage(), e);
             throw new RuntimeException("練習モードのAI応答取得に失敗しました: " + e.getMessage(), e);
         }
     }
@@ -410,8 +406,7 @@ public class BedrockService {
             return aiReply;
 
         } catch (Exception e) {
-            log.error("❌ Bedrock 言い換えエラー: {}", e.getMessage());
-            e.printStackTrace();
+            log.error("Bedrock 言い換えエラー: {}", e.getMessage(), e);
             throw new RuntimeException("言い換え提案の取得に失敗しました: " + e.getMessage(), e);
         }
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/service/ChatMessageService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ChatMessageService.java
@@ -13,8 +13,10 @@ import com.example.FreStyle.entity.User;
 import com.example.FreStyle.repository.ChatMessageRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ChatMessageService {
 
@@ -38,57 +40,19 @@ public class ChatMessageService {
      */
     @Transactional
     public ChatMessageDto addMessage(ChatRoom room, Integer senderId, String content) {
-        System.out.println("\n========== ChatMessageService.addMessage() 実行 ==========");
-        System.out.println("📝 パラメータ:");
-        System.out.println("   - room.id: " + room.getId());
-        System.out.println("   - senderId: " + senderId + " (タイプ: String)");
-        System.out.println("   - content: " + content);
-        
-        try {
-            // ユーザーを Cognito sub で検索
-            System.out.println("🔍 UserIdentityService.findUserBySub(\"" + senderId + "\") を実行中...");
-            System.out.println("   💡 注意: senderId がユーザーID (Integer) か、Cognito sub (String) かを確認");
-            // senderIdをInrtegerに変換してUserを取得する
-            User sender = userService.findUserById(senderId);
-            
-            System.out.println("✅ ユーザー取得成功");
-            System.out.println("   - sender.id: " + sender.getId());
-            System.out.println("   - sender.name: " + sender.getName());
-            System.out.println("   - sender.email: " + sender.getEmail());
-            
-            // メッセージオブジェクトを作成
-            ChatMessage message = new ChatMessage();
-            message.setRoom(room);
-            message.setSender(sender);
-            message.setContent(content);
-            
-            System.out.println("💾 ChatMessageRepository.save() を実行中...");
-            ChatMessage saved = chatMessageRepository.save(message);
-            
-            System.out.println("✅ メッセージ保存成功");
-            System.out.println("   - messageId: " + saved.getId());
-            System.out.println("   - roomId: " + saved.getRoom().getId());
-            System.out.println("   - senderId: " + saved.getSender().getId());
-            System.out.println("========== ChatMessageService.addMessage() 完了 ==========\n");
-            
-            return toDto(saved);
-            
-        } catch (RuntimeException e) {
-            System.out.println("❌ RuntimeException 発生");
-            System.out.println("   - エラーメッセージ: " + e.getMessage());
-            System.out.println("   - 原因: senderId=\"" + senderId + "\" が Cognito sub として見つかりません");
-            System.out.println("   - 推測: senderId がユーザーID (Integer) なのに、Cognito sub (UUID形式) を期待しています");
-            System.out.println("========== ChatMessageService.addMessage() 失敗 ==========\n");
-            e.printStackTrace();
-            throw e;
-        } catch (Exception e) {
-            System.out.println("❌ 予期しないエラー発生");
-            System.out.println("   - エラータイプ: " + e.getClass().getName());
-            System.out.println("   - エラーメッセージ: " + e.getMessage());
-            System.out.println("========== ChatMessageService.addMessage() 失敗 ==========\n");
-            e.printStackTrace();
-            throw e;
-        }
+        log.debug("addMessage - roomId: {}, senderId: {}", room.getId(), senderId);
+
+        User sender = userService.findUserById(senderId);
+
+        ChatMessage message = new ChatMessage();
+        message.setRoom(room);
+        message.setSender(sender);
+        message.setContent(content);
+
+        ChatMessage saved = chatMessageRepository.save(message);
+        log.debug("メッセージ保存成功 - messageId: {}", saved.getId());
+
+        return toDto(saved);
     }
 
     /**

--- a/FreStyle/src/main/java/com/example/FreStyle/service/ChatService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ChatService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.FreStyle.dto.ChatUserDto;
+import lombok.extern.slf4j.Slf4j;
 import com.example.FreStyle.dto.PartnerRoomProjection;
 import com.example.FreStyle.entity.ChatMessage;
 import com.example.FreStyle.entity.ChatRoom;
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 
 // ChatRoomServiceとRoomMemberServiceクラス二つとも関与しているときはこちらのクラスを使う
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ChatService {
     private final ChatRoomRepository chatRoomRepository;
@@ -67,11 +69,11 @@ public class ChatService {
      */
     @Transactional(readOnly = true)
     public List<ChatUserDto> findChatUsers(Integer myUserId, String query) {
-        System.out.println("🔍 findChatUsers 開始 - myUserId: " + myUserId + ", query: " + query);
-        
+        log.debug("findChatUsers 開始 - myUserId: {}, query: {}", myUserId, query);
+
         // 1. 自分が参加しているルームと相手ユーザーIDのペアを取得
         List<PartnerRoomProjection> partnerData = roomMemberRepository.findPartnerUserIdAndRoomIdByUserId(myUserId);
-        System.out.println("📊 取得したルーム数: " + partnerData.size());
+        log.debug("取得したルーム数: {}", partnerData.size());
 
         if (partnerData.isEmpty()) {
             return new ArrayList<>();
@@ -150,7 +152,7 @@ public class ChatService {
             return b.getLastMessageAt().compareTo(a.getLastMessageAt());
         });
         
-        System.out.println("✅ findChatUsers 完了 - 結果数: " + result.size());
+        log.debug("findChatUsers 完了 - 結果数: {}", result.size());
         return result;
     }
 }


### PR DESCRIPTION
## 概要
本番環境のログ品質向上のため、System.out.println / System.err.println / e.printStackTrace() を SLF4J（`@Slf4j`）ロガーに統一。

## 変更内容
- **ChatService**: `System.out.println` → `log.debug`（3箇所）
- **ChatMessageService**: 大量のデバッグログ（約30行）を削除し `log.debug` 2行に簡素化、try-catch削除
- **CognitoAuthService**: `System.out.println` → `log.debug/warn/error`（13箇所）、`@Slf4j` 追加
- **CognitoAuthController**: `System.err.println` → `log.error`（2箇所）、`e.printStackTrace()` → `log.error(..., e)`（8箇所）、未使用変数削除
- **HelloController**: `System.out.println` 3行 → `log.debug` 1行に簡素化、`@Slf4j` 追加
- **BedrockService**: `e.printStackTrace()` 削除、`log.error` にスタックトレース統合（5箇所）

## テスト
- [x] `./gradlew test` — 292テスト中291パス（1件はDB接続の既存問題）

closes #998