### PR TITLE
refactor: ScoreGoalControllerのresolveUserパターン抽出

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreGoalController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreGoalController.java
@@ -28,7 +28,7 @@ public class ScoreGoalController {
 
     @GetMapping
     public ResponseEntity<ScoreGoalDto> getGoal(@AuthenticationPrincipal Jwt jwt) {
-        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        User user = resolveUser(jwt);
         ScoreGoalDto dto = getScoreGoalUseCase.execute(user.getId());
         if (dto == null) {
             return ResponseEntity.noContent().build();
@@ -38,9 +38,13 @@ public class ScoreGoalController {
 
     @PutMapping
     public ResponseEntity<Void> saveGoal(@AuthenticationPrincipal Jwt jwt, @RequestBody SaveGoalRequest request) {
-        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        User user = resolveUser(jwt);
         saveScoreGoalUseCase.execute(user, request.goalScore());
         return ResponseEntity.noContent().build();
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
     }
 
     public record SaveGoalRequest(Double goalScore) {}


### PR DESCRIPTION
## 概要
- ScoreGoalControllerの2つのエンドポイントで重複していたJWT→User解決パターンを`resolveUser(Jwt)`メソッドに抽出

## 変更内容
- `getGoal`: `userIdentityService.findUserBySub(jwt.getSubject())` → `resolveUser(jwt)`
- `saveGoal`: `userIdentityService.findUserBySub(jwt.getSubject())` → `resolveUser(jwt)`
- `resolveUser(Jwt)` privateメソッドを追加

## テスト
- `./gradlew test` 全テストパス

Closes #1187