### PR TITLE
fix: YouTube URL入力ダイアログを外側クリックで閉じられるように修正

### DIFF
--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -31,6 +31,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
   const [youtubeInputOpen, setYoutubeInputOpen] = useState(false);
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const youtubeInputRef = useRef<HTMLInputElement>(null);
+  const youtubeContainerRef = useRef<HTMLDivElement>(null);
 
   const { openFileDialog, handleDrop, handlePaste } = useImageUpload(noteId, editor);
   const { linkBubble, handleEditorClick, handleEditLink, handleRemoveLink } = useLinkEditor(editor, containerRef);
@@ -54,6 +55,19 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
       editor.storage.slashCommand.onYoutubeUrl = null;
     };
   }, [editor, openFileDialog, openEmojiPicker, openYoutubeInput]);
+
+  // YouTube入力の外側クリックで閉じる
+  useEffect(() => {
+    if (!youtubeInputOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (youtubeContainerRef.current && !youtubeContainerRef.current.contains(e.target as Node)) {
+        setYoutubeInputOpen(false);
+        setYoutubeUrl('');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [youtubeInputOpen]);
 
   // Ctrl+F / Cmd+F で検索バーを開く
   useEffect(() => {
@@ -209,7 +223,7 @@ export default function BlockEditor({ content, onChange, noteId }: BlockEditorPr
         </div>
       )}
       {youtubeInputOpen && (
-        <div className="absolute z-50 top-8 left-8 bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-lg shadow-xl p-3">
+        <div ref={youtubeContainerRef} className="absolute z-50 top-8 left-8 bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-lg shadow-xl p-3">
           <p className="text-xs font-medium text-[var(--color-text-secondary)] mb-2">YouTubeのURLを入力</p>
           <div className="flex items-center gap-2">
             <input

--- a/frontend/src/components/__tests__/BlockEditor.test.tsx
+++ b/frontend/src/components/__tests__/BlockEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import BlockEditor from '../BlockEditor';
 
@@ -129,5 +129,16 @@ describe('BlockEditor', () => {
     const container = screen.getByTestId('block-editor');
     expect(container.className).toContain('block-editor');
     expect(container.className).toContain('pl-10');
+  });
+
+  it('YouTube入力の外側クリックで閉じる', () => {
+    render(<BlockEditor {...defaultProps} />);
+    const openYoutube = mockEditor.storage.slashCommand.onYoutubeUrl;
+    expect(openYoutube).not.toBeNull();
+    act(() => openYoutube!());
+    expect(screen.getByLabelText('YouTube URL')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByLabelText('YouTube URL')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- ノートエディタのYouTube URL入力ダイアログが、外側クリックやエディタ操作で閉じられなかった問題を修正

## 変更内容
- `BlockEditor.tsx`: `mousedown`イベントリスナーで外側クリック検知を追加
- `BlockEditor.test.tsx`: 外側クリックで閉じるテストを追加

## Test plan
- [x] BlockEditor テスト全パス（9テスト）
- [x] 新規テスト「YouTube入力の外側クリックで閉じる」パス