### PR TITLE
fix: エラーメッセージ情報漏洩とProfileFormバリデーション不足を修正

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -67,7 +67,7 @@ public class CognitoAuthController {
             return ResponseEntity.badRequest().body(Map.of("error", "パスワードポリシーに違反しています。"));
         } catch (RuntimeException e) {
             log.error("/signup エラー: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            return ResponseEntity.internalServerError().body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 
@@ -91,7 +91,7 @@ public class CognitoAuthController {
                     .body(Map.of("error", "ユーザーが存在しません。"));
         } catch (RuntimeException e) {
             log.error("/confirm エラー: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            return ResponseEntity.internalServerError().body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 
@@ -117,7 +117,7 @@ public class CognitoAuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "無効なアクセスです。"));
         } catch (RuntimeException e) {
             log.error("/login エラー: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            return ResponseEntity.internalServerError().body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 
@@ -136,11 +136,11 @@ public class CognitoAuthController {
 
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", e.getMessage()));
+                    .body(Map.of("error", "認証に失敗しました。"));
         } catch (Exception e) {
             log.error("/callback エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError()
-                    .body(Map.of("error", "server error: " + e.getMessage()));
+                    .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 
@@ -177,7 +177,7 @@ public class CognitoAuthController {
                     .body(Map.of("error", "ユーザーが存在しません。"));
         } catch (RuntimeException e) {
             log.error("/forgot-password エラー: {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().body(Map.of("error", e.getMessage()));
+            return ResponseEntity.internalServerError().body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 
@@ -205,7 +205,7 @@ public class CognitoAuthController {
         } catch (RuntimeException e) {
             log.error("/refresh-token エラー: {}", e.getMessage(), e);
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", e.getMessage()));
+                    .body(Map.of("error", "トークンの更新に失敗しました。"));
         }
     }
 
@@ -233,7 +233,7 @@ public class CognitoAuthController {
         } catch (RuntimeException e) {
             log.error("/confirm-forgot-password エラー: {}", e.getMessage(), e);
             return ResponseEntity.internalServerError()
-                    .body(Map.of("error", e.getMessage()));
+                    .body(Map.of("error", "サーバーエラーが発生しました。"));
         }
     }
 

--- a/FreStyle/src/main/java/com/example/FreStyle/form/ProfileForm.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/form/ProfileForm.java
@@ -13,7 +13,9 @@ import lombok.NoArgsConstructor;
 public class ProfileForm {
   @NotBlank(message = "ユーザー名を入力してください")
   private String name;
+  @Size(max = 500, message = "自己紹介は500文字以内で入力してください")
   private String bio;
+  @Size(max = 2048, message = "アイコンURLが長すぎます")
   private String iconUrl;
   @Size(max = 100, message = "ステータスは100文字以内で入力してください")
   private String status;

--- a/FreStyle/src/test/java/com/example/FreStyle/form/ProfileFormTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/form/ProfileFormTest.java
@@ -75,4 +75,28 @@ class ProfileFormTest {
         Set<ConstraintViolation<ProfileForm>> violations = validator.validate(form);
         assertThat(violations).anyMatch(v -> v.getMessage().equals("ステータスは100文字以内で入力してください"));
     }
+
+    @Test
+    void bioが500文字以内なら通過() {
+        String bio = "あ".repeat(500);
+        ProfileForm form = new ProfileForm("テストユーザー", bio, null, null);
+        Set<ConstraintViolation<ProfileForm>> violations = validator.validate(form);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void bioが500文字を超えるとエラー() {
+        String longBio = "あ".repeat(501);
+        ProfileForm form = new ProfileForm("テストユーザー", longBio, null, null);
+        Set<ConstraintViolation<ProfileForm>> violations = validator.validate(form);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("自己紹介は500文字以内で入力してください"));
+    }
+
+    @Test
+    void iconUrlが2048文字を超えるとエラー() {
+        String longUrl = "https://example.com/" + "a".repeat(2030);
+        ProfileForm form = new ProfileForm("テストユーザー", "bio", longUrl, null);
+        Set<ConstraintViolation<ProfileForm>> violations = validator.validate(form);
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("アイコンURLが長すぎます"));
+    }
 }


### PR DESCRIPTION
## 概要
CognitoAuthControllerでRuntimeExceptionの`e.getMessage()`がHTTPレスポンスに含まれ、内部エラー情報（AWS SDKエラー、DB接続情報等）が漏洩する脆弱性を修正。
ProfileFormの`bio`と`iconUrl`フィールドにサイズ制約を追加。

## 変更内容
### エラーメッセージ情報漏洩修正
- `/signup`, `/confirm`, `/login`, `/callback`, `/forgot-password`, `/confirm-forgot-password`, `/refresh-token` の全7エンドポイント
- RuntimeException/Exception catchブロックの`e.getMessage()`を汎用メッセージに置換
- ログには引き続き詳細エラーを記録

### ProfileFormバリデーション追加
- `bio`: `@Size(max=500)` を追加
- `iconUrl`: `@Size(max=2048)` を追加

## テスト
- CognitoAuthControllerTest: signup/loginのRuntimeExceptionテストでレスポンスボディに内部情報が含まれないことを検証
- ProfileFormTest: bio 500文字超過、iconUrl 2048文字超過の3テスト追加

Closes #1406