### PR TITLE
feat: プロフィール編集画面にニックネーム未入力バリデーション追加

### DIFF
--- a/frontend/src/hooks/__tests__/useProfileEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileEdit.test.ts
@@ -162,4 +162,44 @@ describe('useProfileEdit', () => {
 
     expect(mockUpdateProfile).toHaveBeenCalledWith({ name: '更新太郎', bio: '自己紹介文' });
   });
+
+  it('ニックネームが空の場合エラーメッセージが表示されAPIが呼ばれない', async () => {
+    const { result } = renderHook(() => useProfileEdit());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.updateField('name', '');
+    });
+
+    await act(async () => {
+      await result.current.handleUpdate();
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('ニックネームを入力してください。');
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it('ニックネームが空白のみの場合エラーメッセージが表示されAPIが呼ばれない', async () => {
+    const { result } = renderHook(() => useProfileEdit());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.updateField('name', '   ');
+    });
+
+    await act(async () => {
+      await result.current.handleUpdate();
+    });
+
+    expect(result.current.message?.type).toBe('error');
+    expect(result.current.message?.text).toBe('ニックネームを入力してください。');
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/useProfileEdit.ts
+++ b/frontend/src/hooks/useProfileEdit.ts
@@ -27,6 +27,11 @@ export function useProfileEdit() {
   }, []);
 
   const handleUpdate = useCallback(async () => {
+    if (!form.name.trim()) {
+      setMessage({ type: 'error', text: 'ニックネームを入力してください。' });
+      return;
+    }
+
     setSubmitting(true);
     try {
       const data = await ProfileRepository.updateProfile(form);


### PR DESCRIPTION
## 概要
- プロフィール編集画面でニックネームが未入力の状態での更新を防止するバリデーションを追加

## 変更内容
- `useProfileEdit.ts`: ニックネーム未入力・空白チェックを追加
- `useProfileEdit.test.ts`: バリデーションテスト2件追加

## テスト結果
- フロントエンド: 2003件全テスト通過

closes #1113