### PR TITLE
feat: ユーザーランキング機能を追加 (#1434)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/RankingController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/RankingController.java
@@ -1,0 +1,42 @@
+package com.example.FreStyle.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.RankingDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetRankingUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ranking")
+@Slf4j
+public class RankingController {
+
+    private final UserIdentityService userIdentityService;
+    private final GetRankingUseCase getRankingUseCase;
+
+    @GetMapping
+    public ResponseEntity<RankingDto> getRanking(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(defaultValue = "weekly") String period
+    ) {
+        log.info("========== GET /api/ranking?period={} ==========", period);
+
+        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        RankingDto ranking = getRankingUseCase.execute(period, user.getId());
+
+        log.info("ランキング取得成功 - userId: {}, 件数: {}", user.getId(), ranking.entries().size());
+
+        return ResponseEntity.ok(ranking);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/RankingDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/RankingDto.java
@@ -1,0 +1,17 @@
+package com.example.FreStyle.dto;
+
+import java.util.List;
+
+public record RankingDto(
+    List<RankingEntryDto> entries,
+    RankingEntryDto myRanking
+) {
+    public record RankingEntryDto(
+        int rank,
+        Integer userId,
+        String username,
+        String iconUrl,
+        double averageScore,
+        int sessionCount
+    ) {}
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/CommunicationScoreRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/CommunicationScoreRepository.java
@@ -21,4 +21,11 @@ public interface CommunicationScoreRepository extends JpaRepository<Communicatio
     @Query("SELECT cs FROM CommunicationScore cs WHERE cs.user.id = :userId AND cs.createdAt > :cutoff ORDER BY cs.createdAt DESC")
     List<CommunicationScore> findByUserIdAndCreatedAtAfterOrderByCreatedAtDesc(
             @Param("userId") Integer userId, @Param("cutoff") Timestamp cutoff);
+
+    @Query("SELECT cs.user.id, AVG(cs.score), COUNT(DISTINCT cs.session.id) " +
+           "FROM CommunicationScore cs " +
+           "WHERE cs.createdAt > :cutoff " +
+           "GROUP BY cs.user.id " +
+           "ORDER BY AVG(cs.score) DESC")
+    List<Object[]> findUserAverageScoresAfter(@Param("cutoff") Timestamp cutoff);
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/service/RankingService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/RankingService.java
@@ -1,0 +1,70 @@
+package com.example.FreStyle.service;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.RankingDto;
+import com.example.FreStyle.dto.RankingDto.RankingEntryDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+import com.example.FreStyle.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RankingService {
+
+    private final CommunicationScoreRepository communicationScoreRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public RankingDto getRanking(String period, Integer currentUserId) {
+        Timestamp cutoff = calculateCutoff(period);
+        List<Object[]> results = communicationScoreRepository.findUserAverageScoresAfter(cutoff);
+
+        List<RankingEntryDto> entries = new ArrayList<>();
+        RankingEntryDto myRanking = null;
+
+        for (int i = 0; i < results.size(); i++) {
+            Object[] row = results.get(i);
+            Integer userId = (Integer) row[0];
+            double avgScore = ((Number) row[1]).doubleValue();
+            int sessionCount = ((Number) row[2]).intValue();
+
+            User user = userRepository.findById(userId).orElse(null);
+            if (user == null) continue;
+
+            RankingEntryDto entry = new RankingEntryDto(
+                i + 1,
+                userId,
+                user.getName(),
+                user.getIconUrl(),
+                Math.round(avgScore * 10.0) / 10.0,
+                sessionCount
+            );
+            entries.add(entry);
+
+            if (userId.equals(currentUserId)) {
+                myRanking = entry;
+            }
+        }
+
+        return new RankingDto(entries, myRanking);
+    }
+
+    private Timestamp calculateCutoff(String period) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime cutoff = switch (period) {
+            case "weekly" -> now.minusWeeks(1);
+            case "monthly" -> now.minusMonths(1);
+            default -> now.minusMonths(1);
+        };
+        return Timestamp.valueOf(cutoff);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetRankingUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetRankingUseCase.java
@@ -1,0 +1,21 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.RankingDto;
+import com.example.FreStyle.service.RankingService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetRankingUseCase {
+
+    private final RankingService rankingService;
+
+    public RankingDto execute(String period, Integer currentUserId) {
+        return rankingService.getRanking(period, currentUserId);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/RankingControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/RankingControllerTest.java
@@ -1,0 +1,96 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.RankingDto;
+import com.example.FreStyle.dto.RankingDto.RankingEntryDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetRankingUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RankingController")
+class RankingControllerTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private GetRankingUseCase getRankingUseCase;
+
+    @InjectMocks
+    private RankingController controller;
+
+    private Jwt jwt;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("test-sub");
+
+        user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+    }
+
+    @Nested
+    @DisplayName("GET /api/ranking")
+    class GetRanking {
+
+        @Test
+        @DisplayName("デフォルト期間（weekly）でランキングを取得する")
+        void shouldReturnRankingWithDefaultPeriod() {
+            RankingEntryDto entry = new RankingEntryDto(1, 1, "testUser", null, 8.5, 3);
+            RankingDto ranking = new RankingDto(List.of(entry), entry);
+            when(getRankingUseCase.execute("weekly", 1)).thenReturn(ranking);
+
+            ResponseEntity<RankingDto> response = controller.getRanking(jwt, "weekly");
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().entries()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("指定した期間でランキングを取得する")
+        void shouldReturnRankingWithSpecifiedPeriod() {
+            RankingEntryDto entry = new RankingEntryDto(1, 2, "user2", null, 9.0, 5);
+            RankingDto ranking = new RankingDto(List.of(entry), null);
+            when(getRankingUseCase.execute("monthly", 1)).thenReturn(ranking);
+
+            ResponseEntity<RankingDto> response = controller.getRanking(jwt, "monthly");
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().entries()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("UseCaseにユーザーIDと期間を渡す")
+        void shouldPassUserIdAndPeriodToUseCase() {
+            RankingDto ranking = new RankingDto(List.of(), null);
+            when(getRankingUseCase.execute("weekly", 1)).thenReturn(ranking);
+
+            controller.getRanking(jwt, "weekly");
+
+            verify(getRankingUseCase).execute("weekly", 1);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/service/RankingServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/RankingServiceTest.java
@@ -1,0 +1,114 @@
+package com.example.FreStyle.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.RankingDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.CommunicationScoreRepository;
+import com.example.FreStyle.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RankingService")
+class RankingServiceTest {
+
+    @Mock
+    private CommunicationScoreRepository communicationScoreRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    @Test
+    @DisplayName("ユーザーの平均スコアでランキングを生成する")
+    void shouldGenerateRankingByAverageScore() {
+        // User1: avgScore=8.5, sessionCount=3
+        // User2: avgScore=7.0, sessionCount=2
+        Object[] row1 = new Object[]{1, 8.5, 3L};
+        Object[] row2 = new Object[]{2, 7.0, 2L};
+        when(communicationScoreRepository.findUserAverageScoresAfter(any(Timestamp.class)))
+                .thenReturn(List.of(row1, row2));
+
+        User user1 = new User();
+        user1.setId(1);
+        user1.setName("User1");
+        user1.setIconUrl("icon1.png");
+        when(userRepository.findById(1)).thenReturn(Optional.of(user1));
+
+        User user2 = new User();
+        user2.setId(2);
+        user2.setName("User2");
+        user2.setIconUrl("icon2.png");
+        when(userRepository.findById(2)).thenReturn(Optional.of(user2));
+
+        RankingDto result = rankingService.getRanking("weekly", 99);
+
+        assertThat(result.entries()).hasSize(2);
+        assertThat(result.entries().get(0).rank()).isEqualTo(1);
+        assertThat(result.entries().get(0).username()).isEqualTo("User1");
+        assertThat(result.entries().get(0).averageScore()).isEqualTo(8.5);
+        assertThat(result.entries().get(1).rank()).isEqualTo(2);
+        assertThat(result.entries().get(1).username()).isEqualTo("User2");
+        assertThat(result.entries().get(1).averageScore()).isEqualTo(7.0);
+        assertThat(result.myRanking()).isNull();
+    }
+
+    @Test
+    @DisplayName("現在のユーザーのランキングをmyRankingに設定する")
+    void shouldSetMyRankingForCurrentUser() {
+        Object[] row1 = new Object[]{1, 9.0, 5L};
+        Object[] row2 = new Object[]{2, 7.5, 3L};
+        when(communicationScoreRepository.findUserAverageScoresAfter(any(Timestamp.class)))
+                .thenReturn(List.of(row1, row2));
+
+        User user1 = new User();
+        user1.setId(1);
+        user1.setName("User1");
+        when(userRepository.findById(1)).thenReturn(Optional.of(user1));
+
+        User user2 = new User();
+        user2.setId(2);
+        user2.setName("User2");
+        when(userRepository.findById(2)).thenReturn(Optional.of(user2));
+
+        RankingDto result = rankingService.getRanking("weekly", 2);
+
+        assertThat(result.myRanking()).isNotNull();
+        assertThat(result.myRanking().userId()).isEqualTo(2);
+        assertThat(result.myRanking().rank()).isEqualTo(2);
+        assertThat(result.myRanking().averageScore()).isEqualTo(7.5);
+    }
+
+    @Test
+    @DisplayName("weeklyの場合は1週間前からのデータを取得する")
+    void shouldUseCutoffForWeeklyPeriod() {
+        ArgumentCaptor<Timestamp> cutoffCaptor = ArgumentCaptor.forClass(Timestamp.class);
+        when(communicationScoreRepository.findUserAverageScoresAfter(cutoffCaptor.capture()))
+                .thenReturn(List.of());
+
+        rankingService.getRanking("weekly", 1);
+
+        Timestamp capturedCutoff = cutoffCaptor.getValue();
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        // cutoff should be approximately 7 days ago
+        long diffMillis = now.getTime() - capturedCutoff.getTime();
+        long sevenDaysMillis = 7 * 24 * 60 * 60 * 1000L;
+        // Allow 5 seconds tolerance
+        assertThat(diffMillis).isBetween(sevenDaysMillis - 5000L, sevenDaysMillis + 5000L);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetRankingUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetRankingUseCaseTest.java
@@ -1,0 +1,42 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.RankingDto;
+import com.example.FreStyle.dto.RankingDto.RankingEntryDto;
+import com.example.FreStyle.service.RankingService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetRankingUseCase")
+class GetRankingUseCaseTest {
+
+    @Mock
+    private RankingService rankingService;
+
+    @InjectMocks
+    private GetRankingUseCase useCase;
+
+    @Test
+    @DisplayName("RankingServiceに期間とユーザーIDを委譲する")
+    void shouldDelegateToRankingService() {
+        RankingEntryDto entry = new RankingEntryDto(1, 1, "testUser", null, 8.5, 3);
+        RankingDto expected = new RankingDto(List.of(entry), entry);
+        when(rankingService.getRanking("weekly", 1)).thenReturn(expected);
+
+        RankingDto result = useCase.execute("weekly", 1);
+
+        verify(rankingService).getRanking("weekly", 1);
+        assertThat(result).isEqualTo(expected);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ const NotesPage = lazy(() => import('./pages/NotesPage'));
 const NotificationPage = lazy(() => import('./pages/NotificationPage'));
 const LearningReportPage = lazy(() => import('./pages/LearningReportPage'));
 const FriendshipPage = lazy(() => import('./pages/FriendshipPage'));
+const RankingPage = lazy(() => import('./pages/RankingPage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -89,6 +90,7 @@ export default function App() {
         <Route path="/notifications" element={<NotificationPage />} />
         <Route path="/reports" element={<LearningReportPage />} />
         <Route path="/friends" element={<FriendshipPage />} />
+        <Route path="/ranking" element={<RankingPage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -4,6 +4,7 @@ import {
   SparklesIcon,
   AcademicCapIcon,
   ChartBarIcon,
+  TrophyIcon,
 } from '@heroicons/react/24/outline';
 import Card from './Card';
 
@@ -40,6 +41,13 @@ const MENU_ITEMS = [
     description: 'フィードバック結果の振り返り',
     to: '/scores',
     badgeKey: 'score' as const,
+  },
+  {
+    icon: TrophyIcon,
+    label: 'ランキング',
+    description: 'ユーザー間のスコアランキング',
+    to: '/ranking',
+    badgeKey: null,
   },
 ];
 

--- a/frontend/src/hooks/__tests__/useRanking.test.ts
+++ b/frontend/src/hooks/__tests__/useRanking.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useRanking } from '../useRanking';
+import { RankingRepository } from '../../repositories/RankingRepository';
+
+vi.mock('../../repositories/RankingRepository');
+const mockedRepo = vi.mocked(RankingRepository);
+
+describe('useRanking', () => {
+  const mockRanking = {
+    entries: [
+      { rank: 1, userId: 1, username: 'user1', iconUrl: null, averageScore: 9.0, sessionCount: 5 },
+      { rank: 2, userId: 2, username: 'user2', iconUrl: null, averageScore: 8.0, sessionCount: 3 },
+    ],
+    myRanking: { rank: 2, userId: 2, username: 'user2', iconUrl: null, averageScore: 8.0, sessionCount: 3 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchRanking.mockResolvedValue(mockRanking);
+  });
+
+  it('初期ロード時にweeklyのランキングを取得する', async () => {
+    const { result } = renderHook(() => useRanking());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.ranking).toEqual(mockRanking);
+    expect(result.current.period).toBe('weekly');
+    expect(mockedRepo.fetchRanking).toHaveBeenCalledWith('weekly');
+  });
+
+  it('期間を変更するとデータを再取得する', async () => {
+    const { result } = renderHook(() => useRanking());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.changePeriod('monthly');
+    });
+
+    await waitFor(() => {
+      expect(mockedRepo.fetchRanking).toHaveBeenCalledWith('monthly');
+    });
+  });
+
+  it('エラー時にエラーメッセージを設定する', async () => {
+    mockedRepo.fetchRanking.mockRejectedValue(new Error('API Error'));
+
+    const { result } = renderHook(() => useRanking());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('ランキングの取得に失敗しました');
+  });
+});

--- a/frontend/src/hooks/useRanking.ts
+++ b/frontend/src/hooks/useRanking.ts
@@ -1,0 +1,33 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RankingRepository } from '../repositories/RankingRepository';
+import { Ranking } from '../types';
+
+export function useRanking() {
+  const [ranking, setRanking] = useState<Ranking | null>(null);
+  const [period, setPeriod] = useState<'weekly' | 'monthly'>('weekly');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    RankingRepository.fetchRanking(period)
+      .then((data) => {
+        if (!cancelled) setRanking(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('ランキングの取得に失敗しました');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [period]);
+
+  const changePeriod = useCallback((newPeriod: 'weekly' | 'monthly') => {
+    setPeriod(newPeriod);
+  }, []);
+
+  return { ranking, period, changePeriod, loading, error };
+}

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -1,0 +1,101 @@
+import { useRanking } from '../hooks/useRanking';
+import Loading from '../components/Loading';
+import { RankingEntry } from '../types';
+
+function RankingEntryRow({ entry, isMe }: { entry: RankingEntry; isMe: boolean }) {
+  const medalEmoji = entry.rank === 1 ? '\u{1F947}' : entry.rank === 2 ? '\u{1F948}' : entry.rank === 3 ? '\u{1F949}' : null;
+
+  return (
+    <div
+      className={`flex items-center gap-3 p-3 rounded-lg ${
+        isMe ? 'bg-blue-50 dark:bg-blue-900/20 ring-2 ring-blue-400' : 'bg-white dark:bg-gray-800'
+      }`}
+      data-testid={`ranking-entry-${entry.rank}`}
+    >
+      <div className="w-8 text-center font-bold text-lg">
+        {medalEmoji ?? entry.rank}
+      </div>
+      <div className="w-9 h-9 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden flex-shrink-0">
+        {entry.iconUrl ? (
+          <img src={entry.iconUrl} alt={entry.username} className="w-full h-full object-cover" />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-sm text-gray-500">
+            {entry.username.charAt(0)}
+          </div>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="font-medium truncate">{entry.username}</p>
+        <p className="text-xs text-gray-500">{entry.sessionCount}セッション</p>
+      </div>
+      <div className="text-right">
+        <p className="font-bold text-lg">{entry.averageScore.toFixed(1)}</p>
+        <p className="text-xs text-gray-500">平均スコア</p>
+      </div>
+    </div>
+  );
+}
+
+export default function RankingPage() {
+  const { ranking, period, changePeriod, loading, error } = useRanking();
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-xl font-bold">ランキング</h1>
+
+      <div className="flex gap-2">
+        <button
+          onClick={() => changePeriod('weekly')}
+          className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+            period === 'weekly'
+              ? 'bg-blue-500 text-white'
+              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+          }`}
+          data-testid="period-weekly"
+        >
+          週間
+        </button>
+        <button
+          onClick={() => changePeriod('monthly')}
+          className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
+            period === 'monthly'
+              ? 'bg-blue-500 text-white'
+              : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+          }`}
+          data-testid="period-monthly"
+        >
+          月間
+        </button>
+      </div>
+
+      {loading && <Loading message="ランキングを読み込み中..." />}
+      {error && <p className="text-red-500 text-center">{error}</p>}
+
+      {ranking && !loading && (
+        <>
+          {ranking.myRanking && (
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold text-gray-500">あなたの順位</h2>
+              <RankingEntryRow entry={ranking.myRanking} isMe={true} />
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <h2 className="text-sm font-semibold text-gray-500">トップランキング</h2>
+            {ranking.entries.length === 0 ? (
+              <p className="text-gray-400 text-center py-8">まだランキングデータがありません</p>
+            ) : (
+              ranking.entries.map((entry) => (
+                <RankingEntryRow
+                  key={entry.userId}
+                  entry={entry}
+                  isMe={ranking.myRanking?.userId === entry.userId}
+                />
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/RankingPage.test.tsx
+++ b/frontend/src/pages/__tests__/RankingPage.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import RankingPage from '../RankingPage';
+import { useRanking } from '../../hooks/useRanking';
+
+vi.mock('../../hooks/useRanking');
+const mockedUseRanking = vi.mocked(useRanking);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <RankingPage />
+    </MemoryRouter>
+  );
+}
+
+describe('RankingPage', () => {
+  const mockRanking = {
+    entries: [
+      { rank: 1, userId: 1, username: 'TopUser', iconUrl: null, averageScore: 9.5, sessionCount: 10 },
+      { rank: 2, userId: 2, username: 'SecondUser', iconUrl: null, averageScore: 8.0, sessionCount: 5 },
+    ],
+    myRanking: { rank: 2, userId: 2, username: 'SecondUser', iconUrl: null, averageScore: 8.0, sessionCount: 5 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseRanking.mockReturnValue({
+      ranking: mockRanking,
+      period: 'weekly',
+      changePeriod: vi.fn(),
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('ランキングタイトルを表示する', () => {
+    renderPage();
+    expect(screen.getByText('ランキング')).toBeInTheDocument();
+  });
+
+  it('ランキングエントリーを表示する', () => {
+    renderPage();
+    expect(screen.getByText('TopUser')).toBeInTheDocument();
+    // SecondUserはmyRankingとentriesの両方に表示される
+    expect(screen.getAllByText('SecondUser').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('自分の順位セクションを表示する', () => {
+    renderPage();
+    expect(screen.getByText('あなたの順位')).toBeInTheDocument();
+  });
+
+  it('ローディング中はローディング表示する', () => {
+    mockedUseRanking.mockReturnValue({
+      ranking: null,
+      period: 'weekly',
+      changePeriod: vi.fn(),
+      loading: true,
+      error: null,
+    });
+    renderPage();
+    expect(screen.getByText('ランキングを読み込み中...')).toBeInTheDocument();
+  });
+
+  it('エラー時はエラーメッセージを表示する', () => {
+    mockedUseRanking.mockReturnValue({
+      ranking: null,
+      period: 'weekly',
+      changePeriod: vi.fn(),
+      loading: false,
+      error: 'ランキングの取得に失敗しました',
+    });
+    renderPage();
+    expect(screen.getByText('ランキングの取得に失敗しました')).toBeInTheDocument();
+  });
+
+  it('期間ボタンをクリックするとchangePeriodが呼ばれる', () => {
+    const changePeriod = vi.fn();
+    mockedUseRanking.mockReturnValue({
+      ranking: mockRanking,
+      period: 'weekly',
+      changePeriod,
+      loading: false,
+      error: null,
+    });
+    renderPage();
+    fireEvent.click(screen.getByTestId('period-monthly'));
+    expect(changePeriod).toHaveBeenCalledWith('monthly');
+  });
+});

--- a/frontend/src/repositories/RankingRepository.ts
+++ b/frontend/src/repositories/RankingRepository.ts
@@ -1,0 +1,11 @@
+import apiClient from '../lib/axios';
+import { Ranking } from '../types';
+
+export const RankingRepository = {
+  async fetchRanking(period: string = 'weekly'): Promise<Ranking> {
+    const response = await apiClient.get<Ranking>('/api/ranking', {
+      params: { period },
+    });
+    return response.data;
+  },
+};

--- a/frontend/src/repositories/__tests__/RankingRepository.test.ts
+++ b/frontend/src/repositories/__tests__/RankingRepository.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from '../../lib/axios';
+import { RankingRepository } from '../RankingRepository';
+
+vi.mock('../../lib/axios');
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('RankingRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchRanking', () => {
+    it('デフォルトでweeklyのランキングを取得する', async () => {
+      const mockData = { entries: [], myRanking: null };
+      mockedApiClient.get.mockResolvedValue({ data: mockData });
+
+      const result = await RankingRepository.fetchRanking();
+
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/ranking', {
+        params: { period: 'weekly' },
+      });
+      expect(result).toEqual(mockData);
+    });
+
+    it('指定した期間でランキングを取得する', async () => {
+      const mockData = { entries: [], myRanking: null };
+      mockedApiClient.get.mockResolvedValue({ data: mockData });
+
+      await RankingRepository.fetchRanking('monthly');
+
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/ranking', {
+        params: { period: 'monthly' },
+      });
+    });
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -207,3 +207,19 @@ export interface FollowStatus {
   isFollowedBy: boolean;
   isMutual: boolean;
 }
+
+/** ランキングエントリー */
+export interface RankingEntry {
+  rank: number;
+  userId: number;
+  username: string;
+  iconUrl: string | null;
+  averageScore: number;
+  sessionCount: number;
+}
+
+/** ランキング */
+export interface Ranking {
+  entries: RankingEntry[];
+  myRanking: RankingEntry | null;
+}


### PR DESCRIPTION
## 概要
- コミュニケーションスコアの平均値に基づく週間・月間ランキングを表示する機能を追加
- ゲーミフィケーションによりユーザーのモチベーション向上を図る

## 変更内容
### バックエンド
- `RankingController` - `GET /api/ranking?period=weekly|monthly`
- `GetRankingUseCase` - ランキング取得ユースケース
- `RankingService` - 平均スコアでのランキング生成ロジック
- `RankingDto` - ランキングレスポンスDTO
- `CommunicationScoreRepository` - ユーザー平均スコア集計クエリ追加

### フロントエンド
- `RankingPage` - ランキング表示ページ（メダル表示、自分の順位ハイライト）
- `useRanking` - ランキング取得・期間切替フック
- `RankingRepository` - API呼び出し
- メニューにランキングへのナビゲーションリンク追加

## テスト
### バックエンド (7テスト)
- `RankingControllerTest` - 3テスト
- `GetRankingUseCaseTest` - 1テスト
- `RankingServiceTest` - 3テスト

### フロントエンド (11テスト)
- `RankingRepository.test.ts` - 2テスト
- `useRanking.test.ts` - 3テスト
- `RankingPage.test.tsx` - 6テスト

Closes #1434