### PR TITLE
fix: アクセシビリティ改善（aria-label、dialog属性）

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -58,10 +58,10 @@ export default memo(function AiSessionListItem({
               className="flex-1 text-xs px-2 py-1 border border-[var(--color-border-hover)] rounded focus:outline-none focus:ring-1 focus:ring-primary-400"
               autoFocus
             />
-            <button onClick={() => onSaveTitle(id)} className="p-0.5 hover:bg-green-900/30 rounded">
+            <button onClick={() => onSaveTitle(id)} className="p-0.5 hover:bg-green-900/30 rounded" aria-label="保存">
               <CheckIcon className="w-3.5 h-3.5 text-green-400" />
             </button>
-            <button onClick={onCancelEdit} className="p-0.5 hover:bg-surface-3 rounded">
+            <button onClick={onCancelEdit} className="p-0.5 hover:bg-surface-3 rounded" aria-label="キャンセル">
               <XMarkIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
             </button>
           </div>
@@ -80,6 +80,7 @@ export default memo(function AiSessionListItem({
             onClick={(e) => { e.stopPropagation(); onStartEdit({ id, title }); }}
             className="p-1 hover:bg-blue-900/30 rounded"
             title="タイトルを編集"
+            aria-label="タイトルを編集"
           >
             <PencilSquareIcon className="w-3.5 h-3.5 text-blue-500" />
           </button>
@@ -90,6 +91,7 @@ export default memo(function AiSessionListItem({
             }}
             className="p-1 hover:bg-rose-900/30 rounded"
             title="削除"
+            aria-label="削除"
           >
             <TrashIcon className="w-3.5 h-3.5 text-rose-500" />
           </button>

--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -14,13 +14,16 @@ export default function SessionDetailModal({ session, onClose }: SessionDetailMo
       onClick={onClose}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="session-detail-title"
         className="bg-surface-1 rounded-xl shadow-xl max-w-md w-full max-h-[80vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-5">
           <div className="flex items-start justify-between mb-4">
             <div>
-              <h2 className="text-sm font-bold text-[var(--color-text-primary)]">
+              <h2 id="session-detail-title" className="text-sm font-bold text-[var(--color-text-primary)]">
                 {session.sessionTitle || `セッション #${session.sessionId}`}
               </h2>
               <p className="text-xs text-[var(--color-text-faint)] mt-0.5">


### PR DESCRIPTION
## 概要
- スクリーンリーダー対応を改善するアクセシビリティ属性を追加

## 変更内容
### SessionDetailModal.tsx
- `role="dialog"`, `aria-modal="true"`, `aria-labelledby="session-detail-title"` を追加
- h2タグに `id="session-detail-title"` を追加

### AiSessionListItem.tsx
- 保存ボタン: `aria-label="保存"` 追加
- キャンセルボタン: `aria-label="キャンセル"` 追加
- 編集ボタン: `aria-label="タイトルを編集"` 追加
- 削除ボタン: `aria-label="削除"` 追加

## テスト結果
- フロントエンド: 1924テスト全パス

Closes #1013