### PR TITLE
refactor: ページ内インラインコンポーネントを分離ファイルに抽出

### DIFF
--- a/frontend/src/components/FriendCard.tsx
+++ b/frontend/src/components/FriendCard.tsx
@@ -1,0 +1,52 @@
+import { UserMinusIcon } from '@heroicons/react/24/outline';
+import type { FriendshipUser } from '../types';
+
+interface FriendCardProps {
+  user: FriendshipUser;
+  onUnfollow: (id: number) => void;
+  showUnfollow: boolean;
+}
+
+export default function FriendCard({ user, onUnfollow, showUnfollow }: FriendCardProps) {
+  return (
+    <div className="flex items-center gap-3 bg-surface-1 rounded-lg border border-surface-3 p-3">
+      <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 overflow-hidden">
+        {user.iconUrl ? (
+          <img src={user.iconUrl} alt={user.username} className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-sm font-bold text-[var(--color-text-muted)]">
+            {user.username.charAt(0)}
+          </span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+            {user.username}
+          </span>
+          {user.mutual && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-400 font-medium">
+              相互
+            </span>
+          )}
+        </div>
+        {user.status && (
+          <p className="text-xs text-emerald-400 truncate mt-0.5">{user.status}</p>
+        )}
+        {user.bio && (
+          <p className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">{user.bio}</p>
+        )}
+      </div>
+      {showUnfollow && (
+        <button
+          onClick={() => onUnfollow(user.userId)}
+          className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:bg-red-900/30 hover:text-red-400 transition-colors"
+          title="フォロー解除"
+          aria-label="フォロー解除"
+        >
+          <UserMinusIcon className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/NotificationItem.tsx
+++ b/frontend/src/components/NotificationItem.tsx
@@ -1,0 +1,54 @@
+import { CheckIcon } from '@heroicons/react/24/outline';
+import type { Notification } from '../types';
+
+const TYPE_LABELS: Record<string, string> = {
+  NEW_MESSAGE: 'メッセージ',
+  GOAL_ACHIEVED: '目標達成',
+  SCORE_IMPROVED: 'スコア向上',
+  PRACTICE_REMINDER: '練習リマインダー',
+  SYSTEM: 'システム',
+};
+
+interface NotificationItemProps {
+  notification: Notification;
+  onMarkAsRead: (id: number) => void;
+}
+
+export default function NotificationItem({ notification, onMarkAsRead }: NotificationItemProps) {
+  return (
+    <div
+      className={`p-4 rounded-lg border transition-colors ${
+        notification.isRead
+          ? 'bg-surface-1 border-surface-3'
+          : 'bg-surface-2 border-primary-200'
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-[10px] font-medium text-primary-400 bg-surface-2 px-2 py-0.5 rounded">
+              {TYPE_LABELS[notification.type] ?? notification.type}
+            </span>
+            {!notification.isRead && (
+              <span className="w-2 h-2 rounded-full bg-primary-500 flex-shrink-0" />
+            )}
+          </div>
+          <p className="text-sm font-medium text-[var(--color-text-primary)] mb-0.5">{notification.title}</p>
+          <p className="text-xs text-[var(--color-text-muted)]">{notification.message}</p>
+          <p className="text-[10px] text-[var(--color-text-faint)] mt-1">
+            {new Date(notification.createdAt).toLocaleString('ja-JP')}
+          </p>
+        </div>
+        {!notification.isRead && (
+          <button
+            onClick={() => onMarkAsRead(notification.id)}
+            aria-label="既読にする"
+            className="ml-2 p-1 text-[var(--color-text-faint)] hover:text-primary-500 transition-colors"
+          >
+            <CheckIcon className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ReportCard.tsx
+++ b/frontend/src/components/ReportCard.tsx
@@ -1,0 +1,57 @@
+import { ArrowTrendingUpIcon, ArrowTrendingDownIcon } from '@heroicons/react/24/outline';
+import type { LearningReport } from '../types';
+
+interface ReportCardProps {
+  report: LearningReport;
+}
+
+export default function ReportCard({ report }: ReportCardProps) {
+  const scoreChangeColor = (report.scoreChange ?? 0) >= 0 ? 'text-emerald-500' : 'text-rose-500';
+  const ScoreChangeIcon = (report.scoreChange ?? 0) >= 0 ? ArrowTrendingUpIcon : ArrowTrendingDownIcon;
+
+  return (
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
+          {report.year}年{report.month}月
+        </h3>
+        {report.scoreChange != null && (
+          <div className={`flex items-center gap-1 text-xs font-medium ${scoreChangeColor}`}>
+            <ScoreChangeIcon className="w-3.5 h-3.5" />
+            {report.scoreChange > 0 ? '+' : ''}{report.scoreChange.toFixed(1)}
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mb-3">
+        <div className="text-center">
+          <p className="text-lg font-bold text-primary-500">{report.totalSessions}</p>
+          <p className="text-[10px] text-[var(--color-text-faint)]">セッション数</p>
+        </div>
+        <div className="text-center">
+          <p className="text-lg font-bold text-[var(--color-text-primary)]">{report.averageScore.toFixed(1)}</p>
+          <p className="text-[10px] text-[var(--color-text-faint)]">平均スコア</p>
+        </div>
+        <div className="text-center">
+          <p className="text-lg font-bold text-[var(--color-text-secondary)]">{report.practiceDays}</p>
+          <p className="text-[10px] text-[var(--color-text-faint)]">練習日数</p>
+        </div>
+      </div>
+
+      {(report.bestAxis || report.worstAxis) && (
+        <div className="flex gap-2">
+          {report.bestAxis && (
+            <span className="text-[10px] font-medium text-emerald-400 bg-emerald-900/20 px-2 py-0.5 rounded">
+              強み: {report.bestAxis}
+            </span>
+          )}
+          {report.worstAxis && (
+            <span className="text-[10px] font-medium text-amber-400 bg-amber-900/20 px-2 py-0.5 rounded">
+              課題: {report.worstAxis}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/FriendCard.test.tsx
+++ b/frontend/src/components/__tests__/FriendCard.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FriendCard from '../FriendCard';
+import type { FriendshipUser } from '../../types';
+
+const baseUser: FriendshipUser = {
+  id: 1,
+  userId: 10,
+  username: 'テストユーザー',
+  iconUrl: null,
+  bio: '自己紹介文です',
+  mutual: false,
+  createdAt: '2024-01-01',
+  status: 'オンライン',
+};
+
+describe('FriendCard', () => {
+  it('ユーザー名が表示される', () => {
+    render(<FriendCard user={baseUser} onUnfollow={() => {}} showUnfollow={false} />);
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument();
+  });
+
+  it('相互フォロー時にバッジが表示される', () => {
+    render(<FriendCard user={{ ...baseUser, mutual: true }} onUnfollow={() => {}} showUnfollow={false} />);
+    expect(screen.getByText('相互')).toBeInTheDocument();
+  });
+
+  it('ステータスが表示される', () => {
+    render(<FriendCard user={baseUser} onUnfollow={() => {}} showUnfollow={false} />);
+    expect(screen.getByText('オンライン')).toBeInTheDocument();
+  });
+
+  it('showUnfollow=trueでフォロー解除ボタンが表示される', () => {
+    const onUnfollow = vi.fn();
+    render(<FriendCard user={baseUser} onUnfollow={onUnfollow} showUnfollow={true} />);
+    const btn = screen.getByRole('button', { name: 'フォロー解除' });
+    fireEvent.click(btn);
+    expect(onUnfollow).toHaveBeenCalledWith(10);
+  });
+
+  it('showUnfollow=falseでフォロー解除ボタンが非表示', () => {
+    render(<FriendCard user={baseUser} onUnfollow={() => {}} showUnfollow={false} />);
+    expect(screen.queryByRole('button', { name: 'フォロー解除' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/NotificationItem.test.tsx
+++ b/frontend/src/components/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NotificationItem from '../NotificationItem';
+import type { Notification } from '../../types';
+
+const baseNotification: Notification = {
+  id: 1,
+  type: 'GOAL_ACHIEVED',
+  title: '目標達成おめでとう',
+  message: '今月の学習目標を達成しました',
+  isRead: false,
+  createdAt: '2024-06-15T10:00:00Z',
+};
+
+describe('NotificationItem', () => {
+  it('タイトルとメッセージが表示される', () => {
+    render(<NotificationItem notification={baseNotification} onMarkAsRead={() => {}} />);
+    expect(screen.getByText('目標達成おめでとう')).toBeInTheDocument();
+    expect(screen.getByText('今月の学習目標を達成しました')).toBeInTheDocument();
+  });
+
+  it('タイプラベルが表示される', () => {
+    render(<NotificationItem notification={baseNotification} onMarkAsRead={() => {}} />);
+    expect(screen.getByText('目標達成')).toBeInTheDocument();
+  });
+
+  it('未読時に既読ボタンが表示される', () => {
+    const onMarkAsRead = vi.fn();
+    render(<NotificationItem notification={baseNotification} onMarkAsRead={onMarkAsRead} />);
+    const btn = screen.getByRole('button', { name: '既読にする' });
+    fireEvent.click(btn);
+    expect(onMarkAsRead).toHaveBeenCalledWith(1);
+  });
+
+  it('既読時に既読ボタンが非表示', () => {
+    render(<NotificationItem notification={{ ...baseNotification, isRead: true }} onMarkAsRead={() => {}} />);
+    expect(screen.queryByRole('button', { name: '既読にする' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/ReportCard.test.tsx
+++ b/frontend/src/components/__tests__/ReportCard.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ReportCard from '../ReportCard';
+import type { LearningReport } from '../../types';
+
+const baseReport: LearningReport = {
+  id: 1,
+  year: 2024,
+  month: 6,
+  totalSessions: 15,
+  averageScore: 7.8,
+  practiceDays: 10,
+  scoreChange: 0.5,
+  bestAxis: '傾聴力',
+  worstAxis: '説得力',
+};
+
+describe('ReportCard', () => {
+  it('年月が表示される', () => {
+    render(<ReportCard report={baseReport} />);
+    expect(screen.getByText('2024年6月')).toBeInTheDocument();
+  });
+
+  it('統計データが表示される', () => {
+    render(<ReportCard report={baseReport} />);
+    expect(screen.getByText('15')).toBeInTheDocument();
+    expect(screen.getByText('7.8')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+  });
+
+  it('スコア変動が表示される', () => {
+    render(<ReportCard report={baseReport} />);
+    expect(screen.getByText('+0.5')).toBeInTheDocument();
+  });
+
+  it('強みと課題が表示される', () => {
+    render(<ReportCard report={baseReport} />);
+    expect(screen.getByText('強み: 傾聴力')).toBeInTheDocument();
+    expect(screen.getByText('課題: 説得力')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/FriendshipPage.tsx
+++ b/frontend/src/pages/FriendshipPage.tsx
@@ -2,52 +2,8 @@ import { useState } from 'react';
 import { useFriendship } from '../hooks/useFriendship';
 import EmptyState from '../components/EmptyState';
 import Loading from '../components/Loading';
-import { UsersIcon, UserMinusIcon } from '@heroicons/react/24/outline';
-import type { FriendshipUser } from '../types';
-
-function FriendCard({ user, onUnfollow, showUnfollow }: { user: FriendshipUser; onUnfollow: (id: number) => void; showUnfollow: boolean }) {
-  return (
-    <div className="flex items-center gap-3 bg-surface-1 rounded-lg border border-surface-3 p-3">
-      <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 overflow-hidden">
-        {user.iconUrl ? (
-          <img src={user.iconUrl} alt={user.username} className="w-full h-full object-cover" />
-        ) : (
-          <span className="text-sm font-bold text-[var(--color-text-muted)]">
-            {user.username.charAt(0)}
-          </span>
-        )}
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-            {user.username}
-          </span>
-          {user.mutual && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/20 text-emerald-400 font-medium">
-              相互
-            </span>
-          )}
-        </div>
-        {user.status && (
-          <p className="text-xs text-emerald-400 truncate mt-0.5">{user.status}</p>
-        )}
-        {user.bio && (
-          <p className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">{user.bio}</p>
-        )}
-      </div>
-      {showUnfollow && (
-        <button
-          onClick={() => onUnfollow(user.userId)}
-          className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:bg-red-900/30 hover:text-red-400 transition-colors"
-          title="フォロー解除"
-          aria-label="フォロー解除"
-        >
-          <UserMinusIcon className="w-4 h-4" />
-        </button>
-      )}
-    </div>
-  );
-}
+import FriendCard from '../components/FriendCard';
+import { UsersIcon } from '@heroicons/react/24/outline';
 
 export default function FriendshipPage() {
   const { following, followers, loading, unfollowUser } = useFriendship();

--- a/frontend/src/pages/LearningReportPage.tsx
+++ b/frontend/src/pages/LearningReportPage.tsx
@@ -1,59 +1,8 @@
 import { useLearningReport } from '../hooks/useLearningReport';
 import EmptyState from '../components/EmptyState';
 import Loading from '../components/Loading';
-import { DocumentChartBarIcon, ArrowTrendingUpIcon, ArrowTrendingDownIcon } from '@heroicons/react/24/outline';
-import type { LearningReport } from '../types';
-
-function ReportCard({ report }: { report: LearningReport }) {
-  const scoreChangeColor = (report.scoreChange ?? 0) >= 0 ? 'text-emerald-500' : 'text-rose-500';
-  const ScoreChangeIcon = (report.scoreChange ?? 0) >= 0 ? ArrowTrendingUpIcon : ArrowTrendingDownIcon;
-
-  return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
-          {report.year}年{report.month}月
-        </h3>
-        {report.scoreChange != null && (
-          <div className={`flex items-center gap-1 text-xs font-medium ${scoreChangeColor}`}>
-            <ScoreChangeIcon className="w-3.5 h-3.5" />
-            {report.scoreChange > 0 ? '+' : ''}{report.scoreChange.toFixed(1)}
-          </div>
-        )}
-      </div>
-
-      <div className="grid grid-cols-3 gap-3 mb-3">
-        <div className="text-center">
-          <p className="text-lg font-bold text-primary-500">{report.totalSessions}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)]">セッション数</p>
-        </div>
-        <div className="text-center">
-          <p className="text-lg font-bold text-[var(--color-text-primary)]">{report.averageScore.toFixed(1)}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)]">平均スコア</p>
-        </div>
-        <div className="text-center">
-          <p className="text-lg font-bold text-[var(--color-text-secondary)]">{report.practiceDays}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)]">練習日数</p>
-        </div>
-      </div>
-
-      {(report.bestAxis || report.worstAxis) && (
-        <div className="flex gap-2">
-          {report.bestAxis && (
-            <span className="text-[10px] font-medium text-emerald-400 bg-emerald-900/20 px-2 py-0.5 rounded">
-              強み: {report.bestAxis}
-            </span>
-          )}
-          {report.worstAxis && (
-            <span className="text-[10px] font-medium text-amber-400 bg-amber-900/20 px-2 py-0.5 rounded">
-              課題: {report.worstAxis}
-            </span>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
+import ReportCard from '../components/ReportCard';
+import { DocumentChartBarIcon } from '@heroicons/react/24/outline';
 
 export default function LearningReportPage() {
   const { reports, loading, generating, generateReport } = useLearningReport();

--- a/frontend/src/pages/NotificationPage.tsx
+++ b/frontend/src/pages/NotificationPage.tsx
@@ -1,55 +1,8 @@
 import { useNotification } from '../hooks/useNotification';
 import EmptyState from '../components/EmptyState';
 import Loading from '../components/Loading';
-import { BellIcon, CheckIcon } from '@heroicons/react/24/outline';
-import type { Notification } from '../types';
-
-const TYPE_LABELS: Record<string, string> = {
-  NEW_MESSAGE: 'メッセージ',
-  GOAL_ACHIEVED: '目標達成',
-  SCORE_IMPROVED: 'スコア向上',
-  PRACTICE_REMINDER: '練習リマインダー',
-  SYSTEM: 'システム',
-};
-
-function NotificationItem({ notification, onMarkAsRead }: { notification: Notification; onMarkAsRead: (id: number) => void }) {
-  return (
-    <div
-      className={`p-4 rounded-lg border transition-colors ${
-        notification.isRead
-          ? 'bg-surface-1 border-surface-3'
-          : 'bg-surface-2 border-primary-200'
-      }`}
-    >
-      <div className="flex items-start justify-between">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <span className="text-[10px] font-medium text-primary-400 bg-surface-2 px-2 py-0.5 rounded">
-              {TYPE_LABELS[notification.type] ?? notification.type}
-            </span>
-            {!notification.isRead && (
-              <span className="w-2 h-2 rounded-full bg-primary-500 flex-shrink-0" />
-            )}
-          </div>
-          <p className="text-sm font-medium text-[var(--color-text-primary)] mb-0.5">{notification.title}</p>
-          <p className="text-xs text-[var(--color-text-muted)]">{notification.message}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)] mt-1">
-            {new Date(notification.createdAt).toLocaleString('ja-JP')}
-          </p>
-        </div>
-        {!notification.isRead && (
-          <button
-            onClick={() => onMarkAsRead(notification.id)}
-            aria-label="既読にする"
-            className="ml-2 p-1 text-[var(--color-text-faint)] hover:text-primary-500 transition-colors"
-          >
-            <CheckIcon className="w-4 h-4" />
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}
+import NotificationItem from '../components/NotificationItem';
+import { BellIcon } from '@heroicons/react/24/outline';
 
 export default function NotificationPage() {
   const { notifications, unreadCount, loading, markAsRead, markAllAsRead } = useNotification();


### PR DESCRIPTION
## 概要
ページファイル内に直接定義されていたコンポーネントを `src/components/` に分離し、再利用性・テスト容易性を向上

## 変更内容
- `FriendCard.tsx` を `FriendshipPage.tsx` から分離（テスト5件追加）
- `NotificationItem.tsx` を `NotificationPage.tsx` から分離（テスト4件追加）
- `ReportCard.tsx` を `LearningReportPage.tsx` から分離（テスト4件追加）
- 各ページファイルを分離コンポーネントのインポートに変更

## テスト結果
- `FriendCard.test.tsx`: 5/5 パス
- `NotificationItem.test.tsx`: 4/4 パス
- `ReportCard.test.tsx`: 4/4 パス
- `LearningReportPage.test.tsx`: 3/3 パス（既存テスト全てパス）

Closes #1396