### PR TITLE
test: ScoreCardService・EmojiPickerのテスト拡充

### DIFF
--- a/frontend/src/components/__tests__/EmojiPicker.test.tsx
+++ b/frontend/src/components/__tests__/EmojiPicker.test.tsx
@@ -58,4 +58,35 @@ describe('EmojiPicker', () => {
     // 検索結果に😀が含まれるはず
     expect(screen.getByTestId('emoji-picker')).toBeInTheDocument();
   });
+
+  it('カテゴリタブをクリックするとカテゴリが切り替わる', () => {
+    render(<EmojiPicker isOpen={true} onSelect={onSelect} onClose={onClose} />);
+    const handTab = screen.getByLabelText('手・体');
+    fireEvent.click(handTab);
+    // 「手・体」カテゴリ名が表示される
+    expect(screen.getByText('手・体')).toBeInTheDocument();
+  });
+
+  it('検索中はカテゴリタブが非表示になる', () => {
+    render(<EmojiPicker isOpen={true} onSelect={onSelect} onClose={onClose} />);
+    fireEvent.change(screen.getByPlaceholderText('絵文字を検索...'), {
+      target: { value: 'test' },
+    });
+    // カテゴリタブのaria-labelが見つからない
+    expect(screen.queryByLabelText('よく使う')).not.toBeInTheDocument();
+  });
+
+  it('検索結果がない場合はメッセージが表示される', () => {
+    render(<EmojiPicker isOpen={true} onSelect={onSelect} onClose={onClose} />);
+    fireEvent.change(screen.getByPlaceholderText('絵文字を検索...'), {
+      target: { value: 'zzzznotfound' },
+    });
+    expect(screen.getByText('該当する絵文字がありません')).toBeInTheDocument();
+  });
+
+  it('Escape以外のキーではonCloseが呼ばれない', () => {
+    render(<EmojiPicker isOpen={true} onSelect={onSelect} onClose={onClose} />);
+    fireEvent.keyDown(screen.getByPlaceholderText('絵文字を検索...'), { key: 'Enter' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## 概要
テストカバレッジが低い重要コンポーネントのテストを拡充

## 変更内容

### バックエンド: ScoreCardService (10→15テスト)
- 複数JSONブロックがある場合の最初のブロック使用
- 軸データにフィールド欠損がある場合のデフォルト値
- scoresがオブジェクト型の場合のハンドリング
- JSONブロック内の空白・改行の許容
- テスト追加: +5テスト

### フロントエンド: EmojiPicker (7→11テスト)
- カテゴリタブ切り替え動作
- 検索中のカテゴリタブ非表示
- 検索結果なし時のメッセージ表示
- Escape以外のキーでonCloseが呼ばれないこと
- テスト追加: +4テスト

## テスト
- `./gradlew test --tests ScoreCardServiceTest`: 15テスト全パス
- `npx vitest run EmojiPicker.test.tsx`: 11テスト全パス

Closes #1147