### PR TITLE
test: CreateUserProfileUseCase・GetUserProfileUseCaseのテスト拡充 (2→4)

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateUserProfileUseCaseTest.java
@@ -58,4 +58,33 @@ class CreateUserProfileUseCaseTest {
         assertThatThrownBy(() -> useCase.execute("sub-123", form))
                 .isInstanceOf(RuntimeException.class);
     }
+
+    @Test
+    @DisplayName("findUserBySubとcreateProfileが正しく呼び出される")
+    void verifiesServiceCalls() {
+        User user = new User();
+        user.setId(5);
+        when(userIdentityService.findUserBySub("sub-xyz")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto(null, 5, "テスト", null, null, null, null, null, null);
+        when(userProfileService.createProfile(user, form)).thenReturn(dto);
+
+        useCase.execute("sub-xyz", form);
+
+        verify(userIdentityService).findUserBySub("sub-xyz");
+        verify(userProfileService).createProfile(user, form);
+    }
+
+    @Test
+    @DisplayName("userIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void propagatesExceptionFromUserIdentityService() {
+        when(userIdentityService.findUserBySub("unknown-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        UserProfileForm form = new UserProfileForm();
+
+        assertThatThrownBy(() -> useCase.execute("unknown-sub", form))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ユーザーが見つかりません");
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserProfileUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.example.FreStyle.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -54,5 +55,31 @@ class GetUserProfileUseCaseTest {
         UserProfileDto result = useCase.execute("sub-123");
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("findUserBySubとgetProfileByUserIdが正しく呼び出される")
+    void verifiesServiceCalls() {
+        User user = new User();
+        user.setId(20);
+        when(userIdentityService.findUserBySub("sub-456")).thenReturn(user);
+        UserProfileDto dto = new UserProfileDto(null, 20, "ユーザー2", null, null, null, null, null, null);
+        when(userProfileService.getProfileByUserId(20)).thenReturn(dto);
+
+        useCase.execute("sub-456");
+
+        verify(userIdentityService).findUserBySub("sub-456");
+        verify(userProfileService).getProfileByUserId(20);
+    }
+
+    @Test
+    @DisplayName("userIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void propagatesExceptionFromUserIdentityService() {
+        when(userIdentityService.findUserBySub("invalid-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        assertThatThrownBy(() -> useCase.execute("invalid-sub"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ユーザーが見つかりません");
     }
 }


### PR DESCRIPTION
## 概要
テストが2件のCreateUserProfileUseCaseTest・GetUserProfileUseCaseTestを各4件に拡充

## 追加テスト
### CreateUserProfileUseCaseTest
- findUserBySubとcreateProfileが正しく呼び出されることのverify確認
- userIdentityServiceが例外をスローした場合の伝搬確認

### GetUserProfileUseCaseTest
- findUserBySubとgetProfileByUserIdが正しく呼び出されることのverify確認
- userIdentityServiceが例外をスローした場合の伝搬確認

## テスト結果
- 全テスト通過

closes #1295