### PR TITLE
feat: ログアウト時のフルスクリーンローディング追加とLoading位置の中央配置修正

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from 'react-router-dom';
 import SidebarItem from './SidebarItem';
+import Loading from '../Loading';
 import { useSidebar } from '../../hooks/useSidebar';
 import { useTheme } from '../../hooks/useTheme';
 import {
@@ -46,7 +47,7 @@ interface SidebarProps {
 
 export default function Sidebar({ onNavigate }: SidebarProps) {
   const location = useLocation();
-  const { totalUnread, handleLogout } = useSidebar();
+  const { totalUnread, handleLogout, loggingOut } = useSidebar();
   const { theme, toggleTheme } = useTheme();
 
   const isActive = (item: typeof navItems[0]) => {
@@ -64,6 +65,8 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   };
 
   return (
+    <>
+    {loggingOut && <Loading fullscreen message="ログアウト中..." />}
     <aside className="flex flex-col w-56 h-full bg-surface-1 border-r border-surface-3 flex-shrink-0">
       {/* ロゴ */}
       <div className="h-14 flex items-center px-4 border-b border-surface-3 gap-2.5">
@@ -121,5 +124,6 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
         </button>
       </div>
     </aside>
+    </>
   );
 }

--- a/frontend/src/hooks/__tests__/useSidebar.test.ts
+++ b/frontend/src/hooks/__tests__/useSidebar.test.ts
@@ -150,4 +150,38 @@ describe('useSidebar', () => {
 
     expect(mockDispatch).not.toHaveBeenCalled();
   });
+
+  it('初期状態でloggingOutがfalseである', () => {
+    const { result } = renderHook(() => useSidebar());
+    expect(result.current.loggingOut).toBe(false);
+  });
+
+  it('ログアウト開始時にloggingOutがtrueになる', async () => {
+    let resolveLogout: () => void;
+    mockLogout.mockImplementation(() => new Promise<void>(r => { resolveLogout = r; }));
+
+    const { result } = renderHook(() => useSidebar());
+
+    act(() => {
+      result.current.handleLogout();
+    });
+
+    expect(result.current.loggingOut).toBe(true);
+
+    await act(async () => {
+      resolveLogout!();
+    });
+  });
+
+  it('ログアウト失敗時にloggingOutがfalseに戻る', async () => {
+    mockLogout.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useSidebar());
+
+    await act(async () => {
+      await result.current.handleLogout();
+    });
+
+    expect(result.current.loggingOut).toBe(false);
+  });
 });

--- a/frontend/src/hooks/useSidebar.ts
+++ b/frontend/src/hooks/useSidebar.ts
@@ -9,6 +9,7 @@ export function useSidebar() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const [totalUnread, setTotalUnread] = useState(0);
+  const [loggingOut, setLoggingOut] = useState(false);
 
   useEffect(() => {
     const fetchUnread = async () => {
@@ -26,14 +27,15 @@ export function useSidebar() {
   }, []);
 
   const handleLogout = useCallback(async () => {
+    setLoggingOut(true);
     try {
       await AuthRepository.logout();
       dispatch(clearAuth());
       navigate('/login', { state: { toast: 'ログアウトしました' } });
     } catch {
-      // サイレントに処理
+      setLoggingOut(false);
     }
   }, [dispatch, navigate]);
 
-  return { totalUnread, handleLogout };
+  return { totalUnread, handleLogout, loggingOut };
 }

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -49,7 +49,7 @@ export default function AskAiPage() {
   } = useAskAi();
 
   if (loading && sessions.length === 0) {
-    return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+    return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
   return (

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -43,7 +43,7 @@ export default function ChatPage() {
   const { copiedId, copyToClipboard } = useCopyToClipboard();
 
   if (loading) {
-    return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+    return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
   return (

--- a/frontend/src/pages/FavoritesPage.tsx
+++ b/frontend/src/pages/FavoritesPage.tsx
@@ -15,7 +15,7 @@ export default function FavoritesPage() {
   const [deleteTarget, setDeleteTarget] = useState<FavoritePhrase | null>(null);
 
   if (loading) {
-    return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+    return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
   return (

--- a/frontend/src/pages/FriendshipPage.tsx
+++ b/frontend/src/pages/FriendshipPage.tsx
@@ -50,7 +50,7 @@ export default function FriendshipPage() {
   const { following, followers, loading, unfollowUser } = useFriendship();
   const [tab, setTab] = useState<'following' | 'followers'>('following');
 
-  if (loading) return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+  if (loading) return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
 
   const currentList = tab === 'following' ? following : followers;
 

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -32,7 +32,7 @@ export default function MenuPage() {
   const { scenario: recommendedScenario } = useRecommendedScenario(weakestAxis);
 
   if (loading) {
-    return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+    return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
   const showRecommendation = !latestScore && stats?.chatPartnerCount === 0;

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -30,7 +30,7 @@ export default function UserProfilePage() {
   } = useUserProfilePage();
 
   if (loading) {
-    return <Loading size="medium" message="プロファイルを読み込み中..." className="min-h-[50vh]" />;
+    return <Loading size="medium" message="プロファイルを読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- ログアウトボタン押下時にフルスクリーンのローディングオーバーレイを表示し、バックエンド処理中の操作を防止
- 全ページのLoading表示を `min-h-[calc(100vh-3.5rem)]` に変更し、コンテンツエリア内で正しく縦中央に配置

## Test plan
- [x] useSidebar.test.ts — loggingOut状態の管理テスト追加（13テストパス）
- [x] 全2153テストパス

closes #1326