### PR TITLE
refactor: ScenarioBookmarkControllerのJWT→User解決パターンをresolveUserに抽出 #1163

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScenarioBookmarkController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScenarioBookmarkController.java
@@ -37,8 +37,7 @@ public class ScenarioBookmarkController {
     @GetMapping
     public ResponseEntity<List<Integer>> getBookmarks(@AuthenticationPrincipal Jwt jwt) {
         logger.info("========== GET /api/bookmarks ==========");
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         List<Integer> bookmarkedIds = getUserBookmarksUseCase.execute(user.getId());
         logger.info("ブックマーク一覧取得成功 - 件数: {}", bookmarkedIds.size());
         return ResponseEntity.ok(bookmarkedIds);
@@ -50,8 +49,7 @@ public class ScenarioBookmarkController {
             @PathVariable Integer scenarioId
     ) {
         logger.info("========== POST /api/bookmarks/{} ==========", scenarioId);
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         addScenarioBookmarkUseCase.execute(user, scenarioId);
         logger.info("ブックマーク追加成功 - scenarioId: {}", scenarioId);
         return ResponseEntity.ok().build();
@@ -63,10 +61,13 @@ public class ScenarioBookmarkController {
             @PathVariable Integer scenarioId
     ) {
         logger.info("========== DELETE /api/bookmarks/{} ==========", scenarioId);
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         removeScenarioBookmarkUseCase.execute(user.getId(), scenarioId);
         logger.info("ブックマーク削除成功 - scenarioId: {}", scenarioId);
         return ResponseEntity.ok().build();
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
     }
 }


### PR DESCRIPTION
## 概要
ScenarioBookmarkController内で重複していた「JWT subject → User 解決」処理を `resolveUser(Jwt)` に集約し、NoteController・AiChatController等と同一パターンに統一。

## 変更内容
- `private User resolveUser(Jwt jwt)` メソッドを追加
- 3つのエンドポイント（GET, POST, DELETE）で `resolveUser(jwt)` を使用するよう統一
- 動作の変更なし（純粋なリファクタリング）

## テスト結果
- ScenarioBookmarkControllerTest: 全パス

closes #1163