### PR TITLE
refactor: CognitoAuthControllerのビジネスロジックをUseCase層・Service層に分離

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/service/AuthCookieService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/AuthCookieService.java
@@ -1,0 +1,67 @@
+package com.example.FreStyle.service;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@Service
+public class AuthCookieService {
+
+    public void setAuthCookies(
+            HttpServletResponse response,
+            String accessToken,
+            String refreshToken,
+            String email,
+            String cognitoUsername) {
+
+        ResponseCookie accessCookie = ResponseCookie.from("ACCESS_TOKEN", accessToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60 * 60 * 2)
+                .sameSite("None")
+                .build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("REFRESH_TOKEN", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60 * 60 * 24 * 7)
+                .sameSite("None")
+                .build();
+
+        ResponseCookie emailCookie = ResponseCookie.from("EMAIL", email)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60 * 60 * 24 * 7)
+                .sameSite("None")
+                .build();
+
+        ResponseCookie cognitoUsernameCookie = ResponseCookie.from("COGNITO_USERNAME", cognitoUsername)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60 * 60 * 24 * 7)
+                .sameSite("None")
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, emailCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, cognitoUsernameCookie.toString());
+    }
+
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("REFRESH_TOKEN", null)
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoLoginUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoLoginUseCase.java
@@ -1,0 +1,56 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.AccessTokenService;
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.utils.JwtUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CognitoLoginUseCase {
+
+    private final UserService userService;
+    private final CognitoAuthService cognitoAuthService;
+    private final UserIdentityService userIdentityService;
+    private final AccessTokenService accessTokenService;
+
+    public record Result(String accessToken, String refreshToken, String email, String cognitoUsername) {}
+
+    public Result execute(String email, String password) {
+        log.info("CognitoLoginUseCase: ログイン処理開始 - email: {}", email);
+
+        userService.checkUserIsActive(email);
+
+        Map<String, String> tokens = cognitoAuthService.login(email, password);
+        String idToken = tokens.get("idToken");
+        String accessToken = tokens.get("accessToken");
+        String refreshToken = tokens.get("refreshToken");
+
+        Optional<JWTClaimsSet> claimsOpt = JwtUtils.decode(idToken);
+        if (claimsOpt.isEmpty()) {
+            throw new IllegalStateException("IDトークンのデコードに失敗しました。");
+        }
+
+        JWTClaimsSet claims = claimsOpt.get();
+        User user = userService.findUserByEmail(email);
+        userIdentityService.registerUserIdentity(user, claims.getIssuer(), claims.getSubject());
+
+        Object cognitoUsernameObj = claims.getClaim("cognito:username");
+        String cognitoUsername = cognitoUsernameObj != null ? cognitoUsernameObj.toString() : email;
+
+        accessTokenService.saveTokens(user, accessToken, refreshToken);
+
+        log.info("CognitoLoginUseCase: ログイン処理完了 - userId: {}", user.getId());
+        return new Result(accessToken, refreshToken, email, cognitoUsername);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/AuthCookieServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/AuthCookieServiceTest.java
@@ -1,0 +1,50 @@
+package com.example.FreStyle.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthCookieServiceTest {
+
+    @InjectMocks
+    private AuthCookieService authCookieService;
+
+    @Test
+    @DisplayName("setAuthCookies: 4つのCookieをレスポンスに設定する")
+    void setAuthCookiesSets4Cookies() {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        authCookieService.setAuthCookies(response, "access123", "refresh456", "test@example.com", "user1");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response, times(4)).addHeader(eq("Set-Cookie"), captor.capture());
+
+        var cookies = captor.getAllValues();
+        assertThat(cookies).anyMatch(c -> c.contains("ACCESS_TOKEN=access123"));
+        assertThat(cookies).anyMatch(c -> c.contains("REFRESH_TOKEN=refresh456"));
+        assertThat(cookies).anyMatch(c -> c.contains("EMAIL=test%40example.com") || c.contains("EMAIL=test@example.com"));
+        assertThat(cookies).anyMatch(c -> c.contains("COGNITO_USERNAME=user1"));
+    }
+
+    @Test
+    @DisplayName("clearRefreshTokenCookie: REFRESH_TOKENのCookieを削除する")
+    void clearRefreshTokenCookieDeletesCookie() {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        authCookieService.clearRefreshTokenCookie(response);
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response).addHeader(eq("Set-Cookie"), captor.capture());
+
+        assertThat(captor.getValue()).contains("REFRESH_TOKEN");
+        assertThat(captor.getValue()).contains("Max-Age=0");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoLoginUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoLoginUseCaseTest.java
@@ -1,0 +1,90 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.AccessTokenService;
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.utils.JwtUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CognitoLoginUseCaseTest {
+
+    @Mock private UserService userService;
+    @Mock private CognitoAuthService cognitoAuthService;
+    @Mock private UserIdentityService userIdentityService;
+    @Mock private AccessTokenService accessTokenService;
+
+    @InjectMocks
+    private CognitoLoginUseCase cognitoLoginUseCase;
+
+    @Test
+    @DisplayName("ログイン成功時にResult（トークン情報）を返す")
+    void returnsResultOnSuccess() throws Exception {
+        User user = new User();
+        user.setId(1);
+
+        when(cognitoAuthService.login("test@example.com", "password123"))
+                .thenReturn(Map.of(
+                        "idToken", "id-token-value",
+                        "accessToken", "access-token-value",
+                        "refreshToken", "refresh-token-value"));
+        when(userService.findUserByEmail("test@example.com")).thenReturn(user);
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject("sub-123")
+                .issuer("https://cognito-idp.example.com")
+                .claim("cognito:username", "testuser")
+                .build();
+
+        try (MockedStatic<JwtUtils> jwtUtilsMock = mockStatic(JwtUtils.class)) {
+            jwtUtilsMock.when(() -> JwtUtils.decode("id-token-value"))
+                    .thenReturn(Optional.of(claims));
+
+            CognitoLoginUseCase.Result result = cognitoLoginUseCase.execute("test@example.com", "password123");
+
+            assertThat(result.accessToken()).isEqualTo("access-token-value");
+            assertThat(result.refreshToken()).isEqualTo("refresh-token-value");
+            assertThat(result.email()).isEqualTo("test@example.com");
+            assertThat(result.cognitoUsername()).isEqualTo("testuser");
+
+            verify(userService).checkUserIsActive("test@example.com");
+            verify(userIdentityService).registerUserIdentity(user, "https://cognito-idp.example.com", "sub-123");
+            verify(accessTokenService).saveTokens(user, "access-token-value", "refresh-token-value");
+        }
+    }
+
+    @Test
+    @DisplayName("IDトークンのデコード失敗で例外をスローする")
+    void throwsOnInvalidIdToken() {
+        when(cognitoAuthService.login("test@example.com", "password123"))
+                .thenReturn(Map.of(
+                        "idToken", "invalid-token",
+                        "accessToken", "access-token",
+                        "refreshToken", "refresh-token"));
+
+        try (MockedStatic<JwtUtils> jwtUtilsMock = mockStatic(JwtUtils.class)) {
+            jwtUtilsMock.when(() -> JwtUtils.decode("invalid-token"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cognitoLoginUseCase.execute("test@example.com", "password123"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("IDトークンのデコードに失敗しました。");
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- CognitoAuthControllerからログイン処理をCognitoLoginUseCaseに分離
- Cookie管理をAuthCookieServiceに分離
- コントローラーを582行から344行に削減

## 変更内容
- `CognitoLoginUseCase`: ログイン処理のオーケストレーション（ユーザー確認→認証→JWT解析→ID登録→トークン保存）
- `AuthCookieService`: Cookie設定・削除の責務を集約
- `CognitoAuthController`: login()、logout()、callback()、refresh-token()が新Service/UseCaseに委譲
- テスト: 新クラス4件＋既存テスト更新（login 3件追加、logout検証をAuthCookieService経由に変更）

## テスト
- CognitoLoginUseCaseTest: 2件 ✅
- AuthCookieServiceTest: 2件 ✅
- CognitoAuthControllerTest: 20件（+3件） ✅

closes #1061