### PR TITLE
feat: パスワードリセット画面にパスワード確認フィールドを追加

### DIFF
--- a/frontend/src/hooks/__tests__/useConfirmForgotPassword.test.ts
+++ b/frontend/src/hooks/__tests__/useConfirmForgotPassword.test.ts
@@ -50,6 +50,9 @@ describe('useConfirmForgotPassword', () => {
       result.current.handleChange({
         target: { name: 'newPassword', value: 'newpass123' },
       } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({
+        target: { name: 'confirmPassword', value: 'newpass123' },
+      } as React.ChangeEvent<HTMLInputElement>);
     });
 
     await act(async () => {
@@ -149,5 +152,57 @@ describe('useConfirmForgotPassword', () => {
     });
 
     expect(result.current.loading).toBe(false);
+  });
+
+  it('confirmPasswordの初期値が空文字', () => {
+    const { result } = renderHook(() => useConfirmForgotPassword());
+    expect(result.current.form.confirmPassword).toBe('');
+  });
+
+  it('パスワード不一致時にエラーメッセージが表示される', async () => {
+    const { result } = renderHook(() => useConfirmForgotPassword());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'newPassword', value: 'password1' },
+      } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({
+        target: { name: 'confirmPassword', value: 'password2' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('パスワードが一致しません。');
+    expect(mockConfirmForgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('パスワード一致時にAPIが呼ばれる', async () => {
+    const { result } = renderHook(() => useConfirmForgotPassword());
+
+    act(() => {
+      result.current.handleChange({
+        target: { name: 'code', value: '123456' },
+      } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({
+        target: { name: 'newPassword', value: 'samePassword' },
+      } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({
+        target: { name: 'confirmPassword', value: 'samePassword' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleConfirm({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(mockConfirmForgotPassword).toHaveBeenCalled();
   });
 });

--- a/frontend/src/hooks/useConfirmForgotPassword.ts
+++ b/frontend/src/hooks/useConfirmForgotPassword.ts
@@ -13,12 +13,19 @@ export function useConfirmForgotPassword() {
     email: (location.state as { email?: string })?.email || '',
     code: '',
     newPassword: '',
+    confirmPassword: '',
   });
   const [message, setMessage] = useState<FormMessage | null>(null);
   const [loading, setLoading] = useState(false);
 
   const handleConfirm = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (form.newPassword !== form.confirmPassword) {
+      setMessage({ type: 'error', text: 'パスワードが一致しません。' });
+      return;
+    }
+
     setLoading(true);
 
     try {

--- a/frontend/src/pages/ConfirmForgotPasswordPage.tsx
+++ b/frontend/src/pages/ConfirmForgotPasswordPage.tsx
@@ -37,6 +37,14 @@ export default function ConfirmForgotPasswordPage() {
           onChange={handleChange}
           disabled={loading}
         />
+        <InputField
+          label="パスワード確認"
+          name="confirmPassword"
+          type="password"
+          value={form.confirmPassword}
+          onChange={handleChange}
+          disabled={loading}
+        />
         <PrimaryButton type="submit" loading={loading}>
           {loading ? 'リセット中...' : 'パスワードをリセット'}
         </PrimaryButton>

--- a/frontend/src/pages/__tests__/ConfirmForgotPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ConfirmForgotPasswordPage.test.tsx
@@ -65,6 +65,9 @@ describe('ConfirmForgotPasswordPage', () => {
     fireEvent.change(screen.getByLabelText('新しいパスワード'), {
       target: { value: 'newPassword123', name: 'newPassword' },
     });
+    fireEvent.change(screen.getByLabelText('パスワード確認'), {
+      target: { value: 'newPassword123', name: 'confirmPassword' },
+    });
     fireEvent.click(screen.getByText('パスワードをリセット'));
 
     await waitFor(() => {
@@ -72,6 +75,32 @@ describe('ConfirmForgotPasswordPage', () => {
         state: { message: 'パスワードリセットに成功しました。ログインしてください。' },
       });
     });
+  });
+
+  it('パスワード確認フィールドが表示される', () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    expect(screen.getByLabelText('パスワード確認')).toBeInTheDocument();
+  });
+
+  it('パスワード不一致時にエラーメッセージを表示する', async () => {
+    render(<BrowserRouter><ConfirmForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('確認コード'), {
+      target: { value: '123456', name: 'code' },
+    });
+    fireEvent.change(screen.getByLabelText('新しいパスワード'), {
+      target: { value: 'password1', name: 'newPassword' },
+    });
+    fireEvent.change(screen.getByLabelText('パスワード確認'), {
+      target: { value: 'password2', name: 'confirmPassword' },
+    });
+    fireEvent.click(screen.getByText('パスワードをリセット'));
+
+    await waitFor(() => {
+      expect(screen.getByText('パスワードが一致しません。')).toBeInTheDocument();
+    });
+    expect(authRepository.confirmForgotPassword).not.toHaveBeenCalled();
   });
 
   it('リセット失敗時にエラーメッセージを表示する', async () => {


### PR DESCRIPTION
## 概要
- パスワードリセット確認画面に「パスワード確認」フィールドを追加
- パスワード不一致時にバリデーションエラーを表示し、API呼び出しを防止

## 変更内容
- `useConfirmForgotPassword.ts`: confirmPasswordフィールド追加、不一致バリデーション
- `ConfirmForgotPasswordPage.tsx`: パスワード確認InputField追加
- テスト5件追加（hook 3件、ページ 2件）

## テスト
- フロントエンド: 1989テスト全パス

closes #1089