### PR TITLE
refactor: WebSocketコントローラのcatchブロック簡素化

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
@@ -246,20 +246,11 @@ public class AiChatWebSocketController {
             log.info("========== /ai-chat/send 処理完了 ==========\n");
 
         } catch (NumberFormatException e) {
-            log.error("❌ 型変換エラー発生");
-            log.error("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /ai-chat/send 処理失敗 ==========\n");
+            log.error("AIチャット送信エラー(型変換): {}", e.getMessage(), e);
         } catch (NullPointerException e) {
-            log.error("❌ NullPointerException 発生");
-            log.error("   ペイロードに必須パラメータが不足しています");
-            log.error("   必須: userId, content");
-            log.error("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /ai-chat/send 処理失敗 ==========\n");
+            log.error("AIチャット送信エラー(パラメータ不足): {}", e.getMessage(), e);
         } catch (Exception e) {
-            log.error("❌ 予期しないエラー発生");
-            log.error("   エラータイプ: " + e.getClass().getName());
-            log.error("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /ai-chat/send 処理失敗 ==========\n");
+            log.error("AIチャット送信エラー: {}", e.getMessage(), e);
         }
     }
 
@@ -288,8 +279,7 @@ public class AiChatWebSocketController {
             log.info("========== /ai-chat/response 処理完了 ==========\n");
 
         } catch (Exception e) {
-            log.error("❌ AIレスポンス処理エラー: " + e.getMessage());
-            log.info("========== /ai-chat/response 処理失敗 ==========\n");
+            log.error("AIレスポンス処理エラー: {}", e.getMessage(), e);
         }
     }
 
@@ -327,8 +317,7 @@ public class AiChatWebSocketController {
             log.info("========== /ai-chat/rephrase 処理完了 ==========\n");
 
         } catch (Exception e) {
-            log.error("❌ 言い換え処理エラー: " + e.getMessage());
-            log.info("========== /ai-chat/rephrase 処理失敗 ==========\n");
+            log.error("言い換え処理エラー: {}", e.getMessage(), e);
         }
     }
 
@@ -354,8 +343,7 @@ public class AiChatWebSocketController {
             log.info("========== /ai-chat/delete-session 処理完了 ==========\n");
 
         } catch (Exception e) {
-            log.error("❌ セッション削除エラー: " + e.getMessage());
-            log.info("========== /ai-chat/delete-session 処理失敗 ==========\n");
+            log.error("セッション削除エラー: {}", e.getMessage(), e);
         }
     }
 

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
@@ -167,7 +167,7 @@ public class ChatController {
       
       return ResponseEntity.ok().body(stats);
     } catch (Exception e) {
-      log.info(e.getMessage());
+      log.error("統計情報取得エラー: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "サーバーエラーです。"));
     }
   }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
@@ -121,21 +121,11 @@ public class ChatWebSocketController {
             log.info("========== /chat/send 処理完了 ==========\n");
             
         } catch (NumberFormatException e) {
-            log.error("❌ 型変換エラー発生");
-            log.info("   エラーメッセージ: " + e.getMessage());
-            log.info("   roomId を Integer に変換できませんでした");
-            log.info("========== /chat/send 処理失敗 ==========\n");
+            log.error("メッセージ送信エラー(型変換): {}", e.getMessage(), e);
         } catch (NullPointerException e) {
-            log.error("❌ NullPointerException 発生");
-            log.info("   ペイロードに必須パラメータが不足しています");
-            log.info("   必須: senderId, roomId, content");
-            log.info("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /chat/send 処理失敗 ==========\n");
+            log.error("メッセージ送信エラー(パラメータ不足): {}", e.getMessage(), e);
         } catch (Exception e) {
-            log.error("❌ 予期しないエラー発生");
-            log.info("   エラータイプ: " + e.getClass().getName());
-            log.info("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /chat/send 処理失敗 ==========\n");
+            log.error("メッセージ送信エラー: {}", e.getMessage(), e);
         }
     }
 
@@ -182,21 +172,11 @@ public class ChatWebSocketController {
             log.info("========== /chat/delete 処理完了 ==========\n");
             
         } catch (NumberFormatException e) {
-            log.error("❌ 型変換エラー発生");
-            log.info("   エラーメッセージ: " + e.getMessage());
-            log.info("   messageId または roomId を Integer に変換できませんでした");
-            log.info("========== /chat/delete 処理失敗 ==========\n");
+            log.error("メッセージ削除エラー(型変換): {}", e.getMessage(), e);
         } catch (NullPointerException e) {
-            log.error("❌ NullPointerException 発生");
-            log.info("   ペイロードに必須パラメータが不足しています");
-            log.info("   必須: messageId, roomId");
-            log.info("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /chat/delete 処理失敗 ==========\n");
+            log.error("メッセージ削除エラー(パラメータ不足): {}", e.getMessage(), e);
         } catch (Exception e) {
-            log.error("❌ 予期しないエラー発生");
-            log.info("   エラータイプ: " + e.getClass().getName());
-            log.info("   エラーメッセージ: " + e.getMessage());
-            log.info("========== /chat/delete 処理失敗 ==========\n");
+            log.error("メッセージ削除エラー: {}", e.getMessage(), e);
         }
     }
 }


### PR DESCRIPTION
## 概要
- WebSocketコントローラの冗長なcatchブロックを簡素化
- スタックトレースがSLF4Jログに正しく出力されるよう修正

## 変更内容
### ChatWebSocketController.java
- sendMessage: 3つのcatchブロックを各1行に簡素化（-12行）
- deleteMessage: 3つのcatchブロックを各1行に簡素化（-12行）

### AiChatWebSocketController.java
- sendMessage: 3つのcatchブロックを各1行に簡素化（-9行）
- receiveAiResponse/rephrase/deleteSession: 各1行に簡素化（-6行）

### ChatController.java
- stats: `log.info(e.getMessage())` → `log.error("統計情報取得エラー: {}", e.getMessage(), e)`

## テスト結果
- バックエンド: 292テスト（1 fail = 既知のDB接続エラー）

Closes #1011