### PR TITLE
fix: AiChatController・PracticeControllerに@Validアノテーション追加

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatController.java
@@ -3,6 +3,9 @@ package com.example.FreStyle.controller;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -101,7 +104,7 @@ public class AiChatController {
     @PostMapping("/sessions")
     public ResponseEntity<AiChatSessionDto> createSession(
             @AuthenticationPrincipal Jwt jwt,
-            @RequestBody CreateSessionRequest request
+            @Valid @RequestBody CreateSessionRequest request
     ) {
         log.info("========== POST /api/chat/ai/sessions ==========");
         log.info("📝 リクエスト: {}", request);
@@ -141,7 +144,7 @@ public class AiChatController {
     public ResponseEntity<AiChatSessionDto> updateSessionTitle(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer sessionId,
-            @RequestBody UpdateSessionRequest request
+            @Valid @RequestBody UpdateSessionRequest request
     ) {
         log.info("========== PUT /api/chat/ai/sessions/{} ==========", sessionId);
 
@@ -200,7 +203,7 @@ public class AiChatController {
     public ResponseEntity<AiChatMessageResponseDto> addMessage(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer sessionId,
-            @RequestBody AddMessageRequest request
+            @Valid @RequestBody AddMessageRequest request
     ) {
         log.info("========== POST /api/chat/ai/sessions/{}/messages ==========", sessionId);
         log.info("📝 リクエスト: {}", request);
@@ -244,7 +247,7 @@ public class AiChatController {
     @PostMapping("/rephrase")
     public ResponseEntity<Map<String, String>> rephrase(
             @AuthenticationPrincipal Jwt jwt,
-            @RequestBody RephraseRequest request
+            @Valid @RequestBody RephraseRequest request
     ) {
         log.info("========== POST /api/chat/ai/rephrase ==========");
 
@@ -277,7 +280,7 @@ public class AiChatController {
 
     // リクエスト用のRecord
     record CreateSessionRequest(String title, Integer relatedRoomId) {}
-    record UpdateSessionRequest(String title) {}
-    record AddMessageRequest(String content, String role) {}
-    record RephraseRequest(String originalMessage, String scene) {}
+    record UpdateSessionRequest(@NotBlank String title) {}
+    record AddMessageRequest(@NotBlank String content, @NotBlank String role) {}
+    record RephraseRequest(@NotBlank String originalMessage, @NotBlank String scene) {}
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/PracticeController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/PracticeController.java
@@ -2,6 +2,9 @@ package com.example.FreStyle.controller;
 
 import java.util.List;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -136,7 +139,7 @@ public class PracticeController {
     @PostMapping("/sessions")
     public ResponseEntity<AiChatSessionDto> createPracticeSession(
             @AuthenticationPrincipal Jwt jwt,
-            @RequestBody CreatePracticeSessionRequest request
+            @Valid @RequestBody CreatePracticeSessionRequest request
     ) {
         log.info("========== POST /api/practice/sessions ==========");
 
@@ -180,7 +183,7 @@ public class PracticeController {
         return ResponseEntity.ok(result);
     }
 
-    record CreatePracticeSessionRequest(Integer scenarioId) {}
+    record CreatePracticeSessionRequest(@NotNull Integer scenarioId) {}
 
     private User resolveUser(Jwt jwt) {
         return userIdentityService.findUserBySub(jwt.getSubject());

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
@@ -5,6 +5,11 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -291,6 +296,61 @@ class AiChatControllerTest {
             assertThat(response.getBody().sessionId()).isEqualTo(1);
             assertThat(response.getBody().averageScore()).isEqualTo(80.0);
             verify(getPracticeSessionSummaryUseCase).execute(1, 10);
+        }
+    }
+
+    @Nested
+    @DisplayName("リクエストバリデーション")
+    class RequestValidation {
+
+        private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        @Test
+        @DisplayName("AddMessageRequest: contentが空の場合バリデーションエラー")
+        void addMessageRequest_blankContent_fails() {
+            var request = new AiChatController.AddMessageRequest("", "user");
+            Set<ConstraintViolation<AiChatController.AddMessageRequest>> violations = validator.validate(request);
+            assertThat(violations).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("AddMessageRequest: roleが空の場合バリデーションエラー")
+        void addMessageRequest_blankRole_fails() {
+            var request = new AiChatController.AddMessageRequest("テスト", "");
+            Set<ConstraintViolation<AiChatController.AddMessageRequest>> violations = validator.validate(request);
+            assertThat(violations).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("AddMessageRequest: 正常な値の場合バリデーション成功")
+        void addMessageRequest_valid_passes() {
+            var request = new AiChatController.AddMessageRequest("テスト", "user");
+            Set<ConstraintViolation<AiChatController.AddMessageRequest>> violations = validator.validate(request);
+            assertThat(violations).isEmpty();
+        }
+
+        @Test
+        @DisplayName("UpdateSessionRequest: titleが空の場合バリデーションエラー")
+        void updateSessionRequest_blankTitle_fails() {
+            var request = new AiChatController.UpdateSessionRequest("");
+            Set<ConstraintViolation<AiChatController.UpdateSessionRequest>> violations = validator.validate(request);
+            assertThat(violations).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("RephraseRequest: originalMessageが空の場合バリデーションエラー")
+        void rephraseRequest_blankOriginal_fails() {
+            var request = new AiChatController.RephraseRequest("", "会議");
+            Set<ConstraintViolation<AiChatController.RephraseRequest>> violations = validator.validate(request);
+            assertThat(violations).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("RephraseRequest: sceneが空の場合バリデーションエラー")
+        void rephraseRequest_blankScene_fails() {
+            var request = new AiChatController.RephraseRequest("テスト", "");
+            Set<ConstraintViolation<AiChatController.RephraseRequest>> violations = validator.validate(request);
+            assertThat(violations).isNotEmpty();
         }
     }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/PracticeControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/PracticeControllerTest.java
@@ -6,6 +6,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -158,6 +165,30 @@ class PracticeControllerTest {
             assertThat(response.getBody().recommendations()).hasSize(1);
             assertThat(response.getBody().recommendations().get(0).scenarioName()).isEqualTo("交渉シナリオ");
             verify(getRecommendedScenariosUseCase).execute(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("リクエストバリデーション")
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    class RequestValidation {
+
+        private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+        @Test
+        @DisplayName("CreatePracticeSessionRequest: scenarioIdがnullの場合バリデーションエラー")
+        void createPracticeSessionRequest_nullScenarioId_fails() {
+            var request = new PracticeController.CreatePracticeSessionRequest(null);
+            Set<ConstraintViolation<PracticeController.CreatePracticeSessionRequest>> violations = validator.validate(request);
+            assertThat(violations).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("CreatePracticeSessionRequest: scenarioIdが正常な場合バリデーション成功")
+        void createPracticeSessionRequest_valid_passes() {
+            var request = new PracticeController.CreatePracticeSessionRequest(1);
+            Set<ConstraintViolation<PracticeController.CreatePracticeSessionRequest>> violations = validator.validate(request);
+            assertThat(violations).isEmpty();
         }
     }
 }


### PR DESCRIPTION
## 概要
- AiChatControllerの4つの@RequestBodyパラメータに`@Valid`を追加
- PracticeControllerの1つの@RequestBodyパラメータに`@Valid`を追加
- Record型にバリデーションアノテーション(`@NotBlank`, `@NotNull`)を追加
- バリデーションのユニットテストを8件追加

## 変更内容
### AiChatController
- `CreateSessionRequest`: titleは任意のためアノテーションなし
- `UpdateSessionRequest`: `@NotBlank` on title
- `AddMessageRequest`: `@NotBlank` on content, role
- `RephraseRequest`: `@NotBlank` on originalMessage, scene

### PracticeController
- `CreatePracticeSessionRequest`: `@NotNull` on scenarioId

## テスト
- AiChatControllerTest: 6件のバリデーションテスト追加
- PracticeControllerTest: 2件のバリデーションテスト追加
- 全782件のテスト成功（contextLoads除く）

closes #1418