### PR TITLE
feat: スコア履歴ページに期間フィルタリング機能を追加 #1137

### DIFF
--- a/frontend/src/components/SessionListSection.tsx
+++ b/frontend/src/components/SessionListSection.tsx
@@ -8,7 +8,7 @@ import ScoreHistorySessionCard from './ScoreHistorySessionCard';
 import ScoreFilterSummary from './ScoreFilterSummary';
 import ScoreTrendIndicator from './ScoreTrendIndicator';
 import FilterTabs from './FilterTabs';
-import { FILTERS } from '../hooks/useScoreHistory';
+import { FILTERS, PERIOD_FILTERS } from '../hooks/useScoreHistory';
 import type { ScoreHistoryItem } from '../types';
 import type { ScoreHistoryItemWithDelta } from '../hooks/useScoreHistory';
 
@@ -17,6 +17,8 @@ interface SessionListSectionProps {
   filteredHistoryWithDelta: ScoreHistoryItemWithDelta[];
   filter: string;
   setFilter: (filter: string) => void;
+  periodFilter: string;
+  setPeriodFilter: (period: string) => void;
   selectedSession: ScoreHistoryItem | null;
   setSelectedSession: (session: ScoreHistoryItem | null) => void;
 }
@@ -26,6 +28,8 @@ export default function SessionListSection({
   filteredHistoryWithDelta,
   filter,
   setFilter,
+  periodFilter,
+  setPeriodFilter,
   selectedSession,
   setSelectedSession,
 }: SessionListSectionProps) {
@@ -58,6 +62,8 @@ export default function SessionListSection({
       <SessionTimeCard dates={history.map(h => h.createdAt)} />
 
       <PracticeCalendar practiceDates={history.map(h => h.createdAt)} />
+
+      <FilterTabs tabs={[...PERIOD_FILTERS]} selected={periodFilter} onSelect={setPeriodFilter} />
 
       <FilterTabs tabs={[...FILTERS]} selected={filter} onSelect={setFilter} />
 

--- a/frontend/src/components/__tests__/SessionListSection.test.tsx
+++ b/frontend/src/components/__tests__/SessionListSection.test.tsx
@@ -34,6 +34,8 @@ describe('SessionListSection', () => {
         filteredHistoryWithDelta={mockHistory}
         filter="すべて"
         setFilter={vi.fn()}
+        periodFilter="全期間"
+        setPeriodFilter={vi.fn()}
         selectedSession={null}
         setSelectedSession={vi.fn()}
       />
@@ -49,10 +51,49 @@ describe('SessionListSection', () => {
         filteredHistoryWithDelta={mockHistory}
         filter="すべて"
         setFilter={vi.fn()}
+        periodFilter="全期間"
+        setPeriodFilter={vi.fn()}
         selectedSession={null}
         setSelectedSession={vi.fn()}
       />
     );
     expect(screen.getByRole('tab', { name: 'すべて' })).toBeInTheDocument();
+  });
+
+  it('期間フィルタタブが表示される', () => {
+    render(
+      <SessionListSection
+        history={mockHistory}
+        filteredHistoryWithDelta={mockHistory}
+        filter="すべて"
+        setFilter={vi.fn()}
+        periodFilter="全期間"
+        setPeriodFilter={vi.fn()}
+        selectedSession={null}
+        setSelectedSession={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('tab', { name: '全期間' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '1週間' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '1ヶ月' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '3ヶ月' })).toBeInTheDocument();
+  });
+
+  it('期間フィルタ選択でsetPeriodFilterが呼ばれる', () => {
+    const mockSetPeriodFilter = vi.fn();
+    render(
+      <SessionListSection
+        history={mockHistory}
+        filteredHistoryWithDelta={mockHistory}
+        filter="すべて"
+        setFilter={vi.fn()}
+        periodFilter="全期間"
+        setPeriodFilter={mockSetPeriodFilter}
+        selectedSession={null}
+        setSelectedSession={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole('tab', { name: '1週間' }));
+    expect(mockSetPeriodFilter).toHaveBeenCalledWith('1週間');
   });
 });

--- a/frontend/src/hooks/__tests__/useScoreHistory.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreHistory.test.ts
@@ -310,4 +310,130 @@ describe('useScoreHistory', () => {
 
     expect(result.current.weakestAxis).toBeNull();
   });
+
+  it('期間フィルタ「1週間」で直近1週間のセッションのみ返す', async () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+    const mockData = [
+      { sessionId: 1, sessionTitle: '古い', overallScore: 6.0, scores: [], createdAt: tenDaysAgo },
+      { sessionId: 2, sessionTitle: '新しい', overallScore: 8.0, scores: [], createdAt: twoDaysAgo },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.setPeriodFilter('1週間');
+    });
+
+    expect(result.current.filteredHistory).toHaveLength(1);
+    expect(result.current.filteredHistory[0].sessionTitle).toBe('新しい');
+  });
+
+  it('期間フィルタ「1ヶ月」で直近1ヶ月のセッションのみ返す', async () => {
+    const now = new Date();
+    const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString();
+    const fiftyDaysAgo = new Date(now.getTime() - 50 * 24 * 60 * 60 * 1000).toISOString();
+
+    const mockData = [
+      { sessionId: 1, sessionTitle: '古い', overallScore: 5.0, scores: [], createdAt: fiftyDaysAgo },
+      { sessionId: 2, sessionTitle: '新しい', overallScore: 7.5, scores: [], createdAt: fiveDaysAgo },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.setPeriodFilter('1ヶ月');
+    });
+
+    expect(result.current.filteredHistory).toHaveLength(1);
+    expect(result.current.filteredHistory[0].sessionTitle).toBe('新しい');
+  });
+
+  it('期間フィルタ「3ヶ月」で直近3ヶ月のセッションのみ返す', async () => {
+    const now = new Date();
+    const twentyDaysAgo = new Date(now.getTime() - 20 * 24 * 60 * 60 * 1000).toISOString();
+    const hundredDaysAgo = new Date(now.getTime() - 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const mockData = [
+      { sessionId: 1, sessionTitle: '古い', overallScore: 4.0, scores: [], createdAt: hundredDaysAgo },
+      { sessionId: 2, sessionTitle: '新しい', overallScore: 8.0, scores: [], createdAt: twentyDaysAgo },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.setPeriodFilter('3ヶ月');
+    });
+
+    expect(result.current.filteredHistory).toHaveLength(1);
+    expect(result.current.filteredHistory[0].sessionTitle).toBe('新しい');
+  });
+
+  it('期間フィルタ「全期間」で全セッションを返す', async () => {
+    const now = new Date();
+    const oneYearAgo = new Date(now.getTime() - 365 * 24 * 60 * 60 * 1000).toISOString();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+    const mockData = [
+      { sessionId: 1, sessionTitle: '古い', overallScore: 5.0, scores: [], createdAt: oneYearAgo },
+      { sessionId: 2, sessionTitle: '新しい', overallScore: 9.0, scores: [], createdAt: yesterday },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(2);
+    });
+
+    act(() => {
+      result.current.setPeriodFilter('全期間');
+    });
+
+    expect(result.current.filteredHistory).toHaveLength(2);
+  });
+
+  it('期間フィルタとセッション種別フィルタを組み合わせて使える', async () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const tenDaysAgo = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+    const mockData = [
+      { sessionId: 1, sessionTitle: '練習: 古い', overallScore: 5.0, scores: [], createdAt: tenDaysAgo },
+      { sessionId: 2, sessionTitle: 'フリー新しい', overallScore: 7.0, scores: [], createdAt: twoDaysAgo },
+      { sessionId: 3, sessionTitle: '練習: 新しい', overallScore: 8.0, scores: [], createdAt: twoDaysAgo },
+    ];
+    mockFetchScoreHistory.mockResolvedValue(mockData);
+
+    const { result } = renderHook(() => useScoreHistory());
+
+    await waitFor(() => {
+      expect(result.current.history).toHaveLength(3);
+    });
+
+    act(() => {
+      result.current.setPeriodFilter('1週間');
+      result.current.setFilter('練習');
+    });
+
+    expect(result.current.filteredHistory).toHaveLength(1);
+    expect(result.current.filteredHistory[0].sessionTitle).toBe('練習: 新しい');
+  });
 });

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -9,7 +9,7 @@ import { useScoreGoal } from '../hooks/useScoreGoal';
 
 export default function ScoreHistoryPage() {
   const navigate = useNavigate();
-  const { history, filteredHistoryWithDelta, filter, setFilter, loading, latestSession, averageScore, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
+  const { history, filteredHistoryWithDelta, filter, setFilter, periodFilter, setPeriodFilter, loading, latestSession, averageScore, weakestAxis, selectedSession, setSelectedSession } = useScoreHistory();
   const { goal: scoreGoal } = useScoreGoal();
 
   if (loading) {
@@ -52,6 +52,8 @@ export default function ScoreHistoryPage() {
         filteredHistoryWithDelta={filteredHistoryWithDelta}
         filter={filter}
         setFilter={setFilter}
+        periodFilter={periodFilter}
+        setPeriodFilter={setPeriodFilter}
         selectedSession={selectedSession}
         setSelectedSession={setSelectedSession}
       />


### PR DESCRIPTION
## 概要
スコア履歴ページにセッション種別フィルタに加え、期間ベースのフィルタリング機能を追加。

## 変更内容
- `useScoreHistory` に `periodFilter` / `setPeriodFilter` を追加
- 期間オプション: 全期間 / 1週間 / 1ヶ月 / 3ヶ月
- `SessionListSection` に期間フィルタタブUI追加
- セッション種別フィルタ（すべて/練習/フリー）と組み合わせ可能

## テスト
- useScoreHistoryテスト: 各期間フィルタ5件 + 組み合わせテスト1件
- SessionListSectionテスト: 期間フィルタUI表示・操作テスト2件
- 全2042テストパス

closes #1137