### PR TITLE
refactor: ProfilePageからuseProfileStatsフックを抽出

### DIFF
--- a/frontend/src/hooks/__tests__/useProfileStats.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileStats.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useProfileStats } from '../useProfileStats';
+
+vi.mock('../../repositories/ProfileStatsRepository', () => ({
+  default: {
+    fetchStats: vi.fn(),
+  },
+}));
+
+import ProfileStatsRepository from '../../repositories/ProfileStatsRepository';
+
+const mockFetchStats = ProfileStatsRepository.fetchStats as ReturnType<typeof vi.fn>;
+
+describe('useProfileStats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('初期状態はloading=trueでstats=null', () => {
+    mockFetchStats.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { result } = renderHook(() => useProfileStats());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.stats).toBeNull();
+  });
+
+  it('統計データを正常に取得する', async () => {
+    const mockStats = {
+      totalSessions: 10,
+      averageScore: 7.5,
+      currentStreak: 3,
+      longestStreak: 5,
+      totalAchievedDays: 15,
+      followerCount: 2,
+      followingCount: 4,
+    };
+    mockFetchStats.mockResolvedValue(mockStats);
+
+    const { result } = renderHook(() => useProfileStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toEqual(mockStats);
+  });
+
+  it('取得エラー時はstats=nullでloading=false', async () => {
+    mockFetchStats.mockRejectedValue(new Error('API error'));
+
+    const { result } = renderHook(() => useProfileStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useProfileStats.ts
+++ b/frontend/src/hooks/useProfileStats.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect, useCallback } from 'react';
+import ProfileStatsRepository, { type ProfileStats } from '../repositories/ProfileStatsRepository';
+
+export function useProfileStats() {
+  const [stats, setStats] = useState<ProfileStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadStats = useCallback(async () => {
+    try {
+      const data = await ProfileStatsRepository.fetchStats();
+      setStats(data);
+    } catch {
+      // 統計取得エラーは無視
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  return { stats, loading };
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback, useMemo } from 'react';
+import { useRef, useMemo } from 'react';
 import InputField from '../components/InputField';
 import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
@@ -9,38 +9,20 @@ import ProfileStatsSection from '../components/profile/ProfileStatsSection';
 import ActivityHeatmap from '../components/ActivityHeatmap';
 import { useProfileEdit } from '../hooks/useProfileEdit';
 import { useProfileImageUpload } from '../hooks/useProfileImageUpload';
+import { useProfileStats } from '../hooks/useProfileStats';
 import { useScoreHistory } from '../hooks/useScoreHistory';
-import ProfileStatsRepository, { type ProfileStats } from '../repositories/ProfileStatsRepository';
 import { CameraIcon } from '@heroicons/react/24/outline';
 
 export default function ProfilePage() {
   const { form, message, setMessage, loading, submitting, updateField, handleUpdate } = useProfileEdit();
   const { upload, uploading } = useProfileImageUpload();
+  const { stats, loading: statsLoading } = useProfileStats();
   const { history } = useScoreHistory();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const practiceDates = useMemo(() => {
     return history.map((h) => h.createdAt.split('T')[0]);
   }, [history]);
-
-  // 学習統計
-  const [stats, setStats] = useState<ProfileStats | null>(null);
-  const [statsLoading, setStatsLoading] = useState(true);
-
-  const loadStats = useCallback(async () => {
-    try {
-      const data = await ProfileStatsRepository.fetchStats();
-      setStats(data);
-    } catch {
-      // 統計取得エラーは無視
-    } finally {
-      setStatsLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    loadStats();
-  }, [loadStats]);
 
   const handleImageSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## 概要
- ProfilePage内で直接`ProfileStatsRepository`を呼び出していた統計取得ロジックをカスタムフック`useProfileStats`に分離
- Pages → Hooks → Repositories のレイヤー構造に準拠させるリファクタリング

## 変更内容
- `useProfileStats.ts` フックを新規作成（統計取得・ローディング状態管理）
- `ProfilePage.tsx` からRepository直接呼び出しを削除し、フック経由に変更
- `useProfileStats.test.ts` テスト3件追加（初期状態・成功・エラー）

## テスト結果
- `useProfileStats.test.ts`: 3/3 パス
- `ProfilePage.test.tsx`: 12/12 パス（既存テスト全てパス）

Closes #1392