### PR TITLE
fix: フレンドページのEmptyStateクラッシュ修正・session_notesテーブル追加

### DIFF
--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -256,6 +256,37 @@ CREATE TABLE IF NOT EXISTS notifications (
     INDEX idx_user_created (user_id, created_at DESC)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- セッションノート
+CREATE TABLE IF NOT EXISTS session_notes (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    session_id INT NOT NULL,
+    note TEXT NOT NULL,
+    updated_at DATETIME NOT NULL,
+
+    UNIQUE KEY uk_user_session (user_id, session_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (session_id) REFERENCES ai_chat_sessions(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ユーザープロフィール
+CREATE TABLE IF NOT EXISTS user_profiles (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    display_name VARCHAR(100),
+    self_introduction TEXT,
+    communication_style VARCHAR(50),
+    personality_traits JSON,
+    goals TEXT,
+    concerns TEXT,
+    preferred_feedback_style VARCHAR(50),
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_user_id (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘

--- a/frontend/src/pages/FriendshipPage.tsx
+++ b/frontend/src/pages/FriendshipPage.tsx
@@ -86,7 +86,8 @@ export default function FriendshipPage() {
 
       {currentList.length === 0 ? (
         <EmptyState
-          message={tab === 'following' ? 'まだ誰もフォローしていません' : 'まだフォロワーがいません'}
+          icon={UsersIcon}
+          title={tab === 'following' ? 'まだ誰もフォローしていません' : 'まだフォロワーがいません'}
         />
       ) : (
         <div className="space-y-2">


### PR DESCRIPTION
## 概要
フレンドページ(`/friends`)でErrorBoundaryエラーが発生する問題を修正。

## 原因
`FriendshipPage.tsx`で`EmptyState`コンポーネントに存在しない`message`プロップを渡していた。
`EmptyState`は`icon`（必須）と`title`（必須）を受け取るが、`message`のみ渡していたため`icon`が`undefined`となり、`<Icon />`のレンダリングでクラッシュ。

## 修正内容
- `FriendshipPage.tsx`: `EmptyState`に`icon={UsersIcon}`と`title={...}`を正しく渡すよう修正
- `schema.sql`: `session_notes`と`user_profiles`のCREATE TABLE文を追加（テーブル定義が漏れていた）
- RDS: `session_notes`テーブルを作成済み

## テスト
- `npx vitest run`: 259ファイル / 2155テスト 全パス

Closes #1350