### PR TITLE
test: セキュリティユーティリティ（JwtUtils, PasswordUtils）のテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/utils/JwtUtilsTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/utils/JwtUtilsTest.java
@@ -1,0 +1,71 @@
+package com.example.FreStyle.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+class JwtUtilsTest {
+
+    private String createTestJwt(String subject, String issuer) throws Exception {
+        // テスト用のHMAC秘密鍵（256ビット以上）
+        byte[] secret = new byte[32];
+        for (int i = 0; i < secret.length; i++) {
+            secret[i] = (byte) i;
+        }
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject(subject)
+                .issuer(issuer)
+                .build();
+
+        SignedJWT signedJWT = new SignedJWT(
+                new JWSHeader(JWSAlgorithm.HS256),
+                claims);
+        signedJWT.sign(new MACSigner(secret));
+
+        return signedJWT.serialize();
+    }
+
+    @Test
+    void 正常なJWTをデコードできる() throws Exception {
+        String token = createTestJwt("user-123", "https://cognito-idp.ap-northeast-1.amazonaws.com");
+
+        Optional<JWTClaimsSet> result = JwtUtils.decode(token);
+
+        assertTrue(result.isPresent());
+        assertEquals("user-123", result.get().getSubject());
+        assertEquals("https://cognito-idp.ap-northeast-1.amazonaws.com", result.get().getIssuer());
+    }
+
+    @Test
+    void 無効なトークンの場合はemptyを返す() {
+        Optional<JWTClaimsSet> result = JwtUtils.decode("invalid-token-string");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void 空文字列の場合はemptyを返す() {
+        Optional<JWTClaimsSet> result = JwtUtils.decode("");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void subjectが設定されたJWTを正しくデコードできる() throws Exception {
+        String token = createTestJwt("cognito-sub-abc", null);
+
+        Optional<JWTClaimsSet> result = JwtUtils.decode(token);
+
+        assertTrue(result.isPresent());
+        assertEquals("cognito-sub-abc", result.get().getSubject());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/utils/PasswordUtilsTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/utils/PasswordUtilsTest.java
@@ -1,0 +1,46 @@
+package com.example.FreStyle.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+class PasswordUtilsTest {
+
+    private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    @Test
+    void ハッシュが生成される() {
+        String hash = PasswordUtils.hash("password123");
+
+        assertNotNull(hash);
+        assertFalse(hash.isEmpty());
+    }
+
+    @Test
+    void ハッシュが元のパスワードと一致する() {
+        String password = "mySecretPassword";
+        String hash = PasswordUtils.hash(password);
+
+        assertTrue(encoder.matches(password, hash));
+    }
+
+    @Test
+    void 異なるパスワードのハッシュは一致しない() {
+        String hash = PasswordUtils.hash("correctPassword");
+
+        assertFalse(encoder.matches("wrongPassword", hash));
+    }
+
+    @Test
+    void 同じパスワードでも毎回異なるハッシュが生成される() {
+        String password = "samePassword";
+        String hash1 = PasswordUtils.hash(password);
+        String hash2 = PasswordUtils.hash(password);
+
+        assertNotEquals(hash1, hash2);
+        // ただし両方とも元のパスワードと一致する
+        assertTrue(encoder.matches(password, hash1));
+        assertTrue(encoder.matches(password, hash2));
+    }
+}


### PR DESCRIPTION
## 概要
- JwtUtilsのユニットテスト4件追加
- PasswordUtilsのユニットテスト4件追加

## テスト内容
### JwtUtils (4テスト)
- 有効なJWTトークンのデコード
- 無効なトークンで空のOptionalを返す
- 空文字列で空のOptionalを返す
- subjectクレームの抽出

### PasswordUtils (4テスト)
- ハッシュが生成される
- ハッシュが元のパスワードと一致する
- 異なるパスワードのハッシュは一致しない
- 同じパスワードでも毎回異なるハッシュが生成される

## テスト結果
- バックエンド: 300テスト（+8件新規）

Closes #1015