### PR TITLE
test: GetAiChatMessagesBySessionIdUseCaseTest・GetAiChatSessionsByUserIdUseCaseTestのテスト拡充 (2→4)

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatMessagesBySessionIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatMessagesBySessionIdUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.example.FreStyle.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -62,5 +63,38 @@ class GetAiChatMessagesBySessionIdUseCaseTest {
         List<AiChatMessageResponseDto> result = useCase.execute(999);
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("repositoryとmapperが正しく呼び出される")
+    void verifiesRepositoryAndMapperCalls() {
+        AiChatMessage msg = new AiChatMessage();
+        msg.setId(10);
+        when(aiChatMessageRepository.findBySessionIdOrderByCreatedAtAsc(5))
+                .thenReturn(List.of(msg));
+        when(mapper.toDto(msg))
+                .thenReturn(new AiChatMessageResponseDto(10, null, null, null, null, null));
+
+        useCase.execute(5);
+
+        verify(aiChatMessageRepository).findBySessionIdOrderByCreatedAtAsc(5);
+        verify(mapper).toDto(msg);
+    }
+
+    @Test
+    @DisplayName("単一メッセージの場合でも正しく返す")
+    void shouldReturnSingleMessage() {
+        AiChatMessage msg = new AiChatMessage();
+        msg.setId(42);
+        when(aiChatMessageRepository.findBySessionIdOrderByCreatedAtAsc(3))
+                .thenReturn(List.of(msg));
+        when(mapper.toDto(msg))
+                .thenReturn(new AiChatMessageResponseDto(42, null, null, null, "hello", null));
+
+        List<AiChatMessageResponseDto> result = useCase.execute(3);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().id()).isEqualTo(42);
+        assertThat(result.getFirst().content()).isEqualTo("hello");
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatSessionsByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetAiChatSessionsByUserIdUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.example.FreStyle.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -62,5 +63,38 @@ class GetAiChatSessionsByUserIdUseCaseTest {
         List<AiChatSessionDto> result = useCase.execute(999);
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("repositoryとmapperが正しく呼び出される")
+    void verifiesRepositoryAndMapperCalls() {
+        AiChatSession session = new AiChatSession();
+        session.setId(10);
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(5))
+                .thenReturn(List.of(session));
+        when(mapper.toDto(session))
+                .thenReturn(new AiChatSessionDto(10, null, null, null, null, null, null, null, null));
+
+        useCase.execute(5);
+
+        verify(aiChatSessionRepository).findByUserIdOrderByCreatedAtDesc(5);
+        verify(mapper).toDto(session);
+    }
+
+    @Test
+    @DisplayName("単一セッションの場合でも正しく返す")
+    void shouldReturnSingleSession() {
+        AiChatSession session = new AiChatSession();
+        session.setId(42);
+        when(aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(3))
+                .thenReturn(List.of(session));
+        when(mapper.toDto(session))
+                .thenReturn(new AiChatSessionDto(42, null, "テストセッション", null, null, null, null, null, null));
+
+        List<AiChatSessionDto> result = useCase.execute(3);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().id()).isEqualTo(42);
+        assertThat(result.getFirst().title()).isEqualTo("テストセッション");
     }
 }


### PR DESCRIPTION
## 概要
- `GetAiChatMessagesBySessionIdUseCaseTest`: 2→4テスト
  - repositoryとmapperの呼び出し検証
  - 単一メッセージの場合のテスト
- `GetAiChatSessionsByUserIdUseCaseTest`: 2→4テスト
  - repositoryとmapperの呼び出し検証
  - 単一セッションの場合のテスト

closes #1307