### PR TITLE
perf: ECS vCPUを1から2に増加（CPU 100%スパイク解消）

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -37,7 +37,7 @@
       "volumesFrom": []
     }
   ],
-  "cpu": "1024",
+  "cpu": "2048",
   "memory": "3072",
   "enableFaultInjection": false,
   "executionRoleArn": "arn:aws:iam::010928196665:role/ecsTaskExecutionRole",


### PR DESCRIPTION
## 概要
CloudWatch調査でECS CPUが100%にスパイクし、ALBレスポンスタイムが最大2.4秒に達していたため、vCPUを増加。

## 変更内容
- `.aws/task-definition.json` の `cpu`: 1024 → 2048（1 vCPU → 2 vCPU）

## 期待効果
- CPU 100%スパイクの解消
- ALBレスポンスタイムの安定化（2.4秒 → 数十ms以内）

closes #1335