### PR TITLE
refactor: 非コントローラークラスのLoggerを@Slf4jに統一

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/auth/JwtCookieFilter.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/auth/JwtCookieFilter.java
@@ -7,16 +7,14 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 
 // 1リクエスト1回のみ実行するクラスを継承している
+@Slf4j
 @Component
 public class JwtCookieFilter extends OncePerRequestFilter {
-
-    // ← ここでLoggerを宣言
-    private static final Logger log = LoggerFactory.getLogger(JwtCookieFilter.class);
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.example.FreStyle.auth;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,12 +11,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
-    
-    private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
     
     // Cognitoの.well-known/jwk.json
     // Spring Security は access_token を自動で decode & validate & set Authentication してくれる
@@ -33,14 +31,14 @@ public class SecurityConfig {
     
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        logger.info("========== [SecurityConfig] SecurityFilterChain 構築開始 ==========");
-        logger.info("[SecurityConfig] CorsConfigurationSource注入確認: {}", corsConfigurationSource != null ? "OK" : "NULL ⚠️");
+        log.info("========== [SecurityConfig] SecurityFilterChain 構築開始 ==========");
+        log.info("[SecurityConfig] CorsConfigurationSource注入確認: {}", corsConfigurationSource != null ? "OK" : "NULL ⚠️");
         
         http
                 // 明示的にCorsConfigurationSourceを指定
                 .cors(cors -> {
                     cors.configurationSource(corsConfigurationSource);
-                    logger.info("[SecurityConfig] CORS設定適用完了");
+                    log.info("[SecurityConfig] CORS設定適用完了");
                 })
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
@@ -55,7 +53,7 @@ public class SecurityConfig {
                         .jwtAuthenticationConverter(jwtAuthenticationConverter()) // カスタムコンバーターを作成をする
                         .jwkSetUri(jwkUri)));
         
-        logger.info("========== [SecurityConfig] SecurityFilterChain 構築完了 ==========");
+        log.info("========== [SecurityConfig] SecurityFilterChain 構築完了 ==========");
         return http.build();
     }
     

--- a/FreStyle/src/main/java/com/example/FreStyle/config/CorsConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/CorsConfig.java
@@ -3,8 +3,6 @@ package com.example.FreStyle.config;
 import java.util.Arrays;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -13,10 +11,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Configuration
 public class CorsConfig {
-
-  private static final Logger logger = LoggerFactory.getLogger(CorsConfig.class);
 
   // 許可するオリジンを一元管理
   private static final List<String> ALLOWED_ORIGINS = Arrays.asList(
@@ -37,34 +36,34 @@ public class CorsConfig {
    */
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
-    logger.info("========== [CorsConfig] CorsConfigurationSource Bean 初期化開始 ==========");
+    log.info("========== [CorsConfig] CorsConfigurationSource Bean 初期化開始 ==========");
     
     CorsConfiguration configuration = new CorsConfiguration();
     
     // 許可するオリジン
     configuration.setAllowedOrigins(ALLOWED_ORIGINS);
-    logger.info("[CorsConfig] 許可オリジン設定: {}", ALLOWED_ORIGINS);
+    log.info("[CorsConfig] 許可オリジン設定: {}", ALLOWED_ORIGINS);
     
     // 許可するHTTPメソッド
     configuration.setAllowedMethods(ALLOWED_METHODS);
-    logger.info("[CorsConfig] 許可メソッド設定: {}", ALLOWED_METHODS);
+    log.info("[CorsConfig] 許可メソッド設定: {}", ALLOWED_METHODS);
     
     // 許可するヘッダー
     configuration.setAllowedHeaders(List.of("*"));
-    logger.info("[CorsConfig] 許可ヘッダー設定: *");
+    log.info("[CorsConfig] 許可ヘッダー設定: *");
     
     // クレデンシャル（Cookie等）を許可
     configuration.setAllowCredentials(true);
-    logger.info("[CorsConfig] allowCredentials: true");
+    log.info("[CorsConfig] allowCredentials: true");
     
     // プリフライトリクエストのキャッシュ時間（秒）
     configuration.setMaxAge(3600L);
-    logger.info("[CorsConfig] maxAge: 3600秒");
+    log.info("[CorsConfig] maxAge: 3600秒");
     
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);
     
-    logger.info("========== [CorsConfig] CorsConfigurationSource Bean 初期化完了 ==========");
+    log.info("========== [CorsConfig] CorsConfigurationSource Bean 初期化完了 ==========");
     return source;
   }
 
@@ -73,13 +72,13 @@ public class CorsConfig {
    */
   @Bean
   public WebMvcConfigurer corsConfigurer() {
-    logger.info("[CorsConfig] WebMvcConfigurer (MVC用CORS) Bean 初期化");
+    log.info("[CorsConfig] WebMvcConfigurer (MVC用CORS) Bean 初期化");
     
     return new WebMvcConfigurer() {
 
       @Override
       public void addCorsMappings(CorsRegistry registry) {
-        logger.info("[CorsConfig] addCorsMappings() 実行 - MVC用CORS設定適用");
+        log.info("[CorsConfig] addCorsMappings() 実行 - MVC用CORS設定適用");
         registry.addMapping("/**")
             .allowedOrigins(ALLOWED_ORIGINS.toArray(new String[0]))
             .allowCredentials(true)

--- a/FreStyle/src/main/java/com/example/FreStyle/config/CorsLoggingFilter.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/CorsLoggingFilter.java
@@ -2,8 +2,6 @@ package com.example.FreStyle.config;
 
 import java.io.IOException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -16,15 +14,16 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * CORSリクエストのデバッグ用ロギングフィルター
  * 全てのリクエストでCORS関連のヘッダーをログ出力します
  */
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
 public class CorsLoggingFilter implements Filter {
-
-    private static final Logger logger = LoggerFactory.getLogger(CorsLoggingFilter.class);
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
@@ -41,14 +40,14 @@ public class CorsLoggingFilter implements Filter {
         
         // プリフライトリクエスト（OPTIONS）の場合は詳細ログ
         if ("OPTIONS".equalsIgnoreCase(method)) {
-            logger.info("========== [CORS] プリフライトリクエスト検出 ==========");
-            logger.info("[CORS] URI: {}", uri);
-            logger.info("[CORS] Origin: {}", origin);
-            logger.info("[CORS] Access-Control-Request-Method: {}", accessControlRequestMethod);
-            logger.info("[CORS] Access-Control-Request-Headers: {}", accessControlRequestHeaders);
+            log.info("========== [CORS] プリフライトリクエスト検出 ==========");
+            log.info("[CORS] URI: {}", uri);
+            log.info("[CORS] Origin: {}", origin);
+            log.info("[CORS] Access-Control-Request-Method: {}", accessControlRequestMethod);
+            log.info("[CORS] Access-Control-Request-Headers: {}", accessControlRequestHeaders);
         } else if (origin != null) {
             // 通常のCORSリクエスト
-            logger.info("[CORS] リクエスト - Method: {}, URI: {}, Origin: {}", method, uri, origin);
+            log.info("[CORS] リクエスト - Method: {}, URI: {}, Origin: {}", method, uri, origin);
         }
         
         // フィルターチェーンを続行
@@ -61,20 +60,20 @@ public class CorsLoggingFilter implements Filter {
         String allowCredentials = httpResponse.getHeader("Access-Control-Allow-Credentials");
         
         if ("OPTIONS".equalsIgnoreCase(method) || origin != null) {
-            logger.info("[CORS] レスポンス - Status: {}", httpResponse.getStatus());
-            logger.info("[CORS] Access-Control-Allow-Origin: {}", allowOrigin != null ? allowOrigin : "NOT SET ⚠️");
-            logger.info("[CORS] Access-Control-Allow-Methods: {}", allowMethods != null ? allowMethods : "NOT SET");
-            logger.info("[CORS] Access-Control-Allow-Headers: {}", allowHeaders != null ? allowHeaders : "NOT SET");
-            logger.info("[CORS] Access-Control-Allow-Credentials: {}", allowCredentials != null ? allowCredentials : "NOT SET");
+            log.info("[CORS] レスポンス - Status: {}", httpResponse.getStatus());
+            log.info("[CORS] Access-Control-Allow-Origin: {}", allowOrigin != null ? allowOrigin : "NOT SET ⚠️");
+            log.info("[CORS] Access-Control-Allow-Methods: {}", allowMethods != null ? allowMethods : "NOT SET");
+            log.info("[CORS] Access-Control-Allow-Headers: {}", allowHeaders != null ? allowHeaders : "NOT SET");
+            log.info("[CORS] Access-Control-Allow-Credentials: {}", allowCredentials != null ? allowCredentials : "NOT SET");
             
             // CORSエラーの可能性を警告
             if (origin != null && allowOrigin == null) {
-                logger.error("========== [CORS] ⚠️ 警告: Access-Control-Allow-Origin が設定されていません！ ==========");
-                logger.error("[CORS] リクエストOrigin: {} がCORS設定に含まれているか確認してください", origin);
+                log.error("========== [CORS] ⚠️ 警告: Access-Control-Allow-Origin が設定されていません！ ==========");
+                log.error("[CORS] リクエストOrigin: {} がCORS設定に含まれているか確認してください", origin);
             }
             
             if ("OPTIONS".equalsIgnoreCase(method)) {
-                logger.info("========== [CORS] プリフライトリクエスト処理完了 ==========");
+                log.info("========== [CORS] プリフライトリクエスト処理完了 ==========");
             }
         }
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/config/RequestTimingAspect.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/RequestTimingAspect.java
@@ -5,15 +5,14 @@ import io.micrometer.core.instrument.Timer;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Aspect
 @Component
 public class RequestTimingAspect {
-
-    private static final Logger log = LoggerFactory.getLogger(RequestTimingAspect.class);
 
     private final MeterRegistry meterRegistry;
 

--- a/FreStyle/src/main/java/com/example/FreStyle/exception/GlobalExceptionHandler.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.example.FreStyle.exception;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -9,6 +7,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
 import com.example.FreStyle.dto.ErrorResponseDto;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * グローバル例外ハンドラー
@@ -27,10 +27,9 @@ import com.example.FreStyle.dto.ErrorResponseDto;
  *   <li>適切なHTTPステータスコードとエラーメッセージを返却</li>
  * </ul>
  */
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-
-    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     /**
      * ResourceNotFoundException のハンドラー
@@ -46,7 +45,7 @@ public class GlobalExceptionHandler {
             ResourceNotFoundException ex,
             WebRequest request
     ) {
-        logger.warn("❌ リソースが見つかりません: {}", ex.getMessage());
+        log.warn("❌ リソースが見つかりません: {}", ex.getMessage());
 
         ErrorResponseDto error = ErrorResponseDto.of(
             HttpStatus.NOT_FOUND.value(),
@@ -72,7 +71,7 @@ public class GlobalExceptionHandler {
             UnauthorizedException ex,
             WebRequest request
     ) {
-        logger.warn("❌ 権限エラー: {}", ex.getMessage());
+        log.warn("❌ 権限エラー: {}", ex.getMessage());
 
         ErrorResponseDto error = ErrorResponseDto.of(
             HttpStatus.FORBIDDEN.value(),
@@ -98,7 +97,7 @@ public class GlobalExceptionHandler {
             BusinessException ex,
             WebRequest request
     ) {
-        logger.warn("❌ ビジネスロジックエラー: {}", ex.getMessage());
+        log.warn("❌ ビジネスロジックエラー: {}", ex.getMessage());
 
         ErrorResponseDto error = ErrorResponseDto.of(
             HttpStatus.BAD_REQUEST.value(),
@@ -115,7 +114,7 @@ public class GlobalExceptionHandler {
             IllegalArgumentException ex,
             WebRequest request
     ) {
-        logger.warn("不正な引数: {}", ex.getMessage());
+        log.warn("不正な引数: {}", ex.getMessage());
 
         ErrorResponseDto error = ErrorResponseDto.of(
             HttpStatus.BAD_REQUEST.value(),
@@ -141,7 +140,7 @@ public class GlobalExceptionHandler {
             Exception ex,
             WebRequest request
     ) {
-        logger.error("❌ 予期しないエラー: {}", ex.getMessage(), ex);
+        log.error("❌ 予期しないエラー: {}", ex.getMessage(), ex);
 
         ErrorResponseDto error = ErrorResponseDto.of(
             HttpStatus.INTERNAL_SERVER_ERROR.value(),


### PR DESCRIPTION
## 概要
- コントローラー以外のクラスに残っていた手動Logger宣言を@Slf4jアノテーションに統一

## 対象クラス
- GlobalExceptionHandler
- JwtCookieFilter
- SecurityConfig
- CorsConfig
- RequestTimingAspect
- CorsLoggingFilter

## 変更内容
- `Logger`/`LoggerFactory` インポートと手動宣言を削除
- `@Slf4j` アノテーション追加
- 変数名 `logger` → `log` に統一

Closes #1223