### PR TITLE
リファクタ: ChatControllerのビジネスロジックをUseCase層に分離

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatController.java
@@ -1,6 +1,5 @@
 package com.example.FreStyle.controller;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -18,235 +17,124 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.FreStyle.dto.ChatMessageDto;
 import com.example.FreStyle.dto.ChatUserDto;
 import com.example.FreStyle.dto.UserDto;
-import com.example.FreStyle.entity.ChatRoom;
-import com.example.FreStyle.entity.User;
-import com.example.FreStyle.service.ChatMessageService;
-import com.example.FreStyle.service.ChatRoomService;
-import com.example.FreStyle.service.ChatService;
-import com.example.FreStyle.service.RoomMemberService;
-import com.example.FreStyle.service.UnreadCountService;
-import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.usecase.CreateOrGetChatRoomUseCase;
+import com.example.FreStyle.usecase.GetChatHistoryUseCase;
+import com.example.FreStyle.usecase.GetChatRoomsUseCase;
+import com.example.FreStyle.usecase.GetChatStatsUseCase;
+import com.example.FreStyle.usecase.GetChatUsersUseCase;
+import com.example.FreStyle.usecase.MarkChatAsReadUseCase;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/api/chat/")
 @RequiredArgsConstructor
-@Slf4j
 public class ChatController {
 
-  
-  private final UserService userService;
-  private final ChatService chatService;
-  private final ChatRoomService chatRoomService;
-  private final ChatMessageService chatMessageService; 
-  private final UserIdentityService userIdentityService;
-  private final RoomMemberService roomMemberService;
-  private final UnreadCountService unreadCountService;
+    private final GetChatUsersUseCase getChatUsersUseCase;
+    private final CreateOrGetChatRoomUseCase createOrGetChatRoomUseCase;
+    private final GetChatHistoryUseCase getChatHistoryUseCase;
+    private final GetChatStatsUseCase getChatStatsUseCase;
+    private final MarkChatAsReadUseCase markChatAsReadUseCase;
+    private final GetChatRoomsUseCase getChatRoomsUseCase;
 
-  // ユーザー登録一覧
-  @GetMapping("/users")
-  public ResponseEntity<?> users(@AuthenticationPrincipal Jwt jwt,
-      @RequestParam(name = "query", required = false) String query) {
-    log.info("GET /api/chat/users");
-    String cognitoSub = jwt.getSubject();
-
-    if (cognitoSub == null || cognitoSub.isEmpty()) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+    @GetMapping("/users")
+    public ResponseEntity<?> users(@AuthenticationPrincipal Jwt jwt,
+        @RequestParam(name = "query", required = false) String query) {
+        String cognitoSub = jwt.getSubject();
+        if (cognitoSub == null || cognitoSub.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+        }
+        List<UserDto> users = getChatUsersUseCase.execute(cognitoSub, query);
+        return ResponseEntity.ok().body(Map.of("users", users));
     }
 
-    User myUser = userIdentityService.findUserBySub(cognitoSub);
-
-    List<UserDto> users = userService.findUsersWithRoomId(myUser.getId(), query);
-
-    Map<String, List<UserDto>> responseData = new HashMap<>();
-
-    for (UserDto user : users) {
-      log.info("User_id: {}, User_Email: {}, User_name: {}", user.getId(), user.getEmail(), user.getName());
-    }
-    responseData.put("users", users);
-    return ResponseEntity.ok().body(responseData);
-  }
-
-  @PostMapping("/users/{id}/create")
-  public ResponseEntity<?> create(@AuthenticationPrincipal Jwt jwt, @PathVariable(name = "id") Integer id) {
-    
-    log.info("\n========== ルーム作成リクエスト開始 ==========");
-    log.info("📌 リクエストPathVariable id: {}", id);
-    log.info("📌 JWT null判定: {}", jwt == null ? "NULL" : "存在");
-
-    String cognitoSub = jwt.getSubject();
-    log.info("📌 cognitoSub (Cognito User ID): {}", cognitoSub);
-    
-    if (cognitoSub == null || cognitoSub.isEmpty()) {
-      log.error("❌ cognitoSubがnullまたは空です");
-      log.info("========== ルーム作成リクエスト終了(UNAUTHORIZED) ==========\n");
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "無効なリクエストです。"));
-    }
-    
-    try{
-      log.info("🔍 userIdentityService.findUserBySub() 実行中...");
-      User myUser = userIdentityService.findUserBySub(cognitoSub);
-      log.info("✅ 現在のユーザー取得成功");
-      log.debug("   - myUser.getId(): {}", myUser.getId());
-      log.debug("   - myUser.getName(): {}", myUser.getName());
-      log.debug("   - myUser.getEmail(): {}", myUser.getEmail());
-
-      log.info("🔍 chatService.createOrGetRoom() 実行中...");
-      log.debug("   - myUser.getId(): {} (ログイン中のユーザーID)", myUser.getId());
-      log.debug("   - id (相手ユーザーID): {}", id);
-      Integer roomId = chatService.createOrGetRoom(myUser.getId(), id);
-      
-      log.info("✅ ルーム作成/取得成功");
-      log.debug("   - roomId: {}", roomId);
-      log.info("========== ルーム作成リクエスト終了(OK) ==========\n");
-      return ResponseEntity.ok(Map.of(
-            "roomId", roomId,
-            "status", "success"
-      ));
-  } catch (IllegalStateException e) {
-    log.warn("ルーム作成エラー(不正リクエスト): {}", e.getMessage(), e);
-    return ResponseEntity.badRequest().body(Map.of("error", "無効なリクエストです。"));
-  } catch (Exception e) {
-    log.error("ルーム作成エラー: {}", e.getMessage(), e);
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .body(Map.of("error", "ルーム作成中にエラーが発生しました。"));
-  } 
-}
-
-  
-  @GetMapping("/users/{roomId}/history")
-  public ResponseEntity<?> history(@AuthenticationPrincipal Jwt jwt, @PathVariable(name = "roomId", required = true) Integer roomId) {
-
-    String cognitoSub = jwt.getSubject();
-    
-    if (cognitoSub == null || cognitoSub.isEmpty()) {
-      return ResponseEntity.badRequest().body(Map.of("error", "無効なリクエストです。"));
-    }
-    
-    try {
-      // 自分のユーザー情報を取得
-      User myUser = userIdentityService.findUserBySub(cognitoSub);
-      Integer myUserId = myUser.getId();
-      
-      // すでにroom_idが取得されている状態なのでchatRoomServiceからChatRoomオブジェクトを取得をする
-      ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
-      log.info("chatRoom found: {}", chatRoom.getId());
-      
-      // 履歴の取得 - 現在のユーザーIDを渡す
-      List<ChatMessageDto> history = chatMessageService.getMessagesByRoom(chatRoom, myUserId);
-      log.info("history count: {}", history.size());
-      
-      return ResponseEntity.ok(history);
-      
-    } catch (Exception e) {
-      log.error("履歴取得エラー: {}", e.getMessage(), e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "サーバーエラーです。"));
-    }
-  }
-
-  @GetMapping("/stats")
-  public ResponseEntity<?> stats(@AuthenticationPrincipal Jwt jwt) {
-    String cognitoSub = jwt.getSubject();
-    
-    if (cognitoSub == null || cognitoSub.isEmpty()) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+    @PostMapping("/users/{id}/create")
+    public ResponseEntity<?> create(@AuthenticationPrincipal Jwt jwt, @PathVariable(name = "id") Integer id) {
+        String cognitoSub = jwt.getSubject();
+        if (cognitoSub == null || cognitoSub.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "無効なリクエストです。"));
+        }
+        try {
+            Integer roomId = createOrGetChatRoomUseCase.execute(cognitoSub, id);
+            return ResponseEntity.ok(Map.of("roomId", roomId, "status", "success"));
+        } catch (IllegalStateException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "無効なリクエストです。"));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "ルーム作成中にエラーが発生しました。"));
+        }
     }
 
-    try {
-      User myUser = userIdentityService.findUserBySub(cognitoSub);
-      // 会話したことのあるユーザー数を取得
-      Long chatPartnerCount = roomMemberService.countChatPartners(myUser.getId());
-      
-      Map<String, Object> stats = new HashMap<>();
-      stats.put("chatPartnerCount", chatPartnerCount);
-      stats.put("email", myUser.getEmail());
-      stats.put("username", myUser.getName());
-      
-      return ResponseEntity.ok().body(stats);
-    } catch (Exception e) {
-      log.error("統計情報取得エラー: {}", e.getMessage(), e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "サーバーエラーです。"));
-    }
-  }
-
-  /**
-   * チャットルームの未読数をリセット（既読にする）
-   */
-  @PostMapping("/rooms/{roomId}/read")
-  public ResponseEntity<?> markAsRead(
-      @AuthenticationPrincipal Jwt jwt,
-      @PathVariable("roomId") Integer roomId) {
-
-    if (jwt == null) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body(Map.of("error", "認証されていません。"));
+    @GetMapping("/users/{roomId}/history")
+    public ResponseEntity<?> history(@AuthenticationPrincipal Jwt jwt, @PathVariable(name = "roomId", required = true) Integer roomId) {
+        String cognitoSub = jwt.getSubject();
+        if (cognitoSub == null || cognitoSub.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "無効なリクエストです。"));
+        }
+        try {
+            List<ChatMessageDto> history = getChatHistoryUseCase.execute(cognitoSub, roomId);
+            return ResponseEntity.ok(history);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "サーバーエラーです。"));
+        }
     }
 
-    String cognitoSub = jwt.getSubject();
-    if (cognitoSub == null || cognitoSub.isEmpty()) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+    @GetMapping("/stats")
+    public ResponseEntity<?> stats(@AuthenticationPrincipal Jwt jwt) {
+        String cognitoSub = jwt.getSubject();
+        if (cognitoSub == null || cognitoSub.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+        }
+        try {
+            Map<String, Object> stats = getChatStatsUseCase.execute(cognitoSub);
+            return ResponseEntity.ok().body(stats);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "サーバーエラーです。"));
+        }
     }
 
-    try {
-      User myUser = userIdentityService.findUserBySub(cognitoSub);
-      unreadCountService.resetUnreadCount(myUser.getId(), roomId);
-      return ResponseEntity.ok(Map.of("status", "success"));
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body(Map.of("error", "サーバーエラーが発生しました。"));
+    @PostMapping("/rooms/{roomId}/read")
+    public ResponseEntity<?> markAsRead(
+        @AuthenticationPrincipal Jwt jwt,
+        @PathVariable("roomId") Integer roomId) {
+        if (jwt == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "認証されていません。"));
+        }
+        String cognitoSub = jwt.getSubject();
+        if (cognitoSub == null || cognitoSub.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+        }
+        try {
+            markChatAsReadUseCase.execute(cognitoSub, roomId);
+            return ResponseEntity.ok(Map.of("status", "success"));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "サーバーエラーが発生しました。"));
+        }
     }
-  }
 
-  /**
-   * チャット履歴のあるユーザー一覧を取得
-   * @param jwt 認証トークン
-   * @param query 検索クエリ（名前またはメールで検索、オプション）
-   * @return チャット履歴のあるユーザー一覧（最終メッセージ情報付き）
-   */
-  @GetMapping("/rooms")
-  public ResponseEntity<?> getChatRooms(
-      @AuthenticationPrincipal Jwt jwt,
-      @RequestParam(name = "query", required = false) String query) {
-    
-    log.info("\n========== GET /api/chat/rooms ==========");
-    log.info("📌 query: {}", query);
-    
-    if (jwt == null) {
-      log.error("❌ 認証エラー: JWTがnull");
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+    @GetMapping("/rooms")
+    public ResponseEntity<?> getChatRooms(
+        @AuthenticationPrincipal Jwt jwt,
+        @RequestParam(name = "query", required = false) String query) {
+        if (jwt == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+        }
+        String cognitoSub = jwt.getSubject();
+        if (cognitoSub == null || cognitoSub.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
+        }
+        try {
+            List<ChatUserDto> chatUsers = getChatRoomsUseCase.execute(cognitoSub, query);
+            return ResponseEntity.ok(Map.of("chatUsers", chatUsers));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("error", "サーバーエラーが発生しました。"));
+        }
     }
-    
-    String cognitoSub = jwt.getSubject();
-    
-    if (cognitoSub == null || cognitoSub.isEmpty()) {
-      log.error("❌ 認証エラー: cognitoSubがnullまたは空");
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body(Map.of("error", "タイムアウトをしたか、または未ログインです。"));
-    }
-    
-    try {
-      User myUser = userIdentityService.findUserBySub(cognitoSub);
-      log.info("✅ ユーザー取得成功 - ID: {}, Name: {}", myUser.getId(), myUser.getName());
-      
-      List<ChatUserDto> chatUsers = chatService.findChatUsers(myUser.getId(), query);
-      log.info("✅ チャットユーザー取得成功 - 件数: {}", chatUsers.size());
-      
-      Map<String, Object> response = new HashMap<>();
-      response.put("chatUsers", chatUsers);
-      
-      log.info("========== GET /api/chat/rooms 完了 ==========\n");
-      return ResponseEntity.ok(response);
-      
-    } catch (Exception e) {
-      log.error("チャットルーム取得エラー: {}", e.getMessage(), e);
-      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-          .body(Map.of("error", "サーバーエラーが発生しました。"));
-    }
-  }
-
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateOrGetChatRoomUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateOrGetChatRoomUseCase.java
@@ -1,0 +1,24 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.ChatService;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CreateOrGetChatRoomUseCase {
+
+    private final UserIdentityService userIdentityService;
+    private final ChatService chatService;
+
+    @Transactional
+    public Integer execute(String sub, Integer targetUserId) {
+        User user = userIdentityService.findUserBySub(sub);
+        return chatService.createOrGetRoom(user.getId(), targetUserId);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatHistoryUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatHistoryUseCase.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ChatMessageDto;
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.ChatMessageService;
+import com.example.FreStyle.service.ChatRoomService;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetChatHistoryUseCase {
+
+    private final UserIdentityService userIdentityService;
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageDto> execute(String sub, Integer roomId) {
+        User user = userIdentityService.findUserBySub(sub);
+        ChatRoom chatRoom = chatRoomService.findChatRoomById(roomId);
+        return chatMessageService.getMessagesByRoom(chatRoom, user.getId());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatRoomsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatRoomsUseCase.java
@@ -1,0 +1,27 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ChatUserDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.ChatService;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetChatRoomsUseCase {
+
+    private final UserIdentityService userIdentityService;
+    private final ChatService chatService;
+
+    @Transactional(readOnly = true)
+    public List<ChatUserDto> execute(String sub, String query) {
+        User user = userIdentityService.findUserBySub(sub);
+        return chatService.findChatUsers(user.getId(), query);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatStatsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatStatsUseCase.java
@@ -1,0 +1,33 @@
+package com.example.FreStyle.usecase;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.RoomMemberService;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetChatStatsUseCase {
+
+    private final UserIdentityService userIdentityService;
+    private final RoomMemberService roomMemberService;
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> execute(String sub) {
+        User user = userIdentityService.findUserBySub(sub);
+        Long chatPartnerCount = roomMemberService.countChatPartners(user.getId());
+
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("chatPartnerCount", chatPartnerCount);
+        stats.put("email", user.getEmail());
+        stats.put("username", user.getName());
+        return stats;
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatUsersUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetChatUsersUseCase.java
@@ -1,0 +1,27 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetChatUsersUseCase {
+
+    private final UserIdentityService userIdentityService;
+    private final UserService userService;
+
+    @Transactional(readOnly = true)
+    public List<UserDto> execute(String sub, String query) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userService.findUsersWithRoomId(user.getId(), query);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/MarkChatAsReadUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/MarkChatAsReadUseCase.java
@@ -1,0 +1,24 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UnreadCountService;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MarkChatAsReadUseCase {
+
+    private final UserIdentityService userIdentityService;
+    private final UnreadCountService unreadCountService;
+
+    @Transactional
+    public void execute(String sub, Integer roomId) {
+        User user = userIdentityService.findUserBySub(sub);
+        unreadCountService.resetUnreadCount(user.getId(), roomId);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ChatControllerTest.java
@@ -1,14 +1,14 @@
 package com.example.FreStyle.controller;
 
-import com.example.FreStyle.entity.User;
-import com.example.FreStyle.service.ChatMessageService;
-import com.example.FreStyle.service.ChatRoomService;
-import com.example.FreStyle.service.ChatService;
-import com.example.FreStyle.service.RoomMemberService;
-import com.example.FreStyle.service.UnreadCountService;
-import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
-import org.junit.jupiter.api.BeforeEach;
+import com.example.FreStyle.dto.ChatMessageDto;
+import com.example.FreStyle.dto.ChatUserDto;
+import com.example.FreStyle.dto.UserDto;
+import com.example.FreStyle.usecase.CreateOrGetChatRoomUseCase;
+import com.example.FreStyle.usecase.GetChatHistoryUseCase;
+import com.example.FreStyle.usecase.GetChatRoomsUseCase;
+import com.example.FreStyle.usecase.GetChatStatsUseCase;
+import com.example.FreStyle.usecase.GetChatUsersUseCase;
+import com.example.FreStyle.usecase.MarkChatAsReadUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,11 +22,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import java.util.List;
 import java.util.Map;
 
-import com.example.FreStyle.dto.ChatMessageDto;
-import com.example.FreStyle.dto.ChatUserDto;
-import com.example.FreStyle.dto.UserDto;
-import com.example.FreStyle.entity.ChatRoom;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -34,85 +29,30 @@ import static org.mockito.Mockito.*;
 class ChatControllerTest {
 
     @Mock
-    private UserService userService;
+    private GetChatUsersUseCase getChatUsersUseCase;
 
     @Mock
-    private ChatService chatService;
+    private CreateOrGetChatRoomUseCase createOrGetChatRoomUseCase;
 
     @Mock
-    private ChatRoomService chatRoomService;
+    private GetChatHistoryUseCase getChatHistoryUseCase;
 
     @Mock
-    private ChatMessageService chatMessageService;
+    private GetChatStatsUseCase getChatStatsUseCase;
 
     @Mock
-    private UserIdentityService userIdentityService;
+    private MarkChatAsReadUseCase markChatAsReadUseCase;
 
     @Mock
-    private RoomMemberService roomMemberService;
-
-    @Mock
-    private UnreadCountService unreadCountService;
+    private GetChatRoomsUseCase getChatRoomsUseCase;
 
     @InjectMocks
     private ChatController chatController;
-
-    private User testUser;
-
-    @BeforeEach
-    void setUp() {
-        testUser = new User();
-        testUser.setId(1);
-        testUser.setName("テストユーザー");
-    }
 
     private Jwt createMockJwt() {
         Jwt jwt = mock(Jwt.class);
         when(jwt.getSubject()).thenReturn("cognito-sub-123");
         return jwt;
-    }
-
-    @Test
-    @DisplayName("markAsRead: 正常リクエスト → 200 OKとsuccessを返す")
-    void markAsRead_validRequest_returnsOk() {
-        // Arrange
-        Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-
-        // Act
-        ResponseEntity<?> response = chatController.markAsRead(jwt, 10);
-
-        // Assert
-        assertEquals(HttpStatus.OK, response.getStatusCode());
-        @SuppressWarnings("unchecked")
-        Map<String, Object> body = (Map<String, Object>) response.getBody();
-        assertEquals("success", body.get("status"));
-        verify(unreadCountService).resetUnreadCount(1, 10);
-    }
-
-    @Test
-    @DisplayName("markAsRead: JWTなし → 401 Unauthorizedを返す")
-    void markAsRead_noJwt_returnsUnauthorized() {
-        // Act
-        ResponseEntity<?> response = chatController.markAsRead(null, 10);
-
-        // Assert
-        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
-        verify(unreadCountService, never()).resetUnreadCount(anyInt(), anyInt());
-    }
-
-    @Test
-    @DisplayName("markAsRead: resetUnreadCountが正しいパラメータで呼ばれる")
-    void markAsRead_callsResetWithCorrectParams() {
-        // Arrange
-        Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-
-        // Act
-        chatController.markAsRead(jwt, 25);
-
-        // Assert
-        verify(unreadCountService).resetUnreadCount(1, 25);
     }
 
     // ============================
@@ -122,8 +62,7 @@ class ChatControllerTest {
     @DisplayName("users: 正常リクエスト → ユーザー一覧を返す")
     void users_validRequest_returnsUsers() {
         Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        when(userService.findUsersWithRoomId(1, null)).thenReturn(List.of());
+        when(getChatUsersUseCase.execute("cognito-sub-123", null)).thenReturn(List.of());
 
         ResponseEntity<?> response = chatController.users(jwt, null);
 
@@ -135,14 +74,13 @@ class ChatControllerTest {
 
     @Test
     @DisplayName("users: 検索クエリ付きリクエスト")
-    void users_withQuery_passesQueryToService() {
+    void users_withQuery_passesQueryToUseCase() {
         Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        when(userService.findUsersWithRoomId(1, "テスト")).thenReturn(List.of());
+        when(getChatUsersUseCase.execute("cognito-sub-123", "テスト")).thenReturn(List.of());
 
         chatController.users(jwt, "テスト");
 
-        verify(userService).findUsersWithRoomId(1, "テスト");
+        verify(getChatUsersUseCase).execute("cognito-sub-123", "テスト");
     }
 
     // ============================
@@ -152,8 +90,7 @@ class ChatControllerTest {
     @DisplayName("create: 正常リクエスト → roomIdとsuccessを返す")
     void create_validRequest_returnsRoomId() {
         Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        when(chatService.createOrGetRoom(1, 2)).thenReturn(99);
+        when(createOrGetChatRoomUseCase.execute("cognito-sub-123", 2)).thenReturn(99);
 
         ResponseEntity<?> response = chatController.create(jwt, 2);
 
@@ -166,10 +103,9 @@ class ChatControllerTest {
 
     @Test
     @DisplayName("create: 例外発生時 → 500エラーを返す")
-    void create_serviceThrows_returnsError() {
+    void create_useCaseThrows_returnsError() {
         Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        when(chatService.createOrGetRoom(1, 2)).thenThrow(new RuntimeException("DB error"));
+        when(createOrGetChatRoomUseCase.execute("cognito-sub-123", 2)).thenThrow(new RuntimeException("DB error"));
 
         ResponseEntity<?> response = chatController.create(jwt, 2);
 
@@ -183,11 +119,7 @@ class ChatControllerTest {
     @DisplayName("history: 正常リクエスト → メッセージ履歴を返す")
     void history_validRequest_returnsHistory() {
         Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        ChatRoom chatRoom = new ChatRoom();
-        chatRoom.setId(10);
-        when(chatRoomService.findChatRoomById(10)).thenReturn(chatRoom);
-        when(chatMessageService.getMessagesByRoom(chatRoom, 1)).thenReturn(List.of());
+        when(getChatHistoryUseCase.execute("cognito-sub-123", 10)).thenReturn(List.of());
 
         ResponseEntity<?> response = chatController.history(jwt, 10);
 
@@ -204,9 +136,8 @@ class ChatControllerTest {
     @DisplayName("stats: 正常リクエスト → 統計情報を返す")
     void stats_validRequest_returnsStats() {
         Jwt jwt = createMockJwt();
-        testUser.setEmail("test@example.com");
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        when(roomMemberService.countChatPartners(1)).thenReturn(5L);
+        Map<String, Object> stats = Map.of("chatPartnerCount", 5L, "email", "test@example.com", "username", "テストユーザー");
+        when(getChatStatsUseCase.execute("cognito-sub-123")).thenReturn(stats);
 
         ResponseEntity<?> response = chatController.stats(jwt);
 
@@ -218,14 +149,39 @@ class ChatControllerTest {
     }
 
     // ============================
+    // markAsRead
+    // ============================
+    @Test
+    @DisplayName("markAsRead: 正常リクエスト → 200 OKとsuccessを返す")
+    void markAsRead_validRequest_returnsOk() {
+        Jwt jwt = createMockJwt();
+
+        ResponseEntity<?> response = chatController.markAsRead(jwt, 10);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
+        assertEquals("success", body.get("status"));
+        verify(markChatAsReadUseCase).execute("cognito-sub-123", 10);
+    }
+
+    @Test
+    @DisplayName("markAsRead: JWTなし → 401 Unauthorizedを返す")
+    void markAsRead_noJwt_returnsUnauthorized() {
+        ResponseEntity<?> response = chatController.markAsRead(null, 10);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        verify(markChatAsReadUseCase, never()).execute(anyString(), anyInt());
+    }
+
+    // ============================
     // getChatRooms
     // ============================
     @Test
     @DisplayName("getChatRooms: 正常リクエスト → チャットルーム一覧を返す")
     void getChatRooms_validRequest_returnsChatRooms() {
         Jwt jwt = createMockJwt();
-        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(testUser);
-        when(chatService.findChatUsers(1, null)).thenReturn(List.of());
+        when(getChatRoomsUseCase.execute("cognito-sub-123", null)).thenReturn(List.of());
 
         ResponseEntity<?> response = chatController.getChatRooms(jwt, null);
 

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateOrGetChatRoomUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateOrGetChatRoomUseCaseTest.java
@@ -1,0 +1,55 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.ChatService;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateOrGetChatRoomUseCase テスト")
+class CreateOrGetChatRoomUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private ChatService chatService;
+
+    @InjectMocks
+    private CreateOrGetChatRoomUseCase createOrGetChatRoomUseCase;
+
+    @Test
+    @DisplayName("チャットルームを作成または取得できる")
+    void execute_returnsRoomId() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(chatService.createOrGetRoom(1, 2)).thenReturn(99);
+
+        Integer roomId = createOrGetChatRoomUseCase.execute("sub-123", 2);
+
+        assertEquals(99, roomId);
+    }
+
+    @Test
+    @DisplayName("正しいパラメータでサービスを呼び出す")
+    void execute_callsServiceWithCorrectParams() {
+        User user = new User();
+        user.setId(5);
+        when(userIdentityService.findUserBySub("sub-456")).thenReturn(user);
+        when(chatService.createOrGetRoom(5, 10)).thenReturn(42);
+
+        createOrGetChatRoomUseCase.execute("sub-456", 10);
+
+        verify(chatService).createOrGetRoom(5, 10);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatHistoryUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatHistoryUseCaseTest.java
@@ -1,0 +1,73 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ChatMessageDto;
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.ChatMessageService;
+import com.example.FreStyle.service.ChatRoomService;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetChatHistoryUseCase テスト")
+class GetChatHistoryUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @InjectMocks
+    private GetChatHistoryUseCase getChatHistoryUseCase;
+
+    @Test
+    @DisplayName("チャット履歴を取得できる")
+    void execute_returnsHistory() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.setId(10);
+        when(chatRoomService.findChatRoomById(10)).thenReturn(chatRoom);
+        ChatMessageDto msg = new ChatMessageDto();
+        msg.setContent("テストメッセージ");
+        when(chatMessageService.getMessagesByRoom(chatRoom, 1)).thenReturn(List.of(msg));
+
+        List<ChatMessageDto> result = getChatHistoryUseCase.execute("sub-123", 10);
+
+        assertEquals(1, result.size());
+        assertEquals("テストメッセージ", result.get(0).getContent());
+    }
+
+    @Test
+    @DisplayName("正しいルームIDとユーザーIDでサービスを呼び出す")
+    void execute_callsServicesWithCorrectParams() {
+        User user = new User();
+        user.setId(3);
+        when(userIdentityService.findUserBySub("sub-789")).thenReturn(user);
+        ChatRoom chatRoom = new ChatRoom();
+        chatRoom.setId(20);
+        when(chatRoomService.findChatRoomById(20)).thenReturn(chatRoom);
+        when(chatMessageService.getMessagesByRoom(chatRoom, 3)).thenReturn(List.of());
+
+        getChatHistoryUseCase.execute("sub-789", 20);
+
+        verify(chatRoomService).findChatRoomById(20);
+        verify(chatMessageService).getMessagesByRoom(chatRoom, 3);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatRoomsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatRoomsUseCaseTest.java
@@ -1,0 +1,60 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ChatUserDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.ChatService;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetChatRoomsUseCase テスト")
+class GetChatRoomsUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private ChatService chatService;
+
+    @InjectMocks
+    private GetChatRoomsUseCase getChatRoomsUseCase;
+
+    @Test
+    @DisplayName("チャットルーム一覧を取得できる")
+    void execute_returnsChatRooms() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        ChatUserDto dto = new ChatUserDto(2, "test@example.com", "テスト", 10);
+        when(chatService.findChatUsers(1, null)).thenReturn(List.of(dto));
+
+        List<ChatUserDto> result = getChatRoomsUseCase.execute("sub-123", null);
+
+        assertEquals(1, result.size());
+        assertEquals("テスト", result.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("検索クエリ付きでチャットルーム一覧を取得できる")
+    void execute_withQuery_passesQueryToService() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(chatService.findChatUsers(1, "テスト")).thenReturn(List.of());
+
+        getChatRoomsUseCase.execute("sub-123", "テスト");
+
+        verify(chatService).findChatUsers(1, "テスト");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatStatsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatStatsUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.RoomMemberService;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetChatStatsUseCase テスト")
+class GetChatStatsUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private RoomMemberService roomMemberService;
+
+    @InjectMocks
+    private GetChatStatsUseCase getChatStatsUseCase;
+
+    @Test
+    @DisplayName("チャット統計情報を取得できる")
+    void execute_returnsStats() {
+        User user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+        user.setEmail("test@example.com");
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(roomMemberService.countChatPartners(1)).thenReturn(5L);
+
+        Map<String, Object> result = getChatStatsUseCase.execute("sub-123");
+
+        assertEquals(5L, result.get("chatPartnerCount"));
+        assertEquals("test@example.com", result.get("email"));
+        assertEquals("テストユーザー", result.get("username"));
+    }
+
+    @Test
+    @DisplayName("チャットパートナーが0人の場合")
+    void execute_noPartners_returnsZero() {
+        User user = new User();
+        user.setId(2);
+        user.setName("新規ユーザー");
+        user.setEmail("new@example.com");
+        when(userIdentityService.findUserBySub("sub-new")).thenReturn(user);
+        when(roomMemberService.countChatPartners(2)).thenReturn(0L);
+
+        Map<String, Object> result = getChatStatsUseCase.execute("sub-new");
+
+        assertEquals(0L, result.get("chatPartnerCount"));
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatUsersUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatUsersUseCaseTest.java
@@ -1,0 +1,60 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetChatUsersUseCase テスト")
+class GetChatUsersUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private GetChatUsersUseCase getChatUsersUseCase;
+
+    @Test
+    @DisplayName("ユーザー一覧を取得できる")
+    void execute_returnsUsers() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserDto dto = new UserDto(2, "test@example.com", "テスト");
+        when(userService.findUsersWithRoomId(1, null)).thenReturn(List.of(dto));
+
+        List<UserDto> result = getChatUsersUseCase.execute("sub-123", null);
+
+        assertEquals(1, result.size());
+        assertEquals("テスト", result.get(0).getName());
+    }
+
+    @Test
+    @DisplayName("検索クエリ付きでユーザー一覧を取得できる")
+    void execute_withQuery_passesQueryToService() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(userService.findUsersWithRoomId(1, "検索")).thenReturn(List.of());
+
+        getChatUsersUseCase.execute("sub-123", "検索");
+
+        verify(userService).findUsersWithRoomId(1, "検索");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/MarkChatAsReadUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/MarkChatAsReadUseCaseTest.java
@@ -1,0 +1,52 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UnreadCountService;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MarkChatAsReadUseCase テスト")
+class MarkChatAsReadUseCaseTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private UnreadCountService unreadCountService;
+
+    @InjectMocks
+    private MarkChatAsReadUseCase markChatAsReadUseCase;
+
+    @Test
+    @DisplayName("未読数をリセットできる")
+    void execute_resetsUnreadCount() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+
+        markChatAsReadUseCase.execute("sub-123", 10);
+
+        verify(unreadCountService).resetUnreadCount(1, 10);
+    }
+
+    @Test
+    @DisplayName("正しいパラメータでリセットされる")
+    void execute_callsWithCorrectParams() {
+        User user = new User();
+        user.setId(5);
+        when(userIdentityService.findUserBySub("sub-456")).thenReturn(user);
+
+        markChatAsReadUseCase.execute("sub-456", 25);
+
+        verify(unreadCountService).resetUnreadCount(5, 25);
+    }
+}


### PR DESCRIPTION
## 概要
ChatControllerに直接記述されていた7つのサービス呼び出しを、6つのUseCase層に分離しClean Architectureに準拠させた。

## 変更内容
- `GetChatUsersUseCase` - ユーザー一覧取得ロジック
- `CreateOrGetChatRoomUseCase` - チャットルーム作成/取得ロジック
- `GetChatHistoryUseCase` - チャット履歴取得ロジック
- `GetChatStatsUseCase` - チャット統計情報取得ロジック
- `MarkChatAsReadUseCase` - 既読処理ロジック
- `GetChatRoomsUseCase` - チャットルーム一覧取得ロジック
- ChatControllerをUseCase呼び出しのみにリファクタ
- 冗長なデバッグログを削除

## テスト
- 新規UseCaseテスト: 12件（6UseCase × 各2件）
- ChatControllerTest: UseCase依存に更新（10件）
- 全398ユニットテスト パス

Closes #1037