### PR TITLE
feat: ユーザー検索で未入力時にAPI呼び出しをスキップ

### DIFF
--- a/frontend/src/hooks/useUserSearch.ts
+++ b/frontend/src/hooks/useUserSearch.ts
@@ -21,12 +21,18 @@ export function useUserSearch() {
   }, [searchQuery, debounceSearch]);
 
   useEffect(() => {
+    if (!debounceQuery) {
+      setUsers([]);
+      setLoading(false);
+      return;
+    }
+
     let cancelled = false;
 
     const search = async () => {
       setLoading(true);
       try {
-        const result = await UserSearchRepository.searchUsers(debounceQuery || undefined);
+        const result = await UserSearchRepository.searchUsers(debounceQuery);
         if (!cancelled) {
           setUsers(result);
           setError(null);


### PR DESCRIPTION
## Summary
- 検索ボックス未入力時に全ユーザーが表示される問題を修正
- `useUserSearch`フックで`debounceQuery`が空の場合はAPIを呼ばず空配列を返すように変更
- 未入力時は「ユーザーを検索してみましょう」の案内メッセージが表示される

## 変更ファイル
- `frontend/src/hooks/useUserSearch.ts` - クエリ空時のガード追加
- `frontend/src/hooks/__tests__/useUserSearch.test.ts` - テスト更新・追加

## テスト
- 19テスト全パス（useUserSearch: 11, AddUserPage: 8）

Closes #1344