### PR TITLE
test: FriendshipRepository・FriendshipPageのテスト追加

### DIFF
--- a/frontend/src/pages/__tests__/FriendshipPage.test.tsx
+++ b/frontend/src/pages/__tests__/FriendshipPage.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FriendshipPage from '../FriendshipPage';
+
+const mockUnfollow = vi.fn();
+
+vi.mock('../../hooks/useFriendship', () => ({
+  useFriendship: vi.fn(),
+}));
+
+import { useFriendship } from '../../hooks/useFriendship';
+const mockedUseFriendship = vi.mocked(useFriendship);
+
+const baseUser = {
+  id: 1,
+  userId: 10,
+  username: 'テストユーザー',
+  iconUrl: null,
+  bio: '自己紹介',
+  mutual: false,
+  createdAt: '2024-01-01',
+  status: 'オンライン',
+};
+
+describe('FriendshipPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ローディング中はスピナーが表示される', () => {
+    mockedUseFriendship.mockReturnValue({
+      following: [],
+      followers: [],
+      loading: true,
+      followUser: vi.fn(),
+      unfollowUser: mockUnfollow,
+      refetch: vi.fn(),
+    });
+
+    render(<FriendshipPage />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('フォロー中タブでユーザー一覧が表示される', () => {
+    mockedUseFriendship.mockReturnValue({
+      following: [baseUser],
+      followers: [],
+      loading: false,
+      followUser: vi.fn(),
+      unfollowUser: mockUnfollow,
+      refetch: vi.fn(),
+    });
+
+    render(<FriendshipPage />);
+    expect(screen.getByText('テストユーザー')).toBeInTheDocument();
+    expect(screen.getByText('フォロー中 (1)')).toBeInTheDocument();
+  });
+
+  it('フォロワータブに切り替えできる', () => {
+    mockedUseFriendship.mockReturnValue({
+      following: [],
+      followers: [{ ...baseUser, id: 2, userId: 20, username: 'フォロワー' }],
+      loading: false,
+      followUser: vi.fn(),
+      unfollowUser: mockUnfollow,
+      refetch: vi.fn(),
+    });
+
+    render(<FriendshipPage />);
+    fireEvent.click(screen.getByText('フォロワー (1)'));
+    expect(screen.getByText('フォロワー')).toBeInTheDocument();
+  });
+
+  it('フォロー中が0件の場合はEmptyStateが表示される', () => {
+    mockedUseFriendship.mockReturnValue({
+      following: [],
+      followers: [],
+      loading: false,
+      followUser: vi.fn(),
+      unfollowUser: mockUnfollow,
+      refetch: vi.fn(),
+    });
+
+    render(<FriendshipPage />);
+    expect(screen.getByText('まだ誰もフォローしていません')).toBeInTheDocument();
+  });
+
+  it('フォロワーが0件の場合はEmptyStateが表示される', () => {
+    mockedUseFriendship.mockReturnValue({
+      following: [],
+      followers: [],
+      loading: false,
+      followUser: vi.fn(),
+      unfollowUser: mockUnfollow,
+      refetch: vi.fn(),
+    });
+
+    render(<FriendshipPage />);
+    fireEvent.click(screen.getByText('フォロワー (0)'));
+    expect(screen.getByText('まだフォロワーがいません')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/__tests__/FriendshipRepository.test.ts
+++ b/frontend/src/repositories/__tests__/FriendshipRepository.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+import { FriendshipRepository } from '../FriendshipRepository';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPost = vi.mocked(apiClient.post);
+const mockedDelete = vi.mocked(apiClient.delete);
+
+describe('FriendshipRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getFollowing: フォロー中一覧を取得する', async () => {
+    const users = [{ id: 1, userId: 10, username: 'user1', iconUrl: null, bio: null, mutual: false, createdAt: '2024-01-01', status: null }];
+    mockedGet.mockResolvedValue({ data: users });
+
+    const result = await FriendshipRepository.getFollowing();
+    expect(result).toEqual(users);
+    expect(mockedGet).toHaveBeenCalledWith('/api/friendships/following');
+  });
+
+  it('getFollowers: フォロワー一覧を取得する', async () => {
+    const users = [{ id: 2, userId: 20, username: 'user2', iconUrl: null, bio: null, mutual: true, createdAt: '2024-01-01', status: null }];
+    mockedGet.mockResolvedValue({ data: users });
+
+    const result = await FriendshipRepository.getFollowers();
+    expect(result).toEqual(users);
+    expect(mockedGet).toHaveBeenCalledWith('/api/friendships/followers');
+  });
+
+  it('follow: フォローリクエストを送る', async () => {
+    const user = { id: 3, userId: 30, username: 'user3', iconUrl: null, bio: null, mutual: false, createdAt: '2024-01-01', status: null };
+    mockedPost.mockResolvedValue({ data: user });
+
+    const result = await FriendshipRepository.follow(30);
+    expect(result).toEqual(user);
+    expect(mockedPost).toHaveBeenCalledWith('/api/friendships/30/follow');
+  });
+
+  it('unfollow: フォロー解除する', async () => {
+    mockedDelete.mockResolvedValue({});
+
+    await FriendshipRepository.unfollow(30);
+    expect(mockedDelete).toHaveBeenCalledWith('/api/friendships/30/follow');
+  });
+
+  it('checkStatus: フォロー状態を確認する', async () => {
+    const status = { isFollowing: true, isFollowedBy: false, isMutual: false };
+    mockedGet.mockResolvedValue({ data: status });
+
+    const result = await FriendshipRepository.checkStatus(30);
+    expect(result).toEqual(status);
+    expect(mockedGet).toHaveBeenCalledWith('/api/friendships/30/status');
+  });
+});


### PR DESCRIPTION
## 概要
フレンド機能のRepository/Pageにテストが存在しなかったため追加

## 変更内容
- `FriendshipRepository.test.ts` 追加（5件: getFollowing/getFollowers/follow/unfollow/checkStatus）
- `FriendshipPage.test.tsx` 追加（5件: ローディング/一覧表示/タブ切替/EmptyState×2）

## テスト結果
- `FriendshipRepository.test.ts`: 5/5 パス
- `FriendshipPage.test.tsx`: 5/5 パス

Closes #1400