### PR TITLE
feat: 全角＃ + Enterで見出しに変換する機能を追加

### DIFF
--- a/frontend/src/extensions/FullWidthHeadingEnter.ts
+++ b/frontend/src/extensions/FullWidthHeadingEnter.ts
@@ -1,0 +1,43 @@
+import { Extension } from '@tiptap/core';
+
+/** Enter押下時に全角＃（および半角#）のみの行を見出しに変換するパターン */
+export const HEADING_ENTER_PATTERN = /^[#＃]{1,3}$/;
+
+/**
+ * 全角＃ + Enter で見出し変換する TipTap 拡張
+ *
+ * 日本語IMEで全角＃を入力した場合、TipTapの標準InputRule（スペーストリガー）が
+ * 動作しないため、Enterキーでもハッシュ記号のみの行を見出しに変換する。
+ */
+export const FullWidthHeadingEnter = Extension.create({
+  name: 'fullWidthHeadingEnter',
+
+  addKeyboardShortcuts() {
+    return {
+      Enter: ({ editor }) => {
+        const { state } = editor;
+        const { $from, empty } = state.selection;
+
+        if (!empty) return false;
+        if ($from.parent.type.name !== 'paragraph') return false;
+
+        const text = $from.parent.textContent;
+        const match = text.match(HEADING_ENTER_PATTERN);
+        if (!match) return false;
+
+        const level = match[0].length as 1 | 2 | 3;
+
+        editor
+          .chain()
+          .command(({ tr }) => {
+            tr.delete($from.start(), $from.end());
+            return true;
+          })
+          .setNode('heading', { level })
+          .run();
+
+        return true;
+      },
+    };
+  },
+});

--- a/frontend/src/extensions/__tests__/FullWidthHeadingInputRule.test.ts
+++ b/frontend/src/extensions/__tests__/FullWidthHeadingInputRule.test.ts
@@ -45,3 +45,52 @@ describe('全角＃見出し変換の正規表現', () => {
     expect(HEADING_REGEX_3.test('＃＃＃＃ ')).toBe(false);
   });
 });
+
+describe('全角＃ + Enter見出し変換', () => {
+  // Enter押下時に使うパターン（スペース不要、ハッシュのみ）
+  const HEADING_ENTER_PATTERN = /^[#＃]{1,3}$/;
+
+  it('全角 ＃ のみでマッチする（H1）', () => {
+    const match = '＃'.match(HEADING_ENTER_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![0].length).toBe(1);
+  });
+
+  it('全角 ＃＃ のみでマッチする（H2）', () => {
+    const match = '＃＃'.match(HEADING_ENTER_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![0].length).toBe(2);
+  });
+
+  it('全角 ＃＃＃ のみでマッチする（H3）', () => {
+    const match = '＃＃＃'.match(HEADING_ENTER_PATTERN);
+    expect(match).not.toBeNull();
+    expect(match![0].length).toBe(3);
+  });
+
+  it('半角 # でもマッチする', () => {
+    expect(HEADING_ENTER_PATTERN.test('#')).toBe(true);
+    expect(HEADING_ENTER_PATTERN.test('##')).toBe(true);
+    expect(HEADING_ENTER_PATTERN.test('###')).toBe(true);
+  });
+
+  it('半角と全角混在でマッチする', () => {
+    expect(HEADING_ENTER_PATTERN.test('#＃')).toBe(true);
+    expect(HEADING_ENTER_PATTERN.test('＃#＃')).toBe(true);
+  });
+
+  it('4つ以上のハッシュにはマッチしない', () => {
+    expect(HEADING_ENTER_PATTERN.test('####')).toBe(false);
+    expect(HEADING_ENTER_PATTERN.test('＃＃＃＃')).toBe(false);
+  });
+
+  it('ハッシュ以外のテキストを含む場合はマッチしない', () => {
+    expect(HEADING_ENTER_PATTERN.test('＃ テスト')).toBe(false);
+    expect(HEADING_ENTER_PATTERN.test('テスト＃')).toBe(false);
+    expect(HEADING_ENTER_PATTERN.test('＃ ')).toBe(false);
+  });
+
+  it('空文字にはマッチしない', () => {
+    expect(HEADING_ENTER_PATTERN.test('')).toBe(false);
+  });
+});

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -6,6 +6,7 @@ vi.mock('@tiptap/extension-heading', () => ({
 }));
 vi.mock('@tiptap/core', () => ({
   textblockTypeInputRule: vi.fn(),
+  Extension: { create: vi.fn(() => 'FullWidthHeadingEnter') },
 }));
 vi.mock('@tiptap/extension-placeholder', () => ({ default: { configure: vi.fn(() => 'Placeholder') } }));
 vi.mock('@tiptap/extension-image', () => ({ default: { configure: vi.fn(() => 'Image') } }));
@@ -47,13 +48,16 @@ vi.mock('@tiptap/extension-youtube', () => ({ default: { configure: vi.fn(() => 
 vi.mock('../../extensions/SearchReplaceExtension', () => ({
   SearchReplaceExtension: 'SearchReplace',
 }));
+vi.mock('../../extensions/FullWidthHeadingEnter', () => ({
+  FullWidthHeadingEnter: 'FullWidthHeadingEnter',
+}));
 
 import { createEditorExtensions } from '../editorExtensions';
 
 describe('createEditorExtensions', () => {
-  it('26個のエクステンションを返す', () => {
+  it('27個のエクステンションを返す', () => {
     const extensions = createEditorExtensions();
-    expect(extensions).toHaveLength(26);
+    expect(extensions).toHaveLength(27);
   });
 
   it('主要なエクステンションが含まれる', () => {
@@ -72,6 +76,7 @@ describe('createEditorExtensions', () => {
     expect(extensions).toContain('TableCell');
     expect(extensions).toContain('TableHeader');
     expect(extensions).toContain('SearchReplace');
+    expect(extensions).toContain('FullWidthHeadingEnter');
   });
 
   it('毎回新しい配列を返す', () => {
@@ -86,8 +91,8 @@ describe('createEditorExtensions', () => {
     expect(extensions[0]).toBe('StarterKit');
   });
 
-  it('配列の末尾がSearchReplaceExtensionである', () => {
+  it('配列の末尾がFullWidthHeadingEnterである', () => {
     const extensions = createEditorExtensions();
-    expect(extensions[extensions.length - 1]).toBe('SearchReplace');
+    expect(extensions[extensions.length - 1]).toBe('FullWidthHeadingEnter');
   });
 });

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -25,6 +25,7 @@ import Superscript from '@tiptap/extension-superscript';
 import Subscript from '@tiptap/extension-subscript';
 import Youtube from '@tiptap/extension-youtube';
 import { SearchReplaceExtension } from '../extensions/SearchReplaceExtension';
+import { FullWidthHeadingEnter } from '../extensions/FullWidthHeadingEnter';
 
 export function createEditorExtensions() {
   return [
@@ -86,5 +87,6 @@ export function createEditorExtensions() {
       HTMLAttributes: { class: 'note-youtube' },
     }),
     SearchReplaceExtension,
+    FullWidthHeadingEnter,
   ];
 }


### PR DESCRIPTION
## Summary
- 全角＃を入力してEnterを押すと見出しに変換される機能を追加
  - `＃` + Enter → 見出し1
  - `＃＃` + Enter → 見出し2
  - `＃＃＃` + Enter → 見出し3
- 半角`#`と全角`＃`の混在にも対応
- 日本語IMEで全角＃を入力した場合、TipTapの標準InputRule（スペーストリガー）が動作しないため、Enterキーでの変換を追加

## Test plan
- [x] 全角＃のパターンマッチテスト（8ケース追加）
- [x] editorExtensionsテスト更新（27個のエクステンション）
- [x] 全テストパス（2147テスト）