### PR TITLE
perf: HikariCP maximum-pool-sizeをdb.t4g.microに合わせて10に変更

### DIFF
--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -45,7 +45,7 @@ aws.s3.note-images-bucket=${NOTE_IMAGES_BUCKET}
 aws.s3.note-images-cdn-url=${NOTE_IMAGES_CDN_URL}
 
 # ========== HikariCP接続プール最適化 ==========
-spring.datasource.hikari.maximum-pool-size=20
+spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=5
 spring.datasource.hikari.idle-timeout=600000
 spring.datasource.hikari.connection-timeout=5000


### PR DESCRIPTION
## 概要
RDS db.t4g.micro（1GB RAM）に対してmaximum-pool-size=20は過大なため10に変更。

## 背景
CloudWatch調査でDB接続数が最大20（HikariCP上限）に到達していた。
db.t4g.microのメモリは1GBで空きが170-190MBしかなく、接続数を減らしてメモリ圧迫を軽減する。

## 変更内容
- `spring.datasource.hikari.maximum-pool-size`: 20 → 10

closes #1333