### PR TITLE
refactor: Collectors.toList()→.toList()とget(0)→getFirst()のJava 21イディオム統一

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/service/AiChatMessageService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/AiChatMessageService.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -70,7 +69,7 @@ public class AiChatMessageService {
         List<AiChatMessage> messages = aiChatMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
         return messages.stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -81,7 +80,7 @@ public class AiChatMessageService {
         List<AiChatMessage> messages = aiChatMessageRepository.findByUserIdOrderByCreatedAtAsc(userId);
         return messages.stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/FreStyle/src/main/java/com/example/FreStyle/service/AiChatSessionService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/AiChatSessionService.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,7 +74,7 @@ public class AiChatSessionService {
         List<AiChatSession> sessions = aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId);
         return sessions.stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -118,7 +117,7 @@ public class AiChatSessionService {
         List<AiChatSession> sessions = aiChatSessionRepository.findByRelatedRoomId(roomId);
         return sessions.stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/FreStyle/src/main/java/com/example/FreStyle/service/ChatMessageService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ChatMessageService.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +31,7 @@ public class ChatMessageService {
         List<ChatMessage> messages = chatMessageRepository.findByRoomOrderByCreatedAtAsc(room);
         return messages.stream()
                 .map(msg -> toDto(msg))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/FreStyle/src/main/java/com/example/FreStyle/service/NoteService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/NoteService.java
@@ -13,7 +13,6 @@ import software.amazon.awssdk.services.dynamodb.model.*;
 
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Repository
 public class NoteService implements NoteRepository {
@@ -81,7 +80,7 @@ public class NoteService implements NoteRepository {
 
         return response.items().stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GenerateMonthlyReportUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GenerateMonthlyReportUseCase.java
@@ -38,7 +38,7 @@ public class GenerateMonthlyReportUseCase {
                     LocalDateTime ldt = ts.toLocalDateTime();
                     return ldt.getYear() == year && ldt.getMonthValue() == month;
                 })
-                .collect(Collectors.toList());
+                .toList();
 
         long totalSessions = monthlyScores.stream()
                 .map(s -> s.getSession().getId())

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatMessagesBySessionIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatMessagesBySessionIdUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +49,6 @@ public class GetAiChatMessagesBySessionIdUseCase {
         List<AiChatMessage> messages = aiChatMessageRepository.findBySessionIdOrderByCreatedAtAsc(sessionId);
         return messages.stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatMessagesByUserIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatMessagesByUserIdUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +49,6 @@ public class GetAiChatMessagesByUserIdUseCase {
         List<AiChatMessage> messages = aiChatMessageRepository.findByUserIdOrderByCreatedAtAsc(userId);
         return messages.stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatSessionsByRelatedRoomIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatSessionsByRelatedRoomIdUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +48,6 @@ public class GetAiChatSessionsByRelatedRoomIdUseCase {
         List<AiChatSession> sessions = aiChatSessionRepository.findByRelatedRoomId(roomId);
         return sessions.stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatSessionsByUserIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAiChatSessionsByUserIdUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +49,6 @@ public class GetAiChatSessionsByUserIdUseCase {
         List<AiChatSession> sessions = aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId);
         return sessions.stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAllPracticeScenariosUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetAllPracticeScenariosUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +48,6 @@ public class GetAllPracticeScenariosUseCase {
     public List<PracticeScenarioDto> execute() {
         return practiceScenarioRepository.findAll().stream()
                 .map(mapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetFollowersUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetFollowersUseCase.java
@@ -3,7 +3,6 @@ package com.example.FreStyle.usecase;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,13 +31,13 @@ public class GetFollowersUseCase {
 
         List<Integer> followerIds = friendships.stream()
                 .map(f -> f.getFollower().getId())
-                .collect(Collectors.toList());
+                .toList();
 
         Set<Integer> mutualIds = new HashSet<>(
                 friendshipRepository.findMutualFollowingIds(followerIds, userId));
 
         return friendships.stream()
                 .map(f -> friendshipMapper.toFollowerDto(f, mutualIds.contains(f.getFollower().getId())))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetFollowingUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetFollowingUseCase.java
@@ -3,7 +3,6 @@ package com.example.FreStyle.usecase;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,13 +31,13 @@ public class GetFollowingUseCase {
 
         List<Integer> followingIds = friendships.stream()
                 .map(f -> f.getFollowing().getId())
-                .collect(Collectors.toList());
+                .toList();
 
         Set<Integer> mutualIds = new HashSet<>(
                 friendshipRepository.findMutualFollowerIds(followingIds, userId));
 
         return friendships.stream()
                 .map(f -> friendshipMapper.toFollowingDto(f, mutualIds.contains(f.getFollowing().getId())))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetReportListUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetReportListUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +23,6 @@ public class GetReportListUseCase {
         return learningReportRepository.findByUserIdOrderByYearDescMonthDesc(userId)
                 .stream()
                 .map(learningReportMapper::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetScoreTrendUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetScoreTrendUseCase.java
@@ -51,7 +51,7 @@ public class GetScoreTrendUseCase {
                 })
                 .sorted(Comparator.comparing(ScoreTrendDto.SessionScore::createdAt,
                         Comparator.nullsLast(Comparator.naturalOrder())))
-                .collect(Collectors.toList());
+                .toList();
 
         double overallAverage = filteredScores.stream()
                 .mapToInt(CommunicationScore::getScore)
@@ -64,8 +64,8 @@ public class GetScoreTrendUseCase {
 
         Double improvement = null;
         if (sessionScores.size() >= 2) {
-            double firstAvg = sessionScores.get(0).averageScore();
-            double lastAvg = sessionScores.get(sessionScores.size() - 1).averageScore();
+            double firstAvg = sessionScores.getFirst().averageScore();
+            double lastAvg = sessionScores.getLast().averageScore();
             improvement = lastAvg - firstAvg;
         }
 

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserBookmarksUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserBookmarksUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +19,6 @@ public class GetUserBookmarksUseCase {
     public List<Integer> execute(Integer userId) {
         return scenarioBookmarkRepository.findByUserId(userId).stream()
                 .map(bookmark -> bookmark.getScenario().getId())
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserFavoritePhrasesUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +25,6 @@ public class GetUserFavoritePhrasesUseCase {
                         phrase.getRephrasedText(),
                         phrase.getPattern(),
                         phrase.getCreatedAt() != null ? phrase.getCreatedAt().toInstant().toString() : null))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserNotificationsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserNotificationsUseCase.java
@@ -1,7 +1,6 @@
 package com.example.FreStyle.usecase;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,7 @@ public class GetUserNotificationsUseCase {
         List<Notification> notifications = notificationRepository.findByUserIdOrderByCreatedAtDesc(userId);
         return notifications.stream()
                 .map(this::toDto)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private NotificationDto toDto(Notification notification) {


### PR DESCRIPTION
## 概要
Java 21のイディオムにコードベース全体を統一するリファクタリング

## 変更内容
### Collectors.toList() → .toList()（17ファイル）
- UseCase: 13ファイル
- Service: 4ファイル
- 不要になったCollectorsインポートを14ファイルから削除

### get(0) → getFirst() / get(size-1) → getLast()
- `GetScoreTrendUseCase`: `get(0)` → `getFirst()`, `get(size-1)` → `getLast()`

closes #1311