### PR TITLE
feat: チャット一覧にユーザー数バッジを表示

### DIFF
--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -18,6 +18,7 @@ export default function ChatListPage() {
     <div className="flex h-full">
       <SecondaryPanel
         title="チャット"
+        badge={`${chatUsers.length}件`}
         mobileOpen={mobilePanelOpen}
         onMobileClose={closeMobilePanel}
         headerContent={

--- a/frontend/src/pages/__tests__/ChatListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatListPage.test.tsx
@@ -131,4 +131,21 @@ describe('ChatListPage', () => {
     expect(imgs.length).toBeGreaterThanOrEqual(1);
     expect(imgs[0].getAttribute('src')).toBe('https://example.com/photo.jpg');
   });
+
+  it('チャットユーザー数バッジを表示する', () => {
+    render(<BrowserRouter><ChatListPage /></BrowserRouter>);
+
+    expect(screen.getAllByText('2件').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('チャットユーザーが0件の場合「0件」バッジを表示する', () => {
+    mockUseChatList.mockReturnValue({
+      ...defaultChatListData(),
+      chatUsers: [],
+    });
+
+    render(<BrowserRouter><ChatListPage /></BrowserRouter>);
+
+    expect(screen.getAllByText('0件').length).toBeGreaterThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
## 概要
- ChatListPageのSecondaryPanelに`badge={chatUsers.length + '件'}`を追加
- NotesPage・AskAiPageと同じUIパターンに統一

## テスト
- 2件表示時の「2件」バッジ表示テスト追加
- 0件時の「0件」バッジ表示テスト追加

closes #1209