### PR TITLE
feat: AIセッションタイトル編集時の空タイトルバリデーション追加 (#1121)

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -52,13 +52,13 @@ export default memo(function AiSessionListItem({
               value={editingTitle}
               onChange={(e) => onEditingTitleChange(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') onSaveTitle(id);
+                if (e.key === 'Enter' && editingTitle.trim()) onSaveTitle(id);
                 if (e.key === 'Escape') onCancelEdit();
               }}
               className="flex-1 text-xs px-2 py-1 border border-[var(--color-border-hover)] rounded focus:outline-none focus:ring-1 focus:ring-primary-400"
               autoFocus
             />
-            <button onClick={() => onSaveTitle(id)} className="p-0.5 hover:bg-green-900/30 rounded" aria-label="保存">
+            <button onClick={() => onSaveTitle(id)} disabled={!editingTitle.trim()} className="p-0.5 hover:bg-green-900/30 rounded disabled:opacity-30 disabled:cursor-not-allowed" aria-label="保存">
               <CheckIcon className="w-3.5 h-3.5 text-green-400" />
             </button>
             <button onClick={onCancelEdit} className="p-0.5 hover:bg-surface-3 rounded" aria-label="キャンセル">

--- a/frontend/src/hooks/__tests__/useAiSession.test.ts
+++ b/frontend/src/hooks/__tests__/useAiSession.test.ts
@@ -122,7 +122,7 @@ describe('useAiSession', () => {
     expect(result.current.deleteModal.sessionId).toBeNull();
   });
 
-  it('空タイトル保存時にeditingSessionIdがnullに戻る', async () => {
+  it('空タイトル保存時に編集モードが維持される', async () => {
     const { result } = renderHook(() =>
       useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
     );
@@ -140,7 +140,28 @@ describe('useAiSession', () => {
     });
 
     expect(mockUpdateSessionTitle).not.toHaveBeenCalled();
-    expect(result.current.editingSessionId).toBeNull();
+    expect(result.current.editingSessionId).toBe(10);
+  });
+
+  it('空文字タイトル保存時に編集モードが維持されAPIが呼ばれない', async () => {
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleStartEditTitle({ id: 5, title: '元のタイトル' });
+    });
+
+    act(() => {
+      result.current.setEditingTitle('');
+    });
+
+    await act(async () => {
+      await result.current.handleSaveTitle(5);
+    });
+
+    expect(mockUpdateSessionTitle).not.toHaveBeenCalled();
+    expect(result.current.editingSessionId).toBe(5);
   });
 
   it('handleCancelEditTitleでeditingTitleが空に戻る', () => {

--- a/frontend/src/hooks/useAiSession.ts
+++ b/frontend/src/hooks/useAiSession.ts
@@ -56,7 +56,6 @@ export function useAiSession({ deleteSession, updateSessionTitle }: UseAiSession
 
   const handleSaveTitle = useCallback(async (sessionId: number) => {
     if (!editingTitle.trim()) {
-      setEditingSessionId(null);
       return;
     }
 


### PR DESCRIPTION
## 概要
- AIセッションのタイトル編集時に空タイトルで保存できないようバリデーションを追加

## 変更内容
- `useAiSession.ts`: 空タイトル保存時に`setEditingSessionId(null)`を削除し、編集モードを維持するように変更
- `AiSessionListItem.tsx`: 保存ボタンに`disabled={!editingTitle.trim()}`を追加、Enterキーでの空タイトル保存も防止

## テスト
- テスト2件追加（空白・空文字の保存防止、編集モード維持の検証）
- フロントエンド全2004件パス

Closes #1121