### PR TITLE
refactor: FavoritePhraseDto・FriendshipDto・ErrorResponseDtoをJava recordに変換

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ErrorResponseDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ErrorResponseDto.java
@@ -2,47 +2,13 @@ package com.example.FreStyle.dto;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+public record ErrorResponseDto(
+        LocalDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        String path) {
 
-/**
- * エラーレスポンスDTO
- *
- * <p>役割:</p>
- * <ul>
- *   <li>APIエラー時の統一されたレスポンス形式を提供</li>
- *   <li>クライアントがエラーを適切に処理できるよう必要な情報を含む</li>
- * </ul>
- *
- * <p>フィールド:</p>
- * <ul>
- *   <li>timestamp: エラー発生日時</li>
- *   <li>status: HTTPステータスコード</li>
- *   <li>error: HTTPステータスの説明</li>
- *   <li>message: エラーメッセージ（ユーザーに表示可能）</li>
- *   <li>path: エラーが発生したリクエストパス</li>
- * </ul>
- */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class ErrorResponseDto {
-    private LocalDateTime timestamp;
-    private int status;
-    private String error;
-    private String message;
-    private String path;
-
-    /**
-     * エラーレスポンスを作成（ファクトリーメソッド）
-     *
-     * @param status HTTPステータスコード
-     * @param error HTTPステータスの説明
-     * @param message エラーメッセージ
-     * @param path リクエストパス
-     * @return ErrorResponseDto
-     */
     public static ErrorResponseDto of(int status, String error, String message, String path) {
         return new ErrorResponseDto(
             LocalDateTime.now(),

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/FavoritePhraseDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/FavoritePhraseDto.java
@@ -1,16 +1,9 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class FavoritePhraseDto {
-    private Integer id;
-    private String originalText;
-    private String rephrasedText;
-    private String pattern;
-    private String createdAt;
+public record FavoritePhraseDto(
+        Integer id,
+        String originalText,
+        String rephrasedText,
+        String pattern,
+        String createdAt) {
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/FriendshipDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/FriendshipDto.java
@@ -1,18 +1,11 @@
 package com.example.FreStyle.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class FriendshipDto {
-    private Integer id;
-    private Integer userId;
-    private String username;
-    private String iconUrl;
-    private String bio;
-    private boolean mutual;
-    private String createdAt;
+public record FriendshipDto(
+        Integer id,
+        Integer userId,
+        String username,
+        String iconUrl,
+        String bio,
+        boolean mutual,
+        String createdAt) {
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
@@ -72,7 +72,7 @@ class FavoritePhraseControllerTest {
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
             assertThat(response.getBody()).hasSize(1);
-            assertThat(response.getBody().get(0).getOriginalText()).isEqualTo("元文");
+            assertThat(response.getBody().get(0).originalText()).isEqualTo("元文");
         }
     }
 

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/FriendshipControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/FriendshipControllerTest.java
@@ -92,7 +92,7 @@ class FriendshipControllerTest {
             ResponseEntity<FriendshipDto> response = friendshipController.followUser(mockJwt, 2);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-            assertThat(response.getBody().getUserId()).isEqualTo(2);
+            assertThat(response.getBody().userId()).isEqualTo(2);
         }
     }
 

--- a/FreStyle/src/test/java/com/example/FreStyle/dto/ErrorResponseDtoTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/dto/ErrorResponseDtoTest.java
@@ -16,9 +16,9 @@ class ErrorResponseDtoTest {
 
         ErrorResponseDto dto = ErrorResponseDto.of(404, "Not Found", "リソースが見つかりません", "/api/test");
 
-        assertThat(dto.getTimestamp()).isNotNull();
-        assertThat(dto.getTimestamp()).isAfterOrEqualTo(before);
-        assertThat(dto.getTimestamp()).isBeforeOrEqualTo(LocalDateTime.now());
+        assertThat(dto.timestamp()).isNotNull();
+        assertThat(dto.timestamp()).isAfterOrEqualTo(before);
+        assertThat(dto.timestamp()).isBeforeOrEqualTo(LocalDateTime.now());
     }
 
     @Test
@@ -26,34 +26,22 @@ class ErrorResponseDtoTest {
     void ofSetsAllFields() {
         ErrorResponseDto dto = ErrorResponseDto.of(400, "Bad Request", "不正なリクエストです", "/api/auth/login");
 
-        assertThat(dto.getStatus()).isEqualTo(400);
-        assertThat(dto.getError()).isEqualTo("Bad Request");
-        assertThat(dto.getMessage()).isEqualTo("不正なリクエストです");
-        assertThat(dto.getPath()).isEqualTo("/api/auth/login");
+        assertThat(dto.status()).isEqualTo(400);
+        assertThat(dto.error()).isEqualTo("Bad Request");
+        assertThat(dto.message()).isEqualTo("不正なリクエストです");
+        assertThat(dto.path()).isEqualTo("/api/auth/login");
     }
 
     @Test
-    @DisplayName("AllArgsConstructorで全フィールドが設定される")
-    void allArgsConstructorWorks() {
+    @DisplayName("recordコンストラクタで全フィールドが設定される")
+    void recordConstructorWorks() {
         LocalDateTime now = LocalDateTime.now();
         ErrorResponseDto dto = new ErrorResponseDto(now, 500, "Internal Server Error", "サーバーエラー", "/api/test");
 
-        assertThat(dto.getTimestamp()).isEqualTo(now);
-        assertThat(dto.getStatus()).isEqualTo(500);
-        assertThat(dto.getError()).isEqualTo("Internal Server Error");
-        assertThat(dto.getMessage()).isEqualTo("サーバーエラー");
-        assertThat(dto.getPath()).isEqualTo("/api/test");
-    }
-
-    @Test
-    @DisplayName("NoArgsConstructorで空のDTOが作成される")
-    void noArgsConstructorWorks() {
-        ErrorResponseDto dto = new ErrorResponseDto();
-
-        assertThat(dto.getTimestamp()).isNull();
-        assertThat(dto.getStatus()).isZero();
-        assertThat(dto.getError()).isNull();
-        assertThat(dto.getMessage()).isNull();
-        assertThat(dto.getPath()).isNull();
+        assertThat(dto.timestamp()).isEqualTo(now);
+        assertThat(dto.status()).isEqualTo(500);
+        assertThat(dto.error()).isEqualTo("Internal Server Error");
+        assertThat(dto.message()).isEqualTo("サーバーエラー");
+        assertThat(dto.path()).isEqualTo("/api/test");
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/exception/GlobalExceptionHandlerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/exception/GlobalExceptionHandlerTest.java
@@ -37,10 +37,10 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getStatus()).isEqualTo(404);
-        assertThat(response.getBody().getError()).isEqualTo("Not Found");
-        assertThat(response.getBody().getMessage()).isEqualTo("ノートが見つかりません");
-        assertThat(response.getBody().getPath()).isEqualTo("/api/notes/999");
+        assertThat(response.getBody().status()).isEqualTo(404);
+        assertThat(response.getBody().error()).isEqualTo("Not Found");
+        assertThat(response.getBody().message()).isEqualTo("ノートが見つかりません");
+        assertThat(response.getBody().path()).isEqualTo("/api/notes/999");
     }
 
     @Test
@@ -53,10 +53,10 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getStatus()).isEqualTo(403);
-        assertThat(response.getBody().getError()).isEqualTo("Forbidden");
-        assertThat(response.getBody().getMessage()).isEqualTo("アクセス権限がありません");
-        assertThat(response.getBody().getPath()).isEqualTo("/api/notes/1");
+        assertThat(response.getBody().status()).isEqualTo(403);
+        assertThat(response.getBody().error()).isEqualTo("Forbidden");
+        assertThat(response.getBody().message()).isEqualTo("アクセス権限がありません");
+        assertThat(response.getBody().path()).isEqualTo("/api/notes/1");
     }
 
     @Test
@@ -69,10 +69,10 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getStatus()).isEqualTo(400);
-        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
-        assertThat(response.getBody().getMessage()).isEqualTo("メールアドレスが無効です");
-        assertThat(response.getBody().getPath()).isEqualTo("/api/auth/signup");
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().error()).isEqualTo("Bad Request");
+        assertThat(response.getBody().message()).isEqualTo("メールアドレスが無効です");
+        assertThat(response.getBody().path()).isEqualTo("/api/auth/signup");
     }
 
     @Test
@@ -85,10 +85,10 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getStatus()).isEqualTo(500);
-        assertThat(response.getBody().getError()).isEqualTo("Internal Server Error");
-        assertThat(response.getBody().getMessage()).isEqualTo("サーバーエラーが発生しました。管理者にお問い合わせください。");
-        assertThat(response.getBody().getPath()).isEqualTo("/api/data");
+        assertThat(response.getBody().status()).isEqualTo(500);
+        assertThat(response.getBody().error()).isEqualTo("Internal Server Error");
+        assertThat(response.getBody().message()).isEqualTo("サーバーエラーが発生しました。管理者にお問い合わせください。");
+        assertThat(response.getBody().path()).isEqualTo("/api/data");
     }
 
     @Test
@@ -101,10 +101,10 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getStatus()).isEqualTo(400);
-        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
-        assertThat(response.getBody().getMessage()).isEqualTo("許可されていないファイル形式です");
-        assertThat(response.getBody().getPath()).isEqualTo("/api/notes/1/images");
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().error()).isEqualTo("Bad Request");
+        assertThat(response.getBody().message()).isEqualTo("許可されていないファイル形式です");
+        assertThat(response.getBody().path()).isEqualTo("/api/notes/1/images");
     }
 
     @Test
@@ -117,10 +117,10 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getStatus()).isEqualTo(400);
-        assertThat(response.getBody().getError()).isEqualTo("Bad Request");
-        assertThat(response.getBody().getMessage()).isEqualTo("無効な状態です");
-        assertThat(response.getBody().getPath()).isEqualTo("/api/chat/users/1/create");
+        assertThat(response.getBody().status()).isEqualTo(400);
+        assertThat(response.getBody().error()).isEqualTo("Bad Request");
+        assertThat(response.getBody().message()).isEqualTo("無効な状態です");
+        assertThat(response.getBody().path()).isEqualTo("/api/chat/users/1/create");
     }
 
     @Test
@@ -132,6 +132,6 @@ class GlobalExceptionHandlerTest {
         ResponseEntity<ErrorResponseDto> response = handler.handleResourceNotFoundException(ex, request);
 
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().getTimestamp()).isNotNull();
+        assertThat(response.getBody().timestamp()).isNotNull();
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/FollowUserUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/FollowUserUseCaseTest.java
@@ -63,9 +63,9 @@ class FollowUserUseCaseTest {
         FriendshipDto result = followUserUseCase.execute(follower, following);
 
         assertThat(result).isNotNull();
-        assertThat(result.getUserId()).isEqualTo(2);
-        assertThat(result.getUsername()).isEqualTo("ユーザーB");
-        assertThat(result.isMutual()).isFalse();
+        assertThat(result.userId()).isEqualTo(2);
+        assertThat(result.username()).isEqualTo("ユーザーB");
+        assertThat(result.mutual()).isFalse();
         verify(friendshipRepository).save(any(Friendship.class));
     }
 
@@ -83,7 +83,7 @@ class FollowUserUseCaseTest {
         FriendshipDto result = followUserUseCase.execute(follower, following);
 
         assertThat(result).isNotNull();
-        assertThat(result.isMutual()).isTrue();
+        assertThat(result.mutual()).isTrue();
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetFollowersUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetFollowersUseCaseTest.java
@@ -65,10 +65,10 @@ class GetFollowersUseCaseTest {
         List<FriendshipDto> result = getFollowersUseCase.execute(1);
 
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getUserId()).isEqualTo(2);
-        assertThat(result.get(0).isMutual()).isTrue();
-        assertThat(result.get(1).getUserId()).isEqualTo(3);
-        assertThat(result.get(1).isMutual()).isFalse();
+        assertThat(result.get(0).userId()).isEqualTo(2);
+        assertThat(result.get(0).mutual()).isTrue();
+        assertThat(result.get(1).userId()).isEqualTo(3);
+        assertThat(result.get(1).mutual()).isFalse();
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetFollowingUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetFollowingUseCaseTest.java
@@ -65,10 +65,10 @@ class GetFollowingUseCaseTest {
         List<FriendshipDto> result = getFollowingUseCase.execute(1);
 
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getUserId()).isEqualTo(2);
-        assertThat(result.get(0).isMutual()).isTrue();
-        assertThat(result.get(1).getUserId()).isEqualTo(3);
-        assertThat(result.get(1).isMutual()).isFalse();
+        assertThat(result.get(0).userId()).isEqualTo(2);
+        assertThat(result.get(0).mutual()).isTrue();
+        assertThat(result.get(1).userId()).isEqualTo(3);
+        assertThat(result.get(1).mutual()).isFalse();
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCaseTest.java
@@ -56,9 +56,9 @@ class GetUserFavoritePhrasesUseCaseTest {
         List<FavoritePhraseDto> result = getUserFavoritePhrasesUseCase.execute(1);
 
         assertEquals(2, result.size());
-        assertEquals("確認お願いします", result.get(0).getOriginalText());
-        assertEquals("ご確認いただけますでしょうか", result.get(0).getRephrasedText());
-        assertEquals("フォーマル版", result.get(0).getPattern());
+        assertEquals("確認お願いします", result.get(0).originalText());
+        assertEquals("ご確認いただけますでしょうか", result.get(0).rephrasedText());
+        assertEquals("フォーマル版", result.get(0).pattern());
     }
 
     @Test


### PR DESCRIPTION
## 概要
DTO record化の第3弾。FavoritePhraseDto、FriendshipDto、ErrorResponseDtoをLombok @DataクラスからJava recordに変換

## 変更内容
- 3つのDTOをJava recordに変換
- テスト8ファイルのgetter呼び出しをrecordアクセサに更新
- ErrorResponseDtoのstaticファクトリメソッド`of()`は維持
- NoArgsConstructor関連テスト1件削除

## テスト結果
- 741テスト通過（contextLoads除く）

closes #1269