### PR TITLE
fix: alert()をトースト通知に置き換え

### DIFF
--- a/frontend/src/hooks/__tests__/useChat.test.ts
+++ b/frontend/src/hooks/__tests__/useChat.test.ts
@@ -10,6 +10,10 @@ vi.mock('react-router-dom', () => ({
 }));
 
 vi.mock('../../repositories/ChatRepository');
+const mockShowToast = vi.fn();
+vi.mock('../useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast, toasts: [], removeToast: vi.fn() }),
+}));
 vi.mock('sockjs-client', () => ({ default: vi.fn() }));
 vi.mock('@stomp/stompjs', () => ({
   Client: class MockClient {

--- a/frontend/src/hooks/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginCallback.test.ts
@@ -32,7 +32,6 @@ describe('useLoginCallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = '';
-    vi.spyOn(window, 'alert').mockImplementation(() => {});
   });
 
   it('codeがある場合にauthRepository.callbackを呼び出す', async () => {
@@ -58,7 +57,7 @@ describe('useLoginCallback', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/', { state: { toast: 'ログインしました' } });
   });
 
-  it('callback失敗時にアラートを表示しログインページに遷移する', async () => {
+  it('callback失敗時にトースト付きでログインページに遷移する', async () => {
     mockSearchParams = 'code=test-code';
     vi.mocked(authRepository.callback).mockRejectedValue(new Error('認証失敗'));
 
@@ -66,19 +65,17 @@ describe('useLoginCallback', () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(window.alert).toHaveBeenCalledWith('認証に失敗しました。');
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { toast: '認証に失敗しました' } });
   });
 
-  it('errorパラメータがある場合にアラートを表示しログインページに遷移する', async () => {
+  it('errorパラメータがある場合にトースト付きでログインページに遷移する', async () => {
     mockSearchParams = 'error=access_denied';
 
     await act(async () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(window.alert).toHaveBeenCalledWith('認証エラーが発生しました。access_denied');
-    expect(mockNavigate).toHaveBeenCalledWith('/login');
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { toast: '認証エラーが発生しました' } });
     expect(authRepository.callback).not.toHaveBeenCalled();
   });
 
@@ -125,7 +122,7 @@ describe('useLoginCallback', () => {
     expect(mockNavigate).not.toHaveBeenCalledWith('/', expect.objectContaining({ state: expect.objectContaining({ toast: expect.any(String) }) }));
   });
 
-  it('callback成功時にalertが呼ばれない', async () => {
+  it('callback成功時にエラートーストなしでホームに遷移する', async () => {
     mockSearchParams = 'code=valid-code';
     vi.mocked(authRepository.callback).mockResolvedValue({} as any);
 
@@ -133,7 +130,7 @@ describe('useLoginCallback', () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(window.alert).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalledWith('/login', expect.objectContaining({ state: expect.objectContaining({ toast: expect.any(String) }) }));
   });
 
   it('codeもerrorもない場合にdispatchが呼ばれない', async () => {

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -5,6 +5,7 @@ import { Client } from '@stomp/stompjs';
 import ChatRepository from '../repositories/ChatRepository';
 import { ChatMessage } from '../types';
 import { useMessageSelection } from './useMessageSelection';
+import { useToast } from './useToast';
 
 /**
  * チャットページのコアロジックフック
@@ -13,6 +14,7 @@ import { useMessageSelection } from './useMessageSelection';
  * メッセージ管理・WebSocket接続・選択モード・言い換え提案を担う。
  */
 export function useChat() {
+  const { showToast } = useToast();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [senderId, setSenderId] = useState<number | null>(null);
   const [deleteModal, setDeleteModal] = useState<{ isOpen: boolean; messageId: string | null }>({ isOpen: false, messageId: null });
@@ -169,7 +171,7 @@ export function useChat() {
 
   const handleSendToAi = useCallback(() => {
     if (selection.selectedMessages.size === 0) {
-      alert('メッセージを選択してください');
+      showToast('info', 'メッセージを選択してください');
       return;
     }
     setShowSceneSelector(true);

--- a/frontend/src/hooks/useLoginCallback.ts
+++ b/frontend/src/hooks/useLoginCallback.ts
@@ -13,8 +13,7 @@ export function useLoginCallback() {
 
   useEffect(() => {
     if (error) {
-      alert('認証エラーが発生しました。' + error);
-      navigate('/login');
+      navigate('/login', { state: { toast: '認証エラーが発生しました' } });
       return;
     }
 
@@ -26,8 +25,7 @@ export function useLoginCallback() {
           navigate('/', { state: { toast: 'ログインしました' } });
         })
         .catch(() => {
-          alert('認証に失敗しました。');
-          navigate('/login');
+          navigate('/login', { state: { toast: '認証に失敗しました' } });
         });
     } else {
       navigate('/login');


### PR DESCRIPTION
## 概要
ブラウザのブロッキング `alert()` ダイアログを既存のトースト通知UIに統一

### useLoginCallback
- 認証エラー時の`alert()`を`navigate('/login', { state: { toast: '...' } })`パターンに変更
- 既存の成功時トースト(`navigate('/', { state: { toast: '...' } })`)と同じパターンに統一

### useChat
- メッセージ未選択時の`alert()`を`useToast().showToast('info', '...')`に変更

## テスト
- useLoginCallback: テストを更新（alert → navigate state期待値に変更）
- useChat: useToastモックを追加
- 全20件のテスト成功

closes #1430