### PR TITLE
test: ChatRoomServiceとRoomMemberServiceのテスト拡充

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/ChatRoomServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ChatRoomServiceTest.java
@@ -45,4 +45,14 @@ class ChatRoomServiceTest {
                 () -> chatRoomService.findChatRoomById(999));
         assertEquals("ルームが存在しません。", ex.getMessage());
     }
+
+    @Test
+    @DisplayName("findChatRoomById: リポジトリが例外をスローした場合そのまま伝搬する")
+    void findChatRoomById_propagatesRepositoryException() {
+        when(chatRoomRepository.findById(1))
+                .thenThrow(new RuntimeException("DB接続エラー"));
+
+        assertThrows(RuntimeException.class,
+                () -> chatRoomService.findChatRoomById(1));
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/service/RoomMemberServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/RoomMemberServiceTest.java
@@ -80,4 +80,34 @@ class RoomMemberServiceTest {
         assertEquals(5L, result);
         verify(roomMemberRepository).countDistinctPartnersByUserId(1);
     }
+
+    @Test
+    @DisplayName("findRoomId: ルームが存在しない場合空リストを返す")
+    void findRoomId_returnsEmptyList() {
+        when(roomMemberRepository.findRoomIdByUserId(999)).thenReturn(List.of());
+
+        List<Integer> result = roomMemberService.findRoomId(999);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("findUsers: リポジトリが例外をスローした場合そのまま伝搬する")
+    void findUsers_propagatesRepositoryException() {
+        when(roomMemberRepository.findUsersByUserId(1))
+                .thenThrow(new RuntimeException("DB接続エラー"));
+
+        assertThrows(RuntimeException.class,
+                () -> roomMemberService.findUsers(1));
+    }
+
+    @Test
+    @DisplayName("countChatPartners: 会話相手が0人の場合0を返す")
+    void countChatPartners_returnsZero() {
+        when(roomMemberRepository.countDistinctPartnersByUserId(999)).thenReturn(0L);
+
+        Long result = roomMemberService.countChatPartners(999);
+
+        assertEquals(0L, result);
+    }
 }


### PR DESCRIPTION
## 概要
- ChatRoomService・RoomMemberServiceのテストカバレッジ拡充

## 変更内容
- `ChatRoomServiceTest`: リポジトリ例外伝搬テスト1件追加
- `RoomMemberServiceTest`: 空リスト返却/例外伝搬/0件カウント 3件追加

## テスト
- バックエンド: 493テスト（contextLoads除く全パス）

closes #1093