### PR TITLE
feat: 練習結果サマリーに「もう一度練習」ボタン追加 #1167

### DIFF
--- a/frontend/src/components/PracticeResultSummary.tsx
+++ b/frontend/src/components/PracticeResultSummary.tsx
@@ -1,14 +1,17 @@
 import { useNavigate } from 'react-router-dom';
 import { getAdviceForAxis } from '../constants/axisAdvice';
+import { useStartPracticeSession } from '../hooks/useStartPracticeSession';
 import type { ScoreCard } from '../types';
 
 interface PracticeResultSummaryProps {
   scoreCard: ScoreCard;
   scenarioName: string;
+  scenarioId?: number;
 }
 
-export default function PracticeResultSummary({ scoreCard, scenarioName }: PracticeResultSummaryProps) {
+export default function PracticeResultSummary({ scoreCard, scenarioName, scenarioId }: PracticeResultSummaryProps) {
   const navigate = useNavigate();
+  const { startSession, starting } = useStartPracticeSession();
 
   const scores = Array.isArray(scoreCard.scores) ? scoreCard.scores : [];
   if (scores.length === 0) return null;
@@ -46,13 +49,23 @@ export default function PracticeResultSummary({ scoreCard, scenarioName }: Pract
         <p className="text-xs text-amber-800">{advice}</p>
       </div>
 
-      {/* 次の練習へ */}
-      <button
-        onClick={() => navigate('/practice')}
-        className="w-full py-2 text-sm font-medium text-primary-400 bg-surface-2 hover:bg-surface-3 rounded-lg transition-colors"
-      >
-        次の練習へ
-      </button>
+      <div className="flex flex-col gap-2">
+        {scenarioId && (
+          <button
+            onClick={() => startSession({ id: scenarioId, name: scenarioName })}
+            disabled={starting}
+            className="w-full py-2 text-sm font-medium text-white bg-primary-600 hover:bg-primary-500 disabled:opacity-50 rounded-lg transition-colors"
+          >
+            もう一度練習
+          </button>
+        )}
+        <button
+          onClick={() => navigate('/practice')}
+          className="w-full py-2 text-sm font-medium text-primary-400 bg-surface-2 hover:bg-surface-3 rounded-lg transition-colors"
+        >
+          次の練習へ
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
+++ b/frontend/src/components/__tests__/PracticeResultSummary.test.tsx
@@ -8,6 +8,11 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const mockStartSession = vi.fn();
+vi.mock('../../hooks/useStartPracticeSession', () => ({
+  useStartPracticeSession: () => ({ startSession: mockStartSession, starting: false }),
+}));
+
 describe('PracticeResultSummary', () => {
   const scoreCard: ScoreCard = {
     sessionId: 1,
@@ -23,6 +28,7 @@ describe('PracticeResultSummary', () => {
 
   beforeEach(() => {
     mockNavigate.mockClear();
+    mockStartSession.mockClear();
   });
 
   it('練習結果サマリーのタイトルが表示される', () => {
@@ -91,5 +97,24 @@ describe('PracticeResultSummary', () => {
 
     expect(screen.getByText('強み')).toBeInTheDocument();
     expect(screen.getByText('課題')).toBeInTheDocument();
+  });
+
+  it('scenarioIdがある場合「もう一度練習」ボタンが表示される', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" scenarioId={5} />);
+
+    expect(screen.getByRole('button', { name: 'もう一度練習' })).toBeInTheDocument();
+  });
+
+  it('「もう一度練習」ボタンをクリックすると同じシナリオでセッション開始する', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" scenarioId={5} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'もう一度練習' }));
+    expect(mockStartSession).toHaveBeenCalledWith({ id: 5, name: '障害報告' });
+  });
+
+  it('scenarioIdがない場合「もう一度練習」ボタンは表示されない', () => {
+    render(<PracticeResultSummary scoreCard={scoreCard} scenarioName="障害報告" />);
+
+    expect(screen.queryByRole('button', { name: 'もう一度練習' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -176,6 +176,7 @@ export function useAskAi() {
     scoreCard,
     messagesEndRef,
     isPracticeMode,
+    scenarioId,
     scenarioName,
 
     // セッション管理

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -24,6 +24,7 @@ export default function AskAiPage() {
     scoreCard,
     messagesEndRef,
     isPracticeMode,
+    scenarioId,
     scenarioName,
     currentSessionId,
     deleteModal,
@@ -144,7 +145,7 @@ export default function AskAiPage() {
             <div className="max-w-3xl mx-auto w-full space-y-3">
               <ScoreCardComponent scoreCard={scoreCard} />
               {isPracticeMode && (
-                <PracticeResultSummary scoreCard={scoreCard} scenarioName={scenarioName || '練習'} />
+                <PracticeResultSummary scoreCard={scoreCard} scenarioName={scenarioName || '練習'} scenarioId={scenarioId ?? undefined} />
               )}
               {currentSessionId && (
                 <SessionNoteEditor sessionId={currentSessionId} />


### PR DESCRIPTION
## 概要
練習結果表示後に同じシナリオで再練習できる「もう一度練習」ボタンを追加。

## 変更内容
- **PracticeResultSummary**: `scenarioId` propを追加、`useStartPracticeSession`で同じシナリオの新セッション開始
- **useAskAi**: `scenarioId`をreturnオブジェクトに追加
- **AskAiPage**: PracticeResultSummaryにscenarioIdを渡す

## テスト
- PracticeResultSummary.test.tsx: 3テスト追加（リトライボタン表示、クリック動作、非表示条件）
- フロントエンド全テスト: 256ファイル全パス、2073テスト全パス

closes #1167