### PR TITLE
fix: コントローラーの@Valid不足とRequestレコードのバリデーション追加

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -53,7 +53,7 @@ public class CognitoAuthController {
     // サインアップ
     // -----------------------
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody SignupForm form) {
+    public ResponseEntity<?> signup(@Validated @RequestBody SignupForm form) {
         log.info("POST /api/auth/cognito/signup - email: {}", form.getEmail());
         try {
             cognitoSignupUseCase.execute(form);
@@ -75,7 +75,7 @@ public class CognitoAuthController {
     // サインアップ確認
     // -----------------------
     @PostMapping("/confirm")
-    public ResponseEntity<?> confirm(@RequestBody ConfirmSignupForm form) {
+    public ResponseEntity<?> confirm(@Validated @RequestBody ConfirmSignupForm form) {
         log.info("POST /api/auth/cognito/confirm - email: {}", form.getEmail());
         try {
             cognitoConfirmUseCase.execute(form.getEmail(), form.getCode());
@@ -99,7 +99,7 @@ public class CognitoAuthController {
     // ログイン
     // -----------------------
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginForm form, HttpServletResponse response) {
+    public ResponseEntity<?> login(@Validated @RequestBody LoginForm form, HttpServletResponse response) {
         log.info("POST /api/auth/cognito/login - email: {}", form.getEmail());
         try {
             CognitoLoginUseCase.Result result = cognitoLoginUseCase.execute(form.getEmail(), form.getPassword());

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/NoteController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/NoteController.java
@@ -7,6 +7,10 @@ import com.example.FreStyle.usecase.CreateNoteUseCase;
 import com.example.FreStyle.usecase.DeleteNoteUseCase;
 import com.example.FreStyle.usecase.GetNotesByUserIdUseCase;
 import com.example.FreStyle.usecase.UpdateNoteUseCase;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +44,7 @@ public class NoteController {
     @PostMapping
     public ResponseEntity<NoteDto> createNote(
             @AuthenticationPrincipal Jwt jwt,
-            @RequestBody CreateNoteRequest request
+            @Valid @RequestBody CreateNoteRequest request
     ) {
         User user = resolveUser(jwt);
 
@@ -54,7 +58,7 @@ public class NoteController {
     public ResponseEntity<Void> updateNote(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable String noteId,
-            @RequestBody UpdateNoteRequest request
+            @Valid @RequestBody UpdateNoteRequest request
     ) {
         User user = resolveUser(jwt);
 
@@ -81,6 +85,12 @@ public class NoteController {
         return userIdentityService.findUserBySub(jwt.getSubject());
     }
 
-    public record CreateNoteRequest(String title) {}
-    public record UpdateNoteRequest(String title, String content, Boolean isPinned) {}
+    public record CreateNoteRequest(
+            @NotBlank(message = "タイトルを入力してください") @Size(max = 200, message = "タイトルは200文字以内で入力してください") String title
+    ) {}
+    public record UpdateNoteRequest(
+            @Size(max = 200, message = "タイトルは200文字以内で入力してください") String title,
+            @Size(max = 50000, message = "コンテンツが長すぎます") String content,
+            Boolean isPinned
+    ) {}
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ProfileController.java
@@ -43,7 +43,7 @@ public class ProfileController {
     @PutMapping("/me/update")
     public ResponseEntity<Map<String, String>> updateProfile(
             @AuthenticationPrincipal Jwt jwt,
-            @RequestBody ProfileForm form) {
+            @Valid @RequestBody ProfileForm form) {
         updateProfileUseCase.execute(jwt, form);
         return ResponseEntity.ok(Map.of("message", "プロフィールを更新しました。"));
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreGoalController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ScoreGoalController.java
@@ -1,5 +1,10 @@
 package com.example.FreStyle.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -40,7 +45,7 @@ public class ScoreGoalController {
     }
 
     @PutMapping
-    public ResponseEntity<Void> saveGoal(@AuthenticationPrincipal Jwt jwt, @RequestBody SaveGoalRequest request) {
+    public ResponseEntity<Void> saveGoal(@AuthenticationPrincipal Jwt jwt, @Valid @RequestBody SaveGoalRequest request) {
         User user = resolveUser(jwt);
         log.info("スコア目標設定: userId={}, goalScore={}", user.getId(), request.goalScore());
         saveScoreGoalUseCase.execute(user, request.goalScore());
@@ -51,5 +56,10 @@ public class ScoreGoalController {
         return userIdentityService.findUserBySub(jwt.getSubject());
     }
 
-    public record SaveGoalRequest(Double goalScore) {}
+    public record SaveGoalRequest(
+            @NotNull(message = "目標スコアを入力してください")
+            @Min(value = 0, message = "目標スコアは0以上で入力してください")
+            @Max(value = 100, message = "目標スコアは100以下で入力してください")
+            Double goalScore
+    ) {}
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/SessionNoteController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/SessionNoteController.java
@@ -1,5 +1,8 @@
 package com.example.FreStyle.controller;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -43,7 +46,7 @@ public class SessionNoteController {
     public ResponseEntity<Void> saveNote(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer sessionId,
-            @RequestBody SaveNoteRequest request) {
+            @Valid @RequestBody SaveNoteRequest request) {
         User user = resolveUser(jwt);
         log.info("セッションノート保存: userId={}, sessionId={}", user.getId(), sessionId);
         saveSessionNoteUseCase.execute(user, sessionId, request.note());
@@ -54,5 +57,7 @@ public class SessionNoteController {
         return userIdentityService.findUserBySub(jwt.getSubject());
     }
 
-    public record SaveNoteRequest(String note) {}
+    public record SaveNoteRequest(
+            @Size(max = 10000, message = "ノートは10000文字以内で入力してください") String note
+    ) {}
 }


### PR DESCRIPTION
## 概要
複数のコントローラーで@RequestBodyに@Valid/@Validatedが付いておらず、Formクラスのバリデーションが実行されていなかった問題を修正。
Requestレコードクラスにもバリデーションアノテーションを追加。

## 変更内容

### GlobalExceptionHandler
- `MethodArgumentNotValidException` ハンドラーを追加（フィールドエラーを整形して400レスポンス）

### @Valid/@Validated追加
- `ProfileController.updateProfile`: `@Valid` 追加
- `CognitoAuthController.signup`: `@Validated` 追加
- `CognitoAuthController.confirm`: `@Validated` 追加
- `CognitoAuthController.login`: `@Validated` 追加

### Requestレコードのバリデーション追加
- `NoteController.CreateNoteRequest`: title に `@NotBlank` `@Size(max=200)`
- `NoteController.UpdateNoteRequest`: title に `@Size(max=200)`, content に `@Size(max=50000)`
- `ScoreGoalController.SaveGoalRequest`: goalScore に `@NotNull` `@Min(0)` `@Max(100)`
- `SessionNoteController.SaveNoteRequest`: note に `@Size(max=10000)`

## テスト
- GlobalExceptionHandlerTest: バリデーションエラー時の400レスポンス検証テスト追加
- 全775テスト通過（contextLoads除く）

Closes #1408