### PR TITLE
feat: ログイン/ログアウト時のトースト通知とLoginCallbackのLoading改善

### DIFF
--- a/frontend/src/components/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppShell.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '../../../store/authSlice';
 import AppShell from '../AppShell';
+import { ToastProvider } from '../../../hooks/useToast';
 
 function createTestStore() {
   return configureStore({
@@ -17,11 +18,13 @@ function renderAppShell() {
   return render(
     <Provider store={createTestStore()}>
       <MemoryRouter initialEntries={['/']}>
-        <Routes>
-          <Route element={<AppShell />}>
-            <Route path="/" element={<div>テストコンテンツ</div>} />
-          </Route>
-        </Routes>
+        <ToastProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={<div>テストコンテンツ</div>} />
+            </Route>
+          </Routes>
+        </ToastProvider>
       </MemoryRouter>
     </Provider>
   );

--- a/frontend/src/hooks/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginCallback.test.ts
@@ -24,6 +24,11 @@ vi.mock('../../store/authSlice', () => ({
   setAuthData: () => ({ type: 'auth/setAuthData' }),
 }));
 
+const mockShowToast = vi.fn();
+vi.mock('../useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast, toasts: [], removeToast: vi.fn() }),
+}));
+
 import authRepository from '../../repositories/AuthRepository';
 
 let mockSearchParams = '';
@@ -101,6 +106,28 @@ describe('useLoginCallback', () => {
     });
 
     expect(authRepository.callback).not.toHaveBeenCalled();
+  });
+
+  it('callback成功時にログインしましたトーストを表示する', async () => {
+    mockSearchParams = 'code=valid-code';
+    vi.mocked(authRepository.callback).mockResolvedValue({} as any);
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('success', 'ログインしました');
+  });
+
+  it('callback失敗時にトーストを表示しない', async () => {
+    mockSearchParams = 'code=invalid-code';
+    vi.mocked(authRepository.callback).mockRejectedValue(new Error('認証失敗'));
+
+    await act(async () => {
+      renderHook(() => useLoginCallback());
+    });
+
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 
   it('callback成功時にalertが呼ばれない', async () => {

--- a/frontend/src/hooks/__tests__/useSidebar.test.ts
+++ b/frontend/src/hooks/__tests__/useSidebar.test.ts
@@ -17,6 +17,11 @@ vi.mock('../../store/authSlice', () => ({
   clearAuth: () => ({ type: 'auth/clearAuth' }),
 }));
 
+const mockShowToast = vi.fn();
+vi.mock('../useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast, toasts: [], removeToast: vi.fn() }),
+}));
+
 const mockFetchChatUsers = vi.fn();
 const mockLogout = vi.fn();
 
@@ -115,6 +120,28 @@ describe('useSidebar', () => {
   it('初期状態でtotalUnreadが0である', () => {
     const { result } = renderHook(() => useSidebar());
     expect(result.current.totalUnread).toBe(0);
+  });
+
+  it('ログアウト成功時にログアウトしましたトーストを表示する', async () => {
+    const { result } = renderHook(() => useSidebar());
+
+    await act(async () => {
+      await result.current.handleLogout();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('success', 'ログアウトしました');
+  });
+
+  it('ログアウト失敗時にトーストを表示しない', async () => {
+    mockLogout.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useSidebar());
+
+    await act(async () => {
+      await result.current.handleLogout();
+    });
+
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 
   it('ログアウト失敗時にdispatchも呼ばれない', async () => {

--- a/frontend/src/hooks/useLoginCallback.ts
+++ b/frontend/src/hooks/useLoginCallback.ts
@@ -3,11 +3,13 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setAuthData } from '../store/authSlice';
 import authRepository from '../repositories/AuthRepository';
+import { useToast } from './useToast';
 
 export function useLoginCallback() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const { showToast } = useToast();
   const code = searchParams.get('code');
   const error = searchParams.get('error');
 
@@ -23,6 +25,7 @@ export function useLoginCallback() {
         .callback(code)
         .then(() => {
           dispatch(setAuthData());
+          showToast('success', 'ログインしました');
           navigate('/');
         })
         .catch(() => {
@@ -32,5 +35,5 @@ export function useLoginCallback() {
     } else {
       navigate('/login');
     }
-  }, [code, error, dispatch, navigate]);
+  }, [code, error, dispatch, navigate, showToast]);
 }

--- a/frontend/src/hooks/useSidebar.ts
+++ b/frontend/src/hooks/useSidebar.ts
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import { clearAuth } from '../store/authSlice';
 import ChatRepository from '../repositories/ChatRepository';
 import AuthRepository from '../repositories/AuthRepository';
+import { useToast } from './useToast';
 
 export function useSidebar() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const { showToast } = useToast();
   const [totalUnread, setTotalUnread] = useState(0);
 
   useEffect(() => {
@@ -29,11 +31,12 @@ export function useSidebar() {
     try {
       await AuthRepository.logout();
       dispatch(clearAuth());
+      showToast('success', 'ログアウトしました');
       navigate('/login');
     } catch {
       // サイレントに処理
     }
-  }, [dispatch, navigate]);
+  }, [dispatch, navigate, showToast]);
 
   return { totalUnread, handleLogout };
 }

--- a/frontend/src/pages/LoginCallback.tsx
+++ b/frontend/src/pages/LoginCallback.tsx
@@ -4,5 +4,5 @@ import { useLoginCallback } from '../hooks/useLoginCallback';
 export default function LoginCallback() {
   useLoginCallback();
 
-  return <Loading fullscreen message="ログイン中..." />;
+  return <Loading message="読み込み中..." className="py-12" />;
 }

--- a/frontend/src/pages/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/__tests__/LoginCallback.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import LoginCallback from '../LoginCallback';
 import authReducer from '../../store/authSlice';
 import authRepository from '../../repositories/AuthRepository';
+import { ToastProvider } from '../../hooks/useToast';
 
 const mockNavigate = vi.fn();
 
@@ -24,7 +25,9 @@ function renderWithRoute(search: string) {
   return render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[`/callback${search}`]}>
-        <LoginCallback />
+        <ToastProvider>
+          <LoginCallback />
+        </ToastProvider>
       </MemoryRouter>
     </Provider>,
   );
@@ -41,7 +44,8 @@ describe('LoginCallback', () => {
 
     renderWithRoute('?code=test-code');
 
-    expect(screen.getByText('ログイン中...')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
   });
 
   it('codeがない場合はログインページへリダイレクトする', async () => {


### PR DESCRIPTION
## Summary
- ログイン成功時に「ログインしました」トースト通知を表示
- ログアウト成功時に「ログアウトしました」トースト通知を表示
- LoginCallbackページのfullscreenローディングを通常のLoadingコンポーネントに変更

## 変更ファイル
- `useLoginCallback.ts` — useToast追加、ログイン成功時にトースト表示
- `useSidebar.ts` — useToast追加、ログアウト成功時にトースト表示
- `LoginCallback.tsx` — `<Loading fullscreen>` → `<Loading className="py-12">`
- テスト4ファイル更新（トースト検証追加、ToastProvider追加）

## Test plan
- [x] useLoginCallback: ログイン成功時にトースト表示される（2テスト追加）
- [x] useSidebar: ログアウト成功時にトースト表示される（2テスト追加）
- [x] LoginCallback: 通常のLoadingコンポーネントが表示される
- [x] 全2150テスト通過

Closes #1322