### PR TITLE
refactor: log.info(ERROR)をlog.warnに修正

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -387,7 +387,7 @@ public class CognitoAuthController {
                           (refreshToken != null ? refreshToken.substring(0, Math.min(20, refreshToken.length())) + "..." : "null"));
 
         if (refreshToken == null || refreshToken.isEmpty()) {
-            log.info("[CognitoAuthController /refresh-token] ERROR: REFRESH_TOKEN cookie is null or empty");
+            log.warn("認証エラー: リフレッシュトークンがnullまたは空");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "リフレッシュトークンが存在しません。"));
         }
@@ -479,7 +479,7 @@ public class CognitoAuthController {
         log.info("[CognitoAuthController /me] Endpoint called");
         
         if (jwt == null) {
-            log.info("[CognitoAuthController /me] ERROR: JWT is null - user not authenticated");
+            log.warn("認証エラー: JWTがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証されていません"));
         }
@@ -490,7 +490,7 @@ public class CognitoAuthController {
         log.info("[CognitoAuthController /me] JWT Subject (sub): " + sub);
 
         if (sub == null || sub.isEmpty()) {
-            log.info("[CognitoAuthController /me] ERROR: JWT subject is null or empty");
+            log.warn("認証エラー: JWTのsubがnullまたは空");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "無効なリクエストです。"));
         }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
@@ -40,7 +40,7 @@ public class ProfileController {
         log.info("[ProfileController /me] Endpoint called");
         
         if (jwt == null) {
-            log.info("[ProfileController /me] ERROR: JWT is null - user not authenticated");
+            log.warn("認証エラー: JWTがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
@@ -52,7 +52,7 @@ public class ProfileController {
 
         if (sub == null || sub.isEmpty()) {
             // JWT が無効 → 認証されていない
-            log.info("[ProfileController /me] ERROR: JWT subject is null or empty");
+            log.warn("認証エラー: JWTのsubがnullまたは空");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
@@ -63,7 +63,7 @@ public class ProfileController {
 
             if (user == null) {
                 // sub に紐づくユーザーが DB に存在しない
-                log.info("[ProfileController /me] ERROR: User not found for sub: " + sub);
+                log.warn("ユーザー未存在: sub={}", sub);
                 return ResponseEntity.status(HttpStatus.NOT_FOUND)
                         .body(Map.of("error", "ユーザーが存在しません。"));
             }
@@ -96,7 +96,7 @@ public class ProfileController {
         log.info("[ProfileController /me/update] Endpoint called");
         
         if (jwt == null) {
-            log.info("[ProfileController /me/update] ERROR: JWT is null - user not authenticated");
+            log.warn("認証エラー: JWTがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
@@ -107,7 +107,7 @@ public class ProfileController {
         log.info("[ProfileController /me/update] JWT Subject (sub): " + sub);
 
         if (sub == null || sub.isEmpty()) {
-            log.info("[ProfileController /me/update] ERROR: JWT subject is null or empty");
+            log.warn("認証エラー: JWTのsubがnullまたは空");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
@@ -138,7 +138,7 @@ public class ProfileController {
 
         } catch (IllegalArgumentException e) {
             // フォームの入力値が不正等
-            log.info("[ProfileController /me/update] ERROR: IllegalArgumentException - " + e.getMessage());
+            log.warn("プロフィール更新エラー(入力値不正): {}", e.getMessage());
             return ResponseEntity.badRequest()
                     .body(Map.of("error", e.getMessage()));
 

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/UserProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/UserProfileController.java
@@ -39,7 +39,7 @@ public class UserProfileController {
         log.info("[UserProfileController /me] Endpoint called");
         
         if (jwt == null) {
-            log.info("[UserProfileController /me] ERROR: JWT is null");
+            log.warn("認証エラー: JWTがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
@@ -105,7 +105,7 @@ public class UserProfileController {
             return ResponseEntity.status(HttpStatus.CREATED).body(profileDto);
 
         } catch (RuntimeException e) {
-            log.info("[UserProfileController POST /me] ERROR: " + e.getMessage());
+            log.warn("プロファイル作成エラー(不正リクエスト): {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
@@ -147,7 +147,7 @@ public class UserProfileController {
             return ResponseEntity.ok(profileDto);
 
         } catch (RuntimeException e) {
-            log.info("[UserProfileController PUT /me] ERROR: " + e.getMessage());
+            log.warn("プロファイル更新エラー(不正リクエスト): {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
@@ -189,7 +189,7 @@ public class UserProfileController {
             return ResponseEntity.ok(profileDto);
 
         } catch (RuntimeException e) {
-            log.info("[UserProfileController PUT /me/upsert] ERROR: " + e.getMessage());
+            log.warn("プロファイルupsertエラー(不正リクエスト): {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {
@@ -228,7 +228,7 @@ public class UserProfileController {
             return ResponseEntity.ok(Map.of("message", "プロファイルを削除しました。"));
 
         } catch (RuntimeException e) {
-            log.info("[UserProfileController DELETE /me] ERROR: " + e.getMessage());
+            log.warn("プロファイル削除エラー(不正リクエスト): {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", e.getMessage()));
         } catch (Exception e) {


### PR DESCRIPTION
## 概要
- エラー条件を `log.info("...ERROR...")` で出力していた14箇所を `log.warn` に修正

## 変更内容
### UserProfileController.java（5箇所）
- JWT null/RuntimeException の catch → `log.warn`

### ProfileController.java（6箇所）
- JWT null/空/ユーザー未存在/IllegalArgumentException → `log.warn`

### CognitoAuthController.java（3箇所）
- リフレッシュトークンnull/JWT null/空 → `log.warn`

## テスト結果
- バックエンド: 292テスト（1 fail = 既知のDB接続エラー）

Closes #1009