### PR TITLE
test: コントローラーテストカバレッジの欠落を補完

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
@@ -37,6 +37,8 @@ import com.example.FreStyle.usecase.UpdateAiChatSessionTitleUseCase;
 import com.example.FreStyle.usecase.GetAiChatMessagesBySessionIdUseCase;
 import com.example.FreStyle.usecase.AddAiChatMessageUseCase;
 import com.example.FreStyle.usecase.GetPracticeSessionSummaryUseCase;
+import com.example.FreStyle.usecase.GetAiChatSessionStatsUseCase;
+import com.example.FreStyle.dto.AiChatSessionStatsDto;
 import com.example.FreStyle.dto.PracticeSessionSummaryDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,6 +56,7 @@ class AiChatControllerTest {
     @Mock private GetAiChatMessagesBySessionIdUseCase getAiChatMessagesBySessionIdUseCase;
     @Mock private AddAiChatMessageUseCase addAiChatMessageUseCase;
     @Mock private GetPracticeSessionSummaryUseCase getPracticeSessionSummaryUseCase;
+    @Mock private GetAiChatSessionStatsUseCase getAiChatSessionStatsUseCase;
 
     @InjectMocks
     private AiChatController aiChatController;
@@ -296,6 +299,30 @@ class AiChatControllerTest {
             assertThat(response.getBody().sessionId()).isEqualTo(1);
             assertThat(response.getBody().averageScore()).isEqualTo(80.0);
             verify(getPracticeSessionSummaryUseCase).execute(1, 10);
+        }
+    }
+
+    @Nested
+    @DisplayName("getSessionStats")
+    class GetSessionStats {
+
+        @Test
+        @DisplayName("セッション統計を返す")
+        void returnsSessionStats() {
+            Jwt jwt = mockJwt("sub-123");
+            User user = createUser(10);
+            AiChatSessionStatsDto stats = new AiChatSessionStatsDto(
+                    5, List.of(new AiChatSessionStatsDto.TypeCount("free", 3)),
+                    List.of(new AiChatSessionStatsDto.SceneCount("meeting", 2)));
+            when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
+            when(getAiChatSessionStatsUseCase.execute(10)).thenReturn(stats);
+
+            ResponseEntity<AiChatSessionStatsDto> response = aiChatController.getSessionStats(jwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().totalSessions()).isEqualTo(5);
+            assertThat(response.getBody().sessionsByType()).hasSize(1);
+            verify(getAiChatSessionStatsUseCase).execute(10);
         }
     }
 

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/FavoritePhraseControllerTest.java
@@ -18,9 +18,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import com.example.FreStyle.dto.FavoritePhraseDto;
+import com.example.FreStyle.dto.FavoritePhraseSummaryDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.UserIdentityService;
 import com.example.FreStyle.usecase.AddFavoritePhraseUseCase;
+import com.example.FreStyle.usecase.GetFavoritePhraseSummaryUseCase;
 import com.example.FreStyle.usecase.GetUserFavoritePhrasesUseCase;
 import com.example.FreStyle.usecase.RemoveFavoritePhraseUseCase;
 
@@ -36,6 +38,9 @@ class FavoritePhraseControllerTest {
 
     @Mock
     private RemoveFavoritePhraseUseCase removeFavoritePhraseUseCase;
+
+    @Mock
+    private GetFavoritePhraseSummaryUseCase getFavoritePhraseSummaryUseCase;
 
     @Mock
     private UserIdentityService userIdentityService;
@@ -123,6 +128,26 @@ class FavoritePhraseControllerTest {
 
             org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
                     () -> favoritePhraseController.removeFavoritePhrase(mockJwt, 99));
+        }
+    }
+
+    @Nested
+    @DisplayName("getSummary")
+    class GetSummary {
+
+        @Test
+        @DisplayName("お気に入りフレーズサマリーを返す")
+        void returnsSummary() {
+            FavoritePhraseSummaryDto summary = new FavoritePhraseSummaryDto(
+                    3, List.of(new FavoritePhraseSummaryDto.PatternCount("フォーマル版", 2)));
+            when(getFavoritePhraseSummaryUseCase.execute(1)).thenReturn(summary);
+
+            ResponseEntity<FavoritePhraseSummaryDto> response = favoritePhraseController.getSummary(mockJwt);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody().totalCount()).isEqualTo(3);
+            assertThat(response.getBody().patternCounts()).hasSize(1);
+            verify(getFavoritePhraseSummaryUseCase).execute(1);
         }
     }
 

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/PracticeControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/PracticeControllerTest.java
@@ -33,8 +33,10 @@ import com.example.FreStyle.usecase.CreatePracticeSessionUseCase;
 import com.example.FreStyle.usecase.GetAllPracticeScenariosUseCase;
 import com.example.FreStyle.usecase.GetPracticeScenarioByIdUseCase;
 import com.example.FreStyle.usecase.GetRecommendedScenariosUseCase;
+import com.example.FreStyle.dto.FilteredScenariosDto;
 import com.example.FreStyle.dto.RecommendedScenarioDto;
 import com.example.FreStyle.dto.RecommendedScenarioDto.ScenarioRecommendation;
+import com.example.FreStyle.usecase.FilterPracticeScenariosUseCase;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PracticeController")
@@ -51,6 +53,9 @@ class PracticeControllerTest {
 
     @Mock
     private GetRecommendedScenariosUseCase getRecommendedScenariosUseCase;
+
+    @Mock
+    private FilterPracticeScenariosUseCase filterPracticeScenariosUseCase;
 
     @Mock
     private UserIdentityService userIdentityService;
@@ -165,6 +170,27 @@ class PracticeControllerTest {
             assertThat(response.getBody().recommendations()).hasSize(1);
             assertThat(response.getBody().recommendations().get(0).scenarioName()).isEqualTo("交渉シナリオ");
             verify(getRecommendedScenariosUseCase).execute(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/practice/scenarios/filter - シナリオフィルタリング")
+    class FilterScenarios {
+
+        @Test
+        @DisplayName("難易度とカテゴリでフィルタリングされたシナリオを返す")
+        void shouldReturnFilteredScenarios() {
+            PracticeScenarioDto s1 = new PracticeScenarioDto(1, "障害報告", null, null, "easy", null, null);
+            FilteredScenariosDto dto = new FilteredScenariosDto(
+                    List.of(s1), 1, List.of("easy", "medium"), List.of("business"));
+            when(filterPracticeScenariosUseCase.execute("easy", "business")).thenReturn(dto);
+
+            ResponseEntity<FilteredScenariosDto> response = controller.filterScenarios(jwt, "easy", "business");
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().totalCount()).isEqualTo(1);
+            verify(filterPracticeScenariosUseCase).execute("easy", "business");
         }
     }
 


### PR DESCRIPTION
## 概要
テストが存在しなかった以下のコントローラーメソッドに対するユニットテストを追加:

- **AiChatController.getSessionStats()**: セッション統計取得のテスト
- **PracticeController.filterScenarios()**: シナリオフィルタリングのテスト
- **FavoritePhraseController.getSummary()**: お気に入りフレーズサマリーのテスト

## テスト
- 3件のテスト追加
- 全テスト成功

closes #1426