### PR TITLE
test: CognitoAuthServiceのユニットテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
@@ -1,0 +1,306 @@
+package com.example.FreStyle.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
+
+class CognitoAuthServiceTest {
+
+    private CognitoIdentityProviderClient cognitoClient;
+    private CognitoAuthService service;
+
+    @BeforeEach
+    void setUp() {
+        cognitoClient = mock(CognitoIdentityProviderClient.class);
+        service = new CognitoAuthService("dummyAccessKey", "dummySecretKey", "ap-northeast-1");
+        ReflectionTestUtils.setField(service, "cognitoClient", cognitoClient);
+        ReflectionTestUtils.setField(service, "clientId", "testClientId");
+        ReflectionTestUtils.setField(service, "clientSecret", "testClientSecret");
+    }
+
+    // ============================
+    // signUpUser
+    // ============================
+    @Nested
+    class SignUpUserTest {
+
+        @Test
+        void 正常にサインアップできる() {
+            SignUpResponse response = SignUpResponse.builder()
+                    .userConfirmed(false)
+                    .build();
+            when(cognitoClient.signUp(any(SignUpRequest.class))).thenReturn(response);
+
+            assertDoesNotThrow(() -> service.signUpUser("test@example.com", "Password123!", "テストユーザー"));
+            verify(cognitoClient).signUp(any(SignUpRequest.class));
+        }
+
+        @Test
+        void 既存メールアドレスでUsernameExistsException() {
+            when(cognitoClient.signUp(any(SignUpRequest.class)))
+                    .thenThrow(UsernameExistsException.builder().message("exists").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.signUpUser("existing@example.com", "Password123!", "テスト"));
+            assertEquals("このメールアドレスは既に登録されています。", ex.getMessage());
+        }
+
+        @Test
+        void 不正なパスワードでInvalidPasswordException() {
+            when(cognitoClient.signUp(any(SignUpRequest.class)))
+                    .thenThrow(InvalidPasswordException.builder().message("weak").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.signUpUser("test@example.com", "weak", "テスト"));
+            assertEquals("パスワードが要件を満たしていません。", ex.getMessage());
+        }
+
+        @Test
+        void 確認済みユーザーの場合も正常終了する() {
+            SignUpResponse response = SignUpResponse.builder()
+                    .userConfirmed(true)
+                    .build();
+            when(cognitoClient.signUp(any(SignUpRequest.class))).thenReturn(response);
+
+            assertDoesNotThrow(() -> service.signUpUser("confirmed@example.com", "Password123!", "確認済み"));
+        }
+    }
+
+    // ============================
+    // confirmUserSignup
+    // ============================
+    @Nested
+    class ConfirmUserSignupTest {
+
+        @Test
+        void 正常に確認できる() {
+            when(cognitoClient.confirmSignUp(any(ConfirmSignUpRequest.class)))
+                    .thenReturn(ConfirmSignUpResponse.builder().build());
+
+            assertDoesNotThrow(() -> service.confirmUserSignup("test@example.com", "123456"));
+            verify(cognitoClient).confirmSignUp(any(ConfirmSignUpRequest.class));
+        }
+
+        @Test
+        void ユーザー未存在でUserNotFoundException() {
+            when(cognitoClient.confirmSignUp(any(ConfirmSignUpRequest.class)))
+                    .thenThrow(UserNotFoundException.builder().message("not found").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.confirmUserSignup("unknown@example.com", "123456"));
+            assertEquals("ユーザーが見つかりません。", ex.getMessage());
+        }
+
+        @Test
+        void 確認コード不一致でCodeMismatchException() {
+            when(cognitoClient.confirmSignUp(any(ConfirmSignUpRequest.class)))
+                    .thenThrow(CodeMismatchException.builder().message("mismatch").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.confirmUserSignup("test@example.com", "000000"));
+            assertEquals("確認コードが正しくありません。", ex.getMessage());
+        }
+
+        @Test
+        void 確認コード期限切れでExpiredCodeException() {
+            when(cognitoClient.confirmSignUp(any(ConfirmSignUpRequest.class)))
+                    .thenThrow(ExpiredCodeException.builder().message("expired").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.confirmUserSignup("test@example.com", "123456"));
+            assertEquals("確認コードの有効期限が切れています。", ex.getMessage());
+        }
+    }
+
+    // ============================
+    // login
+    // ============================
+    @Nested
+    class LoginTest {
+
+        @Test
+        void 正常にログインできる() {
+            AuthenticationResultType authResult = AuthenticationResultType.builder()
+                    .accessToken("access-token")
+                    .idToken("id-token")
+                    .refreshToken("refresh-token")
+                    .build();
+            InitiateAuthResponse response = InitiateAuthResponse.builder()
+                    .authenticationResult(authResult)
+                    .build();
+            when(cognitoClient.initiateAuth(any(InitiateAuthRequest.class))).thenReturn(response);
+
+            Map<String, String> tokens = service.login("test@example.com", "Password123!");
+
+            assertEquals("access-token", tokens.get("accessToken"));
+            assertEquals("id-token", tokens.get("idToken"));
+            assertEquals("refresh-token", tokens.get("refreshToken"));
+        }
+
+        @Test
+        void 認証失敗でNotAuthorizedException() {
+            when(cognitoClient.initiateAuth(any(InitiateAuthRequest.class)))
+                    .thenThrow(NotAuthorizedException.builder().message("bad creds").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.login("test@example.com", "WrongPassword"));
+            assertEquals("メールアドレスまたはパスワードが間違っています。", ex.getMessage());
+        }
+
+        @Test
+        void メール未確認でUserNotConfirmedException() {
+            when(cognitoClient.initiateAuth(any(InitiateAuthRequest.class)))
+                    .thenThrow(UserNotConfirmedException.builder().message("not confirmed").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.login("unconfirmed@example.com", "Password123!"));
+            assertEquals("メール確認が完了していません。", ex.getMessage());
+        }
+    }
+
+    // ============================
+    // forgotPassword
+    // ============================
+    @Nested
+    class ForgotPasswordTest {
+
+        @Test
+        void 正常にパスワードリセットリクエストできる() {
+            when(cognitoClient.forgotPassword(any(ForgotPasswordRequest.class)))
+                    .thenReturn(ForgotPasswordResponse.builder().build());
+
+            assertDoesNotThrow(() -> service.forgotPassword("test@example.com"));
+            verify(cognitoClient).forgotPassword(any(ForgotPasswordRequest.class));
+        }
+
+        @Test
+        void ユーザー未存在でUserNotFoundException() {
+            when(cognitoClient.forgotPassword(any(ForgotPasswordRequest.class)))
+                    .thenThrow(UserNotFoundException.builder().message("not found").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.forgotPassword("unknown@example.com"));
+            assertEquals("このメールアドレスは登録されていません。", ex.getMessage());
+        }
+    }
+
+    // ============================
+    // confirmForgotPassword
+    // ============================
+    @Nested
+    class ConfirmForgotPasswordTest {
+
+        @Test
+        void 正常にパスワードリセットできる() {
+            when(cognitoClient.confirmForgotPassword(any(ConfirmForgotPasswordRequest.class)))
+                    .thenReturn(ConfirmForgotPasswordResponse.builder().build());
+
+            assertDoesNotThrow(() -> service.confirmForgotPassword("test@example.com", "123456", "NewPassword123!"));
+            verify(cognitoClient).confirmForgotPassword(any(ConfirmForgotPasswordRequest.class));
+        }
+
+        @Test
+        void 確認コード不一致でCodeMismatchException() {
+            when(cognitoClient.confirmForgotPassword(any(ConfirmForgotPasswordRequest.class)))
+                    .thenThrow(CodeMismatchException.builder().message("mismatch").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.confirmForgotPassword("test@example.com", "000000", "NewPassword123!"));
+            assertEquals("確認コードが間違っています。", ex.getMessage());
+        }
+
+        @Test
+        void 確認コード期限切れでExpiredCodeException() {
+            when(cognitoClient.confirmForgotPassword(any(ConfirmForgotPasswordRequest.class)))
+                    .thenThrow(ExpiredCodeException.builder().message("expired").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.confirmForgotPassword("test@example.com", "123456", "NewPassword123!"));
+            assertEquals("確認コードの有効期限が切れています。", ex.getMessage());
+        }
+    }
+
+    // ============================
+    // updateUserProfile
+    // ============================
+    @Nested
+    class UpdateUserProfileTest {
+
+        @Test
+        void 正常にプロフィール更新できる() {
+            when(cognitoClient.updateUserAttributes(any(UpdateUserAttributesRequest.class)))
+                    .thenReturn(UpdateUserAttributesResponse.builder().build());
+
+            assertDoesNotThrow(() -> service.updateUserProfile("access-token", "新しい名前"));
+            verify(cognitoClient).updateUserAttributes(any(UpdateUserAttributesRequest.class));
+        }
+
+        @Test
+        void 空の名前でRuntimeException() {
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.updateUserProfile("access-token", ""));
+            assertEquals("proceed update profile error", ex.getMessage());
+        }
+
+        @Test
+        void nullの名前でRuntimeException() {
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.updateUserProfile("access-token", null));
+            assertEquals("proceed update profile error", ex.getMessage());
+        }
+
+        @Test
+        void 認証失敗でNotAuthorizedException() {
+            when(cognitoClient.updateUserAttributes(any(UpdateUserAttributesRequest.class)))
+                    .thenThrow(NotAuthorizedException.builder().message("not authorized").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.updateUserProfile("invalid-token", "名前"));
+            assertEquals("invalid parameter retry login", ex.getMessage());
+        }
+    }
+
+    // ============================
+    // refreshAccessToken
+    // ============================
+    @Nested
+    class RefreshAccessTokenTest {
+
+        @Test
+        void 正常にトークンを再発行できる() {
+            AuthenticationResultType authResult = AuthenticationResultType.builder()
+                    .accessToken("new-access-token")
+                    .idToken("new-id-token")
+                    .build();
+            InitiateAuthResponse response = InitiateAuthResponse.builder()
+                    .authenticationResult(authResult)
+                    .build();
+            when(cognitoClient.initiateAuth(any(InitiateAuthRequest.class))).thenReturn(response);
+
+            Map<String, String> tokens = service.refreshAccessToken("valid-refresh-token", "test@example.com");
+
+            assertEquals("new-access-token", tokens.get("accessToken"));
+            assertEquals("new-id-token", tokens.get("idToken"));
+        }
+
+        @Test
+        void 無効なリフレッシュトークンでNotAuthorizedException() {
+            when(cognitoClient.initiateAuth(any(InitiateAuthRequest.class)))
+                    .thenThrow(NotAuthorizedException.builder().message("invalid token").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.refreshAccessToken("invalid-token", "test@example.com"));
+            assertEquals("リフレッシュトークンが無効です。再ログインしてください。", ex.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 概要
CognitoAuthServiceの全7メソッドに対してMockitoベースのユニットテスト22件を追加。

## テスト内容
### signUpUser (4テスト)
- 正常にサインアップできる
- 既存メールアドレスでUsernameExistsException
- 不正なパスワードでInvalidPasswordException
- 確認済みユーザーの場合も正常終了する

### confirmUserSignup (4テスト)
- 正常に確認できる
- ユーザー未存在でUserNotFoundException
- 確認コード不一致でCodeMismatchException
- 確認コード期限切れでExpiredCodeException

### login (3テスト)
- 正常にログインできる
- 認証失敗でNotAuthorizedException
- メール未確認でUserNotConfirmedException

### forgotPassword (2テスト)
- 正常にパスワードリセットリクエストできる
- ユーザー未存在でUserNotFoundException

### confirmForgotPassword (3テスト)
- 正常にパスワードリセットできる
- 確認コード不一致でCodeMismatchException
- 確認コード期限切れでExpiredCodeException

### updateUserProfile (4テスト)
- 正常にプロフィール更新できる
- 空の名前でRuntimeException
- nullの名前でRuntimeException
- 認証失敗でNotAuthorizedException

### refreshAccessToken (2テスト)
- 正常にトークンを再発行できる
- 無効なリフレッシュトークンでNotAuthorizedException

## テスト結果
- バックエンド: 322テスト（+22件新規）

Closes #1017