### PR TITLE
refactor: ScoreCardControllerのresolveUserパターン抽出

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreCardController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreCardController.java
@@ -43,8 +43,7 @@ public class ScoreCardController {
     ) {
         logger.info("========== GET /api/scores/sessions/{} ==========", sessionId);
 
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
 
         // 権限チェック
         getAiChatSessionByIdUseCase.execute(sessionId, user.getId());
@@ -64,12 +63,15 @@ public class ScoreCardController {
     ) {
         logger.info("========== GET /api/scores/history ==========");
 
-        String sub = jwt.getSubject();
-        User user = userIdentityService.findUserBySub(sub);
+        User user = resolveUser(jwt);
 
         List<ScoreHistoryDto> history = getScoreHistoryByUserIdUseCase.execute(user.getId());
         logger.info("✅ スコア履歴取得成功 - userId: {}, 件数: {}", user.getId(), history.size());
 
         return ResponseEntity.ok(history);
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
     }
 }


### PR DESCRIPTION
## 概要
- ScoreCardControllerの2つのエンドポイントで重複していたJWT→User解決パターンを`resolveUser(Jwt)`メソッドに抽出

## 変更内容
- `getSessionScoreCard`: `jwt.getSubject()` → `resolveUser(jwt)`
- `getScoreHistory`: `jwt.getSubject()` → `resolveUser(jwt)`
- `resolveUser(Jwt)` privateメソッドを追加

## テスト
- `./gradlew test` 全テストパス

Closes #1199