### PR TITLE
feat: APIエラーメッセージのユーザーフレンドリー化

### DIFF
--- a/frontend/src/hooks/__tests__/useAiChat.test.ts
+++ b/frontend/src/hooks/__tests__/useAiChat.test.ts
@@ -36,7 +36,7 @@ describe('useAiChat', () => {
       await result.current.fetchSessions();
     });
 
-    expect(result.current.error).toBe('取得失敗');
+    expect(result.current.error).toBe('セッション一覧の取得に失敗しました。');
     expect(result.current.loading).toBe(false);
   });
 

--- a/frontend/src/hooks/__tests__/useAuth.test.ts
+++ b/frontend/src/hooks/__tests__/useAuth.test.ts
@@ -60,7 +60,7 @@ describe('useAuth', () => {
     });
 
     expect(success).toBe(false);
-    expect(result.current.error).toBe('認証失敗');
+    expect(result.current.error).toBe('ログインに失敗しました。');
   });
 
   it('signup: サインアップ成功時にtrueを返す', async () => {
@@ -115,7 +115,7 @@ describe('useAuth', () => {
     });
 
     expect(success).toBe(false);
-    expect(result.current.error).toBe('メールアドレスが既に使用されています');
+    expect(result.current.error).toBe('サインアップに失敗しました。');
   });
 
   it('getCurrentUser: ユーザー情報取得失敗時にnullを返す', async () => {
@@ -129,7 +129,7 @@ describe('useAuth', () => {
     });
 
     expect(user).toBeNull();
-    expect(result.current.error).toBe('セッション切れ');
+    expect(result.current.error).toBe('ユーザー情報の取得に失敗しました。');
   });
 
   it('refreshToken: リフレッシュ失敗時にログインページに遷移する', async () => {

--- a/frontend/src/hooks/__tests__/usePractice.test.ts
+++ b/frontend/src/hooks/__tests__/usePractice.test.ts
@@ -35,7 +35,7 @@ describe('usePractice', () => {
       await result.current.fetchScenarios();
     });
 
-    expect(result.current.error).toBe('取得失敗');
+    expect(result.current.error).toBe('シナリオ一覧の取得に失敗しました。');
   });
 
   it('fetchScenario: シナリオ詳細を取得する', async () => {
@@ -78,7 +78,7 @@ describe('usePractice', () => {
     });
 
     expect(created).toBeNull();
-    expect(result.current.error).toBe('作成失敗');
+    expect(result.current.error).toBe('練習セッションの作成に失敗しました。');
   });
 
   it('初期状態のscenariosが空配列', () => {
@@ -103,6 +103,6 @@ describe('usePractice', () => {
     });
 
     expect(fetched).toBeNull();
-    expect(result.current.error).toBe('詳細取得失敗');
+    expect(result.current.error).toBe('シナリオ詳細の取得に失敗しました。');
   });
 });

--- a/frontend/src/hooks/__tests__/useUserProfile.test.ts
+++ b/frontend/src/hooks/__tests__/useUserProfile.test.ts
@@ -35,7 +35,7 @@ describe('useUserProfile', () => {
       await result.current.fetchMyProfile();
     });
 
-    expect(result.current.error).toBe('取得失敗');
+    expect(result.current.error).toBe('プロファイルの取得に失敗しました。');
   });
 
   it('updateProfile: プロファイルを更新する', async () => {
@@ -64,7 +64,7 @@ describe('useUserProfile', () => {
     });
 
     expect(success).toBe(false);
-    expect(result.current.error).toBe('更新失敗');
+    expect(result.current.error).toBe('プロファイルの更新に失敗しました。');
   });
 
   it('fetchMyProfile: non-Errorオブジェクトのreject時にデフォルトメッセージを設定する', async () => {

--- a/frontend/src/hooks/useAiChat.ts
+++ b/frontend/src/hooks/useAiChat.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { classifyApiError } from '../utils/classifyApiError';
 import AiChatRepository, {
   CreateSessionRequest,
   UpdateSessionTitleRequest,
@@ -41,9 +42,7 @@ export const useAiChat = () => {
       const data = await AiChatRepository.getSessions();
       setSessions(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'セッション一覧の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'セッション一覧の取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -60,9 +59,7 @@ export const useAiChat = () => {
       const data = await AiChatRepository.getSession(sessionId);
       setCurrentSession(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'セッション詳細の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'セッション詳細の取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -82,9 +79,7 @@ export const useAiChat = () => {
         setCurrentSession(data);
         return data;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'セッションの作成に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, 'セッションの作成に失敗しました。'));
         return null;
       } finally {
         setLoading(false);
@@ -111,9 +106,7 @@ export const useAiChat = () => {
         }
         return true;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'セッションタイトルの更新に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, 'セッションタイトルの更新に失敗しました。'));
         return false;
       } finally {
         setLoading(false);
@@ -137,9 +130,7 @@ export const useAiChat = () => {
       }
       return true;
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'セッションの削除に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'セッションの削除に失敗しました。'));
       return false;
     } finally {
       setLoading(false);
@@ -157,9 +148,7 @@ export const useAiChat = () => {
       const data = await AiChatRepository.getMessages(sessionId);
       setMessages(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'メッセージ一覧の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'メッセージ一覧の取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -178,9 +167,7 @@ export const useAiChat = () => {
         setMessages((prev) => [...prev, data]);
         return data;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'メッセージの追加に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, 'メッセージの追加に失敗しました。'));
         return null;
       } finally {
         setLoading(false);
@@ -201,9 +188,7 @@ export const useAiChat = () => {
         const data = await AiChatRepository.rephrase(request);
         return data.result;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : '言い換え提案の取得に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, '言い換え提案の取得に失敗しました。'));
         return null;
       } finally {
         setLoading(false);
@@ -226,9 +211,7 @@ export const useAiChat = () => {
         scores: Array.isArray(data.scores) ? data.scores : [],
       });
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'スコアカードの取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'スコアカードの取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -245,9 +228,7 @@ export const useAiChat = () => {
       const data = await AiChatRepository.getScoreHistory();
       return data;
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'スコア履歴の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'スコア履歴の取得に失敗しました。'));
       return [];
     } finally {
       setLoading(false);

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import { classifyApiError } from '../utils/classifyApiError';
 import AuthRepository, {
   LoginRequest,
   SignupRequest,
@@ -50,8 +51,7 @@ export const useAuth = () => {
         dispatch(setAuthData());
         return true;
       } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'ログインに失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, 'ログインに失敗しました。'));
         return false;
       } finally {
         setLoading(false);
@@ -71,8 +71,7 @@ export const useAuth = () => {
       await AuthRepository.signup(request);
       return true;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'サインアップに失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'サインアップに失敗しました。'));
       return false;
     } finally {
       setLoading(false);
@@ -90,8 +89,7 @@ export const useAuth = () => {
       await AuthRepository.confirmSignup(request);
       return true;
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : '確認に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, '確認に失敗しました。'));
       return false;
     } finally {
       setLoading(false);
@@ -109,9 +107,7 @@ export const useAuth = () => {
       await AuthRepository.forgotPassword(request);
       return true;
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'パスワード再設定リクエストに失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'パスワード再設定リクエストに失敗しました。'));
       return false;
     } finally {
       setLoading(false);
@@ -130,9 +126,7 @@ export const useAuth = () => {
         await AuthRepository.confirmForgotPassword(request);
         return true;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'パスワード再設定確認に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, 'パスワード再設定確認に失敗しました。'));
         return false;
       } finally {
         setLoading(false);
@@ -154,8 +148,7 @@ export const useAuth = () => {
       dispatch(clearAuth());
       navigate('/login');
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'ログアウトに失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'ログアウトに失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -174,9 +167,7 @@ export const useAuth = () => {
       dispatch(setAuthData());
       return userInfo;
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'ユーザー情報の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'ユーザー情報の取得に失敗しました。'));
       dispatch(finishLoading());
       return null;
     } finally {

--- a/frontend/src/hooks/usePractice.ts
+++ b/frontend/src/hooks/usePractice.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { classifyApiError } from '../utils/classifyApiError';
 import PracticeRepository, {
   PracticeScenario,
   PracticeSession,
@@ -37,9 +38,7 @@ export const usePractice = () => {
       const data = await PracticeRepository.getScenarios();
       setScenarios(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'シナリオ一覧の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'シナリオ一覧の取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -57,9 +56,7 @@ export const usePractice = () => {
       setCurrentScenario(data);
       return data;
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'シナリオ詳細の取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'シナリオ詳細の取得に失敗しました。'));
       return null;
     } finally {
       setLoading(false);
@@ -78,9 +75,7 @@ export const usePractice = () => {
         const data = await PracticeRepository.createPracticeSession(request);
         return data;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : '練習セッションの作成に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, '練習セッションの作成に失敗しました。'));
         return null;
       } finally {
         setLoading(false);

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { classifyApiError } from '../utils/classifyApiError';
 import UserProfileRepository, {
   UserProfile,
   UpdateUserProfileRequest,
@@ -35,9 +36,7 @@ export const useUserProfile = () => {
       const data = await UserProfileRepository.getMyProfile();
       setProfile(data);
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'プロファイルの取得に失敗しました。';
-      setError(errorMessage);
+      setError(classifyApiError(err, 'プロファイルの取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -56,9 +55,7 @@ export const useUserProfile = () => {
         setProfile(updatedProfile);
         return true;
       } catch (err) {
-        const errorMessage =
-          err instanceof Error ? err.message : 'プロファイルの更新に失敗しました。';
-        setError(errorMessage);
+        setError(classifyApiError(err, 'プロファイルの更新に失敗しました。'));
         return false;
       } finally {
         setLoading(false);

--- a/frontend/src/utils/__tests__/classifyApiError.test.ts
+++ b/frontend/src/utils/__tests__/classifyApiError.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { classifyApiError } from '../classifyApiError';
+
+function createAxiosError(status: number, message = 'Request failed'): AxiosError {
+  const headers = new AxiosHeaders();
+  return new AxiosError(message, 'ERR_BAD_REQUEST', undefined, undefined, {
+    status,
+    statusText: '',
+    headers: {},
+    config: { headers },
+    data: {},
+  });
+}
+
+function createNetworkError(): AxiosError {
+  return new AxiosError('Network Error', 'ERR_NETWORK', undefined, undefined, undefined);
+}
+
+function createTimeoutError(): AxiosError {
+  return new AxiosError('timeout of 5000ms exceeded', 'ECONNABORTED', undefined, undefined, undefined);
+}
+
+describe('classifyApiError', () => {
+  it('403エラーでアクセス権限メッセージを返す', () => {
+    const error = createAxiosError(403);
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('この操作を行う権限がありません。');
+  });
+
+  it('404エラーでリソース不在メッセージを返す', () => {
+    const error = createAxiosError(404);
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('データが見つかりません。');
+  });
+
+  it('429エラーでレート制限メッセージを返す', () => {
+    const error = createAxiosError(429);
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('リクエストが多すぎます。しばらくしてからお試しください。');
+  });
+
+  it('500エラーでサーバーエラーメッセージを返す', () => {
+    const error = createAxiosError(500);
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('サーバーエラーが発生しました。時間をおいてお試しください。');
+  });
+
+  it('503エラーでサーバーエラーメッセージを返す', () => {
+    const error = createAxiosError(503);
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('サーバーエラーが発生しました。時間をおいてお試しください。');
+  });
+
+  it('ネットワークエラーで接続エラーメッセージを返す', () => {
+    const error = createNetworkError();
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('インターネット接続を確認してください。');
+  });
+
+  it('タイムアウトエラーでタイムアウトメッセージを返す', () => {
+    const error = createTimeoutError();
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('リクエストがタイムアウトしました。再度お試しください。');
+  });
+
+  it('一般的なErrorでデフォルトメッセージを返す', () => {
+    const error = new Error('something went wrong');
+    const result = classifyApiError(error, 'セッション取得に失敗しました。');
+    expect(result).toBe('セッション取得に失敗しました。');
+  });
+
+  it('不明なエラーでデフォルトメッセージを返す', () => {
+    const result = classifyApiError('unknown', 'デフォルトメッセージ');
+    expect(result).toBe('デフォルトメッセージ');
+  });
+
+  it('未対応のHTTPステータスコードでデフォルトメッセージを返す', () => {
+    const error = createAxiosError(418);
+    const result = classifyApiError(error, 'デフォルトメッセージ');
+    expect(result).toBe('デフォルトメッセージ');
+  });
+});

--- a/frontend/src/utils/classifyApiError.ts
+++ b/frontend/src/utils/classifyApiError.ts
@@ -1,0 +1,40 @@
+import { AxiosError } from 'axios';
+
+const STATUS_MESSAGES: Record<number, string> = {
+  403: 'この操作を行う権限がありません。',
+  404: 'データが見つかりません。',
+  429: 'リクエストが多すぎます。しばらくしてからお試しください。',
+};
+
+function isServerError(status: number): boolean {
+  return status >= 500;
+}
+
+export function classifyApiError(error: unknown, fallback: string): string {
+  if (!(error instanceof AxiosError)) {
+    return fallback;
+  }
+
+  if (error.code === 'ERR_NETWORK') {
+    return 'インターネット接続を確認してください。';
+  }
+
+  if (error.code === 'ECONNABORTED') {
+    return 'リクエストがタイムアウトしました。再度お試しください。';
+  }
+
+  const status = error.response?.status;
+  if (!status) {
+    return fallback;
+  }
+
+  if (STATUS_MESSAGES[status]) {
+    return STATUS_MESSAGES[status];
+  }
+
+  if (isServerError(status)) {
+    return 'サーバーエラーが発生しました。時間をおいてお試しください。';
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## 概要
- API呼び出しエラー時のメッセージをHTTPステータスコード・エラー種別に基づき分類
- ネットワークエラー、タイムアウト、403/404/429/5xxを検出し、日本語メッセージを表示

## 変更内容
- `classifyApiError`ユーティリティを新規作成（10テスト）
- `useAiChat`、`usePractice`、`useAuth`、`useUserProfile`の全catchブロックを統一化
- 既存テストのエラーメッセージ期待値を更新

## テスト
- [x] `npm test` 全1947テスト通過（+10件）

closes #1059