### PR TITLE
refactor: ScenarioBookmarkController・ScoreCardControllerのLoggerを@Slf4jに統一

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScenarioBookmarkController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScenarioBookmarkController.java
@@ -2,8 +2,6 @@ package com.example.FreStyle.controller;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -21,13 +19,13 @@ import com.example.FreStyle.usecase.GetUserBookmarksUseCase;
 import com.example.FreStyle.usecase.RemoveScenarioBookmarkUseCase;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/bookmarks")
+@Slf4j
 public class ScenarioBookmarkController {
-
-    private static final Logger logger = LoggerFactory.getLogger(ScenarioBookmarkController.class);
 
     private final GetUserBookmarksUseCase getUserBookmarksUseCase;
     private final AddScenarioBookmarkUseCase addScenarioBookmarkUseCase;
@@ -36,10 +34,10 @@ public class ScenarioBookmarkController {
 
     @GetMapping
     public ResponseEntity<List<Integer>> getBookmarks(@AuthenticationPrincipal Jwt jwt) {
-        logger.info("========== GET /api/bookmarks ==========");
+        log.info("========== GET /api/bookmarks ==========");
         User user = resolveUser(jwt);
         List<Integer> bookmarkedIds = getUserBookmarksUseCase.execute(user.getId());
-        logger.info("ブックマーク一覧取得成功 - 件数: {}", bookmarkedIds.size());
+        log.info("ブックマーク一覧取得成功 - 件数: {}", bookmarkedIds.size());
         return ResponseEntity.ok(bookmarkedIds);
     }
 
@@ -48,10 +46,10 @@ public class ScenarioBookmarkController {
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer scenarioId
     ) {
-        logger.info("========== POST /api/bookmarks/{} ==========", scenarioId);
+        log.info("========== POST /api/bookmarks/{} ==========", scenarioId);
         User user = resolveUser(jwt);
         addScenarioBookmarkUseCase.execute(user, scenarioId);
-        logger.info("ブックマーク追加成功 - scenarioId: {}", scenarioId);
+        log.info("ブックマーク追加成功 - scenarioId: {}", scenarioId);
         return ResponseEntity.ok().build();
     }
 
@@ -60,10 +58,10 @@ public class ScenarioBookmarkController {
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer scenarioId
     ) {
-        logger.info("========== DELETE /api/bookmarks/{} ==========", scenarioId);
+        log.info("========== DELETE /api/bookmarks/{} ==========", scenarioId);
         User user = resolveUser(jwt);
         removeScenarioBookmarkUseCase.execute(user.getId(), scenarioId);
-        logger.info("ブックマーク削除成功 - scenarioId: {}", scenarioId);
+        log.info("ブックマーク削除成功 - scenarioId: {}", scenarioId);
         return ResponseEntity.ok().build();
     }
 

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreCardController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreCardController.java
@@ -1,7 +1,5 @@
 package com.example.FreStyle.controller;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -21,13 +19,13 @@ import com.example.FreStyle.usecase.GetScoreCardBySessionIdUseCase;
 import com.example.FreStyle.usecase.GetScoreHistoryByUserIdUseCase;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/scores")
+@Slf4j
 public class ScoreCardController {
-
-    private static final Logger logger = LoggerFactory.getLogger(ScoreCardController.class);
     private final UserIdentityService userIdentityService;
     private final GetAiChatSessionByIdUseCase getAiChatSessionByIdUseCase;
     private final GetScoreCardBySessionIdUseCase getScoreCardBySessionIdUseCase;
@@ -41,7 +39,7 @@ public class ScoreCardController {
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer sessionId
     ) {
-        logger.info("========== GET /api/scores/sessions/{} ==========", sessionId);
+        log.info("========== GET /api/scores/sessions/{} ==========", sessionId);
 
         User user = resolveUser(jwt);
 
@@ -49,7 +47,7 @@ public class ScoreCardController {
         getAiChatSessionByIdUseCase.execute(sessionId, user.getId());
 
         ScoreCardDto scoreCard = getScoreCardBySessionIdUseCase.execute(sessionId);
-        logger.info("✅ スコアカード取得成功 - sessionId: {}", sessionId);
+        log.info("✅ スコアカード取得成功 - sessionId: {}", sessionId);
 
         return ResponseEntity.ok(scoreCard);
     }
@@ -61,12 +59,12 @@ public class ScoreCardController {
     public ResponseEntity<List<ScoreHistoryDto>> getScoreHistory(
             @AuthenticationPrincipal Jwt jwt
     ) {
-        logger.info("========== GET /api/scores/history ==========");
+        log.info("========== GET /api/scores/history ==========");
 
         User user = resolveUser(jwt);
 
         List<ScoreHistoryDto> history = getScoreHistoryByUserIdUseCase.execute(user.getId());
-        logger.info("✅ スコア履歴取得成功 - userId: {}, 件数: {}", user.getId(), history.size());
+        log.info("✅ スコア履歴取得成功 - userId: {}, 件数: {}", user.getId(), history.size());
 
         return ResponseEntity.ok(history);
     }


### PR DESCRIPTION
## 概要
- `ScenarioBookmarkController`と`ScoreCardController`の手動Logger宣言をLombokの`@Slf4j`アノテーションに置換
- `logger.`を`log.`に変更（@Slf4jデフォルト変数名）
- 他のコントローラー（FavoritePhraseController, CognitoAuthController等）と同じパターンに統一

closes #1211