### PR TITLE
fix: ブロック挿入メニューを外側クリックで閉じられるように修正

### DIFF
--- a/frontend/src/components/BlockInserterButton.tsx
+++ b/frontend/src/components/BlockInserterButton.tsx
@@ -18,12 +18,24 @@ export default function BlockInserterButton({ visible, top, onCommand, onMenuOpe
     onMenuOpenChange?.(open);
   };
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!menuOpen) return;
     setSelectedIndex(0);
     menuRef.current?.focus();
+  }, [menuOpen]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [menuOpen]);
 
   useEffect(() => {
@@ -63,6 +75,7 @@ export default function BlockInserterButton({ visible, top, onCommand, onMenuOpe
 
   return (
     <div
+      ref={containerRef}
       data-block-inserter
       className="absolute left-0 z-10 transition-all duration-150"
       style={{ top: `${top}px` }}

--- a/frontend/src/components/__tests__/BlockInserterButton.test.tsx
+++ b/frontend/src/components/__tests__/BlockInserterButton.test.tsx
@@ -75,4 +75,13 @@ describe('BlockInserterButton', () => {
     const button = screen.getByLabelText('ブロックを追加');
     expect(button.closest('[data-block-inserter]')).toBeInTheDocument();
   });
+
+  it('メニュー表示中に外側クリックで閉じる', () => {
+    render(<BlockInserterButton visible={true} top={100} onCommand={mockOnCommand} onMenuOpenChange={mockOnMenuOpenChange} />);
+    fireEvent.click(screen.getByLabelText('ブロックを追加'));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(mockOnMenuOpenChange).toHaveBeenLastCalledWith(false);
+  });
 });


### PR DESCRIPTION
## Summary
- +ボタンのブロック挿入メニュー（SlashCommandMenu）が外側クリックで閉じない問題を修正
- `containerRef`をルート要素に追加し、`mousedown`イベントで外側クリックを検出

## Test plan
- [x] メニュー表示中に外側クリックで閉じる（新規テスト追加）
- [x] 既存テスト全てパス（11テスト）