### PR TITLE
refactor: コンポーネントのProps命名をComponentNameProps形式に統一

### DIFF
--- a/frontend/src/components/CommunicationStyleCard.tsx
+++ b/frontend/src/components/CommunicationStyleCard.tsx
@@ -1,7 +1,7 @@
 import type { ScoreHistoryItem } from '../types';
 import Card from './Card';
 
-interface Props {
+interface CommunicationStyleCardProps {
   sessions: ScoreHistoryItem[];
 }
 
@@ -53,7 +53,7 @@ function getAverageScores(sessions: ScoreHistoryItem[]): Map<string, number> {
   return averages;
 }
 
-export default function CommunicationStyleCard({ sessions }: Props) {
+export default function CommunicationStyleCard({ sessions }: CommunicationStyleCardProps) {
   if (sessions.length === 0) {
     return (
       <Card>

--- a/frontend/src/components/LearningPatternCard.tsx
+++ b/frontend/src/components/LearningPatternCard.tsx
@@ -45,11 +45,11 @@ function analyzePattern(practiceDates: string[]): { pattern: PatternType; dayCou
   return { pattern, dayCounts };
 }
 
-interface Props {
+interface LearningPatternCardProps {
   practiceDates: string[];
 }
 
-export default function LearningPatternCard({ practiceDates }: Props) {
+export default function LearningPatternCard({ practiceDates }: LearningPatternCardProps) {
   const { pattern, dayCounts } = useMemo(() => analyzePattern(practiceDates), [practiceDates]);
 
   if (practiceDates.length === 0) return null;

--- a/frontend/src/components/ScoreGoalCard.tsx
+++ b/frontend/src/components/ScoreGoalCard.tsx
@@ -2,13 +2,13 @@ import Card from './Card';
 import ProgressBar from './ProgressBar';
 import { useScoreGoal } from '../hooks/useScoreGoal';
 
-interface Props {
+interface ScoreGoalCardProps {
   averageScore: number;
 }
 
 const GOAL_OPTIONS = [6.0, 6.5, 7.0, 7.5, 8.0, 8.5, 9.0, 9.5, 10.0];
 
-export default function ScoreGoalCard({ averageScore }: Props) {
+export default function ScoreGoalCard({ averageScore }: ScoreGoalCardProps) {
   const { goal, saveGoal } = useScoreGoal();
 
   const handleGoalChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/src/components/ScoreGrowthTrendCard.tsx
+++ b/frontend/src/components/ScoreGrowthTrendCard.tsx
@@ -25,11 +25,11 @@ const TREND_CONFIG: Record<TrendType, { label: string; message: string; color: s
   },
 };
 
-interface Props {
+interface ScoreGrowthTrendCardProps {
   scores: number[];
 }
 
-export default function ScoreGrowthTrendCard({ scores }: Props) {
+export default function ScoreGrowthTrendCard({ scores }: ScoreGrowthTrendCardProps) {
   const analysis = useMemo(() => {
     if (!Array.isArray(scores) || scores.length < 2) return null;
 


### PR DESCRIPTION
## 概要
- 4つのコンポーネントで汎用的な`interface Props`を使用していたのを`ComponentNameProps`形式に統一

## 対象
- CommunicationStyleCard: `Props` → `CommunicationStyleCardProps`
- ScoreGoalCard: `Props` → `ScoreGoalCardProps`
- ScoreGrowthTrendCard: `Props` → `ScoreGrowthTrendCardProps`
- LearningPatternCard: `Props` → `LearningPatternCardProps`

## 背景
プロジェクト内の129個のコンポーネントは`ComponentNameProps`形式で統一されているが、上記4ファイルのみ`Props`という汎用名を使用していた。

Closes #1235