### PR TITLE
feat: 認証フォームのローディング状態管理と重複送信防止

### DIFF
--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -11,6 +11,7 @@ interface InputFieldProps {
   onChange: (e: ChangeEvent<HTMLInputElement> | { target: { name: string; value: string } }) => void;
   placeholder?: string;
   error?: string;
+  disabled?: boolean;
 }
 
 export default function InputField({
@@ -20,6 +21,7 @@ export default function InputField({
   value,
   onChange,
   error,
+  disabled,
 }: InputFieldProps) {
   const [inputValue, setInputValue] = useState(value || '');
 
@@ -46,11 +48,12 @@ export default function InputField({
             setInputValue(e.target.value);
             onChange(e);
           }}
+          disabled={disabled}
           aria-invalid={!!error}
           aria-describedby={error ? `${name}-error` : undefined}
-          className={`w-full border rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:ring-1 transition-colors duration-150 ${getFieldBorderClass(!!error)}`}
+          className={`w-full border rounded-lg px-4 py-2.5 pr-10 focus:outline-none focus:ring-1 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed ${getFieldBorderClass(!!error)}`}
         />
-        {inputValue && (
+        {inputValue && !disabled && (
           <button
             type="button"
             onClick={handleClear}

--- a/frontend/src/components/__tests__/InputField.test.tsx
+++ b/frontend/src/components/__tests__/InputField.test.tsx
@@ -89,4 +89,14 @@ describe('InputField', () => {
     expect(input.className).toContain('border-surface-3');
     expect(input.className).not.toContain('border-rose-500');
   });
+
+  it('disabled時にinputが無効化される', () => {
+    render(<InputField label="メール" name="email" value="" onChange={mockOnChange} disabled />);
+    expect(screen.getByLabelText('メール')).toBeDisabled();
+  });
+
+  it('disabled時にクリアボタンが表示されない', () => {
+    render(<InputField label="メール" name="email" value="test" onChange={mockOnChange} disabled />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
 });

--- a/frontend/src/hooks/__tests__/useConfirmForgotPassword.test.ts
+++ b/frontend/src/hooks/__tests__/useConfirmForgotPassword.test.ts
@@ -123,4 +123,31 @@ describe('useConfirmForgotPassword', () => {
 
     expect(preventDefault).toHaveBeenCalled();
   });
+
+  it('初期状態でloadingがfalseである', () => {
+    const { result } = renderHook(() => useConfirmForgotPassword());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('handleConfirm実行中にloadingがtrueになる', async () => {
+    let resolvePromise: (value: unknown) => void;
+    mockConfirmForgotPassword.mockReturnValue(new Promise((resolve) => { resolvePromise = resolve; }));
+    const { result } = renderHook(() => useConfirmForgotPassword());
+
+    let confirmPromise: Promise<void>;
+    act(() => {
+      confirmPromise = result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolvePromise!({ message: 'ok' });
+      await confirmPromise;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
 });

--- a/frontend/src/hooks/__tests__/useConfirmSignup.test.ts
+++ b/frontend/src/hooks/__tests__/useConfirmSignup.test.ts
@@ -129,4 +129,31 @@ describe('useConfirmSignup', () => {
 
     expect(preventDefault).toHaveBeenCalledOnce();
   });
+
+  it('初期状態でloadingがfalseである', () => {
+    const { result } = renderHook(() => useConfirmSignup());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('handleConfirm実行中にloadingがtrueになる', async () => {
+    let resolvePromise: (value: unknown) => void;
+    mockConfirmSignup.mockReturnValue(new Promise((resolve) => { resolvePromise = resolve; }));
+    const { result } = renderHook(() => useConfirmSignup());
+
+    let confirmPromise: Promise<void>;
+    act(() => {
+      confirmPromise = result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolvePromise!({ message: 'ok' });
+      await confirmPromise;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
 });

--- a/frontend/src/hooks/__tests__/useForgotPassword.test.ts
+++ b/frontend/src/hooks/__tests__/useForgotPassword.test.ts
@@ -122,4 +122,31 @@ describe('useForgotPassword', () => {
 
     expect(preventDefault).toHaveBeenCalled();
   });
+
+  it('初期状態でloadingがfalseである', () => {
+    const { result } = renderHook(() => useForgotPassword());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('handleSubmit実行中にloadingがtrueになる', async () => {
+    let resolvePromise: (value: unknown) => void;
+    mockForgotPassword.mockReturnValue(new Promise((resolve) => { resolvePromise = resolve; }));
+    const { result } = renderHook(() => useForgotPassword());
+
+    let submitPromise: Promise<void>;
+    act(() => {
+      submitPromise = result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolvePromise!({ message: 'ok' });
+      await submitPromise;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
 });

--- a/frontend/src/hooks/__tests__/useLoginPage.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginPage.test.ts
@@ -131,4 +131,31 @@ describe('useLoginPage', () => {
 
     expect(mockLogin).toHaveBeenCalledWith({ email: 'user@test.com', password: 'pass123' });
   });
+
+  it('初期状態でloadingがfalseである', () => {
+    const { result } = renderHook(() => useLoginPage());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('handleLogin実行中にloadingがtrueになる', async () => {
+    let resolveLogin: (value: boolean) => void;
+    mockLogin.mockReturnValue(new Promise<boolean>((resolve) => { resolveLogin = resolve; }));
+    const { result } = renderHook(() => useLoginPage());
+
+    let loginPromise: Promise<void>;
+    act(() => {
+      loginPromise = result.current.handleLogin({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolveLogin!(true);
+      await loginPromise;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useConfirmForgotPassword.ts
+++ b/frontend/src/hooks/useConfirmForgotPassword.ts
@@ -15,9 +15,11 @@ export function useConfirmForgotPassword() {
     newPassword: '',
   });
   const [message, setMessage] = useState<FormMessage | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setLoading(true);
 
     try {
       await authRepository.confirmForgotPassword({
@@ -36,8 +38,10 @@ export function useConfirmForgotPassword() {
       } else {
         setMessage({ type: 'error', text: '通信エラーが発生しました。' });
       }
+    } finally {
+      setLoading(false);
     }
   };
 
-  return { form, message, handleChange, handleConfirm };
+  return { form, message, loading, handleChange, handleConfirm };
 }

--- a/frontend/src/hooks/useConfirmSignup.ts
+++ b/frontend/src/hooks/useConfirmSignup.ts
@@ -9,9 +9,11 @@ export function useConfirmSignup() {
   const navigate = useNavigate();
   const { form, handleChange } = useFormField({ email: '', code: '' });
   const [message, setMessage] = useState<FormMessage | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setLoading(true);
 
     try {
       await authRepository.confirmSignup(form);
@@ -26,8 +28,10 @@ export function useConfirmSignup() {
       } else {
         setMessage({ type: 'error', text: '通信エラーが発生しました。' });
       }
+    } finally {
+      setLoading(false);
     }
   };
 
-  return { form, message, handleChange, handleConfirm };
+  return { form, message, loading, handleChange, handleConfirm };
 }

--- a/frontend/src/hooks/useForgotPassword.ts
+++ b/frontend/src/hooks/useForgotPassword.ts
@@ -7,10 +7,12 @@ import type { FormMessage } from '../types';
 export function useForgotPassword() {
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState<FormMessage | null>(null);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setLoading(true);
 
     try {
       await authRepository.forgotPassword({ email });
@@ -22,8 +24,10 @@ export function useForgotPassword() {
       } else {
         setMessage({ type: 'error', text: '通信エラーが発生しました。' });
       }
+    } finally {
+      setLoading(false);
     }
   };
 
-  return { email, setEmail, message, handleSubmit };
+  return { email, setEmail, message, loading, handleSubmit };
 }

--- a/frontend/src/hooks/useLoginPage.ts
+++ b/frontend/src/hooks/useLoginPage.ts
@@ -20,6 +20,7 @@ interface LoginMessage {
 export function useLoginPage() {
   const { form, handleChange } = useFormField({ email: '', password: '' });
   const [loginMessage, setLoginMessage] = useState<LoginMessage | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -29,16 +30,21 @@ export function useLoginPage() {
 
   const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setLoading(true);
 
-    const success = await login({ email: form.email, password: form.password });
+    try {
+      const success = await login({ email: form.email, password: form.password });
 
-    if (success) {
-      navigate('/');
-    } else {
-      setLoginMessage({
-        type: 'error',
-        text: 'ログインに失敗しました。',
-      });
+      if (success) {
+        navigate('/');
+      } else {
+        setLoginMessage({
+          type: 'error',
+          text: 'ログインに失敗しました。',
+        });
+      }
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -46,6 +52,7 @@ export function useLoginPage() {
     form,
     loginMessage,
     flashMessage,
+    loading,
     handleLogin,
     handleChange,
   };

--- a/frontend/src/pages/ConfirmForgotPasswordPage.tsx
+++ b/frontend/src/pages/ConfirmForgotPasswordPage.tsx
@@ -5,7 +5,7 @@ import FormMessage from '../components/FormMessage';
 import { useConfirmForgotPassword } from '../hooks/useConfirmForgotPassword';
 
 export default function ConfirmForgotPasswordPage() {
-  const { form, message, handleChange, handleConfirm } = useConfirmForgotPassword();
+  const { form, message, loading, handleChange, handleConfirm } = useConfirmForgotPassword();
 
   return (
     <AuthLayout>
@@ -20,12 +20,14 @@ export default function ConfirmForgotPasswordPage() {
           type="email"
           value={form.email}
           onChange={handleChange}
+          disabled={loading}
         />
         <InputField
           label="確認コード"
           name="code"
           value={form.code}
           onChange={handleChange}
+          disabled={loading}
         />
         <InputField
           label="新しいパスワード"
@@ -33,8 +35,11 @@ export default function ConfirmForgotPasswordPage() {
           type="password"
           value={form.newPassword}
           onChange={handleChange}
+          disabled={loading}
         />
-        <PrimaryButton type="submit">パスワードをリセット</PrimaryButton>
+        <PrimaryButton type="submit" loading={loading}>
+          {loading ? 'リセット中...' : 'パスワードをリセット'}
+        </PrimaryButton>
       </form>
     </AuthLayout>
   );

--- a/frontend/src/pages/ConfirmPage.tsx
+++ b/frontend/src/pages/ConfirmPage.tsx
@@ -6,7 +6,7 @@ import FormMessage from '../components/FormMessage';
 import { useConfirmSignup } from '../hooks/useConfirmSignup';
 
 export default function ConfirmPage() {
-  const { form, message, handleChange, handleConfirm } = useConfirmSignup();
+  const { form, message, loading, handleChange, handleConfirm } = useConfirmSignup();
 
   return (
     <AuthLayout>
@@ -19,14 +19,18 @@ export default function ConfirmPage() {
           type="email"
           value={form.email}
           onChange={handleChange}
+          disabled={loading}
         />
         <InputField
           label="確認コード"
           name="code"
           value={form.code}
           onChange={handleChange}
+          disabled={loading}
         />
-        <PrimaryButton type="submit">確認する</PrimaryButton>
+        <PrimaryButton type="submit" loading={loading}>
+          {loading ? '確認中...' : '確認する'}
+        </PrimaryButton>
       </form>
       <div className="mt-4 text-center">
         <LinkText to="/signup">アカウント作成に戻る</LinkText>

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -5,7 +5,7 @@ import FormMessage from '../components/FormMessage';
 import { useForgotPassword } from '../hooks/useForgotPassword';
 
 export default function ForgotPasswordPage() {
-  const { email, setEmail, message, handleSubmit } = useForgotPassword();
+  const { email, setEmail, message, loading, handleSubmit } = useForgotPassword();
 
   return (
     <AuthLayout>
@@ -20,8 +20,11 @@ export default function ForgotPasswordPage() {
           type="email"
           value={email}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+          disabled={loading}
         />
-        <PrimaryButton type="submit">確認コードを送信</PrimaryButton>
+        <PrimaryButton type="submit" loading={loading}>
+          {loading ? '送信中...' : '確認コードを送信'}
+        </PrimaryButton>
       </form>
     </AuthLayout>
   );

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -8,7 +8,7 @@ import { useLoginPage } from '../hooks/useLoginPage';
 import { XCircleIcon } from '@heroicons/react/24/outline';
 
 export default function LoginPage() {
-  const { form, loginMessage, flashMessage, handleLogin, handleChange } = useLoginPage();
+  const { form, loginMessage, flashMessage, loading, handleLogin, handleChange } = useLoginPage();
 
   return (
     <AuthLayout>
@@ -39,6 +39,7 @@ export default function LoginPage() {
           type="email"
           value={form.email}
           onChange={handleChange}
+          disabled={loading}
         />
         <InputField
           label="パスワード"
@@ -46,8 +47,11 @@ export default function LoginPage() {
           type="password"
           value={form.password}
           onChange={handleChange}
+          disabled={loading}
         />
-        <PrimaryButton type="submit">ログイン</PrimaryButton>
+        <PrimaryButton type="submit" loading={loading}>
+          {loading ? 'ログイン中...' : 'ログイン'}
+        </PrimaryButton>
       </form>
       <div className="flex justify-between items-center mt-6 text-sm">
         <LinkText to="/forgot-password">パスワードをお忘れですか？</LinkText>

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -23,6 +23,7 @@ export default function SignupPage() {
           name="name"
           value={form.name}
           onChange={handleChange}
+          disabled={loading}
         />
         <InputField
           label="メールアドレス"
@@ -30,6 +31,7 @@ export default function SignupPage() {
           type="email"
           value={form.email}
           onChange={handleChange}
+          disabled={loading}
         />
         <InputField
           label="パスワード"
@@ -37,8 +39,9 @@ export default function SignupPage() {
           type="password"
           value={form.password}
           onChange={handleChange}
+          disabled={loading}
         />
-        <PrimaryButton type="submit" disabled={loading}>
+        <PrimaryButton type="submit" loading={loading}>
           {loading ? '作成中...' : 'アカウント作成'}
         </PrimaryButton>
       </form>


### PR DESCRIPTION
## 概要
認証関連5ページにローディング状態管理を追加し、重複送信を防止する。

## 変更内容
- **InputField**: `disabled` prop追加（送信中の入力フィールド無効化、クリアボタン非表示）
- **useLoginPage**: loading状態を追加
- **useForgotPassword**: loading状態を追加
- **useConfirmSignup**: loading状態を追加
- **useConfirmForgotPassword**: loading状態を追加
- 全5ページで送信中のスピナー表示・入力フィールド無効化・重複送信防止を実装

## テスト
- InputField: +2件（disabled状態、クリアボタン非表示）
- useLoginPage: +2件（初期loading、送信中loading）
- useForgotPassword: +2件（初期loading、送信中loading）
- useConfirmSignup: +2件（初期loading、送信中loading）
- useConfirmForgotPassword: +2件（初期loading、送信中loading）
- 全1957テスト通過 ✅

closes #1065