### PR TITLE
refactor: Repository層のany/unknown型を具体的な型に置換

### DIFF
--- a/frontend/src/hooks/__tests__/useAiChat.test.ts
+++ b/frontend/src/hooks/__tests__/useAiChat.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useAiChat } from '../useAiChat';
 import AiChatRepository from '../../repositories/AiChatRepository';
+import type { ScoreHistoryItem } from '../../types';
 
 vi.mock('../../repositories/AiChatRepository');
 
@@ -124,12 +125,12 @@ describe('useAiChat', () => {
   });
 
   it('fetchScoreHistory: スコア履歴を取得する', async () => {
-    const mockHistory = [{ sessionId: 1, overallScore: 7.5 }];
-    mockedRepo.getScoreHistory.mockResolvedValue(mockHistory as any);
+    const mockHistory: ScoreHistoryItem[] = [{ sessionId: 1, sessionTitle: 'テスト', overallScore: 7.5, scores: [], createdAt: '2025-01-01' }];
+    mockedRepo.getScoreHistory.mockResolvedValue(mockHistory);
 
     const { result } = renderHook(() => useAiChat());
 
-    let history: any[];
+    let history: ScoreHistoryItem[];
     await act(async () => {
       history = await result.current.fetchScoreHistory();
     });

--- a/frontend/src/hooks/useAiChat.ts
+++ b/frontend/src/hooks/useAiChat.ts
@@ -5,7 +5,7 @@ import AiChatRepository, {
   AddMessageRequest,
   RephraseRequest,
 } from '../repositories/AiChatRepository';
-import { AiSession, AiMessage, ScoreCard } from '../types';
+import { AiSession, AiMessage, ScoreCard, ScoreHistoryItem } from '../types';
 
 /**
  * AI Chatフック
@@ -237,7 +237,7 @@ export const useAiChat = () => {
   /**
    * スコア履歴を取得
    */
-  const fetchScoreHistory = useCallback(async (): Promise<any[]> => {
+  const fetchScoreHistory = useCallback(async (): Promise<ScoreHistoryItem[]> => {
     setLoading(true);
     setError(null);
 

--- a/frontend/src/repositories/AiChatRepository.ts
+++ b/frontend/src/repositories/AiChatRepository.ts
@@ -1,5 +1,5 @@
 import apiClient from '../lib/axios';
-import { AiSession, AiMessage, ScoreCard } from '../types';
+import { AiSession, AiMessage, ScoreCard, ScoreHistoryItem } from '../types';
 
 /**
  * AI Chatリポジトリ
@@ -110,7 +110,7 @@ class AiChatRepository {
   /**
    * スコア履歴を取得
    */
-  async getScoreHistory(): Promise<any[]> {
+  async getScoreHistory(): Promise<ScoreHistoryItem[]> {
     const response = await apiClient.get('/api/scores/history');
     return response.data;
   }

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -76,7 +76,7 @@ class AuthRepository {
   /**
    * OAuthコールバック
    */
-  async callback(code: string): Promise<unknown> {
+  async callback(code: string): Promise<{ success: string }> {
     const response = await apiClient.post('/api/auth/cognito/callback', { code });
     return response.data;
   }

--- a/frontend/src/repositories/ChatRepository.ts
+++ b/frontend/src/repositories/ChatRepository.ts
@@ -1,5 +1,5 @@
 import apiClient from '../lib/axios';
-import { ChatUser } from '../types';
+import { ChatUser, ChatMessage } from '../types';
 
 /**
  * Chatリポジトリ
@@ -30,7 +30,7 @@ const ChatRepository = {
     await apiClient.post(`/api/chat/rooms/${roomId}/read`);
   },
 
-  async fetchHistory(roomId: string): Promise<unknown[]> {
+  async fetchHistory(roomId: string): Promise<ChatMessage[]> {
     const res = await apiClient.get(`/api/chat/users/${roomId}/history`);
     return res.data;
   },


### PR DESCRIPTION
## 概要
Repository層とhooksで使用されていた `any` / `unknown` 型を具体的なTypeScript型に置換し、型安全性を向上。

## 変更内容
- **AiChatRepository**: `getScoreHistory(): Promise<any[]>` → `Promise<ScoreHistoryItem[]>`
- **useAiChat**: `fetchScoreHistory(): Promise<any[]>` → `Promise<ScoreHistoryItem[]>`
- **ChatRepository**: `fetchHistory(): Promise<unknown[]>` → `Promise<ChatMessage[]>`
- **AuthRepository**: `callback(): Promise<unknown>` → `Promise<{ success: string }>`
- **useAiChat.test.ts**: `as any` キャストを排除、完全な型付きモックデータに変更

## テスト
- [x] `npx vitest run` — 1920テスト全パス

closes #1002