### PR TITLE
test: SceneDisplayNameTest・BlockquoteButton.testのテスト拡充 (3→5)

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/constant/SceneDisplayNameTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/constant/SceneDisplayNameTest.java
@@ -27,4 +27,14 @@ class SceneDisplayNameTest {
     void 未知のシーンの場合は空文字を返す() {
         assertThat(SceneDisplayName.of("unknown")).isEmpty();
     }
+
+    @Test
+    void 空文字の場合は空文字を返す() {
+        assertThat(SceneDisplayName.of("")).isEmpty();
+    }
+
+    @Test
+    void 大文字のシーン名の場合は空文字を返す() {
+        assertThat(SceneDisplayName.of("MEETING")).isEmpty();
+    }
 }

--- a/frontend/src/components/__tests__/BlockquoteButton.test.tsx
+++ b/frontend/src/components/__tests__/BlockquoteButton.test.tsx
@@ -21,4 +21,20 @@ describe('BlockquoteButton', () => {
     expect(button.tagName).toBe('BUTTON');
     expect(button).toHaveAttribute('type', 'button');
   });
+
+  it('複数回クリックでonBlockquoteが複数回呼ばれる', () => {
+    const onBlockquote = vi.fn();
+    render(<BlockquoteButton onBlockquote={onBlockquote} />);
+    const button = screen.getByLabelText('引用');
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    expect(onBlockquote).toHaveBeenCalledTimes(3);
+  });
+
+  it('SVGアイコンがレンダリングされる', () => {
+    render(<BlockquoteButton onBlockquote={vi.fn()} />);
+    const button = screen.getByLabelText('引用');
+    expect(button.querySelector('svg')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
- SceneDisplayNameTest: 空文字テスト・大文字シーン名テストを追加 (3→5)
- BlockquoteButton.test: 複数回クリックテスト・SVGアイコンレンダリングテストを追加 (3→5)

closes #1237