### PR TITLE
feat: メニューページにブックマーク済みシナリオカードを追加

### DIFF
--- a/frontend/src/components/BookmarkedScenariosCard.tsx
+++ b/frontend/src/components/BookmarkedScenariosCard.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { useBookmarkedScenarios } from '../hooks/useBookmarkedScenarios';
 import { useStartPracticeSession } from '../hooks/useStartPracticeSession';
+import { CATEGORY_LABEL, DIFFICULTY_LABEL } from '../constants/scenarioLabels';
 import Card from './Card';
 
 export default function BookmarkedScenariosCard() {
@@ -11,7 +12,7 @@ export default function BookmarkedScenariosCard() {
   if (loading || scenarios.length === 0) return null;
 
   return (
-    <Card>
+    <Card className="mb-6">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-xs font-semibold text-[var(--color-text-primary)]">ブックマーク済みシナリオ</h3>
         <button
@@ -30,7 +31,7 @@ export default function BookmarkedScenariosCard() {
             <div className="flex-1 min-w-0 mr-3">
               <p className="text-sm text-[var(--color-text-secondary)] truncate">{scenario.name}</p>
               <p className="text-[10px] text-[var(--color-text-faint)]">
-                {scenario.category}・{scenario.difficulty}
+                {CATEGORY_LABEL[scenario.category] ?? scenario.category}・{DIFFICULTY_LABEL[scenario.difficulty] ?? scenario.difficulty}
               </p>
             </div>
             <button

--- a/frontend/src/components/__tests__/BookmarkedScenariosCard.test.tsx
+++ b/frontend/src/components/__tests__/BookmarkedScenariosCard.test.tsx
@@ -14,8 +14,8 @@ vi.mock('../../hooks/useStartPracticeSession', () => ({
 import { useBookmarkedScenarios } from '../../hooks/useBookmarkedScenarios';
 
 const mockScenarios = [
-  { id: 1, name: 'クレーム対応', description: '説明1', category: 'ビジネス', roleName: '顧客', difficulty: '中級', systemPrompt: '' },
-  { id: 2, name: '会議ファシリテーション', description: '説明2', category: 'ビジネス', roleName: '同僚', difficulty: '上級', systemPrompt: '' },
+  { id: 1, name: 'クレーム対応', description: '説明1', category: 'customer', roleName: '顧客', difficulty: 'intermediate', systemPrompt: '' },
+  { id: 2, name: '会議ファシリテーション', description: '説明2', category: 'senior', roleName: '同僚', difficulty: 'advanced', systemPrompt: '' },
 ];
 
 describe('BookmarkedScenariosCard', () => {
@@ -41,8 +41,8 @@ describe('BookmarkedScenariosCard', () => {
 
     render(<BrowserRouter><BookmarkedScenariosCard /></BrowserRouter>);
 
-    expect(screen.getByText('ビジネス・中級')).toBeInTheDocument();
-    expect(screen.getByText('ビジネス・上級')).toBeInTheDocument();
+    expect(screen.getByText('顧客折衝・中級')).toBeInTheDocument();
+    expect(screen.getByText('シニア・上司・上級')).toBeInTheDocument();
   });
 
   it('ブックマークがない場合は何も表示しない', () => {

--- a/frontend/src/hooks/__tests__/useBookmarkedScenarios.test.ts
+++ b/frontend/src/hooks/__tests__/useBookmarkedScenarios.test.ts
@@ -18,9 +18,9 @@ import { BookmarkRepository } from '../../repositories/BookmarkRepository';
 import PracticeRepository from '../../repositories/PracticeRepository';
 
 const mockScenarios = [
-  { id: 1, name: 'クレーム対応', description: '説明1', category: 'ビジネス', roleName: '顧客', difficulty: '中級', systemPrompt: '' },
-  { id: 2, name: '会議ファシリテーション', description: '説明2', category: 'ビジネス', roleName: '同僚', difficulty: '上級', systemPrompt: '' },
-  { id: 3, name: '面接練習', description: '説明3', category: '就活', roleName: '面接官', difficulty: '初級', systemPrompt: '' },
+  { id: 1, name: 'クレーム対応', description: '説明1', category: 'customer', roleName: '顧客', difficulty: 'intermediate', systemPrompt: '' },
+  { id: 2, name: '会議ファシリテーション', description: '説明2', category: 'senior', roleName: '同僚', difficulty: 'advanced', systemPrompt: '' },
+  { id: 3, name: '面接練習', description: '説明3', category: 'team', roleName: '面接官', difficulty: 'beginner', systemPrompt: '' },
 ];
 
 describe('useBookmarkedScenarios', () => {

--- a/frontend/src/hooks/useBookmarkedScenarios.ts
+++ b/frontend/src/hooks/useBookmarkedScenarios.ts
@@ -8,11 +8,14 @@ export function useBookmarkedScenarios(limit = 3) {
 
   useEffect(() => {
     let cancelled = false;
+    setLoading(true);
+    setScenarios([]);
 
     Promise.all([BookmarkRepository.getAll(), PracticeRepository.getScenarios()])
       .then(([bookmarkedIds, allScenarios]) => {
         if (cancelled) return;
-        const bookmarked = allScenarios.filter((s) => bookmarkedIds.includes(s.id));
+        const bookmarkedIdSet = new Set(bookmarkedIds);
+        const bookmarked = allScenarios.filter((s) => bookmarkedIdSet.has(s.id));
         setScenarios(bookmarked.slice(0, limit));
         setLoading(false);
       })

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -161,9 +161,7 @@ export default function MenuPage() {
       )}
 
       {/* ブックマーク済みシナリオ */}
-      <div className="mb-6">
-        <BookmarkedScenariosCard />
-      </div>
+      <BookmarkedScenariosCard />
 
       {/* 最近のメモ */}
       <div className="mb-6">


### PR DESCRIPTION
## 概要
メニューページ（ホーム画面）にブックマーク済みの練習シナリオを表示するカードを追加。お気に入りのシナリオにメニューから直接アクセス・練習開始できる。

## 変更内容
- **useBookmarkedScenarios フック**: BookmarkRepository + PracticeRepository を結合し、ブックマーク済みシナリオの情報を取得
- **BookmarkedScenariosCard コンポーネント**: シナリオ名・カテゴリ・難易度表示、「練習開始」ボタンで即座にセッション開始
- **MenuPage**: 最近のメモカードの上にブックマーク済みシナリオカードを配置

## テスト
- useBookmarkedScenarios: 4テスト（正常取得、空、件数制限、ローディング）
- BookmarkedScenariosCard: 5テスト（タイトル表示、シナリオ名、カテゴリ・難易度、空状態、ローディング）
- フロントエンド全2051テストパス

closes #1143