### PR TITLE
refactor: ProfileControllerの重複認証チェックとtry/catch削除

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
@@ -2,7 +2,6 @@ package com.example.FreStyle.controller;
 
 import java.util.Map;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -13,76 +12,32 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.FreStyle.dto.ProfileDto;
-import com.example.FreStyle.exception.ResourceNotFoundException;
 import com.example.FreStyle.form.ProfileForm;
 import com.example.FreStyle.usecase.GetProfileUseCase;
 import com.example.FreStyle.usecase.UpdateProfileUseCase;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/profile")
-@Slf4j
 public class ProfileController {
 
     private final GetProfileUseCase getProfileUseCase;
     private final UpdateProfileUseCase updateProfileUseCase;
 
     @GetMapping("/me")
-    public ResponseEntity<?> getProfile(@AuthenticationPrincipal Jwt jwt) {
-        if (jwt == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", "認証に失敗しました。"));
-        }
-
+    public ResponseEntity<ProfileDto> getProfile(@AuthenticationPrincipal Jwt jwt) {
         String sub = jwt.getSubject();
-        if (sub == null || sub.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", "認証に失敗しました。"));
-        }
-
-        try {
-            ProfileDto profileDto = getProfileUseCase.execute(sub);
-            return ResponseEntity.ok(profileDto);
-        } catch (ResourceNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(Map.of("error", "ユーザーが存在しません。"));
-        } catch (Exception e) {
-            log.error("プロフィール取得エラー: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("error", "サーバーエラーが発生しました。"));
-        }
+        ProfileDto profileDto = getProfileUseCase.execute(sub);
+        return ResponseEntity.ok(profileDto);
     }
 
     @PutMapping("/me/update")
-    public ResponseEntity<?> updateProfile(
+    public ResponseEntity<Map<String, String>> updateProfile(
             @AuthenticationPrincipal Jwt jwt,
             @RequestBody ProfileForm form) {
-
-        if (jwt == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", "認証に失敗しました。"));
-        }
-
-        String sub = jwt.getSubject();
-        if (sub == null || sub.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", "認証に失敗しました。"));
-        }
-
-        try {
-            updateProfileUseCase.execute(jwt, form);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest()
-                    .body(Map.of("error", e.getMessage()));
-        } catch (Exception e) {
-            log.error("プロフィール更新エラー: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(Map.of("error", "サーバーエラーが発生しました。"));
-        }
-
+        updateProfileUseCase.execute(jwt, form);
         return ResponseEntity.ok(Map.of("message", "プロフィールを更新しました。"));
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/exception/GlobalExceptionHandler.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/exception/GlobalExceptionHandler.java
@@ -110,6 +110,23 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(
+            IllegalArgumentException ex,
+            WebRequest request
+    ) {
+        logger.warn("不正な引数: {}", ex.getMessage());
+
+        ErrorResponseDto error = ErrorResponseDto.of(
+            HttpStatus.BAD_REQUEST.value(),
+            "Bad Request",
+            ex.getMessage(),
+            request.getDescription(false).replace("uri=", "")
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
     /**
      * 汎用Exception のハンドラー
      *


### PR DESCRIPTION
## 概要
- ProfileControllerの手動JWT/subjectチェックとtry/catchブロックを削除
- GlobalExceptionHandlerにIllegalArgumentExceptionハンドラーを追加
- FavoritePhraseController等の新しいコントローラーとパターンを統一

## 変更内容
- **ProfileController**: 88行→43行（52%削減）
  - 手動jwt null/sub emptyチェック削除（Spring Security層に委譲）
  - ResourceNotFoundException/IllegalArgumentExceptionのcatch削除（GlobalExceptionHandlerに委譲）
  - 戻り値の型をジェネリクスから具象型に変更
- **GlobalExceptionHandler**: IllegalArgumentException→400ハンドラー追加
- **ProfileControllerTest**: 冗長なnullチェックテスト4件を削除、例外伝搬テストに変更

## テスト
- バックエンド474件パス（contextLoads除く）

closes #1073