### PR TITLE
feat: 日次学習目標のバックエンド永続化

### DIFF
--- a/FreStyle/migrations/004_add_daily_goals.sql
+++ b/FreStyle/migrations/004_add_daily_goals.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS daily_goals (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    goal_date DATE NOT NULL,
+    target INT NOT NULL DEFAULT 3,
+    completed INT NOT NULL DEFAULT 0,
+    UNIQUE KEY uk_user_date (user_id, goal_date),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/DailyGoalController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/DailyGoalController.java
@@ -1,0 +1,59 @@
+package com.example.FreStyle.controller;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.DailyGoalDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetTodayDailyGoalUseCase;
+import com.example.FreStyle.usecase.IncrementDailyGoalUseCase;
+import com.example.FreStyle.usecase.SetDailyGoalTargetUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/daily-goals")
+public class DailyGoalController {
+
+    private final GetTodayDailyGoalUseCase getTodayDailyGoalUseCase;
+    private final SetDailyGoalTargetUseCase setDailyGoalTargetUseCase;
+    private final IncrementDailyGoalUseCase incrementDailyGoalUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping("/today")
+    public ResponseEntity<DailyGoalDto> getToday(@AuthenticationPrincipal Jwt jwt) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        DailyGoalDto dto = getTodayDailyGoalUseCase.execute(user.getId());
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/target")
+    public ResponseEntity<Void> setTarget(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestBody Map<String, Integer> body) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        setDailyGoalTargetUseCase.execute(user, body.get("target"));
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/increment")
+    public ResponseEntity<DailyGoalDto> increment(@AuthenticationPrincipal Jwt jwt) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        DailyGoalDto dto = incrementDailyGoalUseCase.execute(user);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/DailyGoalDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/DailyGoalDto.java
@@ -1,0 +1,14 @@
+package com.example.FreStyle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyGoalDto {
+    private String date;
+    private Integer target;
+    private Integer completed;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/DailyGoal.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/DailyGoal.java
@@ -1,0 +1,42 @@
+package com.example.FreStyle.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "daily_goals", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "goal_date"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "goal_date", nullable = false)
+    private LocalDate goalDate;
+
+    @Column(name = "target", nullable = false)
+    private Integer target;
+
+    @Column(name = "completed", nullable = false)
+    private Integer completed;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/DailyGoalRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/DailyGoalRepository.java
@@ -1,0 +1,12 @@
+package com.example.FreStyle.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.FreStyle.entity.DailyGoal;
+
+public interface DailyGoalRepository extends JpaRepository<DailyGoal, Integer> {
+    Optional<DailyGoal> findByUserIdAndGoalDate(Integer userId, LocalDate goalDate);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetTodayDailyGoalUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetTodayDailyGoalUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.DailyGoalDto;
+import com.example.FreStyle.repository.DailyGoalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetTodayDailyGoalUseCase {
+
+    private final DailyGoalRepository dailyGoalRepository;
+
+    @Transactional(readOnly = true)
+    public DailyGoalDto execute(Integer userId) {
+        LocalDate today = LocalDate.now();
+        return dailyGoalRepository.findByUserIdAndGoalDate(userId, today)
+                .map(goal -> new DailyGoalDto(goal.getGoalDate().toString(), goal.getTarget(), goal.getCompleted()))
+                .orElse(new DailyGoalDto(today.toString(), 3, 0));
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/IncrementDailyGoalUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/IncrementDailyGoalUseCase.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.usecase;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.DailyGoalDto;
+import com.example.FreStyle.entity.DailyGoal;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.DailyGoalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IncrementDailyGoalUseCase {
+
+    private final DailyGoalRepository dailyGoalRepository;
+
+    @Transactional
+    public DailyGoalDto execute(User user) {
+        LocalDate today = LocalDate.now();
+        DailyGoal goal = dailyGoalRepository.findByUserIdAndGoalDate(user.getId(), today)
+                .orElseGet(() -> {
+                    DailyGoal newGoal = new DailyGoal();
+                    newGoal.setUser(user);
+                    newGoal.setGoalDate(today);
+                    newGoal.setTarget(3);
+                    newGoal.setCompleted(0);
+                    return newGoal;
+                });
+        goal.setCompleted(goal.getCompleted() + 1);
+        dailyGoalRepository.save(goal);
+        return new DailyGoalDto(goal.getGoalDate().toString(), goal.getTarget(), goal.getCompleted());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/SetDailyGoalTargetUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/SetDailyGoalTargetUseCase.java
@@ -1,0 +1,34 @@
+package com.example.FreStyle.usecase;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.DailyGoal;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.DailyGoalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SetDailyGoalTargetUseCase {
+
+    private final DailyGoalRepository dailyGoalRepository;
+
+    @Transactional
+    public void execute(User user, Integer target) {
+        LocalDate today = LocalDate.now();
+        DailyGoal goal = dailyGoalRepository.findByUserIdAndGoalDate(user.getId(), today)
+                .orElseGet(() -> {
+                    DailyGoal newGoal = new DailyGoal();
+                    newGoal.setUser(user);
+                    newGoal.setGoalDate(today);
+                    newGoal.setCompleted(0);
+                    return newGoal;
+                });
+        goal.setTarget(target);
+        dailyGoalRepository.save(goal);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/DailyGoalControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/DailyGoalControllerTest.java
@@ -1,0 +1,96 @@
+package com.example.FreStyle.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.DailyGoalDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetTodayDailyGoalUseCase;
+import com.example.FreStyle.usecase.IncrementDailyGoalUseCase;
+import com.example.FreStyle.usecase.SetDailyGoalTargetUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DailyGoalController テスト")
+class DailyGoalControllerTest {
+
+    @Mock
+    private GetTodayDailyGoalUseCase getTodayDailyGoalUseCase;
+
+    @Mock
+    private SetDailyGoalTargetUseCase setDailyGoalTargetUseCase;
+
+    @Mock
+    private IncrementDailyGoalUseCase incrementDailyGoalUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private DailyGoalController dailyGoalController;
+
+    private Jwt createMockJwt() {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("cognito-sub-123");
+        return jwt;
+    }
+
+    @Test
+    @DisplayName("getToday: 今日のゴールを取得できる")
+    void getToday_returnsGoal() {
+        Jwt jwt = createMockJwt();
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(user);
+        DailyGoalDto dto = new DailyGoalDto(LocalDate.now().toString(), 5, 2);
+        when(getTodayDailyGoalUseCase.execute(1)).thenReturn(dto);
+
+        ResponseEntity<DailyGoalDto> response = dailyGoalController.getToday(jwt);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(5, response.getBody().getTarget());
+    }
+
+    @Test
+    @DisplayName("setTarget: 目標回数を設定できる")
+    void setTarget_setsTarget() {
+        Jwt jwt = createMockJwt();
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(user);
+
+        ResponseEntity<Void> response = dailyGoalController.setTarget(jwt, Map.of("target", 7));
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(setDailyGoalTargetUseCase).execute(user, 7);
+    }
+
+    @Test
+    @DisplayName("increment: 完了数をインクリメントできる")
+    void increment_incrementsCompleted() {
+        Jwt jwt = createMockJwt();
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(user);
+        DailyGoalDto dto = new DailyGoalDto(LocalDate.now().toString(), 3, 1);
+        when(incrementDailyGoalUseCase.execute(user)).thenReturn(dto);
+
+        ResponseEntity<DailyGoalDto> response = dailyGoalController.increment(jwt);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(1, response.getBody().getCompleted());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetTodayDailyGoalUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetTodayDailyGoalUseCaseTest.java
@@ -1,0 +1,64 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.DailyGoalDto;
+import com.example.FreStyle.entity.DailyGoal;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.DailyGoalRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetTodayDailyGoalUseCase テスト")
+class GetTodayDailyGoalUseCaseTest {
+
+    @Mock
+    private DailyGoalRepository dailyGoalRepository;
+
+    @InjectMocks
+    private GetTodayDailyGoalUseCase getTodayDailyGoalUseCase;
+
+    @Test
+    @DisplayName("今日のゴールが存在する場合はそれを返す")
+    void execute_existingGoal_returnsDto() {
+        User user = new User();
+        user.setId(1);
+        DailyGoal goal = new DailyGoal();
+        goal.setId(10);
+        goal.setUser(user);
+        goal.setGoalDate(LocalDate.now());
+        goal.setTarget(5);
+        goal.setCompleted(2);
+        when(dailyGoalRepository.findByUserIdAndGoalDate(1, LocalDate.now()))
+                .thenReturn(Optional.of(goal));
+
+        DailyGoalDto result = getTodayDailyGoalUseCase.execute(1);
+
+        assertEquals(LocalDate.now().toString(), result.getDate());
+        assertEquals(5, result.getTarget());
+        assertEquals(2, result.getCompleted());
+    }
+
+    @Test
+    @DisplayName("今日のゴールが存在しない場合はデフォルト値を返す")
+    void execute_noGoal_returnsDefault() {
+        when(dailyGoalRepository.findByUserIdAndGoalDate(1, LocalDate.now()))
+                .thenReturn(Optional.empty());
+
+        DailyGoalDto result = getTodayDailyGoalUseCase.execute(1);
+
+        assertEquals(LocalDate.now().toString(), result.getDate());
+        assertEquals(3, result.getTarget());
+        assertEquals(0, result.getCompleted());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/IncrementDailyGoalUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/IncrementDailyGoalUseCaseTest.java
@@ -1,0 +1,65 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.DailyGoalDto;
+import com.example.FreStyle.entity.DailyGoal;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.DailyGoalRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IncrementDailyGoalUseCase テスト")
+class IncrementDailyGoalUseCaseTest {
+
+    @Mock
+    private DailyGoalRepository dailyGoalRepository;
+
+    @InjectMocks
+    private IncrementDailyGoalUseCase incrementDailyGoalUseCase;
+
+    @Test
+    @DisplayName("既存ゴールの完了数をインクリメントする")
+    void execute_existingGoal_incrementsCompleted() {
+        User user = new User();
+        user.setId(1);
+        DailyGoal goal = new DailyGoal();
+        goal.setUser(user);
+        goal.setGoalDate(LocalDate.now());
+        goal.setTarget(5);
+        goal.setCompleted(2);
+        when(dailyGoalRepository.findByUserIdAndGoalDate(1, LocalDate.now()))
+                .thenReturn(Optional.of(goal));
+
+        DailyGoalDto result = incrementDailyGoalUseCase.execute(user);
+
+        assertEquals(3, result.getCompleted());
+        verify(dailyGoalRepository).save(argThat(g -> g.getCompleted() == 3));
+    }
+
+    @Test
+    @DisplayName("ゴールが存在しない場合は新規作成してインクリメントする")
+    void execute_noGoal_createsAndIncrements() {
+        User user = new User();
+        user.setId(1);
+        when(dailyGoalRepository.findByUserIdAndGoalDate(1, LocalDate.now()))
+                .thenReturn(Optional.empty());
+
+        DailyGoalDto result = incrementDailyGoalUseCase.execute(user);
+
+        assertEquals(1, result.getCompleted());
+        assertEquals(3, result.getTarget());
+        verify(dailyGoalRepository).save(argThat(g ->
+                g.getCompleted() == 1 && g.getTarget() == 3));
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SetDailyGoalTargetUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SetDailyGoalTargetUseCaseTest.java
@@ -1,0 +1,64 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.DailyGoal;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.DailyGoalRepository;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SetDailyGoalTargetUseCase テスト")
+class SetDailyGoalTargetUseCaseTest {
+
+    @Mock
+    private DailyGoalRepository dailyGoalRepository;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private SetDailyGoalTargetUseCase setDailyGoalTargetUseCase;
+
+    @Test
+    @DisplayName("既存ゴールがある場合はターゲットを更新する")
+    void execute_existingGoal_updatesTarget() {
+        User user = new User();
+        user.setId(1);
+        DailyGoal goal = new DailyGoal();
+        goal.setUser(user);
+        goal.setGoalDate(LocalDate.now());
+        goal.setTarget(3);
+        goal.setCompleted(1);
+        when(dailyGoalRepository.findByUserIdAndGoalDate(1, LocalDate.now()))
+                .thenReturn(Optional.of(goal));
+
+        setDailyGoalTargetUseCase.execute(user, 5);
+
+        verify(dailyGoalRepository).save(argThat(g -> g.getTarget() == 5));
+    }
+
+    @Test
+    @DisplayName("ゴールが存在しない場合は新規作成する")
+    void execute_noGoal_createsNew() {
+        User user = new User();
+        user.setId(1);
+        when(dailyGoalRepository.findByUserIdAndGoalDate(1, LocalDate.now()))
+                .thenReturn(Optional.empty());
+
+        setDailyGoalTargetUseCase.execute(user, 7);
+
+        verify(dailyGoalRepository).save(argThat(g ->
+                g.getTarget() == 7 && g.getCompleted() == 0 && g.getUser().getId() == 1));
+    }
+}

--- a/frontend/src/hooks/useDailyGoal.ts
+++ b/frontend/src/hooks/useDailyGoal.ts
@@ -1,18 +1,31 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { DailyGoalRepository } from '../repositories/DailyGoalRepository';
 import type { DailyGoal } from '../types';
 
 export function useDailyGoal() {
-  const [goal, setGoal] = useState<DailyGoal>(() => DailyGoalRepository.getToday());
+  const [goal, setGoal] = useState<DailyGoal>({ date: '', target: 3, completed: 0 });
+  const [loading, setLoading] = useState(true);
 
-  const setTarget = useCallback((target: number) => {
-    DailyGoalRepository.setTarget(target);
-    setGoal(DailyGoalRepository.getToday());
+  useEffect(() => {
+    let cancelled = false;
+    DailyGoalRepository.getToday().then((data) => {
+      if (!cancelled) {
+        setGoal(data);
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
   }, []);
 
-  const incrementCompleted = useCallback(() => {
-    DailyGoalRepository.incrementCompleted();
-    setGoal(DailyGoalRepository.getToday());
+  const setTarget = useCallback(async (target: number) => {
+    await DailyGoalRepository.setTarget(target);
+    const updated = await DailyGoalRepository.getToday();
+    setGoal(updated);
+  }, []);
+
+  const incrementCompleted = useCallback(async () => {
+    const updated = await DailyGoalRepository.incrementCompleted();
+    setGoal(updated);
   }, []);
 
   const isAchieved = useMemo(() => goal.completed >= goal.target, [goal]);
@@ -21,5 +34,5 @@ export function useDailyGoal() {
     return Math.round((goal.completed / goal.target) * 100);
   }, [goal]);
 
-  return { goal, setTarget, incrementCompleted, isAchieved, progress };
+  return { goal, setTarget, incrementCompleted, isAchieved, progress, loading };
 }

--- a/frontend/src/repositories/DailyGoalRepository.ts
+++ b/frontend/src/repositories/DailyGoalRepository.ts
@@ -1,3 +1,4 @@
+import apiClient from '../lib/axios';
 import type { DailyGoal } from '../types';
 
 const STORAGE_KEY = 'freestyle_daily_goal';
@@ -7,31 +8,54 @@ function getTodayStr(): string {
   return new Date().toISOString().split('T')[0];
 }
 
-export const DailyGoalRepository = {
-  getToday(): DailyGoal {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) {
-      try {
-        const goal: DailyGoal = JSON.parse(raw);
-        if (goal.date === getTodayStr()) {
-          return goal;
-        }
-      } catch {
-        localStorage.removeItem(STORAGE_KEY);
+function getLocalGoal(): DailyGoal {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    try {
+      const goal: DailyGoal = JSON.parse(raw);
+      if (goal.date === getTodayStr()) {
+        return goal;
       }
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
     }
-    return { date: getTodayStr(), target: DEFAULT_TARGET, completed: 0 };
+  }
+  return { date: getTodayStr(), target: DEFAULT_TARGET, completed: 0 };
+}
+
+function saveLocalGoal(goal: DailyGoal): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(goal));
+}
+
+export const DailyGoalRepository = {
+  async getToday(): Promise<DailyGoal> {
+    try {
+      const response = await apiClient.get<DailyGoal>('/api/daily-goals/today');
+      return response.data;
+    } catch {
+      return getLocalGoal();
+    }
   },
 
-  setTarget(target: number): void {
-    const goal = this.getToday();
-    goal.target = target;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(goal));
+  async setTarget(target: number): Promise<void> {
+    try {
+      await apiClient.put('/api/daily-goals/target', { target });
+    } catch {
+      const goal = getLocalGoal();
+      goal.target = target;
+      saveLocalGoal(goal);
+    }
   },
 
-  incrementCompleted(): void {
-    const goal = this.getToday();
-    goal.completed += 1;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(goal));
+  async incrementCompleted(): Promise<DailyGoal> {
+    try {
+      const response = await apiClient.post<DailyGoal>('/api/daily-goals/increment');
+      return response.data;
+    } catch {
+      const goal = getLocalGoal();
+      goal.completed += 1;
+      saveLocalGoal(goal);
+      return goal;
+    }
   },
 };

--- a/frontend/src/repositories/__tests__/DailyGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/DailyGoalRepository.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DailyGoalRepository } from '../DailyGoalRepository';
 
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+const mockPost = vi.fn();
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
 function createMockStorage(): Storage {
   let store: Record<string, string> = {};
   return {
@@ -15,6 +27,7 @@ function createMockStorage(): Storage {
 
 describe('DailyGoalRepository', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.stubGlobal('localStorage', createMockStorage());
   });
 
@@ -22,43 +35,72 @@ describe('DailyGoalRepository', () => {
     vi.unstubAllGlobals();
   });
 
-  it('初期状態ではデフォルト目標を返す', () => {
-    const goal = DailyGoalRepository.getToday();
-    expect(goal.target).toBe(3);
-    expect(goal.completed).toBe(0);
-    expect(goal.date).toBeDefined();
+  describe('API正常系', () => {
+    it('getToday: APIから今日のゴールを取得する', async () => {
+      mockGet.mockResolvedValue({ data: { date: '2026-02-16', target: 5, completed: 2 } });
+
+      const result = await DailyGoalRepository.getToday();
+
+      expect(result.target).toBe(5);
+      expect(result.completed).toBe(2);
+      expect(mockGet).toHaveBeenCalledWith('/api/daily-goals/today');
+    });
+
+    it('setTarget: APIで目標回数を設定する', async () => {
+      mockPut.mockResolvedValue({});
+
+      await DailyGoalRepository.setTarget(7);
+
+      expect(mockPut).toHaveBeenCalledWith('/api/daily-goals/target', { target: 7 });
+    });
+
+    it('incrementCompleted: APIで完了数をインクリメントする', async () => {
+      mockPost.mockResolvedValue({ data: { date: '2026-02-16', target: 3, completed: 1 } });
+
+      const result = await DailyGoalRepository.incrementCompleted();
+
+      expect(result.completed).toBe(1);
+      expect(mockPost).toHaveBeenCalledWith('/api/daily-goals/increment');
+    });
   });
 
-  it('目標数を設定できる', () => {
-    DailyGoalRepository.setTarget(5);
-    const goal = DailyGoalRepository.getToday();
-    expect(goal.target).toBe(5);
-  });
+  describe('APIエラー時のlocalStorageフォールバック', () => {
+    it('getToday: APIエラー時はlocalStorageから取得する', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
+      const today = new Date().toISOString().split('T')[0];
+      localStorage.setItem('freestyle_daily_goal', JSON.stringify({ date: today, target: 4, completed: 1 }));
 
-  it('完了数を増加できる', () => {
-    DailyGoalRepository.incrementCompleted();
-    const goal = DailyGoalRepository.getToday();
-    expect(goal.completed).toBe(1);
+      const result = await DailyGoalRepository.getToday();
 
-    DailyGoalRepository.incrementCompleted();
-    expect(DailyGoalRepository.getToday().completed).toBe(2);
-  });
+      expect(result.target).toBe(4);
+      expect(result.completed).toBe(1);
+    });
 
-  it('日付が変わるとリセットされる', () => {
-    DailyGoalRepository.incrementCompleted();
-    expect(DailyGoalRepository.getToday().completed).toBe(1);
+    it('getToday: APIエラー・localStorage空の場合はデフォルトを返す', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
 
-    // 別の日付のデータを直接セット
-    const yesterday = new Date();
-    yesterday.setDate(yesterday.getDate() - 1);
-    const yesterdayStr = yesterday.toISOString().split('T')[0];
-    localStorage.setItem(
-      'freestyle_daily_goal',
-      JSON.stringify({ date: yesterdayStr, target: 3, completed: 2 })
-    );
+      const result = await DailyGoalRepository.getToday();
 
-    const goal = DailyGoalRepository.getToday();
-    expect(goal.completed).toBe(0);
-    expect(goal.target).toBe(3);
+      expect(result.target).toBe(3);
+      expect(result.completed).toBe(0);
+    });
+
+    it('setTarget: APIエラー時はlocalStorageに保存する', async () => {
+      mockPut.mockRejectedValue(new Error('Network Error'));
+
+      await DailyGoalRepository.setTarget(5);
+
+      expect(localStorage.setItem).toHaveBeenCalled();
+    });
+
+    it('incrementCompleted: APIエラー時はlocalStorageを更新する', async () => {
+      mockPost.mockRejectedValue(new Error('Network Error'));
+      const today = new Date().toISOString().split('T')[0];
+      localStorage.setItem('freestyle_daily_goal', JSON.stringify({ date: today, target: 3, completed: 1 }));
+
+      const result = await DailyGoalRepository.incrementCompleted();
+
+      expect(result.completed).toBe(2);
+    });
   });
 });


### PR DESCRIPTION
## 概要
日次学習目標（DailyGoal）をサーバーサイドで永続化し、ログイン中はAPIで目標を管理、未ログイン時はlocalStorageにフォールバックする仕組みを実装。

## 変更内容
### バックエンド（新規）
- `DailyGoal` エンティティ・JPA リポジトリを追加
- `GetTodayDailyGoalUseCase` / `SetDailyGoalTargetUseCase` / `IncrementDailyGoalUseCase` の3つのUseCaseを追加
- `DailyGoalController`（GET /api/daily-goals/today, PUT /api/daily-goals/target, POST /api/daily-goals/increment）を追加
- DBマイグレーション `004_add_daily_goals.sql` を追加

### フロントエンド（修正）
- `DailyGoalRepository` を同期localStorage → 非同期API + localStorageフォールバックに変更
- `useDailyGoal` フックを非同期対応（`loading` 状態追加）

### テスト
- バックエンド: 9件（UseCase 6件 + Controller 3件）
- フロントエンド: 14件（Repository 7件 + Hook 7件）

## テスト計画
- [x] バックエンドテスト全件パス（`./gradlew test`）
- [x] フロントエンドテスト全件パス（`npm test`）
- [x] 既存のDailyGoalCard・MenuPageテストが引き続きパスすること

closes #1041