### PR TITLE
feat: プロフィールページに年間活動ヒートマップを追加

### DIFF
--- a/frontend/src/components/ActivityHeatmap.tsx
+++ b/frontend/src/components/ActivityHeatmap.tsx
@@ -1,0 +1,130 @@
+import Card from './Card';
+
+interface ActivityHeatmapProps {
+  practiceDates: string[];
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getLast365Days(): Date[] {
+  const days: Date[] = [];
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  for (let i = 364; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    days.push(d);
+  }
+  return days;
+}
+
+function getIntensityClass(count: number): string {
+  if (count === 0) return 'bg-surface-3';
+  if (count === 1) return 'bg-emerald-800';
+  if (count === 2) return 'bg-emerald-600';
+  return 'bg-emerald-400';
+}
+
+const MONTH_LABELS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+
+export default function ActivityHeatmap({ practiceDates }: ActivityHeatmapProps) {
+  const days = getLast365Days();
+  const dateCountMap = new Map<string, number>();
+  practiceDates.forEach((d) => {
+    dateCountMap.set(d, (dateCountMap.get(d) || 0) + 1);
+  });
+
+  const uniqueDays = new Set(practiceDates).size;
+
+  // 週ごとにグループ化（日曜始まり）
+  const weeks: Date[][] = [];
+  let currentWeek: Date[] = [];
+
+  // 最初の週の前にパディング
+  const firstDayOfWeek = days[0].getDay();
+  for (let i = 0; i < firstDayOfWeek; i++) {
+    currentWeek.push(null as unknown as Date);
+  }
+
+  days.forEach((day) => {
+    currentWeek.push(day);
+    if (currentWeek.length === 7) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+  });
+  if (currentWeek.length > 0) {
+    weeks.push(currentWeek);
+  }
+
+  // 月ラベルの位置を計算
+  const monthPositions: { label: string; weekIndex: number }[] = [];
+  let lastMonth = -1;
+  weeks.forEach((week, weekIndex) => {
+    const validDay = week.find((d) => d !== null);
+    if (validDay) {
+      const month = validDay.getMonth();
+      if (month !== lastMonth) {
+        monthPositions.push({ label: MONTH_LABELS[month], weekIndex });
+        lastMonth = month;
+      }
+    }
+  });
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs font-medium text-[var(--color-text-secondary)]">年間の学習活動</p>
+        <p className="text-xs text-[var(--color-text-muted)]">
+          <span className="font-bold text-emerald-400">{uniqueDays}日</span> 練習
+        </p>
+      </div>
+
+      {/* 月ラベル */}
+      <div className="flex mb-1 text-[9px] text-[var(--color-text-faint)]" style={{ paddingLeft: '0px' }}>
+        {monthPositions.map((pos, i) => (
+          <span
+            key={i}
+            style={{
+              position: 'relative',
+              left: `${pos.weekIndex * 11}px`,
+              marginRight: i < monthPositions.length - 1
+                ? `${Math.max(0, (monthPositions[i + 1]?.weekIndex - pos.weekIndex) * 11 - 20)}px`
+                : '0px',
+            }}
+          >
+            {pos.label}
+          </span>
+        ))}
+      </div>
+
+      {/* ヒートマップグリッド */}
+      <div className="flex gap-[2px] overflow-x-auto">
+        {weeks.map((week, weekIndex) => (
+          <div key={weekIndex} className="flex flex-col gap-[2px]">
+            {week.map((day, dayIndex) => {
+              if (!day) {
+                return <div key={dayIndex} className="w-[9px] h-[9px]" />;
+              }
+              const dateStr = formatDate(day);
+              const count = dateCountMap.get(dateStr) || 0;
+              return (
+                <div
+                  key={dayIndex}
+                  title={dateStr}
+                  className={`w-[9px] h-[9px] rounded-[2px] ${getIntensityClass(count)}`}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/__tests__/ActivityHeatmap.test.tsx
+++ b/frontend/src/components/__tests__/ActivityHeatmap.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ActivityHeatmap from '../ActivityHeatmap';
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+describe('ActivityHeatmap', () => {
+  it('ヒートマップが表示される', () => {
+    render(<ActivityHeatmap practiceDates={[]} />);
+
+    expect(screen.getByText('年間の学習活動')).toBeInTheDocument();
+  });
+
+  it('練習日数が表示される', () => {
+    const today = new Date();
+    const dates = [formatDate(today)];
+
+    render(<ActivityHeatmap practiceDates={dates} />);
+
+    expect(screen.getByText(/1日/)).toBeInTheDocument();
+  });
+
+  it('練習した日のセルが色付きで表示される', () => {
+    const today = new Date();
+    const dateStr = formatDate(today);
+
+    render(<ActivityHeatmap practiceDates={[dateStr]} />);
+
+    const activeCell = screen.getByTitle(dateStr);
+    expect(activeCell.className).toContain('bg-emerald');
+  });
+
+  it('練習していない日のセルが薄い色で表示される', () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    const dateStr = formatDate(yesterday);
+
+    // 空の練習日リストなので全セルが非アクティブ
+    render(<ActivityHeatmap practiceDates={[]} />);
+
+    const cell = screen.getByTitle(dateStr);
+    expect(cell.className).toContain('bg-surface');
+  });
+
+  it('月ラベルが表示される', () => {
+    render(<ActivityHeatmap practiceDates={[]} />);
+
+    // 少なくとも1つの月ラベルが表示される
+    const monthLabels = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+    const found = monthLabels.some((label) => screen.queryByText(label) !== null);
+    expect(found).toBe(true);
+  });
+
+  it('複数の練習日を正しく反映する', () => {
+    const today = new Date();
+    const dates = [];
+    for (let i = 0; i < 5; i++) {
+      const d = new Date(today);
+      d.setDate(d.getDate() - i);
+      dates.push(formatDate(d));
+    }
+
+    render(<ActivityHeatmap practiceDates={dates} />);
+
+    expect(screen.getByText(/5日/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback } from 'react';
+import { useRef, useState, useEffect, useCallback, useMemo } from 'react';
 import InputField from '../components/InputField';
 import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
@@ -6,15 +6,22 @@ import FormMessage from '../components/FormMessage';
 import Avatar from '../components/Avatar';
 import Loading from '../components/Loading';
 import ProfileStatsSection from '../components/profile/ProfileStatsSection';
+import ActivityHeatmap from '../components/ActivityHeatmap';
 import { useProfileEdit } from '../hooks/useProfileEdit';
 import { useProfileImageUpload } from '../hooks/useProfileImageUpload';
+import { useScoreHistory } from '../hooks/useScoreHistory';
 import ProfileStatsRepository, { type ProfileStats } from '../repositories/ProfileStatsRepository';
 import { CameraIcon } from '@heroicons/react/24/outline';
 
 export default function ProfilePage() {
   const { form, message, setMessage, loading, submitting, updateField, handleUpdate } = useProfileEdit();
   const { upload, uploading } = useProfileImageUpload();
+  const { history } = useScoreHistory();
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const practiceDates = useMemo(() => {
+    return history.map((h) => h.createdAt.split('T')[0]);
+  }, [history]);
 
   // 学習統計
   const [stats, setStats] = useState<ProfileStats | null>(null);
@@ -126,7 +133,10 @@ export default function ProfilePage() {
         </form>
       </div>
 
-      {/* セクション2: 学習統計 */}
+      {/* セクション2: 年間活動ヒートマップ */}
+      <ActivityHeatmap practiceDates={practiceDates} />
+
+      {/* セクション3: 学習統計 */}
       <ProfileStatsSection stats={stats} loading={statsLoading} />
     </div>
   );


### PR DESCRIPTION
## 概要
プロフィールページにGitHub風の年間活動ヒートマップを追加し、学習継続性を可視化した。

## 変更内容
- `ActivityHeatmap` コンポーネントを新規作成
- 直近365日間の練習日を表示（練習回数に応じた色の濃淡）
- 月ラベル表示
- プロフィールページの学習統計セクション上部に配置

## テスト
- ActivityHeatmap テスト 6件（全パス）
- ProfilePage 既存テスト 12件（全パス）

Closes #1390