### PR TITLE
SessionNoteControllerのJWT→User解決パターンをresolveUserに抽出

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/SessionNoteController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/SessionNoteController.java
@@ -31,8 +31,7 @@ public class SessionNoteController {
     public ResponseEntity<SessionNoteDto> getNote(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer sessionId) {
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         SessionNoteDto dto = getSessionNoteUseCase.execute(user.getId(), sessionId);
         return ResponseEntity.ok(dto);
     }
@@ -42,10 +41,13 @@ public class SessionNoteController {
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer sessionId,
             @RequestBody SaveNoteRequest request) {
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
         saveSessionNoteUseCase.execute(user, sessionId, request.note());
         return ResponseEntity.ok().build();
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
     }
 
     public record SaveNoteRequest(String note) {}


### PR DESCRIPTION
## 概要
- SessionNoteControllerの2エンドポイントで重複していたJWT→User解決パターンを`resolveUser(Jwt)`プライベートメソッドに抽出

## 変更内容
- `getNote`、`saveNote`の各メソッドから`jwt.getSubject()`→`userIdentityService.findUserBySub(sub)`パターンを`resolveUser`に統一

## テスト
- SessionNoteControllerTest 全パス

closes #1181