### PR TITLE
fix: ブラウザオートフィル時の入力欄テキスト色が見えない問題を修正 (#1117)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -49,6 +49,15 @@
     color: var(--color-text-primary);
     background-color: var(--color-surface-2);
   }
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-text-fill-color: var(--color-text-primary);
+    -webkit-box-shadow: 0 0 0px 1000px var(--color-surface-2) inset;
+    transition: background-color 5000s ease-in-out 0s;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## 概要
- ログインページ等でブラウザのオートフィル（自動入力）時にテキストが白色になり見えない問題を修正

## 変更内容
- `index.css`の`@layer base`に`:-webkit-autofill`擬似クラスのスタイルを追加
- `-webkit-text-fill-color`: テキスト色をCSS変数`--color-text-primary`で強制適用
- `-webkit-box-shadow`: オートフィル背景色を`--color-surface-2`で上書き
- `transition`: オートフィル時の背景色フラッシュを防止

## テスト
- ブラウザでオートフィル時にテキストが正しく表示されることを確認

Closes #1117