### PR TITLE
refactor: ログの文字列連結をSLF4Jパラメータ化形式に置換

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
@@ -49,7 +49,7 @@ public class AiChatWebSocketController {
     @MessageMapping("/ai-chat/send")
     public void sendMessage(@Payload Map<String, Object> payload) {
         log.info("\n========== WebSocket /ai-chat/send リクエスト受信 ==========");
-        log.info("📨 ペイロード全体: " + payload);
+        log.info("📨 ペイロード全体: {}", payload);
 
         try {
             // パラメータの取得と検証
@@ -63,14 +63,14 @@ public class AiChatWebSocketController {
             Object sessionTypeObj = payload.get("sessionType"); // セッション種別（normal, practice）
             Object scenarioIdObj = payload.get("scenarioId"); // 練習シナリオID
 
-            log.debug("   - userId タイプ: " + (userIdObj != null ? userIdObj.getClass().getSimpleName() : "null"));
-            log.debug("   - userId 値: " + userIdObj);
-            log.debug("   - sessionId タイプ: " + (sessionIdObj != null ? sessionIdObj.getClass().getSimpleName() : "null"));
-            log.debug("   - sessionId 値: " + sessionIdObj);
-            log.debug("   - content: " + contentObj);
-            log.debug("   - role: " + roleObj);
-            log.debug("   - fromChatFeedback: " + fromChatFeedbackObj);
-            log.debug("   - scene: " + sceneObj);
+            log.debug("   - userId タイプ: {}", userIdObj != null ? userIdObj.getClass().getSimpleName() : "null");
+            log.debug("   - userId 値: {}", userIdObj);
+            log.debug("   - sessionId タイプ: {}", sessionIdObj != null ? sessionIdObj.getClass().getSimpleName() : "null");
+            log.debug("   - sessionId 値: {}", sessionIdObj);
+            log.debug("   - content: {}", contentObj);
+            log.debug("   - role: {}", roleObj);
+            log.debug("   - fromChatFeedback: {}", fromChatFeedbackObj);
+            log.debug("   - scene: {}", sceneObj);
 
             // userId の変換
             Integer userId = convertToInteger(userIdObj);
@@ -96,12 +96,12 @@ public class AiChatWebSocketController {
             boolean isPracticeMode = "practice".equals(sessionType);
 
             log.info("✅ パラメータ抽出成功");
-            log.debug("   - userId (最終): " + userId);
-            log.debug("   - sessionId (最終): " + sessionId);
-            log.debug("   - content: " + content);
-            log.debug("   - role: " + role);
-            log.debug("   - fromChatFeedback (最終): " + fromChatFeedback);
-            log.debug("   - scene (最終): " + scene);
+            log.debug("   - userId (最終): {}", userId);
+            log.debug("   - sessionId (最終): {}", sessionId);
+            log.debug("   - content: {}", content);
+            log.debug("   - role: {}", role);
+            log.debug("   - fromChatFeedback (最終): {}", fromChatFeedback);
+            log.debug("   - scene (最終): {}", scene);
 
             // セッションが存在しない場合は新規作成
             if (sessionId == null) {
@@ -114,7 +114,7 @@ public class AiChatWebSocketController {
                 }
                 AiChatSessionDto newSession = createAiChatSessionUseCase.execute(userId, title, null, scene);
                 sessionId = newSession.getId();
-                log.info("✅ 新規セッション作成完了 - sessionId: " + sessionId);
+                log.info("✅ 新規セッション作成完了 - sessionId: {}", sessionId);
 
                 // 新しいセッション情報をクライアントに通知
                 messagingTemplate.convertAndSend(
@@ -127,12 +127,12 @@ public class AiChatWebSocketController {
             log.info("💾 ユーザーメッセージをデータベースに保存中...");
             AiChatMessageResponseDto savedUserMessage = addAiChatMessageUseCase.execute(sessionId, userId, role, content);
             log.info("✅ ユーザーメッセージ保存成功");
-            log.debug("   - messageId: " + savedUserMessage.getId());
-            log.debug("   - sessionId: " + savedUserMessage.getSessionId());
-            log.debug("   - role: " + savedUserMessage.getRole());
+            log.debug("   - messageId: {}", savedUserMessage.getId());
+            log.debug("   - sessionId: {}", savedUserMessage.getSessionId());
+            log.debug("   - role: {}", savedUserMessage.getRole());
 
             // WebSocket トピックへユーザーメッセージを送信
-            log.info("📤 WebSocket トピック /topic/ai-chat/session/" + sessionId + " へユーザーメッセージを送信中...");
+            log.info("📤 WebSocket トピック /topic/ai-chat/session/{} へユーザーメッセージを送信中...", sessionId);
             messagingTemplate.convertAndSend(
                     "/topic/ai-chat/session/" + sessionId,
                     savedUserMessage
@@ -143,7 +143,7 @@ public class AiChatWebSocketController {
             String aiReply;
             if (isPracticeMode && scenarioId != null) {
                 // 練習モード: シナリオに基づいたロールプレイ
-                log.info("🎭 練習モード: scenarioId=" + scenarioId);
+                log.info("🎭 練習モード: scenarioId={}", scenarioId);
                 PracticeScenarioDto scenario = getPracticeScenarioByIdUseCase.execute(scenarioId);
                 String practicePrompt = systemPromptBuilder.buildPracticePrompt(
                         scenario.getName(), scenario.getRoleName(),
@@ -160,16 +160,16 @@ public class AiChatWebSocketController {
                 }
             } else if (fromChatFeedback) {
                 // チャットフィードバックモード: バックエンドでUserProfileを取得
-                log.info("🤖 フィードバックモード: UserProfileをバックエンドで取得中... scene=" + scene);
+                log.info("🤖 フィードバックモード: UserProfileをバックエンドで取得中... scene={}", scene);
                 UserProfileDto userProfile = userProfileService.getProfileByUserId(userId);
 
                 if (userProfile != null) {
                     log.info("✅ UserProfile取得成功");
                     log.debug("   - UserProfile情報:");
-                    log.info("     - displayName: " + userProfile.getDisplayName());
-                    log.info("     - goals: " + userProfile.getGoals());
-                    log.info("     - concerns: " + userProfile.getConcerns());
-                    log.info("     - preferredFeedbackStyle: " + userProfile.getPreferredFeedbackStyle());
+                    log.info("     - displayName: {}", userProfile.getDisplayName());
+                    log.info("     - goals: {}", userProfile.getGoals());
+                    log.info("     - concerns: {}", userProfile.getConcerns());
+                    log.info("     - preferredFeedbackStyle: {}", userProfile.getPreferredFeedbackStyle());
 
                     String personalityTraits = userProfile.getPersonalityTraits() != null
                         ? String.join(", ", userProfile.getPersonalityTraits())
@@ -197,17 +197,17 @@ public class AiChatWebSocketController {
                 aiReply = bedrockService.chat(content);
             }
             log.info("✅ Bedrock から応答を取得しました");
-            log.debug("   - AI Reply: " + (aiReply.length() > 100 ? aiReply.substring(0, 100) + "..." : aiReply));
+            log.debug("   - AI Reply: {}", aiReply.length() > 100 ? aiReply.substring(0, 100) + "..." : aiReply);
 
             // AI応答をデータベースに保存（role: assistant）
             log.info("💾 AI応答をデータベースに保存中...");
             AiChatMessageResponseDto savedAiMessage = addAiChatMessageUseCase.execute(sessionId, userId, Role.assistant, aiReply);
             log.info("✅ AI応答保存成功");
-            log.debug("   - messageId: " + savedAiMessage.getId());
-            log.debug("   - role: " + savedAiMessage.getRole());
+            log.debug("   - messageId: {}", savedAiMessage.getId());
+            log.debug("   - role: {}", savedAiMessage.getRole());
 
             // WebSocket トピックへAI応答を送信
-            log.info("📤 WebSocket トピック /topic/ai-chat/session/" + sessionId + " へAI応答を送信中...");
+            log.info("📤 WebSocket トピック /topic/ai-chat/session/{} へAI応答を送信中...", sessionId);
             messagingTemplate.convertAndSend(
                     "/topic/ai-chat/session/" + sessionId,
                     savedAiMessage
@@ -222,7 +222,7 @@ public class AiChatWebSocketController {
                             "/topic/ai-chat/user/" + userId + "/scorecard",
                             scoreCard
                     );
-                    log.info("✅ スコアカード送信完了 - 総合スコア: " + scoreCard.getOverallScore());
+                    log.info("✅ スコアカード送信完了 - 総合スコア: {}", scoreCard.getOverallScore());
                 } else {
                     log.warn("⚠️ AI応答からスコアを抽出できませんでした");
                 }
@@ -237,7 +237,7 @@ public class AiChatWebSocketController {
                             "/topic/ai-chat/user/" + userId + "/scorecard",
                             scoreCard
                     );
-                    log.info("✅ 練習スコアカード送信完了 - 総合スコア: " + scoreCard.getOverallScore());
+                    log.info("✅ 練習スコアカード送信完了 - 総合スコア: {}", scoreCard.getOverallScore());
                 } else {
                     log.warn("⚠️ 練習AI応答からスコアを抽出できませんでした");
                 }
@@ -260,7 +260,7 @@ public class AiChatWebSocketController {
     @MessageMapping("/ai-chat/response")
     public void receiveAiResponse(@Payload Map<String, Object> payload) {
         log.info("\n========== WebSocket /ai-chat/response リクエスト受信 ==========");
-        log.info("🤖 AIレスポンス ペイロード: " + payload);
+        log.info("🤖 AIレスポンス ペイロード: {}", payload);
 
         try {
             Integer sessionId = convertToInteger(payload.get("sessionId"));
@@ -297,13 +297,13 @@ public class AiChatWebSocketController {
             Object sceneObj = payload.get("scene");
             String scene = sceneObj != null ? String.valueOf(sceneObj) : null;
 
-            log.debug("   - userId: " + userId);
-            log.debug("   - originalMessage: " + originalMessage);
-            log.debug("   - scene: " + scene);
+            log.debug("   - userId: {}", userId);
+            log.debug("   - originalMessage: {}", originalMessage);
+            log.debug("   - scene: {}", scene);
 
             // Bedrockに言い換えリクエスト
             String rephraseResult = bedrockService.rephrase(originalMessage, scene);
-            log.info("✅ 言い換え結果取得: " + rephraseResult);
+            log.info("✅ 言い換え結果取得: {}", rephraseResult);
 
             // WebSocket トピックへ言い換え結果を送信
             messagingTemplate.convertAndSend(

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
@@ -64,7 +64,7 @@ public class ChatController {
     Map<String, List<UserDto>> responseData = new HashMap<>();
 
     for (UserDto user : users) {
-      log.info("User_id" + user.getId() + "User_Email" + user.getEmail() + "User_name" + user.getName());
+      log.info("User_id: {}, User_Email: {}, User_name: {}", user.getId(), user.getEmail(), user.getName());
     }
     responseData.put("users", users);
     return ResponseEntity.ok().body(responseData);
@@ -74,11 +74,11 @@ public class ChatController {
   public ResponseEntity<?> create(@AuthenticationPrincipal Jwt jwt, @PathVariable(name = "id") Integer id) {
     
     log.info("\n========== ルーム作成リクエスト開始 ==========");
-    log.info("📌 リクエストPathVariable id: " + id);
-    log.info("📌 JWT null判定: " + (jwt == null ? "NULL" : "存在"));
-    
+    log.info("📌 リクエストPathVariable id: {}", id);
+    log.info("📌 JWT null判定: {}", jwt == null ? "NULL" : "存在");
+
     String cognitoSub = jwt.getSubject();
-    log.info("📌 cognitoSub (Cognito User ID): " + cognitoSub);
+    log.info("📌 cognitoSub (Cognito User ID): {}", cognitoSub);
     
     if (cognitoSub == null || cognitoSub.isEmpty()) {
       log.error("❌ cognitoSubがnullまたは空です");
@@ -90,17 +90,17 @@ public class ChatController {
       log.info("🔍 userIdentityService.findUserBySub() 実行中...");
       User myUser = userIdentityService.findUserBySub(cognitoSub);
       log.info("✅ 現在のユーザー取得成功");
-      log.debug("   - myUser.getId(): " + myUser.getId());
-      log.debug("   - myUser.getName(): " + myUser.getName());
-      log.debug("   - myUser.getEmail(): " + myUser.getEmail());
-      
+      log.debug("   - myUser.getId(): {}", myUser.getId());
+      log.debug("   - myUser.getName(): {}", myUser.getName());
+      log.debug("   - myUser.getEmail(): {}", myUser.getEmail());
+
       log.info("🔍 chatService.createOrGetRoom() 実行中...");
-      log.debug("   - myUser.getId(): " + myUser.getId() + " (ログイン中のユーザーID)");
-      log.debug("   - id (相手ユーザーID): " + id);
+      log.debug("   - myUser.getId(): {} (ログイン中のユーザーID)", myUser.getId());
+      log.debug("   - id (相手ユーザーID): {}", id);
       Integer roomId = chatService.createOrGetRoom(myUser.getId(), id);
       
       log.info("✅ ルーム作成/取得成功");
-      log.debug("   - roomId: " + roomId);
+      log.debug("   - roomId: {}", roomId);
       log.info("========== ルーム作成リクエスト終了(OK) ==========\n");
       return ResponseEntity.ok(Map.of(
             "roomId", roomId,
@@ -133,11 +133,11 @@ public class ChatController {
       
       // すでにroom_idが取得されている状態なのでchatRoomServiceからChatRoomオブジェクトを取得をする
       ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
-      log.info("chatRoom found: " + chatRoom.getId());
+      log.info("chatRoom found: {}", chatRoom.getId());
       
       // 履歴の取得 - 現在のユーザーIDを渡す
       List<ChatMessageDto> history = chatMessageService.getMessagesByRoom(chatRoom, myUserId);
-      log.info("history count: " + history.size());
+      log.info("history count: {}", history.size());
       
       return ResponseEntity.ok(history);
       
@@ -213,7 +213,7 @@ public class ChatController {
       @RequestParam(name = "query", required = false) String query) {
     
     log.info("\n========== GET /api/chat/rooms ==========");
-    log.info("📌 query: " + query);
+    log.info("📌 query: {}", query);
     
     if (jwt == null) {
       log.error("❌ 認証エラー: JWTがnull");
@@ -231,10 +231,10 @@ public class ChatController {
     
     try {
       User myUser = userIdentityService.findUserBySub(cognitoSub);
-      log.info("✅ ユーザー取得成功 - ID: " + myUser.getId() + ", Name: " + myUser.getName());
+      log.info("✅ ユーザー取得成功 - ID: {}, Name: {}", myUser.getId(), myUser.getName());
       
       List<ChatUserDto> chatUsers = chatService.findChatUsers(myUser.getId(), query);
-      log.info("✅ チャットユーザー取得成功 - 件数: " + chatUsers.size());
+      log.info("✅ チャットユーザー取得成功 - 件数: {}", chatUsers.size());
       
       Map<String, Object> response = new HashMap<>();
       response.put("chatUsers", chatUsers);

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
@@ -35,21 +35,21 @@ public class ChatWebSocketController {
             @Payload Map<String, Object> payload
     ) {
         log.info("\n========== WebSocket /chat/send リクエスト受信 ==========");
-        log.info("📨 ペイロード全体: " + payload);
-        
+        log.info("📨 ペイロード全体: {}", payload);
+
         try {
             // パラメータの取得と検証
             log.info("🔍 パラメータを抽出中...");
             Object senderIdObj = payload.get("senderId");
             Object roomIdObj = payload.get("roomId");
             Object contentObj = payload.get("content");
-            
-            log.debug("   - senderId タイプ: " + (senderIdObj != null ? senderIdObj.getClass().getSimpleName() : "null"));
-            log.debug("   - senderId 値: " + senderIdObj);
-            log.debug("   - roomId タイプ: " + (roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null"));
-            log.debug("   - roomId 値: " + roomIdObj);
-            log.debug("   - content タイプ: " + (contentObj != null ? contentObj.getClass().getSimpleName() : "null"));
-            log.debug("   - content 値: " + contentObj);
+
+            log.debug("   - senderId タイプ: {}", senderIdObj != null ? senderIdObj.getClass().getSimpleName() : "null");
+            log.debug("   - senderId 値: {}", senderIdObj);
+            log.debug("   - roomId タイプ: {}", roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null");
+            log.debug("   - roomId 値: {}", roomIdObj);
+            log.debug("   - content タイプ: {}", contentObj != null ? contentObj.getClass().getSimpleName() : "null");
+            log.debug("   - content 値: {}", contentObj);
             
             // senderId は String または Integer で来る可能性がある
             // Integer に変換して扱う
@@ -75,27 +75,27 @@ public class ChatWebSocketController {
             String content = (String) payload.get("content");
             
             log.info("✅ パラメータ抽出成功");
-            log.debug("   - senderId (最終): " + senderId + " (タイプ: String)");
-            log.debug("   - roomId (最終): " + roomId + " (タイプ: Integer)");
-            log.debug("   - content: " + content);
-            
+            log.debug("   - senderId (最終): {}", senderId);
+            log.debug("   - roomId (最終): {}", roomId);
+            log.debug("   - content: {}", content);
+
             // ChatRoom 取得
-            log.info("🔍 ChatRoom を roomId=" + roomId + " で取得中...");
+            log.info("🔍 ChatRoom を roomId={} で取得中...", roomId);
             ChatRoom room = chatRoomService.findChatRoomById(roomId);
-            log.info("✅ ChatRoom 取得成功: " + room.getId());
+            log.info("✅ ChatRoom 取得成功: {}", room.getId());
             
             // メッセージ保存
             log.info("💾 メッセージをデータベースに保存中...");
             ChatMessageDto saved = chatMessageService.addMessage(room, senderId, content);
             log.info("✅ メッセージ保存成功");
-            log.debug("   - messageId: " + saved.getId());
-            log.debug("   - roomId: " + saved.getRoomId());
-            log.debug("   - senderId: " + saved.getSenderId());
-            log.debug("   - content: " + saved.getContent());
-            log.debug("   - createdAt: " + saved.getCreatedAt());
+            log.debug("   - messageId: {}", saved.getId());
+            log.debug("   - roomId: {}", saved.getRoomId());
+            log.debug("   - senderId: {}", saved.getSenderId());
+            log.debug("   - content: {}", saved.getContent());
+            log.debug("   - createdAt: {}", saved.getCreatedAt());
 
             // WebSocket トピックへ送信
-            log.info("📤 WebSocket トピック /topic/chat/" + room.getId() + " へメッセージを送信中...");
+            log.info("📤 WebSocket トピック /topic/chat/{} へメッセージを送信中...", room.getId());
             messagingTemplate.convertAndSend(
                     "/topic/chat/" + room.getId(),
                     saved
@@ -115,7 +115,7 @@ public class ChatWebSocketController {
                                 "increment", 1
                         )
                 );
-                log.info("📤 未読数通知を /topic/unread/" + partner.getId() + " へ送信");
+                log.info("📤 未読数通知を /topic/unread/{} へ送信", partner.getId());
             }
 
             log.info("========== /chat/send 処理完了 ==========\n");
@@ -134,7 +134,7 @@ public class ChatWebSocketController {
             @Payload Map<String, Object> payload
     ) {
         log.info("\n========== WebSocket /chat/delete リクエスト受信 ==========");
-        log.info("🗑️ ペイロード全体: " + payload);
+        log.info("🗑️ ペイロード全体: {}", payload);
         
         try {
             // パラメータの取得と検証
@@ -142,25 +142,25 @@ public class ChatWebSocketController {
             Object messageIdObj = payload.get("messageId");
             Object roomIdObj = payload.get("roomId");
             
-            log.debug("   - messageId タイプ: " + (messageIdObj != null ? messageIdObj.getClass().getSimpleName() : "null"));
-            log.debug("   - messageId 値: " + messageIdObj);
-            log.debug("   - roomId タイプ: " + (roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null"));
-            log.debug("   - roomId 値: " + roomIdObj);
+            log.debug("   - messageId タイプ: {}", messageIdObj != null ? messageIdObj.getClass().getSimpleName() : "null");
+            log.debug("   - messageId 値: {}", messageIdObj);
+            log.debug("   - roomId タイプ: {}", roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null");
+            log.debug("   - roomId 値: {}", roomIdObj);
             
             Integer messageId = ((Number) payload.get("messageId")).intValue();
             Integer roomId = ((Number) payload.get("roomId")).intValue();
             
             log.info("✅ パラメータ抽出成功");
-            log.debug("   - messageId (最終): " + messageId);
-            log.debug("   - roomId (最終): " + roomId);
-            
+            log.debug("   - messageId (最終): {}", messageId);
+            log.debug("   - roomId (最終): {}", roomId);
+
             // メッセージ削除
-            log.info("🔍 messageId=" + messageId + " を削除中...");
+            log.info("🔍 messageId={} を削除中...", messageId);
             chatMessageService.deleteMessage(messageId);
             log.info("✅ メッセージ削除成功");
             
             // WebSocket トピックへ削除通知を送信
-            log.info("📤 WebSocket トピック /topic/chat/" + roomId + " へ削除通知を送信中...");
+            log.info("📤 WebSocket トピック /topic/chat/{} へ削除通知を送信中...", roomId);
             messagingTemplate.convertAndSend(
                     "/topic/chat/" + roomId,
                     Map.of(

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -82,8 +82,8 @@ public class CognitoAuthController {
     public ResponseEntity<?> signup(@RequestBody SignupForm form) {
         log.info("\n========== POST /api/auth/cognito/signup リクエスト開始 ==========");
         log.info("📌 リクエストパラメータ:");
-        log.info("   - email: " + form.getEmail());
-        log.info("   - name: " + form.getName());
+        log.info("   - email: {}", form.getEmail());
+        log.info("   - name: {}", form.getName());
         log.info("   - password: [MASKED]");
         
         try {
@@ -100,7 +100,7 @@ public class CognitoAuthController {
                     .body(Map.of("message", "サインアップ成功。確認メールを送信しました。"));
 
         } catch (UsernameExistsException e) {
-            log.info("❌ エラー: ユーザーが既に存在しています - " + form.getEmail());
+            log.info("❌ エラー: ユーザーが既に存在しています - {}", form.getEmail());
             log.info("========== /signup 処理完了(CONFLICT) ==========\n");
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(Map.of("error", "既にユーザーが存在しています。"));
@@ -123,8 +123,8 @@ public class CognitoAuthController {
     public ResponseEntity<?> confirm(@RequestBody ConfirmSignupForm form) {
         log.info("\n========== POST /api/auth/cognito/confirm リクエスト開始 ==========");
         log.info("📌 リクエストパラメータ:");
-        log.info("   - email: " + form.getEmail());
-        log.info("   - code: " + form.getCode());
+        log.info("   - email: {}", form.getEmail());
+        log.info("   - code: {}", form.getCode());
         
         try {
             log.info("🔍 cognitoAuthService.confirmUserSignup() 実行中...");
@@ -150,7 +150,7 @@ public class CognitoAuthController {
                     .body(Map.of("error", "確認コードの有効期限が切れています。"));
 
         } catch (UserNotFoundException e) {
-            log.info("❌ エラー: ユーザーが存在しません - " + form.getEmail());
+            log.info("❌ エラー: ユーザーが存在しません - {}", form.getEmail());
             log.info("========== /confirm 処理完了(NOT_FOUND) ==========\n");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("error", "ユーザーが存在しません。"));
@@ -168,7 +168,7 @@ public class CognitoAuthController {
     public ResponseEntity<?> login(@RequestBody LoginForm form, HttpServletResponse response) {
         log.info("\n========== POST /api/auth/cognito/login リクエスト開始 ==========");
         log.info("📌 リクエストパラメータ:");
-        log.info("   - email: " + form.getEmail());
+        log.info("   - email: {}", form.getEmail());
         log.info("   - password: [MASKED]");
 
         try {
@@ -184,9 +184,9 @@ public class CognitoAuthController {
             String accessToken = tokens.get("accessToken");
             String refreshToken = tokens.get("refreshToken");
             log.info("📌 トークン取得状況:");
-            log.info("   - idToken: " + (idToken != null ? "✓ 取得済" : "null"));
-            log.info("   - accessToken: " + (accessToken != null ? "✓ 取得済" : "null"));
-            log.info("   - refreshToken: " + (refreshToken != null ? "✓ 取得済" : "null"));
+            log.info("   - idToken: {}", idToken != null ? "✓ 取得済" : "null");
+            log.info("   - accessToken: {}", accessToken != null ? "✓ 取得済" : "null");
+            log.info("   - refreshToken: {}", refreshToken != null ? "✓ 取得済" : "null");
 
             log.info("🔍 JwtUtils.decode() 実行中...");
             Optional<JWTClaimsSet> claimsOpt = JwtUtils.decode(idToken);
@@ -199,12 +199,12 @@ public class CognitoAuthController {
 
             JWTClaimsSet claims = claimsOpt.get();
             log.info("📌 JWTクレーム情報:");
-            log.info("   - issuer: " + claims.getIssuer());
-            log.info("   - subject: " + claims.getSubject());
+            log.info("   - issuer: {}", claims.getIssuer());
+            log.info("   - subject: {}", claims.getSubject());
 
             log.info("🔍 userService.findUserByEmail() 実行中...");
             User user = userService.findUserByEmail(form.getEmail());
-            log.info("✅ ユーザー取得成功 - userId: " + user.getId());
+            log.info("✅ ユーザー取得成功 - userId: {}", user.getId());
             
             log.info("🔍 userIdentityService.registerUserIdentity() 実行中...");
             userIdentityService.registerUserIdentity(user, claims.getIssuer(), claims.getSubject());
@@ -234,8 +234,8 @@ public class CognitoAuthController {
     public ResponseEntity<?> callback(@RequestBody Map<String, String> body, HttpServletResponse response) {
         log.info("[CognitoAuthController /callback] Callback endpoint called");
         String code = body.get("code");
-        log.info("[CognitoAuthController /callback] Authorization code received: " + 
-                          (code != null ? code.substring(0, Math.min(20, code.length())) + "..." : "null"));
+        log.info("[CognitoAuthController /callback] Authorization code received: {}",
+                          code != null ? code.substring(0, Math.min(20, code.length())) + "..." : "null");
 
         String basicAuthValue = Base64.getEncoder()
                 .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
@@ -269,9 +269,9 @@ public class CognitoAuthController {
         String accessToken = (String) tokenResponse.get("access_token");
         String refreshToken = (String) tokenResponse.get("refresh_token");
 
-        log.info("[CognitoAuthController /callback] Token types - accessToken: " + 
-                          (accessToken != null ? "✓" : "null") + 
-                          ", refreshToken: " + (refreshToken != null ? "✓" : "null"));
+        log.info("[CognitoAuthController /callback] Token types - accessToken: {}, refreshToken: {}",
+                          accessToken != null ? "✓" : "null",
+                          refreshToken != null ? "✓" : "null");
 
         Optional<JWTClaimsSet> claimsOpt = JwtUtils.decode(idToken);
         if (claimsOpt.isEmpty()) {
@@ -286,12 +286,12 @@ public class CognitoAuthController {
             String email = claims.getStringClaim("email");
             String sub = claims.getSubject();
 
-            log.info("[CognitoAuthController /callback] User info - email: " + email + ", sub: " + sub);
+            log.info("[CognitoAuthController /callback] User info - email: {}, sub: {}", email, sub);
 
             boolean isGoogle = claims.getClaim("identities") != null;
             String provider = isGoogle ? "google" : "cognito";
 
-            log.info("[CognitoAuthController /callback] Registering user - provider: " + provider);
+            log.info("[CognitoAuthController /callback] Registering user - provider: {}", provider);
             User user = userService.registerUserOIDC(name, email, provider, sub);
 
             // アクセストークン、リフレッシュトークン保存
@@ -316,10 +316,10 @@ public class CognitoAuthController {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@AuthenticationPrincipal Jwt jwt, HttpServletResponse response) {
         log.info("\n========== POST /api/auth/cognito/logout リクエスト開始 ==========");
-        log.info("📌 JWT null判定: " + (jwt == null ? "NULL" : "存在"));
+        log.info("📌 JWT null判定: {}", jwt == null ? "NULL" : "存在");
         
         String sub = jwt.getSubject();
-        log.info("📌 JWT Subject (sub): " + sub);
+        log.info("📌 JWT Subject (sub): {}", sub);
 
         if (sub == null || sub.isEmpty()) {
             log.info("❌ エラー: subがnullまたは空です");
@@ -352,7 +352,7 @@ public class CognitoAuthController {
         
         String email = body.get("email");
         log.info("📌 リクエストパラメータ:");
-        log.info("   - email: " + email);
+        log.info("   - email: {}", email);
 
         try {
             log.info("🔍 cognitoAuthService.forgotPassword() 実行中...");
@@ -363,7 +363,7 @@ public class CognitoAuthController {
             return ResponseEntity.ok(Map.of("message", "確認コードを送信しました。"));
 
         } catch (UserNotFoundException e) {
-            log.info("❌ エラー: ユーザーが存在しません - " + email);
+            log.info("❌ エラー: ユーザーが存在しません - {}", email);
             log.info("========== /forgot-password 処理完了(NOT_FOUND) ==========\n");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("error", "ユーザーが存在しません。"));
@@ -383,8 +383,8 @@ public class CognitoAuthController {
                                         HttpServletResponse response) {
 
         log.info("[CognitoAuthController /refresh-token] Endpoint called");
-        log.info("[CognitoAuthController /refresh-token] REFRESH_TOKEN cookie: " + 
-                          (refreshToken != null ? refreshToken.substring(0, Math.min(20, refreshToken.length())) + "..." : "null"));
+        log.info("[CognitoAuthController /refresh-token] REFRESH_TOKEN cookie: {}",
+                          refreshToken != null ? refreshToken.substring(0, Math.min(20, refreshToken.length())) + "..." : "null");
 
         if (refreshToken == null || refreshToken.isEmpty()) {
             log.warn("認証エラー: リフレッシュトークンがnullまたは空");
@@ -427,8 +427,8 @@ public class CognitoAuthController {
         String newPassword = form.getNewPassword();
         
         log.info("📌 リクエストパラメータ:");
-        log.info("   - email: " + email);
-        log.info("   - code: " + code);
+        log.info("   - email: {}", email);
+        log.info("   - code: {}", code);
         log.info("   - newPassword: [MASKED]");
 
         try {
@@ -440,7 +440,7 @@ public class CognitoAuthController {
             return ResponseEntity.ok(Map.of("message", "パスワードをリセットしました。"));
 
         } catch (UserNotFoundException e) {
-            log.info("❌ エラー: ユーザーが存在しません - " + email);
+            log.info("❌ エラー: ユーザーが存在しません - {}", email);
             log.info("========== /confirm-forgot-password 処理完了(NOT_FOUND) ==========\n");
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
                     .body(Map.of("error", "ユーザーが存在しません。"));
@@ -484,10 +484,10 @@ public class CognitoAuthController {
                     .body(Map.of("error", "認証されていません"));
         }
         
-        log.info("[CognitoAuthController /me] JWT Principal: " + jwt.toString());
+        log.info("[CognitoAuthController /me] JWT Principal: {}", jwt);
         
         String sub = jwt.getSubject();
-        log.info("[CognitoAuthController /me] JWT Subject (sub): " + sub);
+        log.info("[CognitoAuthController /me] JWT Subject (sub): {}", sub);
 
         if (sub == null || sub.isEmpty()) {
             log.warn("認証エラー: JWTのsubがnullまたは空");
@@ -496,9 +496,9 @@ public class CognitoAuthController {
         }
 
         try {
-            log.info("[CognitoAuthController /me] Finding user with sub: " + sub);
+            log.info("[CognitoAuthController /me] Finding user with sub: {}", sub);
             Integer id = userIdentityService.findUserBySub(sub).getId();
-            log.info("[CognitoAuthController /me] User found: " + id);
+            log.info("[CognitoAuthController /me] User found: {}", id);
 
             return ResponseEntity.ok(Map.of("id",id));
 

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
@@ -45,10 +45,10 @@ public class ProfileController {
                     .body(Map.of("error", "認証に失敗しました。"));
         }
         
-        log.info("[ProfileController /me] JWT Principal: " + jwt.toString());
-        
+        log.info("[ProfileController /me] JWT Principal: {}", jwt);
+
         String sub = jwt.getSubject();
-        log.info("[ProfileController /me] JWT Subject (sub): " + sub);
+        log.info("[ProfileController /me] JWT Subject (sub): {}", sub);
 
         if (sub == null || sub.isEmpty()) {
             // JWT が無効 → 認証されていない
@@ -58,7 +58,7 @@ public class ProfileController {
         }
 
         try {
-            log.info("[ProfileController /me] Finding user with sub: " + sub);
+            log.info("[ProfileController /me] Finding user with sub: {}", sub);
             User user = userIdentityService.findUserBySub(sub);
 
             if (user == null) {
@@ -68,7 +68,7 @@ public class ProfileController {
                         .body(Map.of("error", "ユーザーが存在しません。"));
             }
             
-            log.info("[ProfileController /me] User found - ID: " + user.getId() + ", Name: " + user.getName());
+            log.info("[ProfileController /me] User found - ID: {}, Name: {}", user.getId(), user.getName());
 
             ProfileDto profileDto = new ProfileDto(
                     user.getName(),
@@ -101,10 +101,10 @@ public class ProfileController {
                     .body(Map.of("error", "認証に失敗しました。"));
         }
         
-        log.info("[ProfileController /me/update] JWT Principal: " + jwt.toString());
+        log.info("[ProfileController /me/update] JWT Principal: {}", jwt);
 
         String sub = jwt.getSubject();
-        log.info("[ProfileController /me/update] JWT Subject (sub): " + sub);
+        log.info("[ProfileController /me/update] JWT Subject (sub): {}", sub);
 
         if (sub == null || sub.isEmpty()) {
             log.warn("認証エラー: JWTのsubがnullまたは空");
@@ -112,12 +112,12 @@ public class ProfileController {
                     .body(Map.of("error", "認証に失敗しました。"));
         }
 
-        log.info("[ProfileController /me/update] Update request - name: " + form.getName() + 
-                          ", bio: " + (form.getBio() != null ? form.getBio().substring(0, Math.min(30, form.getBio().length())) + "..." : "null"));
+        log.info("[ProfileController /me/update] Update request - name: {}, bio: {}", form.getName(),
+                          form.getBio() != null ? form.getBio().substring(0, Math.min(30, form.getBio().length())) + "..." : "null");
 
         try {
             boolean isOidcUser = jwt.hasClaim("cognito:groups");
-            log.info("[ProfileController /me/update] User type - isOidcUser: " + isOidcUser);
+            log.info("[ProfileController /me/update] User type - isOidcUser: {}", isOidcUser);
 
             if (isOidcUser) {
                 // OIDCユーザー → DBのみ更新


### PR DESCRIPTION
## 概要
バックエンド全コントローラーのlog文で使用されている文字列連結（+演算子）をSLF4Jのパラメータ化形式（{}）に置換。

## 変更理由
文字列連結によるログ出力はログレベルが無効な場合でも文字列結合が実行されるため、パフォーマンスに悪影響がある。SLF4Jのパラメータ化形式はログレベルが有効な場合のみ文字列結合を実行する。

## 対象ファイル（5ファイル、約95箇所）
- AiChatWebSocketController.java
- CognitoAuthController.java
- ChatWebSocketController.java
- ChatController.java
- ProfileController.java

## テスト結果
- バックエンド: 354テスト（変更なし）

Closes #1025