### PR TITLE
fix: Fargate互換のメモリ設定に修正（3072→4096）

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -38,7 +38,7 @@
     }
   ],
   "cpu": "2048",
-  "memory": "3072",
+  "memory": "4096",
   "enableFaultInjection": false,
   "executionRoleArn": "arn:aws:iam::010928196665:role/ecsTaskExecutionRole",
   "taskRoleArn": "arn:aws:iam::010928196665:role/ecsTaskExecutionRole",


### PR DESCRIPTION
## 概要
Fargateは2 vCPU (2048) の場合、最低4096MBのメモリが必要。
PR #1336でCPUを2048に変更した際にメモリが3072のままだったためデプロイ失敗。

## 変更内容
- `.aws/task-definition.json` の `memory`: 3072 → 4096

## Fargate有効な組み合わせ（参考）
| vCPU | メモリ |
|------|--------|
| 1024 (1) | 2048, 3072, 4096, ... 8192 |
| 2048 (2) | 4096, 5120, ... 16384 |