### PR TITLE
feat: セッション詳細モーダルに「会話を見る」ボタン追加

### DIFF
--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import type { ScoreHistoryItem } from '../types';
 import AxisScoreBar from './AxisScoreBar';
 
@@ -7,6 +8,8 @@ interface SessionDetailModalProps {
 }
 
 export default function SessionDetailModal({ session, onClose }: SessionDetailModalProps) {
+  const navigate = useNavigate();
+
   return (
     <div
       data-testid="modal-overlay"
@@ -63,12 +66,20 @@ export default function SessionDetailModal({ session, onClose }: SessionDetailMo
             ))}
           </div>
 
-          <button
-            onClick={onClose}
-            className="w-full mt-4 py-2 text-xs font-medium text-[var(--color-text-tertiary)] bg-surface-3 rounded-lg hover:bg-surface-3 transition-colors"
-          >
-            閉じる
-          </button>
+          <div className="flex gap-2 mt-4">
+            <button
+              onClick={() => navigate(`/chat/ask-ai/${session.sessionId}`)}
+              className="flex-1 py-2 text-xs font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-500 transition-colors"
+            >
+              会話を見る
+            </button>
+            <button
+              onClick={onClose}
+              className="flex-1 py-2 text-xs font-medium text-[var(--color-text-tertiary)] bg-surface-3 rounded-lg hover:bg-surface-3 transition-colors"
+            >
+              閉じる
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/__tests__/SessionDetailModal.test.tsx
+++ b/frontend/src/components/__tests__/SessionDetailModal.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import SessionDetailModal from '../SessionDetailModal';
 
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
 const session = {
   sessionId: 1,
   sessionTitle: '障害報告の練習',
@@ -59,5 +64,13 @@ describe('SessionDetailModal', () => {
 
     fireEvent.click(screen.getByTestId('modal-overlay'));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('「会話を見る」ボタンをクリックするとセッション画面に遷移する', () => {
+    const onClose = vi.fn();
+    render(<SessionDetailModal session={session} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '会話を見る' }));
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai/1');
   });
 });


### PR DESCRIPTION
## 概要
スコア履歴のセッション詳細モーダルに「会話を見る」ボタンを追加し、
スコア確認後にそのセッションのAI会話画面に直接遷移できるようにする。

## 変更内容
- **SessionDetailModal.tsx**: 「会話を見る」ボタン追加（`/chat/ask-ai/{sessionId}`に遷移）
- **SessionDetailModal.test.tsx**: 遷移テスト追加

## テスト
- `npm test` 全パス（7テスト）

closes #1155