### PR TITLE
fix: コンポーネントのアクセシビリティ改善

### DIFF
--- a/frontend/src/components/DifficultyFilter.tsx
+++ b/frontend/src/components/DifficultyFilter.tsx
@@ -7,13 +7,14 @@ interface DifficultyFilterProps {
 
 export default function DifficultyFilter({ selected, onChange }: DifficultyFilterProps) {
   return (
-    <div className="flex gap-1.5">
+    <div className="flex gap-1.5" role="group" aria-label="難易度フィルター">
       {DIFFICULTY_OPTIONS.map(({ value, label, style }) => {
         const isActive = selected === value;
         return (
           <button
             key={label}
             onClick={() => onChange(value)}
+            aria-pressed={isActive}
             className={`text-[10px] font-medium px-2.5 py-1 rounded-full transition-colors ${
               isActive
                 ? style

--- a/frontend/src/components/EmojiPicker.tsx
+++ b/frontend/src/components/EmojiPicker.tsx
@@ -55,6 +55,7 @@ export default function EmojiPicker({ isOpen, onSelect, onClose }: EmojiPickerPr
           ref={inputRef}
           type="text"
           placeholder="絵文字を検索..."
+          aria-label="絵文字を検索"
           value={search}
           onChange={e => setSearch(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/frontend/src/components/ExportSessionButton.tsx
+++ b/frontend/src/components/ExportSessionButton.tsx
@@ -34,6 +34,7 @@ export default function ExportSessionButton({ messages }: ExportSessionButtonPro
       onClick={handleCopy}
       disabled={messages.length === 0}
       title={copied ? 'コピーしました' : '会話をコピー'}
+      aria-label={copied ? 'コピーしました' : '会話をコピー'}
       className="p-1.5 rounded-lg hover:bg-surface-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
     >
       {copied ? (

--- a/frontend/src/components/RephraseModal.tsx
+++ b/frontend/src/components/RephraseModal.tsx
@@ -55,8 +55,8 @@ export default function RephraseModal({ result, onClose, originalText = '' }: Re
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 animate-fade-in">
-      <div className="bg-surface-1 rounded-lg shadow-lg max-w-lg w-full mx-4 p-5 animate-scale-in">
-        <h3 className="text-sm font-semibold text-[var(--color-text-primary)] mb-4">言い換え提案</h3>
+      <div role="dialog" aria-modal="true" aria-labelledby="rephrase-modal-title" className="bg-surface-1 rounded-lg shadow-lg max-w-lg w-full mx-4 p-5 animate-scale-in">
+        <h3 id="rephrase-modal-title" className="text-sm font-semibold text-[var(--color-text-primary)] mb-4">言い換え提案</h3>
 
         {result === null ? (
           <div className="flex items-center justify-center py-8">

--- a/frontend/src/components/SortSelector.tsx
+++ b/frontend/src/components/SortSelector.tsx
@@ -11,13 +11,14 @@ export type { SortOption };
 
 export default function SortSelector<T extends string = SortOption>({ options = SORT_OPTIONS as { value: T; label: string }[], selected, onChange }: SortSelectorProps<T>) {
   return (
-    <div className="flex gap-1.5">
+    <div className="flex gap-1.5" role="group" aria-label="並び替え">
       {options.map(({ value, label }) => {
         const isActive = selected === value;
         return (
           <button
             key={value}
             onClick={() => onChange(value)}
+            aria-pressed={isActive}
             className={`text-[10px] font-medium px-2.5 py-1 rounded-full transition-colors ${
               isActive
                 ? 'text-[var(--color-text-secondary)] bg-surface-2'

--- a/frontend/src/components/__tests__/DifficultyFilter.test.tsx
+++ b/frontend/src/components/__tests__/DifficultyFilter.test.tsx
@@ -62,4 +62,19 @@ describe('DifficultyFilter', () => {
     expect(buttons).toHaveLength(4);
     expect(buttons.map((b) => b.textContent)).toEqual(['全レベル', '初級', '中級', '上級']);
   });
+
+  it('選択中のボタンにaria-pressed=trueが設定される', () => {
+    render(<DifficultyFilter selected="初級" onChange={mockOnChange} />);
+
+    expect(screen.getByText('初級')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('中級')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText('上級')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('フィルターグループにrole=groupとaria-labelが設定される', () => {
+    render(<DifficultyFilter selected={null} onChange={mockOnChange} />);
+
+    const group = screen.getByRole('group', { name: '難易度フィルター' });
+    expect(group).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/EmojiPicker.test.tsx
+++ b/frontend/src/components/__tests__/EmojiPicker.test.tsx
@@ -89,4 +89,18 @@ describe('EmojiPicker', () => {
     fireEvent.keyDown(screen.getByPlaceholderText('絵文字を検索...'), { key: 'Enter' });
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it('検索入力にaria-labelが設定される', () => {
+    render(<EmojiPicker isOpen={true} onSelect={onSelect} onClose={onClose} />);
+    expect(screen.getByLabelText('絵文字を検索')).toBeInTheDocument();
+  });
+
+  it('絵文字ボタンにaria-labelが設定される', () => {
+    render(<EmojiPicker isOpen={true} onSelect={onSelect} onClose={onClose} />);
+    const emojiButtons = screen.getAllByRole('button').filter(btn => {
+      const label = btn.getAttribute('aria-label');
+      return label !== null && label !== 'よく使う' && label !== '顔' && label !== '手・体' && label !== '動物・自然' && label !== '食べ物' && label !== 'オブジェクト' && label !== '記号';
+    });
+    expect(emojiButtons.length).toBeGreaterThan(0);
+  });
 });

--- a/frontend/src/components/__tests__/ExportSessionButton.test.tsx
+++ b/frontend/src/components/__tests__/ExportSessionButton.test.tsx
@@ -112,4 +112,9 @@ describe('ExportSessionButton', () => {
     });
     expect(screen.getByTitle('会話をコピー')).toBeInTheDocument();
   });
+
+  it('ボタンにaria-labelが設定される', () => {
+    render(<ExportSessionButton messages={mockMessages} />);
+    expect(screen.getByRole('button', { name: '会話をコピー' })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/__tests__/RephraseModal.test.tsx
+++ b/frontend/src/components/__tests__/RephraseModal.test.tsx
@@ -113,4 +113,11 @@ describe('RephraseModal', () => {
     // コピー成功フィードバック
     expect(await screen.findByText('コピーしました')).toBeInTheDocument();
   });
+
+  it('モーダルにrole=dialogとaria-modal属性が設定される', () => {
+    render(<RephraseModal result={rephraseResult} onClose={mockOnClose} originalText="元のテキスト" />);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+  });
 });

--- a/frontend/src/components/__tests__/SortSelector.test.tsx
+++ b/frontend/src/components/__tests__/SortSelector.test.tsx
@@ -66,4 +66,18 @@ describe('SortSelector', () => {
     expect(screen.getByText('難易度↓').className).toContain('text-[var(--color-text-secondary)]');
     expect(screen.getByText('デフォルト').className).toContain('text-[var(--color-text-muted)]');
   });
+
+  it('選択中のボタンにaria-pressed=trueが設定される', () => {
+    render(<SortSelector selected="name" onChange={mockOnChange} />);
+
+    expect(screen.getByText('名前順')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('デフォルト')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('ソートグループにrole=groupとaria-labelが設定される', () => {
+    render(<SortSelector selected="default" onChange={mockOnChange} />);
+
+    const group = screen.getByRole('group', { name: '並び替え' });
+    expect(group).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ChatListPage.tsx
+++ b/frontend/src/pages/ChatListPage.tsx
@@ -44,6 +44,7 @@ export default function ChatListPage() {
             <button
               key={user.roomId}
               onClick={() => { navigate(`/chat/users/${user.roomId}`); closeMobilePanel(); }}
+              aria-label={`${user.name || 'Unknown User'}とのチャット`}
               className="w-full px-4 py-3 flex items-center gap-3 hover:bg-surface-2 transition-colors border-b border-surface-3 text-left"
             >
               <Avatar name={user.name} src={user.profileImage} />

--- a/frontend/src/pages/__tests__/ChatListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ChatListPage.test.tsx
@@ -148,4 +148,11 @@ describe('ChatListPage', () => {
 
     expect(screen.getAllByText('0件').length).toBeGreaterThanOrEqual(1);
   });
+
+  it('チャットアイテムにaria-labelが設定される', () => {
+    render(<BrowserRouter><ChatListPage /></BrowserRouter>);
+
+    expect(screen.getAllByRole('button', { name: /田中太郎/ }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole('button', { name: /佐藤花子/ }).length).toBeGreaterThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
## 概要
- 6コンポーネントのaria属性・セマンティクスを強化し、スクリーンリーダー対応を改善
- 対応するアクセシビリティテストも追加

## 変更内容
- DifficultyFilter / SortSelector: `role="group"`, `aria-label`, `aria-pressed`追加
- EmojiPicker: 検索入力に`aria-label`追加
- ExportSessionButton: `aria-label`追加
- RephraseModal: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`追加
- ChatListPage: チャットアイテムに`aria-label`追加

## テスト
- DifficultyFilter: 2件追加（全9件パス）
- SortSelector: 2件追加（全9件パス）
- EmojiPicker: 2件追加（全13件パス）
- ExportSessionButton: 1件追加（全11件パス）
- RephraseModal: 1件追加（全12件パス）
- ChatListPage: 1件追加（全11件パス）

closes #1412