### PR TITLE
test: JwtCookieFilter・HttpServletRequestWrapperWithHeaderのテスト追加

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/auth/HttpServletRequestWrapperWithHeaderTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/auth/HttpServletRequestWrapperWithHeaderTest.java
@@ -1,0 +1,50 @@
+package com.example.FreStyle.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+class HttpServletRequestWrapperWithHeaderTest {
+
+    @Test
+    void カスタムヘッダーが取得できる() {
+        HttpServletRequest original = mock(HttpServletRequest.class);
+        HttpServletRequestWrapperWithHeader wrapper =
+                new HttpServletRequestWrapperWithHeader(original, "Authorization", "Bearer token123");
+
+        assertEquals("Bearer token123", wrapper.getHeader("Authorization"));
+    }
+
+    @Test
+    void 元のヘッダーがカスタムヘッダーに含まれない場合はオリジナルから取得する() {
+        HttpServletRequest original = mock(HttpServletRequest.class);
+        when(original.getHeader("Content-Type")).thenReturn("application/json");
+
+        HttpServletRequestWrapperWithHeader wrapper =
+                new HttpServletRequestWrapperWithHeader(original, "Authorization", "Bearer token");
+
+        assertEquals("application/json", wrapper.getHeader("Content-Type"));
+    }
+
+    @Test
+    void getHeaderNamesにカスタムヘッダーが含まれる() {
+        HttpServletRequest original = mock(HttpServletRequest.class);
+        when(original.getHeaderNames()).thenReturn(Collections.enumeration(List.of("Content-Type")));
+
+        HttpServletRequestWrapperWithHeader wrapper =
+                new HttpServletRequestWrapperWithHeader(original, "Authorization", "Bearer token");
+
+        Enumeration<String> names = wrapper.getHeaderNames();
+        List<String> nameList = Collections.list(names);
+
+        assertTrue(nameList.contains("Authorization"));
+        assertTrue(nameList.contains("Content-Type"));
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/auth/JwtCookieFilterTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/auth/JwtCookieFilterTest.java
@@ -1,0 +1,83 @@
+package com.example.FreStyle.auth;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+class JwtCookieFilterTest {
+
+    private JwtCookieFilter filter;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        filter = new JwtCookieFilter();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        filterChain = mock(FilterChain.class);
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestURI()).thenReturn("/api/test");
+    }
+
+    @Test
+    void ACCESS_TOKENクッキーがある場合Authorizationヘッダーが付与される() throws ServletException, IOException {
+        Cookie accessToken = new Cookie("ACCESS_TOKEN", "my-jwt-token");
+        when(request.getCookies()).thenReturn(new Cookie[]{accessToken});
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(captor.capture(), eq(response));
+
+        HttpServletRequest wrappedRequest = captor.getValue();
+        assertInstanceOf(HttpServletRequestWrapperWithHeader.class, wrappedRequest);
+        assertEquals("Bearer my-jwt-token", wrappedRequest.getHeader("Authorization"));
+    }
+
+    @Test
+    void クッキーがnullの場合リクエストがそのまま渡される() throws ServletException, IOException {
+        when(request.getCookies()).thenReturn(null);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void ACCESS_TOKENクッキーがない場合リクエストがそのまま渡される() throws ServletException, IOException {
+        Cookie otherCookie = new Cookie("OTHER_COOKIE", "value");
+        when(request.getCookies()).thenReturn(new Cookie[]{otherCookie});
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void 複数クッキーからACCESS_TOKENが正しく選択される() throws ServletException, IOException {
+        Cookie session = new Cookie("SESSION_ID", "session-value");
+        Cookie accessToken = new Cookie("ACCESS_TOKEN", "correct-token");
+        Cookie refresh = new Cookie("REFRESH_TOKEN", "refresh-value");
+        when(request.getCookies()).thenReturn(new Cookie[]{session, accessToken, refresh});
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        ArgumentCaptor<HttpServletRequest> captor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        verify(filterChain).doFilter(captor.capture(), eq(response));
+
+        assertEquals("Bearer correct-token", captor.getValue().getHeader("Authorization"));
+    }
+}


### PR DESCRIPTION
## 概要
認証レイヤーのJwtCookieFilterとHttpServletRequestWrapperWithHeaderにMockitoベースのユニットテスト7件を追加。

## テスト内容
### JwtCookieFilter (4テスト)
- ACCESS_TOKENクッキーがある場合Authorizationヘッダーが付与される
- クッキーがnullの場合リクエストがそのまま渡される
- ACCESS_TOKENクッキーがない場合リクエストがそのまま渡される
- 複数クッキーからACCESS_TOKENが正しく選択される

### HttpServletRequestWrapperWithHeader (3テスト)
- カスタムヘッダーが取得できる
- 元のヘッダーがカスタムヘッダーに含まれない場合はオリジナルから取得する
- getHeaderNamesにカスタムヘッダーが含まれる

## テスト結果
- バックエンド: 329テスト（+7件新規）

Closes #1019