### PR TITLE
feat: お気に入りフレーズ集のバックエンド永続化

### DIFF
--- a/FreStyle/migrations/003_add_favorite_phrases.sql
+++ b/FreStyle/migrations/003_add_favorite_phrases.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS favorite_phrases (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    original_text TEXT NOT NULL,
+    rephrased_text TEXT NOT NULL,
+    pattern VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/FavoritePhraseController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/FavoritePhraseController.java
@@ -1,0 +1,69 @@
+package com.example.FreStyle.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.FavoritePhraseDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.AddFavoritePhraseUseCase;
+import com.example.FreStyle.usecase.GetUserFavoritePhrasesUseCase;
+import com.example.FreStyle.usecase.RemoveFavoritePhraseUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/favorite-phrases")
+@Slf4j
+public class FavoritePhraseController {
+
+    private final GetUserFavoritePhrasesUseCase getUserFavoritePhrasesUseCase;
+    private final AddFavoritePhraseUseCase addFavoritePhraseUseCase;
+    private final RemoveFavoritePhraseUseCase removeFavoritePhraseUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping
+    public ResponseEntity<List<FavoritePhraseDto>> getFavoritePhrases(@AuthenticationPrincipal Jwt jwt) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        List<FavoritePhraseDto> phrases = getUserFavoritePhrasesUseCase.execute(user.getId());
+        return ResponseEntity.ok(phrases);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addFavoritePhrase(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody Map<String, String> body) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        addFavoritePhraseUseCase.execute(
+                user,
+                body.get("originalText"),
+                body.get("rephrasedText"),
+                body.get("pattern"));
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{phraseId}")
+    public ResponseEntity<Void> removeFavoritePhrase(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer phraseId) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        removeFavoritePhraseUseCase.execute(user.getId(), phraseId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/FavoritePhraseDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/FavoritePhraseDto.java
@@ -1,0 +1,16 @@
+package com.example.FreStyle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FavoritePhraseDto {
+    private Integer id;
+    private String originalText;
+    private String rephrasedText;
+    private String pattern;
+    private String createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/FavoritePhrase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/FavoritePhrase.java
@@ -1,0 +1,44 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "favorite_phrases")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoritePhrase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "original_text", nullable = false, columnDefinition = "TEXT")
+    private String originalText;
+
+    @Column(name = "rephrased_text", nullable = false, columnDefinition = "TEXT")
+    private String rephrasedText;
+
+    @Column(name = "pattern", nullable = false, length = 50)
+    private String pattern;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/FavoritePhraseRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/FavoritePhraseRepository.java
@@ -1,0 +1,17 @@
+package com.example.FreStyle.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.FreStyle.entity.FavoritePhrase;
+
+@Repository
+public interface FavoritePhraseRepository extends JpaRepository<FavoritePhrase, Integer> {
+    List<FavoritePhrase> findByUserIdOrderByCreatedAtDesc(Integer userId);
+
+    boolean existsByUserIdAndRephrasedTextAndPattern(Integer userId, String rephrasedText, String pattern);
+
+    void deleteByIdAndUserId(Integer id, Integer userId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/AddFavoritePhraseUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/AddFavoritePhraseUseCase.java
@@ -1,0 +1,32 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.FavoritePhrase;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.FavoritePhraseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AddFavoritePhraseUseCase {
+
+    private final FavoritePhraseRepository favoritePhraseRepository;
+
+    @Transactional
+    public void execute(User user, String originalText, String rephrasedText, String pattern) {
+        if (favoritePhraseRepository.existsByUserIdAndRephrasedTextAndPattern(
+                user.getId(), rephrasedText, pattern)) {
+            return;
+        }
+
+        FavoritePhrase phrase = new FavoritePhrase();
+        phrase.setUser(user);
+        phrase.setOriginalText(originalText);
+        phrase.setRephrasedText(rephrasedText);
+        phrase.setPattern(pattern);
+        favoritePhraseRepository.save(phrase);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCase.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.FavoritePhraseDto;
+import com.example.FreStyle.repository.FavoritePhraseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserFavoritePhrasesUseCase {
+
+    private final FavoritePhraseRepository favoritePhraseRepository;
+
+    @Transactional(readOnly = true)
+    public List<FavoritePhraseDto> execute(Integer userId) {
+        return favoritePhraseRepository.findByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(phrase -> new FavoritePhraseDto(
+                        phrase.getId(),
+                        phrase.getOriginalText(),
+                        phrase.getRephrasedText(),
+                        phrase.getPattern(),
+                        phrase.getCreatedAt() != null ? phrase.getCreatedAt().toInstant().toString() : null))
+                .collect(Collectors.toList());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/RemoveFavoritePhraseUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/RemoveFavoritePhraseUseCase.java
@@ -1,0 +1,20 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.repository.FavoritePhraseRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RemoveFavoritePhraseUseCase {
+
+    private final FavoritePhraseRepository favoritePhraseRepository;
+
+    @Transactional
+    public void execute(Integer userId, Integer phraseId) {
+        favoritePhraseRepository.deleteByIdAndUserId(phraseId, userId);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
@@ -1,0 +1,112 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.FavoritePhraseDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.AddFavoritePhraseUseCase;
+import com.example.FreStyle.usecase.GetUserFavoritePhrasesUseCase;
+import com.example.FreStyle.usecase.RemoveFavoritePhraseUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FavoritePhraseController")
+class FavoritePhraseControllerTest {
+
+    @Mock
+    private GetUserFavoritePhrasesUseCase getUserFavoritePhrasesUseCase;
+
+    @Mock
+    private AddFavoritePhraseUseCase addFavoritePhraseUseCase;
+
+    @Mock
+    private RemoveFavoritePhraseUseCase removeFavoritePhraseUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private FavoritePhraseController favoritePhraseController;
+
+    private Jwt mockJwt;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        mockJwt = mock(Jwt.class);
+        when(mockJwt.getSubject()).thenReturn("sub-123");
+
+        testUser = new User();
+        testUser.setId(1);
+        testUser.setName("テストユーザー");
+
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(testUser);
+    }
+
+    @Nested
+    @DisplayName("getFavoritePhrases")
+    class GetFavoritePhrases {
+
+        @Test
+        @DisplayName("お気に入りフレーズ一覧を取得できる")
+        void returnsPhrases() {
+            FavoritePhraseDto dto = new FavoritePhraseDto(1, "元文", "変換文", "フォーマル版", "2026-01-01T00:00:00Z");
+            when(getUserFavoritePhrasesUseCase.execute(1)).thenReturn(List.of(dto));
+
+            ResponseEntity<List<FavoritePhraseDto>> response = favoritePhraseController.getFavoritePhrases(mockJwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).hasSize(1);
+            assertThat(response.getBody().get(0).getOriginalText()).isEqualTo("元文");
+        }
+    }
+
+    @Nested
+    @DisplayName("addFavoritePhrase")
+    class AddFavoritePhrase {
+
+        @Test
+        @DisplayName("お気に入りフレーズを追加できる")
+        void addsPhrase() {
+            Map<String, String> body = Map.of(
+                    "originalText", "確認お願い",
+                    "rephrasedText", "ご確認ください",
+                    "pattern", "フォーマル版");
+
+            ResponseEntity<Void> response = favoritePhraseController.addFavoritePhrase(mockJwt, body);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(addFavoritePhraseUseCase).execute(testUser, "確認お願い", "ご確認ください", "フォーマル版");
+        }
+    }
+
+    @Nested
+    @DisplayName("removeFavoritePhrase")
+    class RemoveFavoritePhrase {
+
+        @Test
+        @DisplayName("お気に入りフレーズを削除できる")
+        void removesPhrase() {
+            ResponseEntity<Void> response = favoritePhraseController.removeFavoritePhrase(mockJwt, 5);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(removeFavoritePhraseUseCase).execute(1, 5);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/AddFavoritePhraseUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/AddFavoritePhraseUseCaseTest.java
@@ -1,0 +1,58 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.FavoritePhrase;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.FavoritePhraseRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AddFavoritePhraseUseCase テスト")
+class AddFavoritePhraseUseCaseTest {
+
+    @Mock
+    private FavoritePhraseRepository favoritePhraseRepository;
+
+    @InjectMocks
+    private AddFavoritePhraseUseCase addFavoritePhraseUseCase;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1);
+        testUser.setName("テストユーザー");
+    }
+
+    @Test
+    @DisplayName("新規お気に入りフレーズを追加できる")
+    void execute_AddsNewPhrase() {
+        when(favoritePhraseRepository.existsByUserIdAndRephrasedTextAndPattern(1, "ご確認ください", "フォーマル版"))
+                .thenReturn(false);
+
+        addFavoritePhraseUseCase.execute(testUser, "確認お願い", "ご確認ください", "フォーマル版");
+
+        verify(favoritePhraseRepository).save(any(FavoritePhrase.class));
+    }
+
+    @Test
+    @DisplayName("既に同一フレーズが存在する場合は重複保存しない")
+    void execute_SkipsWhenAlreadyExists() {
+        when(favoritePhraseRepository.existsByUserIdAndRephrasedTextAndPattern(1, "ご確認ください", "フォーマル版"))
+                .thenReturn(true);
+
+        addFavoritePhraseUseCase.execute(testUser, "確認お願い", "ご確認ください", "フォーマル版");
+
+        verify(favoritePhraseRepository, never()).save(any(FavoritePhrase.class));
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCaseTest.java
@@ -1,0 +1,74 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.FavoritePhraseDto;
+import com.example.FreStyle.entity.FavoritePhrase;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.FavoritePhraseRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetUserFavoritePhrasesUseCase テスト")
+class GetUserFavoritePhrasesUseCaseTest {
+
+    @Mock
+    private FavoritePhraseRepository favoritePhraseRepository;
+
+    @InjectMocks
+    private GetUserFavoritePhrasesUseCase getUserFavoritePhrasesUseCase;
+
+    @Test
+    @DisplayName("ユーザーのお気に入りフレーズ一覧を取得できる")
+    void execute_ReturnsFavoritePhrases() {
+        User user = new User();
+        user.setId(1);
+
+        FavoritePhrase phrase1 = new FavoritePhrase();
+        phrase1.setId(1);
+        phrase1.setUser(user);
+        phrase1.setOriginalText("確認お願いします");
+        phrase1.setRephrasedText("ご確認いただけますでしょうか");
+        phrase1.setPattern("フォーマル版");
+        phrase1.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        FavoritePhrase phrase2 = new FavoritePhrase();
+        phrase2.setId(2);
+        phrase2.setUser(user);
+        phrase2.setOriginalText("すみません");
+        phrase2.setRephrasedText("恐れ入りますが");
+        phrase2.setPattern("ソフト版");
+        phrase2.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        when(favoritePhraseRepository.findByUserIdOrderByCreatedAtDesc(1))
+                .thenReturn(List.of(phrase1, phrase2));
+
+        List<FavoritePhraseDto> result = getUserFavoritePhrasesUseCase.execute(1);
+
+        assertEquals(2, result.size());
+        assertEquals("確認お願いします", result.get(0).getOriginalText());
+        assertEquals("ご確認いただけますでしょうか", result.get(0).getRephrasedText());
+        assertEquals("フォーマル版", result.get(0).getPattern());
+    }
+
+    @Test
+    @DisplayName("お気に入りが空の場合は空リストを返す")
+    void execute_ReturnsEmptyList() {
+        when(favoritePhraseRepository.findByUserIdOrderByCreatedAtDesc(1))
+                .thenReturn(List.of());
+
+        List<FavoritePhraseDto> result = getUserFavoritePhrasesUseCase.execute(1);
+
+        assertTrue(result.isEmpty());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/RemoveFavoritePhraseUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/RemoveFavoritePhraseUseCaseTest.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.repository.FavoritePhraseRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RemoveFavoritePhraseUseCase テスト")
+class RemoveFavoritePhraseUseCaseTest {
+
+    @Mock
+    private FavoritePhraseRepository favoritePhraseRepository;
+
+    @InjectMocks
+    private RemoveFavoritePhraseUseCase removeFavoritePhraseUseCase;
+
+    @Test
+    @DisplayName("お気に入りフレーズを削除できる")
+    void execute_RemovesPhrase() {
+        removeFavoritePhraseUseCase.execute(1, 5);
+
+        verify(favoritePhraseRepository).deleteByIdAndUserId(5, 1);
+    }
+}

--- a/frontend/src/repositories/FavoritePhraseRepository.ts
+++ b/frontend/src/repositories/FavoritePhraseRepository.ts
@@ -1,39 +1,82 @@
+import apiClient from '../lib/axios';
 import type { FavoritePhrase } from '../types';
 
 const STORAGE_KEY = 'freestyle_favorite_phrases';
 
+function getLocalPhrases(): FavoritePhrase[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const phrases: FavoritePhrase[] = JSON.parse(raw);
+    return phrases.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  } catch {
+    localStorage.removeItem(STORAGE_KEY);
+    return [];
+  }
+}
+
+function saveLocalPhrases(phrases: FavoritePhrase[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(phrases));
+}
+
+interface ApiFavoritePhraseDto {
+  id: number;
+  originalText: string;
+  rephrasedText: string;
+  pattern: string;
+  createdAt: string;
+}
+
+function toFavoritePhrase(dto: ApiFavoritePhraseDto): FavoritePhrase {
+  return {
+    id: String(dto.id),
+    originalText: dto.originalText,
+    rephrasedText: dto.rephrasedText,
+    pattern: dto.pattern,
+    createdAt: dto.createdAt,
+  };
+}
+
 export const FavoritePhraseRepository = {
-  getAll(): FavoritePhrase[] {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
+  async getAll(): Promise<FavoritePhrase[]> {
     try {
-      const phrases: FavoritePhrase[] = JSON.parse(raw);
-      return phrases.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      const response = await apiClient.get<ApiFavoritePhraseDto[]>('/api/favorite-phrases');
+      return response.data.map(toFavoritePhrase);
     } catch {
-      localStorage.removeItem(STORAGE_KEY);
-      return [];
+      return getLocalPhrases();
     }
   },
 
-  save(phrase: Omit<FavoritePhrase, 'id' | 'createdAt'>): void {
-    const all = this.getAll();
-    const newPhrase: FavoritePhrase = {
-      ...phrase,
-      id: `fav_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
-      createdAt: new Date(Date.now()).toISOString(),
-    };
-    all.push(newPhrase);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  async save(phrase: Omit<FavoritePhrase, 'id' | 'createdAt'>): Promise<void> {
+    try {
+      await apiClient.post('/api/favorite-phrases', {
+        originalText: phrase.originalText,
+        rephrasedText: phrase.rephrasedText,
+        pattern: phrase.pattern,
+      });
+    } catch {
+      const all = getLocalPhrases();
+      const newPhrase: FavoritePhrase = {
+        ...phrase,
+        id: `fav_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        createdAt: new Date(Date.now()).toISOString(),
+      };
+      all.push(newPhrase);
+      saveLocalPhrases(all);
+    }
   },
 
-  remove(id: string): void {
-    const all = this.getAll();
-    const filtered = all.filter((p) => p.id !== id);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+  async remove(id: string): Promise<void> {
+    try {
+      await apiClient.delete(`/api/favorite-phrases/${id}`);
+    } catch {
+      const all = getLocalPhrases().filter((p) => p.id !== id);
+      saveLocalPhrases(all);
+    }
   },
 
-  exists(rephrasedText: string, pattern: string): boolean {
-    const all = this.getAll();
+  async exists(rephrasedText: string, pattern: string): Promise<boolean> {
+    const all = await this.getAll();
     return all.some((p) => p.rephrasedText === rephrasedText && p.pattern === pattern);
   },
 };


### PR DESCRIPTION
## 概要
localStorageのみだったお気に入りフレーズ機能をREST API経由でサーバーサイドに永続化。
ログイン中はAPIでDB保存、未ログイン/APIエラー時はlocalStorageにフォールバック。

## 変更内容
### バックエンド
- `FavoritePhrase` エンティティ（user_id外部キー + TEXT型カラム）
- `FavoritePhraseDto` レスポンスDTO
- `FavoritePhraseRepository` JPAリポジトリ
- `AddFavoritePhraseUseCase` - 冪等なフレーズ追加（同一テキスト+パターンの重複防止）
- `GetUserFavoritePhrasesUseCase` - 新しい順でフレーズ一覧取得
- `RemoveFavoritePhraseUseCase` - フレーズ削除（ユーザーID検証付き）
- `FavoritePhraseController` - REST API（GET/POST/DELETE `/api/favorite-phrases`）
- DBマイグレーション `003_add_favorite_phrases.sql`

### フロントエンド
- `FavoritePhraseRepository` をAPI対応に変更（localStorageフォールバック付き）
- `useFavoritePhrase` フックを非同期化（楽観的UI更新）
- `isFavorite` をローカルstate判定に変更（同期的使用を維持）
- ID型変換（backend: Integer → frontend: string）をRepository層で吸収

### テスト
- バックエンド: 8件（UseCase 5件 + Controller 3件）
- フロントエンド: 16件（Repository 7件 + Hook 9件）

## テスト計画
- [x] バックエンドユニットテスト全パス
- [x] フロントエンドユニットテスト全パス
- [x] 関連コンポーネント（RephraseModal/FavoritesPage）のテスト影響なし
- [ ] ブラウザでお気に入りの追加・削除が動作すること

Closes #1035