### PR TITLE
test: バックエンドUseCase・ExceptionHandlerのテスト拡充（+5件）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/exception/GlobalExceptionHandlerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/GlobalExceptionHandlerTest.java
@@ -92,6 +92,22 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("IllegalArgumentExceptionで400を返す")
+    void returnsBadRequestOnIllegalArgumentException() {
+        WebRequest request = mockRequest("/api/notes/1/images");
+        IllegalArgumentException ex = new IllegalArgumentException("許可されていないファイル形式です");
+
+        ResponseEntity<ErrorResponseDto> response = handler.handleIllegalArgumentException(ex, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getStatus()).isEqualTo(400);
+        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
+        assertThat(response.getBody().getMessage()).isEqualTo("許可されていないファイル形式です");
+        assertThat(response.getBody().getPath()).isEqualTo("/api/notes/1/images");
+    }
+
+    @Test
     @DisplayName("エラーレスポンスにタイムスタンプが含まれる")
     void responseContainsTimestamp() {
         WebRequest request = mockRequest("/api/test");

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateOrGetChatRoomUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateOrGetChatRoomUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.example.FreStyle.usecase;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -51,5 +52,30 @@ class CreateOrGetChatRoomUseCaseTest {
         createOrGetChatRoomUseCase.execute("sub-456", 10);
 
         verify(chatService).createOrGetRoom(5, 10);
+    }
+
+    @Test
+    @DisplayName("UserIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void execute_propagatesUserIdentityException() {
+        when(userIdentityService.findUserBySub("unknown-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        assertThatThrownBy(() -> createOrGetChatRoomUseCase.execute("unknown-sub", 2))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ユーザーが見つかりません");
+    }
+
+    @Test
+    @DisplayName("ChatServiceが例外をスローした場合そのまま伝搬する")
+    void execute_propagatesChatServiceException() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(chatService.createOrGetRoom(1, 2))
+                .thenThrow(new RuntimeException("ルーム作成失敗"));
+
+        assertThatThrownBy(() -> createOrGetChatRoomUseCase.execute("sub-123", 2))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ルーム作成失敗");
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteChatMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteChatMessageUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.example.FreStyle.usecase;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -26,5 +27,16 @@ class DeleteChatMessageUseCaseTest {
         useCase.execute(100);
 
         verify(chatMessageService).deleteMessage(100);
+    }
+
+    @Test
+    @DisplayName("ChatMessageServiceが例外をスローした場合そのまま伝搬する")
+    void execute_propagatesServiceException() {
+        doThrow(new RuntimeException("削除失敗"))
+                .when(chatMessageService).deleteMessage(100);
+
+        assertThatThrownBy(() -> useCase.execute(100))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("削除失敗");
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GeneratePresignedUrlUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GeneratePresignedUrlUseCaseTest.java
@@ -55,4 +55,14 @@ class GeneratePresignedUrlUseCaseTest {
         assertThrows(IllegalArgumentException.class,
                 () -> useCase.execute("test-sub", "note1", "file.exe", "application/octet-stream"));
     }
+
+    @Test
+    @DisplayName("UserIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void execute_propagatesUserIdentityException() {
+        when(userIdentityService.findUserBySub("unknown-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        assertThrows(RuntimeException.class,
+                () -> useCase.execute("unknown-sub", "note1", "image.png", "image/png"));
+    }
 }


### PR DESCRIPTION
## 概要
- GlobalExceptionHandlerTest: IllegalArgumentException→400レスポンステスト追加
- DeleteChatMessageUseCaseTest: サービス例外伝搬テスト追加
- CreateOrGetChatRoomUseCaseTest: UserIdentityService・ChatService例外伝搬テスト追加（2件）
- GeneratePresignedUrlUseCaseTest: UserIdentityService例外伝搬テスト追加

## テスト結果
- バックエンド: 482件（contextLoads除外）

Closes #1075