### PR TITLE
refactor: ProfileControllerのビジネスロジックをUseCase層に分離

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
@@ -13,11 +13,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.FreStyle.dto.ProfileDto;
-import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
 import com.example.FreStyle.form.ProfileForm;
-import com.example.FreStyle.service.CognitoAuthService;
-import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.usecase.GetProfileUseCase;
+import com.example.FreStyle.usecase.UpdateProfileUseCase;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,128 +27,62 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ProfileController {
 
-    private final CognitoAuthService cognitoAuthService;
-    private final UserService userService;
-    private final UserIdentityService userIdentityService;
+    private final GetProfileUseCase getProfileUseCase;
+    private final UpdateProfileUseCase updateProfileUseCase;
 
-    // -----------------------
-    // GET /me
-    // -----------------------
     @GetMapping("/me")
     public ResponseEntity<?> getProfile(@AuthenticationPrincipal Jwt jwt) {
-        log.info("[ProfileController /me] Endpoint called");
-        
         if (jwt == null) {
-            log.warn("認証エラー: JWTがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
-        
-        log.info("[ProfileController /me] JWT Principal: {}", jwt);
 
         String sub = jwt.getSubject();
-        log.info("[ProfileController /me] JWT Subject (sub): {}", sub);
-
         if (sub == null || sub.isEmpty()) {
-            // JWT が無効 → 認証されていない
-            log.warn("認証エラー: JWTのsubがnullまたは空");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
 
         try {
-            log.info("[ProfileController /me] Finding user with sub: {}", sub);
-            User user = userIdentityService.findUserBySub(sub);
-
-            if (user == null) {
-                // sub に紐づくユーザーが DB に存在しない
-                log.warn("ユーザー未存在: sub={}", sub);
-                return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                        .body(Map.of("error", "ユーザーが存在しません。"));
-            }
-            
-            log.info("[ProfileController /me] User found - ID: {}, Name: {}", user.getId(), user.getName());
-
-            ProfileDto profileDto = new ProfileDto(
-                    user.getName(),
-                    user.getBio());
-
-            log.info("[ProfileController /me] Returning profile data");
+            ProfileDto profileDto = getProfileUseCase.execute(sub);
             return ResponseEntity.ok(profileDto);
-
+        } catch (ResourceNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "ユーザーが存在しません。"));
         } catch (Exception e) {
-            // 想定外のエラー
             log.error("プロフィール取得エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 
-    // -----------------------
-    // PUT /me/update
-    // -----------------------
     @PutMapping("/me/update")
     public ResponseEntity<?> updateProfile(
             @AuthenticationPrincipal Jwt jwt,
             @RequestBody ProfileForm form) {
 
-        log.info("[ProfileController /me/update] Endpoint called");
-        
         if (jwt == null) {
-            log.warn("認証エラー: JWTがnull");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
-        
-        log.info("[ProfileController /me/update] JWT Principal: {}", jwt);
 
         String sub = jwt.getSubject();
-        log.info("[ProfileController /me/update] JWT Subject (sub): {}", sub);
-
         if (sub == null || sub.isEmpty()) {
-            log.warn("認証エラー: JWTのsubがnullまたは空");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(Map.of("error", "認証に失敗しました。"));
         }
 
-        log.info("[ProfileController /me/update] Update request - name: {}, bio: {}", form.getName(),
-                          form.getBio() != null ? form.getBio().substring(0, Math.min(30, form.getBio().length())) + "..." : "null");
-
         try {
-            boolean isOidcUser = jwt.hasClaim("cognito:groups");
-            log.info("[ProfileController /me/update] User type - isOidcUser: {}", isOidcUser);
-
-            if (isOidcUser) {
-                // OIDCユーザー → DBのみ更新
-                log.info("[ProfileController /me/update] OIDC user detected - updating DB only");
-                userService.updateUser(form, sub);
-                log.info("[ProfileController /me/update] DB update successful");
-
-            } else {
-                // Cognitoユーザー → Cognito + DB 更新
-                log.info("[ProfileController /me/update] Cognito user detected - updating Cognito and DB");
-                String accessToken = jwt.getTokenValue();
-                log.info("[ProfileController /me/update] Updating Cognito profile");
-                cognitoAuthService.updateUserProfile(accessToken, form.getName());
-                log.info("[ProfileController /me/update] Cognito update successful - updating DB");
-                userService.updateUser(form, sub);
-                log.info("[ProfileController /me/update] DB update successful");
-            }
-
+            updateProfileUseCase.execute(jwt, form);
         } catch (IllegalArgumentException e) {
-            // フォームの入力値が不正等
-            log.warn("プロフィール更新エラー(入力値不正): {}", e.getMessage());
             return ResponseEntity.badRequest()
                     .body(Map.of("error", e.getMessage()));
-
         } catch (Exception e) {
-            // 想定外エラー
             log.error("プロフィール更新エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
 
-        log.info("[ProfileController /me/update] Profile update completed successfully");
         return ResponseEntity.ok(Map.of("message", "プロフィールを更新しました。"));
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetProfileUseCase.java
@@ -1,0 +1,27 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetProfileUseCase {
+
+    private final UserIdentityService userIdentityService;
+
+    @Transactional(readOnly = true)
+    public ProfileDto execute(String sub) {
+        User user = userIdentityService.findUserBySub(sub);
+        if (user == null) {
+            throw new ResourceNotFoundException("ユーザーが見つかりません: sub=" + sub);
+        }
+        return new ProfileDto(user.getName(), user.getBio());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateProfileUseCase.java
@@ -1,0 +1,32 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.form.ProfileForm;
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateProfileUseCase {
+
+    private final CognitoAuthService cognitoAuthService;
+    private final UserService userService;
+
+    @Transactional
+    public void execute(Jwt jwt, ProfileForm form) {
+        String sub = jwt.getSubject();
+        boolean isOidcUser = jwt.hasClaim("cognito:groups");
+
+        if (!isOidcUser) {
+            String accessToken = jwt.getTokenValue();
+            cognitoAuthService.updateUserProfile(accessToken, form.getName());
+        }
+
+        userService.updateUser(form, sub);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetProfileUseCaseTest.java
@@ -1,0 +1,60 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetProfileUseCase テスト")
+class GetProfileUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private GetProfileUseCase getProfileUseCase;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1);
+        testUser.setName("テストユーザー");
+        testUser.setEmail("test@example.com");
+        testUser.setBio("テスト自己紹介");
+    }
+
+    @Test
+    @DisplayName("subからProfileDtoを取得できる")
+    void execute_ReturnsProfileDto() {
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(testUser);
+
+        ProfileDto result = getProfileUseCase.execute("sub-123");
+
+        assertEquals("テストユーザー", result.getName());
+        assertEquals("テスト自己紹介", result.getBio());
+    }
+
+    @Test
+    @DisplayName("ユーザーが見つからない場合はResourceNotFoundExceptionをスロー")
+    void execute_ThrowsException_WhenUserNotFound() {
+        when(userIdentityService.findUserBySub("sub-999")).thenReturn(null);
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            getProfileUseCase.execute("sub-999");
+        });
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateProfileUseCaseTest.java
@@ -1,0 +1,79 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.form.ProfileForm;
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateProfileUseCase テスト")
+class UpdateProfileUseCaseTest {
+
+    @Mock
+    private CognitoAuthService cognitoAuthService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UpdateProfileUseCase updateProfileUseCase;
+
+    @Test
+    @DisplayName("Cognitoユーザーの場合、CognitoとDBの両方を更新する")
+    void execute_UpdatesCognitoAndDb_WhenCognitoUser() {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("sub-123");
+        when(jwt.hasClaim("cognito:groups")).thenReturn(false);
+        when(jwt.getTokenValue()).thenReturn("access-token");
+
+        ProfileForm form = new ProfileForm("新しい名前", "新しい自己紹介");
+
+        updateProfileUseCase.execute(jwt, form);
+
+        verify(cognitoAuthService).updateUserProfile("access-token", "新しい名前");
+        verify(userService).updateUser(form, "sub-123");
+    }
+
+    @Test
+    @DisplayName("OIDCユーザーの場合、DBのみ更新する")
+    void execute_UpdatesDbOnly_WhenOidcUser() {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("sub-456");
+        when(jwt.hasClaim("cognito:groups")).thenReturn(true);
+
+        ProfileForm form = new ProfileForm("OIDC名前", "OIDC自己紹介");
+
+        updateProfileUseCase.execute(jwt, form);
+
+        verify(cognitoAuthService, never()).updateUserProfile(anyString(), anyString());
+        verify(userService).updateUser(form, "sub-456");
+    }
+
+    @Test
+    @DisplayName("入力値不正時はIllegalArgumentExceptionをスロー")
+    void execute_ThrowsException_WhenInvalidInput() {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("sub-123");
+        when(jwt.hasClaim("cognito:groups")).thenReturn(false);
+        when(jwt.getTokenValue()).thenReturn("access-token");
+
+        ProfileForm form = new ProfileForm("名前", "自己紹介");
+
+        doThrow(new IllegalArgumentException("名前が不正です"))
+                .when(cognitoAuthService).updateUserProfile("access-token", "名前");
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            updateProfileUseCase.execute(jwt, form);
+        });
+    }
+}


### PR DESCRIPTION
## 概要
ProfileControllerに含まれていたビジネスロジック（OIDCユーザー判定、Cognito更新分岐、ユーザー検索・DTO変換）をUseCase層に分離。

## 変更内容
- `GetProfileUseCase` 新規作成: sub → ProfileDto変換、ユーザー未存在時はResourceNotFoundException
- `UpdateProfileUseCase` 新規作成: OIDC/Cognito判定を含むプロフィール更新ロジック
- `ProfileController` 簡素化: UseCase呼び出しのみ、冗長なデバッグログ削除
- `ProfileControllerTest` 更新: UseCase mockに変更

## テスト
- GetProfileUseCaseTest: 2件
- UpdateProfileUseCaseTest: 3件
- ProfileControllerTest: 5件（Nested構造維持）
- 全テストパス

## テスト計画
- [x] UseCase単体テスト全パス
- [x] Controller単体テスト全パス
- [ ] プロフィール取得・更新がブラウザで正常動作すること

Closes #1031