### PR TITLE
feat: セッションメモのバックエンド永続化

### DIFF
--- a/FreStyle/migrations/005_add_session_notes.sql
+++ b/FreStyle/migrations/005_add_session_notes.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS session_notes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    session_id INT NOT NULL,
+    note TEXT NOT NULL,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uk_user_session (user_id, session_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/SessionNoteController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/SessionNoteController.java
@@ -1,0 +1,52 @@
+package com.example.FreStyle.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.SessionNoteDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetSessionNoteUseCase;
+import com.example.FreStyle.usecase.SaveSessionNoteUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/session-notes")
+public class SessionNoteController {
+
+    private final GetSessionNoteUseCase getSessionNoteUseCase;
+    private final SaveSessionNoteUseCase saveSessionNoteUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping("/{sessionId}")
+    public ResponseEntity<SessionNoteDto> getNote(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer sessionId) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        SessionNoteDto dto = getSessionNoteUseCase.execute(user.getId(), sessionId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/{sessionId}")
+    public ResponseEntity<Void> saveNote(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer sessionId,
+            @RequestBody SaveNoteRequest request) {
+        String sub = jwt.getSubject();
+        User user = userIdentityService.findUserBySub(sub);
+        saveSessionNoteUseCase.execute(user, sessionId, request.note());
+        return ResponseEntity.ok().build();
+    }
+
+    public record SaveNoteRequest(String note) {}
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/SessionNoteDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/SessionNoteDto.java
@@ -1,0 +1,14 @@
+package com.example.FreStyle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SessionNoteDto {
+    private Integer sessionId;
+    private String note;
+    private String updatedAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/SessionNote.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/SessionNote.java
@@ -1,0 +1,50 @@
+package com.example.FreStyle.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "session_notes", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "session_id"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionNote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "session_id", nullable = false)
+    private Integer sessionId;
+
+    @Column(name = "note", nullable = false, columnDefinition = "TEXT")
+    private String note;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    public void updateTimestamp() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/SessionNoteRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/SessionNoteRepository.java
@@ -1,0 +1,11 @@
+package com.example.FreStyle.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.FreStyle.entity.SessionNote;
+
+public interface SessionNoteRepository extends JpaRepository<SessionNote, Integer> {
+    Optional<SessionNote> findByUserIdAndSessionId(Integer userId, Integer sessionId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetSessionNoteUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetSessionNoteUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.SessionNoteDto;
+import com.example.FreStyle.repository.SessionNoteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetSessionNoteUseCase {
+
+    private final SessionNoteRepository sessionNoteRepository;
+
+    @Transactional(readOnly = true)
+    public SessionNoteDto execute(Integer userId, Integer sessionId) {
+        return sessionNoteRepository.findByUserIdAndSessionId(userId, sessionId)
+                .map(note -> new SessionNoteDto(
+                        note.getSessionId(),
+                        note.getNote(),
+                        note.getUpdatedAt().toString()))
+                .orElse(null);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveSessionNoteUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveSessionNoteUseCase.java
@@ -1,0 +1,30 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.SessionNote;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.SessionNoteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SaveSessionNoteUseCase {
+
+    private final SessionNoteRepository sessionNoteRepository;
+
+    @Transactional
+    public void execute(User user, Integer sessionId, String note) {
+        SessionNote sessionNote = sessionNoteRepository.findByUserIdAndSessionId(user.getId(), sessionId)
+                .orElseGet(() -> {
+                    SessionNote newNote = new SessionNote();
+                    newNote.setUser(user);
+                    newNote.setSessionId(sessionId);
+                    return newNote;
+                });
+        sessionNote.setNote(note);
+        sessionNoteRepository.save(sessionNote);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/SessionNoteControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/SessionNoteControllerTest.java
@@ -1,0 +1,88 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.SessionNoteDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetSessionNoteUseCase;
+import com.example.FreStyle.usecase.SaveSessionNoteUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SessionNoteController")
+class SessionNoteControllerTest {
+
+    @Mock
+    private GetSessionNoteUseCase getSessionNoteUseCase;
+
+    @Mock
+    private SaveSessionNoteUseCase saveSessionNoteUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private SessionNoteController sessionNoteController;
+
+    private Jwt mockJwt(String sub) {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn(sub);
+        return jwt;
+    }
+
+    @Test
+    @DisplayName("GET: セッションメモを取得できる")
+    void getNote_returnsNote() {
+        Jwt jwt = mockJwt("sub-123");
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        SessionNoteDto dto = new SessionNoteDto(100, "テストメモ", "2026-02-16T10:00:00");
+        when(getSessionNoteUseCase.execute(1, 100)).thenReturn(dto);
+
+        ResponseEntity<SessionNoteDto> response = sessionNoteController.getNote(jwt, 100);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().getNote()).isEqualTo("テストメモ");
+    }
+
+    @Test
+    @DisplayName("GET: メモが存在しない場合も200を返す")
+    void getNote_returnsNullBody() {
+        Jwt jwt = mockJwt("sub-123");
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(getSessionNoteUseCase.execute(1, 999)).thenReturn(null);
+
+        ResponseEntity<SessionNoteDto> response = sessionNoteController.getNote(jwt, 999);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNull();
+    }
+
+    @Test
+    @DisplayName("PUT: セッションメモを保存できる")
+    void saveNote_savesNote() {
+        Jwt jwt = mockJwt("sub-123");
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+
+        ResponseEntity<Void> response = sessionNoteController.saveNote(jwt, 100, new SessionNoteController.SaveNoteRequest("保存メモ"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(saveSessionNoteUseCase).execute(user, 100, "保存メモ");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetSessionNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetSessionNoteUseCaseTest.java
@@ -1,0 +1,62 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.SessionNoteDto;
+import com.example.FreStyle.entity.SessionNote;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.SessionNoteRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSessionNoteUseCase")
+class GetSessionNoteUseCaseTest {
+
+    @Mock
+    private SessionNoteRepository sessionNoteRepository;
+
+    @InjectMocks
+    private GetSessionNoteUseCase useCase;
+
+    @Test
+    @DisplayName("セッションIDでメモを取得する")
+    void returnsNoteForSession() {
+        User user = new User();
+        user.setId(1);
+        SessionNote note = new SessionNote();
+        note.setId(10);
+        note.setUser(user);
+        note.setSessionId(100);
+        note.setNote("振り返りメモ");
+        note.setUpdatedAt(LocalDateTime.of(2026, 2, 16, 10, 0));
+        when(sessionNoteRepository.findByUserIdAndSessionId(1, 100))
+                .thenReturn(Optional.of(note));
+
+        SessionNoteDto result = useCase.execute(1, 100);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getSessionId()).isEqualTo(100);
+        assertThat(result.getNote()).isEqualTo("振り返りメモ");
+    }
+
+    @Test
+    @DisplayName("メモが存在しない場合nullを返す")
+    void returnsNullWhenNotFound() {
+        when(sessionNoteRepository.findByUserIdAndSessionId(1, 999))
+                .thenReturn(Optional.empty());
+
+        SessionNoteDto result = useCase.execute(1, 999);
+
+        assertThat(result).isNull();
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveSessionNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveSessionNoteUseCaseTest.java
@@ -1,0 +1,63 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.SessionNote;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.SessionNoteRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SaveSessionNoteUseCase")
+class SaveSessionNoteUseCaseTest {
+
+    @Mock
+    private SessionNoteRepository sessionNoteRepository;
+
+    @InjectMocks
+    private SaveSessionNoteUseCase useCase;
+
+    @Test
+    @DisplayName("新規メモを作成する")
+    void createsNewNote() {
+        User user = new User();
+        user.setId(1);
+        when(sessionNoteRepository.findByUserIdAndSessionId(1, 100))
+                .thenReturn(Optional.empty());
+
+        useCase.execute(user, 100, "新規メモ");
+
+        verify(sessionNoteRepository).save(argThat(n ->
+                n.getSessionId() == 100 && n.getNote().equals("新規メモ") && n.getUser().getId() == 1));
+    }
+
+    @Test
+    @DisplayName("既存メモを更新する")
+    void updatesExistingNote() {
+        User user = new User();
+        user.setId(1);
+        SessionNote existing = new SessionNote();
+        existing.setId(10);
+        existing.setUser(user);
+        existing.setSessionId(100);
+        existing.setNote("旧メモ");
+        existing.setUpdatedAt(LocalDateTime.of(2026, 2, 15, 10, 0));
+        when(sessionNoteRepository.findByUserIdAndSessionId(1, 100))
+                .thenReturn(Optional.of(existing));
+
+        useCase.execute(user, 100, "更新メモ");
+
+        verify(sessionNoteRepository).save(argThat(n ->
+                n.getId() == 10 && n.getNote().equals("更新メモ")));
+    }
+}

--- a/frontend/src/hooks/useSessionNote.ts
+++ b/frontend/src/hooks/useSessionNote.ts
@@ -1,18 +1,31 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { SessionNoteRepository } from '../repositories/SessionNoteRepository';
 
 export function useSessionNote(sessionId: number | null) {
-  const [note, setNote] = useState<string>(() => {
-    if (!sessionId) return '';
-    const saved = SessionNoteRepository.get(sessionId);
-    return saved?.note || '';
-  });
+  const [note, setNote] = useState<string>('');
+  const [loading, setLoading] = useState(true);
 
-  const saveNote = useCallback((text: string) => {
+  useEffect(() => {
+    if (!sessionId) {
+      setNote('');
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    SessionNoteRepository.get(sessionId).then((saved) => {
+      if (!cancelled) {
+        setNote(saved?.note || '');
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, [sessionId]);
+
+  const saveNote = useCallback(async (text: string) => {
     if (!sessionId) return;
-    SessionNoteRepository.save(sessionId, text);
+    await SessionNoteRepository.save(sessionId, text);
     setNote(text);
   }, [sessionId]);
 
-  return { note, saveNote };
+  return { note, saveNote, loading };
 }

--- a/frontend/src/repositories/SessionNoteRepository.ts
+++ b/frontend/src/repositories/SessionNoteRepository.ts
@@ -1,8 +1,9 @@
+import apiClient from '../lib/axios';
 import type { SessionNote } from '../types';
 
 const STORAGE_KEY = 'freestyle_session_notes';
 
-function getAllNotes(): Record<string, SessionNote> {
+function getAllLocalNotes(): Record<string, SessionNote> {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return {};
   try {
@@ -13,23 +14,36 @@ function getAllNotes(): Record<string, SessionNote> {
   }
 }
 
+function saveLocalNote(sessionId: number, note: string): void {
+  const notes = getAllLocalNotes();
+  notes[String(sessionId)] = {
+    sessionId,
+    note,
+    updatedAt: new Date().toISOString(),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+}
+
 export const SessionNoteRepository = {
   getAll(): Record<string, SessionNote> {
-    return getAllNotes();
+    return getAllLocalNotes();
   },
 
-  get(sessionId: number): SessionNote | null {
-    const notes = getAllNotes();
-    return notes[String(sessionId)] || null;
+  async get(sessionId: number): Promise<SessionNote | null> {
+    try {
+      const response = await apiClient.get<SessionNote>(`/api/session-notes/${sessionId}`);
+      return response.data;
+    } catch {
+      const notes = getAllLocalNotes();
+      return notes[String(sessionId)] || null;
+    }
   },
 
-  save(sessionId: number, note: string): void {
-    const notes = getAllNotes();
-    notes[String(sessionId)] = {
-      sessionId,
-      note,
-      updatedAt: new Date().toISOString(),
-    };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+  async save(sessionId: number, note: string): Promise<void> {
+    try {
+      await apiClient.put(`/api/session-notes/${sessionId}`, { note });
+    } catch {
+      saveLocalNote(sessionId, note);
+    }
   },
 };

--- a/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionNoteRepository } from '../SessionNoteRepository';
 
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: (...args: unknown[]) => mockGet(...args),
+    put: (...args: unknown[]) => mockPut(...args),
+  },
+}));
+
 function createMockStorage(): Storage {
   let store: Record<string, string> = {};
   return {
@@ -15,6 +25,7 @@ function createMockStorage(): Storage {
 
 describe('SessionNoteRepository', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.stubGlobal('localStorage', createMockStorage());
   });
 
@@ -22,30 +33,64 @@ describe('SessionNoteRepository', () => {
     vi.unstubAllGlobals();
   });
 
-  it('初期状態ではnullを返す', () => {
-    expect(SessionNoteRepository.get(1)).toBeNull();
+  describe('API正常系', () => {
+    it('get: APIからメモを取得する', async () => {
+      mockGet.mockResolvedValue({ data: { sessionId: 1, note: 'APIメモ', updatedAt: '2026-02-16T10:00:00' } });
+
+      const result = await SessionNoteRepository.get(1);
+
+      expect(result).not.toBeNull();
+      expect(result!.note).toBe('APIメモ');
+      expect(mockGet).toHaveBeenCalledWith('/api/session-notes/1');
+    });
+
+    it('save: APIでメモを保存する', async () => {
+      mockPut.mockResolvedValue({});
+
+      await SessionNoteRepository.save(1, '保存メモ');
+
+      expect(mockPut).toHaveBeenCalledWith('/api/session-notes/1', { note: '保存メモ' });
+    });
   });
 
-  it('メモを保存・取得できる', () => {
-    SessionNoteRepository.save(1, '良い練習でした');
-    const note = SessionNoteRepository.get(1);
-    expect(note).not.toBeNull();
-    expect(note!.note).toBe('良い練習でした');
-    expect(note!.sessionId).toBe(1);
-    expect(note!.updatedAt).toBeDefined();
+  describe('APIエラー時のlocalStorageフォールバック', () => {
+    it('get: APIエラー時はlocalStorageから取得する', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
+      localStorage.setItem('freestyle_session_notes', JSON.stringify({ '1': { sessionId: 1, note: 'ローカルメモ', updatedAt: '2026-02-16' } }));
+
+      const result = await SessionNoteRepository.get(1);
+
+      expect(result!.note).toBe('ローカルメモ');
+    });
+
+    it('get: APIエラー・localStorage空の場合はnullを返す', async () => {
+      mockGet.mockRejectedValue(new Error('Network Error'));
+
+      const result = await SessionNoteRepository.get(999);
+
+      expect(result).toBeNull();
+    });
+
+    it('save: APIエラー時はlocalStorageに保存する', async () => {
+      mockPut.mockRejectedValue(new Error('Network Error'));
+
+      await SessionNoteRepository.save(1, 'フォールバックメモ');
+
+      expect(localStorage.setItem).toHaveBeenCalled();
+    });
   });
 
-  it('メモを上書き保存できる', () => {
-    SessionNoteRepository.save(1, '初回メモ');
-    SessionNoteRepository.save(1, '更新メモ');
-    const note = SessionNoteRepository.get(1);
-    expect(note!.note).toBe('更新メモ');
-  });
+  describe('getAll', () => {
+    it('localStorageから全メモを取得する', () => {
+      localStorage.setItem('freestyle_session_notes', JSON.stringify({
+        '1': { sessionId: 1, note: 'メモ1', updatedAt: '2026-02-16' },
+        '2': { sessionId: 2, note: 'メモ2', updatedAt: '2026-02-16' },
+      }));
 
-  it('異なるセッションのメモを独立して保存できる', () => {
-    SessionNoteRepository.save(1, 'セッション1のメモ');
-    SessionNoteRepository.save(2, 'セッション2のメモ');
-    expect(SessionNoteRepository.get(1)!.note).toBe('セッション1のメモ');
-    expect(SessionNoteRepository.get(2)!.note).toBe('セッション2のメモ');
+      const result = SessionNoteRepository.getAll();
+
+      expect(Object.keys(result)).toHaveLength(2);
+      expect(result['1'].note).toBe('メモ1');
+    });
   });
 });


### PR DESCRIPTION
## 概要
- セッションメモをlocalStorage専用からAPI+localStorageフォールバック構成に変更
- バックエンドにEntity/DTO/Repository/UseCase/Controller/Migrationを新規作成
- フロントエンドのリポジトリとフックを非同期対応に更新

## 変更内容
### バックエンド（新規）
- `SessionNote` エンティティ（user_id + session_id のユニーク制約）
- `SessionNoteDto` DTO
- `SessionNoteRepository` JPA
- `GetSessionNoteUseCase` / `SaveSessionNoteUseCase`
- `SessionNoteController`（GET/PUT `/api/session-notes/{sessionId}`）
- DBマイグレーション `005_add_session_notes.sql`

### フロントエンド（修正）
- `SessionNoteRepository.ts`: 同期→非同期（API + localStorageフォールバック）
- `useSessionNote.ts`: 同期→非同期（useEffect + loading状態）

### テスト
- バックエンド: 7件（Controller 3 + UseCase 4）
- フロントエンド: 15件（Repository 6 + Hook 9）

closes #1047