### PR TITLE
refactor: ChatMessageDtoをJava recordに変換

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ChatMessageDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ChatMessageDto.java
@@ -3,19 +3,12 @@ package com.example.FreStyle.dto;
 
 import java.sql.Timestamp;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class ChatMessageDto {
-    private Integer id;
-    private Integer roomId;
-    private Integer senderId;  // 送信者のユーザーID（内部用）
-    private String senderName;
-    private String content;
-    private Timestamp createdAt;
-    private Timestamp updatedAt;
-}
+public record ChatMessageDto(
+        Integer id,
+        Integer roomId,
+        Integer senderId,
+        String senderName,
+        String content,
+        Timestamp createdAt,
+        Timestamp updatedAt
+) {}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ChatWebSocketControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ChatWebSocketControllerTest.java
@@ -39,13 +39,8 @@ class ChatWebSocketControllerTest {
 
     @BeforeEach
     void setUp() {
-        savedMessage = new ChatMessageDto();
-        savedMessage.setId(100);
-        savedMessage.setRoomId(10);
-        savedMessage.setSenderId(1);
-        savedMessage.setSenderName("送信者");
-        savedMessage.setContent("テストメッセージ");
-        savedMessage.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        savedMessage = new ChatMessageDto(100, 10, 1, "送信者", "テストメッセージ",
+                new Timestamp(System.currentTimeMillis()), null);
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/service/ChatMessageServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ChatMessageServiceTest.java
@@ -68,8 +68,8 @@ class ChatMessageServiceTest {
         List<ChatMessageDto> result = chatMessageService.getMessagesByRoom(room, 10);
 
         assertEquals(2, result.size());
-        assertEquals("こんにちは", result.get(0).getContent());
-        assertEquals("お元気ですか", result.get(1).getContent());
+        assertEquals("こんにちは", result.get(0).content());
+        assertEquals("お元気ですか", result.get(1).content());
     }
 
     @Test
@@ -84,10 +84,10 @@ class ChatMessageServiceTest {
 
         ChatMessageDto dto = chatMessageService.addMessage(room, 10, "新メッセージ");
 
-        assertEquals(100, dto.getId());
-        assertEquals(1, dto.getRoomId());
-        assertEquals(10, dto.getSenderId());
-        assertEquals("新メッセージ", dto.getContent());
+        assertEquals(100, dto.id());
+        assertEquals(1, dto.roomId());
+        assertEquals(10, dto.senderId());
+        assertEquals("新メッセージ", dto.content());
     }
 
     @Test
@@ -101,7 +101,7 @@ class ChatMessageServiceTest {
 
         ChatMessageDto dto = chatMessageService.updateMessage(1, "新内容");
 
-        assertEquals("新内容", dto.getContent());
+        assertEquals("新内容", dto.content());
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatHistoryUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetChatHistoryUseCaseTest.java
@@ -44,14 +44,13 @@ class GetChatHistoryUseCaseTest {
         ChatRoom chatRoom = new ChatRoom();
         chatRoom.setId(10);
         when(chatRoomService.findChatRoomById(10)).thenReturn(chatRoom);
-        ChatMessageDto msg = new ChatMessageDto();
-        msg.setContent("テストメッセージ");
+        ChatMessageDto msg = new ChatMessageDto(null, null, null, null, "テストメッセージ", null, null);
         when(chatMessageService.getMessagesByRoom(chatRoom, 1)).thenReturn(List.of(msg));
 
         List<ChatMessageDto> result = getChatHistoryUseCase.execute("sub-123", 10);
 
         assertEquals(1, result.size());
-        assertEquals("テストメッセージ", result.get(0).getContent());
+        assertEquals("テストメッセージ", result.get(0).content());
     }
 
     @Test

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SendChatMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SendChatMessageUseCaseTest.java
@@ -50,13 +50,8 @@ class SendChatMessageUseCaseTest {
         testRoom = new ChatRoom();
         testRoom.setId(10);
 
-        savedMessage = new ChatMessageDto();
-        savedMessage.setId(100);
-        savedMessage.setRoomId(10);
-        savedMessage.setSenderId(1);
-        savedMessage.setSenderName("送信者");
-        savedMessage.setContent("テストメッセージ");
-        savedMessage.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        savedMessage = new ChatMessageDto(100, 10, 1, "送信者", "テストメッセージ",
+                new Timestamp(System.currentTimeMillis()), null);
 
         partner = new User();
         partner.setId(2);


### PR DESCRIPTION
## 概要
ChatMessageDtoをLombok @DataクラスからJava recordに変換し、不変性を保証。

## 変更内容
- ChatMessageDtoを@Dataからrecordに変換（1ファイル）
- テストコードのgetter/setter/no-argsコンストラクタ修正（4ファイル）

## 除外理由
UserDtoはmainコード（UserService.findUsersWithRoomId）でsetRoomId()が使われているためrecord変換不可。

## テスト結果
- 全764テストパス

Closes #1281