### PR TITLE
fix: useBookmarkの楽観的更新にAPI失敗時のロールバック処理を追加

### DIFF
--- a/frontend/src/hooks/__tests__/useBookmark.test.ts
+++ b/frontend/src/hooks/__tests__/useBookmark.test.ts
@@ -129,4 +129,34 @@ describe('useBookmark', () => {
       expect(result.current.loading).toBe(false);
     });
   });
+
+  it('ブックマーク追加API失敗時に状態がロールバックされる', async () => {
+    mockAdd.mockRejectedValue(new Error('API error'));
+    const { result } = renderHook(() => useBookmark());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggleBookmark(5);
+    });
+
+    expect(result.current.bookmarkedIds).not.toContain(5);
+  });
+
+  it('ブックマーク削除API失敗時に状態がロールバックされる', async () => {
+    mockRemove.mockRejectedValue(new Error('API error'));
+    const { result } = renderHook(() => useBookmark());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.toggleBookmark(1);
+    });
+
+    expect(result.current.bookmarkedIds).toContain(1);
+  });
 });

--- a/frontend/src/hooks/useBookmark.ts
+++ b/frontend/src/hooks/useBookmark.ts
@@ -18,12 +18,21 @@ export function useBookmark() {
 
   const toggleBookmark = useCallback(async (scenarioId: number) => {
     const isCurrentlyBookmarked = bookmarkedIds.includes(scenarioId);
+    const snapshot = bookmarkedIds;
     if (isCurrentlyBookmarked) {
       setBookmarkedIds(prev => prev.filter(id => id !== scenarioId));
-      await BookmarkRepository.remove(scenarioId);
+      try {
+        await BookmarkRepository.remove(scenarioId);
+      } catch {
+        setBookmarkedIds(snapshot);
+      }
     } else {
       setBookmarkedIds(prev => [...prev, scenarioId]);
-      await BookmarkRepository.add(scenarioId);
+      try {
+        await BookmarkRepository.add(scenarioId);
+      } catch {
+        setBookmarkedIds(snapshot);
+      }
     }
   }, [bookmarkedIds]);
 


### PR DESCRIPTION
## 概要
- `toggleBookmark`で楽観的にUI状態を更新後、APIが失敗した場合に元の状態にロールバックする処理を追加
- サーバーとクライアントの状態不整合を防止

## テスト
- ブックマーク追加API失敗時のロールバックテストを1件追加
- ブックマーク削除API失敗時のロールバックテストを1件追加
- 全11件のテスト成功

closes #1428