### PR TITLE
feat: スコア改善トレンドAPI追加

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreTrendController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreTrendController.java
@@ -3,6 +3,7 @@ package com.example.FreStyle.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,12 +14,14 @@ import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.UserIdentityService;
 import com.example.FreStyle.usecase.GetScoreTrendUseCase;
 
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/scores")
+@Validated
 @Slf4j
 public class ScoreTrendController {
 
@@ -28,7 +31,7 @@ public class ScoreTrendController {
     @GetMapping("/trend")
     public ResponseEntity<ScoreTrendDto> getTrend(
             @AuthenticationPrincipal Jwt jwt,
-            @RequestParam(defaultValue = "30") int days) {
+            @RequestParam(defaultValue = "30") @Min(1) int days) {
         User user = resolveUser(jwt);
         log.info("GET /api/scores/trend - userId={}, days={}", user.getId(), days);
         ScoreTrendDto result = getScoreTrendUseCase.execute(user.getId(), days);

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreTrendDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreTrendDto.java
@@ -7,7 +7,8 @@ public record ScoreTrendDto(
         List<SessionScore> sessionScores,
         double overallAverage,
         SessionScore bestSession,
-        int totalSessions) {
+        int totalSessions,
+        Double improvement) {
 
     public record SessionScore(
             Integer sessionId,

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/CommunicationScoreRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/CommunicationScoreRepository.java
@@ -1,5 +1,6 @@
 package com.example.FreStyle.repository;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,4 +17,8 @@ public interface CommunicationScoreRepository extends JpaRepository<Communicatio
 
     @Query("SELECT cs FROM CommunicationScore cs WHERE cs.user.id = :userId ORDER BY cs.createdAt DESC")
     List<CommunicationScore> findByUserIdOrderByCreatedAtDesc(@Param("userId") Integer userId);
+
+    @Query("SELECT cs FROM CommunicationScore cs WHERE cs.user.id = :userId AND cs.createdAt > :cutoff ORDER BY cs.createdAt DESC")
+    List<CommunicationScore> findByUserIdAndCreatedAtAfterOrderByCreatedAtDesc(
+            @Param("userId") Integer userId, @Param("cutoff") Timestamp cutoff);
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreTrendControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreTrendControllerTest.java
@@ -35,13 +35,13 @@ class ScoreTrendControllerTest {
 
     @Test
     @DisplayName("スコアトレンドを取得できる")
-    void getTrend_returnsTrend() {
+    void getTrendReturnsTrend() {
         Jwt jwt = mock(Jwt.class);
         when(jwt.getSubject()).thenReturn("sub-123");
         User user = new User();
         user.setId(1);
         when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
-        ScoreTrendDto dto = new ScoreTrendDto(30, List.of(), 0.0, null, 0);
+        ScoreTrendDto dto = new ScoreTrendDto(30, List.of(), 0.0, null, 0, null);
         when(getScoreTrendUseCase.execute(1, 30)).thenReturn(dto);
 
         ResponseEntity<ScoreTrendDto> response = scoreTrendController.getTrend(jwt, 30);
@@ -51,18 +51,18 @@ class ScoreTrendControllerTest {
     }
 
     @Test
-    @DisplayName("days未指定時はデフォルト30日になる")
-    void getTrend_defaultDays() {
+    @DisplayName("UseCaseに正しいuserIdとdaysを渡している")
+    void getTrendPassesCorrectArguments() {
         Jwt jwt = mock(Jwt.class);
-        when(jwt.getSubject()).thenReturn("sub-123");
+        when(jwt.getSubject()).thenReturn("sub-456");
         User user = new User();
-        user.setId(1);
-        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
-        ScoreTrendDto dto = new ScoreTrendDto(30, List.of(), 0.0, null, 0);
-        when(getScoreTrendUseCase.execute(1, 30)).thenReturn(dto);
+        user.setId(42);
+        when(userIdentityService.findUserBySub("sub-456")).thenReturn(user);
+        ScoreTrendDto dto = new ScoreTrendDto(7, List.of(), 0.0, null, 0, null);
+        when(getScoreTrendUseCase.execute(42, 7)).thenReturn(dto);
 
-        ResponseEntity<ScoreTrendDto> response = scoreTrendController.getTrend(jwt, 30);
+        scoreTrendController.getTrend(jwt, 7);
 
-        verify(getScoreTrendUseCase).execute(1, 30);
+        verify(getScoreTrendUseCase).execute(42, 7);
     }
 }


### PR DESCRIPTION
## 概要
- 指定期間内のセッション別平均スコアの推移を取得するAPIを追加
- 全体平均スコア、最高スコアセッション情報も含む

## エンドポイント
`GET /api/scores/trend?days=30`

## 新規ファイル
- `ScoreTrendDto` (record) - レスポンスDTO
- `GetScoreTrendUseCase` - トレンド算出ロジック
- `ScoreTrendController` - エンドポイント

## テスト結果
- 733テスト通過（+7新規、1失敗はcontextLoads）
- UseCase: 5テスト（複数セッション、空データ、期間外除外、ソート順、days指定）
- Controller: 2テスト（正常取得、引数検証）

closes #1261