### PR TITLE
test: UseCase・Service・Repositoryのテスト拡充（+5件）

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/AuthCookieServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/AuthCookieServiceTest.java
@@ -47,4 +47,32 @@ class AuthCookieServiceTest {
         assertThat(captor.getValue()).contains("REFRESH_TOKEN");
         assertThat(captor.getValue()).contains("Max-Age=0");
     }
+
+    @Test
+    @DisplayName("setAuthCookies: CookieにHttpOnly属性が設定される")
+    void setAuthCookiesSetsHttpOnlyAttribute() {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        authCookieService.setAuthCookies(response, "access", "refresh", "test@example.com", "user1");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response, times(4)).addHeader(eq("Set-Cookie"), captor.capture());
+
+        captor.getAllValues().forEach(cookie ->
+                assertThat(cookie).contains("HttpOnly"));
+    }
+
+    @Test
+    @DisplayName("setAuthCookies: CookieにSecure属性が設定される")
+    void setAuthCookiesSetsSecureAttribute() {
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        authCookieService.setAuthCookies(response, "access", "refresh", "test@example.com", "user1");
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(response, times(4)).addHeader(eq("Set-Cookie"), captor.capture());
+
+        captor.getAllValues().forEach(cookie ->
+                assertThat(cookie).contains("Secure"));
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteNoteUseCaseTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,6 +33,17 @@ class DeleteNoteUseCaseTest {
             useCase.execute(1, "note-1");
 
             verify(noteRepository, times(1)).delete(1, "note-1");
+        }
+
+        @Test
+        @DisplayName("NoteRepositoryが例外をスローした場合そのまま伝搬する")
+        void shouldPropagateRepositoryException() {
+            doThrow(new RuntimeException("DynamoDB error"))
+                    .when(noteRepository).delete(1, "note-1");
+
+            assertThatThrownBy(() -> useCase.execute(1, "note-1"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("DynamoDB error");
         }
     }
 }

--- a/frontend/src/repositories/__tests__/UserProfileRepository.test.ts
+++ b/frontend/src/repositories/__tests__/UserProfileRepository.test.ts
@@ -40,4 +40,18 @@ describe('UserProfileRepository', () => {
     expect(mockedApiClient.post).toHaveBeenCalledWith('/api/user-profile/me', updateRequest);
     expect(result).toEqual(mockProfile);
   });
+
+  it('getMyProfile: APIエラー時に例外がそのまま伝搬する', async () => {
+    mockedApiClient.get.mockRejectedValue(new Error('Network Error'));
+
+    await expect(userProfileRepository.getMyProfile()).rejects.toThrow('Network Error');
+  });
+
+  it('updateProfile: APIエラー時に例外がそのまま伝搬する', async () => {
+    mockedApiClient.post.mockRejectedValue(new Error('Server Error'));
+
+    await expect(
+      userProfileRepository.updateProfile({ displayName: 'テスト' })
+    ).rejects.toThrow('Server Error');
+  });
 });


### PR DESCRIPTION
## 概要
- DeleteNoteUseCaseTest: リポジトリ例外伝搬テスト追加
- AuthCookieServiceTest: Cookie HttpOnly・Secure属性検証テスト追加（2件）
- UserProfileRepository.test.ts: APIエラー伝搬テスト追加（2件）

## テスト結果
- フロントエンド: 1979件
- バックエンド: 485件（contextLoads除外）

Closes #1081