### PR TITLE
perf: 本番環境のSpring Boot設定を最適化

### DIFF
--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -48,7 +48,7 @@ aws.s3.note-images-cdn-url=${NOTE_IMAGES_CDN_URL}
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=5
 spring.datasource.hikari.idle-timeout=300000
-spring.datasource.hikari.connection-timeout=20000
+spring.datasource.hikari.connection-timeout=10000
 spring.datasource.hikari.max-lifetime=600000
 spring.datasource.hikari.register-mbeans=true
 


### PR DESCRIPTION
## 概要
ALBレスポンスタイムに最大2.4秒のスパイクが発生していたため、AWS CloudWatchメトリクスで原因を調査。
RDS（CPU 3%, Read 0.2ms）とECS（CPU 0-9%, Memory 14-17%）は問題なく、Spring Boot設定がボトルネックと特定。

## 変更内容

### 1. ログレベル最適化（DEBUG → WARN）
- Spring Security: DEBUG → WARN
- CORS: DEBUG → WARN
- Hibernate SQL: DEBUG → WARN
- Hibernate統計: DEBUG → WARN
- リクエスト毎のDEBUGログ出力を大幅に削減

### 2. HikariCP接続プールチューニング
- `maximum-pool-size=10` （デフォルトと同じだが明示化）
- `minimum-idle=5` （アイドル接続を5本維持して接続確立コストを回避）
- `idle-timeout=300000` （5分）
- `connection-timeout=20000` （20秒）
- `max-lifetime=600000` （10分）

### 3. Hibernate統計無効化
- `generate_statistics=false` （全クエリへの統計収集オーバーヘッドを除去）
- CloudWatchメトリクス + RequestTimingAspectで代替可能

## テスト
- 815テスト全パス（contextLoads除く）

Closes #1318