### PR TITLE
refactor: PracticeControllerのresolveUserパターン抽出

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/PracticeController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/PracticeController.java
@@ -77,8 +77,7 @@ public class PracticeController {
         logger.info("========== GET /api/practice/scenarios ==========");
 
         // 認証チェック
-        String sub = jwt.getSubject();
-        userIdentityService.findUserBySub(sub);
+        resolveUser(jwt);
 
         // ユースケース実行
         List<PracticeScenarioDto> scenarios = getAllPracticeScenariosUseCase.execute();
@@ -104,8 +103,7 @@ public class PracticeController {
         logger.info("========== GET /api/practice/scenarios/{} ==========", scenarioId);
 
         // 認証チェック
-        String sub = jwt.getSubject();
-        userIdentityService.findUserBySub(sub);
+        resolveUser(jwt);
 
         // ユースケース実行
         PracticeScenarioDto scenario = getPracticeScenarioByIdUseCase.execute(scenarioId);
@@ -138,8 +136,7 @@ public class PracticeController {
         logger.info("========== POST /api/practice/sessions ==========");
 
         // 認証チェック & ユーザー取得
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
 
         // ユースケース実行
         AiChatSessionDto session = createPracticeSessionUseCase.execute(user, request.scenarioId());
@@ -154,5 +151,9 @@ public class PracticeController {
      * @param scenarioId 練習シナリオID
      */
     record CreatePracticeSessionRequest(Integer scenarioId) {}
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
+    }
 }
 


### PR DESCRIPTION
## 概要
- PracticeControllerの3つのエンドポイントで重複していたJWT→User解決パターンを`resolveUser(Jwt)`メソッドに抽出

## 変更内容
- `getScenarios`: `jwt.getSubject()` → `resolveUser(jwt)` → `resolveUser(jwt)`
- `getScenario`: `jwt.getSubject()` → `resolveUser(jwt)`
- `createPracticeSession`: `jwt.getSubject()` → `resolveUser(jwt)`
- `resolveUser(Jwt)` privateメソッドを追加

## テスト
- `./gradlew test` 全テストパス

Closes #1193