### PR TITLE
refactor: AxisScore内部クラスのrecord化とRequestTimingAspectの@RequiredArgsConstructor適用

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/config/RequestTimingAspect.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/RequestTimingAspect.java
@@ -7,18 +7,16 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Aspect
 @Component
+@RequiredArgsConstructor
 public class RequestTimingAspect {
 
     private final MeterRegistry meterRegistry;
-
-    public RequestTimingAspect(MeterRegistry meterRegistry) {
-        this.meterRegistry = meterRegistry;
-    }
 
     @Around("execution(* com.example.FreStyle.controller..*(..))")
     public Object timeControllerMethods(ProceedingJoinPoint joinPoint) throws Throwable {

--- a/FreStyle/src/main/java/com/example/FreStyle/service/ScoreCardService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ScoreCardService.java
@@ -80,35 +80,11 @@ public class ScoreCardService {
             return 0.0;
         }
         return scores.stream()
-                .mapToInt(AxisScore::getScore)
+                .mapToInt(AxisScore::score)
                 .average()
                 .orElse(0.0);
     }
 
-    /**
-     * 評価軸スコアの内部表現
-     */
-    public static class AxisScore {
-        private final String axis;
-        private final int score;
-        private final String comment;
-
-        public AxisScore(String axis, int score, String comment) {
-            this.axis = axis;
-            this.score = score;
-            this.comment = comment;
-        }
-
-        public String getAxis() {
-            return axis;
-        }
-
-        public int getScore() {
-            return score;
-        }
-
-        public String getComment() {
-            return comment;
-        }
+    public record AxisScore(String axis, int score, String comment) {
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveScoreCardUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveScoreCardUseCase.java
@@ -67,9 +67,9 @@ public class SaveScoreCardUseCase {
             CommunicationScore entity = new CommunicationScore();
             entity.setSession(session);
             entity.setUser(user);
-            entity.setAxisName(axisScore.getAxis());
-            entity.setScore(axisScore.getScore());
-            entity.setComment(axisScore.getComment());
+            entity.setAxisName(axisScore.axis());
+            entity.setScore(axisScore.score());
+            entity.setComment(axisScore.comment());
             entity.setScene(scene);
             communicationScoreRepository.save(entity);
         }
@@ -79,7 +79,7 @@ public class SaveScoreCardUseCase {
         double overallScore = scoreCardService.calculateOverallScore(scores);
 
         List<ScoreCardDto.AxisScoreDto> scoreDtos = scores.stream()
-                .map(s -> new ScoreCardDto.AxisScoreDto(s.getAxis(), s.getScore(), s.getComment()))
+                .map(s -> new ScoreCardDto.AxisScoreDto(s.axis(), s.score(), s.comment()))
                 .toList();
 
         return new ScoreCardDto(sessionId, scoreDtos, overallScore);

--- a/FreStyle/src/test/java/com/example/FreStyle/service/ScoreCardServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/ScoreCardServiceTest.java
@@ -31,9 +31,9 @@ class ScoreCardServiceTest {
             List<ScoreCardService.AxisScore> scores = service.parseScoresFromResponse(aiResponse);
 
             assertThat(scores).hasSize(5);
-            assertThat(scores.get(0).getAxis()).isEqualTo("論理的構成力");
-            assertThat(scores.get(0).getScore()).isEqualTo(8);
-            assertThat(scores.get(0).getComment()).isEqualTo("良い");
+            assertThat(scores.get(0).axis()).isEqualTo("論理的構成力");
+            assertThat(scores.get(0).score()).isEqualTo(8);
+            assertThat(scores.get(0).comment()).isEqualTo("良い");
         }
 
         @Test
@@ -151,8 +151,8 @@ class ScoreCardServiceTest {
             List<ScoreCardService.AxisScore> scores = service.parseScoresFromResponse(aiResponse);
 
             assertThat(scores).hasSize(1);
-            assertThat(scores.get(0).getAxis()).isEqualTo("論理的構成力");
-            assertThat(scores.get(0).getScore()).isEqualTo(8);
+            assertThat(scores.get(0).axis()).isEqualTo("論理的構成力");
+            assertThat(scores.get(0).score()).isEqualTo(8);
         }
 
         @Test
@@ -163,9 +163,9 @@ class ScoreCardServiceTest {
             List<ScoreCardService.AxisScore> scores = service.parseScoresFromResponse(aiResponse);
 
             assertThat(scores).hasSize(1);
-            assertThat(scores.get(0).getAxis()).isEqualTo("テスト");
-            assertThat(scores.get(0).getScore()).isEqualTo(0);
-            assertThat(scores.get(0).getComment()).isEmpty();
+            assertThat(scores.get(0).axis()).isEqualTo("テスト");
+            assertThat(scores.get(0).score()).isEqualTo(0);
+            assertThat(scores.get(0).comment()).isEmpty();
         }
 
         @Test
@@ -186,8 +186,8 @@ class ScoreCardServiceTest {
             List<ScoreCardService.AxisScore> scores = service.parseScoresFromResponse(aiResponse);
 
             assertThat(scores).hasSize(1);
-            assertThat(scores.get(0).getAxis()).isEqualTo("配慮表現");
-            assertThat(scores.get(0).getScore()).isEqualTo(7);
+            assertThat(scores.get(0).axis()).isEqualTo("配慮表現");
+            assertThat(scores.get(0).score()).isEqualTo(7);
         }
     }
 }


### PR DESCRIPTION
## 概要
- ScoreCardService.AxisScoreの手動コンストラクタ+getterクラスをJava recordに変換
- RequestTimingAspectの手動コンストラクタを@RequiredArgsConstructorに置き換え

## 変更内容
- ScoreCardService.AxisScore: 22行の内部クラス → 2行のrecordに簡素化
- SaveScoreCardUseCase: getAxis()/getScore()/getComment() → axis()/score()/comment()
- ScoreCardServiceTest: 同様にrecordアクセサに変更
- RequestTimingAspect: @RequiredArgsConstructor適用、手動コンストラクタ削除

## テスト
- 全782テスト通過（contextLoadsのDB接続失敗は既知）

closes #1293