### PR TITLE
refactor: 残存するe.printStackTrace()をSLF4Jに置換

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
@@ -107,17 +107,10 @@ public class ChatController {
             "status", "success"
       ));
   } catch (IllegalStateException e) {
-    log.info("⚠️ IllegalStateException発生: " + e.getMessage());
-    log.info("   スタックトレース:");
-    e.printStackTrace();
-    log.info("========== ルーム作成リクエスト終了(BAD_REQUEST) ==========\n");
+    log.warn("ルーム作成エラー(不正リクエスト): {}", e.getMessage(), e);
     return ResponseEntity.badRequest().body(Map.of("error", "無効なリクエストです。"));
   } catch (Exception e) {
-    log.error("❌ 予期しない例外発生: " + e.getClass().getName());
-    log.info("   メッセージ: " + e.getMessage());
-    log.info("   スタックトレース:");
-    e.printStackTrace();
-    log.info("========== ルーム作成リクエスト終了(INTERNAL_SERVER_ERROR) ==========\n");
+    log.error("ルーム作成エラー: {}", e.getMessage(), e);
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
               .body(Map.of("error", "ルーム作成中にエラーが発生しました。"));
   } 
@@ -149,8 +142,7 @@ public class ChatController {
       return ResponseEntity.ok(history);
       
     } catch (Exception e) {
-      log.info("Error in history endpoint: " + e.getMessage());
-      e.printStackTrace();
+      log.error("履歴取得エラー: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "サーバーエラーです。"));
     }
   }
@@ -251,8 +243,7 @@ public class ChatController {
       return ResponseEntity.ok(response);
       
     } catch (Exception e) {
-      log.error("❌ エラー発生: " + e.getMessage());
-      e.printStackTrace();
+      log.error("チャットルーム取得エラー: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
           .body(Map.of("error", "サーバーエラーが発生しました。"));
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
@@ -79,8 +79,7 @@ public class ProfileController {
 
         } catch (Exception e) {
             // 想定外のエラー
-            log.info("[ProfileController /me] ERROR: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロフィール取得エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
@@ -145,8 +144,7 @@ public class ProfileController {
 
         } catch (Exception e) {
             // 想定外エラー
-            log.info("[ProfileController /me/update] ERROR: " + e.getClass().getSimpleName() + " - " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロフィール更新エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/UserProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/UserProfileController.java
@@ -67,8 +67,7 @@ public class UserProfileController {
             return ResponseEntity.ok(profileDto);
 
         } catch (Exception e) {
-            log.info("[UserProfileController /me] ERROR: " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロファイル取得エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
@@ -110,8 +109,7 @@ public class UserProfileController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
-            log.info("[UserProfileController POST /me] ERROR: " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロファイル作成エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
@@ -153,8 +151,7 @@ public class UserProfileController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
-            log.info("[UserProfileController PUT /me] ERROR: " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロファイル更新エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
@@ -196,8 +193,7 @@ public class UserProfileController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
-            log.info("[UserProfileController PUT /me/upsert] ERROR: " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロファイルupsertエラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
@@ -236,8 +232,7 @@ public class UserProfileController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
-            log.info("[UserProfileController DELETE /me] ERROR: " + e.getMessage());
-            e.printStackTrace();
+            log.error("プロファイル削除エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }


### PR DESCRIPTION
## 概要
- PR #999 で主要ファイルからe.printStackTrace()を除去した続き
- 残り3ファイル11箇所のe.printStackTrace()をSLF4Jログに置換

## 変更内容
### ChatController.java（4箇所）
- `e.printStackTrace()` + 冗長なログ行 → `log.warn()`/`log.error()` に統合

### UserProfileController.java（5箇所）
- `log.info("ERROR: ...")` + `e.printStackTrace()` → `log.error()` に統合

### ProfileController.java（2箇所）
- `log.info("ERROR: ...")` + `e.printStackTrace()` → `log.error()` に統合

## テスト結果
- バックエンド: 292テスト（1 fail = 既知のDB接続エラー）

Closes #1007