### PR TITLE
fix: ログイン/ログアウト後のトースト通知が表示されるよう修正

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { Routes, Route } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import LoginCallback from './pages/LoginCallback';
@@ -24,9 +25,23 @@ import AuthInitializer from './utils/AuthInitializer';
 import Protected from './utils/Protected';
 import AppShell from './components/layout/AppShell';
 import ErrorBoundary from './components/ErrorBoundary';
-import { ToastProvider } from './hooks/useToast';
+import { ToastProvider, useToast } from './hooks/useToast';
 import ToastContainer from './components/ToastContainer';
 
+function NavigationToast() {
+  const location = useLocation();
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    const toast = (location.state as { toast?: string })?.toast;
+    if (toast) {
+      showToast('success', toast);
+      window.history.replaceState({}, '');
+    }
+  }, [location, showToast]);
+
+  return null;
+}
 
 export default function App() {
   return (
@@ -72,6 +87,7 @@ export default function App() {
         <Route path="/friends" element={<FriendshipPage />} />
       </Route>
     </Routes>
+    <NavigationToast />
     <ToastContainer />
     </ToastProvider>
     </ErrorBoundary>

--- a/frontend/src/hooks/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginCallback.test.ts
@@ -24,11 +24,6 @@ vi.mock('../../store/authSlice', () => ({
   setAuthData: () => ({ type: 'auth/setAuthData' }),
 }));
 
-const mockShowToast = vi.fn();
-vi.mock('../useToast', () => ({
-  useToast: () => ({ showToast: mockShowToast, toasts: [], removeToast: vi.fn() }),
-}));
-
 import authRepository from '../../repositories/AuthRepository';
 
 let mockSearchParams = '';
@@ -60,7 +55,7 @@ describe('useLoginCallback', () => {
     });
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'auth/setAuthData' });
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/', { state: { toast: 'ログインしました' } });
   });
 
   it('callback失敗時にアラートを表示しログインページに遷移する', async () => {
@@ -108,7 +103,7 @@ describe('useLoginCallback', () => {
     expect(authRepository.callback).not.toHaveBeenCalled();
   });
 
-  it('callback成功時にログインしましたトーストを表示する', async () => {
+  it('callback成功時にトースト付きでホームに遷移する', async () => {
     mockSearchParams = 'code=valid-code';
     vi.mocked(authRepository.callback).mockResolvedValue({} as any);
 
@@ -116,10 +111,10 @@ describe('useLoginCallback', () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(mockShowToast).toHaveBeenCalledWith('success', 'ログインしました');
+    expect(mockNavigate).toHaveBeenCalledWith('/', { state: { toast: 'ログインしました' } });
   });
 
-  it('callback失敗時にトーストを表示しない', async () => {
+  it('callback失敗時にトースト付きで遷移しない', async () => {
     mockSearchParams = 'code=invalid-code';
     vi.mocked(authRepository.callback).mockRejectedValue(new Error('認証失敗'));
 
@@ -127,7 +122,7 @@ describe('useLoginCallback', () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/', expect.objectContaining({ state: expect.objectContaining({ toast: expect.any(String) }) }));
   });
 
   it('callback成功時にalertが呼ばれない', async () => {

--- a/frontend/src/hooks/__tests__/useSidebar.test.ts
+++ b/frontend/src/hooks/__tests__/useSidebar.test.ts
@@ -17,11 +17,6 @@ vi.mock('../../store/authSlice', () => ({
   clearAuth: () => ({ type: 'auth/clearAuth' }),
 }));
 
-const mockShowToast = vi.fn();
-vi.mock('../useToast', () => ({
-  useToast: () => ({ showToast: mockShowToast, toasts: [], removeToast: vi.fn() }),
-}));
-
 const mockFetchChatUsers = vi.fn();
 const mockLogout = vi.fn();
 
@@ -67,7 +62,7 @@ describe('useSidebar', () => {
 
     expect(mockLogout).toHaveBeenCalledOnce();
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'auth/clearAuth' });
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { toast: 'ログアウトしました' } });
   });
 
   it('ログアウト失敗時はnavigate呼ばない', async () => {
@@ -122,17 +117,17 @@ describe('useSidebar', () => {
     expect(result.current.totalUnread).toBe(0);
   });
 
-  it('ログアウト成功時にログアウトしましたトーストを表示する', async () => {
+  it('ログアウト成功時にトースト付きでログインページに遷移する', async () => {
     const { result } = renderHook(() => useSidebar());
 
     await act(async () => {
       await result.current.handleLogout();
     });
 
-    expect(mockShowToast).toHaveBeenCalledWith('success', 'ログアウトしました');
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { toast: 'ログアウトしました' } });
   });
 
-  it('ログアウト失敗時にトーストを表示しない', async () => {
+  it('ログアウト失敗時にトースト付きで遷移しない', async () => {
     mockLogout.mockRejectedValue(new Error('Network Error'));
 
     const { result } = renderHook(() => useSidebar());
@@ -141,7 +136,7 @@ describe('useSidebar', () => {
       await result.current.handleLogout();
     });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
   it('ログアウト失敗時にdispatchも呼ばれない', async () => {

--- a/frontend/src/hooks/useLoginCallback.ts
+++ b/frontend/src/hooks/useLoginCallback.ts
@@ -3,13 +3,11 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setAuthData } from '../store/authSlice';
 import authRepository from '../repositories/AuthRepository';
-import { useToast } from './useToast';
 
 export function useLoginCallback() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { showToast } = useToast();
   const code = searchParams.get('code');
   const error = searchParams.get('error');
 
@@ -25,8 +23,7 @@ export function useLoginCallback() {
         .callback(code)
         .then(() => {
           dispatch(setAuthData());
-          showToast('success', 'ログインしました');
-          navigate('/');
+          navigate('/', { state: { toast: 'ログインしました' } });
         })
         .catch(() => {
           alert('認証に失敗しました。');
@@ -35,5 +32,5 @@ export function useLoginCallback() {
     } else {
       navigate('/login');
     }
-  }, [code, error, dispatch, navigate, showToast]);
+  }, [code, error, dispatch, navigate]);
 }

--- a/frontend/src/hooks/useSidebar.ts
+++ b/frontend/src/hooks/useSidebar.ts
@@ -4,12 +4,10 @@ import { useNavigate } from 'react-router-dom';
 import { clearAuth } from '../store/authSlice';
 import ChatRepository from '../repositories/ChatRepository';
 import AuthRepository from '../repositories/AuthRepository';
-import { useToast } from './useToast';
 
 export function useSidebar() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { showToast } = useToast();
   const [totalUnread, setTotalUnread] = useState(0);
 
   useEffect(() => {
@@ -31,12 +29,11 @@ export function useSidebar() {
     try {
       await AuthRepository.logout();
       dispatch(clearAuth());
-      showToast('success', 'ログアウトしました');
-      navigate('/login');
+      navigate('/login', { state: { toast: 'ログアウトしました' } });
     } catch {
       // サイレントに処理
     }
-  }, [dispatch, navigate, showToast]);
+  }, [dispatch, navigate]);
 
   return { totalUnread, handleLogout };
 }

--- a/frontend/src/pages/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/__tests__/LoginCallback.test.tsx
@@ -72,7 +72,7 @@ describe('LoginCallback', () => {
 
     await waitFor(() => {
       expect(authRepository.callback).toHaveBeenCalledWith('valid-code');
-      expect(mockNavigate).toHaveBeenCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/', { state: { toast: 'ログインしました' } });
     });
   });
 


### PR DESCRIPTION
## Summary
- `showToast` + `navigate` の組み合わせではReactバッチ処理によりトーストが表示されない問題を修正
- `navigate` の `state` パラメータでトーストメッセージを遷移先に渡す方式に変更
- App.tsx に `NavigationToast` コンポーネントを追加し、`location.state.toast` を読み取ってトースト表示

## Test plan
- [x] useLoginCallback.test.ts — navigate stateにトーストメッセージが含まれることを検証（10テストパス）
- [x] useSidebar.test.ts — navigate stateにトーストメッセージが含まれることを検証（10テストパス）
- [x] LoginCallback.test.tsx — 認証成功時のnavigate呼び出しを検証（5テストパス）
- [x] 全2150テストパス

closes #1324