### PR TITLE
refactor: ChatWebSocketControllerのビジネスロジックをUseCase層に分離

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ChatWebSocketController.java
@@ -1,20 +1,14 @@
 package com.example.FreStyle.controller;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
-import com.example.FreStyle.dto.ChatMessageDto;
-import com.example.FreStyle.entity.ChatRoom;
-import com.example.FreStyle.entity.User;
-import com.example.FreStyle.repository.RoomMemberRepository;
-import com.example.FreStyle.service.ChatMessageService;
-import com.example.FreStyle.service.ChatRoomService;
-import com.example.FreStyle.service.UnreadCountService;
+import com.example.FreStyle.usecase.DeleteChatMessageUseCase;
+import com.example.FreStyle.usecase.SendChatMessageUseCase;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,157 +18,51 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ChatWebSocketController {
 
-    private final ChatRoomService chatRoomService;
-    private final ChatMessageService chatMessageService;
+    private final SendChatMessageUseCase sendChatMessageUseCase;
+    private final DeleteChatMessageUseCase deleteChatMessageUseCase;
     private final SimpMessagingTemplate messagingTemplate;
-    private final UnreadCountService unreadCountService;
-    private final RoomMemberRepository roomMemberRepository;
 
     @MessageMapping("/chat/send")
-    public void sendMessage(
-            @Payload Map<String, Object> payload
-    ) {
-        log.info("\n========== WebSocket /chat/send リクエスト受信 ==========");
-        log.info("📨 ペイロード全体: {}", payload);
-
+    public void sendMessage(@Payload Map<String, Object> payload) {
         try {
-            // パラメータの取得と検証
-            log.info("🔍 パラメータを抽出中...");
-            Object senderIdObj = payload.get("senderId");
-            Object roomIdObj = payload.get("roomId");
-            Object contentObj = payload.get("content");
-
-            log.debug("   - senderId タイプ: {}", senderIdObj != null ? senderIdObj.getClass().getSimpleName() : "null");
-            log.debug("   - senderId 値: {}", senderIdObj);
-            log.debug("   - roomId タイプ: {}", roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null");
-            log.debug("   - roomId 値: {}", roomIdObj);
-            log.debug("   - content タイプ: {}", contentObj != null ? contentObj.getClass().getSimpleName() : "null");
-            log.debug("   - content 値: {}", contentObj);
-            
-            // senderId は String または Integer で来る可能性がある
-            // Integer に変換して扱う
-            Integer senderId;
-            if (senderIdObj instanceof Integer) {
-                // Object型をIntegerに変換をしてから格納をする
-                senderId = (Integer) senderIdObj;
-                log.info("   💡 senderId を Integer から String に変換");
-            } else {
-                senderId = (Integer) senderIdObj;
-            }
-            
-            // roomId は String または Integer で来る可能性がある
-            Integer roomId;
-            if (roomIdObj instanceof Integer) {
-                roomId = (Integer) roomIdObj;
-                log.info("   💡 roomId を Integer として取得");
-            } else {
-                roomId = Integer.parseInt((String) roomIdObj);
-                log.info("   💡 roomId を String から Integer に変換");
-            }
-            
+            Integer senderId = ((Number) payload.get("senderId")).intValue();
+            Integer roomId = ((Number) payload.get("roomId")).intValue();
             String content = (String) payload.get("content");
-            
-            log.info("✅ パラメータ抽出成功");
-            log.debug("   - senderId (最終): {}", senderId);
-            log.debug("   - roomId (最終): {}", roomId);
-            log.debug("   - content: {}", content);
 
-            // ChatRoom 取得
-            log.info("🔍 ChatRoom を roomId={} で取得中...", roomId);
-            ChatRoom room = chatRoomService.findChatRoomById(roomId);
-            log.info("✅ ChatRoom 取得成功: {}", room.getId());
-            
-            // メッセージ保存
-            log.info("💾 メッセージをデータベースに保存中...");
-            ChatMessageDto saved = chatMessageService.addMessage(room, senderId, content);
-            log.info("✅ メッセージ保存成功");
-            log.debug("   - messageId: {}", saved.getId());
-            log.debug("   - roomId: {}", saved.getRoomId());
-            log.debug("   - senderId: {}", saved.getSenderId());
-            log.debug("   - content: {}", saved.getContent());
-            log.debug("   - createdAt: {}", saved.getCreatedAt());
+            SendChatMessageUseCase.Result result = sendChatMessageUseCase.execute(senderId, roomId, content);
 
-            // WebSocket トピックへ送信
-            log.info("📤 WebSocket トピック /topic/chat/{} へメッセージを送信中...", room.getId());
-            messagingTemplate.convertAndSend(
-                    "/topic/chat/" + room.getId(),
-                    saved
-            );
-            log.info("✅ WebSocket 送信完了");
+            messagingTemplate.convertAndSend("/topic/chat/" + roomId, result.message());
 
-            // 相手ユーザーの未読数をインクリメントし、WebSocketで通知
-            Optional<User> partnerOpt = roomMemberRepository.findPartnerByRoomIdAndUserId(roomId, senderId);
-            if (partnerOpt.isPresent()) {
-                User partner = partnerOpt.get();
-                unreadCountService.incrementUnreadCount(partner.getId(), roomId);
+            if (result.partnerId() != null) {
                 messagingTemplate.convertAndSend(
-                        "/topic/unread/" + partner.getId(),
+                        "/topic/unread/" + result.partnerId(),
                         Map.of(
                                 "type", "unread_update",
                                 "roomId", roomId,
                                 "increment", 1
                         )
                 );
-                log.info("📤 未読数通知を /topic/unread/{} へ送信", partner.getId());
             }
-
-            log.info("========== /chat/send 処理完了 ==========\n");
-            
-        } catch (NumberFormatException e) {
-            log.error("メッセージ送信エラー(型変換): {}", e.getMessage(), e);
-        } catch (NullPointerException e) {
-            log.error("メッセージ送信エラー(パラメータ不足): {}", e.getMessage(), e);
         } catch (Exception e) {
             log.error("メッセージ送信エラー: {}", e.getMessage(), e);
         }
     }
 
     @MessageMapping("/chat/delete")
-    public void deleteMessage(
-            @Payload Map<String, Object> payload
-    ) {
-        log.info("\n========== WebSocket /chat/delete リクエスト受信 ==========");
-        log.info("🗑️ ペイロード全体: {}", payload);
-        
+    public void deleteMessage(@Payload Map<String, Object> payload) {
         try {
-            // パラメータの取得と検証
-            log.info("🔍 パラメータを抽出中...");
-            Object messageIdObj = payload.get("messageId");
-            Object roomIdObj = payload.get("roomId");
-            
-            log.debug("   - messageId タイプ: {}", messageIdObj != null ? messageIdObj.getClass().getSimpleName() : "null");
-            log.debug("   - messageId 値: {}", messageIdObj);
-            log.debug("   - roomId タイプ: {}", roomIdObj != null ? roomIdObj.getClass().getSimpleName() : "null");
-            log.debug("   - roomId 値: {}", roomIdObj);
-            
             Integer messageId = ((Number) payload.get("messageId")).intValue();
             Integer roomId = ((Number) payload.get("roomId")).intValue();
-            
-            log.info("✅ パラメータ抽出成功");
-            log.debug("   - messageId (最終): {}", messageId);
-            log.debug("   - roomId (最終): {}", roomId);
 
-            // メッセージ削除
-            log.info("🔍 messageId={} を削除中...", messageId);
-            chatMessageService.deleteMessage(messageId);
-            log.info("✅ メッセージ削除成功");
-            
-            // WebSocket トピックへ削除通知を送信
-            log.info("📤 WebSocket トピック /topic/chat/{} へ削除通知を送信中...", roomId);
+            deleteChatMessageUseCase.execute(messageId);
+
             messagingTemplate.convertAndSend(
                     "/topic/chat/" + roomId,
                     Map.of(
-                        "type", "delete",
-                        "messageId", messageId
+                            "type", "delete",
+                            "messageId", messageId
                     )
             );
-            log.info("✅ WebSocket 送信完了");
-            log.info("========== /chat/delete 処理完了 ==========\n");
-            
-        } catch (NumberFormatException e) {
-            log.error("メッセージ削除エラー(型変換): {}", e.getMessage(), e);
-        } catch (NullPointerException e) {
-            log.error("メッセージ削除エラー(パラメータ不足): {}", e.getMessage(), e);
         } catch (Exception e) {
             log.error("メッセージ削除エラー: {}", e.getMessage(), e);
         }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteChatMessageUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteChatMessageUseCase.java
@@ -1,0 +1,20 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.service.ChatMessageService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteChatMessageUseCase {
+
+    private final ChatMessageService chatMessageService;
+
+    @Transactional
+    public void execute(Integer messageId) {
+        chatMessageService.deleteMessage(messageId);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/SendChatMessageUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/SendChatMessageUseCase.java
@@ -1,0 +1,43 @@
+package com.example.FreStyle.usecase;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.ChatMessageDto;
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.RoomMemberRepository;
+import com.example.FreStyle.service.ChatMessageService;
+import com.example.FreStyle.service.ChatRoomService;
+import com.example.FreStyle.service.UnreadCountService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SendChatMessageUseCase {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+    private final UnreadCountService unreadCountService;
+    private final RoomMemberRepository roomMemberRepository;
+
+    public record Result(ChatMessageDto message, Integer partnerId) {}
+
+    @Transactional
+    public Result execute(Integer senderId, Integer roomId, String content) {
+        ChatRoom room = chatRoomService.findChatRoomById(roomId);
+        ChatMessageDto saved = chatMessageService.addMessage(room, senderId, content);
+
+        Optional<User> partnerOpt = roomMemberRepository.findPartnerByRoomIdAndUserId(roomId, senderId);
+        Integer partnerId = null;
+        if (partnerOpt.isPresent()) {
+            partnerId = partnerOpt.get().getId();
+            unreadCountService.incrementUnreadCount(partnerId, roomId);
+        }
+
+        return new Result(saved, partnerId);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteChatMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteChatMessageUseCaseTest.java
@@ -1,0 +1,30 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.service.ChatMessageService;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteChatMessageUseCaseTest {
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @InjectMocks
+    private DeleteChatMessageUseCase useCase;
+
+    @Test
+    @DisplayName("メッセージを削除する")
+    void execute_deletesMessage() {
+        useCase.execute(100);
+
+        verify(chatMessageService).deleteMessage(100);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SendChatMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SendChatMessageUseCaseTest.java
@@ -1,0 +1,92 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ChatMessageDto;
+import com.example.FreStyle.entity.ChatRoom;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.RoomMemberRepository;
+import com.example.FreStyle.service.ChatMessageService;
+import com.example.FreStyle.service.ChatRoomService;
+import com.example.FreStyle.service.UnreadCountService;
+
+@ExtendWith(MockitoExtension.class)
+class SendChatMessageUseCaseTest {
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    @Mock
+    private UnreadCountService unreadCountService;
+
+    @Mock
+    private RoomMemberRepository roomMemberRepository;
+
+    @InjectMocks
+    private SendChatMessageUseCase useCase;
+
+    private ChatRoom testRoom;
+    private ChatMessageDto savedMessage;
+    private User partner;
+
+    @BeforeEach
+    void setUp() {
+        testRoom = new ChatRoom();
+        testRoom.setId(10);
+
+        savedMessage = new ChatMessageDto();
+        savedMessage.setId(100);
+        savedMessage.setRoomId(10);
+        savedMessage.setSenderId(1);
+        savedMessage.setSenderName("送信者");
+        savedMessage.setContent("テストメッセージ");
+        savedMessage.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+
+        partner = new User();
+        partner.setId(2);
+        partner.setName("相手");
+    }
+
+    @Test
+    @DisplayName("メッセージを保存しChatMessageDtoと相手IDを返す")
+    void execute_savesMessageAndReturnsResult() {
+        when(chatRoomService.findChatRoomById(10)).thenReturn(testRoom);
+        when(chatMessageService.addMessage(testRoom, 1, "テストメッセージ")).thenReturn(savedMessage);
+        when(roomMemberRepository.findPartnerByRoomIdAndUserId(10, 1)).thenReturn(Optional.of(partner));
+
+        SendChatMessageUseCase.Result result = useCase.execute(1, 10, "テストメッセージ");
+
+        assertEquals(savedMessage, result.message());
+        assertEquals(2, result.partnerId());
+        verify(unreadCountService).incrementUnreadCount(2, 10);
+    }
+
+    @Test
+    @DisplayName("相手がいない場合はpartnerIdがnullで未読数インクリメントしない")
+    void execute_noPartner_returnsNullPartnerId() {
+        when(chatRoomService.findChatRoomById(10)).thenReturn(testRoom);
+        when(chatMessageService.addMessage(testRoom, 1, "テストメッセージ")).thenReturn(savedMessage);
+        when(roomMemberRepository.findPartnerByRoomIdAndUserId(10, 1)).thenReturn(Optional.empty());
+
+        SendChatMessageUseCase.Result result = useCase.execute(1, 10, "テストメッセージ");
+
+        assertEquals(savedMessage, result.message());
+        assertNull(result.partnerId());
+        verify(unreadCountService, never()).incrementUnreadCount(anyInt(), anyInt());
+    }
+}


### PR DESCRIPTION
## 概要
- ChatWebSocketControllerの5つのService直接注入を2つのUseCase+MessagingTemplate構成に変更
- 冗長なログ（絵文字付きデバッグログ多数）を整理し、182行→70行に削減

## 変更内容
### 新規UseCase
- `SendChatMessageUseCase`: メッセージ保存・相手ユーザー検索・未読数インクリメント
- `DeleteChatMessageUseCase`: メッセージ削除

### リファクタリング
- `ChatWebSocketController`: 5 Service依存 → 2 UseCase + SimpMessagingTemplate
- `ChatWebSocketControllerTest`: UseCase mockに変更

### テスト
- UseCase: 3件（Send 2 + Delete 1）
- Controller: 3件（送信通知・相手なし・削除通知）

closes #1049