### PR TITLE
refactor: シンプルなDTOクラスをJava recordに変換

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/dto/DailyGoalDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/DailyGoalDto.java
@@ -1,14 +1,7 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class DailyGoalDto {
-    private String date;
-    private Integer target;
-    private Integer completed;
+public record DailyGoalDto(
+        String date,
+        Integer target,
+        Integer completed) {
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ProfileDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ProfileDto.java
@@ -1,14 +1,7 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class ProfileDto {
-  private String name;
-  private String bio;
-  private String iconUrl;
+public record ProfileDto(
+        String name,
+        String bio,
+        String iconUrl) {
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreGoalDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreGoalDto.java
@@ -1,12 +1,5 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class ScoreGoalDto {
-    private Double goalScore;
+public record ScoreGoalDto(
+        Double goalScore) {
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/SessionNoteDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/SessionNoteDto.java
@@ -1,14 +1,7 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class SessionNoteDto {
-    private Integer sessionId;
-    private String note;
-    private String updatedAt;
+public record SessionNoteDto(
+        Integer sessionId,
+        String note,
+        String updatedAt) {
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/DailyGoalControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/DailyGoalControllerTest.java
@@ -60,7 +60,7 @@ class DailyGoalControllerTest {
         ResponseEntity<DailyGoalDto> response = dailyGoalController.getToday(jwt);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(5, response.getBody().getTarget());
+        assertEquals(5, response.getBody().target());
     }
 
     @Test
@@ -76,8 +76,8 @@ class DailyGoalControllerTest {
 
         ResponseEntity<DailyGoalDto> response = dailyGoalController.getToday(jwt);
 
-        assertEquals(2, response.getBody().getCompleted());
-        assertEquals(today, response.getBody().getDate());
+        assertEquals(2, response.getBody().completed());
+        assertEquals(today, response.getBody().date());
     }
 
     @Test
@@ -120,7 +120,7 @@ class DailyGoalControllerTest {
         ResponseEntity<DailyGoalDto> response = dailyGoalController.increment(jwt);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals(1, response.getBody().getCompleted());
+        assertEquals(1, response.getBody().completed());
     }
 
     @Test
@@ -136,8 +136,8 @@ class DailyGoalControllerTest {
 
         ResponseEntity<DailyGoalDto> response = dailyGoalController.increment(jwt);
 
-        assertEquals(5, response.getBody().getTarget());
-        assertEquals(today, response.getBody().getDate());
+        assertEquals(5, response.getBody().target());
+        assertEquals(today, response.getBody().date());
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ProfileControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ProfileControllerTest.java
@@ -60,8 +60,8 @@ class ProfileControllerTest {
             ResponseEntity<ProfileDto> response = profileController.getProfile(jwt);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getName()).isEqualTo("テストユーザー");
-            assertThat(response.getBody().getBio()).isEqualTo("テスト自己紹介");
+            assertThat(response.getBody().name()).isEqualTo("テストユーザー");
+            assertThat(response.getBody().bio()).isEqualTo("テスト自己紹介");
         }
 
         @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreGoalControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreGoalControllerTest.java
@@ -54,7 +54,7 @@ class ScoreGoalControllerTest {
         ResponseEntity<ScoreGoalDto> response = scoreGoalController.getGoal(jwt);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getGoalScore()).isEqualTo(8.5);
+        assertThat(response.getBody().goalScore()).isEqualTo(8.5);
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/SessionNoteControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/SessionNoteControllerTest.java
@@ -55,7 +55,7 @@ class SessionNoteControllerTest {
         ResponseEntity<SessionNoteDto> response = sessionNoteController.getNote(jwt, 100);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody().getNote()).isEqualTo("テストメモ");
+        assertThat(response.getBody().note()).isEqualTo("テストメモ");
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetProfileUseCaseTest.java
@@ -45,9 +45,9 @@ class GetProfileUseCaseTest {
 
         ProfileDto result = getProfileUseCase.execute("sub-123");
 
-        assertEquals("テストユーザー", result.getName());
-        assertEquals("テスト自己紹介", result.getBio());
-        assertEquals("https://cdn.example.com/profiles/1/avatar.png", result.getIconUrl());
+        assertEquals("テストユーザー", result.name());
+        assertEquals("テスト自己紹介", result.bio());
+        assertEquals("https://cdn.example.com/profiles/1/avatar.png", result.iconUrl());
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreGoalUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreGoalUseCaseTest.java
@@ -35,7 +35,7 @@ class GetScoreGoalUseCaseTest {
         ScoreGoalDto result = useCase.execute(1);
 
         assertNotNull(result);
-        assertEquals(8.5, result.getGoalScore());
+        assertEquals(8.5, result.goalScore());
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetSessionNoteUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetSessionNoteUseCaseTest.java
@@ -45,8 +45,8 @@ class GetSessionNoteUseCaseTest {
         SessionNoteDto result = useCase.execute(1, 100);
 
         assertThat(result).isNotNull();
-        assertThat(result.getSessionId()).isEqualTo(100);
-        assertThat(result.getNote()).isEqualTo("振り返りメモ");
+        assertThat(result.sessionId()).isEqualTo(100);
+        assertThat(result.note()).isEqualTo("振り返りメモ");
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetTodayDailyGoalUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetTodayDailyGoalUseCaseTest.java
@@ -44,9 +44,9 @@ class GetTodayDailyGoalUseCaseTest {
 
         DailyGoalDto result = getTodayDailyGoalUseCase.execute(1);
 
-        assertEquals(LocalDate.now().toString(), result.getDate());
-        assertEquals(5, result.getTarget());
-        assertEquals(2, result.getCompleted());
+        assertEquals(LocalDate.now().toString(), result.date());
+        assertEquals(5, result.target());
+        assertEquals(2, result.completed());
     }
 
     @Test
@@ -57,8 +57,8 @@ class GetTodayDailyGoalUseCaseTest {
 
         DailyGoalDto result = getTodayDailyGoalUseCase.execute(1);
 
-        assertEquals(LocalDate.now().toString(), result.getDate());
-        assertEquals(3, result.getTarget());
-        assertEquals(0, result.getCompleted());
+        assertEquals(LocalDate.now().toString(), result.date());
+        assertEquals(3, result.target());
+        assertEquals(0, result.completed());
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/IncrementDailyGoalUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/IncrementDailyGoalUseCaseTest.java
@@ -43,7 +43,7 @@ class IncrementDailyGoalUseCaseTest {
 
         DailyGoalDto result = incrementDailyGoalUseCase.execute(user);
 
-        assertEquals(3, result.getCompleted());
+        assertEquals(3, result.completed());
         verify(dailyGoalRepository).save(argThat(g -> g.getCompleted() == 3));
     }
 
@@ -57,8 +57,8 @@ class IncrementDailyGoalUseCaseTest {
 
         DailyGoalDto result = incrementDailyGoalUseCase.execute(user);
 
-        assertEquals(1, result.getCompleted());
-        assertEquals(3, result.getTarget());
+        assertEquals(1, result.completed());
+        assertEquals(3, result.target());
         verify(dailyGoalRepository).save(argThat(g ->
                 g.getCompleted() == 1 && g.getTarget() == 3));
     }
@@ -78,7 +78,7 @@ class IncrementDailyGoalUseCaseTest {
 
         DailyGoalDto result = incrementDailyGoalUseCase.execute(user);
 
-        assertEquals(LocalDate.now().toString(), result.getDate());
+        assertEquals(LocalDate.now().toString(), result.date());
     }
 
     @Test
@@ -96,7 +96,7 @@ class IncrementDailyGoalUseCaseTest {
 
         DailyGoalDto result = incrementDailyGoalUseCase.execute(user);
 
-        assertEquals(5, result.getCompleted());
-        assertEquals(5, result.getTarget());
+        assertEquals(5, result.completed());
+        assertEquals(5, result.target());
     }
 }


### PR DESCRIPTION
## 概要
- DailyGoalDto, SessionNoteDto, ProfileDto, ScoreGoalDtoの4つのDTOをJava recordに変換
- Lombok @Data + @AllArgsConstructor + @NoArgsConstructor → Java record
- テストのgetter呼び出しをrecord accessor形式（getXxx() → xxx()）に更新

## 変更ファイル
**DTO (4ファイル)**
- `DailyGoalDto` (3フィールド)
- `SessionNoteDto` (3フィールド)
- `ProfileDto` (3フィールド)
- `ScoreGoalDto` (1フィールド)

**テスト (9ファイル)**
- getter → record accessor形式に更新

## テスト結果
- 720テスト通過（1失敗はcontextLoads = DB接続不要テスト）

closes #1257