### PR TITLE
fix: useNoteEditorのアンマウント時タイマークリーンアップを追加

### DIFF
--- a/frontend/src/hooks/__tests__/useNoteEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useNoteEditor.test.ts
@@ -262,4 +262,20 @@ describe('useNoteEditor', () => {
       isPinned: false,
     });
   });
+
+  it('アンマウント時に保存タイマーがクリアされる', () => {
+    const { result, unmount } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => {
+      result.current.handleTitleChange('変更中');
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(mockUpdateNote).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/hooks/useNoteEditor.ts
+++ b/frontend/src/hooks/useNoteEditor.ts
@@ -24,6 +24,12 @@ export function useNoteEditor(
     setSaveStatus('idle');
   }, [selectedNoteId]);
 
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
   const handleAutoSave = useCallback(
     (title: string, content: string) => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);


### PR DESCRIPTION
## 概要
- `useNoteEditor`の自動保存デバウンスタイマーがアンマウント時にクリアされていなかった問題を修正
- `useEffect`のcleanup関数で`saveTimerRef`をクリアするようにした

## テスト
- アンマウント時にタイマーがクリアされることを検証するテストを1件追加
- 全19件のテスト成功

closes #1420