### PR TITLE
ScoreCardDto・NotificationDto・ScoreHistoryDtoをJava recordに変換

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
@@ -282,7 +282,7 @@ public class AiChatWebSocketController {
                     "/topic/ai-chat/user/" + userId + "/scorecard",
                     scoreCard
             );
-            log.info("✅ {}送信完了 - 総合スコア: {}", logLabel, scoreCard.getOverallScore());
+            log.info("✅ {}送信完了 - 総合スコア: {}", logLabel, scoreCard.overallScore());
         } else {
             log.warn("⚠️ AI応答からスコアを抽出できませんでした");
         }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/NotificationDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/NotificationDto.java
@@ -1,18 +1,11 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class NotificationDto {
-    private Integer id;
-    private String type;
-    private String title;
-    private String message;
-    private Boolean isRead;
-    private Integer relatedId;
-    private String createdAt;
+public record NotificationDto(
+        Integer id,
+        String type,
+        String title,
+        String message,
+        Boolean isRead,
+        Integer relatedId,
+        String createdAt) {
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreCardDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreCardDto.java
@@ -2,25 +2,14 @@ package com.example.FreStyle.dto;
 
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+public record ScoreCardDto(
+        Integer sessionId,
+        List<AxisScoreDto> scores,
+        double overallScore) {
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class ScoreCardDto {
-
-    private Integer sessionId;
-    private List<AxisScoreDto> scores;
-    private double overallScore;
-
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AxisScoreDto {
-        private String axis;
-        private int score;
-        private String comment;
+    public record AxisScoreDto(
+            String axis,
+            int score,
+            String comment) {
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreHistoryDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreHistoryDto.java
@@ -3,18 +3,10 @@ package com.example.FreStyle.dto;
 import java.sql.Timestamp;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class ScoreHistoryDto {
-
-    private Integer sessionId;
-    private String sessionTitle;
-    private double overallScore;
-    private List<ScoreCardDto.AxisScoreDto> scores;
-    private Timestamp createdAt;
+public record ScoreHistoryDto(
+        Integer sessionId,
+        String sessionTitle,
+        double overallScore,
+        List<ScoreCardDto.AxisScoreDto> scores,
+        Timestamp createdAt) {
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/NotificationControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/NotificationControllerTest.java
@@ -78,7 +78,7 @@ class NotificationControllerTest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).hasSize(1);
-            assertThat(response.getBody().get(0).getType()).isEqualTo("NEW_MESSAGE");
+            assertThat(response.getBody().get(0).type()).isEqualTo("NEW_MESSAGE");
         }
 
         @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreCardControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreCardControllerTest.java
@@ -65,23 +65,21 @@ class ScoreCardControllerTest {
         @Test
         @DisplayName("スコアカードを取得する")
         void shouldReturnScoreCard() {
-            ScoreCardDto scoreCard = new ScoreCardDto();
-            scoreCard.setSessionId(10);
-            scoreCard.setOverallScore(8.5);
+            ScoreCardDto scoreCard = new ScoreCardDto(10, List.of(), 8.5);
             when(getScoreCardBySessionIdUseCase.execute(10)).thenReturn(scoreCard);
 
             ResponseEntity<ScoreCardDto> response = controller.getSessionScoreCard(jwt, 10);
 
             assertThat(response.getStatusCode().value()).isEqualTo(200);
             assertThat(response.getBody()).isNotNull();
-            assertThat(response.getBody().getSessionId()).isEqualTo(10);
-            assertThat(response.getBody().getOverallScore()).isEqualTo(8.5);
+            assertThat(response.getBody().sessionId()).isEqualTo(10);
+            assertThat(response.getBody().overallScore()).isEqualTo(8.5);
         }
 
         @Test
         @DisplayName("権限チェックが実行される")
         void shouldCheckAuthorization() {
-            ScoreCardDto scoreCard = new ScoreCardDto();
+            ScoreCardDto scoreCard = new ScoreCardDto(10, List.of(), 0.0);
             when(getScoreCardBySessionIdUseCase.execute(10)).thenReturn(scoreCard);
 
             controller.getSessionScoreCard(jwt, 10);
@@ -97,12 +95,8 @@ class ScoreCardControllerTest {
         @Test
         @DisplayName("スコア履歴を取得する")
         void shouldReturnScoreHistory() {
-            ScoreHistoryDto history1 = new ScoreHistoryDto();
-            history1.setSessionId(1);
-            history1.setOverallScore(7.5);
-            ScoreHistoryDto history2 = new ScoreHistoryDto();
-            history2.setSessionId(2);
-            history2.setOverallScore(8.0);
+            ScoreHistoryDto history1 = new ScoreHistoryDto(1, null, 7.5, List.of(), null);
+            ScoreHistoryDto history2 = new ScoreHistoryDto(2, null, 8.0, List.of(), null);
             when(getScoreHistoryByUserIdUseCase.execute(1))
                     .thenReturn(List.of(history1, history2));
 

--- a/FreStyle/src/test/java/com/example/FreStyle/dto/ScoreCardDtoTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/dto/ScoreCardDtoTest.java
@@ -10,17 +10,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ScoreCardDtoTest {
 
     @Test
-    @DisplayName("AllArgsConstructorでスコアカードが作成される")
-    void allArgsConstructorWorks() {
+    @DisplayName("スコアカードが正しく作成される")
+    void constructorWorks() {
         List<ScoreCardDto.AxisScoreDto> scores = List.of(
                 new ScoreCardDto.AxisScoreDto("論理的構成力", 8, "良い構成です"),
                 new ScoreCardDto.AxisScoreDto("表現力", 7, "改善の余地あり"));
 
         ScoreCardDto dto = new ScoreCardDto(1, scores, 7.5);
 
-        assertThat(dto.getSessionId()).isEqualTo(1);
-        assertThat(dto.getScores()).hasSize(2);
-        assertThat(dto.getOverallScore()).isEqualTo(7.5);
+        assertThat(dto.sessionId()).isEqualTo(1);
+        assertThat(dto.scores()).hasSize(2);
+        assertThat(dto.overallScore()).isEqualTo(7.5);
     }
 
     @Test
@@ -28,28 +28,8 @@ class ScoreCardDtoTest {
     void axisScoreDtoFieldsAreSet() {
         ScoreCardDto.AxisScoreDto axisScore = new ScoreCardDto.AxisScoreDto("傾聴力", 9, "素晴らしい");
 
-        assertThat(axisScore.getAxis()).isEqualTo("傾聴力");
-        assertThat(axisScore.getScore()).isEqualTo(9);
-        assertThat(axisScore.getComment()).isEqualTo("素晴らしい");
-    }
-
-    @Test
-    @DisplayName("NoArgsConstructorで空のスコアカードが作成される")
-    void noArgsConstructorWorks() {
-        ScoreCardDto dto = new ScoreCardDto();
-
-        assertThat(dto.getSessionId()).isNull();
-        assertThat(dto.getScores()).isNull();
-        assertThat(dto.getOverallScore()).isZero();
-    }
-
-    @Test
-    @DisplayName("AxisScoreDto NoArgsConstructorで空のスコアが作成される")
-    void axisScoreDtoNoArgsConstructorWorks() {
-        ScoreCardDto.AxisScoreDto axisScore = new ScoreCardDto.AxisScoreDto();
-
-        assertThat(axisScore.getAxis()).isNull();
-        assertThat(axisScore.getScore()).isZero();
-        assertThat(axisScore.getComment()).isNull();
+        assertThat(axisScore.axis()).isEqualTo("傾聴力");
+        assertThat(axisScore.score()).isEqualTo(9);
+        assertThat(axisScore.comment()).isEqualTo("素晴らしい");
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/mapper/ScoreCardMapperTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/mapper/ScoreCardMapperTest.java
@@ -52,11 +52,11 @@ class ScoreCardMapperTest {
 
             ScoreCardDto dto = mapper.toScoreCardDto(1, scores);
 
-            assertThat(dto.getSessionId()).isEqualTo(1);
-            assertThat(dto.getScores()).hasSize(2);
-            assertThat(dto.getScores().get(0).getAxis()).isEqualTo("明瞭性");
-            assertThat(dto.getScores().get(0).getScore()).isEqualTo(8);
-            assertThat(dto.getScores().get(0).getComment()).isEqualTo("良い");
+            assertThat(dto.sessionId()).isEqualTo(1);
+            assertThat(dto.scores()).hasSize(2);
+            assertThat(dto.scores().get(0).axis()).isEqualTo("明瞭性");
+            assertThat(dto.scores().get(0).score()).isEqualTo(8);
+            assertThat(dto.scores().get(0).comment()).isEqualTo("良い");
         }
 
         @Test
@@ -71,7 +71,7 @@ class ScoreCardMapperTest {
 
             ScoreCardDto dto = mapper.toScoreCardDto(1, scores);
 
-            assertThat(dto.getOverallScore()).isEqualTo(6.0);
+            assertThat(dto.overallScore()).isEqualTo(6.0);
         }
 
         @Test
@@ -79,8 +79,8 @@ class ScoreCardMapperTest {
         void returnsZeroForEmptyList() {
             ScoreCardDto dto = mapper.toScoreCardDto(1, List.of());
 
-            assertThat(dto.getScores()).isEmpty();
-            assertThat(dto.getOverallScore()).isEqualTo(0.0);
+            assertThat(dto.scores()).isEmpty();
+            assertThat(dto.overallScore()).isEqualTo(0.0);
         }
 
         @Test
@@ -111,10 +111,10 @@ class ScoreCardMapperTest {
             List<ScoreHistoryDto> history = mapper.toScoreHistoryDtoList(scores);
 
             assertThat(history).hasSize(2);
-            assertThat(history.get(0).getSessionId()).isEqualTo(1);
-            assertThat(history.get(0).getSessionTitle()).isEqualTo("セッション1");
-            assertThat(history.get(0).getScores()).hasSize(2);
-            assertThat(history.get(1).getSessionId()).isEqualTo(2);
+            assertThat(history.get(0).sessionId()).isEqualTo(1);
+            assertThat(history.get(0).sessionTitle()).isEqualTo("セッション1");
+            assertThat(history.get(0).scores()).hasSize(2);
+            assertThat(history.get(1).sessionId()).isEqualTo(2);
         }
 
         @Test
@@ -128,7 +128,7 @@ class ScoreCardMapperTest {
 
             List<ScoreHistoryDto> history = mapper.toScoreHistoryDtoList(scores);
 
-            assertThat(history.get(0).getOverallScore()).isEqualTo(8.0);
+            assertThat(history.get(0).overallScore()).isEqualTo(8.0);
         }
 
         @Test
@@ -157,7 +157,7 @@ class ScoreCardMapperTest {
 
             List<ScoreHistoryDto> history = mapper.toScoreHistoryDtoList(scores);
 
-            assertThat(history.get(0).getCreatedAt()).isNotNull();
+            assertThat(history.get(0).createdAt()).isNotNull();
         }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreCardBySessionIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreCardBySessionIdUseCaseTest.java
@@ -73,9 +73,9 @@ class GetScoreCardBySessionIdUseCaseTest {
             ScoreCardDto result = useCase.execute(sessionId);
 
             // Assert
-            assertThat(result.getSessionId()).isEqualTo(sessionId);
-            assertThat(result.getScores()).hasSize(2);
-            assertThat(result.getOverallScore()).isEqualTo(7.0);
+            assertThat(result.sessionId()).isEqualTo(sessionId);
+            assertThat(result.scores()).hasSize(2);
+            assertThat(result.overallScore()).isEqualTo(7.0);
 
             verify(communicationScoreRepository, times(1)).findBySessionId(sessionId);
             verify(mapper, times(1)).toScoreCardDto(sessionId, entities);
@@ -97,9 +97,9 @@ class GetScoreCardBySessionIdUseCaseTest {
             ScoreCardDto result = useCase.execute(sessionId);
 
             // Assert
-            assertThat(result.getSessionId()).isEqualTo(sessionId);
-            assertThat(result.getScores()).isEmpty();
-            assertThat(result.getOverallScore()).isEqualTo(0.0);
+            assertThat(result.sessionId()).isEqualTo(sessionId);
+            assertThat(result.scores()).isEmpty();
+            assertThat(result.overallScore()).isEqualTo(0.0);
 
             verify(communicationScoreRepository, times(1)).findBySessionId(sessionId);
             verify(mapper, times(1)).toScoreCardDto(sessionId, emptyList);

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCaseTest.java
@@ -83,9 +83,9 @@ class GetScoreHistoryByUserIdUseCaseTest {
 
             // Assert
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).getSessionId()).isEqualTo(10);
-            assertThat(result.get(0).getOverallScore()).isEqualTo(7.0);
-            assertThat(result.get(0).getScores()).hasSize(2);
+            assertThat(result.get(0).sessionId()).isEqualTo(10);
+            assertThat(result.get(0).overallScore()).isEqualTo(7.0);
+            assertThat(result.get(0).scores()).hasSize(2);
 
             verify(communicationScoreRepository, times(1)).findByUserIdOrderByCreatedAtDesc(userId);
             verify(mapper, times(1)).toScoreHistoryDtoList(entities);

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserNotificationsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserNotificationsUseCaseTest.java
@@ -49,10 +49,10 @@ class GetUserNotificationsUseCaseTest {
         List<NotificationDto> result = getUserNotificationsUseCase.execute(1);
 
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getId()).isEqualTo(10);
-        assertThat(result.get(0).getType()).isEqualTo("NEW_MESSAGE");
-        assertThat(result.get(0).getTitle()).isEqualTo("新しいメッセージ");
-        assertThat(result.get(0).getIsRead()).isFalse();
+        assertThat(result.get(0).id()).isEqualTo(10);
+        assertThat(result.get(0).type()).isEqualTo("NEW_MESSAGE");
+        assertThat(result.get(0).title()).isEqualTo("新しいメッセージ");
+        assertThat(result.get(0).isRead()).isFalse();
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveScoreCardUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveScoreCardUseCaseTest.java
@@ -72,11 +72,11 @@ class SaveScoreCardUseCaseTest {
 
             // Assert
             assertThat(result).isNotNull();
-            assertThat(result.getSessionId()).isEqualTo(sessionId);
-            assertThat(result.getScores()).hasSize(1);
-            assertThat(result.getScores().get(0).getAxis()).isEqualTo("論理的構成力");
-            assertThat(result.getScores().get(0).getScore()).isEqualTo(8);
-            assertThat(result.getOverallScore()).isEqualTo(8.0);
+            assertThat(result.sessionId()).isEqualTo(sessionId);
+            assertThat(result.scores()).hasSize(1);
+            assertThat(result.scores().get(0).axis()).isEqualTo("論理的構成力");
+            assertThat(result.scores().get(0).score()).isEqualTo(8);
+            assertThat(result.overallScore()).isEqualTo(8.0);
 
             verify(communicationScoreRepository, times(1)).save(any(CommunicationScore.class));
         }
@@ -108,8 +108,8 @@ class SaveScoreCardUseCaseTest {
             ScoreCardDto result = useCase.execute(sessionId, userId, aiResponse, null);
 
             // Assert
-            assertThat(result.getScores()).hasSize(3);
-            assertThat(result.getOverallScore()).isEqualTo(7.0);
+            assertThat(result.scores()).hasSize(3);
+            assertThat(result.overallScore()).isEqualTo(7.0);
 
             ArgumentCaptor<CommunicationScore> captor = ArgumentCaptor.forClass(CommunicationScore.class);
             verify(communicationScoreRepository, times(3)).save(captor.capture());


### PR DESCRIPTION
## 概要
- ScoreCardDto（AxisScoreDto含む）、NotificationDto、ScoreHistoryDtoをLombok `@Data`クラスからJava recordに変換
- 関連するテスト・ソースコードのgetter呼び出しをrecordアクセサに更新（`getXxx()` → `xxx()`）
- no-argコンストラクタ＋setter使用箇所をrecordコンストラクタに置き換え

## 変更ファイル
- DTO: ScoreCardDto, NotificationDto, ScoreHistoryDto
- テスト: ScoreCardDtoTest, ScoreCardMapperTest, ScoreCardControllerTest, GetScoreCardBySessionIdUseCaseTest, SaveScoreCardUseCaseTest, GetUserNotificationsUseCaseTest, NotificationControllerTest, GetScoreHistoryByUserIdUseCaseTest
- ソース: AiChatWebSocketController (getter→recordアクセサ)

## テスト結果
- 731テスト通過（contextLoads除く）
- ScoreCardDtoTestからNoArgsConstructor関連の2テストを削除（recordに不要）

closes #1263