### PR TITLE
feat: ダッシュボードにクイックスタートボタンを追加

### DIFF
--- a/frontend/src/components/QuickStartButton.tsx
+++ b/frontend/src/components/QuickStartButton.tsx
@@ -1,0 +1,46 @@
+import { useNavigate } from 'react-router-dom';
+import { RocketLaunchIcon } from '@heroicons/react/24/solid';
+import { useStartPracticeSession } from '../hooks/useStartPracticeSession';
+
+interface QuickStartButtonProps {
+  scenario: {
+    id: number;
+    name: string;
+    description?: string;
+    category?: string;
+    roleName?: string;
+    difficulty?: string;
+  } | null;
+}
+
+export default function QuickStartButton({ scenario }: QuickStartButtonProps) {
+  const navigate = useNavigate();
+  const { startSession, starting } = useStartPracticeSession();
+
+  const handleClick = () => {
+    if (scenario) {
+      startSession(scenario);
+    } else {
+      navigate('/practice');
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={starting}
+      aria-label="練習を始める"
+      className="w-full flex items-center gap-3 px-5 py-4 rounded-xl bg-gradient-to-r from-primary-600 to-primary-500 hover:from-primary-500 hover:to-primary-400 text-white shadow-lg shadow-primary-600/20 transition-all disabled:opacity-60"
+    >
+      <RocketLaunchIcon className="w-6 h-6 flex-shrink-0" />
+      <div className="flex-1 text-left">
+        <p className="text-sm font-bold">
+          {starting ? '練習を開始中...' : '練習を始める'}
+        </p>
+        <p className="text-xs opacity-80 mt-0.5">
+          {scenario ? scenario.name : 'シナリオを選んで練習'}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/QuickStartButton.test.tsx
+++ b/frontend/src/components/__tests__/QuickStartButton.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import QuickStartButton from '../QuickStartButton';
+
+const mockStartSession = vi.fn();
+vi.mock('../../hooks/useStartPracticeSession', () => ({
+  useStartPracticeSession: () => ({
+    startSession: mockStartSession,
+    starting: false,
+  }),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const defaultScenario = {
+  id: 1,
+  name: '本番障害の緊急報告',
+  description: '本番環境で障害が発生し、顧客に緊急報告する場面です。',
+  category: 'customer',
+  roleName: '顧客',
+  difficulty: 'intermediate',
+};
+
+describe('QuickStartButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ボタンが表示される', () => {
+    render(
+      <MemoryRouter>
+        <QuickStartButton scenario={null} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('button', { name: /練習を始める/i })).toBeInTheDocument();
+  });
+
+  it('推奨シナリオがある場合、シナリオ名が表示される', () => {
+    render(
+      <MemoryRouter>
+        <QuickStartButton scenario={defaultScenario} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('本番障害の緊急報告')).toBeInTheDocument();
+  });
+
+  it('推奨シナリオがある場合、クリックでstartSessionが呼ばれる', () => {
+    render(
+      <MemoryRouter>
+        <QuickStartButton scenario={defaultScenario} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /練習を始める/i }));
+
+    expect(mockStartSession).toHaveBeenCalledWith(defaultScenario);
+  });
+
+  it('推奨シナリオがない場合、クリックで練習ページに遷移する', () => {
+    render(
+      <MemoryRouter>
+        <QuickStartButton scenario={null} />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /練習を始める/i }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/practice');
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  it('推奨シナリオがない場合、「シナリオを選んで練習」と表示される', () => {
+    render(
+      <MemoryRouter>
+        <QuickStartButton scenario={null} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('シナリオを選んで練習')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -21,6 +21,7 @@ import SessionCountMilestoneCard from '../components/SessionCountMilestoneCard';
 import ScoreSparkline from '../components/ScoreSparkline';
 import RecommendedScenarioCard from '../components/RecommendedScenarioCard';
 import BookmarkedScenariosCard from '../components/BookmarkedScenariosCard';
+import QuickStartButton from '../components/QuickStartButton';
 import Loading from '../components/Loading';
 import { useMenuData } from '../hooks/useMenuData';
 import { useScoreHistory } from '../hooks/useScoreHistory';
@@ -39,6 +40,11 @@ export default function MenuPage() {
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
+      {/* クイックスタート */}
+      <div className="mb-6">
+        <QuickStartButton scenario={recommendedScenario} />
+      </div>
+
       {/* 学習インサイト */}
       {totalSessions > 0 && (
         <div className="mb-6">


### PR DESCRIPTION
## 概要
ダッシュボード（MenuPage）の最上部にクイックスタートボタンを追加し、練習開始の摩擦を軽減する。

## 変更内容
- `QuickStartButton` コンポーネントを新規作成
- 推奨シナリオがある場合: ワンクリックでそのシナリオの練習を開始
- 推奨シナリオがない場合: 練習ページ（シナリオ選択）に遷移
- ダッシュボード最上部に配置

## テスト
- QuickStartButton のユニットテスト 5件（全パス）
- MenuPage の既存テスト 7件（全パス）

Closes #1382