### PR TITLE
fix: LocalStorageリポジトリのJSON.parseにtry-catch追加

### DIFF
--- a/frontend/src/repositories/BookmarkRepository.ts
+++ b/frontend/src/repositories/BookmarkRepository.ts
@@ -4,7 +4,12 @@ export const BookmarkRepository = {
   getAll(): number[] {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
-    return JSON.parse(raw);
+    try {
+      return JSON.parse(raw);
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+      return [];
+    }
   },
 
   add(scenarioId: number): void {

--- a/frontend/src/repositories/DailyGoalRepository.ts
+++ b/frontend/src/repositories/DailyGoalRepository.ts
@@ -11,9 +11,13 @@ export const DailyGoalRepository = {
   getToday(): DailyGoal {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
-      const goal: DailyGoal = JSON.parse(raw);
-      if (goal.date === getTodayStr()) {
-        return goal;
+      try {
+        const goal: DailyGoal = JSON.parse(raw);
+        if (goal.date === getTodayStr()) {
+          return goal;
+        }
+      } catch {
+        localStorage.removeItem(STORAGE_KEY);
       }
     }
     return { date: getTodayStr(), target: DEFAULT_TARGET, completed: 0 };

--- a/frontend/src/repositories/FavoritePhraseRepository.ts
+++ b/frontend/src/repositories/FavoritePhraseRepository.ts
@@ -6,8 +6,13 @@ export const FavoritePhraseRepository = {
   getAll(): FavoritePhrase[] {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
-    const phrases: FavoritePhrase[] = JSON.parse(raw);
-    return phrases.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    try {
+      const phrases: FavoritePhrase[] = JSON.parse(raw);
+      return phrases.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+      return [];
+    }
   },
 
   save(phrase: Omit<FavoritePhrase, 'id' | 'createdAt'>): void {

--- a/frontend/src/repositories/SessionNoteRepository.ts
+++ b/frontend/src/repositories/SessionNoteRepository.ts
@@ -5,7 +5,12 @@ const STORAGE_KEY = 'freestyle_session_notes';
 function getAllNotes(): Record<string, SessionNote> {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return {};
-  return JSON.parse(raw);
+  try {
+    return JSON.parse(raw);
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return {};
+  }
 }
 
 export const SessionNoteRepository = {


### PR DESCRIPTION
## 概要
LocalStorageからの読み込み時にJSON.parseが保護されていない4ファイルにtry-catchを追加。
破損データや不正なJSONが保存されている場合のクラッシュを防止する。

## 変更内容
- **DailyGoalRepository**: パースエラー時にキー削除 + デフォルト目標値を返す
- **SessionNoteRepository**: パースエラー時にキー削除 + 空オブジェクトを返す
- **FavoritePhraseRepository**: パースエラー時にキー削除 + 空配列を返す
- **BookmarkRepository**: パースエラー時にキー削除 + 空配列を返す

## テスト
- [x] `npx vitest run` — 1920テスト全パス

closes #1000