### PR TITLE
feat: お気に入りフレーズのワンクリックコピー機能を追加

### DIFF
--- a/frontend/src/pages/FavoritesPage.tsx
+++ b/frontend/src/pages/FavoritesPage.tsx
@@ -1,17 +1,19 @@
 import { useState } from 'react';
 import { useFavoritePhrase } from '../hooks/useFavoritePhrase';
+import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
 import SearchBox from '../components/SearchBox';
 import FavoriteStatsCard from '../components/FavoriteStatsCard';
 import EmptyState from '../components/EmptyState';
 import ConfirmModal from '../components/ConfirmModal';
 import Loading from '../components/Loading';
-import { StarIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { StarIcon, XMarkIcon, ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline';
 import type { FavoritePhrase } from '../types';
 
 const PATTERN_FILTERS = ['すべて', 'フォーマル', 'ソフト', '簡潔'] as const;
 
 export default function FavoritesPage() {
   const { phrases, filteredPhrases, searchQuery, setSearchQuery, patternFilter, setPatternFilter, removeFavorite, loading } = useFavoritePhrase();
+  const { copiedId, copyToClipboard } = useCopyToClipboard();
   const [deleteTarget, setDeleteTarget] = useState<FavoritePhrase | null>(null);
 
   if (loading) {
@@ -93,7 +95,20 @@ export default function FavoritesPage() {
                   </button>
                 </div>
               </div>
-              <p className="text-sm text-[var(--color-text-primary)] mb-1">{phrase.rephrasedText}</p>
+              <div className="flex items-start justify-between gap-2 mb-1">
+                <p className="text-sm text-[var(--color-text-primary)] flex-1">{phrase.rephrasedText}</p>
+                <button
+                  onClick={() => copyToClipboard(phrase.id, phrase.rephrasedText)}
+                  aria-label="フレーズをコピー"
+                  className="flex-shrink-0 p-1 rounded hover:bg-surface-2 transition-colors"
+                >
+                  {copiedId === phrase.id ? (
+                    <CheckIcon className="w-4 h-4 text-emerald-500" />
+                  ) : (
+                    <ClipboardDocumentIcon className="w-4 h-4 text-[var(--color-text-faint)]" />
+                  )}
+                </button>
+              </div>
               <p className="text-xs text-[var(--color-text-faint)]">元: {phrase.originalText}</p>
             </div>
           ))}

--- a/frontend/src/pages/__tests__/FavoritesPage.test.tsx
+++ b/frontend/src/pages/__tests__/FavoritesPage.test.tsx
@@ -174,4 +174,23 @@ describe('FavoritesPage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /お気に入りフレーズ/ })).not.toBeInTheDocument();
   });
+
+  it('各フレーズにコピーボタンが表示される', () => {
+    render(<FavoritesPage />);
+
+    const copyButtons = screen.getAllByLabelText('フレーズをコピー');
+    expect(copyButtons).toHaveLength(2);
+  });
+
+  it('コピーボタンクリックでクリップボードにコピーされる', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<FavoritesPage />);
+
+    const copyButtons = screen.getAllByLabelText('フレーズをコピー');
+    fireEvent.click(copyButtons[0]);
+
+    expect(writeText).toHaveBeenCalledWith('ご確認いただけますでしょうか');
+  });
 });


### PR DESCRIPTION
## 概要
お気に入りフレーズ一覧の各フレーズにワンクリックでクリップボードにコピーできるボタンを追加した。

## 変更内容
- 各フレーズカードにコピーボタン（ClipboardDocumentIcon）を配置
- 既存の `useCopyToClipboard` hookを活用
- コピー成功時はチェックアイコンに切り替わり、2秒後にリセット

## テスト
- FavoritesPage テスト 16件（既存14件 + 新規2件）全パス

Closes #1388