### PR TITLE
fix: schema.sqlに未定義テーブル3つを追加

### DIFF
--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -218,6 +218,44 @@ CREATE TABLE IF NOT EXISTS scenario_bookmarks (
     FOREIGN KEY (scenario_id) REFERENCES practice_scenarios(id) ON DELETE CASCADE
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- スコア目標
+CREATE TABLE IF NOT EXISTS score_goals (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    goal_score DOUBLE NOT NULL,
+    updated_at DATETIME NOT NULL,
+
+    UNIQUE KEY uk_user_id (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- お気に入りフレーズ
+CREATE TABLE IF NOT EXISTS favorite_phrases (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    original_text TEXT NOT NULL,
+    rephrased_text TEXT NOT NULL,
+    pattern VARCHAR(50) NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- 通知
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    message TEXT NOT NULL,
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    related_id INT,
+    created_at DATETIME NOT NULL,
+
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_user_created (user_id, created_at DESC)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘


### PR DESCRIPTION
## 概要
フレンドページ等でアクセスすると500エラーが発生していた問題を修正。

## 原因
以下のエンティティに対応するテーブルがRDBに存在しなかった:
- `score_goals` (ScoreGoal)
- `favorite_phrases` (FavoritePhrase) 
- `notifications` (Notification)

## 修正内容
1. RDBに3テーブルをCREATE TABLEで作成済み
2. `schema.sql`にCREATE TABLE文を追加（今後の環境構築時に自動作成されるように）

## テスト
- `./gradlew test` — 797テスト中796通過（contextLoadsのみ失敗=DB接続不要のため想定内）

Closes #1348