### PR TITLE
docs: AWS構成図をリファレンスデザインのアイコンスタイルで再作成 (#1369)

### DIFF
--- a/architecture/aws/freestyle-aws-architecture.drawio
+++ b/architecture/aws/freestyle-aws-architecture.drawio
@@ -1,277 +1,390 @@
-<mxfile host="app.diagrams.net" agent="draw.io" version="24.0.0">
-  <diagram id="freestyle-aws" name="FreStyle AWS Architecture">
-    <mxGraphModel dx="2037" dy="1356" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="1900" pageHeight="1400" background="light-dark(#ffffff, #ededed)" math="0" shadow="0">
+<mxfile host="app.diagrams.net" agent="draw.io" version="28.1.2">
+  <diagram name="FreStyle AWS Architecture" id="freestyle-current-arch">
+    <mxGraphModel dx="2037" dy="1356" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="3300" pageHeight="2800" background="#ffffff" math="0" shadow="1">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
 
         <!-- ===== Users ===== -->
-        <mxCell id="user" parent="1" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#232F3E;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.users;" value="users" vertex="1">
-          <mxGeometry x="30" y="330" width="78" height="78" as="geometry" />
+        <mxCell id="users" value="&lt;font style=&quot;font-size: 23px;&quot;&gt;users&lt;/font&gt;" style="sketch=0;outlineConnect=0;gradientColor=none;fontColor=#545B64;strokeColor=none;fillColor=#879196;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.illustration_users;pointerEvents=1" parent="1" vertex="1">
+          <mxGeometry x="60" y="880" width="100" height="100" as="geometry" />
         </mxCell>
 
-        <!-- ===== CI/CD (top) ===== -->
-        <mxCell id="gha" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#1B1F23;fontColor=#ffffff;strokeColor=none;fontSize=11;fontStyle=1;" value="GitHub Actions&lt;br&gt;(CI/CD)" vertex="1">
-          <mxGeometry x="60" y="20" width="140" height="45" as="geometry" />
+        <!-- ===== CI/CD: GitHub ===== -->
+        <mxCell id="github" value="" style="verticalLabelPosition=bottom;html=1;verticalAlign=top;align=center;strokeColor=none;fillColor=#00BEF2;shape=mxgraph.azure.github_code;pointerEvents=1;" parent="1" vertex="1">
+          <mxGeometry x="380" y="100" width="97" height="92" as="geometry" />
         </mxCell>
 
-        <!-- ===== Email (outside cloud) ===== -->
-        <mxCell id="email" parent="1" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#232F3E;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.email;" value="Email&lt;br&gt;(Gmail通知)" vertex="1">
-          <mxGeometry x="1580" y="820" width="60" height="60" as="geometry" />
+        <!-- ===== CI/CD: ECR group ===== -->
+        <mxCell id="ecr_group" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="620" y="95" width="173" height="119" as="geometry" />
+        </mxCell>
+        <mxCell id="ecr_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecr;" parent="ecr_group" vertex="1">
+          <mxGeometry width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="ecr_label" value="&lt;font color=&quot;#000000&quot;&gt;&lt;span style=&quot;font-size: 21px;&quot;&gt;ECR&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="ecr_group" vertex="1">
+          <mxGeometry x="9" y="89" width="60" height="30" as="geometry" />
+        </mxCell>
+
+        <!-- ===== CI/CD: ECS on Fargate group ===== -->
+        <mxCell id="ecs_top_group" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="930" y="88" width="153" height="138" as="geometry" />
+        </mxCell>
+        <mxCell id="ecs_top_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.ecs;" parent="ecs_top_group" vertex="1">
+          <mxGeometry x="37" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="ecs_top_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;ECS on Fargate&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="ecs_top_group" vertex="1">
+          <mxGeometry y="70" width="153" height="68" as="geometry" />
+        </mxCell>
+
+        <!-- ===== Email ===== -->
+        <mxCell id="email_group" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="2350" y="2100" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="email_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#232F3E;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.email;" parent="email_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="email_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;Email（Gmail）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="email_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
         <!-- ===== AWS Cloud ===== -->
-        <mxCell id="aws" parent="1" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=1;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;" value="AWS Cloud (ap-northeast-1)" vertex="1">
-          <mxGeometry x="150" y="90" width="1400" height="880" as="geometry" />
+        <mxCell id="aws_cloud" value="&lt;font style=&quot;font-size: 23px;&quot;&gt;AWS Cloud&lt;/font&gt;" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_aws_cloud_alt;strokeColor=#232F3E;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#232F3E;dashed=0;" parent="1" vertex="1">
+          <mxGeometry x="250" y="350" width="2100" height="1700" as="geometry" />
         </mxCell>
 
-        <!-- ===== Edge: WAF ===== -->
-        <mxCell id="waf" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#DD344C;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.wafv2;" value="WAF" vertex="1">
-          <mxGeometry x="40" y="200" width="60" height="60" as="geometry" />
+        <!-- == WAF group == -->
+        <mxCell id="waf_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="30" y="200" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="waf_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.wafv2;" parent="waf_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="waf_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;WAF&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="waf_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
-        <!-- ===== Edge: CloudFront ===== -->
-        <mxCell id="cf" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.cloudfront;" value="CloudFront" vertex="1">
-          <mxGeometry x="170" y="200" width="60" height="60" as="geometry" />
+        <!-- == CloudFront group == -->
+        <mxCell id="cf_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="30" y="450" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="cf_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudfront;" parent="cf_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="cf_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;CloudFront&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="cf_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
-        <!-- ===== S3 Frontend ===== -->
-        <mxCell id="s3f" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.s3;" value="S3（React）" vertex="1">
-          <mxGeometry x="170" y="370" width="60" height="60" as="geometry" />
+        <!-- == S3 (React) group == -->
+        <mxCell id="s3fe_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="30" y="700" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="s3fe_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="s3fe_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="s3fe_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;S3（React）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="s3fe_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
-        <!-- ===== VPC ===== -->
-        <mxCell id="vpc" parent="aws" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_vpc2;strokeColor=#8C4FFF;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#AAB7B8;dashed=0;" value="VPC: 10.0.0.0/20" vertex="1">
-          <mxGeometry x="290" y="30" width="580" height="560" as="geometry" />
+        <!-- == Cognito group == -->
+        <mxCell id="cognito_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="850" y="30" width="173" height="146" as="geometry" />
+        </mxCell>
+        <mxCell id="cognito_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#DD344C;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cognito;" parent="cognito_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="cognito_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;Cognito（JWT）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="cognito_group" vertex="1">
+          <mxGeometry y="86" width="173" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ===== Public Subnet ===== -->
-        <mxCell id="pub_sub" parent="vpc" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=11;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_security_group;grStroke=0;strokeColor=#7AA116;fillColor=#F2F6E8;verticalAlign=top;align=left;spacingLeft=30;fontColor=#248814;dashed=0;" value="Public Subnets (1a / 1c)" vertex="1">
-          <mxGeometry x="20" y="40" width="540" height="150" as="geometry" />
+        <!-- == Public Subnet == -->
+        <mxCell id="pub_sub" value="Public subnet" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_security_group;grStroke=0;strokeColor=#7AA116;fillColor=#F2F6E8;verticalAlign=top;align=left;spacingLeft=30;fontColor=#248814;dashed=0;" parent="aws_cloud" vertex="1">
+          <mxGeometry x="310" y="250" width="300" height="350" as="geometry" />
+        </mxCell>
+        <mxCell id="alb_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.elastic_load_balancing;" parent="pub_sub" vertex="1">
+          <mxGeometry x="111" y="80" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="alb_label" value="&lt;font color=&quot;#000000&quot;&gt;&lt;span style=&quot;font-size: 21px;&quot;&gt;ALB&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="pub_sub" vertex="1">
+          <mxGeometry x="63" y="170" width="173" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ALB -->
-        <mxCell id="alb" parent="pub_sub" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.application_load_balancer;" value="ALB" vertex="1">
-          <mxGeometry x="230" y="35" width="60" height="60" as="geometry" />
+        <!-- == Private Subnet == -->
+        <mxCell id="priv_sub" value="Private subnet" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_security_group;grStroke=0;strokeColor=#00A4A6;fillColor=#E6F6F7;verticalAlign=top;align=left;spacingLeft=30;fontColor=#147EBA;dashed=0;" parent="aws_cloud" vertex="1">
+          <mxGeometry x="710" y="200" width="850" height="650" as="geometry" />
         </mxCell>
 
-        <!-- ===== Private Subnet ===== -->
-        <mxCell id="priv_sub" parent="vpc" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=11;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_security_group;grStroke=0;strokeColor=#147EBA;fillColor=#E6F2F8;verticalAlign=top;align=left;spacingLeft=30;fontColor=#147EBA;dashed=0;" value="Private Subnets (1a / 1c)" vertex="1">
-          <mxGeometry x="20" y="220" width="540" height="320" as="geometry" />
+        <!-- Spot Fleet (ECS Fargate) -->
+        <mxCell id="spot_fleet" value="ECS Fargate (2 vCPU / 4GB)" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=12;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_spot_fleet;strokeColor=#D86613;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#D86613;dashed=0;" parent="priv_sub" vertex="1">
+          <mxGeometry x="30" y="40" width="480" height="370" as="geometry" />
         </mxCell>
 
-        <!-- ===== ECS Cluster ===== -->
-        <mxCell id="ecs" parent="priv_sub" style="points=[[0,0],[0.25,0],[0.5,0],[0.75,0],[1,0],[1,0.25],[1,0.5],[1,0.75],[1,1],[0.75,1],[0.5,1],[0.25,1],[0,1],[0,0.75],[0,0.5],[0,0.25]];outlineConnect=0;gradientColor=none;html=1;whiteSpace=wrap;fontSize=11;fontStyle=0;container=1;pointerEvents=0;collapsible=0;recursiveResize=0;shape=mxgraph.aws4.group;grIcon=mxgraph.aws4.group_spot_fleet;strokeColor=#ED7100;fillColor=none;verticalAlign=top;align=left;spacingLeft=30;fontColor=#ED7100;dashed=0;" value="ECS Fargate (2 vCPU / 4GB)" vertex="1">
-          <mxGeometry x="20" y="40" width="330" height="200" as="geometry" />
+        <!-- Fargate (Spring Boot) -->
+        <mxCell id="fargate_group" value="" style="group" parent="spot_fleet" vertex="1" connectable="0">
+          <mxGeometry x="40" y="80" width="173" height="152" as="geometry" />
+        </mxCell>
+        <mxCell id="fargate_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.fargate;" parent="fargate_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="fargate_label" value="&lt;font color=&quot;#000000&quot;&gt;&lt;span style=&quot;font-size: 21px;&quot;&gt;Fargate（Spring）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="fargate_group" vertex="1">
+          <mxGeometry y="78" width="173" height="74" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot (Fargate) -->
-        <mxCell id="app" parent="ecs" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.fargate;" value="Fargate（Spring Boot）" vertex="1">
-          <mxGeometry x="30" y="55" width="60" height="60" as="geometry" />
+        <!-- X-Ray Daemon (sidecar) -->
+        <mxCell id="xrayd_group" value="" style="group" parent="spot_fleet" vertex="1" connectable="0">
+          <mxGeometry x="270" y="80" width="173" height="152" as="geometry" />
+        </mxCell>
+        <mxCell id="xrayd_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" parent="xrayd_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="xrayd_label" value="&lt;font color=&quot;#000000&quot;&gt;&lt;span style=&quot;font-size: 21px;&quot;&gt;X-Ray Daemon&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="xrayd_group" vertex="1">
+          <mxGeometry y="78" width="173" height="74" as="geometry" />
         </mxCell>
 
-        <!-- Service icon -->
-        <mxCell id="svc_icon" parent="ecs" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.ecs_service;" value="Service" vertex="1">
-          <mxGeometry x="140" y="40" width="48" height="48" as="geometry" />
+        <!-- Database area -->
+        <mxCell id="db_area" value="&lt;font style=&quot;font-size: 23px;&quot;&gt;Database&lt;/font&gt;" style="fillColor=none;strokeColor=#5A6C86;dashed=1;verticalAlign=top;fontStyle=0;fontColor=#5A6C86;whiteSpace=wrap;html=1;" parent="priv_sub" vertex="1">
+          <mxGeometry x="560" y="40" width="260" height="570" as="geometry" />
         </mxCell>
 
-        <!-- Task icon -->
-        <mxCell id="task_icon" parent="ecs" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.ecs_task;" value="Task" vertex="1">
-          <mxGeometry x="140" y="110" width="48" height="48" as="geometry" />
+        <!-- RDS group -->
+        <mxCell id="rds_group" value="" style="group" parent="priv_sub" vertex="1" connectable="0">
+          <mxGeometry x="604" y="100" width="173" height="141" as="geometry" />
+        </mxCell>
+        <mxCell id="rds_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.rds;" parent="rds_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="rds_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;RDS&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="rds_group" vertex="1">
+          <mxGeometry y="87" width="173" height="54" as="geometry" />
         </mxCell>
 
-        <!-- X-Ray Daemon -->
-        <mxCell id="xrayd" parent="ecs" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=10;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" value="X-Ray Daemon&lt;br&gt;(sidecar)" vertex="1">
-          <mxGeometry x="240" y="65" width="50" height="50" as="geometry" />
+        <!-- DynamoDB group -->
+        <mxCell id="ddb_group" value="" style="group" parent="priv_sub" vertex="1" connectable="0">
+          <mxGeometry x="597" y="320" width="176" height="143" as="geometry" />
+        </mxCell>
+        <mxCell id="ddb_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#C925D1;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.dynamodb;" parent="ddb_group" vertex="1">
+          <mxGeometry x="48" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="ddb_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;DynamoDB&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="ddb_group" vertex="1">
+          <mxGeometry y="82" width="176" height="61" as="geometry" />
         </mxCell>
 
-        <!-- ===== Database area ===== -->
-        <mxCell id="db_area" parent="priv_sub" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#C925D1;dashed=1;verticalAlign=top;fontSize=12;fontStyle=1;fontColor=#C925D1;container=1;collapsible=0;" value="Database" vertex="1">
-          <mxGeometry x="380" y="40" width="140" height="260" as="geometry" />
+        <!-- == Bedrock group == -->
+        <mxCell id="bedrock_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1680" y="250" width="173" height="156" as="geometry" />
+        </mxCell>
+        <mxCell id="bedrock_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#01A88D;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.bedrock;" parent="bedrock_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="bedrock_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;Bedrock&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="bedrock_group" vertex="1">
+          <mxGeometry y="94" width="173" height="62" as="geometry" />
         </mxCell>
 
-        <!-- RDS -->
-        <mxCell id="rds" parent="db_area" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C925D1;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.rds;" value="RDS&lt;br&gt;(MariaDB)" vertex="1">
-          <mxGeometry x="40" y="35" width="60" height="60" as="geometry" />
+        <!-- == S3 Images group == -->
+        <mxCell id="s3img_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1680" y="500" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="s3img_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#7AA116;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.s3;" parent="s3img_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="s3img_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;S3（Note Images）&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="s3img_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
-        <!-- DynamoDB -->
-        <mxCell id="ddb" parent="db_area" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#C925D1;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.dynamodb;" value="DynamoDB" vertex="1">
-          <mxGeometry x="40" y="145" width="60" height="60" as="geometry" />
+        <!-- == SQS group == -->
+        <mxCell id="sqs_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1680" y="750" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="sqs_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.sqs;" parent="sqs_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="sqs_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;SQS&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="sqs_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
-        <!-- ===== Services outside VPC (right side) ===== -->
-
-        <!-- Cognito -->
-        <mxCell id="cognito" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#DD344C;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.cognito;" value="Cognito（JWT）" vertex="1">
-          <mxGeometry x="960" y="80" width="60" height="60" as="geometry" />
+        <!-- == SQS DLQ group == -->
+        <mxCell id="dlq_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1900" y="750" width="173" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="dlq_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.sqs;" parent="dlq_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="dlq_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;SQS DLQ&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="dlq_group" vertex="1">
+          <mxGeometry y="90" width="173" height="50" as="geometry" />
         </mxCell>
 
-        <!-- Bedrock -->
-        <mxCell id="bedrock" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#01A88D;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.machine_learning;" value="Bedrock（AI Chat）" vertex="1">
-          <mxGeometry x="960" y="220" width="60" height="60" as="geometry" />
+        <!-- == API Gateway group == -->
+        <mxCell id="apigw_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="310" y="1050" width="173" height="147" as="geometry" />
+        </mxCell>
+        <mxCell id="apigw_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#8C4FFF;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.api_gateway;" parent="apigw_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="apigw_label" value="&lt;font color=&quot;#000000&quot;&gt;&lt;span style=&quot;font-size: 21px;&quot;&gt;API Gateway&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="apigw_group" vertex="1">
+          <mxGeometry y="94" width="173" height="53" as="geometry" />
         </mxCell>
 
-        <!-- S3 Images -->
-        <mxCell id="s3i" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#3F8624;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.s3;" value="S3（Note Images）" vertex="1">
-          <mxGeometry x="960" y="370" width="60" height="60" as="geometry" />
+        <!-- == Lambda group == -->
+        <mxCell id="lambda_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="600" y="1050" width="173" height="154" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#ED7100;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.lambda;" parent="lambda_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="lambda_label" value="&lt;font color=&quot;#000000&quot;&gt;&lt;span style=&quot;font-size: 21px;&quot;&gt;Lambda&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="lambda_group" vertex="1">
+          <mxGeometry y="94" width="173" height="60" as="geometry" />
         </mxCell>
 
-        <!-- SQS -->
-        <mxCell id="sqs" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.sqs;" value="SQS" vertex="1">
-          <mxGeometry x="1130" y="80" width="60" height="60" as="geometry" />
+        <!-- == CloudWatch group == -->
+        <mxCell id="cw_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1000" y="1200" width="173" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="cw_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" parent="cw_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="cw_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;CloudWatch&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="cw_group" vertex="1">
+          <mxGeometry y="90" width="173" height="60" as="geometry" />
         </mxCell>
 
-        <!-- SQS DLQ -->
-        <mxCell id="dlq" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.sqs;" value="SQS DLQ" vertex="1">
-          <mxGeometry x="1280" y="80" width="60" height="60" as="geometry" />
+        <!-- == X-Ray group == -->
+        <mxCell id="xray_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1300" y="1200" width="173" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="xray_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.cloudwatch_2;" parent="xray_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="xray_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;X-Ray&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="xray_group" vertex="1">
+          <mxGeometry y="90" width="173" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ECR -->
-        <mxCell id="ecr" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.ecr;" value="ECR" vertex="1">
-          <mxGeometry x="1130" y="370" width="60" height="60" as="geometry" />
+        <!-- == SNS group == -->
+        <mxCell id="sns_group" value="" style="group" parent="aws_cloud" vertex="1" connectable="0">
+          <mxGeometry x="1600" y="1200" width="173" height="150" as="geometry" />
+        </mxCell>
+        <mxCell id="sns_icon" value="" style="sketch=0;points=[[0,0,0],[0.25,0,0],[0.5,0,0],[0.75,0,0],[1,0,0],[0,1,0],[0.25,1,0],[0.5,1,0],[0.75,1,0],[1,1,0],[0,0.25,0],[0,0.5,0],[0,0.75,0],[1,0.25,0],[1,0.5,0],[1,0.75,0]];outlineConnect=0;fontColor=#232F3E;fillColor=#E7157B;strokeColor=#ffffff;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=12;fontStyle=0;aspect=fixed;shape=mxgraph.aws4.resourceIcon;resIcon=mxgraph.aws4.sns;" parent="sns_group" vertex="1">
+          <mxGeometry x="47.5" width="78" height="78" as="geometry" />
+        </mxCell>
+        <mxCell id="sns_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;SNS&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="sns_group" vertex="1">
+          <mxGeometry y="90" width="173" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ECS top icon (deploy target) -->
-        <mxCell id="ecs_top" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.ecs;" value="ECS on Fargate" vertex="1">
-          <mxGeometry x="1280" y="370" width="60" height="60" as="geometry" />
+        <!-- == WebSocket label == -->
+        <mxCell id="ws_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;WebSocket通信&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+          <mxGeometry x="350" y="970" width="255" height="60" as="geometry" />
         </mxCell>
 
-        <!-- ===== Monitoring ===== -->
-
-        <!-- CloudWatch -->
-        <mxCell id="cw" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.cloudwatch_2;" value="CloudWatch&lt;br&gt;Alarms" vertex="1">
-          <mxGeometry x="960" y="560" width="60" height="60" as="geometry" />
+        <!-- == Monitoring label == -->
+        <mxCell id="mon_label" value="&lt;font style=&quot;font-size: 21px;&quot; color=&quot;#000000&quot;&gt;&lt;span&gt;モニタリング &amp;amp; アラート&lt;/span&gt;&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="aws_cloud" vertex="1">
+          <mxGeometry x="1150" y="1130" width="300" height="60" as="geometry" />
         </mxCell>
 
-        <!-- X-Ray -->
-        <mxCell id="xray" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.cloudwatch_2;" value="X-Ray" vertex="1">
-          <mxGeometry x="1130" y="560" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- SNS -->
-        <mxCell id="sns" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#E7157B;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.sns;" value="SNS" vertex="1">
-          <mxGeometry x="1280" y="560" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- ===== WebSocket path ===== -->
-        <mxCell id="apigw" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#8C4FFF;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.api_gateway;" value="API Gateway&lt;br&gt;(WebSocket)" vertex="1">
-          <mxGeometry x="40" y="560" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <mxCell id="lambda" parent="aws" style="outlineConnect=0;fontColor=#232F3E;gradientColor=none;fillColor=#ED7100;strokeColor=none;dashed=0;verticalLabelPosition=bottom;verticalAlign=top;align=center;html=1;fontSize=11;fontStyle=0;aspect=fixed;pointerEvents=1;shape=mxgraph.aws4.lambda;" value="Lambda" vertex="1">
-          <mxGeometry x="170" y="560" width="60" height="60" as="geometry" />
-        </mxCell>
-
-        <!-- ===== EDGES ===== -->
+        <!-- ========== EDGES ========== -->
 
         <!-- Users → WAF -->
-        <mxCell id="e1" edge="1" parent="1" source="user" target="waf" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#232F3E;strokeWidth=2;" value="">
+        <mxCell id="e1" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="users" target="waf_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- WAF → CloudFront -->
-        <mxCell id="e2" edge="1" parent="1" source="waf" target="cf" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#232F3E;strokeWidth=2;" value="">
+        <mxCell id="e2" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="waf_icon" target="cf_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- CloudFront → S3 Frontend -->
-        <mxCell id="e3" edge="1" parent="1" source="cf" target="s3f" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#3F8624;strokeWidth=1;dashed=1;fontSize=10;" value="静的コンテンツ">
+        <!-- CloudFront → S3 (static) -->
+        <mxCell id="e3" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="cf_icon" target="s3fe_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- CloudFront → ALB -->
-        <mxCell id="e4" edge="1" parent="1" source="cf" target="alb" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#8C4FFF;strokeWidth=2;fontSize=10;" value="API">
+        <mxCell id="e4" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="cf_icon" target="alb_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- ALB → Spring Boot -->
-        <mxCell id="e5" edge="1" parent="1" source="alb" target="app" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#ED7100;strokeWidth=2;fontSize=10;" value=":8080">
+        <!-- ALB → Fargate -->
+        <mxCell id="e5" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="alb_icon" target="fargate_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → RDS -->
-        <mxCell id="e6" edge="1" parent="1" source="app" target="rds" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#C925D1;strokeWidth=1;fontSize=10;" value="JDBC">
+        <!-- Fargate → RDS -->
+        <mxCell id="e6" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="fargate_icon" target="rds_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → Cognito -->
-        <mxCell id="e7" edge="1" parent="1" source="app" target="cognito" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#DD344C;strokeWidth=1;fontSize=10;" value="JWT検証">
+        <!-- Fargate → DynamoDB -->
+        <mxCell id="e7" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="fargate_icon" target="ddb_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → DynamoDB -->
-        <mxCell id="e8" edge="1" parent="1" source="app" target="ddb" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#C925D1;strokeWidth=1;" value="">
+        <!-- Fargate → Cognito -->
+        <mxCell id="e8" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="fargate_icon" target="cognito_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → S3 Images -->
-        <mxCell id="e9" edge="1" parent="1" source="app" target="s3i" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#3F8624;strokeWidth=1;fontSize=10;" value="Presigned URL">
+        <!-- Fargate → Bedrock -->
+        <mxCell id="e9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="fargate_icon" target="bedrock_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → Bedrock -->
-        <mxCell id="e10" edge="1" parent="1" source="app" target="bedrock" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#01A88D;strokeWidth=1;fontSize=10;" value="AI推論">
+        <!-- Fargate → S3 Images -->
+        <mxCell id="e10" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="fargate_icon" target="s3img_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → SQS -->
-        <mxCell id="e11" edge="1" parent="1" source="app" target="sqs" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#E7157B;strokeWidth=1;fontSize=10;" value="enqueue">
+        <!-- Fargate → SQS -->
+        <mxCell id="e11" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="fargate_icon" target="sqs_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- SQS → DLQ -->
-        <mxCell id="e12" edge="1" parent="1" source="sqs" target="dlq" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#E7157B;strokeWidth=1;dashed=1;fontSize=10;" value="失敗">
+        <mxCell id="e12" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="sqs_icon" target="dlq_icon" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Cognito → ALB (auth) -->
+        <mxCell id="e13" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="cognito_icon" target="alb_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- X-Ray Daemon → X-Ray -->
-        <mxCell id="e13" edge="1" parent="1" source="xrayd" target="xray" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#E7157B;strokeWidth=1;dashed=1;fontSize=10;" value="traces">
+        <mxCell id="e14" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="xrayd_icon" target="xray_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- Spring Boot → CloudWatch -->
-        <mxCell id="e14" edge="1" parent="1" source="app" target="cw" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#E7157B;strokeWidth=1;dashed=1;fontSize=10;" value="metrics">
+        <!-- Fargate → CloudWatch -->
+        <mxCell id="e15" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="fargate_icon" target="cw_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- CloudWatch → SNS -->
-        <mxCell id="e15" edge="1" parent="1" source="cw" target="sns" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#E7157B;strokeWidth=1;fontSize=10;" value="alarm">
+        <mxCell id="e16" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="cw_icon" target="sns_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- SNS → Email -->
-        <mxCell id="e16" edge="1" parent="1" source="sns" target="email" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#E7157B;strokeWidth=1;fontSize=10;" value="通知">
+        <mxCell id="e17" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="sns_icon" target="email_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- GitHub Actions → ECR -->
-        <mxCell id="e17" edge="1" parent="1" source="gha" target="ecr" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#ED7100;strokeWidth=1;fontSize=10;" value="docker push">
+        <!-- GitHub → ECR -->
+        <mxCell id="e18" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="github" target="ecr_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- ECR → ECS top -->
-        <mxCell id="e18" edge="1" parent="1" source="ecr" target="ecs_top" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#ED7100;strokeWidth=2;" value="">
+        <!-- ECR → ECS on Fargate -->
+        <mxCell id="e19" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="ecr_icon" target="ecs_top_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
-        <!-- ECS top → Spring Boot (deploy) -->
-        <mxCell id="e19" edge="1" parent="1" source="ecs_top" target="app" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#ED7100;strokeWidth=1;dashed=1;fontSize=10;" value="deploy">
+        <!-- ECS top → Fargate (deploy) -->
+        <mxCell id="e20" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;dashed=1;" parent="1" source="ecs_top_icon" target="fargate_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- API Gateway → Lambda -->
-        <mxCell id="e20" edge="1" parent="1" source="apigw" target="lambda" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#8C4FFF;strokeWidth=1;fontSize=10;" value="WebSocket">
+        <mxCell id="e21" style="edgeStyle=orthogonalEdgeStyle;html=1;endArrow=block;elbow=vertical;startArrow=none;endFill=1;strokeColor=#545B64;rounded=0;" parent="1" source="apigw_icon" target="lambda_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 
         <!-- Lambda → DynamoDB -->
-        <mxCell id="e21" edge="1" parent="1" source="lambda" target="ddb" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#C925D1;strokeWidth=1;" value="">
-          <mxGeometry relative="1" as="geometry" />
-        </mxCell>
-
-        <!-- Cognito → ALB (auth flow) -->
-        <mxCell id="e22" edge="1" parent="1" source="cognito" target="alb" style="edgeStyle=orthogonalEdgeStyle;html=1;strokeColor=#DD344C;strokeWidth=1;dashed=1;fontSize=10;" value="">
+        <mxCell id="e22" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#000000;" parent="1" source="lambda_icon" target="ddb_icon" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
 


### PR DESCRIPTION
## Summary
- リファレンスファイル(AWSアーキテクチャ図.drawio)と同じAWS公式アイコン(mxgraph.aws4.resourceIcon 78x78)を使用し、現在のAWSアーキテクチャ構成図を再作成
- サービスカテゴリ別の正しいカラーコード（Compute=#ED7100, Storage=#7AA116, DB=#C925D1, Network=#8C4FFF, Security=#DD344C, AI=#01A88D, Integration=#E7157B）を適用
- Public/Private Subnet、Spot Fleet等のAWS公式グループスタイルを適用

## Test plan
- [ ] draw.ioエディタ（app.diagrams.net）で開いてAWSアイコンが正しく表示されることを確認
- [ ] 全サービス（WAF, CloudFront, ALB, ECS Fargate, RDS, DynamoDB, Cognito, Bedrock, S3×2, SQS, DLQ, API Gateway, Lambda, CloudWatch, X-Ray, SNS, ECR）が含まれていることを確認

closes #1369