### PR TITLE
test: UserProfileService・CognitoAuthService・UnreadCountServiceのテスト拡充（+6件）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
@@ -268,6 +268,26 @@ class CognitoAuthServiceTest {
                     () -> service.updateUserProfile("invalid-token", "名前"));
             assertEquals("invalid parameter retry login", ex.getMessage());
         }
+
+        @Test
+        void InvalidUserPoolConfigurationExceptionでRuntimeException() {
+            when(cognitoClient.updateUserAttributes(any(UpdateUserAttributesRequest.class)))
+                    .thenThrow(InvalidUserPoolConfigurationException.builder().message("bad config").build());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.updateUserProfile("access-token", "名前"));
+            assertEquals("user configuration setting", ex.getMessage());
+        }
+
+        @Test
+        void InvalidParameterExceptionでRuntimeException() {
+            when(cognitoClient.updateUserAttributes(any(UpdateUserAttributesRequest.class)))
+                    .thenThrow(new java.security.InvalidParameterException("invalid param"));
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.updateUserProfile("access-token", "名前"));
+            assertEquals("invalid parameter", ex.getMessage());
+        }
     }
 
     // ============================

--- a/FreStyle/src/test/java/com/example/FreStyle/service/UnreadCountServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/UnreadCountServiceTest.java
@@ -171,4 +171,28 @@ class UnreadCountServiceTest {
         assertTrue(result.isEmpty());
         verify(unreadCountRepository, never()).findByUserIdAndRoomIds(anyInt(), anyList());
     }
+
+    @Test
+    @DisplayName("getUnreadCountsByUserAndRooms: 部分的なルームのみ未読レコードがある場合そのルームだけ返す")
+    void getUnreadCountsByUserAndRooms_partialRooms_returnsOnlyExistingRooms() {
+        // Arrange - 3ルームリクエストだが、未読レコードは1ルーム分のみ
+        ChatRoom room1 = new ChatRoom();
+        room1.setId(10);
+
+        UnreadCount uc1 = new UnreadCount();
+        uc1.setRoom(room1);
+        uc1.setCount(5);
+
+        when(unreadCountRepository.findByUserIdAndRoomIds(1, List.of(10, 20, 30)))
+                .thenReturn(List.of(uc1));
+
+        // Act
+        Map<Integer, Integer> result = unreadCountService.getUnreadCountsByUserAndRooms(1, List.of(10, 20, 30));
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(5, result.get(10));
+        assertNull(result.get(20));
+        assertNull(result.get(30));
+    }
 }


### PR DESCRIPTION
## 概要
テストカバレッジギャップを補完するテスト6件を追加。

## 追加テスト

### UserProfileService (+3件)
- `convertToDto`: 不正なJSON personalityTraitsが空リストにフォールバックすること
- `updateProfileFromForm`: JsonProcessingException発生時にRuntimeExceptionをスローすること
- `createProfile`: personalityTraitsがnullの場合にnullが設定されること

### CognitoAuthService (+2件)
- `updateUserProfile`: InvalidUserPoolConfigurationException発生時のエラーメッセージ確認
- `updateUserProfile`: InvalidParameterException発生時のエラーメッセージ確認

### UnreadCountService (+1件)
- `getUnreadCountsByUserAndRooms`: 部分的なルームのみ未読レコードがある場合のMap確認

closes #1063