### PR TITLE
fix: schema.sqlにdaily_goals・scenario_bookmarksテーブルを追加

### DIFF
--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -219,6 +219,30 @@ CREATE TABLE IF NOT EXISTS friendships (
     INDEX idx_following (following_id)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- デイリー目標
+CREATE TABLE IF NOT EXISTS daily_goals (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    goal_date DATE NOT NULL,
+    target INT NOT NULL,
+    completed INT NOT NULL DEFAULT 0,
+
+    UNIQUE KEY uk_user_goal_date (user_id, goal_date),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- シナリオブックマーク
+CREATE TABLE IF NOT EXISTS scenario_bookmarks (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    scenario_id INT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_user_scenario (user_id, scenario_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (scenario_id) REFERENCES practice_scenarios(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘


### PR DESCRIPTION
## Summary
- `schema.sql` に `daily_goals` と `scenario_bookmarks` の CREATE TABLE 文を追加
- エンティティ（Java）は存在していたが、schema.sql に定義がなくRDSにテーブルが未作成だった
- ページ読み込みのたびに SQL エラーが発生し、約600ms（各310ms）のレスポンス遅延の原因になっていた

## 根拠（ECSログ）
```
[TIMING] ScenarioBookmarkController.getBookmarks - 313ms (exception: Table 'fre_style.scenario_bookmarks' doesn't exist)
[TIMING] DailyGoalController.getToday - 310ms (exception: Table 'fre_style.daily_goals' doesn't exist)
```

## Test plan
- [ ] デプロイ後、ECSログで `scenario_bookmarks doesn't exist` / `daily_goals doesn't exist` エラーが解消されることを確認
- [ ] メニューページの読み込み速度が改善されることを確認

Closes #1320