### PR TITLE
test: ResourceNotFoundExceptionTest・WordCount.testのテスト拡充

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/exception/ResourceNotFoundExceptionTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/ResourceNotFoundExceptionTest.java
@@ -34,4 +34,21 @@ class ResourceNotFoundExceptionTest {
 
         assertInstanceOf(RuntimeException.class, exception);
     }
+
+    @Test
+    @DisplayName("nullメッセージでもnullが保持される")
+    void constructor_WithNullMessage() {
+        ResourceNotFoundException exception = new ResourceNotFoundException(null);
+
+        assertNull(exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("2引数コンストラクタでcauseがnullでも正常に動作する")
+    void constructor_WithNullCause() {
+        ResourceNotFoundException exception = new ResourceNotFoundException("エラー", null);
+
+        assertEquals("エラー", exception.getMessage());
+        assertNull(exception.getCause());
+    }
 }

--- a/frontend/src/components/__tests__/WordCount.test.tsx
+++ b/frontend/src/components/__tests__/WordCount.test.tsx
@@ -17,4 +17,16 @@ describe('WordCount', () => {
     render(<WordCount charCount={1500} />);
     expect(screen.getByText('1500文字')).toBeInTheDocument();
   });
+
+  it('正しいスタイルクラスが適用される', () => {
+    render(<WordCount charCount={5} />);
+    const element = screen.getByText('5文字');
+    expect(element.className).toContain('text-[10px]');
+  });
+
+  it('div要素としてレンダリングされる', () => {
+    render(<WordCount charCount={3} />);
+    const element = screen.getByText('3文字');
+    expect(element.tagName).toBe('DIV');
+  });
 });


### PR DESCRIPTION
## 概要
- テスト品質改善として2ファイルのテストを3件→5件に拡充

## 追加テスト
### ResourceNotFoundExceptionTest (3→5)
- nullメッセージでもnullが保持される
- 2引数コンストラクタでcauseがnullでも正常動作

### WordCount.test.tsx (3→5)
- 正しいスタイルクラス(text-[10px])が適用される
- div要素としてレンダリングされる

Closes #1225