### PR TITLE
feat: ForgotPasswordPageにメールアドレスバリデーション追加

### DIFF
--- a/frontend/src/hooks/__tests__/useForgotPassword.test.ts
+++ b/frontend/src/hooks/__tests__/useForgotPassword.test.ts
@@ -63,6 +63,10 @@ describe('useForgotPassword', () => {
 
     const { result } = renderHook(() => useForgotPassword());
 
+    act(() => {
+      result.current.setEmail('test@example.com');
+    });
+
     await act(async () => {
       await result.current.handleSubmit({
         preventDefault: vi.fn(),
@@ -77,6 +81,10 @@ describe('useForgotPassword', () => {
     mockForgotPassword.mockRejectedValue(new Error('Network Error'));
 
     const { result } = renderHook(() => useForgotPassword());
+
+    act(() => {
+      result.current.setEmail('test@example.com');
+    });
 
     await act(async () => {
       await result.current.handleSubmit({
@@ -128,10 +136,62 @@ describe('useForgotPassword', () => {
     expect(result.current.loading).toBe(false);
   });
 
+  it('メールアドレスが空の場合エラーメッセージが表示されAPIが呼ばれない', async () => {
+    const { result } = renderHook(() => useForgotPassword());
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('メールアドレスを入力してください。');
+    expect(mockForgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('メールアドレス形式が無効の場合エラーメッセージが表示されAPIが呼ばれない', async () => {
+    const { result } = renderHook(() => useForgotPassword());
+
+    act(() => {
+      result.current.setEmail('invalid-email');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('有効なメールアドレスを入力してください。');
+    expect(mockForgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('有効なメールアドレスの場合APIが呼ばれる', async () => {
+    const { result } = renderHook(() => useForgotPassword());
+
+    act(() => {
+      result.current.setEmail('valid@example.com');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    expect(mockForgotPassword).toHaveBeenCalledWith({ email: 'valid@example.com' });
+  });
+
   it('handleSubmit実行中にloadingがtrueになる', async () => {
     let resolvePromise: (value: unknown) => void;
     mockForgotPassword.mockReturnValue(new Promise((resolve) => { resolvePromise = resolve; }));
     const { result } = renderHook(() => useForgotPassword());
+
+    act(() => {
+      result.current.setEmail('test@example.com');
+    });
 
     let submitPromise: Promise<void>;
     act(() => {

--- a/frontend/src/hooks/useForgotPassword.ts
+++ b/frontend/src/hooks/useForgotPassword.ts
@@ -12,6 +12,18 @@ export function useForgotPassword() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (!email.trim()) {
+      setMessage({ type: 'error', text: 'メールアドレスを入力してください。' });
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setMessage({ type: 'error', text: '有効なメールアドレスを入力してください。' });
+      return;
+    }
+
     setLoading(true);
 
     try {

--- a/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/frontend/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -74,6 +74,31 @@ describe('ForgotPasswordPage', () => {
     });
   });
 
+  it('メールアドレス未入力で送信するとバリデーションエラーが表示される', async () => {
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.click(screen.getByText('確認コードを送信'));
+
+    await waitFor(() => {
+      expect(screen.getByText('メールアドレスを入力してください。')).toBeInTheDocument();
+    });
+    expect(authRepository.forgotPassword).not.toHaveBeenCalled();
+  });
+
+  it('無効なメールアドレスで送信するとバリデーションエラーが表示される', async () => {
+    render(<BrowserRouter><ForgotPasswordPage /></BrowserRouter>);
+
+    fireEvent.change(screen.getByLabelText('メールアドレス'), {
+      target: { value: 'invalid-email' },
+    });
+    fireEvent.submit(screen.getByText('確認コードを送信').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('有効なメールアドレスを入力してください。')).toBeInTheDocument();
+    });
+    expect(authRepository.forgotPassword).not.toHaveBeenCalled();
+  });
+
   it('通信エラー時にエラーメッセージを表示する', async () => {
     vi.mocked(authRepository.forgotPassword).mockRejectedValue(new Error('Network error'));
 


### PR DESCRIPTION
## 概要
- メールアドレス未入力時に「メールアドレスを入力してください。」エラー表示
- メール形式不正時に「有効なメールアドレスを入力してください。」エラー表示
- バリデーションエラー時はAPIを呼び出さない

## テスト
- useForgotPasswordフック: +3テスト（空文字・形式不正・有効メール）
- ForgotPasswordPage: +2テスト（未入力・無効メールのUI表示）
- 全1994テスト合格

closes #1095