### PR TITLE
test: AiChatMessageService・AiChatSessionServiceのテスト拡充

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/AiChatMessageServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/AiChatMessageServiceTest.java
@@ -165,4 +165,33 @@ class AiChatMessageServiceTest {
 
         assertEquals(5L, count);
     }
+
+    @Test
+    @DisplayName("getMessagesByUserId: ユーザーの全メッセージを返す")
+    void getMessagesByUserId_returnsList() {
+        AiChatSession session = createSession(1);
+        User user = createUser(10);
+        AiChatMessage msg1 = createMessage(1, session, user, Role.user, "質問1");
+        AiChatMessage msg2 = createMessage(2, session, user, Role.assistant, "回答1");
+        when(aiChatMessageRepository.findByUserIdOrderByCreatedAtAsc(10))
+                .thenReturn(List.of(msg1, msg2));
+
+        List<AiChatMessageResponseDto> result = aiChatMessageService.getMessagesByUserId(10);
+
+        assertEquals(2, result.size());
+        assertEquals("質問1", result.get(0).getContent());
+        assertEquals("回答1", result.get(1).getContent());
+        assertEquals(10, result.get(0).getUserId());
+    }
+
+    @Test
+    @DisplayName("getMessagesByUserId: メッセージがない場合は空リスト")
+    void getMessagesByUserId_returnsEmptyList() {
+        when(aiChatMessageRepository.findByUserIdOrderByCreatedAtAsc(999))
+                .thenReturn(List.of());
+
+        List<AiChatMessageResponseDto> result = aiChatMessageService.getMessagesByUserId(999);
+
+        assertTrue(result.isEmpty());
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/service/AiChatSessionServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/AiChatSessionServiceTest.java
@@ -169,4 +169,35 @@ class AiChatSessionServiceTest {
 
         verify(aiChatSessionRepository).delete(session);
     }
+
+    @Test
+    @DisplayName("getSessionsByRelatedRoomId: 関連ルームのセッション一覧を返す")
+    void getSessionsByRelatedRoomId_returnsList() {
+        User user = createUser(1);
+        ChatRoom room = new ChatRoom();
+        room.setId(5);
+        AiChatSession s1 = createSession(1, user, "ルーム関連1");
+        s1.setRelatedRoom(room);
+        AiChatSession s2 = createSession(2, user, "ルーム関連2");
+        s2.setRelatedRoom(room);
+        when(aiChatSessionRepository.findByRelatedRoomId(5))
+                .thenReturn(List.of(s1, s2));
+
+        List<AiChatSessionDto> result = aiChatSessionService.getSessionsByRelatedRoomId(5);
+
+        assertEquals(2, result.size());
+        assertEquals("ルーム関連1", result.get(0).getTitle());
+        assertEquals(5, result.get(0).getRelatedRoomId());
+    }
+
+    @Test
+    @DisplayName("getSessionsByRelatedRoomId: セッションがない場合は空リスト")
+    void getSessionsByRelatedRoomId_returnsEmptyList() {
+        when(aiChatSessionRepository.findByRelatedRoomId(999))
+                .thenReturn(List.of());
+
+        List<AiChatSessionDto> result = aiChatSessionService.getSessionsByRelatedRoomId(999);
+
+        assertTrue(result.isEmpty());
+    }
 }


### PR DESCRIPTION
## 概要
テストが不足していた2つのServiceメソッドのユニットテストを追加

## 追加テスト
- `AiChatMessageService.getMessagesByUserId()`: 正常系 + 空リスト（+2件、計9件）
- `AiChatSessionService.getSessionsByRelatedRoomId()`: 正常系 + 空リスト（+2件、計10件）

closes #1051