### PR TITLE
feat: 会話テンプレート機能を追加 (#1436)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ConversationTemplateController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ConversationTemplateController.java
@@ -1,0 +1,46 @@
+package com.example.FreStyle.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+import com.example.FreStyle.dto.ConversationTemplateDto;
+import com.example.FreStyle.usecase.GetConversationTemplatesUseCase;
+import com.example.FreStyle.usecase.GetConversationTemplateByIdUseCase;
+import com.example.FreStyle.entity.ConversationTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/templates")
+@Slf4j
+public class ConversationTemplateController {
+    private final GetConversationTemplatesUseCase getTemplatesUseCase;
+    private final GetConversationTemplateByIdUseCase getTemplateByIdUseCase;
+
+    @GetMapping
+    public ResponseEntity<List<ConversationTemplateDto>> getTemplates(
+            @AuthenticationPrincipal Jwt jwt,
+            @RequestParam(required = false) String category
+    ) {
+        log.info("========== GET /api/templates?category={} ==========", category);
+        List<ConversationTemplateDto> templates = getTemplatesUseCase.execute(category);
+        log.info("テンプレート一覧取得成功 - 件数: {}", templates.size());
+        return ResponseEntity.ok(templates);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ConversationTemplateDto> getTemplateById(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer id
+    ) {
+        log.info("========== GET /api/templates/{} ==========", id);
+        ConversationTemplate t = getTemplateByIdUseCase.execute(id);
+        ConversationTemplateDto dto = new ConversationTemplateDto(
+            t.getId(), t.getTitle(), t.getDescription(),
+            t.getCategory(), t.getOpeningMessage(), t.getDifficulty());
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ConversationTemplateDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ConversationTemplateDto.java
@@ -1,0 +1,10 @@
+package com.example.FreStyle.dto;
+
+public record ConversationTemplateDto(
+    Integer id,
+    String title,
+    String description,
+    String category,
+    String openingMessage,
+    String difficulty
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/ConversationTemplate.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/ConversationTemplate.java
@@ -1,0 +1,37 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "conversation_templates")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationTemplate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "title", length = 100, nullable = false)
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "category", length = 50, nullable = false)
+    private String category;
+
+    @Column(name = "opening_message", columnDefinition = "TEXT", nullable = false)
+    private String openingMessage;
+
+    @Column(name = "system_context", columnDefinition = "TEXT", nullable = false)
+    private String systemContext;
+
+    @Column(name = "difficulty", length = 20)
+    private String difficulty;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/ConversationTemplateRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/ConversationTemplateRepository.java
@@ -1,0 +1,12 @@
+package com.example.FreStyle.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.example.FreStyle.entity.ConversationTemplate;
+
+@Repository
+public interface ConversationTemplateRepository extends JpaRepository<ConversationTemplate, Integer> {
+    List<ConversationTemplate> findByCategory(String category);
+    List<ConversationTemplate> findByDifficulty(String difficulty);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetConversationTemplateByIdUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetConversationTemplateByIdUseCase.java
@@ -1,0 +1,19 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.FreStyle.entity.ConversationTemplate;
+import com.example.FreStyle.repository.ConversationTemplateRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetConversationTemplateByIdUseCase {
+    private final ConversationTemplateRepository repository;
+
+    public ConversationTemplate execute(Integer id) {
+        return repository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("テンプレートが見つかりません: " + id));
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetConversationTemplatesUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetConversationTemplatesUseCase.java
@@ -1,0 +1,28 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.FreStyle.dto.ConversationTemplateDto;
+import com.example.FreStyle.entity.ConversationTemplate;
+import com.example.FreStyle.repository.ConversationTemplateRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetConversationTemplatesUseCase {
+    private final ConversationTemplateRepository repository;
+
+    public List<ConversationTemplateDto> execute(String category) {
+        List<ConversationTemplate> templates = (category == null || category.isEmpty())
+            ? repository.findAll()
+            : repository.findByCategory(category);
+
+        return templates.stream()
+            .map(t -> new ConversationTemplateDto(
+                t.getId(), t.getTitle(), t.getDescription(),
+                t.getCategory(), t.getOpeningMessage(), t.getDifficulty()))
+            .toList();
+    }
+}

--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -270,6 +270,29 @@ CREATE TABLE IF NOT EXISTS session_notes (
     FOREIGN KEY (session_id) REFERENCES ai_chat_sessions(id) ON DELETE CASCADE
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- 会話テンプレート
+CREATE TABLE IF NOT EXISTS conversation_templates (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(100) NOT NULL,
+    description TEXT,
+    category VARCHAR(50) NOT NULL,
+    opening_message TEXT NOT NULL,
+    system_context TEXT NOT NULL,
+    difficulty VARCHAR(20) DEFAULT 'intermediate',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- 初期テンプレートデータ
+INSERT IGNORE INTO conversation_templates (id, title, description, category, opening_message, system_context, difficulty) VALUES
+(1, '会議の進行', 'チーム定例会議のファシリテーション練習', 'meeting', 'それでは定例会議を始めます。まず先週の進捗を確認しましょう。', 'あなたはチームメンバーとして定例会議に参加しています。', 'beginner'),
+(2, 'プレゼン質疑応答', '技術プレゼン後の質疑応答対応', 'presentation', 'プレゼンありがとうございました。いくつか質問があります。', 'プレゼンテーション後の質疑応答の場面です。技術的な質問や懸念に対応してください。', 'intermediate'),
+(3, '商談クロージング', '契約締結に向けた最終交渉', 'negotiation', '提案内容については概ね理解しました。いくつか条件を確認させてください。', '商談の最終段階で、契約条件の詰めを行う場面です。', 'advanced'),
+(4, '報告メール作成', '上司への週次報告メールの作成練習', 'email', '今週の報告をお願いします。主要なトピックを教えてください。', '週次報告メールを作成する場面です。要点を簡潔にまとめる練習です。', 'beginner'),
+(5, 'クレーム対応', '顧客からのクレームに対する初期対応', 'customer_support', 'サービスに問題があり、非常に困っています。', '顧客からクレームを受けた場面です。まず共感と謝罪から始めてください。', 'intermediate'),
+(6, 'チーム1on1', 'メンバーとの1on1ミーティング練習', 'meeting', '最近の業務で気になることはありますか？', 'マネージャーとしてチームメンバーと1on1を行う場面です。', 'beginner'),
+(7, '技術提案書説明', '非技術者への技術提案の説明', 'presentation', '新しいシステムの提案について説明をお願いします。', '経営層に対して技術的な提案を分かりやすく説明する場面です。', 'advanced'),
+(8, '予算交渉', 'プロジェクト予算の追加要求', 'negotiation', '追加予算の件ですが、もう少し詳しく聞かせてください。', 'プロジェクトの予算追加を上層部に交渉する場面です。', 'advanced');
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ConversationTemplateControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ConversationTemplateControllerTest.java
@@ -1,0 +1,118 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.ConversationTemplateDto;
+import com.example.FreStyle.entity.ConversationTemplate;
+import com.example.FreStyle.usecase.GetConversationTemplatesUseCase;
+import com.example.FreStyle.usecase.GetConversationTemplateByIdUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ConversationTemplateController")
+class ConversationTemplateControllerTest {
+
+    @Mock
+    private GetConversationTemplatesUseCase getTemplatesUseCase;
+
+    @Mock
+    private GetConversationTemplateByIdUseCase getTemplateByIdUseCase;
+
+    @InjectMocks
+    private ConversationTemplateController controller;
+
+    private Jwt jwt;
+
+    @BeforeEach
+    void setUp() {
+        jwt = mock(Jwt.class);
+    }
+
+    @Nested
+    @DisplayName("GET /api/templates")
+    class GetTemplates {
+
+        @Test
+        @DisplayName("テンプレート一覧を取得する")
+        void shouldReturnTemplateList() {
+            // Arrange
+            List<ConversationTemplateDto> templates = List.of(
+                    new ConversationTemplateDto(1, "会議の進行", "会議練習", "meeting", "定例会議を始めます", "beginner"),
+                    new ConversationTemplateDto(2, "プレゼン質疑応答", "質疑応答対応", "presentation", "質問があります", "intermediate")
+            );
+            when(getTemplatesUseCase.execute(null)).thenReturn(templates);
+
+            // Act
+            ResponseEntity<List<ConversationTemplateDto>> response = controller.getTemplates(jwt, null);
+
+            // Assert
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).hasSize(2);
+            verify(getTemplatesUseCase).execute(null);
+        }
+
+        @Test
+        @DisplayName("カテゴリでフィルタリングする")
+        void shouldFilterByCategory() {
+            // Arrange
+            List<ConversationTemplateDto> templates = List.of(
+                    new ConversationTemplateDto(1, "会議の進行", "会議練習", "meeting", "定例会議を始めます", "beginner")
+            );
+            when(getTemplatesUseCase.execute("meeting")).thenReturn(templates);
+
+            // Act
+            ResponseEntity<List<ConversationTemplateDto>> response = controller.getTemplates(jwt, "meeting");
+
+            // Assert
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).hasSize(1);
+            assertThat(response.getBody().get(0).category()).isEqualTo("meeting");
+            verify(getTemplatesUseCase).execute("meeting");
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/templates/{id}")
+    class GetTemplateById {
+
+        @Test
+        @DisplayName("IDでテンプレートを取得する")
+        void shouldReturnTemplateById() {
+            // Arrange
+            ConversationTemplate template = new ConversationTemplate();
+            template.setId(1);
+            template.setTitle("会議の進行");
+            template.setDescription("会議練習");
+            template.setCategory("meeting");
+            template.setOpeningMessage("定例会議を始めます");
+            template.setDifficulty("beginner");
+
+            when(getTemplateByIdUseCase.execute(1)).thenReturn(template);
+
+            // Act
+            ResponseEntity<ConversationTemplateDto> response = controller.getTemplateById(jwt, 1);
+
+            // Assert
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().id()).isEqualTo(1);
+            assertThat(response.getBody().title()).isEqualTo("会議の進行");
+            verify(getTemplateByIdUseCase).execute(1);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetConversationTemplateByIdUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetConversationTemplateByIdUseCaseTest.java
@@ -1,0 +1,72 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.ConversationTemplate;
+import com.example.FreStyle.repository.ConversationTemplateRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetConversationTemplateByIdUseCase")
+class GetConversationTemplateByIdUseCaseTest {
+
+    @Mock
+    private ConversationTemplateRepository repository;
+
+    @InjectMocks
+    private GetConversationTemplateByIdUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - IDでテンプレート取得")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("IDでテンプレートを取得する")
+        void shouldReturnTemplateById() {
+            // Arrange
+            ConversationTemplate template = new ConversationTemplate();
+            template.setId(1);
+            template.setTitle("会議の進行");
+            template.setCategory("meeting");
+            template.setOpeningMessage("定例会議を始めます");
+            template.setSystemContext("チームメンバーとして参加");
+            template.setDifficulty("beginner");
+
+            when(repository.findById(1)).thenReturn(Optional.of(template));
+
+            // Act
+            ConversationTemplate result = useCase.execute(1);
+
+            // Assert
+            assertThat(result.getId()).isEqualTo(1);
+            assertThat(result.getTitle()).isEqualTo("会議の進行");
+            verify(repository).findById(1);
+        }
+
+        @Test
+        @DisplayName("存在しないIDで例外を投げる")
+        void shouldThrowExceptionWhenNotFound() {
+            // Arrange
+            when(repository.findById(999)).thenReturn(Optional.empty());
+
+            // Act & Assert
+            assertThatThrownBy(() -> useCase.execute(999))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("テンプレートが見つかりません: 999");
+
+            verify(repository).findById(999);
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetConversationTemplatesUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetConversationTemplatesUseCaseTest.java
@@ -1,0 +1,121 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ConversationTemplateDto;
+import com.example.FreStyle.entity.ConversationTemplate;
+import com.example.FreStyle.repository.ConversationTemplateRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetConversationTemplatesUseCase")
+class GetConversationTemplatesUseCaseTest {
+
+    @Mock
+    private ConversationTemplateRepository repository;
+
+    @InjectMocks
+    private GetConversationTemplatesUseCase useCase;
+
+    @Nested
+    @DisplayName("execute - テンプレート一覧取得")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("全テンプレートを取得する")
+        void shouldReturnAllTemplates() {
+            // Arrange
+            List<ConversationTemplate> templates = List.of(
+                    createTemplate(1, "会議の進行", "会議練習", "meeting", "定例会議を始めます", "チームメンバーとして参加", "beginner"),
+                    createTemplate(2, "プレゼン質疑応答", "質疑応答対応", "presentation", "質問があります", "質疑応答の場面", "intermediate")
+            );
+            when(repository.findAll()).thenReturn(templates);
+
+            // Act
+            List<ConversationTemplateDto> result = useCase.execute(null);
+
+            // Assert
+            assertThat(result).hasSize(2);
+            verify(repository).findAll();
+        }
+
+        @Test
+        @DisplayName("カテゴリ指定で取得する")
+        void shouldReturnTemplatesByCategory() {
+            // Arrange
+            List<ConversationTemplate> templates = List.of(
+                    createTemplate(1, "会議の進行", "会議練習", "meeting", "定例会議を始めます", "チームメンバーとして参加", "beginner")
+            );
+            when(repository.findByCategory("meeting")).thenReturn(templates);
+
+            // Act
+            List<ConversationTemplateDto> result = useCase.execute("meeting");
+
+            // Assert
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).category()).isEqualTo("meeting");
+            verify(repository).findByCategory("meeting");
+        }
+
+        @Test
+        @DisplayName("DTOに正しく変換する")
+        void shouldConvertToDto() {
+            // Arrange
+            List<ConversationTemplate> templates = List.of(
+                    createTemplate(1, "会議の進行", "会議練習", "meeting", "定例会議を始めます", "チームメンバーとして参加", "beginner")
+            );
+            when(repository.findAll()).thenReturn(templates);
+
+            // Act
+            List<ConversationTemplateDto> result = useCase.execute(null);
+
+            // Assert
+            assertThat(result).hasSize(1);
+            ConversationTemplateDto dto = result.get(0);
+            assertThat(dto.id()).isEqualTo(1);
+            assertThat(dto.title()).isEqualTo("会議の進行");
+            assertThat(dto.description()).isEqualTo("会議練習");
+            assertThat(dto.category()).isEqualTo("meeting");
+            assertThat(dto.openingMessage()).isEqualTo("定例会議を始めます");
+            assertThat(dto.difficulty()).isEqualTo("beginner");
+        }
+
+        @Test
+        @DisplayName("空文字カテゴリは全件取得する")
+        void shouldReturnAllTemplatesWhenCategoryIsEmpty() {
+            // Arrange
+            when(repository.findAll()).thenReturn(List.of());
+
+            // Act
+            List<ConversationTemplateDto> result = useCase.execute("");
+
+            // Assert
+            assertThat(result).isEmpty();
+            verify(repository).findAll();
+        }
+    }
+
+    private ConversationTemplate createTemplate(Integer id, String title, String description,
+            String category, String openingMessage, String systemContext, String difficulty) {
+        ConversationTemplate t = new ConversationTemplate();
+        t.setId(id);
+        t.setTitle(title);
+        t.setDescription(description);
+        t.setCategory(category);
+        t.setOpeningMessage(openingMessage);
+        t.setSystemContext(systemContext);
+        t.setDifficulty(difficulty);
+        return t;
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ const NotificationPage = lazy(() => import('./pages/NotificationPage'));
 const LearningReportPage = lazy(() => import('./pages/LearningReportPage'));
 const FriendshipPage = lazy(() => import('./pages/FriendshipPage'));
 const RankingPage = lazy(() => import('./pages/RankingPage'));
+const TemplatePage = lazy(() => import('./pages/TemplatePage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -91,6 +92,7 @@ export default function App() {
         <Route path="/reports" element={<LearningReportPage />} />
         <Route path="/friends" element={<FriendshipPage />} />
         <Route path="/ranking" element={<RankingPage />} />
+        <Route path="/templates" element={<TemplatePage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -5,6 +5,7 @@ import {
   AcademicCapIcon,
   ChartBarIcon,
   TrophyIcon,
+  DocumentTextIcon,
 } from '@heroicons/react/24/outline';
 import Card from './Card';
 
@@ -47,6 +48,13 @@ const MENU_ITEMS = [
     label: 'ランキング',
     description: 'ユーザー間のスコアランキング',
     to: '/ranking',
+    badgeKey: null,
+  },
+  {
+    icon: DocumentTextIcon,
+    label: '会話テンプレート',
+    description: 'シーン別の会話テンプレートで練習',
+    to: '/templates',
     badgeKey: null,
   },
 ];

--- a/frontend/src/hooks/__tests__/useTemplates.test.ts
+++ b/frontend/src/hooks/__tests__/useTemplates.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useTemplates } from '../useTemplates';
+import { TemplateRepository } from '../../repositories/TemplateRepository';
+
+vi.mock('../../repositories/TemplateRepository');
+const mockedRepo = vi.mocked(TemplateRepository);
+
+describe('useTemplates', () => {
+  const mockTemplates = [
+    { id: 1, title: '会議の進行', description: 'desc', category: 'meeting', openingMessage: 'msg', difficulty: 'beginner' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchTemplates.mockResolvedValue(mockTemplates);
+  });
+
+  it('初期ロード時に全テンプレートを取得する', async () => {
+    const { result } = renderHook(() => useTemplates());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.templates).toEqual(mockTemplates);
+    expect(mockedRepo.fetchTemplates).toHaveBeenCalledWith(undefined);
+  });
+
+  it('カテゴリ変更でデータを再取得する', async () => {
+    const { result } = renderHook(() => useTemplates());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.changeCategory('meeting'));
+    await waitFor(() => expect(mockedRepo.fetchTemplates).toHaveBeenCalledWith('meeting'));
+  });
+
+  it('エラー時にエラーメッセージを設定する', async () => {
+    mockedRepo.fetchTemplates.mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useTemplates());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('テンプレートの取得に失敗しました');
+  });
+});

--- a/frontend/src/hooks/useTemplates.ts
+++ b/frontend/src/hooks/useTemplates.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react';
+import { TemplateRepository } from '../repositories/TemplateRepository';
+import { ConversationTemplate } from '../types';
+
+const CATEGORIES = [
+  { key: '', label: 'すべて' },
+  { key: 'meeting', label: '会議' },
+  { key: 'presentation', label: 'プレゼン' },
+  { key: 'negotiation', label: '商談' },
+  { key: 'email', label: 'メール' },
+  { key: 'customer_support', label: 'サポート' },
+];
+
+export function useTemplates() {
+  const [templates, setTemplates] = useState<ConversationTemplate[]>([]);
+  const [category, setCategory] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    TemplateRepository.fetchTemplates(category || undefined)
+      .then((data) => {
+        if (!cancelled) setTemplates(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('テンプレートの取得に失敗しました');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [category]);
+
+  const changeCategory = useCallback((newCategory: string) => {
+    setCategory(newCategory);
+  }, []);
+
+  return { templates, category, categories: CATEGORIES, changeCategory, loading, error };
+}

--- a/frontend/src/pages/TemplatePage.tsx
+++ b/frontend/src/pages/TemplatePage.tsx
@@ -1,0 +1,83 @@
+import { useNavigate } from 'react-router-dom';
+import { useTemplates } from '../hooks/useTemplates';
+import Loading from '../components/Loading';
+import { ConversationTemplate } from '../types';
+
+const difficultyLabels: Record<string, { label: string; color: string }> = {
+  beginner: { label: '初級', color: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400' },
+  intermediate: { label: '中級', color: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' },
+  advanced: { label: '上級', color: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' },
+};
+
+function TemplateCard({ template, onStart }: { template: ConversationTemplate; onStart: () => void }) {
+  const diff = difficultyLabels[template.difficulty] ?? difficultyLabels.intermediate;
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-2" data-testid={`template-${template.id}`}>
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold">{template.title}</h3>
+        <span className={`text-xs px-2 py-0.5 rounded-full ${diff.color}`}>{diff.label}</span>
+      </div>
+      <p className="text-sm text-gray-500 dark:text-gray-400">{template.description}</p>
+      <div className="bg-gray-50 dark:bg-gray-700/50 rounded p-2">
+        <p className="text-xs text-gray-400 mb-1">会話の出だし:</p>
+        <p className="text-sm italic">{template.openingMessage}</p>
+      </div>
+      <button
+        onClick={onStart}
+        className="w-full mt-2 px-4 py-2 bg-blue-500 text-white rounded-lg text-sm font-medium hover:bg-blue-600 transition-colors"
+        data-testid={`start-template-${template.id}`}
+      >
+        このテンプレートで練習する
+      </button>
+    </div>
+  );
+}
+
+export default function TemplatePage() {
+  const navigate = useNavigate();
+  const { templates, category, categories, changeCategory, loading, error } = useTemplates();
+
+  const handleStart = (template: ConversationTemplate) => {
+    navigate('/chat/ask-ai', {
+      state: { templateTitle: template.title, templateMessage: template.openingMessage },
+    });
+  };
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-xl font-bold">会話テンプレート</h1>
+
+      <div className="flex gap-2 overflow-x-auto pb-2">
+        {categories.map((cat) => (
+          <button
+            key={cat.key}
+            onClick={() => changeCategory(cat.key)}
+            className={`px-3 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
+              category === cat.key
+                ? 'bg-blue-500 text-white'
+                : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+            }`}
+            data-testid={`category-${cat.key || 'all'}`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {loading && <Loading message="テンプレートを読み込み中..." />}
+      {error && <p className="text-red-500 text-center">{error}</p>}
+
+      {!loading && !error && templates.length === 0 && (
+        <p className="text-gray-400 text-center py-8">テンプレートがありません</p>
+      )}
+
+      {!loading && !error && (
+        <div className="space-y-3">
+          {templates.map((t) => (
+            <TemplateCard key={t.id} template={t} onStart={() => handleStart(t)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/TemplatePage.test.tsx
+++ b/frontend/src/pages/__tests__/TemplatePage.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TemplatePage from '../TemplatePage';
+import { useTemplates } from '../../hooks/useTemplates';
+
+vi.mock('../../hooks/useTemplates');
+const mockedUseTemplates = vi.mocked(useTemplates);
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function renderPage() {
+  return render(<MemoryRouter><TemplatePage /></MemoryRouter>);
+}
+
+describe('TemplatePage', () => {
+  const mockTemplates = [
+    { id: 1, title: '会議の進行', description: 'ファシリテーション', category: 'meeting', openingMessage: 'msg', difficulty: 'beginner' },
+    { id: 2, title: 'プレゼン質疑', description: '質問対応', category: 'presentation', openingMessage: 'msg2', difficulty: 'intermediate' },
+  ];
+  const categories = [
+    { key: '', label: 'すべて' },
+    { key: 'meeting', label: '会議' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseTemplates.mockReturnValue({
+      templates: mockTemplates,
+      category: '',
+      categories,
+      changeCategory: vi.fn(),
+      loading: false,
+      error: null,
+    });
+  });
+
+  it('タイトルを表示する', () => {
+    renderPage();
+    expect(screen.getByText('会話テンプレート')).toBeInTheDocument();
+  });
+
+  it('テンプレートカードを表示する', () => {
+    renderPage();
+    expect(screen.getByText('会議の進行')).toBeInTheDocument();
+    expect(screen.getByText('プレゼン質疑')).toBeInTheDocument();
+  });
+
+  it('ローディング中はローディング表示する', () => {
+    mockedUseTemplates.mockReturnValue({ templates: [], category: '', categories, changeCategory: vi.fn(), loading: true, error: null });
+    renderPage();
+    expect(screen.getByText('テンプレートを読み込み中...')).toBeInTheDocument();
+  });
+
+  it('練習開始ボタンクリックでAIチャットに遷移する', () => {
+    renderPage();
+    fireEvent.click(screen.getAllByText('このテンプレートで練習する')[0]);
+    expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai', {
+      state: { templateTitle: '会議の進行', templateMessage: 'msg' },
+    });
+  });
+
+  it('エラー時にエラーメッセージを表示する', () => {
+    mockedUseTemplates.mockReturnValue({ templates: [], category: '', categories, changeCategory: vi.fn(), loading: false, error: 'テンプレートの取得に失敗しました' });
+    renderPage();
+    expect(screen.getByText('テンプレートの取得に失敗しました')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/TemplateRepository.ts
+++ b/frontend/src/repositories/TemplateRepository.ts
@@ -1,0 +1,16 @@
+import apiClient from '../lib/axios';
+import { ConversationTemplate } from '../types';
+
+export const TemplateRepository = {
+  async fetchTemplates(category?: string): Promise<ConversationTemplate[]> {
+    const response = await apiClient.get<ConversationTemplate[]>('/api/templates', {
+      params: category ? { category } : {},
+    });
+    return response.data;
+  },
+
+  async fetchTemplateById(id: number): Promise<ConversationTemplate> {
+    const response = await apiClient.get<ConversationTemplate>(`/api/templates/${id}`);
+    return response.data;
+  },
+};

--- a/frontend/src/repositories/__tests__/TemplateRepository.test.ts
+++ b/frontend/src/repositories/__tests__/TemplateRepository.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from '../../lib/axios';
+import { TemplateRepository } from '../TemplateRepository';
+
+vi.mock('../../lib/axios');
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('TemplateRepository', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('fetchTemplates', () => {
+    it('カテゴリなしで全テンプレートを取得する', async () => {
+      mockedApiClient.get.mockResolvedValue({ data: [] });
+      await TemplateRepository.fetchTemplates();
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/templates', { params: {} });
+    });
+
+    it('カテゴリ指定でテンプレートを取得する', async () => {
+      mockedApiClient.get.mockResolvedValue({ data: [] });
+      await TemplateRepository.fetchTemplates('meeting');
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/templates', { params: { category: 'meeting' } });
+    });
+  });
+
+  describe('fetchTemplateById', () => {
+    it('IDでテンプレートを取得する', async () => {
+      const mockTemplate = { id: 1, title: 'Test', description: '', category: 'meeting', openingMessage: 'Hello', difficulty: 'beginner' };
+      mockedApiClient.get.mockResolvedValue({ data: mockTemplate });
+      const result = await TemplateRepository.fetchTemplateById(1);
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/templates/1');
+      expect(result).toEqual(mockTemplate);
+    });
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -223,3 +223,13 @@ export interface Ranking {
   entries: RankingEntry[];
   myRanking: RankingEntry | null;
 }
+
+/** 会話テンプレート */
+export interface ConversationTemplate {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  openingMessage: string;
+  difficulty: string;
+}


### PR DESCRIPTION
## 概要
- ビジネスシーン別の会話テンプレートを用意し、ワンタップでAI練習を開始できる機能を追加
- カテゴリ別フィルタリング（会議・プレゼン・商談・メール・サポート）

## 変更内容
### バックエンド
- `ConversationTemplate` エンティティ + DBテーブル（8件の初期データ）
- `ConversationTemplateController` - `GET /api/templates`, `GET /api/templates/{id}`
- `GetConversationTemplatesUseCase` / `GetConversationTemplateByIdUseCase`

### フロントエンド
- `TemplatePage` - テンプレート一覧（難易度バッジ・カテゴリタブ・会話出だしプレビュー）
- `useTemplates` フック
- `TemplateRepository` - API呼び出し
- メニューにテンプレートへのナビゲーション追加

## テスト
- バックエンド: 9テスト（Controller 3 + UseCase 6）
- フロントエンド: 11テスト（Repository 3 + Hook 3 + Page 5）

Closes #1436