### PR TITLE
fix: ユーザー検索500エラーを修正（@Paramパラメータ名不一致）

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/repository/UserRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/UserRepository.java
@@ -20,8 +20,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByEmail(String email);
 
-    @Query("SELECT new com.example.FreStyle.dto.UserDto(u.id, u.email, u.name) FROM User u WHERE u.email LIKE :query OR u.name LIKE :query AND u.id <> :id")
-    List<UserDto> findIdAndEmailByEmailLikeDtos(@Param("id") Integer id, @Param("email") String query);
+    @Query("SELECT new com.example.FreStyle.dto.UserDto(u.id, u.email, u.name) FROM User u WHERE (u.email LIKE :query OR u.name LIKE :query) AND u.id <> :id")
+    List<UserDto> findIdAndEmailByEmailLikeDtos(@Param("id") Integer id, @Param("query") String query);
 
     @Query("SELECT new com.example.FreStyle.dto.UserDto(u.id, u.email, u.name) FROM User u WHERE u.id <> :id")
     List<UserDto> findAllUserDtos(@Param("id") Integer id);


### PR DESCRIPTION
## 概要
ユーザー検索 (`/api/chat/users?query=xxx`) で500エラーが発生していた問題を修正。

## 原因
- `UserRepository.findIdAndEmailByEmailLikeDtos()` の `@Param("email")` が、JPQLの `:query` パラメータ名と一致していなかった
- `No argument for named parameter ':query'` エラーが発生

## 修正内容
1. `@Param("email")` → `@Param("query")` に変更
2. JPQL演算子優先順位バグ修正: `(u.email LIKE :query OR u.name LIKE :query) AND u.id <> :id` （括弧追加）

## テスト
- `UserServiceTest` 全テスト通過
- `useUserSearch.test.ts` 全11テスト通過

Closes #1346