### PR TITLE
test: テストカバレッジ拡充（NoteImageService・FavoritePhraseController・SessionNoteRepository他）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
@@ -108,5 +108,29 @@ class FavoritePhraseControllerTest {
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             verify(removeFavoritePhraseUseCase).execute(1, 5);
         }
+
+        @Test
+        @DisplayName("削除UseCase例外時にそのまま伝搬する")
+        void throwsWhenUseCaseFails() {
+            doThrow(new RuntimeException("削除失敗")).when(removeFavoritePhraseUseCase).execute(1, 99);
+
+            org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+                    () -> favoritePhraseController.removeFavoritePhrase(mockJwt, 99));
+        }
+    }
+
+    @Nested
+    @DisplayName("共通エラー")
+    class CommonErrors {
+
+        @Test
+        @DisplayName("UserIdentityService例外時にそのまま伝搬する")
+        void throwsWhenUserNotFound() {
+            when(userIdentityService.findUserBySub("sub-123"))
+                    .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+            org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+                    () -> favoritePhraseController.getFavoritePhrases(mockJwt));
+        }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/service/NoteImageServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/NoteImageServiceTest.java
@@ -84,4 +84,37 @@ class NoteImageServiceTest {
                 service.generatePresignedUrl(1, "note1", "file.exe", "application/octet-stream")
         ).isInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void S3Presignerが例外をスローした場合そのまま伝搬する() {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenThrow(new RuntimeException("S3 error"));
+
+        assertThatThrownBy(() ->
+                service.generatePresignedUrl(1, "note1", "image.png", "image/png")
+        ).isInstanceOf(RuntimeException.class)
+                .hasMessage("S3 error");
+    }
+
+    @Test
+    void webp形式のcontentTypeが許可される() throws Exception {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenReturn(presignedPutObjectRequest);
+        when(presignedPutObjectRequest.url()).thenReturn(new URL("https://s3.example.com/upload"));
+
+        PresignedUrlResponse response = service.generatePresignedUrl(1, "note1", "image.webp", "image/webp");
+
+        assertThat(response.uploadUrl()).isNotNull();
+    }
+
+    @Test
+    void svg形式のcontentTypeが許可される() throws Exception {
+        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+                .thenReturn(presignedPutObjectRequest);
+        when(presignedPutObjectRequest.url()).thenReturn(new URL("https://s3.example.com/upload"));
+
+        PresignedUrlResponse response = service.generatePresignedUrl(1, "note1", "icon.svg", "image/svg+xml");
+
+        assertThat(response.uploadUrl()).isNotNull();
+    }
 }

--- a/frontend/src/repositories/__tests__/NoteImageRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteImageRepository.test.ts
@@ -52,5 +52,22 @@ describe('NoteImageRepository', () => {
         headers: { 'Content-Type': 'image/png' },
       });
     });
+
+    it('S3アップロード失敗時にエラーが伝搬する', async () => {
+      vi.mocked(axios.put).mockRejectedValue(new Error('Network Error'));
+      const file = new File(['test'], 'image.png', { type: 'image/png' });
+
+      await expect(NoteImageRepository.uploadToS3('https://s3.example.com/upload', file))
+        .rejects.toThrow('Network Error');
+    });
+  });
+
+  describe('getPresignedUrl エラー', () => {
+    it('API失敗時にエラーが伝搬する', async () => {
+      vi.mocked(apiClient.post).mockRejectedValue(new Error('Server Error'));
+
+      await expect(NoteImageRepository.getPresignedUrl('note1', 'image.png', 'image/png'))
+        .rejects.toThrow('Server Error');
+    });
   });
 });

--- a/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
@@ -92,5 +92,19 @@ describe('SessionNoteRepository', () => {
       expect(Object.keys(result)).toHaveLength(2);
       expect(result['1'].note).toBe('メモ1');
     });
+
+    it('localStorageが空の場合は空オブジェクトを返す', () => {
+      const result = SessionNoteRepository.getAll();
+      expect(result).toEqual({});
+    });
+
+    it('localStorageのJSONが破損している場合は空オブジェクトを返しキーを削除する', () => {
+      localStorage.setItem('freestyle_session_notes', '{invalid-json');
+
+      const result = SessionNoteRepository.getAll();
+
+      expect(result).toEqual({});
+      expect(localStorage.removeItem).toHaveBeenCalledWith('freestyle_session_notes');
+    });
   });
 });

--- a/frontend/src/utils/__tests__/markdownToTiptap.test.ts
+++ b/frontend/src/utils/__tests__/markdownToTiptap.test.ts
@@ -92,4 +92,33 @@ describe('markdownToTiptap', () => {
     expect(result.content.some((b: { type: string }) => b.type === 'paragraph')).toBe(true);
     expect(result.content.some((b: { type: string }) => b.type === 'bulletList')).toBe(true);
   });
+
+  it('CRLF改行を正しく処理する', () => {
+    const result = markdownToTiptap('- 項目1\r\n- 項目2\r\n- 項目3');
+    expect(result.content[0].type).toBe('bulletList');
+    expect(result.content[0].content).toHaveLength(3);
+  });
+
+  it('空白のみの文字列で空のdocを返す', () => {
+    const result = markdownToTiptap('   \n  \n   ');
+    expect(result).toEqual({ type: 'doc', content: [] });
+  });
+
+  it('リスト項目内の太字を変換する', () => {
+    const result = markdownToTiptap('- **重要な**項目');
+    const listItem = result.content[0].content![0];
+    const paragraph = listItem.content![0];
+    const boldNode = paragraph.content!.find(
+      (n: { marks?: { type: string }[] }) => n.marks?.some(m => m.type === 'bold')
+    );
+    expect(boldNode).toBeDefined();
+    expect(boldNode!.text).toBe('重要な');
+  });
+
+  it('CR改行を正しく処理する', () => {
+    const result = markdownToTiptap('行1\r行2');
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0].type).toBe('paragraph');
+    expect(result.content[1].type).toBe('paragraph');
+  });
 });


### PR DESCRIPTION
## 概要
テストカバレッジの不足箇所を補完（+13件）

## 追加テスト
### バックエンド（+5件）
- **NoteImageService**: S3Presigner例外伝搬、webp/svg形式の許可確認
- **FavoritePhraseController**: 削除UseCase例外伝搬、UserIdentityService例外伝搬

### フロントエンド（+8件）
- **SessionNoteRepository**: localStorage空時の空オブジェクト返却、破損JSON回復
- **markdownToTiptap**: CRLF改行処理、空白のみ入力、リスト内太字、CR改行処理
- **NoteImageRepository**: S3アップロードエラー伝搬、API失敗エラー伝搬

## テスト
- バックエンド478件パス（contextLoads除く）
- フロントエンド1969件パス

closes #1069