### PR TITLE
refactor: NoteImageControllerのビジネスロジックをUseCase層に分離

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/NoteImageController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/NoteImageController.java
@@ -2,13 +2,10 @@ package com.example.FreStyle.controller;
 
 import com.example.FreStyle.dto.PresignedUrlRequest;
 import com.example.FreStyle.dto.PresignedUrlResponse;
-import com.example.FreStyle.entity.User;
-import com.example.FreStyle.service.NoteImageService;
-import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GeneratePresignedUrlUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -17,11 +14,10 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notes")
+@Slf4j
 public class NoteImageController {
 
-    private static final Logger logger = LoggerFactory.getLogger(NoteImageController.class);
-    private final NoteImageService noteImageService;
-    private final UserIdentityService userIdentityService;
+    private final GeneratePresignedUrlUseCase generatePresignedUrlUseCase;
 
     @PostMapping("/{noteId}/images/presigned-url")
     public ResponseEntity<?> getPresignedUrl(
@@ -29,28 +25,14 @@ public class NoteImageController {
             @PathVariable String noteId,
             @Valid @RequestBody PresignedUrlRequest request
     ) {
-        logger.info("Presigned URLリクエスト受信 - noteId: {}, fileName: {}, contentType: {}",
-                noteId, request.fileName(), request.contentType());
         try {
-            if (jwt == null) {
-                logger.warn("JWT is null - 認証されていないリクエスト");
-                return ResponseEntity.status(401).body(java.util.Map.of("error", "認証が必要です"));
-            }
-            String sub = jwt.getSubject();
-            logger.debug("JWT subject: {}", sub);
-            User user = userIdentityService.findUserBySub(sub);
-
-            PresignedUrlResponse response = noteImageService.generatePresignedUrl(
-                    user.getId(), noteId, request.fileName(), request.contentType()
-            );
-            logger.info("Presigned URL生成成功 - noteId: {}, fileName: {}", noteId, request.fileName());
-
+            PresignedUrlResponse response = generatePresignedUrlUseCase.execute(
+                    jwt.getSubject(), noteId, request.fileName(), request.contentType());
             return ResponseEntity.ok(response);
         } catch (IllegalArgumentException e) {
-            logger.warn("Presigned URL生成失敗 - 不正なリクエスト: {}", e.getMessage());
             return ResponseEntity.badRequest().body(java.util.Map.of("error", e.getMessage()));
         } catch (Exception e) {
-            logger.error("Presigned URL生成失敗 - noteId: {}, fileName: {}", noteId, request.fileName(), e);
+            log.error("Presigned URL生成失敗 - noteId: {}, fileName: {}", noteId, request.fileName(), e);
             return ResponseEntity.internalServerError().body(java.util.Map.of("error", "画像アップロードの準備に失敗しました"));
         }
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GeneratePresignedUrlUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GeneratePresignedUrlUseCase.java
@@ -1,0 +1,23 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+
+import com.example.FreStyle.dto.PresignedUrlResponse;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.NoteImageService;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GeneratePresignedUrlUseCase {
+
+    private final NoteImageService noteImageService;
+    private final UserIdentityService userIdentityService;
+
+    public PresignedUrlResponse execute(String sub, String noteId, String fileName, String contentType) {
+        User user = userIdentityService.findUserBySub(sub);
+        return noteImageService.generatePresignedUrl(user.getId(), noteId, fileName, contentType);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GeneratePresignedUrlUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GeneratePresignedUrlUseCaseTest.java
@@ -1,0 +1,58 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.PresignedUrlResponse;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.NoteImageService;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+class GeneratePresignedUrlUseCaseTest {
+
+    @Mock
+    private NoteImageService noteImageService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private GeneratePresignedUrlUseCase useCase;
+
+    @Test
+    @DisplayName("Presigned URLを生成して返す")
+    void execute_generatesPresignedUrl() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+        PresignedUrlResponse expected = new PresignedUrlResponse(
+                "https://s3.example.com/upload", "https://cdn.example.com/image.png");
+        when(noteImageService.generatePresignedUrl(1, "note1", "image.png", "image/png"))
+                .thenReturn(expected);
+
+        PresignedUrlResponse result = useCase.execute("test-sub", "note1", "image.png", "image/png");
+
+        assertEquals(expected, result);
+    }
+
+    @Test
+    @DisplayName("不正なcontentTypeでIllegalArgumentExceptionがスローされる")
+    void execute_throwsForInvalidContentType() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+        when(noteImageService.generatePresignedUrl(1, "note1", "file.exe", "application/octet-stream"))
+                .thenThrow(new IllegalArgumentException("許可されていないファイル形式です"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> useCase.execute("test-sub", "note1", "file.exe", "application/octet-stream"));
+    }
+}


### PR DESCRIPTION
## 概要
- NoteImageControllerからビジネスロジックを`GeneratePresignedUrlUseCase`に抽出
- コントローラの依存を2サービス → 1 UseCaseに削減（58行 → 40行）

## 変更内容
- `GeneratePresignedUrlUseCase` を新規作成（UserIdentityService + NoteImageServiceを統合）
- `NoteImageController` を UseCase 呼び出しに簡素化
- `GeneratePresignedUrlUseCaseTest`（2件）、`NoteImageControllerTest`（3件）を更新

## テスト
- [x] `./gradlew test` 全テスト通過

closes #1055