### PR TITLE
refactor: CognitoAuthControllerのビジネスロジックをUseCase層に抽出

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoCallbackUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoCallbackUseCase.java
@@ -1,0 +1,110 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.AccessTokenService;
+import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.utils.JwtUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CognitoCallbackUseCase {
+
+    @Value("${cognito.client-id}")
+    private String clientId;
+
+    @Value("${cognito.client-secret}")
+    private String clientSecret;
+
+    @Value("${cognito.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${cognito.token-uri}")
+    private String tokenUri;
+
+    private final WebClient webClient;
+    private final UserService userService;
+    private final AccessTokenService accessTokenService;
+
+    public record Result(String accessToken, String refreshToken, String email, String cognitoUsername) {}
+
+    public Result execute(String code) {
+        log.info("CognitoCallbackUseCase: OIDCコールバック処理開始");
+
+        Map<String, Object> tokenResponse = exchangeCodeForTokens(code);
+
+        if (tokenResponse == null) {
+            throw new IllegalStateException("トークン取得に失敗しました。");
+        }
+
+        String idToken = (String) tokenResponse.get("id_token");
+        String accessToken = (String) tokenResponse.get("access_token");
+        String refreshToken = (String) tokenResponse.get("refresh_token");
+
+        Optional<JWTClaimsSet> claimsOpt = JwtUtils.decode(idToken);
+        if (claimsOpt.isEmpty()) {
+            throw new IllegalStateException("無効なIDトークンです。");
+        }
+
+        try {
+            JWTClaimsSet claims = claimsOpt.get();
+            String name = claims.getStringClaim("name");
+            String email = claims.getStringClaim("email");
+            String sub = claims.getSubject();
+
+            boolean isGoogle = claims.getClaim("identities") != null;
+            String provider = isGoogle ? "google" : "cognito";
+
+            User user = userService.registerUserOIDC(name, email, provider, sub);
+
+            Object cognitoUsernameObj = claims.getClaim("cognito:username");
+            String cognitoUsername = cognitoUsernameObj != null ? cognitoUsernameObj.toString() : sub;
+
+            accessTokenService.saveTokens(user, accessToken, refreshToken);
+
+            log.info("CognitoCallbackUseCase: OIDCコールバック処理完了 - userId: {}", user.getId());
+            return new Result(accessToken, refreshToken, email, cognitoUsername);
+
+        } catch (Exception e) {
+            log.error("CognitoCallbackUseCase: OIDCコールバック処理中にエラー: {}", e.getMessage(), e);
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private Map<String, Object> exchangeCodeForTokens(String code) {
+        String basicAuthValue = Base64.getEncoder()
+                .encodeToString((clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8));
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("grant_type", "authorization_code");
+        formData.add("code", code);
+        formData.add("redirect_uri", redirectUri);
+        formData.add("client_id", clientId);
+
+        return webClient.post()
+                .uri(tokenUri)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .header(HttpHeaders.AUTHORIZATION, "Basic " + basicAuthValue)
+                .body(BodyInserters.fromFormData(formData))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoConfirmUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoConfirmUseCase.java
@@ -1,0 +1,25 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CognitoConfirmUseCase {
+
+    private final CognitoAuthService cognitoAuthService;
+    private final UserService userService;
+
+    public void execute(String email, String code) {
+        log.info("CognitoConfirmUseCase: サインアップ確認処理開始 - email: {}", email);
+
+        cognitoAuthService.confirmUserSignup(email, code);
+        userService.activeUser(email);
+
+        log.info("CognitoConfirmUseCase: サインアップ確認処理完了 - email: {}", email);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoRefreshTokenUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoRefreshTokenUseCase.java
@@ -1,0 +1,33 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.entity.AccessToken;
+import com.example.FreStyle.service.AccessTokenService;
+import com.example.FreStyle.service.CognitoAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CognitoRefreshTokenUseCase {
+
+    private final AccessTokenService accessTokenService;
+    private final CognitoAuthService cognitoAuthService;
+
+    public record Result(String newAccessToken) {}
+
+    public Result execute(String refreshToken, String username) {
+        log.info("CognitoRefreshTokenUseCase: トークン更新処理開始");
+
+        AccessToken accessTokenEntity = accessTokenService.findAccessTokenByRefreshToken(refreshToken);
+        Map<String, String> tokens = cognitoAuthService.refreshAccessToken(refreshToken, username);
+
+        accessTokenService.updateTokens(accessTokenEntity, tokens.get("accessToken"));
+
+        log.info("CognitoRefreshTokenUseCase: トークン更新処理完了");
+        return new Result(tokens.get("accessToken"));
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoSignupUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoSignupUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.form.SignupForm;
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CognitoSignupUseCase {
+
+    private final CognitoAuthService cognitoAuthService;
+    private final UserService userService;
+
+    public void execute(SignupForm form) {
+        log.info("CognitoSignupUseCase: サインアップ処理開始 - email: {}", form.getEmail());
+
+        cognitoAuthService.signUpUser(form.getEmail(), form.getPassword(), form.getName());
+        userService.registerUser(form);
+
+        log.info("CognitoSignupUseCase: サインアップ処理完了 - email: {}", form.getEmail());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoCallbackUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoCallbackUseCaseTest.java
@@ -1,0 +1,163 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.AccessTokenService;
+import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.utils.JwtUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CognitoCallbackUseCaseTest {
+
+    @Mock private WebClient webClient;
+    @Mock private UserService userService;
+    @Mock private AccessTokenService accessTokenService;
+
+    @InjectMocks
+    private CognitoCallbackUseCase cognitoCallbackUseCase;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(cognitoCallbackUseCase, "clientId", "test-client-id");
+        ReflectionTestUtils.setField(cognitoCallbackUseCase, "clientSecret", "test-client-secret");
+        ReflectionTestUtils.setField(cognitoCallbackUseCase, "redirectUri", "https://example.com/callback");
+        ReflectionTestUtils.setField(cognitoCallbackUseCase, "tokenUri", "https://cognito.example.com/oauth2/token");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setupWebClientMock(Mono<?> responseMono) {
+        WebClient.RequestBodyUriSpec requestBodyUriSpec = mock(WebClient.RequestBodyUriSpec.class);
+        WebClient.RequestBodySpec requestBodySpec = mock(WebClient.RequestBodySpec.class);
+        WebClient.RequestHeadersSpec requestHeadersSpec = mock(WebClient.RequestHeadersSpec.class);
+        WebClient.ResponseSpec responseSpec = mock(WebClient.ResponseSpec.class);
+
+        when(webClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.header(anyString(), anyString())).thenReturn(requestBodySpec);
+        doReturn(requestHeadersSpec).when(requestBodySpec).body(any());
+        when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+        doReturn(responseMono).when(responseSpec).bodyToMono(any(ParameterizedTypeReference.class));
+    }
+
+    @Test
+    @DisplayName("OIDCコールバック成功時にユーザー登録・トークン保存・Result返却が行われる")
+    void returnsResultOnSuccess() throws Exception {
+        User user = new User();
+        user.setId(1);
+
+        Map<String, Object> tokenResponse = Map.of(
+                "id_token", "id-token-value",
+                "access_token", "access-token-value",
+                "refresh_token", "refresh-token-value");
+
+        setupWebClientMock(Mono.just(tokenResponse));
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject("sub-123")
+                .claim("name", "テストユーザー")
+                .claim("email", "test@example.com")
+                .claim("cognito:username", "google_12345")
+                .claim("identities", "google")
+                .build();
+
+        when(userService.registerUserOIDC("テストユーザー", "test@example.com", "google", "sub-123"))
+                .thenReturn(user);
+
+        try (MockedStatic<JwtUtils> jwtUtilsMock = mockStatic(JwtUtils.class)) {
+            jwtUtilsMock.when(() -> JwtUtils.decode("id-token-value"))
+                    .thenReturn(Optional.of(claims));
+
+            CognitoCallbackUseCase.Result result = cognitoCallbackUseCase.execute("auth-code-123");
+
+            assertThat(result.accessToken()).isEqualTo("access-token-value");
+            assertThat(result.refreshToken()).isEqualTo("refresh-token-value");
+            assertThat(result.email()).isEqualTo("test@example.com");
+            assertThat(result.cognitoUsername()).isEqualTo("google_12345");
+
+            verify(accessTokenService).saveTokens(user, "access-token-value", "refresh-token-value");
+        }
+    }
+
+    @Test
+    @DisplayName("トークンレスポンスがnullの場合に例外をスローする")
+    void throwsWhenTokenResponseIsNull() {
+        setupWebClientMock(Mono.empty());
+
+        assertThatThrownBy(() -> cognitoCallbackUseCase.execute("auth-code-123"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("トークン取得に失敗しました。");
+    }
+
+    @Test
+    @DisplayName("IDトークンのデコード失敗時に例外をスローする")
+    void throwsWhenIdTokenDecodeFails() {
+        Map<String, Object> tokenResponse = Map.of(
+                "id_token", "invalid-token",
+                "access_token", "access-token",
+                "refresh_token", "refresh-token");
+
+        setupWebClientMock(Mono.just(tokenResponse));
+
+        try (MockedStatic<JwtUtils> jwtUtilsMock = mockStatic(JwtUtils.class)) {
+            jwtUtilsMock.when(() -> JwtUtils.decode("invalid-token"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cognitoCallbackUseCase.execute("auth-code-123"))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("無効なIDトークンです。");
+        }
+    }
+
+    @Test
+    @DisplayName("cognito:usernameがない場合はsubをcognitoUsernameとして使用する")
+    void usesSubAsCognitoUsernameWhenAbsent() throws Exception {
+        User user = new User();
+        user.setId(1);
+
+        Map<String, Object> tokenResponse = Map.of(
+                "id_token", "id-token-value",
+                "access_token", "access-token-value",
+                "refresh_token", "refresh-token-value");
+
+        setupWebClientMock(Mono.just(tokenResponse));
+
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .subject("sub-456")
+                .claim("name", "テストユーザー")
+                .claim("email", "test@example.com")
+                .build();
+
+        when(userService.registerUserOIDC("テストユーザー", "test@example.com", "cognito", "sub-456"))
+                .thenReturn(user);
+
+        try (MockedStatic<JwtUtils> jwtUtilsMock = mockStatic(JwtUtils.class)) {
+            jwtUtilsMock.when(() -> JwtUtils.decode("id-token-value"))
+                    .thenReturn(Optional.of(claims));
+
+            CognitoCallbackUseCase.Result result = cognitoCallbackUseCase.execute("auth-code-123");
+
+            assertThat(result.cognitoUsername()).isEqualTo("sub-456");
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoConfirmUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoConfirmUseCaseTest.java
@@ -1,0 +1,44 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CognitoConfirmUseCaseTest {
+
+    @Mock private CognitoAuthService cognitoAuthService;
+    @Mock private UserService userService;
+
+    @InjectMocks
+    private CognitoConfirmUseCase cognitoConfirmUseCase;
+
+    @Test
+    @DisplayName("確認成功時にCognito確認とユーザー有効化が行われる")
+    void confirmsAndActivatesUser() {
+        cognitoConfirmUseCase.execute("test@example.com", "123456");
+
+        verify(cognitoAuthService).confirmUserSignup("test@example.com", "123456");
+        verify(userService).activeUser("test@example.com");
+    }
+
+    @Test
+    @DisplayName("Cognito確認失敗時にユーザー有効化が呼ばれない")
+    void doesNotActivateWhenCognitoFails() {
+        doThrow(new RuntimeException("Code mismatch"))
+                .when(cognitoAuthService).confirmUserSignup("test@example.com", "wrong-code");
+
+        assertThatThrownBy(() -> cognitoConfirmUseCase.execute("test@example.com", "wrong-code"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(userService, never()).activeUser(any());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoRefreshTokenUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoRefreshTokenUseCaseTest.java
@@ -1,0 +1,75 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.entity.AccessToken;
+import com.example.FreStyle.service.AccessTokenService;
+import com.example.FreStyle.service.AuthCookieService;
+import com.example.FreStyle.service.CognitoAuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CognitoRefreshTokenUseCaseTest {
+
+    @Mock private AccessTokenService accessTokenService;
+    @Mock private CognitoAuthService cognitoAuthService;
+
+    @InjectMocks
+    private CognitoRefreshTokenUseCase cognitoRefreshTokenUseCase;
+
+    @Test
+    @DisplayName("リフレッシュトークン更新成功時にResult（新トークン情報）を返す")
+    void returnsResultOnSuccess() {
+        AccessToken accessTokenEntity = new AccessToken();
+
+        when(accessTokenService.findAccessTokenByRefreshToken("refresh-token-123"))
+                .thenReturn(accessTokenEntity);
+        when(cognitoAuthService.refreshAccessToken("refresh-token-123", "testuser"))
+                .thenReturn(Map.of("accessToken", "new-access-token"));
+
+        CognitoRefreshTokenUseCase.Result result =
+                cognitoRefreshTokenUseCase.execute("refresh-token-123", "testuser");
+
+        assertThat(result.newAccessToken()).isEqualTo("new-access-token");
+
+        verify(accessTokenService).updateTokens(accessTokenEntity, "new-access-token");
+    }
+
+    @Test
+    @DisplayName("無効なリフレッシュトークンで例外をスローする")
+    void throwsWhenRefreshTokenInvalid() {
+        when(accessTokenService.findAccessTokenByRefreshToken("invalid-token"))
+                .thenThrow(new RuntimeException("無効なリフレッシュトークンです。"));
+
+        assertThatThrownBy(() -> cognitoRefreshTokenUseCase.execute("invalid-token", "testuser"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("無効なリフレッシュトークンです。");
+
+        verify(cognitoAuthService, never()).refreshAccessToken(any(), any());
+    }
+
+    @Test
+    @DisplayName("Cognitoトークン更新失敗時に例外をスローする")
+    void throwsWhenCognitoRefreshFails() {
+        AccessToken accessTokenEntity = new AccessToken();
+
+        when(accessTokenService.findAccessTokenByRefreshToken("refresh-token-123"))
+                .thenReturn(accessTokenEntity);
+        when(cognitoAuthService.refreshAccessToken("refresh-token-123", "testuser"))
+                .thenThrow(new RuntimeException("リフレッシュトークンが無効です。"));
+
+        assertThatThrownBy(() -> cognitoRefreshTokenUseCase.execute("refresh-token-123", "testuser"))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(accessTokenService, never()).updateTokens(any(), any());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoSignupUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CognitoSignupUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.example.FreStyle.usecase;
+
+import com.example.FreStyle.form.SignupForm;
+import com.example.FreStyle.service.CognitoAuthService;
+import com.example.FreStyle.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CognitoSignupUseCaseTest {
+
+    @Mock private CognitoAuthService cognitoAuthService;
+    @Mock private UserService userService;
+
+    @InjectMocks
+    private CognitoSignupUseCase cognitoSignupUseCase;
+
+    @Test
+    @DisplayName("サインアップ成功時にCognitoとDBの両方にユーザーが登録される")
+    void registersUserInCognitoAndDb() {
+        SignupForm form = new SignupForm("test@example.com", "password123", "テストユーザー");
+
+        cognitoSignupUseCase.execute(form);
+
+        verify(cognitoAuthService).signUpUser("test@example.com", "password123", "テストユーザー");
+        verify(userService).registerUser(form);
+    }
+
+    @Test
+    @DisplayName("Cognito登録失敗時にDB登録が呼ばれない")
+    void doesNotRegisterInDbWhenCognitoFails() {
+        SignupForm form = new SignupForm("test@example.com", "password123", "テストユーザー");
+
+        doThrow(new RuntimeException("Cognito error"))
+                .when(cognitoAuthService).signUpUser("test@example.com", "password123", "テストユーザー");
+
+        assertThatThrownBy(() -> cognitoSignupUseCase.execute(form))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(userService, never()).registerUser(any());
+    }
+}


### PR DESCRIPTION
## 概要
CognitoAuthControllerに直接実装されていたビジネスロジックを4つのUseCase層に抽出し、コントローラーをHTTP関心事（リクエスト解析・レスポンス生成・エラーハンドリング）のみに限定。

## 変更内容
- **CognitoSignupUseCase**: サインアップ処理（Cognito登録 + DB登録の2ステップ）
- **CognitoConfirmUseCase**: サインアップ確認処理（Cognito確認 + ユーザー有効化）
- **CognitoCallbackUseCase**: OIDCコールバック処理（トークン交換 + JWT解析 + ユーザーOIDC登録 + トークン保存）
- **CognitoRefreshTokenUseCase**: リフレッシュトークン処理（トークン検証 + Cognito更新 + DB更新）
- CognitoAuthControllerからWebClient / UserService / AccessTokenServiceの直接依存を除去
- コントローラーは`@RequiredArgsConstructor`でUseCase群を注入するシンプルな構成に

## テスト
- 新規UseCase テスト: 11テスト（Signup 2 / Confirm 2 / Callback 4 / RefreshToken 3）
- コントローラーテスト: 30テスト（既存をUseCase検証に更新 + callback / refreshToken 追加）
- バックエンド全601テストパス（contextLoads除く）
- フロントエンド全2042テストパス

closes #1139