### PR TITLE
fix: ノートエディタのタイトルとコンテンツの左揃え位置を統一

### DIFF
--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -80,7 +80,7 @@ export default function NoteEditor({
         }}
         placeholder="無題"
         aria-label="ノートのタイトル"
-        className="text-3xl font-bold text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full mb-4 placeholder:text-[var(--color-text-faint)]"
+        className="text-3xl font-bold text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full mb-4 pl-10 placeholder:text-[var(--color-text-faint)]"
       />
 
       {headings.length > 0 && (


### PR DESCRIPTION
## Summary
- ノートエディタのタイトル入力欄にBlockEditorと同じ `pl-10` を追加し、左端の開始位置を統一

## 変更内容
- `NoteEditor.tsx`: タイトル `input` に `pl-10` クラスを追加（BlockEditorの `pl-10` と揃える）

## Test plan
- [x] NoteEditor テスト全パス（10テスト）