### PR TITLE
feat: スコア詳細モーダルにリトライボタンを追加

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreHistoryDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ScoreHistoryDto.java
@@ -6,6 +6,7 @@ import java.util.List;
 public record ScoreHistoryDto(
         Integer sessionId,
         String sessionTitle,
+        Integer scenarioId,
         double overallScore,
         List<ScoreCardDto.AxisScoreDto> scores,
         Timestamp createdAt) {

--- a/FreStyle/src/main/java/com/example/FreStyle/mapper/ScoreCardMapper.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/mapper/ScoreCardMapper.java
@@ -77,6 +77,7 @@ public class ScoreCardMapper {
                     double overallScore = calculateOverallScore(sessionScores);
                     return new ScoreHistoryDto(
                             entry.getKey(), first.getSession().getTitle(),
+                            first.getSession().getScenarioId(),
                             overallScore, scoreDtos, first.getCreatedAt());
                 })
                 .toList();

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreCardControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ScoreCardControllerTest.java
@@ -95,8 +95,8 @@ class ScoreCardControllerTest {
         @Test
         @DisplayName("スコア履歴を取得する")
         void shouldReturnScoreHistory() {
-            ScoreHistoryDto history1 = new ScoreHistoryDto(1, null, 7.5, List.of(), null);
-            ScoreHistoryDto history2 = new ScoreHistoryDto(2, null, 8.0, List.of(), null);
+            ScoreHistoryDto history1 = new ScoreHistoryDto(1, null, null, 7.5, List.of(), null);
+            ScoreHistoryDto history2 = new ScoreHistoryDto(2, null, null, 8.0, List.of(), null);
             when(getScoreHistoryByUserIdUseCase.execute(1))
                     .thenReturn(List.of(history1, history2));
 

--- a/FreStyle/src/test/java/com/example/FreStyle/mapper/ScoreCardMapperTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/mapper/ScoreCardMapperTest.java
@@ -37,6 +37,12 @@ class ScoreCardMapperTest {
         return session;
     }
 
+    private AiChatSession createPracticeSession(Integer id, String title, Integer scenarioId) {
+        AiChatSession session = createSession(id, title);
+        session.setScenarioId(scenarioId);
+        return session;
+    }
+
     @Nested
     @DisplayName("toScoreCardDto")
     class ToScoreCardDto {
@@ -158,6 +164,32 @@ class ScoreCardMapperTest {
             List<ScoreHistoryDto> history = mapper.toScoreHistoryDtoList(scores);
 
             assertThat(history.get(0).createdAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("練習セッションのscenarioIdが設定される")
+        void setsScenarioIdForPracticeSession() {
+            AiChatSession session = createPracticeSession(1, "練習セッション", 3);
+            List<CommunicationScore> scores = List.of(
+                createScore(session, "明瞭性", 8, "")
+            );
+
+            List<ScoreHistoryDto> history = mapper.toScoreHistoryDtoList(scores);
+
+            assertThat(history.get(0).scenarioId()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("通常セッションのscenarioIdはnullになる")
+        void scenarioIdIsNullForNormalSession() {
+            AiChatSession session = createSession(1, "通常セッション");
+            List<CommunicationScore> scores = List.of(
+                createScore(session, "明瞭性", 8, "")
+            );
+
+            List<ScoreHistoryDto> history = mapper.toScoreHistoryDtoList(scores);
+
+            assertThat(history.get(0).scenarioId()).isNull();
         }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetScoreHistoryByUserIdUseCaseTest.java
@@ -66,6 +66,7 @@ class GetScoreHistoryByUserIdUseCaseTest {
                     new ScoreHistoryDto(
                             10,
                             "セッション1",
+                            null,
                             7.0,
                             List.of(
                                     new ScoreCardDto.AxisScoreDto("論理的構成力", 8, "良い"),

--- a/frontend/src/components/SessionDetailModal.tsx
+++ b/frontend/src/components/SessionDetailModal.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import type { ScoreHistoryItem } from '../types';
 import AxisScoreBar from './AxisScoreBar';
+import { useStartPracticeSession } from '../hooks/useStartPracticeSession';
 
 interface SessionDetailModalProps {
   session: ScoreHistoryItem;
@@ -9,6 +10,7 @@ interface SessionDetailModalProps {
 
 export default function SessionDetailModal({ session, onClose }: SessionDetailModalProps) {
   const navigate = useNavigate();
+  const { startSession, starting } = useStartPracticeSession();
 
   return (
     <div
@@ -73,6 +75,15 @@ export default function SessionDetailModal({ session, onClose }: SessionDetailMo
             >
               会話を見る
             </button>
+            {session.scenarioId && (
+              <button
+                onClick={() => startSession({ id: session.scenarioId!, name: session.sessionTitle })}
+                disabled={starting}
+                className="flex-1 py-2 text-xs font-medium text-primary-400 bg-primary-600/10 rounded-lg hover:bg-primary-600/20 transition-colors disabled:opacity-50"
+              >
+                {starting ? '開始中...' : 'もう一度挑戦'}
+              </button>
+            )}
             <button
               onClick={onClose}
               className="flex-1 py-2 text-xs font-medium text-[var(--color-text-tertiary)] bg-surface-3 rounded-lg hover:bg-surface-3 transition-colors"

--- a/frontend/src/components/__tests__/SessionDetailModal.test.tsx
+++ b/frontend/src/components/__tests__/SessionDetailModal.test.tsx
@@ -7,9 +7,18 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+const mockStartSession = vi.fn();
+vi.mock('../../hooks/useStartPracticeSession', () => ({
+  useStartPracticeSession: () => ({
+    startSession: mockStartSession,
+    starting: false,
+  }),
+}));
+
 const session = {
   sessionId: 1,
   sessionTitle: '障害報告の練習',
+  scenarioId: 3,
   overallScore: 7.5,
   scores: [
     { axis: '論理的構成力', score: 8, comment: '構成が明確でした' },
@@ -72,5 +81,29 @@ describe('SessionDetailModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '会話を見る' }));
     expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai/1');
+  });
+
+  it('scenarioIdがある場合「もう一度挑戦」ボタンが表示される', () => {
+    render(<SessionDetailModal session={session} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'もう一度挑戦' })).toBeInTheDocument();
+  });
+
+  it('scenarioIdがない場合「もう一度挑戦」ボタンが表示されない', () => {
+    const normalSession = { ...session, scenarioId: null };
+    render(<SessionDetailModal session={normalSession} onClose={vi.fn()} />);
+
+    expect(screen.queryByRole('button', { name: 'もう一度挑戦' })).not.toBeInTheDocument();
+  });
+
+  it('「もう一度挑戦」クリックでstartSessionが呼ばれる', () => {
+    render(<SessionDetailModal session={session} onClose={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'もう一度挑戦' }));
+
+    expect(mockStartSession).toHaveBeenCalledWith({
+      id: 3,
+      name: '障害報告の練習',
+    });
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -159,6 +159,7 @@ export interface ScoreHistory {
 export interface ScoreHistoryItem {
   sessionId: number;
   sessionTitle: string;
+  scenarioId: number | null;
   overallScore: number;
   scores: AxisScore[];
   createdAt: string;


### PR DESCRIPTION
## 概要
スコア履歴のセッション詳細モーダルに「もう一度挑戦」ボタンを追加し、同じシナリオで再練習できるようにした。

## 変更内容
### バックエンド
- `ScoreHistoryDto` に `scenarioId` フィールドを追加
- `ScoreCardMapper` でセッションの `scenarioId` をマッピング

### フロントエンド
- `ScoreHistoryItem` 型に `scenarioId` を追加
- `SessionDetailModal` に「もう一度挑戦」ボタンを追加（`scenarioId` がある場合のみ表示）

## テスト
- バックエンド: ScoreCardMapperTest に2件追加（練習/通常セッションのscenarioId検証）
- フロントエンド: SessionDetailModal テスト 3件追加（リトライボタン表示/非表示/クリック）

Closes #1384