### PR TITLE
fix: WebSocket送信者ID偽装脆弱性を修正

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/config/WebSocketAuthHandshakeInterceptor.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/WebSocketAuthHandshakeInterceptor.java
@@ -1,0 +1,53 @@
+package com.example.FreStyle.config;
+
+import java.util.Map;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketAuthHandshakeInterceptor implements HandshakeInterceptor {
+
+    public static final String AUTHENTICATED_USER_ID = "authenticatedUserId";
+
+    private final UserIdentityService userIdentityService;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                    WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        try {
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+                String sub = jwt.getSubject();
+                User user = userIdentityService.findUserBySub(sub);
+                attributes.put(AUTHENTICATED_USER_ID, user.getId());
+                log.debug("WebSocket認証成功 - userId: {}", user.getId());
+            } else {
+                log.warn("WebSocketハンドシェイク: 認証情報なし");
+            }
+        } catch (Exception e) {
+            log.warn("WebSocketハンドシェイク認証エラー: {}", e.getMessage());
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                               WebSocketHandler wsHandler, Exception exception) {
+        // no-op
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/config/WebSocketConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/WebSocketConfig.java
@@ -6,9 +6,14 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthHandshakeInterceptor authHandshakeInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -20,11 +25,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         // ユーザーチャット用エンドポイント
         registry.addEndpoint("/ws/chat")
+                .addInterceptors(authHandshakeInterceptor)
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
-        
+
         // AIチャット用エンドポイント
         registry.addEndpoint("/ws/ai-chat")
+                .addInterceptors(authHandshakeInterceptor)
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
     }

--- a/FreStyle/src/test/java/com/example/FreStyle/config/WebSocketAuthHandshakeInterceptorTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/config/WebSocketAuthHandshakeInterceptorTest.java
@@ -1,0 +1,103 @@
+package com.example.FreStyle.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.socket.WebSocketHandler;
+
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WebSocketAuthHandshakeInterceptor")
+class WebSocketAuthHandshakeInterceptorTest {
+
+    @Mock private UserIdentityService userIdentityService;
+    @Mock private ServerHttpRequest request;
+    @Mock private ServerHttpResponse response;
+    @Mock private WebSocketHandler wsHandler;
+
+    @InjectMocks
+    private WebSocketAuthHandshakeInterceptor interceptor;
+
+    @Test
+    @DisplayName("認証済みユーザーのIDがセッション属性に設定される")
+    void authenticatedUser_setsUserIdInAttributes() throws Exception {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("cognito-sub-123");
+
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(jwt);
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(securityContext);
+
+        User user = new User();
+        user.setId(42);
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(user);
+
+        Map<String, Object> attributes = new HashMap<>();
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        assertTrue(result);
+        assertEquals(42, attributes.get(WebSocketAuthHandshakeInterceptor.AUTHENTICATED_USER_ID));
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("認証情報がない場合はユーザーIDが設定されない")
+    void noAuthentication_doesNotSetUserId() throws Exception {
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(null);
+        SecurityContextHolder.setContext(securityContext);
+
+        Map<String, Object> attributes = new HashMap<>();
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        assertTrue(result);
+        assertNull(attributes.get(WebSocketAuthHandshakeInterceptor.AUTHENTICATED_USER_ID));
+
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("UserIdentityServiceが例外をスローしても接続を許可する")
+    void exceptionDuringLookup_stillAllowsConnection() throws Exception {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("unknown-sub");
+
+        Authentication auth = mock(Authentication.class);
+        when(auth.getPrincipal()).thenReturn(jwt);
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(auth);
+        SecurityContextHolder.setContext(securityContext);
+
+        when(userIdentityService.findUserBySub("unknown-sub")).thenThrow(new RuntimeException("ユーザー不明"));
+
+        Map<String, Object> attributes = new HashMap<>();
+        boolean result = interceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        assertTrue(result);
+        assertNull(attributes.get(WebSocketAuthHandshakeInterceptor.AUTHENTICATED_USER_ID));
+
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatWebSocketControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatWebSocketControllerTest.java
@@ -1,12 +1,17 @@
 package com.example.FreStyle.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,8 +19,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import com.example.FreStyle.config.WebSocketAuthHandshakeInterceptor;
 import com.example.FreStyle.dto.AiChatMessageResponseDto;
 import com.example.FreStyle.service.BedrockService;
 import com.example.FreStyle.usecase.AddAiChatMessageUseCase;
@@ -39,6 +46,22 @@ class AiChatWebSocketControllerTest {
     @InjectMocks
     private AiChatWebSocketController controller;
 
+    private SimpMessageHeaderAccessor headerAccessor;
+
+    @BeforeEach
+    void setUp() {
+        headerAccessor = SimpMessageHeaderAccessor.create();
+        Map<String, Object> sessionAttributes = new HashMap<>();
+        sessionAttributes.put(WebSocketAuthHandshakeInterceptor.AUTHENTICATED_USER_ID, 5);
+        headerAccessor.setSessionAttributes(sessionAttributes);
+    }
+
+    private SimpMessageHeaderAccessor createUnauthenticatedHeader() {
+        SimpMessageHeaderAccessor header = SimpMessageHeaderAccessor.create();
+        header.setSessionAttributes(new HashMap<>());
+        return header;
+    }
+
     @Nested
     @DisplayName("receiveAiResponse")
     class ReceiveAiResponse {
@@ -51,14 +74,26 @@ class AiChatWebSocketControllerTest {
 
             Map<String, Object> payload = Map.of(
                 "sessionId", 10,
-                "userId", 5,
                 "content", "AI応答"
             );
 
-            controller.receiveAiResponse(payload);
+            controller.receiveAiResponse(payload, headerAccessor);
 
             verify(addAiChatMessageUseCase).executeAssistantMessage(10, 5, "AI応答");
             verify(messagingTemplate).convertAndSend("/topic/ai-chat/session/10", saved);
+        }
+
+        @Test
+        @DisplayName("未認証ユーザーの場合はAI応答を保存しない")
+        void unauthenticated_doesNotSave() {
+            Map<String, Object> payload = Map.of(
+                "sessionId", 10,
+                "content", "AI応答"
+            );
+
+            controller.receiveAiResponse(payload, createUnauthenticatedHeader());
+
+            verify(addAiChatMessageUseCase, never()).executeAssistantMessage(anyInt(), anyInt(), anyString());
         }
     }
 
@@ -72,12 +107,11 @@ class AiChatWebSocketControllerTest {
             when(bedrockService.rephrase("元のメッセージ", "meeting")).thenReturn("言い換え結果");
 
             Map<String, Object> payload = Map.of(
-                "userId", 5,
                 "originalMessage", "元のメッセージ",
                 "scene", "meeting"
             );
 
-            controller.rephraseMessage(payload);
+            controller.rephraseMessage(payload, headerAccessor);
 
             verify(bedrockService).rephrase("元のメッセージ", "meeting");
             verify(messagingTemplate).convertAndSend(
@@ -92,13 +126,24 @@ class AiChatWebSocketControllerTest {
             when(bedrockService.rephrase("テスト", null)).thenReturn("結果");
 
             Map<String, Object> payload = Map.of(
-                "userId", 5,
                 "originalMessage", "テスト"
             );
 
-            controller.rephraseMessage(payload);
+            controller.rephraseMessage(payload, headerAccessor);
 
             verify(bedrockService).rephrase("テスト", null);
+        }
+
+        @Test
+        @DisplayName("未認証ユーザーの場合は言い換えしない")
+        void unauthenticated_doesNotRephrase() {
+            Map<String, Object> payload = Map.of(
+                "originalMessage", "テスト"
+            );
+
+            controller.rephraseMessage(payload, createUnauthenticatedHeader());
+
+            verify(bedrockService, never()).rephrase(anyString(), anyString());
         }
     }
 
@@ -110,17 +155,28 @@ class AiChatWebSocketControllerTest {
         @DisplayName("セッションを削除して通知する")
         void deletesAndNotifies() {
             Map<String, Object> payload = Map.of(
-                "sessionId", 10,
-                "userId", 5
+                "sessionId", 10
             );
 
-            controller.deleteSession(payload);
+            controller.deleteSession(payload, headerAccessor);
 
             verify(deleteAiChatSessionUseCase).execute(10, 5);
             verify(messagingTemplate).convertAndSend(
                 eq("/topic/ai-chat/user/5/session-deleted"),
                 any(Map.class)
             );
+        }
+
+        @Test
+        @DisplayName("未認証ユーザーの場合はセッション削除しない")
+        void unauthenticated_doesNotDelete() {
+            Map<String, Object> payload = Map.of(
+                "sessionId", 10
+            );
+
+            controller.deleteSession(payload, createUnauthenticatedHeader());
+
+            verify(deleteAiChatSessionUseCase, never()).execute(anyInt(), anyInt());
         }
     }
 


### PR DESCRIPTION
## 概要
WebSocketメッセージの送信者IDをクライアントのpayloadから取得していたため、他ユーザーになりすましてメッセージを送信できる脆弱性を修正。

## 変更内容
- `WebSocketAuthHandshakeInterceptor` を新規作成: ハンドシェイク時にJWT認証済みユーザーIDをセッション属性に格納
- `WebSocketConfig`: 両エンドポイントにインターセプターを登録
- `ChatWebSocketController`: payloadの`senderId`ではなくセッション属性から認証済みユーザーIDを取得
- `AiChatWebSocketController`: 全4エンドポイントで同様にセッション属性からユーザーIDを取得

## テスト
- `WebSocketAuthHandshakeInterceptorTest`: 認証成功/未認証/例外の3ケース
- `ChatWebSocketControllerTest`: 既存テスト更新 + 未認証テスト追加（6テスト）
- `AiChatWebSocketControllerTest`: 既存テスト更新 + 未認証テスト3件追加（9テスト）

Closes #1404