### PR TITLE
perf: Cognito認証・リクエスト処理の計測ログを追加

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/auth/JwtCookieFilter.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/auth/JwtCookieFilter.java
@@ -54,6 +54,13 @@ public class JwtCookieFilter extends OncePerRequestFilter {
             }
         }
 
+        long start = System.currentTimeMillis();
         filterChain.doFilter(wrappedRequest, response);
+        long elapsed = System.currentTimeMillis() - start;
+        if (elapsed > 100) {
+            log.warn("[REQUEST-TIMING] {} {} - {}ms (status={})", request.getMethod(), request.getRequestURI(), elapsed, response.getStatus());
+        } else {
+            log.info("[REQUEST-TIMING] {} {} - {}ms (status={})", request.getMethod(), request.getRequestURI(), elapsed, response.getStatus());
+        }
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/config/RequestTimingAspect.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/RequestTimingAspect.java
@@ -28,6 +28,11 @@ public class RequestTimingAspect {
         return timeMethod(joinPoint, "service");
     }
 
+    @Around("execution(* com.example.FreStyle.usecase..*(..))")
+    public Object timeUseCaseMethods(ProceedingJoinPoint joinPoint) throws Throwable {
+        return timeMethod(joinPoint, "usecase");
+    }
+
     private Object timeMethod(ProceedingJoinPoint joinPoint, String layer) throws Throwable {
         String className = joinPoint.getSignature().getDeclaringTypeName();
         String methodName = joinPoint.getSignature().getName();

--- a/FreStyle/src/main/java/com/example/FreStyle/service/CognitoAuthService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/CognitoAuthService.java
@@ -135,7 +135,9 @@ public class CognitoAuthService {
                 .authParameters(authParams)
                 .build();
 
+        long start = System.currentTimeMillis();
         InitiateAuthResponse response = cognitoClient.initiateAuth(authRequest);
+        log.info("[COGNITO-TIMING] login initiateAuth: {}ms", System.currentTimeMillis() - start);
         AuthenticationResultType result = response.authenticationResult();
 
         Map<String, String> tokens = new HashMap<>();
@@ -205,7 +207,9 @@ public class CognitoAuthService {
             .build();
 
         try {
+            long start = System.currentTimeMillis();
             InitiateAuthResponse response = cognitoClient.initiateAuth(authRequest);
+            log.info("[COGNITO-TIMING] refreshAccessToken initiateAuth: {}ms", System.currentTimeMillis() - start);
             AuthenticationResultType result = response.authenticationResult();
 
             log.debug("トークン再発行成功");

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoCallbackUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CognitoCallbackUseCase.java
@@ -98,7 +98,8 @@ public class CognitoCallbackUseCase {
         formData.add("redirect_uri", redirectUri);
         formData.add("client_id", clientId);
 
-        return webClient.post()
+        long start = System.currentTimeMillis();
+        Map<String, Object> result = webClient.post()
                 .uri(tokenUri)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .header(HttpHeaders.AUTHORIZATION, "Basic " + basicAuthValue)
@@ -106,5 +107,7 @@ public class CognitoCallbackUseCase {
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .block();
+        log.info("[COGNITO-TIMING] exchangeCodeForTokens: {}ms", System.currentTimeMillis() - start);
+        return result;
     }
 }


### PR DESCRIPTION
## 概要
バックエンドの応答速度のボトルネックを特定するための計測ログを追加。

## 変更内容
- `JwtCookieFilter`: リクエスト全体の処理時間ログ `[REQUEST-TIMING]`（100ms超はWARN）
- `CognitoCallbackUseCase`: OIDCトークン交換HTTP通信時間 `[COGNITO-TIMING]`
- `CognitoAuthService`: ログイン・リフレッシュのCognito API呼び出し時間 `[COGNITO-TIMING]`
- `RequestTimingAspect`: usecaseレイヤーの計測を追加 `[TIMING]`

## CloudWatch調査結果
- 直近7日間で`[TIMING]`ログがゼロ（デプロイ後のユーザーAPIリクエスト未発生のため）
- ECSタスク起動時間: 作成→起動完了 約39秒

## テスト
- バックエンドテスト: 738件合格（contextLoadsはDB未接続のため失敗OK）

closes #1331