### PR TITLE
feat: ユーザー統計API（セッション数・フォロワー数・平均スコア）

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/UserStatsController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/UserStatsController.java
@@ -1,0 +1,45 @@
+package com.example.FreStyle.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.UserStatsDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.usecase.GetUserStatsUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Slf4j
+public class UserStatsController {
+
+    private final GetUserStatsUseCase getUserStatsUseCase;
+    private final UserIdentityService userIdentityService;
+    private final UserService userService;
+
+    @GetMapping("/me/stats")
+    public ResponseEntity<UserStatsDto> getMyStats(@AuthenticationPrincipal Jwt jwt) {
+        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        log.info("ユーザー統計取得: userId={}", user.getId());
+        UserStatsDto stats = getUserStatsUseCase.execute(user.getId());
+        return ResponseEntity.ok(stats);
+    }
+
+    @GetMapping("/{userId}/stats")
+    public ResponseEntity<UserStatsDto> getUserStats(@PathVariable Integer userId) {
+        userService.findUserById(userId);
+        log.info("ユーザー統計取得: userId={}", userId);
+        UserStatsDto stats = getUserStatsUseCase.execute(userId);
+        return ResponseEntity.ok(stats);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/UserStatsDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/UserStatsDto.java
@@ -1,0 +1,9 @@
+package com.example.FreStyle.dto;
+
+public record UserStatsDto(
+        long totalSessions,
+        long practiceSessionCount,
+        long followerCount,
+        long followingCount,
+        double averageScore) {
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserStatsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserStatsUseCase.java
@@ -1,0 +1,44 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserStatsDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+import com.example.FreStyle.repository.FriendshipRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserStatsUseCase {
+
+    private final AiChatSessionRepository aiChatSessionRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final CommunicationScoreRepository communicationScoreRepository;
+
+    @Transactional(readOnly = true)
+    public UserStatsDto execute(Integer userId) {
+        List<AiChatSession> sessions = aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        long totalSessions = sessions.size();
+        long practiceSessionCount = sessions.stream()
+                .filter(s -> "practice".equals(s.getSessionType()))
+                .count();
+
+        long followerCount = friendshipRepository.countByFollowingId(userId);
+        long followingCount = friendshipRepository.countByFollowerId(userId);
+
+        List<CommunicationScore> scores = communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        double averageScore = scores.stream()
+                .mapToInt(CommunicationScore::getScore)
+                .average()
+                .orElse(0.0);
+
+        return new UserStatsDto(totalSessions, practiceSessionCount, followerCount, followingCount, averageScore);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/UserStatsControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/UserStatsControllerTest.java
@@ -1,0 +1,84 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.UserStatsDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserService;
+import com.example.FreStyle.usecase.GetUserStatsUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserStatsController テスト")
+class UserStatsControllerTest {
+
+    @Mock
+    private GetUserStatsUseCase getUserStatsUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private Jwt jwt;
+
+    @InjectMocks
+    private UserStatsController userStatsController;
+
+    private User currentUser;
+
+    @BeforeEach
+    void setUp() {
+        currentUser = new User();
+        currentUser.setId(1);
+        currentUser.setName("テストユーザー");
+    }
+
+    @Test
+    @DisplayName("自分の統計を取得できる")
+    void getMyStats_returnsStats() {
+        when(jwt.getSubject()).thenReturn("sub-123");
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(currentUser);
+
+        UserStatsDto stats = new UserStatsDto(10, 5, 20, 15, 75.5);
+        when(getUserStatsUseCase.execute(1)).thenReturn(stats);
+
+        ResponseEntity<UserStatsDto> response = userStatsController.getMyStats(jwt);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().totalSessions()).isEqualTo(10);
+        assertThat(response.getBody().averageScore()).isEqualTo(75.5);
+    }
+
+    @Test
+    @DisplayName("指定ユーザーの統計を取得できる")
+    void getUserStats_returnsStats() {
+        User targetUser = new User();
+        targetUser.setId(2);
+        when(userService.findUserById(2)).thenReturn(targetUser);
+
+        UserStatsDto stats = new UserStatsDto(5, 3, 8, 4, 60.0);
+        when(getUserStatsUseCase.execute(2)).thenReturn(stats);
+
+        ResponseEntity<UserStatsDto> response = userStatsController.getUserStats(2);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().totalSessions()).isEqualTo(5);
+        assertThat(response.getBody().followerCount()).isEqualTo(8);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserStatsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserStatsUseCaseTest.java
@@ -1,0 +1,161 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserStatsDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.CommunicationScore;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+import com.example.FreStyle.repository.FriendshipRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetUserStatsUseCase テスト")
+class GetUserStatsUseCaseTest {
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
+
+    @Mock
+    private CommunicationScoreRepository communicationScoreRepository;
+
+    @InjectMocks
+    private GetUserStatsUseCase getUserStatsUseCase;
+
+    @Test
+    @DisplayName("ユーザー統計を正しく取得する")
+    void execute_returnsCorrectStats() {
+        Integer userId = 1;
+
+        AiChatSession normalSession = new AiChatSession();
+        normalSession.setSessionType("normal");
+        AiChatSession practiceSession1 = new AiChatSession();
+        practiceSession1.setSessionType("practice");
+        AiChatSession practiceSession2 = new AiChatSession();
+        practiceSession2.setSessionType("practice");
+
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(normalSession, practiceSession1, practiceSession2));
+        when(friendshipRepository.countByFollowingId(userId)).thenReturn(10L);
+        when(friendshipRepository.countByFollowerId(userId)).thenReturn(5L);
+
+        CommunicationScore score1 = new CommunicationScore();
+        score1.setScore(80);
+        CommunicationScore score2 = new CommunicationScore();
+        score2.setScore(60);
+        when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(score1, score2));
+
+        UserStatsDto result = getUserStatsUseCase.execute(userId);
+
+        assertThat(result.totalSessions()).isEqualTo(3);
+        assertThat(result.practiceSessionCount()).isEqualTo(2);
+        assertThat(result.followerCount()).isEqualTo(10);
+        assertThat(result.followingCount()).isEqualTo(5);
+        assertThat(result.averageScore()).isEqualTo(70.0);
+    }
+
+    @Test
+    @DisplayName("セッションが0件の場合は全て0を返す")
+    void execute_noSessions_returnsZeros() {
+        Integer userId = 2;
+
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of());
+        when(friendshipRepository.countByFollowingId(userId)).thenReturn(0L);
+        when(friendshipRepository.countByFollowerId(userId)).thenReturn(0L);
+        when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of());
+
+        UserStatsDto result = getUserStatsUseCase.execute(userId);
+
+        assertThat(result.totalSessions()).isZero();
+        assertThat(result.practiceSessionCount()).isZero();
+        assertThat(result.followerCount()).isZero();
+        assertThat(result.followingCount()).isZero();
+        assertThat(result.averageScore()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("normalセッションのみの場合practiceSessionCountは0")
+    void execute_onlyNormalSessions() {
+        Integer userId = 3;
+
+        AiChatSession session = new AiChatSession();
+        session.setSessionType("normal");
+
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(session));
+        when(friendshipRepository.countByFollowingId(userId)).thenReturn(0L);
+        when(friendshipRepository.countByFollowerId(userId)).thenReturn(0L);
+
+        CommunicationScore score = new CommunicationScore();
+        score.setScore(90);
+        when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(score));
+
+        UserStatsDto result = getUserStatsUseCase.execute(userId);
+
+        assertThat(result.totalSessions()).isEqualTo(1);
+        assertThat(result.practiceSessionCount()).isZero();
+        assertThat(result.averageScore()).isEqualTo(90.0);
+    }
+
+    @Test
+    @DisplayName("スコアが複数ある場合の平均値が正しい")
+    void execute_multipleScores_correctAverage() {
+        Integer userId = 4;
+
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of());
+        when(friendshipRepository.countByFollowingId(userId)).thenReturn(0L);
+        when(friendshipRepository.countByFollowerId(userId)).thenReturn(0L);
+
+        CommunicationScore s1 = new CommunicationScore();
+        s1.setScore(100);
+        CommunicationScore s2 = new CommunicationScore();
+        s2.setScore(50);
+        CommunicationScore s3 = new CommunicationScore();
+        s3.setScore(70);
+        when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(s1, s2, s3));
+
+        UserStatsDto result = getUserStatsUseCase.execute(userId);
+
+        assertThat(result.averageScore()).isCloseTo(73.33, org.assertj.core.data.Offset.offset(0.01));
+    }
+
+    @Test
+    @DisplayName("sessionTypeがnullの場合はpracticeにカウントされない")
+    void execute_nullSessionType_notCountedAsPractice() {
+        Integer userId = 5;
+
+        AiChatSession session = new AiChatSession();
+        session.setSessionType(null);
+
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(session));
+        when(friendshipRepository.countByFollowingId(userId)).thenReturn(0L);
+        when(friendshipRepository.countByFollowerId(userId)).thenReturn(0L);
+        when(communicationScoreRepository.findByUserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of());
+
+        UserStatsDto result = getUserStatsUseCase.execute(userId);
+
+        assertThat(result.totalSessions()).isEqualTo(1);
+        assertThat(result.practiceSessionCount()).isZero();
+    }
+}


### PR DESCRIPTION
## 概要
Closes #1249

ユーザーのプロフィールページに表示する統計データを返すAPIエンドポイントを追加。

## エンドポイント
- `GET /api/users/me/stats` - ログインユーザーの統計
- `GET /api/users/{userId}/stats` - 指定ユーザーの統計

## レスポンス（UserStatsDto record）
| フィールド | 型 | 説明 |
|---|---|---|
| totalSessions | long | AIチャットセッション総数 |
| practiceSessionCount | long | 練習セッション数 |
| followerCount | long | フォロワー数 |
| followingCount | long | フォロー中数 |
| averageScore | double | 全スコアの平均値 |

## 実装
- **UseCase**: `GetUserStatsUseCase` - 既存リポジトリ3つ（AiChatSession, Friendship, CommunicationScore）から集計
- **Controller**: `UserStatsController` - 2エンドポイント
- **DTO**: `UserStatsDto` - Java record
- 新規エンティティ・DB変更なし

## テストプラン
- [x] GetUserStatsUseCaseTest: 5件（正常系、0件、normalのみ、平均値計算、null sessionType）
- [x] UserStatsControllerTest: 2件（自分の統計、指定ユーザーの統計）
- [x] バックエンドテスト712件通過