### PR TITLE
fix: AIフィードバックメッセージからJSONスコアカードブロックを除去

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
@@ -111,8 +111,11 @@ public class AiChatWebSocketController {
             var aiReplyCommand = new GetAiReplyUseCase.Command(content, isPracticeMode, scenarioId, fromChatFeedback, scene, userId);
             String aiReply = getAiReplyUseCase.execute(aiReplyCommand);
 
+            // AI応答からJSONスコアカードブロックを除去（ScoreCardとして別途送信するため）
+            String displayReply = aiReply.replaceAll("(?s)```json\\s*\\n?.*?\\n?```", "").trim();
+
             // AI応答をデータベースに保存（role: assistant）
-            AiChatMessageResponseDto savedAiMessage = addAiChatMessageUseCase.execute(sessionId, userId, "assistant", aiReply);
+            AiChatMessageResponseDto savedAiMessage = addAiChatMessageUseCase.execute(sessionId, userId, "assistant", displayReply);
 
             // WebSocket トピックへAI応答を送信
             messagingTemplate.convertAndSend(


### PR DESCRIPTION
## 概要
- AIフィードバック応答に含まれる` ```json...``` `ブロックがチャット画面にそのままテキスト表示されていた問題を修正
- メッセージ保存・送信前にJSONブロックを除去し、スコアカードは従来通り別途抽出・送信

## 変更箇所
- `AiChatWebSocketController.java`: AI応答から`(?s)```json...````パターンを除去してから保存・表示用に使用。スコアカード抽出には元の応答を引き続き使用

## テスト
- `./gradlew test` 全786テスト成功（contextLoads除く）