### PR TITLE
test: CognitoAuthService・ProfileController・NoteImageControllerのテスト拡充 (#1119)

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ProfileControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ProfileControllerTest.java
@@ -69,6 +69,19 @@ class ProfileControllerTest {
             assertThrows(ResourceNotFoundException.class,
                     () -> profileController.getProfile(jwt));
         }
+
+        @Test
+        @DisplayName("JWTのsubjectがnullの場合useCaseにnullが渡される")
+        void passesNullSubjectToUseCase() {
+            Jwt jwt = mock(Jwt.class);
+            when(jwt.getSubject()).thenReturn(null);
+            when(getProfileUseCase.execute(null))
+                    .thenThrow(new ResourceNotFoundException("ユーザーが見つかりません"));
+
+            assertThrows(ResourceNotFoundException.class,
+                    () -> profileController.getProfile(jwt));
+            verify(getProfileUseCase).execute(null);
+        }
     }
 
     @Nested

--- a/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
@@ -312,5 +312,15 @@ class CognitoAuthServiceTest {
                     () -> service.refreshAccessToken("invalid-token", "test@example.com"));
             assertEquals("リフレッシュトークンが無効です。再ログインしてください。", ex.getMessage());
         }
+
+        @Test
+        void 予期しない例外でRuntimeExceptionにラップされる() {
+            when(cognitoClient.initiateAuth(any(InitiateAuthRequest.class)))
+                    .thenThrow(new RuntimeException("unexpected error"));
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> service.refreshAccessToken("valid-token", "test@example.com"));
+            assertEquals("アクセストークン再発行中にエラーが発生しました。", ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## 概要
テストカバレッジを向上させるため、未カバーだったエラーパス・エッジケースのテストを追加。

## 追加テスト（+4件）
- **CognitoAuthServiceTest**: `refreshAccessToken`で汎用Exception発生時にRuntimeExceptionにラップされることを検証
- **ProfileControllerTest**: JWT subjectがnullの場合、useCaseにnullが渡されることを検証
- **NoteImageControllerTest**: 400エラー時のレスポンスボディにエラーメッセージが含まれることを検証
- **NoteImageControllerTest**: 500エラー時のレスポンスボディに固定メッセージが含まれることを検証

## テスト結果
- 追加テスト4件含め全515件パス（contextLoads除く）

Closes #1119