### PR TITLE
feat: AddUserPageに検索中のローディング表示を追加

### DIFF
--- a/frontend/src/pages/AddUserPage.tsx
+++ b/frontend/src/pages/AddUserPage.tsx
@@ -1,6 +1,7 @@
 import MemberList from '../components/MemberList';
 import SearchBox from '../components/SearchBox';
 import FormMessage from '../components/FormMessage';
+import Loading from '../components/Loading';
 import {
   MagnifyingGlassIcon,
   UserPlusIcon,
@@ -26,8 +27,8 @@ export default function AddUserPage() {
 
       {/* ローディング中 */}
       {loading && (
-        <div className="flex items-center justify-center py-12">
-          <p className="text-sm text-[var(--color-text-muted)]">検索中...</p>
+        <div className="py-12">
+          <Loading message="検索中..." />
         </div>
       )}
 

--- a/frontend/src/pages/__tests__/AddUserPage.test.tsx
+++ b/frontend/src/pages/__tests__/AddUserPage.test.tsx
@@ -86,7 +86,7 @@ describe('AddUserPage', () => {
     expect(screen.getByText('2人のユーザーが見つかりました')).toBeInTheDocument();
   });
 
-  it('検索中にローディングメッセージが表示される', () => {
+  it('検索中にローディングが表示される', () => {
     mockUseUserSearch.mockReturnValue({
       ...defaultData(),
       loading: true,
@@ -95,10 +95,11 @@ describe('AddUserPage', () => {
 
     render(<BrowserRouter><AddUserPage /></BrowserRouter>);
 
+    expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText('検索中...')).toBeInTheDocument();
   });
 
-  it('検索中は検索案内が表示されない', () => {
+  it('検索中は検索案内・検索結果なし・ユーザーリストが表示されない', () => {
     mockUseUserSearch.mockReturnValue({
       ...defaultData(),
       loading: true,
@@ -108,5 +109,7 @@ describe('AddUserPage', () => {
     render(<BrowserRouter><AddUserPage /></BrowserRouter>);
 
     expect(screen.queryByText('ユーザーを検索してみましょう')).not.toBeInTheDocument();
+    expect(screen.queryByText('ユーザーが見つかりませんでした')).not.toBeInTheDocument();
+    expect(screen.queryByText(/人のユーザーが見つかりました/)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
- AddUserPageでユーザー検索中のローディング表示を追加

## 背景
- useUserSearchフックはloading状態を返しているが、AddUserPageでは未使用だった
- MemberPageではLoadingコンポーネントを使用しており、UIの一貫性が不足

## 変更内容
- useUserSearchからloadingを取得
- 検索中に「検索中...」メッセージを表示
- ローディング中は検索案内・検索結果なし・ユーザーリストを非表示

## テスト
- 検索中にローディングメッセージが表示されるテスト追加
- 検索中は検索案内が表示されないテスト追加

Closes #1233