### PR TITLE
fix: useImageUploadのファイルinput要素がDOMに残る問題を修正

### DIFF
--- a/frontend/src/hooks/__tests__/useImageUpload.test.ts
+++ b/frontend/src/hooks/__tests__/useImageUpload.test.ts
@@ -86,6 +86,23 @@ describe('useImageUpload', () => {
     expect(result.current.uploadError).toBe('画像アップロードに失敗しました');
   });
 
+  it('アンマウント時にファイルinput要素がDOMから削除される', () => {
+    const editor = createMockEditor();
+    const { result, unmount } = renderHook(() => useImageUpload('note1', editor as any));
+
+    act(() => {
+      result.current.openFileDialog();
+    });
+
+    const inputs = document.querySelectorAll('input[type="file"]');
+    expect(inputs.length).toBe(1);
+
+    unmount();
+
+    const inputsAfter = document.querySelectorAll('input[type="file"]');
+    expect(inputsAfter.length).toBe(0);
+  });
+
   it('再アップロード成功時にuploadErrorがクリアされる', async () => {
     const editor = createMockEditor();
     vi.mocked(NoteImageRepository.getPresignedUrl)

--- a/frontend/src/hooks/useImageUpload.ts
+++ b/frontend/src/hooks/useImageUpload.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/core';
 import NoteImageRepository from '../repositories/NoteImageRepository';
 
@@ -44,6 +44,15 @@ export function useImageUpload(noteId: string | null, editor: Editor | null) {
     }
     fileInputRef.current.click();
   }, [handleFilesFromInput]);
+
+  useEffect(() => {
+    return () => {
+      if (fileInputRef.current) {
+        fileInputRef.current.remove();
+        fileInputRef.current = null;
+      }
+    };
+  }, []);
 
   const handleDrop = useCallback((event: React.DragEvent) => {
     const files = event.dataTransfer?.files;


### PR DESCRIPTION
## 概要
- `openFileDialog`で作成されるinput要素がアンマウント後もDOMに残り続けるメモリリークを修正
- `useEffect`のcleanup関数でDOM要素を削除するようにした

## テスト
- アンマウント時にinput要素がDOMから削除されることを検証するテストを1件追加
- 全6件のテスト成功

closes #1424