### PR TITLE
fix: useNoteEditorの自動保存エラーハンドリングを追加

### DIFF
--- a/frontend/src/hooks/__tests__/useNoteEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useNoteEditor.test.ts
@@ -278,4 +278,30 @@ describe('useNoteEditor', () => {
 
     expect(mockUpdateNote).not.toHaveBeenCalled();
   });
+
+  it('自動保存失敗時にsaveStatusがidleに戻る', async () => {
+    mockUpdateNote.mockRejectedValue(new Error('保存失敗'));
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    act(() => {
+      result.current.handleTitleChange('変更');
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(800);
+    });
+
+    expect(result.current.saveStatus).toBe('idle');
+  });
+
+  it('forceSave失敗時にsaveStatusがidleに戻る', async () => {
+    mockUpdateNote.mockRejectedValue(new Error('保存失敗'));
+    const { result } = renderHook(() => useNoteEditor('n1', baseNote, mockUpdateNote));
+
+    await act(async () => {
+      result.current.forceSave();
+    });
+
+    expect(result.current.saveStatus).toBe('idle');
+  });
 });

--- a/frontend/src/hooks/useNoteEditor.ts
+++ b/frontend/src/hooks/useNoteEditor.ts
@@ -37,12 +37,16 @@ export function useNoteEditor(
       saveTimerRef.current = setTimeout(async () => {
         if (selectedNoteId) {
           setSaveStatus('saving');
-          await updateNote(selectedNoteId, {
-            title,
-            content,
-            isPinned: selectedNote?.isPinned || false,
-          });
-          setSaveStatus('saved');
+          try {
+            await updateNote(selectedNoteId, {
+              title,
+              content,
+              isPinned: selectedNote?.isPinned || false,
+            });
+            setSaveStatus('saved');
+          } catch {
+            setSaveStatus('idle');
+          }
         }
       }, 800);
     },
@@ -69,12 +73,16 @@ export function useNoteEditor(
     if (!selectedNoteId) return;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setSaveStatus('saving');
-    await updateNote(selectedNoteId, {
-      title: editTitle,
-      content: editContent,
-      isPinned: selectedNote?.isPinned || false,
-    });
-    setSaveStatus('saved');
+    try {
+      await updateNote(selectedNoteId, {
+        title: editTitle,
+        content: editContent,
+        isPinned: selectedNote?.isPinned || false,
+      });
+      setSaveStatus('saved');
+    } catch {
+      setSaveStatus('idle');
+    }
   }, [selectedNoteId, editTitle, editContent, selectedNote, updateNote]);
 
   return {


### PR DESCRIPTION
## 概要
- `handleAutoSave`と`forceSave`で`updateNote`が失敗した場合、`saveStatus`が`saving`のまま止まる問題を修正
- try-catchで捕捉し、失敗時は`saveStatus`を`idle`に戻すようにした

## テスト
- 自動保存失敗時のテストを1件追加
- forceSave失敗時のテストを1件追加
- 全21件のテスト成功

closes #1422