### PR TITLE
feat: シナリオブックマークのバックエンド永続化

### DIFF
--- a/FreStyle/migrations/002_add_scenario_bookmarks.sql
+++ b/FreStyle/migrations/002_add_scenario_bookmarks.sql
@@ -1,0 +1,10 @@
+-- シナリオブックマークテーブルの作成
+CREATE TABLE IF NOT EXISTS scenario_bookmarks (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    scenario_id INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_user_scenario (user_id, scenario_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (scenario_id) REFERENCES practice_scenarios(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScenarioBookmarkController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScenarioBookmarkController.java
@@ -1,0 +1,72 @@
+package com.example.FreStyle.controller;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.AddScenarioBookmarkUseCase;
+import com.example.FreStyle.usecase.GetUserBookmarksUseCase;
+import com.example.FreStyle.usecase.RemoveScenarioBookmarkUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/bookmarks")
+public class ScenarioBookmarkController {
+
+    private static final Logger logger = LoggerFactory.getLogger(ScenarioBookmarkController.class);
+
+    private final GetUserBookmarksUseCase getUserBookmarksUseCase;
+    private final AddScenarioBookmarkUseCase addScenarioBookmarkUseCase;
+    private final RemoveScenarioBookmarkUseCase removeScenarioBookmarkUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping
+    public ResponseEntity<List<Integer>> getBookmarks(@AuthenticationPrincipal Jwt jwt) {
+        logger.info("========== GET /api/bookmarks ==========");
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        List<Integer> bookmarkedIds = getUserBookmarksUseCase.execute(user.getId());
+        logger.info("ブックマーク一覧取得成功 - 件数: {}", bookmarkedIds.size());
+        return ResponseEntity.ok(bookmarkedIds);
+    }
+
+    @PostMapping("/{scenarioId}")
+    public ResponseEntity<Void> addBookmark(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer scenarioId
+    ) {
+        logger.info("========== POST /api/bookmarks/{} ==========", scenarioId);
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        addScenarioBookmarkUseCase.execute(user, scenarioId);
+        logger.info("ブックマーク追加成功 - scenarioId: {}", scenarioId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{scenarioId}")
+    public ResponseEntity<Void> removeBookmark(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer scenarioId
+    ) {
+        logger.info("========== DELETE /api/bookmarks/{} ==========", scenarioId);
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        removeScenarioBookmarkUseCase.execute(user.getId(), scenarioId);
+        logger.info("ブックマーク削除成功 - scenarioId: {}", scenarioId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/ScenarioBookmark.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/ScenarioBookmark.java
@@ -1,0 +1,41 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "scenario_bookmarks", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "scenario_id"})
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScenarioBookmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "scenario_id", nullable = false)
+    private PracticeScenario scenario;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/ScenarioBookmarkRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/ScenarioBookmarkRepository.java
@@ -1,0 +1,21 @@
+package com.example.FreStyle.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.FreStyle.entity.ScenarioBookmark;
+
+@Repository
+public interface ScenarioBookmarkRepository extends JpaRepository<ScenarioBookmark, Integer> {
+
+    List<ScenarioBookmark> findByUserId(Integer userId);
+
+    Optional<ScenarioBookmark> findByUserIdAndScenarioId(Integer userId, Integer scenarioId);
+
+    boolean existsByUserIdAndScenarioId(Integer userId, Integer scenarioId);
+
+    void deleteByUserIdAndScenarioId(Integer userId, Integer scenarioId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/AddScenarioBookmarkUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/AddScenarioBookmarkUseCase.java
@@ -1,0 +1,36 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.PracticeScenario;
+import com.example.FreStyle.entity.ScenarioBookmark;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.PracticeScenarioRepository;
+import com.example.FreStyle.repository.ScenarioBookmarkRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AddScenarioBookmarkUseCase {
+
+    private final ScenarioBookmarkRepository scenarioBookmarkRepository;
+    private final PracticeScenarioRepository practiceScenarioRepository;
+
+    @Transactional
+    public void execute(User user, Integer scenarioId) {
+        if (scenarioBookmarkRepository.existsByUserIdAndScenarioId(user.getId(), scenarioId)) {
+            return;
+        }
+
+        PracticeScenario scenario = practiceScenarioRepository.findById(scenarioId)
+                .orElseThrow(() -> new ResourceNotFoundException("シナリオが見つかりません: ID=" + scenarioId));
+
+        ScenarioBookmark bookmark = new ScenarioBookmark();
+        bookmark.setUser(user);
+        bookmark.setScenario(scenario);
+        scenarioBookmarkRepository.save(bookmark);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserBookmarksUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserBookmarksUseCase.java
@@ -1,0 +1,25 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.repository.ScenarioBookmarkRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserBookmarksUseCase {
+
+    private final ScenarioBookmarkRepository scenarioBookmarkRepository;
+
+    @Transactional(readOnly = true)
+    public List<Integer> execute(Integer userId) {
+        return scenarioBookmarkRepository.findByUserId(userId).stream()
+                .map(bookmark -> bookmark.getScenario().getId())
+                .collect(Collectors.toList());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/RemoveScenarioBookmarkUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/RemoveScenarioBookmarkUseCase.java
@@ -1,0 +1,20 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.repository.ScenarioBookmarkRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RemoveScenarioBookmarkUseCase {
+
+    private final ScenarioBookmarkRepository scenarioBookmarkRepository;
+
+    @Transactional
+    public void execute(Integer userId, Integer scenarioId) {
+        scenarioBookmarkRepository.deleteByUserIdAndScenarioId(userId, scenarioId);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ScenarioBookmarkControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ScenarioBookmarkControllerTest.java
@@ -1,0 +1,116 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.AddScenarioBookmarkUseCase;
+import com.example.FreStyle.usecase.GetUserBookmarksUseCase;
+import com.example.FreStyle.usecase.RemoveScenarioBookmarkUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ScenarioBookmarkController")
+class ScenarioBookmarkControllerTest {
+
+    @Mock
+    private GetUserBookmarksUseCase getUserBookmarksUseCase;
+
+    @Mock
+    private AddScenarioBookmarkUseCase addScenarioBookmarkUseCase;
+
+    @Mock
+    private RemoveScenarioBookmarkUseCase removeScenarioBookmarkUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private ScenarioBookmarkController controller;
+
+    private Jwt jwt;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("test-sub");
+
+        user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+    }
+
+    @Nested
+    @DisplayName("GET /api/bookmarks - ブックマーク一覧取得")
+    class GetBookmarks {
+
+        @Test
+        @DisplayName("ブックマーク済みシナリオIDリストを返す")
+        void shouldReturnBookmarkedIds() {
+            when(getUserBookmarksUseCase.execute(1)).thenReturn(List.of(1, 3, 5));
+
+            ResponseEntity<List<Integer>> response = controller.getBookmarks(jwt);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).containsExactly(1, 3, 5);
+            verify(getUserBookmarksUseCase).execute(1);
+        }
+
+        @Test
+        @DisplayName("ブックマークが無い場合は空リストを返す")
+        void shouldReturnEmptyList() {
+            when(getUserBookmarksUseCase.execute(1)).thenReturn(List.of());
+
+            ResponseEntity<List<Integer>> response = controller.getBookmarks(jwt);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/bookmarks/{scenarioId} - ブックマーク追加")
+    class AddBookmark {
+
+        @Test
+        @DisplayName("ブックマークを追加する")
+        void shouldAddBookmark() {
+            ResponseEntity<Void> response = controller.addBookmark(jwt, 3);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            verify(addScenarioBookmarkUseCase).execute(user, 3);
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/bookmarks/{scenarioId} - ブックマーク削除")
+    class RemoveBookmark {
+
+        @Test
+        @DisplayName("ブックマークを削除する")
+        void shouldRemoveBookmark() {
+            ResponseEntity<Void> response = controller.removeBookmark(jwt, 3);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            verify(removeScenarioBookmarkUseCase).execute(1, 3);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/AddScenarioBookmarkUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/AddScenarioBookmarkUseCaseTest.java
@@ -1,0 +1,85 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.PracticeScenario;
+import com.example.FreStyle.entity.ScenarioBookmark;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.PracticeScenarioRepository;
+import com.example.FreStyle.repository.ScenarioBookmarkRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AddScenarioBookmarkUseCase テスト")
+class AddScenarioBookmarkUseCaseTest {
+
+    @Mock
+    private ScenarioBookmarkRepository scenarioBookmarkRepository;
+
+    @Mock
+    private PracticeScenarioRepository practiceScenarioRepository;
+
+    @InjectMocks
+    private AddScenarioBookmarkUseCase addScenarioBookmarkUseCase;
+
+    private User testUser;
+    private PracticeScenario testScenario;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1);
+        testUser.setName("テストユーザー");
+        testUser.setEmail("test@example.com");
+
+        testScenario = new PracticeScenario();
+        testScenario.setId(1);
+        testScenario.setName("テストシナリオ");
+    }
+
+    @Test
+    @DisplayName("新規ブックマークを追加できる")
+    void execute_AddsNewBookmark() {
+        when(scenarioBookmarkRepository.existsByUserIdAndScenarioId(1, 1)).thenReturn(false);
+        when(practiceScenarioRepository.findById(1)).thenReturn(Optional.of(testScenario));
+
+        addScenarioBookmarkUseCase.execute(testUser, 1);
+
+        verify(scenarioBookmarkRepository).save(any(ScenarioBookmark.class));
+    }
+
+    @Test
+    @DisplayName("既にブックマーク済みの場合は重複保存しない")
+    void execute_SkipsWhenAlreadyBookmarked() {
+        when(scenarioBookmarkRepository.existsByUserIdAndScenarioId(1, 1)).thenReturn(true);
+
+        addScenarioBookmarkUseCase.execute(testUser, 1);
+
+        verify(scenarioBookmarkRepository, never()).save(any(ScenarioBookmark.class));
+    }
+
+    @Test
+    @DisplayName("存在しないシナリオIDの場合はResourceNotFoundExceptionをスロー")
+    void execute_ThrowsException_WhenScenarioNotFound() {
+        when(scenarioBookmarkRepository.existsByUserIdAndScenarioId(1, 999)).thenReturn(false);
+        when(practiceScenarioRepository.findById(999)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            addScenarioBookmarkUseCase.execute(testUser, 999);
+        });
+
+        verify(scenarioBookmarkRepository, never()).save(any(ScenarioBookmark.class));
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserBookmarksUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserBookmarksUseCaseTest.java
@@ -1,0 +1,83 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.PracticeScenario;
+import com.example.FreStyle.entity.ScenarioBookmark;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.ScenarioBookmarkRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetUserBookmarksUseCase テスト")
+class GetUserBookmarksUseCaseTest {
+
+    @Mock
+    private ScenarioBookmarkRepository scenarioBookmarkRepository;
+
+    @InjectMocks
+    private GetUserBookmarksUseCase getUserBookmarksUseCase;
+
+    private User testUser;
+    private PracticeScenario testScenario;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1);
+        testUser.setName("テストユーザー");
+        testUser.setEmail("test@example.com");
+
+        testScenario = new PracticeScenario();
+        testScenario.setId(1);
+        testScenario.setName("テストシナリオ");
+    }
+
+    @Test
+    @DisplayName("ユーザーのブックマーク済みシナリオIDリストを取得できる")
+    void execute_ReturnsBookmarkedScenarioIds() {
+        ScenarioBookmark bookmark1 = new ScenarioBookmark();
+        bookmark1.setId(1);
+        bookmark1.setUser(testUser);
+        PracticeScenario scenario1 = new PracticeScenario();
+        scenario1.setId(1);
+        bookmark1.setScenario(scenario1);
+
+        ScenarioBookmark bookmark2 = new ScenarioBookmark();
+        bookmark2.setId(2);
+        bookmark2.setUser(testUser);
+        PracticeScenario scenario2 = new PracticeScenario();
+        scenario2.setId(3);
+        bookmark2.setScenario(scenario2);
+
+        when(scenarioBookmarkRepository.findByUserId(1)).thenReturn(List.of(bookmark1, bookmark2));
+
+        List<Integer> result = getUserBookmarksUseCase.execute(testUser.getId());
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains(1));
+        assertTrue(result.contains(3));
+        verify(scenarioBookmarkRepository).findByUserId(1);
+    }
+
+    @Test
+    @DisplayName("ブックマークが空の場合、空のリストを返す")
+    void execute_ReturnsEmptyList_WhenNoBookmarks() {
+        when(scenarioBookmarkRepository.findByUserId(1)).thenReturn(List.of());
+
+        List<Integer> result = getUserBookmarksUseCase.execute(testUser.getId());
+
+        assertTrue(result.isEmpty());
+        verify(scenarioBookmarkRepository).findByUserId(1);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/RemoveScenarioBookmarkUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/RemoveScenarioBookmarkUseCaseTest.java
@@ -1,0 +1,41 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.repository.ScenarioBookmarkRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RemoveScenarioBookmarkUseCase テスト")
+class RemoveScenarioBookmarkUseCaseTest {
+
+    @Mock
+    private ScenarioBookmarkRepository scenarioBookmarkRepository;
+
+    @InjectMocks
+    private RemoveScenarioBookmarkUseCase removeScenarioBookmarkUseCase;
+
+    @Test
+    @DisplayName("ブックマークを削除できる")
+    void execute_RemovesBookmark() {
+        removeScenarioBookmarkUseCase.execute(1, 1);
+
+        verify(scenarioBookmarkRepository).deleteByUserIdAndScenarioId(1, 1);
+    }
+
+    @Test
+    @DisplayName("存在しないブックマークの削除も正常に完了する")
+    void execute_DoesNotThrow_WhenBookmarkNotExists() {
+        doNothing().when(scenarioBookmarkRepository).deleteByUserIdAndScenarioId(1, 999);
+
+        removeScenarioBookmarkUseCase.execute(1, 999);
+
+        verify(scenarioBookmarkRepository).deleteByUserIdAndScenarioId(1, 999);
+    }
+}

--- a/frontend/src/repositories/BookmarkRepository.ts
+++ b/frontend/src/repositories/BookmarkRepository.ts
@@ -1,31 +1,55 @@
+import apiClient from '../lib/axios';
+
 const STORAGE_KEY = 'freestyle_scenario_bookmarks';
 
+function getLocalBookmarks(): number[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return [];
+  }
+}
+
+function saveLocalBookmarks(ids: number[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+}
+
 export const BookmarkRepository = {
-  getAll(): number[] {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
+  async getAll(): Promise<number[]> {
     try {
-      return JSON.parse(raw);
+      const response = await apiClient.get<number[]>('/api/bookmarks');
+      return response.data;
     } catch {
-      localStorage.removeItem(STORAGE_KEY);
-      return [];
+      return getLocalBookmarks();
     }
   },
 
-  add(scenarioId: number): void {
-    const ids = this.getAll();
-    if (!ids.includes(scenarioId)) {
-      ids.push(scenarioId);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  async add(scenarioId: number): Promise<void> {
+    try {
+      await apiClient.post(`/api/bookmarks/${scenarioId}`);
+    } catch {
+      const ids = getLocalBookmarks();
+      if (!ids.includes(scenarioId)) {
+        ids.push(scenarioId);
+        saveLocalBookmarks(ids);
+      }
     }
   },
 
-  remove(scenarioId: number): void {
-    const ids = this.getAll().filter(id => id !== scenarioId);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(ids));
+  async remove(scenarioId: number): Promise<void> {
+    try {
+      await apiClient.delete(`/api/bookmarks/${scenarioId}`);
+    } catch {
+      const ids = getLocalBookmarks().filter(id => id !== scenarioId);
+      saveLocalBookmarks(ids);
+    }
   },
 
-  isBookmarked(scenarioId: number): boolean {
-    return this.getAll().includes(scenarioId);
+  async isBookmarked(scenarioId: number): Promise<boolean> {
+    const ids = await this.getAll();
+    return ids.includes(scenarioId);
   },
 };


### PR DESCRIPTION
## 概要
localStorageのみだったシナリオブックマーク機能をREST API経由でサーバーサイドに永続化。
ログイン中はAPIでDB保存、未ログイン/APIエラー時はlocalStorageにフォールバック。

## 変更内容
### バックエンド
- `ScenarioBookmark` エンティティ（user_id + scenario_id のユニーク制約）
- `ScenarioBookmarkRepository` JPA リポジトリ
- `AddScenarioBookmarkUseCase` - 冪等なブックマーク追加
- `GetUserBookmarksUseCase` - ユーザーのブックマーク済みシナリオID一覧取得
- `RemoveScenarioBookmarkUseCase` - ブックマーク削除
- `ScenarioBookmarkController` - REST API（GET/POST/DELETE `/api/bookmarks`）
- DBマイグレーション `002_add_scenario_bookmarks.sql`

### フロントエンド
- `BookmarkRepository` をAPI対応に変更（localStorageフォールバック付き）
- `useBookmark` フックを非同期化（楽観的UI更新）

### テスト
- バックエンド: 11件（UseCase 7件 + Controller 4件）
- フロントエンド: 18件（Repository 9件 + Hook 9件）

## テスト計画
- [x] バックエンドユニットテスト全パス
- [x] フロントエンドユニットテスト全パス
- [ ] ブラウザでブックマークの追加・削除が動作すること
- [ ] ログアウト→ログイン後もブックマークが保持されること

Closes #1029