### PR TITLE
test: Protected コンポーネントのテスト追加

### DIFF
--- a/frontend/src/utils/__tests__/Protected.test.tsx
+++ b/frontend/src/utils/__tests__/Protected.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Protected from '../Protected';
+import authReducer from '../../store/authSlice';
+
+function renderWithAuth(isAuthenticated: boolean) {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: { isAuthenticated, loading: false },
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route
+            path="/protected"
+            element={
+              <Protected>
+                <div>保護されたコンテンツ</div>
+              </Protected>
+            }
+          />
+          <Route path="/login" element={<div>ログインページ</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('Protected', () => {
+  it('認証済みの場合、childrenを表示する', () => {
+    renderWithAuth(true);
+    expect(screen.getByText('保護されたコンテンツ')).toBeInTheDocument();
+  });
+
+  it('認証済みの場合、ログインページにリダイレクトしない', () => {
+    renderWithAuth(true);
+    expect(screen.queryByText('ログインページ')).not.toBeInTheDocument();
+  });
+
+  it('未認証の場合、/login にリダイレクトする', () => {
+    renderWithAuth(false);
+    expect(screen.getByText('ログインページ')).toBeInTheDocument();
+  });
+
+  it('未認証の場合、childrenを表示しない', () => {
+    renderWithAuth(false);
+    expect(screen.queryByText('保護されたコンテンツ')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- `Protected` コンポーネント（認証ガード）のユニットテストを追加

## テスト内容
- 認証済みの場合、children を正常にレンダリングすること
- 認証済みの場合、ログインページにリダイレクトしないこと
- 未認証の場合、`/login` にリダイレクトすること
- 未認証の場合、children を表示しないこと

## テスト結果
- 全1924テスト パス（新規4テスト追加）

Closes #1005