### PR TITLE
fix: X-Ray自動instrumentor削除 + 起動時DBウォームアップ追加

### DIFF
--- a/FreStyle/build.gradle
+++ b/FreStyle/build.gradle
@@ -84,10 +84,8 @@ dependencies {
 	// SQS (非同期メッセージキュー)
 	implementation 'software.amazon.awssdk:sqs'
 
-	// AWS X-Ray トレーシング
+	// AWS X-Ray トレーシング（HTTPリクエストのみトレース）
 	implementation 'com.amazonaws:aws-xray-recorder-sdk-core:2.18.2'
-	implementation 'com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2:2.18.2'
-	implementation 'com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2-instrumentor:2.18.2'
 	
 	// Httpクライアント
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/FreStyle/src/main/java/com/example/FreStyle/config/WarmupListener.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/WarmupListener.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.config;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.example.FreStyle.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WarmupListener {
+
+    private final UserRepository userRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        log.info("ウォームアップ開始: DB接続プール・Hibernateの事前初期化");
+        try {
+            long start = System.currentTimeMillis();
+            userRepository.count();
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("ウォームアップ完了: {}ms", elapsed);
+        } catch (Exception e) {
+            log.warn("ウォームアップ中にエラーが発生しましたが、起動は継続します: {}", e.getMessage());
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/config/WarmupListenerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/config/WarmupListenerTest.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.config;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.repository.UserRepository;
+
+@DisplayName("WarmupListener テスト")
+@ExtendWith(MockitoExtension.class)
+class WarmupListenerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private WarmupListener warmupListener;
+
+    @Test
+    @DisplayName("onApplicationReady実行時にDBウォームアップクエリが実行される")
+    void onApplicationReadyExecutesWarmupQuery() {
+        warmupListener.onApplicationReady();
+
+        verify(userRepository).count();
+    }
+}


### PR DESCRIPTION
## Summary
- X-Ray SDK v2 instrumentor依存を削除し、SQSバックグラウンドポーリングによるエラーログスパムを解消
- 起動時にDBウォームアップクエリを実行し、コールドスタートのレイテンシを改善

## 変更内容

### X-Ray instrumentor削除
- `aws-xray-recorder-sdk-aws-sdk-v2` と `aws-xray-recorder-sdk-aws-sdk-v2-instrumentor` を `build.gradle` から削除
- `aws-xray-recorder-sdk-core` は維持（`XRayTracingFilter` によるHTTPリクエストトレースは継続）
- SQSポーリング（5秒間隔）の `Failed to begin subsegment named 'Sqs': segment cannot be found` エラーが解消される

### WarmupListener追加
- `ApplicationReadyEvent` でDBウォームアップクエリ（`userRepository.count()`）を実行
- DB接続プールとHibernateの事前初期化により、最初のリクエストのレイテンシを改善
- TDDで `WarmupListenerTest` を先に作成

## Test plan
- [x] `WarmupListenerTest` 作成・パス確認済み
- [x] バックエンド全テストパス（762テスト）
- [x] デプロイ後、CloudWatchログで `Failed to begin subsegment` エラーが消えることを確認
- [x] デプロイ後、ウォームアップログ出力を確認