### PR TITLE
feat: SQSによる月次レポート生成の非同期化

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -95,6 +95,7 @@ jobs:
             DYNAMODB_CHAT_TABLE=${{ secrets.DYNAMODB_CHAT_TABLE }}
             NOTE_IMAGES_BUCKET=${{ secrets.NOTE_IMAGES_BUCKET }}
             NOTE_IMAGES_CDN_URL=${{ secrets.NOTE_IMAGES_CDN_URL }}
+            SQS_REPORT_QUEUE_URL=${{ secrets.SQS_REPORT_QUEUE_URL }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/FreStyle/build.gradle
+++ b/FreStyle/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 	
 	// Bedrock (AIチャット用)
 	implementation 'software.amazon.awssdk:bedrockruntime'
+
+	// SQS (非同期メッセージキュー)
+	implementation 'software.amazon.awssdk:sqs'
 	
 	// Httpクライアント
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/FreStyle/src/main/java/com/example/FreStyle/config/SqsConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/SqsConfig.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+@Configuration
+@EnableScheduling
+public class SqsConfig {
+
+    @Value("${aws.access-key}")
+    private String accessKey;
+
+    @Value("${aws.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public SqsClient sqsClient() {
+        return SqsClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/infrastructure/SqsMessageConsumer.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/infrastructure/SqsMessageConsumer.java
@@ -1,0 +1,101 @@
+package com.example.FreStyle.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.UserRepository;
+import com.example.FreStyle.usecase.CreateNotificationUseCase;
+import com.example.FreStyle.usecase.GenerateMonthlyReportUseCase;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+@Component
+@Slf4j
+public class SqsMessageConsumer {
+
+    private final SqsClient sqsClient;
+    private final GenerateMonthlyReportUseCase generateMonthlyReportUseCase;
+    private final CreateNotificationUseCase createNotificationUseCase;
+    private final UserRepository userRepository;
+    private final String queueUrl;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SqsMessageConsumer(SqsClient sqsClient,
+                               GenerateMonthlyReportUseCase generateMonthlyReportUseCase,
+                               CreateNotificationUseCase createNotificationUseCase,
+                               UserRepository userRepository,
+                               @Value("${aws.sqs.report-queue-url}") String queueUrl) {
+        this.sqsClient = sqsClient;
+        this.generateMonthlyReportUseCase = generateMonthlyReportUseCase;
+        this.createNotificationUseCase = createNotificationUseCase;
+        this.userRepository = userRepository;
+        this.queueUrl = queueUrl;
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    public void pollMessages() {
+        List<Message> messages = sqsClient.receiveMessage(ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .maxNumberOfMessages(10)
+                .waitTimeSeconds(0)
+                .build())
+                .messages();
+
+        for (Message message : messages) {
+            try {
+                processMessage(message);
+            } catch (Exception e) {
+                log.error("SQSメッセージ処理失敗: {}", message.body(), e);
+            }
+        }
+    }
+
+    private void processMessage(Message message) throws Exception {
+        try {
+            JsonNode body = objectMapper.readTree(message.body());
+            int userId = body.get("userId").asInt();
+            int year = body.get("year").asInt();
+            int month = body.get("month").asInt();
+
+            log.info("レポート生成メッセージ受信: userId={}, year={}, month={}", userId, year, month);
+
+            Optional<User> userOpt = userRepository.findById(userId);
+            if (userOpt.isEmpty()) {
+                log.warn("ユーザーが見つかりません: userId={}", userId);
+                return;
+            }
+
+            User user = userOpt.get();
+            generateMonthlyReportUseCase.execute(user, year, month);
+
+            createNotificationUseCase.execute(
+                    user,
+                    "report",
+                    "月次レポート生成完了",
+                    year + "年" + month + "月の月次レポートが生成されました。",
+                    null);
+
+            log.info("レポート生成完了: userId={}, year={}, month={}", userId, year, month);
+        } finally {
+            deleteMessage(message);
+        }
+    }
+
+    private void deleteMessage(Message message) {
+        sqsClient.deleteMessage(DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(message.receiptHandle())
+                .build());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/infrastructure/SqsMessageProducer.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/infrastructure/SqsMessageProducer.java
@@ -1,0 +1,41 @@
+package com.example.FreStyle.infrastructure;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+@Component
+@Slf4j
+public class SqsMessageProducer {
+
+    private final SqsClient sqsClient;
+    private final String queueUrl;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SqsMessageProducer(SqsClient sqsClient,
+                               @Value("${aws.sqs.report-queue-url}") String queueUrl) {
+        this.sqsClient = sqsClient;
+        this.queueUrl = queueUrl;
+    }
+
+    public void sendReportGenerationMessage(Integer userId, Integer year, Integer month) {
+        ObjectNode message = objectMapper.createObjectNode();
+        message.put("userId", userId);
+        message.put("year", year);
+        message.put("month", month);
+
+        String messageBody = message.toString();
+        log.info("SQSメッセージ送信: queue={}, body={}", queueUrl, messageBody);
+
+        sqsClient.sendMessage(SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .build());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/EnqueueReportGenerationUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/EnqueueReportGenerationUseCase.java
@@ -1,0 +1,18 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+
+import com.example.FreStyle.infrastructure.SqsMessageProducer;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class EnqueueReportGenerationUseCase {
+
+    private final SqsMessageProducer sqsMessageProducer;
+
+    public void execute(Integer userId, Integer year, Integer month) {
+        sqsMessageProducer.sendReportGenerationMessage(userId, year, month);
+    }
+}

--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -44,6 +44,9 @@ aws.dynamodb.table-name.notes=fre_style_notes
 aws.s3.note-images-bucket=${NOTE_IMAGES_BUCKET}
 aws.s3.note-images-cdn-url=${NOTE_IMAGES_CDN_URL}
 
+# SQS レポート生成キュー
+aws.sqs.report-queue-url=${SQS_REPORT_QUEUE_URL:}
+
 # ========== HikariCP接続プール最適化 ==========
 spring.datasource.hikari.maximum-pool-size=10
 spring.datasource.hikari.minimum-idle=5

--- a/FreStyle/src/test/java/com/example/FreStyle/infrastructure/SqsMessageConsumerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/infrastructure/SqsMessageConsumerTest.java
@@ -1,0 +1,119 @@
+package com.example.FreStyle.infrastructure;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.UserRepository;
+import com.example.FreStyle.usecase.CreateNotificationUseCase;
+import com.example.FreStyle.usecase.GenerateMonthlyReportUseCase;
+
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SqsMessageConsumer テスト")
+class SqsMessageConsumerTest {
+
+    @Mock
+    private SqsClient sqsClient;
+
+    @Mock
+    private GenerateMonthlyReportUseCase generateMonthlyReportUseCase;
+
+    @Mock
+    private CreateNotificationUseCase createNotificationUseCase;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private SqsMessageConsumer sqsMessageConsumer;
+
+    private static final String QUEUE_URL = "https://sqs.ap-northeast-1.amazonaws.com/123456789/test-queue";
+
+    @BeforeEach
+    void setUp() {
+        sqsMessageConsumer = new SqsMessageConsumer(
+                sqsClient, generateMonthlyReportUseCase, createNotificationUseCase, userRepository, QUEUE_URL);
+    }
+
+    @Test
+    @DisplayName("メッセージ受信→レポート生成→通知作成→メッセージ削除")
+    void processesMessageSuccessfully() {
+        User user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+
+        String messageBody = "{\"userId\":1,\"year\":2026,\"month\":2}";
+        Message message = Message.builder()
+                .body(messageBody)
+                .receiptHandle("receipt-123")
+                .build();
+
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
+                .thenReturn(ReceiveMessageResponse.builder().messages(List.of(message)).build());
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+        sqsMessageConsumer.pollMessages();
+
+        verify(generateMonthlyReportUseCase).execute(user, 2026, 2);
+        verify(createNotificationUseCase).execute(
+                eq(user), eq("report"), eq("月次レポート生成完了"),
+                eq("2026年2月の月次レポートが生成されました。"), any());
+
+        ArgumentCaptor<DeleteMessageRequest> deleteCaptor = ArgumentCaptor.forClass(DeleteMessageRequest.class);
+        verify(sqsClient).deleteMessage(deleteCaptor.capture());
+        assertThat(deleteCaptor.getValue().receiptHandle()).isEqualTo("receipt-123");
+    }
+
+    @Test
+    @DisplayName("キューにメッセージがない場合は何もしない")
+    void doesNothingWhenNoMessages() {
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
+                .thenReturn(ReceiveMessageResponse.builder().messages(Collections.emptyList()).build());
+
+        sqsMessageConsumer.pollMessages();
+
+        verify(generateMonthlyReportUseCase, never()).execute(any(), any(), any());
+        verify(createNotificationUseCase, never()).execute(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("ユーザーが見つからない場合でもメッセージを削除する")
+    void deletesMessageWhenUserNotFound() {
+        String messageBody = "{\"userId\":999,\"year\":2026,\"month\":2}";
+        Message message = Message.builder()
+                .body(messageBody)
+                .receiptHandle("receipt-456")
+                .build();
+
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
+                .thenReturn(ReceiveMessageResponse.builder().messages(List.of(message)).build());
+        when(userRepository.findById(999)).thenReturn(Optional.empty());
+
+        sqsMessageConsumer.pollMessages();
+
+        verify(generateMonthlyReportUseCase, never()).execute(any(), any(), any());
+        verify(sqsClient).deleteMessage(any(DeleteMessageRequest.class));
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/infrastructure/SqsMessageProducerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/infrastructure/SqsMessageProducerTest.java
@@ -1,0 +1,52 @@
+package com.example.FreStyle.infrastructure;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SqsMessageProducer テスト")
+class SqsMessageProducerTest {
+
+    @Mock
+    private SqsClient sqsClient;
+
+    @InjectMocks
+    private SqsMessageProducer sqsMessageProducer;
+
+    @Test
+    @DisplayName("レポート生成メッセージをSQSに送信できる")
+    void sendsReportGenerationMessage() throws Exception {
+        when(sqsClient.sendMessage(any(SendMessageRequest.class)))
+                .thenReturn(SendMessageResponse.builder().messageId("msg-123").build());
+
+        sqsMessageProducer.sendReportGenerationMessage(1, 2026, 2);
+
+        ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(sqsClient).sendMessage(captor.capture());
+
+        SendMessageRequest request = captor.getValue();
+        ObjectMapper mapper = new ObjectMapper();
+        var body = mapper.readTree(request.messageBody());
+
+        assertThat(body.get("userId").asInt()).isEqualTo(1);
+        assertThat(body.get("year").asInt()).isEqualTo(2026);
+        assertThat(body.get("month").asInt()).isEqualTo(2);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/EnqueueReportGenerationUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/EnqueueReportGenerationUseCaseTest.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.usecase;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.infrastructure.SqsMessageProducer;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("EnqueueReportGenerationUseCase テスト")
+class EnqueueReportGenerationUseCaseTest {
+
+    @Mock
+    private SqsMessageProducer sqsMessageProducer;
+
+    @InjectMocks
+    private EnqueueReportGenerationUseCase enqueueReportGenerationUseCase;
+
+    @Test
+    @DisplayName("SQSにレポート生成メッセージを送信する")
+    void enqueuesMessage() {
+        enqueueReportGenerationUseCase.execute(1, 2026, 2);
+
+        verify(sqsMessageProducer).sendReportGenerationMessage(1, 2026, 2);
+    }
+}

--- a/frontend/src/hooks/useLearningReport.ts
+++ b/frontend/src/hooks/useLearningReport.ts
@@ -1,35 +1,63 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { LearningReportRepository } from '../repositories/LearningReportRepository';
 import type { LearningReport } from '../types';
 
 export function useLearningReport() {
   const [reports, setReports] = useState<LearningReport[]>([]);
   const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const reportCountRef = useRef(0);
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
 
   const fetchReports = useCallback(async () => {
     try {
       const data = await LearningReportRepository.getAll();
       setReports(data);
+      return data.length;
     } catch {
       setReports([]);
+      return 0;
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchReports();
+    fetchReports().then((count) => {
+      reportCountRef.current = count;
+    });
   }, [fetchReports]);
+
+  useEffect(() => {
+    return () => stopPolling();
+  }, [stopPolling]);
 
   const generateReport = useCallback(async (year: number, month: number) => {
     try {
       await LearningReportRepository.generate(year, month);
+      setGenerating(true);
+
+      // ポーリング開始（5秒間隔）
+      stopPolling();
+      pollingRef.current = setInterval(async () => {
+        const newCount = await fetchReports();
+        if (newCount > reportCountRef.current) {
+          reportCountRef.current = newCount;
+          setGenerating(false);
+          stopPolling();
+        }
+      }, 5000);
     } catch {
-      // エラー時もUIを最新状態に更新
-    } finally {
       await fetchReports();
     }
-  }, [fetchReports]);
+  }, [fetchReports, stopPolling]);
 
-  return { reports, loading, generateReport, refresh: fetchReports };
+  return { reports, loading, generating, generateReport, refresh: fetchReports };
 }

--- a/frontend/src/pages/LearningReportPage.tsx
+++ b/frontend/src/pages/LearningReportPage.tsx
@@ -56,7 +56,7 @@ function ReportCard({ report }: { report: LearningReport }) {
 }
 
 export default function LearningReportPage() {
-  const { reports, loading, generateReport } = useLearningReport();
+  const { reports, loading, generating, generateReport } = useLearningReport();
 
   const handleGenerate = () => {
     const now = new Date();
@@ -82,9 +82,10 @@ export default function LearningReportPage() {
         </h2>
         <button
           onClick={handleGenerate}
-          className="text-xs text-primary-500 hover:text-primary-600 transition-colors"
+          disabled={generating}
+          className="text-xs text-primary-500 hover:text-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          今月のレポートを生成
+          {generating ? '生成中...' : '今月のレポートを生成'}
         </button>
       </div>
 

--- a/frontend/src/pages/__tests__/LearningReportPage.test.tsx
+++ b/frontend/src/pages/__tests__/LearningReportPage.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import LearningReportPage from '../LearningReportPage';
+import * as useLearningReportModule from '../../hooks/useLearningReport';
+import type { LearningReport } from '../../types';
+
+vi.mock('../../hooks/useLearningReport');
+
+const mockReport: LearningReport = {
+  id: 1,
+  year: 2026,
+  month: 2,
+  totalSessions: 5,
+  averageScore: 75.0,
+  previousAverageScore: 70.0,
+  scoreChange: 5.0,
+  bestAxis: '論理的構成力',
+  worstAxis: '配慮表現',
+  practiceDays: 3,
+  createdAt: '2026-02-01T00:00:00',
+};
+
+describe('LearningReportPage', () => {
+  it('生成中はボタンが「生成中...」になり無効化される', () => {
+    vi.mocked(useLearningReportModule.useLearningReport).mockReturnValue({
+      reports: [mockReport],
+      loading: false,
+      generating: true,
+      generateReport: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<LearningReportPage />);
+
+    const button = screen.getByRole('button', { name: '生成中...' });
+    expect(button).toBeDisabled();
+  });
+
+  it('生成中でない場合はボタンが有効', () => {
+    vi.mocked(useLearningReportModule.useLearningReport).mockReturnValue({
+      reports: [mockReport],
+      loading: false,
+      generating: false,
+      generateReport: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    render(<LearningReportPage />);
+
+    const button = screen.getByRole('button', { name: '今月のレポートを生成' });
+    expect(button).not.toBeDisabled();
+  });
+
+  it('ボタンクリックでgenerateReportが呼ばれる', () => {
+    const mockGenerateReport = vi.fn();
+    vi.mocked(useLearningReportModule.useLearningReport).mockReturnValue({
+      reports: [mockReport],
+      loading: false,
+      generating: false,
+      generateReport: mockGenerateReport,
+      refresh: vi.fn(),
+    });
+
+    render(<LearningReportPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: '今月のレポートを生成' }));
+    expect(mockGenerateReport).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/repositories/LearningReportRepository.ts
+++ b/frontend/src/repositories/LearningReportRepository.ts
@@ -16,8 +16,8 @@ export const LearningReportRepository = {
     }
   },
 
-  async generate(year: number, month: number): Promise<LearningReport> {
-    const response = await apiClient.post<LearningReport>('/api/reports/generate', { year, month });
+  async generate(year: number, month: number): Promise<{ status: string }> {
+    const response = await apiClient.post<{ status: string }>('/api/reports/generate', { year, month });
     return response.data;
   },
 };


### PR DESCRIPTION
## 概要
月次レポート生成APIを同期処理からSQS非同期処理に変更。

closes #1357

## 変更内容

### バックエンド
- **SqsConfig**: SqsClient Bean + @EnableScheduling
- **SqsMessageProducer**: SQSへJSON形式でメッセージ送信
- **SqsMessageConsumer**: @Scheduled(5秒間隔)でポーリング → レポート生成 → 通知作成 → メッセージ削除
- **EnqueueReportGenerationUseCase**: SQS投入のUseCase
- **LearningReportController**: `200 OK + LearningReportDto` → `202 Accepted + {"status": "processing"}`
- **application.properties**: `aws.sqs.report-queue-url` 追加

### フロントエンド
- **LearningReportRepository**: `generate()` のレスポンス型を `{status: string}` に変更
- **useLearningReport**: `generating` state + 5秒間隔ポーリング（レポート増加で停止）
- **LearningReportPage**: 生成中ボタン無効化 + 「生成中...」テキスト

### インフラ
- SQSキュー作成済み（DLQ付き、maxReceiveCount=3）
- ECSタスク定義にSQS_REPORT_QUEUE_URL環境変数追加済み
- GitHub Actions CDワークフロー更新
- SpringBootSDK IAMユーザーにSQSFullAccess付与済み
- GitHub SecretにSQS_REPORT_QUEUE_URL登録済み

## テスト
- バックエンド: SqsMessageProducerTest, SqsMessageConsumerTest, EnqueueReportGenerationUseCaseTest, LearningReportControllerTest
- フロントエンド: useLearningReport.test.ts, LearningReportPage.test.tsx