### PR TITLE
refactor: useScoreGoalからScoreGoalRepositoryを分離

### DIFF
--- a/frontend/src/hooks/useScoreGoal.ts
+++ b/frontend/src/hooks/useScoreGoal.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import apiClient from '../lib/axios';
+import { ScoreGoalRepository } from '../repositories/ScoreGoalRepository';
 
 const STORAGE_KEY = 'scoreGoal';
 const DEFAULT_GOAL = 8.0;
@@ -27,15 +27,12 @@ export function useScoreGoal() {
 
   useEffect(() => {
     let cancelled = false;
-    apiClient.get<{ goalScore: number }>('/api/score-goal')
-      .then((response) => {
-        if (!cancelled && response.data?.goalScore != null) {
-          setGoal(response.data.goalScore);
-          setLocalGoal(response.data.goalScore);
+    ScoreGoalRepository.fetchGoal()
+      .then((goalScore) => {
+        if (!cancelled && goalScore != null) {
+          setGoal(goalScore);
+          setLocalGoal(goalScore);
         }
-      })
-      .catch(() => {
-        // API失敗時はlocalStorageの値を維持
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -46,11 +43,7 @@ export function useScoreGoal() {
   const saveGoal = useCallback(async (newGoal: number) => {
     setGoal(newGoal);
     setLocalGoal(newGoal);
-    try {
-      await apiClient.put('/api/score-goal', { goalScore: newGoal });
-    } catch {
-      // API失敗時もlocalStorageには保存済み
-    }
+    await ScoreGoalRepository.saveGoal(newGoal);
   }, []);
 
   return { goal, saveGoal, loading };

--- a/frontend/src/repositories/ScoreGoalRepository.ts
+++ b/frontend/src/repositories/ScoreGoalRepository.ts
@@ -1,0 +1,20 @@
+import apiClient from '../lib/axios';
+
+export const ScoreGoalRepository = {
+  async fetchGoal(): Promise<number | null> {
+    try {
+      const response = await apiClient.get<{ goalScore: number }>('/api/score-goal');
+      return response.data?.goalScore ?? null;
+    } catch {
+      return null;
+    }
+  },
+
+  async saveGoal(goalScore: number): Promise<void> {
+    try {
+      await apiClient.put('/api/score-goal', { goalScore });
+    } catch {
+      // API失敗時は呼び出し元でlocalStorage保存済み
+    }
+  },
+};

--- a/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPut = vi.mocked(apiClient.put);
+
+describe('ScoreGoalRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetchGoal: API成功時にgoalScoreを返す', async () => {
+    mockedGet.mockResolvedValue({ data: { goalScore: 9.0 } });
+    const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
+    const result = await ScoreGoalRepository.fetchGoal();
+    expect(result).toBe(9.0);
+    expect(mockedGet).toHaveBeenCalledWith('/api/score-goal');
+  });
+
+  it('fetchGoal: API失敗時にnullを返す', async () => {
+    mockedGet.mockRejectedValue(new Error('Network error'));
+    const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
+    const result = await ScoreGoalRepository.fetchGoal();
+    expect(result).toBeNull();
+  });
+
+  it('saveGoal: APIにPUTリクエストを送る', async () => {
+    mockedPut.mockResolvedValue({ data: {} });
+    const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
+    await ScoreGoalRepository.saveGoal(7.5);
+    expect(mockedPut).toHaveBeenCalledWith('/api/score-goal', { goalScore: 7.5 });
+  });
+
+  it('saveGoal: API失敗時にエラーをスローしない', async () => {
+    mockedPut.mockRejectedValue(new Error('Network error'));
+    const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
+    await expect(ScoreGoalRepository.saveGoal(7.5)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要
- `useScoreGoal` フック内で直接 `apiClient` を呼び出していたAPI通信ロジックを `ScoreGoalRepository` に分離
- Hooks → Repositories のレイヤー構造に準拠

## 変更内容
- `ScoreGoalRepository.ts` を新規作成（fetchGoal / saveGoal）
- `useScoreGoal.ts` をRepository経由のAPI呼び出しに変更
- `ScoreGoalRepository.test.ts` テスト4件追加

## テスト結果
- `ScoreGoalRepository.test.ts`: 4/4 パス
- `useScoreGoal.test.ts`: 5/5 パス（既存テスト全てパス）

Closes #1394