### PR TITLE
fix: WebSocketメッセージ送信時のroomId型変換を修正

### DIFF
--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -130,7 +130,7 @@ export function useChat() {
     if (!stompClientRef.current?.connected) return;
     stompClientRef.current.publish({
       destination: '/app/chat/send',
-      body: JSON.stringify({ roomId, senderId, content: text }),
+      body: JSON.stringify({ roomId: parseInt(roomId!, 10), senderId, content: text }),
     });
   }, [roomId, senderId]);
 


### PR DESCRIPTION
## Summary
- WebSocketメッセージ送信時に`roomId`がURL paramsの文字列のまま送信されていたバグを修正
- `parseInt(roomId!, 10)`で数値に変換して送信するように変更
- バックエンドの`ChatWebSocketController`で`ClassCastException`が解消される

## 原因
DynamoDB移行時に`confirmDelete`では`parseInt`変換を追加したが、`handleSend`では変換が漏れていた

Closes #1342