### PR TITLE
feat: フォームメッセージの自動消去と閉じるボタン追加

### DIFF
--- a/frontend/src/components/FormMessage.tsx
+++ b/frontend/src/components/FormMessage.tsx
@@ -1,10 +1,18 @@
-import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/24/solid';
+import { useEffect } from 'react';
+import { CheckCircleIcon, ExclamationCircleIcon, XMarkIcon } from '@heroicons/react/24/solid';
 
 interface FormMessageProps {
   message: { type: 'error' | 'success'; text: string } | null;
+  onDismiss?: () => void;
 }
 
-export default function FormMessage({ message }: FormMessageProps) {
+export default function FormMessage({ message, onDismiss }: FormMessageProps) {
+  useEffect(() => {
+    if (!message || !onDismiss) return;
+    const timer = setTimeout(onDismiss, 5000);
+    return () => clearTimeout(timer);
+  }, [message, onDismiss]);
+
   if (!message) return null;
 
   const isError = message.type === 'error';
@@ -23,7 +31,17 @@ export default function FormMessage({ message }: FormMessageProps) {
       ) : (
         <CheckCircleIcon className="w-5 h-5 flex-shrink-0 mt-0.5" />
       )}
-      <span>{message.text}</span>
+      <span className="flex-1">{message.text}</span>
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="閉じる"
+          className="flex-shrink-0 mt-0.5 hover:opacity-70 transition-opacity"
+        >
+          <XMarkIcon className="w-4 h-4" />
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/FormMessage.test.tsx
+++ b/frontend/src/components/__tests__/FormMessage.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import FormMessage from '../FormMessage';
 
 describe('FormMessage', () => {
@@ -65,5 +65,71 @@ describe('FormMessage', () => {
 
     const el = screen.getByText('テスト').closest('div');
     expect(el?.className).toContain('border');
+  });
+
+  describe('自動消去', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('5秒後にonDismissが呼ばれる', () => {
+      const onDismiss = vi.fn();
+      render(<FormMessage message={{ type: 'error', text: 'エラー' }} onDismiss={onDismiss} />);
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it('onDismissが未指定の場合はタイマーが動作しない', () => {
+      render(<FormMessage message={{ type: 'error', text: 'エラー' }} />);
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(screen.getByText('エラー')).toBeInTheDocument();
+    });
+
+    it('messageがnullの場合タイマーが設定されない', () => {
+      const onDismiss = vi.fn();
+      render(<FormMessage message={null} onDismiss={onDismiss} />);
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('閉じるボタン', () => {
+    it('onDismiss指定時に閉じるボタンが表示される', () => {
+      const onDismiss = vi.fn();
+      render(<FormMessage message={{ type: 'error', text: 'エラー' }} onDismiss={onDismiss} />);
+
+      expect(screen.getByRole('button', { name: '閉じる' })).toBeInTheDocument();
+    });
+
+    it('閉じるボタンクリックでonDismissが呼ばれる', () => {
+      const onDismiss = vi.fn();
+      render(<FormMessage message={{ type: 'error', text: 'エラー' }} onDismiss={onDismiss} />);
+
+      fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
+
+      expect(onDismiss).toHaveBeenCalledOnce();
+    });
+
+    it('onDismiss未指定時に閉じるボタンが表示されない', () => {
+      render(<FormMessage message={{ type: 'error', text: 'エラー' }} />);
+
+      expect(screen.queryByRole('button', { name: '閉じる' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/hooks/useConfirmForgotPassword.ts
+++ b/frontend/src/hooks/useConfirmForgotPassword.ts
@@ -39,5 +39,7 @@ export function useConfirmForgotPassword() {
     }
   };
 
-  return { form, message, loading, handleChange, handleConfirm };
+  const clearMessage = () => setMessage(null);
+
+  return { form, message, loading, handleChange, handleConfirm, clearMessage };
 }

--- a/frontend/src/hooks/useConfirmSignup.ts
+++ b/frontend/src/hooks/useConfirmSignup.ts
@@ -29,5 +29,7 @@ export function useConfirmSignup() {
     }
   };
 
-  return { form, message, loading, handleChange, handleConfirm };
+  const clearMessage = () => setMessage(null);
+
+  return { form, message, loading, handleChange, handleConfirm, clearMessage };
 }

--- a/frontend/src/hooks/useForgotPassword.ts
+++ b/frontend/src/hooks/useForgotPassword.ts
@@ -25,5 +25,7 @@ export function useForgotPassword() {
     }
   };
 
-  return { email, setEmail, message, loading, handleSubmit };
+  const clearMessage = () => setMessage(null);
+
+  return { email, setEmail, message, loading, handleSubmit, clearMessage };
 }

--- a/frontend/src/hooks/useSignupPage.ts
+++ b/frontend/src/hooks/useSignupPage.ts
@@ -36,11 +36,14 @@ export function useSignupPage() {
     }
   };
 
+  const clearMessage = () => setMessage(null);
+
   return {
     form,
     message,
     loading,
     handleChange,
     handleSignup,
+    clearMessage,
   };
 }

--- a/frontend/src/pages/ConfirmForgotPasswordPage.tsx
+++ b/frontend/src/pages/ConfirmForgotPasswordPage.tsx
@@ -5,11 +5,11 @@ import FormMessage from '../components/FormMessage';
 import { useConfirmForgotPassword } from '../hooks/useConfirmForgotPassword';
 
 export default function ConfirmForgotPasswordPage() {
-  const { form, message, loading, handleChange, handleConfirm } = useConfirmForgotPassword();
+  const { form, message, loading, handleChange, handleConfirm, clearMessage } = useConfirmForgotPassword();
 
   return (
     <AuthLayout>
-      <FormMessage message={message} />
+      <FormMessage message={message} onDismiss={clearMessage} />
       <h2 className="text-2xl font-bold mb-6 text-center">
         パスワードリセット確認
       </h2>

--- a/frontend/src/pages/ConfirmPage.tsx
+++ b/frontend/src/pages/ConfirmPage.tsx
@@ -6,11 +6,11 @@ import FormMessage from '../components/FormMessage';
 import { useConfirmSignup } from '../hooks/useConfirmSignup';
 
 export default function ConfirmPage() {
-  const { form, message, loading, handleChange, handleConfirm } = useConfirmSignup();
+  const { form, message, loading, handleChange, handleConfirm, clearMessage } = useConfirmSignup();
 
   return (
     <AuthLayout>
-      <FormMessage message={message} />
+      <FormMessage message={message} onDismiss={clearMessage} />
       <h2 className="text-2xl font-bold mb-6 text-center">確認コードの入力</h2>
       <form onSubmit={handleConfirm}>
         <InputField

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -5,11 +5,11 @@ import FormMessage from '../components/FormMessage';
 import { useForgotPassword } from '../hooks/useForgotPassword';
 
 export default function ForgotPasswordPage() {
-  const { email, setEmail, message, loading, handleSubmit } = useForgotPassword();
+  const { email, setEmail, message, loading, handleSubmit, clearMessage } = useForgotPassword();
 
   return (
     <AuthLayout>
-      <FormMessage message={message} />
+      <FormMessage message={message} onDismiss={clearMessage} />
       <h2 className="text-2xl font-bold mb-6 text-center">
         パスワードリセット
       </h2>

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -6,11 +6,11 @@ import FormMessage from '../components/FormMessage';
 import { useSignupPage } from '../hooks/useSignupPage';
 
 export default function SignupPage() {
-  const { form, message, loading, handleChange, handleSignup } = useSignupPage();
+  const { form, message, loading, handleChange, handleSignup, clearMessage } = useSignupPage();
 
   return (
     <AuthLayout>
-      <FormMessage message={message} />
+      <FormMessage message={message} onDismiss={clearMessage} />
       <h2 className="text-3xl font-bold mb-2 text-center text-[var(--color-text-primary)]">
         アカウント作成
       </h2>


### PR DESCRIPTION
## 概要
- FormMessageコンポーネントに5秒後の自動消去機能と手動閉じるボタンを追加
- 認証フォーム5ページ（Signup, ForgotPassword, Confirm, ConfirmForgotPassword）に適用

## 変更内容
- `FormMessage`: `onDismiss` prop追加、5秒タイマー、Xボタン表示
- 4つの認証フック: `clearMessage`関数を追加してreturn
- 4つのページ: `onDismiss={clearMessage}`を接続

## テスト
- FormMessageテスト6件追加（自動消去3件 + 閉じるボタン3件）
- フロントエンド全1975件パス

closes #1071