### PR TITLE
test: GetChatStatsUseCaseTest・GetChatRoomsUseCaseTestのテスト拡充 (2→4)

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatRoomsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatRoomsUseCaseTest.java
@@ -57,4 +57,36 @@ class GetChatRoomsUseCaseTest {
 
         verify(chatService).findChatUsers(1, "テスト");
     }
+
+    @Test
+    @DisplayName("チャットルームが0件の場合は空リストを返す")
+    void execute_noRooms_returnsEmptyList() {
+        User user = new User();
+        user.setId(5);
+        when(userIdentityService.findUserBySub("sub-empty")).thenReturn(user);
+        when(chatService.findChatUsers(5, null)).thenReturn(List.of());
+
+        List<ChatUserDto> result = getChatRoomsUseCase.execute("sub-empty", null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("複数のチャットルームを正しい順序で取得できる")
+    void execute_multipleRooms_returnsAll() {
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("sub-multi")).thenReturn(user);
+        ChatUserDto dto1 = new ChatUserDto(2, "a@example.com", "ユーザーA", 10);
+        ChatUserDto dto2 = new ChatUserDto(3, "b@example.com", "ユーザーB", 20);
+        ChatUserDto dto3 = new ChatUserDto(4, "c@example.com", "ユーザーC", 30);
+        when(chatService.findChatUsers(1, null)).thenReturn(List.of(dto1, dto2, dto3));
+
+        List<ChatUserDto> result = getChatRoomsUseCase.execute("sub-multi", null);
+
+        assertEquals(3, result.size());
+        assertEquals("ユーザーA", result.get(0).getName());
+        assertEquals("ユーザーB", result.get(1).getName());
+        assertEquals("ユーザーC", result.get(2).getName());
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatStatsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatStatsUseCaseTest.java
@@ -60,4 +60,38 @@ class GetChatStatsUseCaseTest {
 
         assertEquals(0L, result.get("chatPartnerCount"));
     }
+
+    @Test
+    @DisplayName("返却MapにchatPartnerCount・email・usernameの3キーが含まれる")
+    void execute_returnsAllExpectedKeys() {
+        User user = new User();
+        user.setId(3);
+        user.setName("キー検証ユーザー");
+        user.setEmail("keys@example.com");
+        when(userIdentityService.findUserBySub("sub-keys")).thenReturn(user);
+        when(roomMemberService.countChatPartners(3)).thenReturn(10L);
+
+        Map<String, Object> result = getChatStatsUseCase.execute("sub-keys");
+
+        assertEquals(3, result.size());
+        assertTrue(result.containsKey("chatPartnerCount"));
+        assertTrue(result.containsKey("email"));
+        assertTrue(result.containsKey("username"));
+    }
+
+    @Test
+    @DisplayName("正しいsubでUserIdentityServiceとRoomMemberServiceを呼び出す")
+    void execute_callsServicesWithCorrectParams() {
+        User user = new User();
+        user.setId(7);
+        user.setName("検証ユーザー");
+        user.setEmail("verify@example.com");
+        when(userIdentityService.findUserBySub("sub-verify")).thenReturn(user);
+        when(roomMemberService.countChatPartners(7)).thenReturn(3L);
+
+        getChatStatsUseCase.execute("sub-verify");
+
+        verify(userIdentityService).findUserBySub("sub-verify");
+        verify(roomMemberService).countChatPartners(7);
+    }
 }


### PR DESCRIPTION
## 概要
テスト品質向上のため、2つのUseCaseテストクラスのテストケースを2件→4件に拡充。

## 追加テストケース
- **GetChatStatsUseCaseTest**: 返却Map全キー存在検証、サービス呼び出しパラメータ検証
- **GetChatRoomsUseCaseTest**: 空リストのハンドリング、複数結果の順序検証

## テスト結果
- 全テストパス

Closes #1277