### PR TITLE
feat: InputFieldのクリアボタンにaria-labelを追加

### DIFF
--- a/frontend/src/components/InputField.tsx
+++ b/frontend/src/components/InputField.tsx
@@ -68,6 +68,7 @@ export default function InputField({
           <button
             type="button"
             onClick={handleClear}
+            aria-label="入力をクリア"
             className="absolute right-3 top-1/2 transform -translate-y-1/2 text-[var(--color-text-faint)] hover:text-[var(--color-text-tertiary)] transition-colors"
           >
             <XMarkIcon className="w-5 h-5" />

--- a/frontend/src/components/__tests__/InputField.test.tsx
+++ b/frontend/src/components/__tests__/InputField.test.tsx
@@ -127,4 +127,9 @@ describe('InputField', () => {
     render(<InputField label="パスワード" name="password" type="password" value="secret" onChange={mockOnChange} />);
     expect(screen.queryByLabelText('入力をクリア')).toBeNull();
   });
+
+  it('クリアボタンにaria-label="入力をクリア"が設定される', () => {
+    render(<InputField label="メール" name="email" value="test" onChange={mockOnChange} />);
+    expect(screen.getByLabelText('入力をクリア')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- InputFieldコンポーネントのクリアボタンにaria-label属性を追加

## 背景
- パスワード表示/非表示ボタンにはaria-label設定済み
- SearchBoxのクリアボタンにもaria-label設定済み
- InputFieldのクリアボタンのみ未設定でアクセシビリティが不十分だった

## 変更内容
- クリアボタンに `aria-label="入力をクリア"` を追加
- aria-labelの存在を検証するテストを追加

Closes #1227