### PR TITLE
feat: ノート一覧に読了時間を表示

### DIFF
--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -1,9 +1,11 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import { MapPinIcon as MapPinOutline } from '@heroicons/react/24/outline';
 import { MapPinIcon as MapPinSolid } from '@heroicons/react/24/solid';
 import { tiptapToPlainText } from '../utils/tiptapToPlainText';
 import { formatMonthDay } from '../utils/formatters';
+import { getNoteStats } from '../utils/noteStats';
+import ReadingTime from './ReadingTime';
 
 interface NoteListItemProps {
   noteId: string;
@@ -31,6 +33,7 @@ export default memo(function NoteListItem({
   const displayTitle = title || '無題';
   const preview = tiptapToPlainText(content).replace(/\n/g, ' ').slice(0, 60);
   const dateStr = formatMonthDay(updatedAt);
+  const stats = useMemo(() => getNoteStats(content), [content]);
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -68,7 +71,7 @@ export default memo(function NoteListItem({
             </p>
           )}
           <p className="text-[11px] text-[var(--color-text-faint)] mt-1">
-            {dateStr}
+            {dateStr} · <ReadingTime charCount={stats.charCount} />
           </p>
         </div>
         <div className="flex items-center gap-0.5">

--- a/frontend/src/components/__tests__/NoteListItem.test.tsx
+++ b/frontend/src/components/__tests__/NoteListItem.test.tsx
@@ -103,4 +103,14 @@ describe('NoteListItem', () => {
     const preview = screen.getByText('あ'.repeat(60));
     expect(preview).toBeInTheDocument();
   });
+
+  it('読了時間が表示される', () => {
+    render(<NoteListItem {...defaultProps} content="テスト内容" />);
+    expect(screen.getByText(/約\d+分/)).toBeInTheDocument();
+  });
+
+  it('空の内容では読了時間が約0分と表示される', () => {
+    render(<NoteListItem {...defaultProps} content="" />);
+    expect(screen.getByText('約0分')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- ノート一覧(NoteListItem)の日付の横に読了時間（約N分）を表示

## 変更内容
- `NoteListItem`に既存の`getNoteStats`と`ReadingTime`コンポーネントを統合
- 日付の横に「· 約N分」形式で読了時間を表示

## テスト
- 読了時間表示テスト追加
- 空の内容での読了時間テスト追加
- `npm test` 全テストパス

Closes #1191