### PR TITLE
fix: カスタムフックのタイマークリーンアップとエラーハンドリング改善

### DIFF
--- a/frontend/src/hooks/__tests__/useChatRoomCreation.test.ts
+++ b/frontend/src/hooks/__tests__/useChatRoomCreation.test.ts
@@ -65,4 +65,28 @@ describe('useChatRoomCreation', () => {
     expect(mockedRepo.createRoom).toHaveBeenCalledWith(1);
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it('ルーム作成失敗時にerrorが設定される', async () => {
+    mockedRepo.createRoom.mockRejectedValue(new Error('失敗'));
+
+    const { result } = renderHook(() => useChatRoomCreation());
+
+    await act(async () => {
+      await result.current.openChat(1, undefined);
+    });
+
+    expect(result.current.error).toBe('チャットルームの作成に失敗しました');
+  });
+
+  it('ルーム作成成功時にerrorがnullのまま', async () => {
+    mockedRepo.createRoom.mockResolvedValue({ roomId: 200 });
+
+    const { result } = renderHook(() => useChatRoomCreation());
+
+    await act(async () => {
+      await result.current.openChat(1, undefined);
+    });
+
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/frontend/src/hooks/__tests__/useCopyToClipboard.test.ts
+++ b/frontend/src/hooks/__tests__/useCopyToClipboard.test.ts
@@ -144,4 +144,21 @@ describe('useCopyToClipboard', () => {
 
     expect(result.current.copiedId).toBeNull();
   });
+
+  it('アンマウント時にタイマーがクリアされる', async () => {
+    const { result, unmount } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copyToClipboard(1, 'テスト');
+    });
+
+    expect(result.current.copiedId).toBe(1);
+
+    unmount();
+
+    // アンマウント後にタイマーが発火してもエラーにならない
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+  });
 });

--- a/frontend/src/hooks/__tests__/useSignupPage.test.ts
+++ b/frontend/src/hooks/__tests__/useSignupPage.test.ts
@@ -265,4 +265,30 @@ describe('useSignupPage', () => {
     expect(result.current.message?.text).toBe('有効なメールアドレスを入力してください。');
     expect(mockSignup).not.toHaveBeenCalled();
   });
+
+  it('アンマウント時にナビゲーションタイマーがクリアされる', async () => {
+    mockSignup.mockResolvedValue(true);
+    const { result, unmount } = renderHook(() => useSignupPage());
+
+    act(() => {
+      result.current.handleChange({ target: { name: 'name', value: 'テスト' } } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({ target: { name: 'email', value: 'test@example.com' } } as React.ChangeEvent<HTMLInputElement>);
+      result.current.handleChange({ target: { name: 'password', value: 'pass123' } } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    await act(async () => {
+      await result.current.handleSignup({
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>);
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    // アンマウント後はナビゲートされない
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/useChatRoomCreation.ts
+++ b/frontend/src/hooks/useChatRoomCreation.ts
@@ -1,9 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ChatRepository from '../repositories/ChatRepository';
 
 export function useChatRoomCreation() {
   const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
 
   const openChat = useCallback(async (userId: number, roomId?: number) => {
     if (roomId) {
@@ -17,9 +18,9 @@ export function useChatRoomCreation() {
         navigate(`/chat/users/${data.roomId}`);
       }
     } catch {
-      // エラーはaxiosインターセプターが処理
+      setError('チャットルームの作成に失敗しました');
     }
   }, [navigate]);
 
-  return { openChat };
+  return { openChat, error };
 }

--- a/frontend/src/hooks/useCopyToClipboard.ts
+++ b/frontend/src/hooks/useCopyToClipboard.ts
@@ -1,8 +1,14 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 
 export function useCopyToClipboard() {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
 
   const copyToClipboard = useCallback(async (id: string, text: string) => {
     try {

--- a/frontend/src/hooks/useSignupPage.ts
+++ b/frontend/src/hooks/useSignupPage.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from './useAuth';
 import type { FormMessage } from '../types';
@@ -9,6 +9,13 @@ export function useSignupPage() {
   const [message, setMessage] = useState<FormMessage | null>(null);
   const navigate = useNavigate();
   const { signup, loading } = useAuth();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
 
   const handleSignup = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -32,7 +39,7 @@ export function useSignupPage() {
 
     if (success) {
       setMessage({ type: 'success', text: 'サインアップに成功しました！' });
-      setTimeout(() => {
+      timerRef.current = setTimeout(() => {
         navigate('/confirm', {
           state: {
             message: 'サインアップに成功しました！メール確認をお願いします。',


### PR DESCRIPTION
## 概要
- タイマーのアンマウント時クリーンアップ未実装によるメモリリークを修正
- エラー握りつぶしをerrorステートに置き換え

## 変更内容
- `useCopyToClipboard`: useEffectでアンマウント時にtimerRefをクリア
- `useSignupPage`: ナビゲーションのsetTimeoutをtimerRefで管理し、アンマウント時にクリア
- `useChatRoomCreation`: catch内の空コメントをerror stateに置き換え

## テスト
- useCopyToClipboard: 1件追加（全10件パス）
- useSignupPage: 1件追加（全15件パス）
- useChatRoomCreation: 2件追加（全6件パス）

closes #1414