### PR TITLE
test: バックエンドテストカバレッジ100%達成

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/HelloControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/HelloControllerTest.java
@@ -1,0 +1,20 @@
+package com.example.FreStyle.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HelloController テスト")
+class HelloControllerTest {
+
+    private final HelloController helloController = new HelloController();
+
+    @Test
+    @DisplayName("helloエンドポイントが'hello'を返す")
+    void hello_ReturnsHelloString() {
+        String result = helloController.hello();
+
+        assertEquals("hello", result);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/exception/BusinessExceptionTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/BusinessExceptionTest.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("BusinessException テスト")
+class BusinessExceptionTest {
+
+    @Test
+    @DisplayName("メッセージ付きコンストラクタでメッセージを保持する")
+    void constructor_WithMessage() {
+        BusinessException exception = new BusinessException("テストエラー");
+
+        assertEquals("テストエラー", exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    @DisplayName("メッセージ・原因例外付きコンストラクタで両方を保持する")
+    void constructor_WithMessageAndCause() {
+        RuntimeException cause = new RuntimeException("原因");
+        BusinessException exception = new BusinessException("テストエラー", cause);
+
+        assertEquals("テストエラー", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    @DisplayName("RuntimeExceptionのサブクラスである")
+    void isRuntimeException() {
+        BusinessException exception = new BusinessException("テスト");
+
+        assertInstanceOf(RuntimeException.class, exception);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/exception/ResourceNotFoundExceptionTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/ResourceNotFoundExceptionTest.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ResourceNotFoundException テスト")
+class ResourceNotFoundExceptionTest {
+
+    @Test
+    @DisplayName("メッセージ付きコンストラクタでメッセージを保持する")
+    void constructor_WithMessage() {
+        ResourceNotFoundException exception = new ResourceNotFoundException("リソース未検出");
+
+        assertEquals("リソース未検出", exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    @DisplayName("メッセージ・原因例外付きコンストラクタで両方を保持する")
+    void constructor_WithMessageAndCause() {
+        RuntimeException cause = new RuntimeException("原因");
+        ResourceNotFoundException exception = new ResourceNotFoundException("リソース未検出", cause);
+
+        assertEquals("リソース未検出", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    @DisplayName("RuntimeExceptionのサブクラスである")
+    void isRuntimeException() {
+        ResourceNotFoundException exception = new ResourceNotFoundException("テスト");
+
+        assertInstanceOf(RuntimeException.class, exception);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/exception/UnauthorizedExceptionTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/UnauthorizedExceptionTest.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.exception;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UnauthorizedException テスト")
+class UnauthorizedExceptionTest {
+
+    @Test
+    @DisplayName("メッセージ付きコンストラクタでメッセージを保持する")
+    void constructor_WithMessage() {
+        UnauthorizedException exception = new UnauthorizedException("権限エラー");
+
+        assertEquals("権限エラー", exception.getMessage());
+        assertNull(exception.getCause());
+    }
+
+    @Test
+    @DisplayName("メッセージ・原因例外付きコンストラクタで両方を保持する")
+    void constructor_WithMessageAndCause() {
+        RuntimeException cause = new RuntimeException("原因");
+        UnauthorizedException exception = new UnauthorizedException("権限エラー", cause);
+
+        assertEquals("権限エラー", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    @DisplayName("RuntimeExceptionのサブクラスである")
+    void isRuntimeException() {
+        UnauthorizedException exception = new UnauthorizedException("テスト");
+
+        assertInstanceOf(RuntimeException.class, exception);
+    }
+}


### PR DESCRIPTION
## 概要
テスト未作成だった4クラスにユニットテストを追加し、バックエンド全レイヤーのテストカバレッジを100%に統一。

## 追加テスト
- `HelloControllerTest` - ヘルスチェックエンドポイント応答テスト（1件）
- `BusinessExceptionTest` - コンストラクタ・継承テスト（3件）
- `ResourceNotFoundExceptionTest` - コンストラクタ・継承テスト（3件）
- `UnauthorizedExceptionTest` - コンストラクタ・継承テスト（3件）

## テスト計画
- [x] 新規10件のテスト全パス
- [x] 既存テスト影響なし

Closes #1033