### PR TITLE
docs: README更新 - AWS構成図Mermaid追加 + サービス一覧最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,18 @@
 
 ### AWS サービス詳細
 
-| カテゴリ | サービス |
-|---------|----------|
-| **Compute** | ECS (Fargate), Lambda |
-| **Networking** | API Gateway, Route53, CloudFront, ALB |
-| **Database** | RDS (MariaDB), DynamoDB |
-| **Storage** | S3 |
-| **Auth** | Cognito |
+| カテゴリ | サービス | 用途 |
+|---------|----------|------|
+| **Compute** | ECS (Fargate), ECR | コンテナ実行・イメージ管理 |
+| **Networking** | CloudFront, ALB, Route 53 | CDN・ロードバランシング・DNS |
+| **Database** | RDS (MariaDB), DynamoDB | リレーショナルDB・NoSQL |
+| **Storage** | S3 | フロントエンドホスティング・画像保存 |
+| **Auth** | Cognito | JWT認証 (HttpOnly Cookie) |
+| **AI** | Bedrock | AIチャット（コミュニケーションスコア評価） |
+| **Messaging** | SQS | 非同期レポート生成 |
+| **Security** | WAF | XSS・SQLi・DDoS防御・レート制限 |
+| **Monitoring** | CloudWatch, X-Ray, SNS | メトリクス・分散トレーシング・エラー通知 |
+| **CI/CD** | GitHub Actions | 自動テスト・デプロイ |
 
 ---
 
@@ -152,17 +157,90 @@ Repository (Infrastructure層) ← DB操作
 
 ## AWSアーキテクチャ構成図
 
-### AWS全体構成図（変更前）
+### 現在のAWS全体構成図
+
+```mermaid
+graph TB
+    User["👤 User (Browser/Mobile)"]
+
+    subgraph Edge["Edge Layer"]
+        WAF["🛡️ WAF<br/>XSS/SQLi/DDoS防御"]
+        CF["🌐 CloudFront<br/>CDN + HTTPS"]
+    end
+
+    subgraph VPC["VPC: 10.0.0.0/20"]
+        subgraph Public["Public Subnets (1a/1c)"]
+            ALB["⚖️ ALB<br/>fre-style-alb"]
+        end
+        subgraph Private["Private Subnets (1a/1c)"]
+            subgraph ECS["ECS Fargate (2 vCPU / 4GB)"]
+                App["☕ Spring Boot 3.5.6<br/>Java 21"]
+                XRayD["📡 X-Ray Daemon<br/>sidecar"]
+            end
+            RDS["🗄️ RDS MariaDB<br/>db.t4g.small"]
+        end
+    end
+
+    subgraph Services["AWS Services"]
+        Cognito["🔐 Cognito<br/>JWT Auth"]
+        Bedrock["🤖 Bedrock<br/>AI Chat"]
+        DDB["📊 DynamoDB<br/>ai_chat / chat / notes"]
+        S3F["📦 S3<br/>Frontend Hosting"]
+        S3I["🖼️ S3<br/>Note Images"]
+        SQS["📬 SQS<br/>Async Report"]
+        DLQ["⚠️ SQS DLQ"]
+    end
+
+    subgraph Monitoring["Monitoring & Alerts"]
+        CW["📈 CloudWatch<br/>Metrics / Alarms"]
+        XRay["🔍 X-Ray<br/>Distributed Tracing"]
+        SNS["📧 SNS<br/>Error Alerts"]
+    end
+
+    subgraph CICD["CI/CD"]
+        GHA["⚙️ GitHub Actions"]
+        ECR["📦 ECR"]
+    end
+
+    Email["✉️ Email (Gmail)"]
+
+    User --> WAF --> CF
+    CF -->|静的コンテンツ| S3F
+    CF -->|API| ALB
+    ALB -->|:8080| App
+    App -->|JDBC| RDS
+    App -->|JWT検証| Cognito
+    App --> DDB
+    App -->|Presigned URL| S3I
+    App -->|AI推論| Bedrock
+    App -->|enqueue| SQS
+    SQS -->|失敗| DLQ
+    XRayD -->|traces| XRay
+    App -.->|metrics| CW
+    CW -->|alarm| SNS
+    SNS --> Email
+    GHA -->|docker push| ECR
+    ECR -.->|deploy| App
+```
+
+### 旧AWS構成図
+
+<details>
+<summary>変更前の構成図（クリックで展開）</summary>
+
+#### AWS全体構成図（変更前）
 ![AWSアーキテクチャ構成図](./architecture/aws/image.png)
 
-### ユーザー同士のチャット（変更前）
+#### ユーザー同士のチャット（変更前）
 ![ユーザー同士のチャット](./architecture/aws/aws-architecture-chat.png)
 
-### AIとユーザーのチャット（変更前）
+#### AIとユーザーのチャット（変更前）
 ![AIとユーザーのチャット](./architecture/aws/aws-architecture-ai-chat.png)
 
-### 変更後のAWSアーキテクチャー図
+#### 変更後のAWSアーキテクチャー図
 ![AWSアーキテクチャ構成図](./architecture/aws/AWSアーキテクチャー設計修正後.png)
+
+</details>
 
 ### なぜアーキテクチャーを変えたのか
 1. AIへのフィードバックにユーザーがより自分の性格を把握できるように複雑なクエリを実行する必要があったのでDynamoDBではサービス層が複雑になるのでRDSに変更をした


### PR DESCRIPTION
## 概要
READMEのAWSアーキテクチャセクションを最新化。

closes #1363

## 変更内容
- **AWSサービス詳細テーブル**: 5カテゴリ → 10カテゴリに更新（Bedrock, SQS, WAF, CloudWatch, X-Ray, SNS, ECR追加）
- **Mermaid構成図**: 現在のAWS全体構成をMermaid図で追加（GitHubで直接レンダリング）
- **旧構成図**: `<details>`タグで折りたたみに変更（READMEをスッキリ）

## テスト計画
- [x] GitHubでMermaid図が正常にレンダリングされることを確認