### PR TITLE
perf: リストアイテムコンポーネントにReact.memo適用

### DIFF
--- a/frontend/src/components/FriendCard.tsx
+++ b/frontend/src/components/FriendCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { UserMinusIcon } from '@heroicons/react/24/outline';
 import type { FriendshipUser } from '../types';
 
@@ -7,7 +8,7 @@ interface FriendCardProps {
   showUnfollow: boolean;
 }
 
-export default function FriendCard({ user, onUnfollow, showUnfollow }: FriendCardProps) {
+export default memo(function FriendCard({ user, onUnfollow, showUnfollow }: FriendCardProps) {
   return (
     <div className="flex items-center gap-3 bg-surface-1 rounded-lg border border-surface-3 p-3">
       <div className="w-10 h-10 rounded-full bg-surface-3 flex items-center justify-center flex-shrink-0 overflow-hidden">
@@ -49,4 +50,4 @@ export default function FriendCard({ user, onUnfollow, showUnfollow }: FriendCar
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/NotificationItem.tsx
+++ b/frontend/src/components/NotificationItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import type { Notification } from '../types';
 
@@ -14,7 +15,7 @@ interface NotificationItemProps {
   onMarkAsRead: (id: number) => void;
 }
 
-export default function NotificationItem({ notification, onMarkAsRead }: NotificationItemProps) {
+export default memo(function NotificationItem({ notification, onMarkAsRead }: NotificationItemProps) {
   return (
     <div
       className={`p-4 rounded-lg border transition-colors ${
@@ -51,4 +52,4 @@ export default function NotificationItem({ notification, onMarkAsRead }: Notific
       </div>
     </div>
   );
-}
+});

--- a/frontend/src/components/ScenarioCard.tsx
+++ b/frontend/src/components/ScenarioCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { PracticeScenario } from '../types';
 import Card from './Card';
 import { BookmarkIcon as BookmarkOutlineIcon, UserIcon } from '@heroicons/react/24/outline';
@@ -19,7 +20,7 @@ function getDifficultyColor(difficulty: string): string {
     : 'bg-surface-2 text-[var(--color-text-muted)]';
 }
 
-export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggleBookmark }: ScenarioCardProps) {
+export default memo(function ScenarioCard({ scenario, onSelect, isBookmarked, onToggleBookmark }: ScenarioCardProps) {
   const handleBookmarkClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onToggleBookmark?.(scenario.id);
@@ -62,4 +63,4 @@ export default function ScenarioCard({ scenario, onSelect, isBookmarked, onToggl
       </div>
     </Card>
   );
-}
+});


### PR DESCRIPTION
## 概要
頻繁にリストで再レンダリングされるコンポーネントにReact.memoを適用

## 変更内容
- `ScenarioCard`: PracticePageで多数表示されるカード
- `NotificationItem`: NotificationPageの通知リスト
- `FriendCard`: FriendshipPageのフレンドカード

## 期待効果
リストの親コンポーネントのステート更新時に、propsが変わっていない子コンポーネントの再レンダリングをスキップ

## テスト
既存テスト全30件パス（ScenarioCard: 21件, NotificationItem: 4件, FriendCard: 5件）

closes #1416