### PR TITLE
fix: カスタムフックのエラーハンドリング強化

### DIFF
--- a/frontend/src/hooks/__tests__/useFriendship.test.ts
+++ b/frontend/src/hooks/__tests__/useFriendship.test.ts
@@ -87,7 +87,7 @@ describe('useFriendship', () => {
     expect(mockUnfollow).toHaveBeenCalledWith(2);
   });
 
-  it('API失敗時はエラーなく空リストを返す', async () => {
+  it('API失敗時はerrorが設定され空リストを返す', async () => {
     mockGetFollowing.mockRejectedValue(new Error('API Error'));
     mockGetFollowers.mockRejectedValue(new Error('API Error'));
 
@@ -99,5 +99,38 @@ describe('useFriendship', () => {
 
     expect(result.current.following).toEqual([]);
     expect(result.current.followers).toEqual([]);
+    expect(result.current.error).toBe('フレンド情報の取得に失敗しました');
+  });
+
+  it('フォロー失敗時にerrorが設定される', async () => {
+    mockFollow.mockRejectedValue(new Error('Follow failed'));
+
+    const { result } = renderHook(() => useFriendship());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.followUser(5);
+    });
+
+    expect(result.current.error).toBe('フォローに失敗しました');
+  });
+
+  it('フォロー解除失敗時にerrorが設定される', async () => {
+    mockUnfollow.mockRejectedValue(new Error('Unfollow failed'));
+
+    const { result } = renderHook(() => useFriendship());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.unfollowUser(2);
+    });
+
+    expect(result.current.error).toBe('フォロー解除に失敗しました');
   });
 });

--- a/frontend/src/hooks/useFriendship.ts
+++ b/frontend/src/hooks/useFriendship.ts
@@ -6,8 +6,10 @@ export function useFriendship() {
   const [following, setFollowing] = useState<FriendshipUser[]>([]);
   const [followers, setFollowers] = useState<FriendshipUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
+    setError(null);
     try {
       const [followingData, followersData] = await Promise.all([
         FriendshipRepository.getFollowing(),
@@ -18,6 +20,7 @@ export function useFriendship() {
     } catch {
       setFollowing([]);
       setFollowers([]);
+      setError('フレンド情報の取得に失敗しました');
     } finally {
       setLoading(false);
     }
@@ -32,7 +35,7 @@ export function useFriendship() {
       await FriendshipRepository.follow(userId);
       await fetchData();
     } catch {
-      // エラーハンドリング
+      setError('フォローに失敗しました');
     }
   }, [fetchData]);
 
@@ -41,9 +44,9 @@ export function useFriendship() {
       await FriendshipRepository.unfollow(userId);
       await fetchData();
     } catch {
-      // エラーハンドリング
+      setError('フォロー解除に失敗しました');
     }
   }, [fetchData]);
 
-  return { following, followers, loading, followUser, unfollowUser, refetch: fetchData };
+  return { following, followers, loading, error, followUser, unfollowUser, refetch: fetchData };
 }

--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -7,6 +7,7 @@ export function useNotes() {
   const [notes, setNotes] = useState<Note[]>([]);
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [noteSort, setNoteSort] = useState<NoteSortOption>('default');
@@ -15,11 +16,12 @@ export function useNotes() {
 
   const fetchNotes = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
       const data = await NoteRepository.fetchNotes();
       setNotes(Array.isArray(data) ? data : []);
     } catch {
-      // エラーハンドリング
+      setError('ノートの取得に失敗しました');
     } finally {
       setLoading(false);
     }
@@ -43,7 +45,7 @@ export function useNotes() {
         prev.map((n) => (n.noteId === noteId ? { ...n, ...data, updatedAt: Date.now() } : n))
       );
     } catch {
-      // エラーハンドリング
+      setError('ノートの更新に失敗しました');
     }
   }, []);
 
@@ -53,7 +55,7 @@ export function useNotes() {
       setNotes((prev) => prev.filter((n) => n.noteId !== noteId));
       setSelectedNoteId((prev) => (prev === noteId ? null : prev));
     } catch {
-      // エラーハンドリング
+      setError('ノートの削除に失敗しました');
     }
   }, []);
 
@@ -71,7 +73,7 @@ export function useNotes() {
         prev.map((n) => (n.noteId === noteId ? { ...n, isPinned: newPinned } : n))
       );
     } catch {
-      // エラーハンドリング
+      setError('ピン留めの変更に失敗しました');
     }
   }, []);
 
@@ -129,6 +131,7 @@ export function useNotes() {
     selectedNoteId,
     selectedNote,
     loading,
+    error,
     searchQuery,
     setSearchQuery,
     fetchNotes,


### PR DESCRIPTION
## 概要
- useNotes, useFriendship, useImageUploadの各フックで空catchブロックやconsole.errorをerrorステートに置き換え
- UIからエラー状態を参照できるようにした

## 変更内容
- `useNotes`: fetchNotes, updateNote, deleteNote, togglePinのエラーをerrorステートに設定
- `useFriendship`: fetchData, followUser, unfollowUserのエラーをerrorステートに設定
- `useImageUpload`: console.errorをuploadErrorステートに置き換え

## テスト
- useNotes: エラーハンドリングテスト4件追加（全44件パス）
- useFriendship: エラーハンドリングテスト3件追加/修正（全7件パス）
- useImageUpload: エラーステートテスト2件追加/修正（全5件パス）

closes #1410