### PR TITLE
refactor: DailyGoalControllerのJWT→User解決パターンをresolveUserに抽出 #1169

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/DailyGoalController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/DailyGoalController.java
@@ -33,8 +33,7 @@ public class DailyGoalController {
 
     @GetMapping("/today")
     public ResponseEntity<DailyGoalDto> getToday(@AuthenticationPrincipal Jwt jwt) {
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         DailyGoalDto dto = getTodayDailyGoalUseCase.execute(user.getId());
         return ResponseEntity.ok(dto);
     }
@@ -43,17 +42,19 @@ public class DailyGoalController {
     public ResponseEntity<Void> setTarget(
             @AuthenticationPrincipal Jwt jwt,
             @RequestBody Map<String, Integer> body) {
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         setDailyGoalTargetUseCase.execute(user, body.get("target"));
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/increment")
     public ResponseEntity<DailyGoalDto> increment(@AuthenticationPrincipal Jwt jwt) {
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         DailyGoalDto dto = incrementDailyGoalUseCase.execute(user);
         return ResponseEntity.ok(dto);
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
     }
 }


### PR DESCRIPTION
## 概要
DailyGoalController内で重複していた「JWT subject → User 解決」処理を `resolveUser(Jwt)` に集約。

## 変更内容
- `private User resolveUser(Jwt jwt)` メソッドを追加
- 3つのエンドポイント（getToday, setTarget, increment）で `resolveUser(jwt)` を使用するよう統一
- 動作の変更なし（純粋なリファクタリング）

## テスト結果
- DailyGoalControllerTest: 全8テストパス

closes #1169