### PR TITLE
fix: 空テキストの見出しが目次に表示される問題を修正

### DIFF
--- a/frontend/src/hooks/__tests__/useTableOfContents.test.ts
+++ b/frontend/src/hooks/__tests__/useTableOfContents.test.ts
@@ -54,6 +54,21 @@ describe('useTableOfContents', () => {
     ]);
   });
 
+  it('テキストが空の見出しは除外する', () => {
+    const content = JSON.stringify({
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: '大見出し' }] },
+        { type: 'heading', attrs: { level: 2 } },
+        { type: 'heading', attrs: { level: 3 }, content: [] },
+      ],
+    });
+    const { result } = renderHook(() => useTableOfContents(content));
+    expect(result.current.headings).toEqual([
+      { level: 1, text: '大見出し', id: 'heading-0' },
+    ]);
+  });
+
   it('レガシーMarkdownの場合は空リストを返す', () => {
     const { result } = renderHook(() => useTableOfContents('普通のテキスト'));
     expect(result.current.headings).toEqual([]);

--- a/frontend/src/hooks/useTableOfContents.ts
+++ b/frontend/src/hooks/useTableOfContents.ts
@@ -38,8 +38,9 @@ export function useTableOfContents(content: string) {
         .map((node) => ({
           level: node.attrs!.level!,
           text: node.content ? extractText(node.content) : '',
-          id: `heading-${index++}`,
-        }));
+        }))
+        .filter((h) => h.text.trim() !== '')
+        .map((h) => ({ ...h, id: `heading-${index++}` }));
     } catch {
       return [];
     }


### PR DESCRIPTION
## Summary
- 空テキストの見出しノード（＃+Enterで変換直後の空見出し等）が目次に表示される問題を修正
- `useTableOfContents`フックで`text.trim()`が空の見出しをフィルタリング

## Test plan
- [x] テキストが空の見出しは除外する（新規テスト追加）
- [x] 既存テスト全てパス（9テスト）