### PR TITLE
feat: ノート一覧にノート件数を表示

### DIFF
--- a/frontend/src/components/layout/SecondaryPanel.tsx
+++ b/frontend/src/components/layout/SecondaryPanel.tsx
@@ -2,13 +2,14 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 
 interface SecondaryPanelProps {
   title: string;
+  badge?: string;
   headerContent?: React.ReactNode;
   children: React.ReactNode;
   mobileOpen?: boolean;
   onMobileClose?: () => void;
 }
 
-export default function SecondaryPanel({ title, headerContent, children, mobileOpen = false, onMobileClose }: SecondaryPanelProps) {
+export default function SecondaryPanel({ title, badge, headerContent, children, mobileOpen = false, onMobileClose }: SecondaryPanelProps) {
   return (
     <>
       {/* モバイルオーバーレイ */}
@@ -26,7 +27,10 @@ export default function SecondaryPanel({ title, headerContent, children, mobileO
         }`}
       >
         <div className="px-4 py-3 border-b border-surface-3 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h2>
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+            {title}
+            {badge && <span className="ml-2 text-xs font-normal text-[var(--color-text-muted)]">{badge}</span>}
+          </h2>
           <button
             onClick={onMobileClose}
             className="p-1 hover:bg-surface-2 rounded transition-colors"
@@ -42,7 +46,10 @@ export default function SecondaryPanel({ title, headerContent, children, mobileO
       {/* デスクトップパネル */}
       <div className="hidden md:flex w-72 bg-surface-1 border-r border-surface-3 flex-col h-full flex-shrink-0">
         <div className="px-4 py-3 border-b border-surface-3">
-          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h2>
+          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+            {title}
+            {badge && <span className="ml-2 text-xs font-normal text-[var(--color-text-muted)]">{badge}</span>}
+          </h2>
           {headerContent && <div className="mt-2">{headerContent}</div>}
         </div>
         <div className="flex-1 overflow-y-auto">{children}</div>

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -74,6 +74,7 @@ export default function NotesPage() {
     <div className="flex h-full">
       <SecondaryPanel
         title="ノート"
+        badge={`${notes.length}件`}
         mobileOpen={mobilePanelOpen}
         onMobileClose={closeMobilePanel}
         headerContent={

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -318,6 +318,26 @@ describe('NotesPage', () => {
     expect(mockShowToast).toHaveBeenCalledWith('success', 'ノートを削除しました');
   });
 
+  it('ノートがある場合、件数が表示される', () => {
+    const noteList = [
+      { noteId: 'n1', userId: 1, title: 'テスト1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+      { noteId: 'n2', userId: 1, title: 'テスト2', content: '内容2', isPinned: false, createdAt: 1500, updatedAt: 3000 },
+      { noteId: 'n3', userId: 1, title: 'テスト3', content: '内容3', isPinned: false, createdAt: 2000, updatedAt: 4000 },
+    ];
+    vi.mocked(useNotes).mockReturnValue({
+      ...mockUseNotes,
+      notes: noteList,
+      filteredNotes: noteList,
+    });
+    render(<NotesPage />);
+    expect(screen.getAllByText('3件').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ノートが0件の場合、件数が表示される', () => {
+    render(<NotesPage />);
+    expect(screen.getAllByText('0件').length).toBeGreaterThanOrEqual(1);
+  });
+
   it('複数ノートがある場合、正しいノートのrequestDeleteが呼ばれる', () => {
     const noteList = [
       { noteId: 'n1', userId: 1, title: 'ノート1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },


### PR DESCRIPTION
## 概要
- ノート一覧パネルのタイトル横にノート件数バッジを表示

## 変更内容
- `SecondaryPanel`にオプショナルな`badge`プロパティを追加
- `NotesPage`で`badge={notes.length + '件'}`を渡す
- タイトル横に小さめのテキストで件数表示

## テスト
- ノート件数表示テスト2件追加
- `npm test` 全テストパス

Closes #1197