### PR TITLE
feat: バックエンドCDワークフローに手動トリガーを追加

### DIFF
--- a/.github/workflows/back-deploy.yml
+++ b/.github/workflows/back-deploy.yml
@@ -3,6 +3,7 @@ name: Deploy Spring Boot on ECS
 on:
   push:
     branches: ["main"]
+  workflow_dispatch:
     
 env:
   AWS_REGION: ap-northeast-1


### PR DESCRIPTION
## 概要
- バックエンドCDワークフロー（`back-deploy.yml`）に `workflow_dispatch` を追加
- GitHub UI や `gh workflow run` から手動でCDを実行可能にした

## 背景
- CloudFormationでインフラを再構築した際、GitHub Actions CDを手動トリガーする必要がある