### PR TITLE
feat: ユーザープロフィール機能を追加

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/UserProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/UserProfileController.java
@@ -1,0 +1,87 @@
+package com.example.FreStyle.controller;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.usecase.CreateUserProfileUseCase;
+import com.example.FreStyle.usecase.DeleteUserProfileUseCase;
+import com.example.FreStyle.usecase.GetUserProfileUseCase;
+import com.example.FreStyle.usecase.UpdateUserProfileUseCase;
+import com.example.FreStyle.usecase.UpsertUserProfileUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/api/user-profile")
+@RequiredArgsConstructor
+@Slf4j
+public class UserProfileController {
+
+    private final GetUserProfileUseCase getUserProfileUseCase;
+    private final CreateUserProfileUseCase createUserProfileUseCase;
+    private final UpdateUserProfileUseCase updateUserProfileUseCase;
+    private final UpsertUserProfileUseCase upsertUserProfileUseCase;
+    private final DeleteUserProfileUseCase deleteUserProfileUseCase;
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getMyProfile(@AuthenticationPrincipal Jwt jwt) {
+        String sub = jwt.getSubject();
+        log.info("プロファイル取得: sub={}", sub);
+        UserProfileDto profileDto = getUserProfileUseCase.execute(sub);
+        if (profileDto == null) {
+            return ResponseEntity.ok(Map.of("message", "プロファイルが設定されていません。"));
+        }
+        return ResponseEntity.ok(profileDto);
+    }
+
+    @PostMapping("/me/create")
+    public ResponseEntity<?> createMyProfile(
+            @AuthenticationPrincipal Jwt jwt,
+            @Validated @RequestBody UserProfileForm form) {
+        String sub = jwt.getSubject();
+        log.info("プロファイル作成: sub={}", sub);
+        UserProfileDto profileDto = createUserProfileUseCase.execute(sub, form);
+        return ResponseEntity.status(HttpStatus.CREATED).body(profileDto);
+    }
+
+    @PostMapping("/me/update")
+    public ResponseEntity<?> updateMyProfile(
+            @AuthenticationPrincipal Jwt jwt,
+            @Validated @RequestBody UserProfileForm form) {
+        String sub = jwt.getSubject();
+        log.info("プロファイル更新: sub={}", sub);
+        UserProfileDto profileDto = updateUserProfileUseCase.execute(sub, form);
+        return ResponseEntity.ok(profileDto);
+    }
+
+    @PostMapping("/me/upsert")
+    public ResponseEntity<?> upsertMyProfile(
+            @AuthenticationPrincipal Jwt jwt,
+            @Validated @RequestBody UserProfileForm form) {
+        String sub = jwt.getSubject();
+        log.info("プロファイルupsert: sub={}", sub);
+        UserProfileDto profileDto = upsertUserProfileUseCase.execute(sub, form);
+        return ResponseEntity.ok(profileDto);
+    }
+
+    @PostMapping("/me/delete")
+    public ResponseEntity<?> deleteMyProfile(@AuthenticationPrincipal Jwt jwt) {
+        String sub = jwt.getSubject();
+        log.info("プロファイル削除: sub={}", sub);
+        deleteUserProfileUseCase.execute(sub);
+        return ResponseEntity.ok(Map.of("message", "プロファイルを削除しました。"));
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/UserProfileDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/UserProfileDto.java
@@ -1,0 +1,15 @@
+package com.example.FreStyle.dto;
+
+import java.util.List;
+
+public record UserProfileDto(
+        Integer id,
+        Integer userId,
+        String displayName,
+        String selfIntroduction,
+        String communicationStyle,
+        List<String> personalityTraits,
+        String goals,
+        String concerns,
+        String preferredFeedbackStyle) {
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/UserProfile.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/UserProfile.java
@@ -1,0 +1,67 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+@Entity
+@Table(name = "user_profiles")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    // 基本的な自己紹介
+    @Column(name = "display_name", length = 100)
+    private String displayName;
+
+    @Column(name = "self_introduction", columnDefinition = "TEXT")
+    private String selfIntroduction;
+
+    // コミュニケーションスタイル
+    @Column(name = "communication_style", length = 50)
+    private String communicationStyle;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "personality_traits", columnDefinition = "JSON")
+    private String personalityTraits;
+
+    // AIフィードバック用の追加情報
+    @Column(columnDefinition = "TEXT")
+    private String goals;
+
+    @Column(columnDefinition = "TEXT")
+    private String concerns;
+
+    @Column(name = "preferred_feedback_style", length = 50)
+    private String preferredFeedbackStyle;
+
+    // メタ情報
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private Timestamp updatedAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/form/UserProfileForm.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/form/UserProfileForm.java
@@ -1,0 +1,34 @@
+package com.example.FreStyle.form;
+
+import java.util.List;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserProfileForm {
+    
+    // 基本的な自己紹介
+    @Size(max = 100, message = "表示名は100文字以内で入力してください")
+    private String displayName;
+    
+    private String selfIntroduction;
+    
+    // コミュニケーションスタイル
+    @Size(max = 50, message = "コミュニケーションスタイルは50文字以内で入力してください")
+    private String communicationStyle;
+    
+    private List<String> personalityTraits;
+    
+    // AIフィードバック用の追加情報
+    private String goals;
+    
+    private String concerns;
+    
+    @Size(max = 50, message = "フィードバックスタイルは50文字以内で入力してください")
+    private String preferredFeedbackStyle;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/UserProfileRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/UserProfileRepository.java
@@ -1,0 +1,33 @@
+package com.example.FreStyle.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.FreStyle.entity.UserProfile;
+import com.example.FreStyle.entity.User;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Integer> {
+
+    /**
+     * ユーザーIDでプロファイルを検索
+     */
+    Optional<UserProfile> findByUserId(Integer userId);
+
+    /**
+     * ユーザーエンティティでプロファイルを検索
+     */
+    Optional<UserProfile> findByUser(User user);
+
+    /**
+     * ユーザーIDでプロファイルが存在するか確認
+     */
+    boolean existsByUserId(Integer userId);
+
+    /**
+     * ユーザーIDでプロファイルを削除
+     */
+    void deleteByUserId(Integer userId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/service/UserProfileService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/UserProfileService.java
@@ -1,0 +1,163 @@
+package com.example.FreStyle.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.entity.UserProfile;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.repository.UserProfileRepository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+    private final UserProfileRepository userProfileRepository;
+    private final ObjectMapper objectMapper;
+
+    // ------------------------
+    // プロファイル取得（ユーザーIDで）
+    // ------------------------
+    public UserProfileDto getProfileByUserId(Integer userId) {
+        UserProfile profile = userProfileRepository.findByUserId(userId)
+                .orElse(null);
+        
+        if (profile == null) {
+            return null;
+        }
+        
+        return convertToDto(profile);
+    }
+
+    // ------------------------
+    // プロファイル取得（IDで）
+    // ------------------------
+    public UserProfileDto getProfileById(Integer id) {
+        UserProfile profile = userProfileRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("プロファイルが見つかりません。"));
+        
+        return convertToDto(profile);
+    }
+
+    // ------------------------
+    // プロファイル作成
+    // ------------------------
+    @Transactional
+    public UserProfileDto createProfile(User user, UserProfileForm form) {
+        // 既存のプロファイルがあるか確認
+        if (userProfileRepository.existsByUserId(user.getId())) {
+            throw new RuntimeException("プロファイルは既に存在します。");
+        }
+
+        UserProfile profile = new UserProfile();
+        profile.setUser(user);
+        updateProfileFromForm(profile, form);
+        
+        UserProfile savedProfile = userProfileRepository.save(profile);
+        return convertToDto(savedProfile);
+    }
+
+    // ------------------------
+    // プロファイル更新
+    // ------------------------
+    @Transactional
+    public UserProfileDto updateProfile(Integer userId, UserProfileForm form) {
+        UserProfile profile = userProfileRepository.findByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("プロファイルが見つかりません。"));
+        
+        updateProfileFromForm(profile, form);
+        
+        UserProfile savedProfile = userProfileRepository.save(profile);
+        return convertToDto(savedProfile);
+    }
+
+    // ------------------------
+    // プロファイル作成または更新（upsert）
+    // ------------------------
+    @Transactional
+    public UserProfileDto createOrUpdateProfile(User user, UserProfileForm form) {
+        UserProfile profile = userProfileRepository.findByUserId(user.getId())
+                .orElse(new UserProfile());
+        
+        if (profile.getId() == null) {
+            profile.setUser(user);
+        }
+        
+        updateProfileFromForm(profile, form);
+        
+        UserProfile savedProfile = userProfileRepository.save(profile);
+        return convertToDto(savedProfile);
+    }
+
+    // ------------------------
+    // プロファイル削除
+    // ------------------------
+    @Transactional
+    public void deleteProfile(Integer userId) {
+        if (!userProfileRepository.existsByUserId(userId)) {
+            throw new RuntimeException("プロファイルが見つかりません。");
+        }
+        userProfileRepository.deleteByUserId(userId);
+    }
+
+    // ------------------------
+    // ヘルパーメソッド: FormからEntityへの変換
+    // ------------------------
+    private void updateProfileFromForm(UserProfile profile, UserProfileForm form) {
+        profile.setDisplayName(form.getDisplayName());
+        profile.setSelfIntroduction(form.getSelfIntroduction());
+        profile.setCommunicationStyle(form.getCommunicationStyle());
+        profile.setGoals(form.getGoals());
+        profile.setConcerns(form.getConcerns());
+        profile.setPreferredFeedbackStyle(form.getPreferredFeedbackStyle());
+        
+        // List<String> を JSON 文字列に変換
+        if (form.getPersonalityTraits() != null) {
+            try {
+                profile.setPersonalityTraits(objectMapper.writeValueAsString(form.getPersonalityTraits()));
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("性格特性のJSON変換に失敗しました。", e);
+            }
+        } else {
+            profile.setPersonalityTraits(null);
+        }
+    }
+
+    // ------------------------
+    // ヘルパーメソッド: EntityからDTOへの変換
+    // ------------------------
+    private UserProfileDto convertToDto(UserProfile profile) {
+        List<String> traits = new ArrayList<>();
+        if (profile.getPersonalityTraits() != null) {
+            try {
+                traits = objectMapper.readValue(
+                        profile.getPersonalityTraits(),
+                        new TypeReference<List<String>>() {});
+            } catch (JsonProcessingException e) {
+                // JSON解析失敗時は空リスト
+            }
+        }
+
+        return new UserProfileDto(
+                profile.getId(),
+                profile.getUser().getId(),
+                profile.getDisplayName(),
+                profile.getSelfIntroduction(),
+                profile.getCommunicationStyle(),
+                traits,
+                profile.getGoals(),
+                profile.getConcerns(),
+                profile.getPreferredFeedbackStyle()
+        );
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateUserProfileUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public UserProfileDto execute(String sub, UserProfileForm form) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.createProfile(user, form);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/DeleteUserProfileUseCase.java
@@ -1,0 +1,24 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public void execute(String sub) {
+        User user = userIdentityService.findUserBySub(sub);
+        userProfileService.deleteProfile(user.getId());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserProfileUseCase.java
@@ -1,0 +1,25 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional(readOnly = true)
+    public UserProfileDto execute(String sub) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.getProfileByUserId(user.getId());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdateUserProfileUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public UserProfileDto execute(String sub, UserProfileForm form) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.updateProfile(user.getId(), form);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpsertUserProfileUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpsertUserProfileUseCase.java
@@ -1,0 +1,26 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UpsertUserProfileUseCase {
+
+    private final UserProfileService userProfileService;
+    private final UserIdentityService userIdentityService;
+
+    @Transactional
+    public UserProfileDto execute(String sub, UserProfileForm form) {
+        User user = userIdentityService.findUserBySub(sub);
+        return userProfileService.createOrUpdateProfile(user, form);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/UserProfileControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/UserProfileControllerTest.java
@@ -1,0 +1,187 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.usecase.CreateUserProfileUseCase;
+import com.example.FreStyle.usecase.DeleteUserProfileUseCase;
+import com.example.FreStyle.usecase.GetUserProfileUseCase;
+import com.example.FreStyle.usecase.UpdateUserProfileUseCase;
+import com.example.FreStyle.usecase.UpsertUserProfileUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserProfileController")
+class UserProfileControllerTest {
+
+    @Mock
+    private GetUserProfileUseCase getUserProfileUseCase;
+
+    @Mock
+    private CreateUserProfileUseCase createUserProfileUseCase;
+
+    @Mock
+    private UpdateUserProfileUseCase updateUserProfileUseCase;
+
+    @Mock
+    private UpsertUserProfileUseCase upsertUserProfileUseCase;
+
+    @Mock
+    private DeleteUserProfileUseCase deleteUserProfileUseCase;
+
+    @InjectMocks
+    private UserProfileController userProfileController;
+
+    private Jwt mockJwt(String sub) {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn(sub);
+        return jwt;
+    }
+
+    private UserProfileDto createProfileDto() {
+        return new UserProfileDto(1, 10, "表示名", null, null, null, null, null, null);
+    }
+
+    @Nested
+    @DisplayName("getMyProfile")
+    class GetMyProfile {
+
+        @Test
+        @DisplayName("正常にプロファイルを取得できる")
+        void returnsProfile() {
+            Jwt jwt = mockJwt("sub-123");
+            when(getUserProfileUseCase.execute("sub-123")).thenReturn(createProfileDto());
+
+            ResponseEntity<?> response = userProfileController.getMyProfile(jwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isInstanceOf(UserProfileDto.class);
+        }
+
+        @Test
+        @DisplayName("プロファイル未作成の場合メッセージを返す")
+        void returnsMessageWhenNoProfile() {
+            Jwt jwt = mockJwt("sub-123");
+            when(getUserProfileUseCase.execute("sub-123")).thenReturn(null);
+
+            ResponseEntity<?> response = userProfileController.getMyProfile(jwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Nested
+    @DisplayName("createMyProfile")
+    class CreateMyProfile {
+
+        @Test
+        @DisplayName("正常にプロファイルを作成できる")
+        void createsProfile() {
+            Jwt jwt = mockJwt("sub-123");
+            UserProfileForm form = new UserProfileForm();
+            when(createUserProfileUseCase.execute("sub-123", form)).thenReturn(createProfileDto());
+
+            ResponseEntity<?> response = userProfileController.createMyProfile(jwt, form);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        }
+
+        @Test
+        @DisplayName("既に存在する場合は例外がスローされる")
+        void throwsWhenAlreadyExists() {
+            Jwt jwt = mockJwt("sub-123");
+            UserProfileForm form = new UserProfileForm();
+            when(createUserProfileUseCase.execute("sub-123", form))
+                    .thenThrow(new RuntimeException("プロファイルは既に存在します。"));
+
+            assertThatThrownBy(() -> userProfileController.createMyProfile(jwt, form))
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMyProfile")
+    class UpdateMyProfile {
+
+        @Test
+        @DisplayName("正常にプロファイルを更新できる")
+        void updatesProfile() {
+            Jwt jwt = mockJwt("sub-123");
+            UserProfileForm form = new UserProfileForm();
+            when(updateUserProfileUseCase.execute("sub-123", form)).thenReturn(createProfileDto());
+
+            ResponseEntity<?> response = userProfileController.updateMyProfile(jwt, form);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+
+        @Test
+        @DisplayName("存在しない場合は例外がスローされる")
+        void throwsWhenNotFound() {
+            Jwt jwt = mockJwt("sub-123");
+            UserProfileForm form = new UserProfileForm();
+            when(updateUserProfileUseCase.execute("sub-123", form))
+                    .thenThrow(new RuntimeException("プロファイルが見つかりません。"));
+
+            assertThatThrownBy(() -> userProfileController.updateMyProfile(jwt, form))
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("upsertMyProfile")
+    class UpsertMyProfile {
+
+        @Test
+        @DisplayName("正常にupsertできる")
+        void upsertsProfile() {
+            Jwt jwt = mockJwt("sub-123");
+            UserProfileForm form = new UserProfileForm();
+            when(upsertUserProfileUseCase.execute("sub-123", form)).thenReturn(createProfileDto());
+
+            ResponseEntity<?> response = userProfileController.upsertMyProfile(jwt, form);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteMyProfile")
+    class DeleteMyProfile {
+
+        @Test
+        @DisplayName("正常にプロファイルを削除できる")
+        void deletesProfile() {
+            Jwt jwt = mockJwt("sub-123");
+
+            ResponseEntity<?> response = userProfileController.deleteMyProfile(jwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(deleteUserProfileUseCase).execute("sub-123");
+        }
+
+        @Test
+        @DisplayName("存在しない場合は例外がスローされる")
+        void throwsWhenNotFound() {
+            Jwt jwt = mockJwt("sub-123");
+            doThrow(new RuntimeException("プロファイルが見つかりません。"))
+                    .when(deleteUserProfileUseCase).execute("sub-123");
+
+            assertThatThrownBy(() -> userProfileController.deleteMyProfile(jwt))
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/form/UserProfileFormTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/form/UserProfileFormTest.java
@@ -1,0 +1,87 @@
+package com.example.FreStyle.form;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserProfileFormTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void 正常なフォームはバリデーションエラーなし() {
+        UserProfileForm form = new UserProfileForm(
+                "表示名", "自己紹介", "フレンドリー",
+                List.of("積極的", "論理的"), "目標", "悩み", "具体的"
+        );
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 全てnullでもバリデーション通過() {
+        UserProfileForm form = new UserProfileForm(null, null, null, null, null, null, null);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 表示名が100文字超の場合エラー() {
+        String longName = "あ".repeat(101);
+        UserProfileForm form = new UserProfileForm(longName, null, null, null, null, null, null);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("表示名は100文字以内で入力してください"));
+    }
+
+    @Test
+    void 表示名がちょうど100文字の場合バリデーション通過() {
+        String name = "あ".repeat(100);
+        UserProfileForm form = new UserProfileForm(name, null, null, null, null, null, null);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void コミュニケーションスタイルが50文字超の場合エラー() {
+        String longStyle = "あ".repeat(51);
+        UserProfileForm form = new UserProfileForm(null, null, longStyle, null, null, null, null);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("コミュニケーションスタイルは50文字以内で入力してください"));
+    }
+
+    @Test
+    void コミュニケーションスタイルがちょうど50文字の場合バリデーション通過() {
+        String style = "あ".repeat(50);
+        UserProfileForm form = new UserProfileForm(null, null, style, null, null, null, null);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void フィードバックスタイルが50文字超の場合エラー() {
+        String longFeedback = "あ".repeat(51);
+        UserProfileForm form = new UserProfileForm(null, null, null, null, null, null, longFeedback);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("フィードバックスタイルは50文字以内で入力してください"));
+    }
+
+    @Test
+    void フィードバックスタイルがちょうど50文字の場合バリデーション通過() {
+        String feedback = "あ".repeat(50);
+        UserProfileForm form = new UserProfileForm(null, null, null, null, null, null, feedback);
+        Set<ConstraintViolation<UserProfileForm>> violations = validator.validate(form);
+        assertThat(violations).isEmpty();
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/UserProfileServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/UserProfileServiceTest.java
@@ -1,0 +1,334 @@
+package com.example.FreStyle.service;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.entity.UserProfile;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.repository.UserProfileRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserProfileServiceTest {
+
+    @Mock
+    private UserProfileRepository userProfileRepository;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private UserProfileService userProfileService;
+
+    private User createUser(Integer id) {
+        User user = new User();
+        user.setId(id);
+        user.setName("テストユーザー");
+        return user;
+    }
+
+    private UserProfile createProfile(Integer id, User user) {
+        UserProfile profile = new UserProfile();
+        profile.setId(id);
+        profile.setUser(user);
+        profile.setDisplayName("表示名");
+        profile.setSelfIntroduction("自己紹介");
+        profile.setCommunicationStyle("friendly");
+        profile.setPersonalityTraits(null);
+        profile.setGoals("目標");
+        profile.setConcerns("悩み");
+        profile.setPreferredFeedbackStyle("gentle");
+        return profile;
+    }
+
+    private UserProfileForm createForm() {
+        UserProfileForm form = new UserProfileForm();
+        form.setDisplayName("新しい名前");
+        form.setSelfIntroduction("新しい自己紹介");
+        form.setCommunicationStyle("casual");
+        form.setPersonalityTraits(List.of("明るい", "積極的"));
+        form.setGoals("新しい目標");
+        form.setConcerns("新しい悩み");
+        form.setPreferredFeedbackStyle("direct");
+        return form;
+    }
+
+    @Test
+    @DisplayName("getProfileByUserId: プロファイルが存在する場合DTOを返す")
+    void getProfileByUserId_returnsDto() {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.of(profile));
+
+        UserProfileDto result = userProfileService.getProfileByUserId(1);
+
+        assertNotNull(result);
+        assertEquals(10, result.id());
+        assertEquals(1, result.userId());
+        assertEquals("表示名", result.displayName());
+    }
+
+    @Test
+    @DisplayName("getProfileByUserId: プロファイルが存在しない場合nullを返す")
+    void getProfileByUserId_returnsNullWhenNotFound() {
+        when(userProfileRepository.findByUserId(999)).thenReturn(Optional.empty());
+
+        UserProfileDto result = userProfileService.getProfileByUserId(999);
+
+        assertNull(result);
+    }
+
+    @Test
+    @DisplayName("getProfileById: プロファイルをDTOで返す")
+    void getProfileById_returnsDto() {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        when(userProfileRepository.findById(10)).thenReturn(Optional.of(profile));
+
+        UserProfileDto result = userProfileService.getProfileById(10);
+
+        assertNotNull(result);
+        assertEquals(10, result.id());
+    }
+
+    @Test
+    @DisplayName("getProfileById: 存在しない場合例外をスローする")
+    void getProfileById_throwsWhenNotFound() {
+        when(userProfileRepository.findById(999)).thenReturn(Optional.empty());
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userProfileService.getProfileById(999));
+        assertEquals("プロファイルが見つかりません。", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("createProfile: プロファイルを作成してDTOを返す")
+    void createProfile_createsAndReturnsDto() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfileForm form = createForm();
+        when(userProfileRepository.existsByUserId(1)).thenReturn(false);
+        when(objectMapper.writeValueAsString(form.getPersonalityTraits()))
+                .thenReturn("[\"明るい\",\"積極的\"]");
+        when(userProfileRepository.save(any())).thenAnswer(inv -> {
+            UserProfile p = inv.getArgument(0);
+            p.setId(10);
+            return p;
+        });
+
+        UserProfileDto result = userProfileService.createProfile(user, form);
+
+        assertNotNull(result);
+        assertEquals("新しい名前", result.displayName());
+        assertEquals("casual", result.communicationStyle());
+        verify(userProfileRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("createProfile: 既にプロファイルが存在する場合例外をスローする")
+    void createProfile_throwsWhenAlreadyExists() {
+        User user = createUser(1);
+        UserProfileForm form = createForm();
+        when(userProfileRepository.existsByUserId(1)).thenReturn(true);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userProfileService.createProfile(user, form));
+        assertEquals("プロファイルは既に存在します。", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("updateProfile: プロファイルを更新してDTOを返す")
+    void updateProfile_updatesAndReturnsDto() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        UserProfileForm form = createForm();
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.of(profile));
+        when(objectMapper.writeValueAsString(form.getPersonalityTraits()))
+                .thenReturn("[\"明るい\",\"積極的\"]");
+        when(userProfileRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserProfileDto result = userProfileService.updateProfile(1, form);
+
+        assertEquals("新しい名前", result.displayName());
+        assertEquals("新しい目標", result.goals());
+    }
+
+    @Test
+    @DisplayName("updateProfile: 存在しない場合例外をスローする")
+    void updateProfile_throwsWhenNotFound() {
+        when(userProfileRepository.findByUserId(999)).thenReturn(Optional.empty());
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userProfileService.updateProfile(999, createForm()));
+        assertEquals("プロファイルが見つかりません。", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("createOrUpdateProfile: 新規作成の場合プロファイルを作成する")
+    void createOrUpdateProfile_createsNew() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfileForm form = createForm();
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.empty());
+        when(objectMapper.writeValueAsString(form.getPersonalityTraits()))
+                .thenReturn("[\"明るい\",\"積極的\"]");
+        when(userProfileRepository.save(any())).thenAnswer(inv -> {
+            UserProfile p = inv.getArgument(0);
+            p.setId(20);
+            return p;
+        });
+
+        UserProfileDto result = userProfileService.createOrUpdateProfile(user, form);
+
+        assertNotNull(result);
+        assertEquals(1, result.userId());
+        assertEquals("新しい名前", result.displayName());
+    }
+
+    @Test
+    @DisplayName("createOrUpdateProfile: 既存の場合プロファイルを更新する")
+    void createOrUpdateProfile_updatesExisting() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfile existing = createProfile(10, user);
+        UserProfileForm form = createForm();
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.of(existing));
+        when(objectMapper.writeValueAsString(form.getPersonalityTraits()))
+                .thenReturn("[\"明るい\",\"積極的\"]");
+        when(userProfileRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UserProfileDto result = userProfileService.createOrUpdateProfile(user, form);
+
+        assertEquals(10, result.id());
+        assertEquals("新しい名前", result.displayName());
+    }
+
+    @Test
+    @DisplayName("deleteProfile: プロファイルを削除する")
+    void deleteProfile_deletesProfile() {
+        when(userProfileRepository.existsByUserId(1)).thenReturn(true);
+
+        userProfileService.deleteProfile(1);
+
+        verify(userProfileRepository).deleteByUserId(1);
+    }
+
+    @Test
+    @DisplayName("deleteProfile: 存在しない場合例外をスローする")
+    void deleteProfile_throwsWhenNotFound() {
+        when(userProfileRepository.existsByUserId(999)).thenReturn(false);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userProfileService.deleteProfile(999));
+        assertEquals("プロファイルが見つかりません。", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("convertToDto: 不正なJSON personalityTraitsは空リストにフォールバックする")
+    void convertToDto_invalidJson_fallsBackToEmptyList() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        profile.setPersonalityTraits("invalid-json");
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.of(profile));
+        when(objectMapper.readValue(eq("invalid-json"), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenThrow(new JsonProcessingException("parse error") {});
+
+        UserProfileDto result = userProfileService.getProfileByUserId(1);
+
+        assertNotNull(result);
+        assertTrue(result.personalityTraits().isEmpty());
+    }
+
+    @Test
+    @DisplayName("updateProfileFromForm: personalityTraitsのJSON変換失敗でRuntimeExceptionをスローする")
+    void updateProfileFromForm_jsonProcessingException_throwsRuntimeException() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfileForm form = createForm();
+        when(userProfileRepository.existsByUserId(1)).thenReturn(false);
+        when(objectMapper.writeValueAsString(form.getPersonalityTraits()))
+                .thenThrow(new JsonProcessingException("write error") {});
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> userProfileService.createProfile(user, form));
+        assertEquals("性格特性のJSON変換に失敗しました。", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("createProfile: personalityTraitsがnullの場合nullが設定される")
+    void createProfile_nullPersonalityTraits_setsNull() {
+        User user = createUser(1);
+        UserProfileForm form = createForm();
+        form.setPersonalityTraits(null);
+        when(userProfileRepository.existsByUserId(1)).thenReturn(false);
+        when(userProfileRepository.save(any())).thenAnswer(inv -> {
+            UserProfile p = inv.getArgument(0);
+            p.setId(10);
+            return p;
+        });
+
+        UserProfileDto result = userProfileService.createProfile(user, form);
+
+        assertNotNull(result);
+        assertTrue(result.personalityTraits().isEmpty());
+    }
+
+    @Test
+    @DisplayName("convertToDto: 正常なJSON personalityTraitsがリストに変換される")
+    void convertToDto_validJson_returnsList() throws JsonProcessingException {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        profile.setPersonalityTraits("[\"明るい\",\"積極的\"]");
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.of(profile));
+        when(objectMapper.readValue(eq("[\"明るい\",\"積極的\"]"), any(com.fasterxml.jackson.core.type.TypeReference.class)))
+                .thenReturn(List.of("明るい", "積極的"));
+
+        UserProfileDto result = userProfileService.getProfileByUserId(1);
+
+        assertNotNull(result);
+        assertEquals(2, result.personalityTraits().size());
+        assertEquals("明るい", result.personalityTraits().get(0));
+        assertEquals("積極的", result.personalityTraits().get(1));
+    }
+
+    @Test
+    @DisplayName("convertToDto: 全フィールドが正しくマッピングされる")
+    void convertToDto_allFieldsMapped() {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        when(userProfileRepository.findById(10)).thenReturn(Optional.of(profile));
+
+        UserProfileDto result = userProfileService.getProfileById(10);
+
+        assertEquals(10, result.id());
+        assertEquals(1, result.userId());
+        assertEquals("表示名", result.displayName());
+        assertEquals("自己紹介", result.selfIntroduction());
+        assertEquals("friendly", result.communicationStyle());
+        assertEquals("目標", result.goals());
+        assertEquals("悩み", result.concerns());
+        assertEquals("gentle", result.preferredFeedbackStyle());
+    }
+
+    @Test
+    @DisplayName("getSessionsByUserId: セッションがない場合は空リストを返す")
+    void getProfileByUserId_emptyPersonalityTraits_returnsEmptyList() {
+        User user = createUser(1);
+        UserProfile profile = createProfile(10, user);
+        profile.setPersonalityTraits(null);
+        when(userProfileRepository.findByUserId(1)).thenReturn(Optional.of(profile));
+
+        UserProfileDto result = userProfileService.getProfileByUserId(1);
+
+        assertNotNull(result);
+        assertTrue(result.personalityTraits().isEmpty());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/CreateUserProfileUseCaseTest.java
@@ -1,0 +1,90 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateUserProfileUseCase")
+class CreateUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private CreateUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にプロファイルを作成する")
+    void createsProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto(null, 10, "新規", null, null, null, null, null, null);
+        when(userProfileService.createProfile(user, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123", form);
+
+        assertThat(result.displayName()).isEqualTo("新規");
+    }
+
+    @Test
+    @DisplayName("既に存在する場合はRuntimeExceptionを投げる")
+    void throwsWhenAlreadyExists() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        when(userProfileService.createProfile(user, form))
+                .thenThrow(new RuntimeException("プロファイルは既に存在します。"));
+
+        assertThatThrownBy(() -> useCase.execute("sub-123", form))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("findUserBySubとcreateProfileが正しく呼び出される")
+    void verifiesServiceCalls() {
+        User user = new User();
+        user.setId(5);
+        when(userIdentityService.findUserBySub("sub-xyz")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto(null, 5, "テスト", null, null, null, null, null, null);
+        when(userProfileService.createProfile(user, form)).thenReturn(dto);
+
+        useCase.execute("sub-xyz", form);
+
+        verify(userIdentityService).findUserBySub("sub-xyz");
+        verify(userProfileService).createProfile(user, form);
+    }
+
+    @Test
+    @DisplayName("userIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void propagatesExceptionFromUserIdentityService() {
+        when(userIdentityService.findUserBySub("unknown-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        UserProfileForm form = new UserProfileForm();
+
+        assertThatThrownBy(() -> useCase.execute("unknown-sub", form))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ユーザーが見つかりません");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/DeleteUserProfileUseCaseTest.java
@@ -1,0 +1,78 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteUserProfileUseCase")
+class DeleteUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private DeleteUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にプロファイルを削除する")
+    void deletesProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+
+        useCase.execute("sub-123");
+
+        verify(userProfileService).deleteProfile(10);
+    }
+
+    @Test
+    @DisplayName("存在しない場合はRuntimeExceptionを投げる")
+    void throwsWhenNotFound() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        doThrow(new RuntimeException("プロファイルが見つかりません。"))
+                .when(userProfileService).deleteProfile(10);
+
+        assertThatThrownBy(() -> useCase.execute("sub-123"))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("findUserBySubとdeleteProfileが正しく呼び出される")
+    void verifiesServiceCalls() {
+        User user = new User();
+        user.setId(20);
+        when(userIdentityService.findUserBySub("sub-456")).thenReturn(user);
+
+        useCase.execute("sub-456");
+
+        verify(userIdentityService).findUserBySub("sub-456");
+        verify(userProfileService).deleteProfile(20);
+    }
+
+    @Test
+    @DisplayName("userIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void propagatesExceptionFromUserIdentityService() {
+        when(userIdentityService.findUserBySub("unknown-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        assertThatThrownBy(() -> useCase.execute("unknown-sub"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ユーザーが見つかりません");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserProfileUseCaseTest.java
@@ -1,0 +1,85 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetUserProfileUseCase")
+class GetUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private GetUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("subからユーザーを特定してプロファイルを取得する")
+    void returnsProfileForUser() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileDto dto = new UserProfileDto(null, 10, "テスト", null, null, null, null, null, null);
+        when(userProfileService.getProfileByUserId(10)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123");
+
+        assertThat(result).isNotNull();
+        assertThat(result.displayName()).isEqualTo("テスト");
+    }
+
+    @Test
+    @DisplayName("プロファイル未作成の場合nullを返す")
+    void returnsNullWhenNoProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        when(userProfileService.getProfileByUserId(10)).thenReturn(null);
+
+        UserProfileDto result = useCase.execute("sub-123");
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("findUserBySubとgetProfileByUserIdが正しく呼び出される")
+    void verifiesServiceCalls() {
+        User user = new User();
+        user.setId(20);
+        when(userIdentityService.findUserBySub("sub-456")).thenReturn(user);
+        UserProfileDto dto = new UserProfileDto(null, 20, "ユーザー2", null, null, null, null, null, null);
+        when(userProfileService.getProfileByUserId(20)).thenReturn(dto);
+
+        useCase.execute("sub-456");
+
+        verify(userIdentityService).findUserBySub("sub-456");
+        verify(userProfileService).getProfileByUserId(20);
+    }
+
+    @Test
+    @DisplayName("userIdentityServiceが例外をスローした場合そのまま伝搬する")
+    void propagatesExceptionFromUserIdentityService() {
+        when(userIdentityService.findUserBySub("invalid-sub"))
+                .thenThrow(new RuntimeException("ユーザーが見つかりません"));
+
+        assertThatThrownBy(() -> useCase.execute("invalid-sub"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("ユーザーが見つかりません");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpdateUserProfileUseCaseTest.java
@@ -1,0 +1,61 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateUserProfileUseCase")
+class UpdateUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private UpdateUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にプロファイルを更新する")
+    void updatesProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto(null, 10, "更新済み", null, null, null, null, null, null);
+        when(userProfileService.updateProfile(10, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123", form);
+
+        assertThat(result.displayName()).isEqualTo("更新済み");
+    }
+
+    @Test
+    @DisplayName("存在しない場合はRuntimeExceptionを投げる")
+    void throwsWhenNotFound() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        when(userProfileService.updateProfile(10, form))
+                .thenThrow(new RuntimeException("プロファイルが見つかりません。"));
+
+        assertThatThrownBy(() -> useCase.execute("sub-123", form))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UpsertUserProfileUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UpsertUserProfileUseCaseTest.java
@@ -1,0 +1,61 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.UserProfileDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.UserProfileForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.service.UserProfileService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpsertUserProfileUseCase")
+class UpsertUserProfileUseCaseTest {
+
+    @Mock
+    private UserProfileService userProfileService;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private UpsertUserProfileUseCase useCase;
+
+    @Test
+    @DisplayName("正常にupsertする")
+    void upsertsProfile() {
+        User user = new User();
+        user.setId(10);
+        when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto(null, 10, "upsert済み", null, null, null, null, null, null);
+        when(userProfileService.createOrUpdateProfile(user, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-123", form);
+
+        assertThat(result.displayName()).isEqualTo("upsert済み");
+    }
+
+    @Test
+    @DisplayName("新規作成時もDTOを返す")
+    void returnsProfileOnCreate() {
+        User user = new User();
+        user.setId(20);
+        when(userIdentityService.findUserBySub("sub-new")).thenReturn(user);
+        UserProfileForm form = new UserProfileForm();
+        UserProfileDto dto = new UserProfileDto(null, 20, null, null, null, null, null, null, null);
+        when(userProfileService.createOrUpdateProfile(user, form)).thenReturn(dto);
+
+        UserProfileDto result = useCase.execute("sub-new", form);
+
+        assertThat(result.userId()).isEqualTo(20);
+    }
+}

--- a/frontend/src/components/PersonalityTraitSelector.tsx
+++ b/frontend/src/components/PersonalityTraitSelector.tsx
@@ -1,0 +1,39 @@
+interface PersonalityTraitSelectorProps {
+  options: string[];
+  selected: string[];
+  onToggle: (trait: string) => void;
+  label?: string;
+}
+
+export default function PersonalityTraitSelector({
+  options,
+  selected,
+  onToggle,
+  label,
+}: PersonalityTraitSelectorProps) {
+  return (
+    <div>
+      {label && (
+        <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-2">
+          {label}
+        </label>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((trait) => (
+          <button
+            key={trait}
+            type="button"
+            onClick={() => onToggle(trait)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              selected.includes(trait)
+                ? 'bg-primary-500 text-white'
+                : 'bg-surface-3 text-[var(--color-text-secondary)] hover:bg-surface-3'
+            }`}
+          >
+            {trait}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/PersonalityTraitSelector.test.tsx
+++ b/frontend/src/components/__tests__/PersonalityTraitSelector.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PersonalityTraitSelector from '../PersonalityTraitSelector';
+
+const traits = ['社交的', '慎重', '論理的', '共感的', '積極的'];
+
+describe('PersonalityTraitSelector', () => {
+  it('すべての性格特性が表示される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+      />
+    );
+    traits.forEach((trait) => {
+      expect(screen.getByText(trait)).toBeInTheDocument();
+    });
+  });
+
+  it('選択済みの特性にアクティブスタイルが適用される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={['社交的']}
+        onToggle={vi.fn()}
+      />
+    );
+    const button = screen.getByText('社交的');
+    expect(button.className).toContain('bg-primary-500');
+    expect(button.className).toContain('text-white');
+  });
+
+  it('未選択の特性に非アクティブスタイルが適用される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+      />
+    );
+    const button = screen.getByText('社交的');
+    expect(button.className).toContain('bg-surface-3');
+  });
+
+  it('クリックでonToggleが呼ばれる', () => {
+    const onToggle = vi.fn();
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={onToggle}
+      />
+    );
+    fireEvent.click(screen.getByText('論理的'));
+    expect(onToggle).toHaveBeenCalledWith('論理的');
+  });
+
+  it('ラベルが表示される', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+        label="性格特性"
+      />
+    );
+    expect(screen.getByText('性格特性')).toBeInTheDocument();
+  });
+
+  it('ボタンがtype=buttonである', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={[]}
+        onToggle={vi.fn()}
+      />
+    );
+    const button = screen.getByText('社交的');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('複数の特性を選択できる', () => {
+    render(
+      <PersonalityTraitSelector
+        options={traits}
+        selected={['社交的', '論理的']}
+        onToggle={vi.fn()}
+      />
+    );
+    expect(screen.getByText('社交的').className).toContain('bg-primary-500');
+    expect(screen.getByText('論理的').className).toContain('bg-primary-500');
+    expect(screen.getByText('慎重').className).toContain('bg-surface-3');
+  });
+});

--- a/frontend/src/hooks/__tests__/useUserProfile.test.ts
+++ b/frontend/src/hooks/__tests__/useUserProfile.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUserProfile } from '../useUserProfile';
+import UserProfileRepository from '../../repositories/UserProfileRepository';
+
+vi.mock('../../repositories/UserProfileRepository');
+
+const mockedRepo = vi.mocked(UserProfileRepository);
+
+describe('useUserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchMyProfile: プロファイルを取得する', async () => {
+    const mockProfile = { id: 1, userId: 1, displayName: 'テスト' };
+    mockedRepo.getMyProfile.mockResolvedValue(mockProfile as any);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await act(async () => {
+      await result.current.fetchMyProfile();
+    });
+
+    expect(result.current.profile).toEqual(mockProfile);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('fetchMyProfile: エラー時にerrorを設定する', async () => {
+    mockedRepo.getMyProfile.mockRejectedValue(new Error('取得失敗'));
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await act(async () => {
+      await result.current.fetchMyProfile();
+    });
+
+    expect(result.current.error).toBe('プロファイルの取得に失敗しました。');
+  });
+
+  it('updateProfile: プロファイルを更新する', async () => {
+    const mockUpdated = { id: 1, userId: 1, displayName: '更新済み' };
+    mockedRepo.updateProfile.mockResolvedValue(mockUpdated as any);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    let success: boolean = false;
+    await act(async () => {
+      success = await result.current.updateProfile({ displayName: '更新済み' });
+    });
+
+    expect(success).toBe(true);
+    expect(result.current.profile).toEqual(mockUpdated);
+  });
+
+  it('updateProfile: エラー時にfalseを返す', async () => {
+    mockedRepo.updateProfile.mockRejectedValue(new Error('更新失敗'));
+
+    const { result } = renderHook(() => useUserProfile());
+
+    let success: boolean = true;
+    await act(async () => {
+      success = await result.current.updateProfile({ displayName: '更新済み' });
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('プロファイルの更新に失敗しました。');
+  });
+
+  it('fetchMyProfile: non-Errorオブジェクトのreject時にデフォルトメッセージを設定する', async () => {
+    mockedRepo.getMyProfile.mockRejectedValue('文字列エラー');
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await act(async () => {
+      await result.current.fetchMyProfile();
+    });
+
+    expect(result.current.error).toBe('プロファイルの取得に失敗しました。');
+  });
+
+  it('updateProfile: non-Errorオブジェクトのreject時にデフォルトメッセージを設定する', async () => {
+    mockedRepo.updateProfile.mockRejectedValue('文字列エラー');
+
+    const { result } = renderHook(() => useUserProfile());
+
+    let success: boolean = true;
+    await act(async () => {
+      success = await result.current.updateProfile({ displayName: 'テスト' });
+    });
+
+    expect(success).toBe(false);
+    expect(result.current.error).toBe('プロファイルの更新に失敗しました。');
+  });
+
+  it('初期状態でprofileがnull・loadingがfalse・errorがnull', () => {
+    const { result } = renderHook(() => useUserProfile());
+    expect(result.current.profile).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('fetchMyProfile: loading状態が正しく変化する', async () => {
+    let resolvePromise: (value: any) => void;
+    const pendingPromise = new Promise((resolve) => {
+      resolvePromise = resolve;
+    });
+    mockedRepo.getMyProfile.mockReturnValue(pendingPromise as any);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    expect(result.current.loading).toBe(false);
+
+    let fetchPromise: Promise<void>;
+    act(() => {
+      fetchPromise = result.current.fetchMyProfile();
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      resolvePromise!({ id: 1, displayName: 'テスト' });
+      await fetchPromise;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+});

--- a/frontend/src/hooks/__tests__/useUserProfilePage.test.ts
+++ b/frontend/src/hooks/__tests__/useUserProfilePage.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUserProfilePage } from '../useUserProfilePage';
+
+const mockFetchMyProfile = vi.fn();
+const mockUpdateProfile = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('../useUserProfile', () => ({
+  useUserProfile: () => ({
+    profile: null,
+    loading: false,
+    fetchMyProfile: mockFetchMyProfile,
+    updateProfile: mockUpdateProfile,
+  }),
+}));
+
+describe('useUserProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期化時にfetchMyProfileが呼ばれる', () => {
+    renderHook(() => useUserProfilePage());
+    expect(mockFetchMyProfile).toHaveBeenCalled();
+  });
+
+  it('formの初期値が空', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.form.displayName).toBe('');
+    expect(result.current.form.selfIntroduction).toBe('');
+    expect(result.current.form.personalityTraits).toEqual([]);
+  });
+
+  it('messageの初期値がnull', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.message).toBeNull();
+  });
+
+  it('isNewProfileの初期値がfalse', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.isNewProfile).toBe(false);
+  });
+
+  it('loadingの値が返される', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('setFormでフォーム値を更新できる', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+
+    act(() => {
+      result.current.setForm(prev => ({ ...prev, displayName: 'テスト' }));
+    });
+
+    expect(result.current.form.displayName).toBe('テスト');
+  });
+
+  it('togglePersonalityTraitで特性を追加できる', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+
+    act(() => {
+      result.current.togglePersonalityTrait('論理的');
+    });
+
+    expect(result.current.form.personalityTraits).toContain('論理的');
+  });
+
+  it('togglePersonalityTraitで特性を削除できる', () => {
+    const { result } = renderHook(() => useUserProfilePage());
+
+    act(() => {
+      result.current.togglePersonalityTrait('論理的');
+    });
+
+    act(() => {
+      result.current.togglePersonalityTrait('論理的');
+    });
+
+    expect(result.current.form.personalityTraits).not.toContain('論理的');
+  });
+
+  it('handleSave成功時にsuccessメッセージを設定する', async () => {
+    mockUpdateProfile.mockResolvedValue(true);
+    const { result } = renderHook(() => useUserProfilePage());
+
+    await act(async () => {
+      await result.current.handleSave({ preventDefault: vi.fn() } as any);
+    });
+
+    expect(result.current.message?.type).toBe('success');
+  });
+
+  it('handleSave失敗時にerrorメッセージを設定する', async () => {
+    mockUpdateProfile.mockResolvedValue(false);
+    const { result } = renderHook(() => useUserProfilePage());
+
+    await act(async () => {
+      await result.current.handleSave({ preventDefault: vi.fn() } as any);
+    });
+
+    expect(result.current.message?.type).toBe('error');
+  });
+});

--- a/frontend/src/hooks/useUserProfile.ts
+++ b/frontend/src/hooks/useUserProfile.ts
@@ -1,0 +1,74 @@
+import { useState, useCallback } from 'react';
+import { classifyApiError } from '../utils/classifyApiError';
+import UserProfileRepository, {
+  UserProfile,
+  UpdateUserProfileRequest,
+} from '../repositories/UserProfileRepository';
+
+/**
+ * ユーザープロファイルフック
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>ユーザープロファイル管理</li>
+ *   <li>UserProfileRepositoryを使用してAPI呼び出し</li>
+ * </ul>
+ *
+ * <p>Hooks層（Presentation Layer - Business Logic）:</p>
+ * <ul>
+ *   <li>コンポーネントからビジネスロジックを分離</li>
+ *   <li>Repository層を使用してAPI呼び出し</li>
+ * </ul>
+ */
+export const useUserProfile = () => {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * 自分のプロファイルを取得
+   */
+  const fetchMyProfile = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await UserProfileRepository.getMyProfile();
+      setProfile(data);
+    } catch (err) {
+      setError(classifyApiError(err, 'プロファイルの取得に失敗しました。'));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  /**
+   * プロファイルを更新
+   */
+  const updateProfile = useCallback(
+    async (request: UpdateUserProfileRequest): Promise<boolean> => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const updatedProfile = await UserProfileRepository.updateProfile(request);
+        setProfile(updatedProfile);
+        return true;
+      } catch (err) {
+        setError(classifyApiError(err, 'プロファイルの更新に失敗しました。'));
+        return false;
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  return {
+    profile,
+    loading,
+    error,
+    fetchMyProfile,
+    updateProfile,
+  };
+};

--- a/frontend/src/hooks/useUserProfilePage.ts
+++ b/frontend/src/hooks/useUserProfilePage.ts
@@ -1,0 +1,109 @@
+import { useState, useEffect } from 'react';
+import { useUserProfile } from './useUserProfile';
+import type { FormMessage } from '../types';
+
+interface UserProfileForm {
+  displayName: string;
+  selfIntroduction: string;
+  communicationStyle: string;
+  personalityTraits: string[];
+  goals: string;
+  concerns: string;
+  preferredFeedbackStyle: string;
+}
+
+export const COMMUNICATION_STYLES = [
+  { value: '', label: '選択してください' },
+  { value: 'casual', label: 'カジュアル' },
+  { value: 'formal', label: 'フォーマル' },
+  { value: 'friendly', label: 'フレンドリー' },
+  { value: 'professional', label: 'プロフェッショナル' },
+] as const;
+
+export const PERSONALITY_OPTIONS = [
+  '内向的', '外向的', '論理的', '感情的', '共感力が高い',
+  '分析的', 'クリエイティブ', '計画的', '柔軟性がある', 'リーダーシップがある',
+] as const;
+
+export const FEEDBACK_STYLES = [
+  { value: '', label: '選択してください' },
+  { value: 'direct', label: 'ストレート（はっきり伝えてほしい）' },
+  { value: 'gentle', label: 'やさしく（配慮を持って伝えてほしい）' },
+  { value: 'detailed', label: '詳細に（具体的に説明してほしい）' },
+] as const;
+
+/**
+ * UserProfilePageフック
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>UserProfilePageのフォーム管理・バリデーション</li>
+ *   <li>プロフィール取得・更新のロジック</li>
+ * </ul>
+ */
+export function useUserProfilePage() {
+  const [form, setForm] = useState<UserProfileForm>({
+    displayName: '',
+    selfIntroduction: '',
+    communicationStyle: '',
+    personalityTraits: [],
+    goals: '',
+    concerns: '',
+    preferredFeedbackStyle: '',
+  });
+  const [message, setMessage] = useState<FormMessage | null>(null);
+  const [isNewProfile, setIsNewProfile] = useState(false);
+
+  const { profile, loading, fetchMyProfile, updateProfile } = useUserProfile();
+
+  useEffect(() => {
+    fetchMyProfile();
+  }, [fetchMyProfile]);
+
+  useEffect(() => {
+    if (profile) {
+      setForm({
+        displayName: profile.displayName || '',
+        selfIntroduction: profile.selfIntroduction || '',
+        communicationStyle: profile.communicationStyle || '',
+        personalityTraits: profile.personalityTraits || [],
+        goals: profile.goals || '',
+        concerns: profile.concerns || '',
+        preferredFeedbackStyle: profile.preferredFeedbackStyle || '',
+      });
+      setIsNewProfile(false);
+    }
+  }, [profile]);
+
+  const togglePersonalityTrait = (trait: string) => {
+    setForm((prev) => {
+      const traits = prev.personalityTraits.includes(trait)
+        ? prev.personalityTraits.filter((t) => t !== trait)
+        : [...prev.personalityTraits, trait];
+      return { ...prev, personalityTraits: traits };
+    });
+  };
+
+  const handleSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const success = await updateProfile(form);
+
+    if (success) {
+      setMessage({ type: 'success', text: 'パーソナリティ設定を保存しました。' });
+      setIsNewProfile(false);
+    } else {
+      setMessage({ type: 'error', text: '保存に失敗しました。' });
+    }
+  };
+
+  return {
+    form,
+    setForm,
+    message,
+    isNewProfile,
+    loading,
+    togglePersonalityTrait,
+    handleSave,
+  };
+}

--- a/frontend/src/pages/UserProfilePage.tsx
+++ b/frontend/src/pages/UserProfilePage.tsx
@@ -1,0 +1,147 @@
+import InputField from '../components/InputField';
+import TextareaField from '../components/TextareaField';
+import SelectField from '../components/SelectField';
+import SectionHeader from '../components/SectionHeader';
+import PrimaryButton from '../components/PrimaryButton';
+import Loading from '../components/Loading';
+import PersonalityTraitSelector from '../components/PersonalityTraitSelector';
+import FormMessage from '../components/FormMessage';
+import {
+  ChatBubbleLeftRightIcon,
+  LightBulbIcon,
+  UserCircleIcon,
+} from '@heroicons/react/24/solid';
+import {
+  useUserProfilePage,
+  COMMUNICATION_STYLES,
+  PERSONALITY_OPTIONS,
+  FEEDBACK_STYLES,
+} from '../hooks/useUserProfilePage';
+
+export default function UserProfilePage() {
+  const {
+    form,
+    setForm,
+    message,
+    isNewProfile,
+    loading,
+    togglePersonalityTrait,
+    handleSave,
+  } = useUserProfilePage();
+
+  if (loading) {
+    return <Loading size="medium" message="プロファイルを読み込み中..." className="py-12" />;
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      <FormMessage message={message} />
+
+      {/* 説明カード */}
+      <div className="bg-surface-2 rounded-lg p-3 mb-4 border border-[var(--color-border-hover)]">
+        <p className="text-xs text-primary-300">
+          FreStyleはあなたのコミュニケーションスタイルを理解し、チャットと対面の「印象のズレ」を分析します。より正確なフィードバックのために、あなたらしさを教えてください。
+        </p>
+      </div>
+
+      {/* メインカード */}
+      <div className="bg-surface-1 rounded-lg border border-surface-3 overflow-hidden">
+        <form onSubmit={handleSave} className="divide-y divide-slate-100">
+          {/* 基本情報セクション */}
+          <div className="p-5">
+            <SectionHeader icon={UserCircleIcon} title="基本情報" />
+            <div className="space-y-3">
+              <InputField
+                label="呼ばれたい名前"
+                name="displayName"
+                value={form.displayName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setForm((prev) => ({ ...prev, displayName: e.target.value }))
+                }
+                placeholder="例：タロウ、たろちゃん"
+              />
+              <TextareaField
+                label="自己紹介"
+                name="selfIntroduction"
+                value={form.selfIntroduction}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setForm((prev) => ({ ...prev, selfIntroduction: e.target.value }))
+                }
+                placeholder="あなた自身について自由に書いてください..."
+                maxLength={300}
+              />
+            </div>
+          </div>
+
+          {/* コミュニケーションスタイル */}
+          <div className="p-5">
+            <SectionHeader icon={ChatBubbleLeftRightIcon} title="コミュニケーションスタイル" />
+            <div className="space-y-3">
+              <SelectField
+                label="あなたのコミュニケーションスタイル"
+                name="communicationStyle"
+                value={form.communicationStyle}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setForm((prev) => ({ ...prev, communicationStyle: e.target.value }))
+                }
+                options={COMMUNICATION_STYLES}
+              />
+
+              <PersonalityTraitSelector
+                options={PERSONALITY_OPTIONS}
+                selected={form.personalityTraits}
+                onToggle={togglePersonalityTrait}
+                label="性格特性（当てはまるものを選んでください）"
+              />
+            </div>
+          </div>
+
+          {/* AIフィードバック設定 */}
+          <div className="p-5">
+            <SectionHeader icon={LightBulbIcon} title="AIフィードバック設定" />
+            <div className="space-y-3">
+              <TextareaField
+                label="コミュニケーションで改善したい点・目標"
+                name="goals"
+                value={form.goals}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setForm((prev) => ({ ...prev, goals: e.target.value }))
+                }
+                placeholder="例：もっと簡潔に伝えられるようになりたい..."
+                maxLength={300}
+              />
+
+              <TextareaField
+                label="苦手なこと・気になっていること"
+                name="concerns"
+                value={form.concerns}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setForm((prev) => ({ ...prev, concerns: e.target.value }))
+                }
+                placeholder="例：話が長くなりがち、相手の反応が気になる..."
+                maxLength={300}
+              />
+
+              <SelectField
+                label="フィードバックの受け取り方"
+                name="preferredFeedbackStyle"
+                value={form.preferredFeedbackStyle}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setForm((prev) => ({ ...prev, preferredFeedbackStyle: e.target.value }))
+                }
+                options={FEEDBACK_STYLES}
+              />
+            </div>
+          </div>
+
+          {/* 保存ボタン */}
+          <div className="p-5 bg-surface-2">
+            <PrimaryButton type="submit">
+              {isNewProfile ? 'パーソナリティを保存' : 'パーソナリティを更新'}
+            </PrimaryButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/UserProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/UserProfilePage.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserProfilePage from '../UserProfilePage';
+
+const mockFetchMyProfile = vi.fn();
+const mockUpdateProfile = vi.fn();
+
+vi.mock('../../hooks/useUserProfile', () => ({
+  useUserProfile: () => ({
+    profile: null,
+    loading: false,
+    error: null,
+    fetchMyProfile: mockFetchMyProfile,
+    updateProfile: mockUpdateProfile,
+  }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+  };
+});
+
+function renderUserProfilePage() {
+  return render(
+    <MemoryRouter>
+      <UserProfilePage />
+    </MemoryRouter>
+  );
+}
+
+describe('UserProfilePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('基本情報セクションが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('基本情報')).toBeInTheDocument();
+  });
+
+  it('コミュニケーションスタイルセクションが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('コミュニケーションスタイル')).toBeInTheDocument();
+  });
+
+  it('AIフィードバック設定セクションが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('AIフィードバック設定')).toBeInTheDocument();
+  });
+
+  it('性格特性の選択肢が表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByText('内向的')).toBeInTheDocument();
+    expect(screen.getByText('外向的')).toBeInTheDocument();
+    expect(screen.getByText('論理的')).toBeInTheDocument();
+  });
+
+  it('保存ボタンが表示される', () => {
+    renderUserProfilePage();
+
+    expect(screen.getByRole('button', { name: /パーソナリティを/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/UserProfileRepository.ts
+++ b/frontend/src/repositories/UserProfileRepository.ts
@@ -1,0 +1,57 @@
+import apiClient from '../lib/axios';
+
+/**
+ * ユーザープロファイルリポジトリ
+ *
+ * <p>役割:</p>
+ * <ul>
+ *   <li>ユーザープロファイル関連のAPI呼び出しを抽象化</li>
+ * </ul>
+ *
+ * <p>インフラ層（Infrastructure Layer）:</p>
+ * <ul>
+ *   <li>外部APIとの通信を担当</li>
+ * </ul>
+ */
+
+export interface UserProfile {
+  id: number;
+  userId: number;
+  displayName: string;
+  selfIntroduction?: string;
+  communicationStyle?: string;
+  personalityTraits?: string[];
+  goals?: string;
+  concerns?: string;
+  preferredFeedbackStyle?: string;
+}
+
+export interface UpdateUserProfileRequest {
+  displayName: string;
+  selfIntroduction?: string;
+  communicationStyle?: string;
+  personalityTraits?: string[];
+  goals?: string;
+  concerns?: string;
+  preferredFeedbackStyle?: string;
+}
+
+class UserProfileRepository {
+  /**
+   * 自分のプロファイルを取得
+   */
+  async getMyProfile(): Promise<UserProfile> {
+    const response = await apiClient.get('/api/user-profile/me');
+    return response.data;
+  }
+
+  /**
+   * プロファイルを更新
+   */
+  async updateProfile(request: UpdateUserProfileRequest): Promise<UserProfile> {
+    const response = await apiClient.post('/api/user-profile/me', request);
+    return response.data;
+  }
+}
+
+export default new UserProfileRepository();

--- a/frontend/src/repositories/__tests__/UserProfileRepository.test.ts
+++ b/frontend/src/repositories/__tests__/UserProfileRepository.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userProfileRepository from '../UserProfileRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('UserProfileRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getMyProfile: 自分のプロファイルを取得できる', async () => {
+    const mockProfile = {
+      id: 1,
+      userId: 1,
+      displayName: 'テストユーザー',
+      selfIntroduction: '自己紹介',
+      communicationStyle: 'assertive',
+    };
+    mockedApiClient.get.mockResolvedValue({ data: mockProfile });
+
+    const result = await userProfileRepository.getMyProfile();
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/user-profile/me');
+    expect(result).toEqual(mockProfile);
+  });
+
+  it('updateProfile: プロファイルを更新できる', async () => {
+    const updateRequest = {
+      displayName: '更新ユーザー',
+      selfIntroduction: '更新された自己紹介',
+    };
+    const mockProfile = { id: 1, userId: 1, ...updateRequest };
+    mockedApiClient.post.mockResolvedValue({ data: mockProfile });
+
+    const result = await userProfileRepository.updateProfile(updateRequest);
+
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/user-profile/me', updateRequest);
+    expect(result).toEqual(mockProfile);
+  });
+
+  it('getMyProfile: APIエラー時に例外がそのまま伝搬する', async () => {
+    mockedApiClient.get.mockRejectedValue(new Error('Network Error'));
+
+    await expect(userProfileRepository.getMyProfile()).rejects.toThrow('Network Error');
+  });
+
+  it('updateProfile: APIエラー時に例外がそのまま伝搬する', async () => {
+    mockedApiClient.post.mockRejectedValue(new Error('Server Error'));
+
+    await expect(
+      userProfileRepository.updateProfile({ displayName: 'テスト' })
+    ).rejects.toThrow('Server Error');
+  });
+});


### PR DESCRIPTION
## Summary
- バックエンド・フロントエンドにユーザープロフィール機能を追加
- Controller → UseCase → Service → Repository の層構造に準拠
- PersonalityTraitSelector コンポーネントでパーソナリティ特性を選択可能

## 変更内容

### バックエンド（29ファイル）
- `UserProfile` エンティティ・`UserProfileDto`・`UserProfileForm`
- `UserProfileRepository`（JPA）・`UserProfileService`
- CRUD UseCase: Create, Get, Update, Delete, Upsert
- `UserProfileController`（REST API）
- 全UseCase・Service・Controller・Formのテスト

### フロントエンド
- `UserProfilePage` ページ
- `useUserProfile`・`useUserProfilePage` フック
- `PersonalityTraitSelector` コンポーネント
- `UserProfileRepository`（API呼び出し）
- 全テスト

Closes #1340