### PR TITLE
refactor: UserProfileControllerのビジネスロジックを5つのUseCase層に分離

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateUserProfileUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public UserProfileDto execute(String sub, UserProfileForm form) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.createProfile(user, form);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteUserProfileUseCase.java
@@ -1,0 +1,24 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public void execute(String sub) {
+        User user = userIdentityService.findUserBySub(sub);
+        userProfileService.deleteProfile(user.getId());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserProfileUseCase.java
@@ -1,0 +1,25 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional(readOnly = true)
+    public UserProfileDto execute(String sub) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.getProfileByUserId(user.getId());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateUserProfileUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public UserProfileDto execute(String sub, UserProfileForm form) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.updateProfile(user.getId(), form);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpsertUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpsertUserProfileUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpsertUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public UserProfileDto execute(String sub, UserProfileForm form) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.createOrUpdateProfile(user, form);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateUserProfileUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateUserProfileUseCase")
+class CreateUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private CreateUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にプロファイルを作成する")
+    void createsProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto();
+        dto.setDisplayName("新規");
+        when(userProfileService.createProfile(user, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123", form);
+
+        assertThat(result.getDisplayName()).isEqualTo("新規");
+    }
+
+    @Test
+    @DisplayName("既に存在する場合はRuntimeExceptionを投げる")
+    void throwsWhenAlreadyExists() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        when(userProfileService.createProfile(user, form))
+                .thenThrow(new RuntimeException("プロファイルは既に存在します。"));
+
+        assertThatThrownBy(() -> useCase.execute("sub-123", form))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteUserProfileUseCaseTest.java
@@ -1,0 +1,54 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteUserProfileUseCase")
+class DeleteUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private DeleteUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にプロファイルを削除する")
+    void deletesProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+
+        useCase.execute("sub-123");
+
+        verify(userProfileService).deleteProfile(10);
+    }
+
+    @Test
+    @DisplayName("存在しない場合はRuntimeExceptionを投げる")
+    void throwsWhenNotFound() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        doThrow(new RuntimeException("プロファイルが見つかりません。"))
+                .when(userProfileService).deleteProfile(10);
+
+        assertThatThrownBy(() -> useCase.execute("sub-123"))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserProfileUseCaseTest.java
@@ -1,0 +1,59 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetUserProfileUseCase")
+class GetUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private GetUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("subからユーザーを特定してプロファイルを取得する")
+    void returnsProfileForUser() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileDto dto = new UserProfileDto();
+        dto.setDisplayName("テスト");
+        when(userProfileService.getProfileByUserId(10)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getDisplayName()).isEqualTo("テスト");
+    }
+
+    @Test
+    @DisplayName("プロファイル未作成の場合nullを返す")
+    void returnsNullWhenNoProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(userProfileService.getProfileByUserId(10)).thenReturn(null);
+
+        UserProfileDto result = useCase.execute("sub-123");
+
+        assertThat(result).isNull();
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateUserProfileUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateUserProfileUseCase")
+class UpdateUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private UpdateUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にプロファイルを更新する")
+    void updatesProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto();
+        dto.setDisplayName("更新済み");
+        when(userProfileService.updateProfile(10, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123", form);
+
+        assertThat(result.getDisplayName()).isEqualTo("更新済み");
+    }
+
+    @Test
+    @DisplayName("存在しない場合はRuntimeExceptionを投げる")
+    void throwsWhenNotFound() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        when(userProfileService.updateProfile(10, form))
+                .thenThrow(new RuntimeException("プロファイルが見つかりません。"));
+
+        assertThatThrownBy(() -> useCase.execute("sub-123", form))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpsertUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpsertUserProfileUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpsertUserProfileUseCase")
+class UpsertUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private UpsertUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にupsertする")
+    void upsertsProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto();
+        dto.setDisplayName("upsert済み");
+        when(userProfileService.createOrUpdateProfile(user, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123", form);
+
+        assertThat(result.getDisplayName()).isEqualTo("upsert済み");
+    }
+
+    @Test
+    @DisplayName("新規作成時もDTOを返す")
+    void returnsProfileOnCreate() {
+        User user = new User();
+        user.setId(20);
+        when(userIdentityService.findUserBySub("sub-new")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto();
+        dto.setUserId(20);
+        when(userProfileService.createOrUpdateProfile(user, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-new", form);
+
+        assertThat(result.getUserId()).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
## 概要
UserProfileController（240行→132行）のビジネスロジックを5つのUseCase層に分離し、Controllerの責務をHTTP関心事のみに絞った。

## 変更内容
- 5つのUseCaseを新規作成:
  - `GetUserProfileUseCase` / `CreateUserProfileUseCase` / `UpdateUserProfileUseCase` / `UpsertUserProfileUseCase` / `DeleteUserProfileUseCase`
- ControllerからUserProfileService・UserIdentityServiceの直接依存を除去
- verbose なデバッグログと`@Slf4j`を除去
- ControllerテストをUseCase mockに更新（既存テスト件数維持）

## テスト計画
- [x] UseCase単体テスト 10件パス
- [x] Controllerテスト 11件パス
- [x] 全体テスト `./gradlew test` パス

closes #1043