### PR TITLE
refactor: ScoreCardMapper・FriendshipMapperのコード改善

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/mapper/FriendshipMapper.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/mapper/FriendshipMapper.java
@@ -10,26 +10,20 @@ import com.example.FreStyle.entity.User;
 public class FriendshipMapper {
 
     public FriendshipDto toFollowingDto(Friendship friendship, boolean mutual) {
-        User following = friendship.getFollowing();
-        return new FriendshipDto(
-                friendship.getId(),
-                following.getId(),
-                following.getName(),
-                following.getIconUrl(),
-                following.getBio(),
-                mutual,
-                friendship.getCreatedAt() != null ? friendship.getCreatedAt().toString() : null
-        );
+        return toDto(friendship, friendship.getFollowing(), mutual);
     }
 
     public FriendshipDto toFollowerDto(Friendship friendship, boolean mutual) {
-        User follower = friendship.getFollower();
+        return toDto(friendship, friendship.getFollower(), mutual);
+    }
+
+    private FriendshipDto toDto(Friendship friendship, User user, boolean mutual) {
         return new FriendshipDto(
                 friendship.getId(),
-                follower.getId(),
-                follower.getName(),
-                follower.getIconUrl(),
-                follower.getBio(),
+                user.getId(),
+                user.getName(),
+                user.getIconUrl(),
+                user.getBio(),
                 mutual,
                 friendship.getCreatedAt() != null ? friendship.getCreatedAt().toString() : null
         );


### PR DESCRIPTION
## 概要
マッパークラスのコード品質改善

## 変更内容
### ScoreCardMapper
- 手動LinkedHashMapループをCollectors.groupingBy（Stream API）に置き換え
- get(0)をgetFirst()に変更（Java 21イディオム）
- ArrayListインポートを削除

### FriendshipMapper
- toFollowingDtoとtoFollowerDtoの重複コード（各11行）を共通toDtoメソッドに抽出
- 公開メソッドは1行の委譲のみに簡素化

## テスト
- 全792テスト通過（contextLoadsのDB接続失敗は既知）

closes #1299