### PR TITLE
test: NotificationRepository・NotificationPageのテスト追加

### DIFF
--- a/frontend/src/pages/__tests__/NotificationPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotificationPage.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NotificationPage from '../NotificationPage';
+
+const mockMarkAsRead = vi.fn();
+const mockMarkAllAsRead = vi.fn();
+
+vi.mock('../../hooks/useNotification', () => ({
+  useNotification: vi.fn(),
+}));
+
+import { useNotification } from '../../hooks/useNotification';
+const mockedUseNotification = vi.mocked(useNotification);
+
+describe('NotificationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ローディング中はスピナーが表示される', () => {
+    mockedUseNotification.mockReturnValue({
+      notifications: [],
+      unreadCount: 0,
+      loading: true,
+      markAsRead: mockMarkAsRead,
+      markAllAsRead: mockMarkAllAsRead,
+      refresh: vi.fn(),
+    });
+
+    render(<NotificationPage />);
+    expect(screen.getByText('通知を読み込み中...')).toBeInTheDocument();
+  });
+
+  it('通知がない場合はEmptyStateが表示される', () => {
+    mockedUseNotification.mockReturnValue({
+      notifications: [],
+      unreadCount: 0,
+      loading: false,
+      markAsRead: mockMarkAsRead,
+      markAllAsRead: mockMarkAllAsRead,
+      refresh: vi.fn(),
+    });
+
+    render(<NotificationPage />);
+    expect(screen.getByText('通知はありません')).toBeInTheDocument();
+  });
+
+  it('通知一覧が表示される', () => {
+    mockedUseNotification.mockReturnValue({
+      notifications: [
+        { id: 1, type: 'GOAL_ACHIEVED', title: '月間目標を達成しました', message: 'おめでとう', isRead: false, createdAt: '2024-06-15T10:00:00Z' },
+        { id: 2, type: 'SYSTEM', title: 'システム通知', message: 'メンテナンス', isRead: true, createdAt: '2024-06-14T10:00:00Z' },
+      ],
+      unreadCount: 1,
+      loading: false,
+      markAsRead: mockMarkAsRead,
+      markAllAsRead: mockMarkAllAsRead,
+      refresh: vi.fn(),
+    });
+
+    render(<NotificationPage />);
+    expect(screen.getByText('月間目標を達成しました')).toBeInTheDocument();
+    expect(screen.getByText('システム通知')).toBeInTheDocument();
+    expect(screen.getByText('1件の未読')).toBeInTheDocument();
+  });
+
+  it('未読がある場合「すべて既読にする」ボタンが表示される', () => {
+    mockedUseNotification.mockReturnValue({
+      notifications: [
+        { id: 1, type: 'GOAL_ACHIEVED', title: '目標達成', message: 'テスト', isRead: false, createdAt: '2024-06-15T10:00:00Z' },
+      ],
+      unreadCount: 1,
+      loading: false,
+      markAsRead: mockMarkAsRead,
+      markAllAsRead: mockMarkAllAsRead,
+      refresh: vi.fn(),
+    });
+
+    render(<NotificationPage />);
+    const btn = screen.getByText('すべて既読にする');
+    fireEvent.click(btn);
+    expect(mockMarkAllAsRead).toHaveBeenCalled();
+  });
+
+  it('未読が0件の場合「すべて既読にする」ボタンが非表示', () => {
+    mockedUseNotification.mockReturnValue({
+      notifications: [
+        { id: 1, type: 'SYSTEM', title: '通知', message: 'テスト', isRead: true, createdAt: '2024-06-15T10:00:00Z' },
+      ],
+      unreadCount: 0,
+      loading: false,
+      markAsRead: mockMarkAsRead,
+      markAllAsRead: mockMarkAllAsRead,
+      refresh: vi.fn(),
+    });
+
+    render(<NotificationPage />);
+    expect(screen.queryByText('すべて既読にする')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/__tests__/NotificationRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NotificationRepository.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+import { NotificationRepository } from '../NotificationRepository';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPut = vi.mocked(apiClient.put);
+
+describe('NotificationRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getAll: 通知一覧を取得する', async () => {
+    const notifications = [
+      { id: 1, type: 'GOAL_ACHIEVED', title: 'テスト', message: '本文', isRead: false, createdAt: '2024-01-01' },
+    ];
+    mockedGet.mockResolvedValue({ data: notifications });
+
+    const result = await NotificationRepository.getAll();
+    expect(result).toEqual(notifications);
+    expect(mockedGet).toHaveBeenCalledWith('/api/notifications');
+  });
+
+  it('markAsRead: 指定IDの通知を既読にする', async () => {
+    mockedPut.mockResolvedValue({});
+
+    await NotificationRepository.markAsRead(5);
+    expect(mockedPut).toHaveBeenCalledWith('/api/notifications/5/read');
+  });
+
+  it('markAllAsRead: 全通知を既読にする', async () => {
+    mockedPut.mockResolvedValue({});
+
+    await NotificationRepository.markAllAsRead();
+    expect(mockedPut).toHaveBeenCalledWith('/api/notifications/read-all');
+  });
+
+  it('getUnreadCount: 未読数を取得する', async () => {
+    mockedGet.mockResolvedValue({ data: 3 });
+
+    const result = await NotificationRepository.getUnreadCount();
+    expect(result).toBe(3);
+    expect(mockedGet).toHaveBeenCalledWith('/api/notifications/unread-count');
+  });
+});


### PR DESCRIPTION
## 概要
通知機能のRepository/Pageにテストが存在しなかったため追加

## 変更内容
- `NotificationRepository.test.ts` 追加（4件: getAll/markAsRead/markAllAsRead/getUnreadCount）
- `NotificationPage.test.tsx` 追加（5件: ローディング/空状態/一覧表示/全既読ボタン/非表示）

## テスト結果
- `NotificationRepository.test.ts`: 4/4 パス
- `NotificationPage.test.tsx`: 5/5 パス

Closes #1398