### PR TITLE
test: AiChatController・ChatControllerのテスト拡充（+14件）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
@@ -17,6 +17,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import com.example.FreStyle.dto.AiChatMessageDto;
+import com.example.FreStyle.dto.AiChatMessageResponseDto;
 import com.example.FreStyle.dto.AiChatSessionDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.AiChatService;
@@ -137,6 +139,139 @@ class AiChatControllerTest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody().get("result")).isEqualTo("言い換え結果");
+        }
+    }
+
+    @Nested
+    @DisplayName("getChatHistory")
+    class GetChatHistory {
+
+        @Test
+        @DisplayName("AI履歴を返す")
+        void returnsChatHistory() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            List<AiChatMessageDto> history = List.of(
+                    new AiChatMessageDto("こんにちは", true, System.currentTimeMillis()));
+            when(aiChatService.getChatHistory(10)).thenReturn(history);
+
+            ResponseEntity<?> response = aiChatController.getChatHistory(jwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isEqualTo(history);
+        }
+    }
+
+    @Nested
+    @DisplayName("createSession")
+    class CreateSession {
+
+        @Test
+        @DisplayName("新規セッションを作成する")
+        void createsSession() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            AiChatSessionDto dto = new AiChatSessionDto();
+            dto.setId(5);
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            when(createAiChatSessionUseCase.execute(10, "テストセッション", null)).thenReturn(dto);
+
+            var request = new AiChatController.CreateSessionRequest("テストセッション", null);
+            ResponseEntity<AiChatSessionDto> response = aiChatController.createSession(jwt, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(5);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateSessionTitle")
+    class UpdateSessionTitle {
+
+        @Test
+        @DisplayName("セッションタイトルを更新する")
+        void updatesTitle() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            AiChatSessionDto dto = new AiChatSessionDto();
+            dto.setId(1);
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            when(updateAiChatSessionTitleUseCase.execute(1, 10, "新しいタイトル")).thenReturn(dto);
+
+            var request = new AiChatController.UpdateSessionRequest("新しいタイトル");
+            ResponseEntity<AiChatSessionDto> response = aiChatController.updateSessionTitle(jwt, 1, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(updateAiChatSessionTitleUseCase).execute(1, 10, "新しいタイトル");
+        }
+    }
+
+    @Nested
+    @DisplayName("getMessages")
+    class GetMessages {
+
+        @Test
+        @DisplayName("セッション内のメッセージ一覧を返す")
+        void returnsMessages() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            AiChatSessionDto sessionDto = new AiChatSessionDto();
+            sessionDto.setId(1);
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            when(getAiChatSessionByIdUseCase.execute(1, 10)).thenReturn(sessionDto);
+            when(getAiChatMessagesBySessionIdUseCase.execute(1)).thenReturn(List.of());
+
+            ResponseEntity<List<AiChatMessageResponseDto>> response = aiChatController.getMessages(jwt, 1);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isEmpty();
+            verify(getAiChatSessionByIdUseCase).execute(1, 10);
+        }
+    }
+
+    @Nested
+    @DisplayName("addMessage")
+    class AddMessage {
+
+        @Test
+        @DisplayName("ユーザーメッセージを追加する")
+        void addsUserMessage() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            AiChatSessionDto sessionDto = new AiChatSessionDto();
+            sessionDto.setId(1);
+            AiChatMessageResponseDto messageDto = new AiChatMessageResponseDto();
+            messageDto.setId(100);
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            when(getAiChatSessionByIdUseCase.execute(1, 10)).thenReturn(sessionDto);
+            when(addAiChatMessageUseCase.executeUserMessage(1, 10, "テスト")).thenReturn(messageDto);
+
+            var request = new AiChatController.AddMessageRequest("テスト", "user");
+            ResponseEntity<AiChatMessageResponseDto> response = aiChatController.addMessage(jwt, 1, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(100);
+        }
+
+        @Test
+        @DisplayName("アシスタントメッセージを追加する")
+        void addsAssistantMessage() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            AiChatSessionDto sessionDto = new AiChatSessionDto();
+            sessionDto.setId(1);
+            AiChatMessageResponseDto messageDto = new AiChatMessageResponseDto();
+            messageDto.setId(101);
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            when(getAiChatSessionByIdUseCase.execute(1, 10)).thenReturn(sessionDto);
+            when(addAiChatMessageUseCase.executeAssistantMessage(1, 10, "AI応答")).thenReturn(messageDto);
+
+            var request = new AiChatController.AddMessageRequest("AI応答", "assistant");
+            ResponseEntity<AiChatMessageResponseDto> response = aiChatController.addMessage(jwt, 1, request);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().getId()).isEqualTo(101);
         }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ChatControllerTest.java
@@ -19,7 +19,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 
+import java.util.List;
 import java.util.Map;
+
+import com.example.FreStyle.dto.ChatMessageDto;
+import com.example.FreStyle.dto.ChatUserDto;
+import com.example.FreStyle.dto.UserDto;
+import com.example.FreStyle.entity.ChatRoom;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -107,5 +113,133 @@ class ChatControllerTest {
 
         // Assert
         verify(unreadCountService).resetUnreadCount(1, 25);
+    }
+
+    // ============================
+    // users
+    // ============================
+    @Test
+    @DisplayName("users: 正常リクエスト → ユーザー一覧を返す")
+    void users_validRequest_returnsUsers() {
+        Jwt jwt = createMockJwt();
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        when(userService.findUsersWithRoomId(1, null)).thenReturn(List.of());
+
+        ResponseEntity<?> response = chatController.users(jwt, null);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        @SuppressWarnings("unchecked")
+        Map<String, List<UserDto>> body = (Map<String, List<UserDto>>) response.getBody();
+        assertNotNull(body.get("users"));
+    }
+
+    @Test
+    @DisplayName("users: 検索クエリ付きリクエスト")
+    void users_withQuery_passesQueryToService() {
+        Jwt jwt = createMockJwt();
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        when(userService.findUsersWithRoomId(1, "テスト")).thenReturn(List.of());
+
+        chatController.users(jwt, "テスト");
+
+        verify(userService).findUsersWithRoomId(1, "テスト");
+    }
+
+    // ============================
+    // create
+    // ============================
+    @Test
+    @DisplayName("create: 正常リクエスト → roomIdとsuccessを返す")
+    void create_validRequest_returnsRoomId() {
+        Jwt jwt = createMockJwt();
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        when(chatService.createOrGetRoom(1, 2)).thenReturn(99);
+
+        ResponseEntity<?> response = chatController.create(jwt, 2);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertEquals(99, body.get("roomId"));
+        assertEquals("success", body.get("status"));
+    }
+
+    @Test
+    @DisplayName("create: 例外発生時 → 500エラーを返す")
+    void create_serviceThrows_returnsError() {
+        Jwt jwt = createMockJwt();
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        when(chatService.createOrGetRoom(1, 2)).thenThrow(new RuntimeException("DB error"));
+
+        ResponseEntity<?> response = chatController.create(jwt, 2);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+    }
+
+    // ============================
+    // history
+    // ============================
+    @Test
+    @DisplayName("history: 正常リクエスト → メッセージ履歴を返す")
+    void history_validRequest_returnsHistory() {
+        Jwt jwt = createMockJwt();
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.setId(10);
+        when(chatRoomService.findChatRoomById(10)).thenReturn(chatRoom);
+        when(chatMessageService.getMessagesByRoom(chatRoom, 1)).thenReturn(List.of());
+
+        ResponseEntity<?> response = chatController.history(jwt, 10);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        @SuppressWarnings("unchecked")
+        List<ChatMessageDto> body = (List<ChatMessageDto>) response.getBody();
+        assertNotNull(body);
+    }
+
+    // ============================
+    // stats
+    // ============================
+    @Test
+    @DisplayName("stats: 正常リクエスト → 統計情報を返す")
+    void stats_validRequest_returnsStats() {
+        Jwt jwt = createMockJwt();
+        testUser.setEmail("test@example.com");
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        when(roomMemberService.countChatPartners(1)).thenReturn(5L);
+
+        ResponseEntity<?> response = chatController.stats(jwt);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertEquals(5L, body.get("chatPartnerCount"));
+        assertEquals("テストユーザー", body.get("username"));
+    }
+
+    // ============================
+    // getChatRooms
+    // ============================
+    @Test
+    @DisplayName("getChatRooms: 正常リクエスト → チャットルーム一覧を返す")
+    void getChatRooms_validRequest_returnsChatRooms() {
+        Jwt jwt = createMockJwt();
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
+        when(chatService.findChatUsers(1, null)).thenReturn(List.of());
+
+        ResponseEntity<?> response = chatController.getChatRooms(jwt, null);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertNotNull(body.get("chatUsers"));
+    }
+
+    @Test
+    @DisplayName("getChatRooms: JWTなし → 401 Unauthorizedを返す")
+    void getChatRooms_noJwt_returnsUnauthorized() {
+        ResponseEntity<?> response = chatController.getChatRooms(null, null);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
     }
 }


### PR DESCRIPTION
## 概要
AiChatControllerとChatControllerの不足テストを追加。

## 追加テスト内容
### AiChatController (+6テスト、計10件)
- getChatHistory: AI履歴取得
- createSession: 新規セッション作成
- updateSessionTitle: タイトル更新
- getMessages: メッセージ一覧取得
- addMessage: ユーザーメッセージ追加、アシスタントメッセージ追加

### ChatController (+8テスト、計11件)
- users: ユーザー一覧取得、検索クエリ付き
- create: ルーム作成成功、例外時500エラー
- history: メッセージ履歴取得
- stats: 統計情報取得
- getChatRooms: チャットルーム一覧取得、JWT未認証時401

## テスト結果
- バックエンド: 354テスト（+14件新規）

Closes #1023