### PR TITLE
test: UserDtoTest・UserAvatar.testのテスト拡充

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/dto/UserDtoTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/dto/UserDtoTest.java
@@ -36,4 +36,27 @@ class UserDtoTest {
         dto.setRoomId(10);
         assertThat(dto.getRoomId()).isEqualTo(10);
     }
+
+    @Test
+    @DisplayName("NoArgsConstructorで全フィールドがnull")
+    void noArgsConstructorAllFieldsNull() {
+        UserDto dto = new UserDto();
+
+        assertThat(dto.getId()).isNull();
+        assertThat(dto.getEmail()).isNull();
+        assertThat(dto.getName()).isNull();
+        assertThat(dto.getRoomId()).isNull();
+    }
+
+    @Test
+    @DisplayName("setterでemail・nameを変更できる")
+    void setEmailAndName() {
+        UserDto dto = new UserDto(1, "old@example.com", "旧名前");
+
+        dto.setEmail("new@example.com");
+        dto.setName("新名前");
+
+        assertThat(dto.getEmail()).isEqualTo("new@example.com");
+        assertThat(dto.getName()).isEqualTo("新名前");
+    }
 }

--- a/frontend/src/components/layout/__tests__/UserAvatar.test.tsx
+++ b/frontend/src/components/layout/__tests__/UserAvatar.test.tsx
@@ -20,4 +20,20 @@ describe('UserAvatar', () => {
 
     expect(screen.getByText('?')).toBeInTheDocument();
   });
+
+  it('size="sm"でsmクラスが適用される', () => {
+    const { container } = render(<UserAvatar name="太郎" size="sm" />);
+
+    const avatar = container.firstElementChild!;
+    expect(avatar.className).toContain('w-7');
+    expect(avatar.className).toContain('h-7');
+  });
+
+  it('デフォルトサイズでmdクラスが適用される', () => {
+    const { container } = render(<UserAvatar name="太郎" />);
+
+    const avatar = container.firstElementChild!;
+    expect(avatar.className).toContain('w-8');
+    expect(avatar.className).toContain('h-8');
+  });
 });


### PR DESCRIPTION
## 概要
- `UserDtoTest`: NoArgsConstructor全フィールドnull検証・email/name setter変更テスト追加（3→5件）
- `UserAvatar.test.tsx`: size="sm"クラス検証・デフォルトmdクラス検証テスト追加（3→5件）

closes #1213