### PR TITLE
test: UserService・ProfileController・BedrockServiceのテスト拡充（+6件）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ProfileControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ProfileControllerTest.java
@@ -65,6 +65,17 @@ class ProfileControllerTest {
         }
 
         @Test
+        @DisplayName("JWTのsubjectが空文字の場合401を返す")
+        void returnsUnauthorizedWhenSubjectEmpty() {
+            Jwt jwt = mock(Jwt.class);
+            when(jwt.getSubject()).thenReturn("");
+
+            ResponseEntity<?> response = profileController.getProfile(jwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
         @DisplayName("ユーザーが見つからない場合404を返す")
         void returnsNotFoundWhenUserNotFound() {
             Jwt jwt = mock(Jwt.class);
@@ -102,6 +113,19 @@ class ProfileControllerTest {
             ProfileForm form = new ProfileForm("名前", "自己紹介");
 
             ResponseEntity<?> response = profileController.updateProfile(null, form);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        @Test
+        @DisplayName("JWTのsubjectが空文字の場合401を返す")
+        void returnsUnauthorizedWhenSubjectEmpty() {
+            Jwt jwt = mock(Jwt.class);
+            when(jwt.getSubject()).thenReturn("");
+
+            ProfileForm form = new ProfileForm("名前", "自己紹介");
+
+            ResponseEntity<?> response = profileController.updateProfile(jwt, form);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         }

--- a/FreStyle/src/test/java/com/example/FreStyle/service/BedrockServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/BedrockServiceTest.java
@@ -278,4 +278,17 @@ class BedrockServiceTest {
         assertThat(json.get("max_tokens").asInt()).isEqualTo(2048);
         assertThat(json.has("system")).isTrue();
     }
+
+    @Test
+    @DisplayName("chatWithUserProfileAndScene()でエラー時にRuntimeExceptionをスローする")
+    void chatWithUserProfileAndSceneShouldThrowOnError() {
+        when(bedrockClient.invokeModel(any(InvokeModelRequest.class)))
+                .thenThrow(new RuntimeException("Bedrock error"));
+
+        assertThatThrownBy(() -> bedrockService.chatWithUserProfileAndScene(
+                "テストメッセージ", "meeting",
+                "太郎", "自己紹介", "丁寧", "真面目", "目標", "懸念", "優しく"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("AI応答の取得に失敗しました");
+    }
 }


### PR DESCRIPTION
## 概要
- テストカバレッジのギャップ3箇所を補完

## 変更内容
- `UserServiceTest`: `findUsersWithRoomId()`のテスト3件追加（クエリなし・クエリあり・空文字クエリ）
- `ProfileControllerTest`: `getProfile()`・`updateProfile()`のJWT空文字subjectエッジケーステスト2件追加
- `BedrockServiceTest`: `chatWithUserProfileAndScene()`のエラーケーステスト1件追加

## テスト
- [x] `./gradlew test` 全テスト通過

closes #1057