### PR TITLE
test: UnauthorizedExceptionTest・CardHeading.testのテスト拡充

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/exception/UnauthorizedExceptionTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/UnauthorizedExceptionTest.java
@@ -34,4 +34,21 @@ class UnauthorizedExceptionTest {
 
         assertInstanceOf(RuntimeException.class, exception);
     }
+
+    @Test
+    @DisplayName("nullメッセージでもnullが保持される")
+    void constructor_WithNullMessage() {
+        UnauthorizedException exception = new UnauthorizedException(null);
+
+        assertNull(exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("2引数コンストラクタでcauseがnullでも正常に動作する")
+    void constructor_WithNullCause() {
+        UnauthorizedException exception = new UnauthorizedException("エラー", null);
+
+        assertEquals("エラー", exception.getMessage());
+        assertNull(exception.getCause());
+    }
 }

--- a/frontend/src/components/__tests__/CardHeading.test.tsx
+++ b/frontend/src/components/__tests__/CardHeading.test.tsx
@@ -20,4 +20,15 @@ describe('CardHeading', () => {
     const heading = screen.getByText('タイトル');
     expect(heading.tagName).toBe('P');
   });
+
+  it('mb-3クラスが適用される', () => {
+    render(<CardHeading>タイトル</CardHeading>);
+    const heading = screen.getByText('タイトル');
+    expect(heading.className).toContain('mb-3');
+  });
+
+  it('異なるテキストが正しく表示される', () => {
+    render(<CardHeading>スコア推移</CardHeading>);
+    expect(screen.getByText('スコア推移')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- テスト品質改善として2ファイルのテストを3件→5件に拡充

## 追加テスト
### UnauthorizedExceptionTest (3→5)
- nullメッセージでもnullが保持される
- 2引数コンストラクタでcauseがnullでも正常動作

### CardHeading.test.tsx (3→5)
- mb-3クラスが適用される（マージン検証）
- 異なるテキストが正しく表示される

Closes #1231