### PR TITLE
feat: お気に入りフレーズ削除時に確認ダイアログを表示

### DIFF
--- a/frontend/src/pages/FavoritesPage.tsx
+++ b/frontend/src/pages/FavoritesPage.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react';
 import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
 import SearchBox from '../components/SearchBox';
 import FavoriteStatsCard from '../components/FavoriteStatsCard';
 import EmptyState from '../components/EmptyState';
+import ConfirmModal from '../components/ConfirmModal';
 import { StarIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import type { FavoritePhrase } from '../types';
 
 const PATTERN_FILTERS = ['すべて', 'フォーマル', 'ソフト', '簡潔'] as const;
 
 export default function FavoritesPage() {
   const { phrases, filteredPhrases, searchQuery, setSearchQuery, patternFilter, setPatternFilter, removeFavorite } = useFavoritePhrase();
+  const [deleteTarget, setDeleteTarget] = useState<FavoritePhrase | null>(null);
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
@@ -71,7 +75,7 @@ export default function FavoritesPage() {
                     {new Date(phrase.createdAt).toLocaleDateString('ja-JP')}
                   </span>
                   <button
-                    onClick={() => removeFavorite(phrase.id)}
+                    onClick={() => setDeleteTarget(phrase)}
                     aria-label="お気に入りから削除"
                     className="text-xs text-[var(--color-text-faint)] hover:text-rose-500 transition-colors"
                   >
@@ -85,6 +89,18 @@ export default function FavoritesPage() {
           ))}
         </div>
       )}
+      <ConfirmModal
+        isOpen={deleteTarget !== null}
+        title="フレーズを削除"
+        message={`「${deleteTarget?.rephrasedText ?? ''}」を削除しますか？`}
+        onConfirm={() => {
+          if (deleteTarget) {
+            removeFavorite(deleteTarget.id);
+          }
+          setDeleteTarget(null);
+        }}
+        onCancel={() => setDeleteTarget(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/FavoritesPage.test.tsx
+++ b/frontend/src/pages/__tests__/FavoritesPage.test.tsx
@@ -77,13 +77,35 @@ describe('FavoritesPage', () => {
     expect(screen.getByText(/これでいいですか/)).toBeInTheDocument();
   });
 
-  it('削除ボタンでremoveFavoriteが呼ばれる', () => {
+  it('削除ボタンクリックで確認ダイアログが表示される', () => {
     render(<FavoritesPage />);
 
     const deleteButtons = screen.getAllByLabelText('お気に入りから削除');
     fireEvent.click(deleteButtons[0]);
 
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/「ご確認いただけますでしょうか」を削除しますか/)).toBeInTheDocument();
+  });
+
+  it('確認ダイアログで削除を実行するとremoveFavoriteが呼ばれる', () => {
+    render(<FavoritesPage />);
+
+    const deleteButtons = screen.getAllByLabelText('お気に入りから削除');
+    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(screen.getByText('削除'));
+
     expect(mockRemoveFavorite).toHaveBeenCalledWith('1');
+  });
+
+  it('確認ダイアログでキャンセルするとremoveFavoriteが呼ばれない', () => {
+    render(<FavoritesPage />);
+
+    const deleteButtons = screen.getAllByLabelText('お気に入りから削除');
+    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(screen.getByText('キャンセル'));
+
+    expect(mockRemoveFavorite).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('検索ボックスが表示される', () => {


### PR DESCRIPTION
## 概要
- お気に入りフレーズの削除ボタンクリック時にConfirmModalを表示
- 確認後に削除を実行、キャンセルで元に戻る
- 誤操作による意図しない削除を防止

## 変更内容
- `FavoritesPage.tsx`: 削除ボタンクリックでConfirmModal表示 → 確認後にremoveFavorite実行
- `FavoritesPage.test.tsx`: 確認ダイアログ表示・削除実行・キャンセルの3テスト追加

## テスト結果
- フロントエンド: 1977件全件パス

Closes #1077