### PR TITLE
refactor: サービスクラスの手動コンストラクタを@RequiredArgsConstructorに置き換え

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/service/AccessTokenService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/AccessTokenService.java
@@ -8,14 +8,13 @@ import com.example.FreStyle.entity.AccessToken;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.repository.AccessTokenRepository;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class AccessTokenService {
 
     private final AccessTokenRepository accessTokenRepository;
-
-    public AccessTokenService(AccessTokenRepository accessTokenRepository) {
-        this.accessTokenRepository = accessTokenRepository;
-    }
 
     @Transactional
     public void saveTokens(

--- a/FreStyle/src/main/java/com/example/FreStyle/service/RoomMemberService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/RoomMemberService.java
@@ -6,15 +6,14 @@ import org.springframework.stereotype.Service;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.repository.RoomMemberRepository;
 
+import lombok.RequiredArgsConstructor;
+
 // ユーザー同士のチャットの管理
 @Service
+@RequiredArgsConstructor
 public class RoomMemberService {
-  
+
   private final RoomMemberRepository roomMemberRepository;
-  
-  public RoomMemberService(RoomMemberRepository roomMemberRepository) {
-    this.roomMemberRepository = roomMemberRepository;
-  } 
   
   public boolean existsRoom(Integer roomId, Integer userId) {
     return roomMemberRepository.existsByRoom_IdAndUser_Id(roomId, userId);

--- a/FreStyle/src/main/java/com/example/FreStyle/service/UserIdentityService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/UserIdentityService.java
@@ -7,14 +7,13 @@ import com.example.FreStyle.entity.User;
 import com.example.FreStyle.entity.UserIdentity;
 import com.example.FreStyle.repository.UserIdentityRepository;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class UserIdentityService {
 
     private final UserIdentityRepository userIdentityRepository;
-
-    public UserIdentityService(UserIdentityRepository userIdentityRepository) {
-        this.userIdentityRepository = userIdentityRepository;
-    }
 
     // ------------------------
     // UserIdentity を登録


### PR DESCRIPTION
## 概要
- 手動コンストラクタを持つサービスクラスをLombokの@RequiredArgsConstructorに統一

## 対象クラス
- AccessTokenService
- RoomMemberService
- UserIdentityService

## 変更内容
- 各クラスの手動コンストラクタを削除
- `@RequiredArgsConstructor` アノテーションを追加
- テストは@InjectMocks互換のため変更不要

Closes #1229