### PR TITLE
feat: AIセッション一覧にセッション件数を表示

### DIFF
--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -19,6 +19,7 @@ export default function AskAiPage() {
   const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
   const { copiedId, copyToClipboard } = useCopyToClipboard();
   const {
+    sessions,
     filteredSessions,
     messages,
     scoreCard,
@@ -50,6 +51,7 @@ export default function AskAiPage() {
       {/* セカンダリパネル: セッション一覧 */}
       <SecondaryPanel
         title="セッション"
+        badge={`${sessions.length}件`}
         mobileOpen={mobilePanelOpen}
         onMobileClose={closeMobilePanel}
         headerContent={

--- a/frontend/src/pages/__tests__/AskAiPage.test.tsx
+++ b/frontend/src/pages/__tests__/AskAiPage.test.tsx
@@ -166,4 +166,23 @@ describe('AskAiPage', () => {
     expect(screen.queryByText('AIが相手役を演じます')).not.toBeInTheDocument();
     expect(screen.queryByText('練習終了')).not.toBeInTheDocument();
   });
+
+  it('セッション件数が表示される', () => {
+    const sessionData = [
+      { id: 1, title: 'セッション1', createdAt: '2026-02-10T10:00:00Z' },
+      { id: 2, title: 'セッション2', createdAt: '2026-02-11T10:00:00Z' },
+    ];
+    vi.mocked(useAskAi).mockReturnValue({
+      ...mockUseAskAi,
+      sessions: sessionData as any,
+      filteredSessions: sessionData as any,
+    });
+    render(<AskAiPage />);
+    expect(screen.getAllByText('2件').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('セッション0件の場合、0件と表示される', () => {
+    render(<AskAiPage />);
+    expect(screen.getAllByText('0件').length).toBeGreaterThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
## 概要
- AIセッション一覧パネルのタイトル横にセッション件数バッジを表示
- NotesPageと同じパターンで統一的なUI

## 変更内容
- `AskAiPage`のSecondaryPanelに`badge`プロパティ追加
- `sessions`をdestructureに追加

## テスト
- セッション件数表示テスト2件追加
- `npm test` 全テストパス

Closes #1203