### PR TITLE
feat: スコア履歴のCSVエクスポート機能を追加

### DIFF
--- a/frontend/src/components/ExportScoreHistoryButton.tsx
+++ b/frontend/src/components/ExportScoreHistoryButton.tsx
@@ -1,0 +1,62 @@
+import { ArrowDownTrayIcon } from '@heroicons/react/24/outline';
+import type { ScoreHistoryItem } from '../types';
+
+interface ExportScoreHistoryButtonProps {
+  history: ScoreHistoryItem[];
+}
+
+function toCSV(history: ScoreHistoryItem[]): string {
+  // 全セッションの軸名を収集（順序統一）
+  const allAxes = Array.from(
+    new Set(history.flatMap((h) => h.scores.map((s) => s.axis)))
+  );
+
+  const header = ['日時', 'セッション名', '総合スコア', ...allAxes];
+  const rows = history.map((h) => {
+    const date = new Date(h.createdAt).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const axisScores = allAxes.map((axis) => {
+      const found = h.scores.find((s) => s.axis === axis);
+      return found ? found.score.toFixed(1) : '';
+    });
+    return [date, h.sessionTitle || '', h.overallScore.toFixed(1), ...axisScores];
+  });
+
+  const csvContent = [header, ...rows]
+    .map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+
+  // BOM付きでExcel対応
+  return '\uFEFF' + csvContent;
+}
+
+export default function ExportScoreHistoryButton({ history }: ExportScoreHistoryButtonProps) {
+  const handleExport = () => {
+    const csv = toCSV(history);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `スコア履歴_${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button
+      onClick={handleExport}
+      disabled={history.length === 0}
+      aria-label="CSVエクスポート"
+      className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] bg-surface-2 rounded-lg hover:bg-surface-3 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+    >
+      <ArrowDownTrayIcon className="w-3.5 h-3.5" />
+      CSV
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/ExportScoreHistoryButton.test.tsx
+++ b/frontend/src/components/__tests__/ExportScoreHistoryButton.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExportScoreHistoryButton from '../ExportScoreHistoryButton';
+import type { ScoreHistoryItem } from '../../types';
+
+// URL.createObjectURL / revokeObjectURL のモック
+const mockCreateObjectURL = vi.fn(() => 'blob:mock-url');
+const mockRevokeObjectURL = vi.fn();
+global.URL.createObjectURL = mockCreateObjectURL;
+global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+const history: ScoreHistoryItem[] = [
+  {
+    sessionId: 1,
+    sessionTitle: '障害報告の練習',
+    scenarioId: 3,
+    overallScore: 7.5,
+    scores: [
+      { axis: '論理的構成力', score: 8, comment: '良い' },
+      { axis: '配慮表現', score: 7, comment: 'まずまず' },
+    ],
+    createdAt: '2026-02-10T10:00:00',
+  },
+  {
+    sessionId: 2,
+    sessionTitle: '進捗報告',
+    scenarioId: null,
+    overallScore: 6.0,
+    scores: [
+      { axis: '論理的構成力', score: 6, comment: '' },
+      { axis: '配慮表現', score: 6, comment: '' },
+    ],
+    createdAt: '2026-02-11T14:30:00',
+  },
+];
+
+describe('ExportScoreHistoryButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('エクスポートボタンが表示される', () => {
+    render(<ExportScoreHistoryButton history={history} />);
+
+    expect(screen.getByRole('button', { name: /CSV/i })).toBeInTheDocument();
+  });
+
+  it('履歴が空の場合はボタンが無効になる', () => {
+    render(<ExportScoreHistoryButton history={[]} />);
+
+    expect(screen.getByRole('button', { name: /CSV/i })).toBeDisabled();
+  });
+
+  it('クリックでcreateObjectURLが呼ばれる', () => {
+    render(<ExportScoreHistoryButton history={history} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /CSV/i }));
+
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('クリックでBlobが作成される', () => {
+    render(<ExportScoreHistoryButton history={history} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /CSV/i }));
+
+    const blobArg = mockCreateObjectURL.mock.calls[0]?.[0];
+    expect(blobArg).toBeInstanceOf(Blob);
+  });
+});

--- a/frontend/src/pages/ScoreHistoryPage.tsx
+++ b/frontend/src/pages/ScoreHistoryPage.tsx
@@ -4,6 +4,7 @@ import { SkeletonCard } from '../components/Skeleton';
 import EmptyState from '../components/EmptyState';
 import ScoreOverviewSection from '../components/ScoreOverviewSection';
 import SessionListSection from '../components/SessionListSection';
+import ExportScoreHistoryButton from '../components/ExportScoreHistoryButton';
 import { useScoreHistory } from '../hooks/useScoreHistory';
 import { useScoreGoal } from '../hooks/useScoreGoal';
 
@@ -39,7 +40,10 @@ export default function ScoreHistoryPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-4 space-y-3">
-      <p className="text-xs text-[var(--color-text-muted)]">スコア履歴 {history.length}件</p>
+      <div className="flex items-center justify-between">
+        <p className="text-xs text-[var(--color-text-muted)]">スコア履歴 {history.length}件</p>
+        <ExportScoreHistoryButton history={history} />
+      </div>
       <ScoreOverviewSection
         history={history}
         latestSession={latestSession!}


### PR DESCRIPTION
## 概要
スコア履歴ページにCSVダウンロードボタンを追加し、成長記録をエクスポート可能にした。

## 変更内容
- `ExportScoreHistoryButton` コンポーネントを新規作成
- スコア履歴をCSV形式に変換（日時・タイトル・総合スコア・各軸スコア）
- BOM付きでExcelでの文字化けに対応
- ScoreHistoryPage の件数表示横に配置

## テスト
- ExportScoreHistoryButton テスト 4件（全パス）
- ScoreHistoryPage 既存テスト 14件（全パス）

Closes #1386