### PR TITLE
feat: 練習リマインダー機能を追加 (#1438)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/ReminderSettingController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/ReminderSettingController.java
@@ -1,0 +1,45 @@
+package com.example.FreStyle.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+import com.example.FreStyle.dto.ReminderSettingDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.ReminderSettingForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetReminderSettingUseCase;
+import com.example.FreStyle.usecase.SaveReminderSettingUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reminder")
+@Slf4j
+public class ReminderSettingController {
+    private final UserIdentityService userIdentityService;
+    private final GetReminderSettingUseCase getReminderSettingUseCase;
+    private final SaveReminderSettingUseCase saveReminderSettingUseCase;
+
+    @GetMapping
+    public ResponseEntity<ReminderSettingDto> getSetting(@AuthenticationPrincipal Jwt jwt) {
+        log.info("========== GET /api/reminder ==========");
+        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        ReminderSettingDto setting = getReminderSettingUseCase.execute(user.getId());
+        return ResponseEntity.ok(setting);
+    }
+
+    @PutMapping
+    public ResponseEntity<ReminderSettingDto> saveSetting(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody ReminderSettingForm form
+    ) {
+        log.info("========== PUT /api/reminder ==========");
+        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        ReminderSettingDto setting = saveReminderSettingUseCase.execute(user.getId(), form);
+        log.info("リマインダー設定保存成功 - userId: {}", user.getId());
+        return ResponseEntity.ok(setting);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/ReminderSettingDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/ReminderSettingDto.java
@@ -1,0 +1,7 @@
+package com.example.FreStyle.dto;
+
+public record ReminderSettingDto(
+    boolean enabled,
+    String reminderTime,
+    String daysOfWeek
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/ReminderSetting.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/ReminderSetting.java
@@ -1,0 +1,32 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "reminder_settings")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReminderSetting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private Boolean enabled;
+
+    @Column(name = "reminder_time", length = 5, nullable = false)
+    private String reminderTime;
+
+    @Column(name = "days_of_week", length = 50, nullable = false)
+    private String daysOfWeek;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private Timestamp updatedAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/form/ReminderSettingForm.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/form/ReminderSettingForm.java
@@ -1,0 +1,11 @@
+package com.example.FreStyle.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record ReminderSettingForm(
+    @NotNull Boolean enabled,
+    @NotBlank @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$") String reminderTime,
+    @NotBlank String daysOfWeek
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/ReminderSettingRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/ReminderSettingRepository.java
@@ -1,0 +1,11 @@
+package com.example.FreStyle.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.example.FreStyle.entity.ReminderSetting;
+
+@Repository
+public interface ReminderSettingRepository extends JpaRepository<ReminderSetting, Integer> {
+    Optional<ReminderSetting> findByUserId(Integer userId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetReminderSettingUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetReminderSettingUseCase.java
@@ -1,0 +1,20 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.FreStyle.dto.ReminderSettingDto;
+import com.example.FreStyle.repository.ReminderSettingRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetReminderSettingUseCase {
+    private final ReminderSettingRepository repository;
+
+    public ReminderSettingDto execute(Integer userId) {
+        return repository.findByUserId(userId)
+            .map(s -> new ReminderSettingDto(s.getEnabled(), s.getReminderTime(), s.getDaysOfWeek()))
+            .orElse(new ReminderSettingDto(true, "20:00", "mon,tue,wed,thu,fri"));
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveReminderSettingUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/SaveReminderSettingUseCase.java
@@ -1,0 +1,39 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.FreStyle.dto.ReminderSettingDto;
+import com.example.FreStyle.entity.ReminderSetting;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.ReminderSettingForm;
+import com.example.FreStyle.repository.ReminderSettingRepository;
+import com.example.FreStyle.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SaveReminderSettingUseCase {
+    private final ReminderSettingRepository reminderSettingRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ReminderSettingDto execute(Integer userId, ReminderSettingForm form) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("ユーザーが見つかりません"));
+
+        ReminderSetting setting = reminderSettingRepository.findByUserId(userId)
+            .orElseGet(() -> {
+                ReminderSetting s = new ReminderSetting();
+                s.setUser(user);
+                return s;
+            });
+
+        setting.setEnabled(form.enabled());
+        setting.setReminderTime(form.reminderTime());
+        setting.setDaysOfWeek(form.daysOfWeek());
+
+        reminderSettingRepository.save(setting);
+
+        return new ReminderSettingDto(setting.getEnabled(), setting.getReminderTime(), setting.getDaysOfWeek());
+    }
+}

--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -293,6 +293,19 @@ INSERT IGNORE INTO conversation_templates (id, title, description, category, ope
 (7, '技術提案書説明', '非技術者への技術提案の説明', 'presentation', '新しいシステムの提案について説明をお願いします。', '経営層に対して技術的な提案を分かりやすく説明する場面です。', 'advanced'),
 (8, '予算交渉', 'プロジェクト予算の追加要求', 'negotiation', '追加予算の件ですが、もう少し詳しく聞かせてください。', 'プロジェクトの予算追加を上層部に交渉する場面です。', 'advanced');
 
+-- リマインダー設定
+CREATE TABLE IF NOT EXISTS reminder_settings (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    reminder_time VARCHAR(5) NOT NULL DEFAULT '20:00',
+    days_of_week VARCHAR(50) NOT NULL DEFAULT 'mon,tue,wed,thu,fri',
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_user_id (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/ReminderSettingControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/ReminderSettingControllerTest.java
@@ -1,0 +1,105 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.ReminderSettingDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.ReminderSettingForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetReminderSettingUseCase;
+import com.example.FreStyle.usecase.SaveReminderSettingUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReminderSettingController")
+class ReminderSettingControllerTest {
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @Mock
+    private GetReminderSettingUseCase getReminderSettingUseCase;
+
+    @Mock
+    private SaveReminderSettingUseCase saveReminderSettingUseCase;
+
+    @InjectMocks
+    private ReminderSettingController controller;
+
+    private Jwt jwt;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("test-sub");
+
+        user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+    }
+
+    @Nested
+    @DisplayName("GET /api/reminder")
+    class GetSetting {
+
+        @Test
+        @DisplayName("設定を取得する")
+        void shouldReturnSetting() {
+            ReminderSettingDto dto = new ReminderSettingDto(true, "20:00", "mon,tue,wed,thu,fri");
+            when(getReminderSettingUseCase.execute(1)).thenReturn(dto);
+
+            ResponseEntity<ReminderSettingDto> response = controller.getSetting(jwt);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().enabled()).isTrue();
+            assertThat(response.getBody().reminderTime()).isEqualTo("20:00");
+            assertThat(response.getBody().daysOfWeek()).isEqualTo("mon,tue,wed,thu,fri");
+        }
+
+        @Test
+        @DisplayName("UseCaseにユーザーIDを渡す")
+        void shouldPassUserIdToUseCase() {
+            when(getReminderSettingUseCase.execute(1)).thenReturn(
+                    new ReminderSettingDto(true, "20:00", "mon,tue,wed,thu,fri"));
+
+            controller.getSetting(jwt);
+
+            verify(getReminderSettingUseCase).execute(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/reminder")
+    class SaveSetting {
+
+        @Test
+        @DisplayName("設定を保存する")
+        void shouldSaveSetting() {
+            ReminderSettingForm form = new ReminderSettingForm(false, "18:30", "mon,wed,fri");
+            ReminderSettingDto dto = new ReminderSettingDto(false, "18:30", "mon,wed,fri");
+            when(saveReminderSettingUseCase.execute(1, form)).thenReturn(dto);
+
+            ResponseEntity<ReminderSettingDto> response = controller.saveSetting(jwt, form);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(200);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().enabled()).isFalse();
+            assertThat(response.getBody().reminderTime()).isEqualTo("18:30");
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetReminderSettingUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetReminderSettingUseCaseTest.java
@@ -1,0 +1,57 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ReminderSettingDto;
+import com.example.FreStyle.entity.ReminderSetting;
+import com.example.FreStyle.repository.ReminderSettingRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetReminderSettingUseCaseTest {
+
+    @Mock
+    private ReminderSettingRepository repository;
+
+    @InjectMocks
+    private GetReminderSettingUseCase useCase;
+
+    @Test
+    @DisplayName("設定が存在する場合にDTOを返す")
+    void execute_returnsDtoWhenSettingExists() {
+        ReminderSetting setting = new ReminderSetting();
+        setting.setEnabled(false);
+        setting.setReminderTime("18:30");
+        setting.setDaysOfWeek("mon,wed,fri");
+        when(repository.findByUserId(1)).thenReturn(Optional.of(setting));
+
+        ReminderSettingDto result = useCase.execute(1);
+
+        assertNotNull(result);
+        assertEquals(false, result.enabled());
+        assertEquals("18:30", result.reminderTime());
+        assertEquals("mon,wed,fri", result.daysOfWeek());
+    }
+
+    @Test
+    @DisplayName("設定が存在しない場合にデフォルト値を返す")
+    void execute_returnsDefaultWhenSettingNotFound() {
+        when(repository.findByUserId(999)).thenReturn(Optional.empty());
+
+        ReminderSettingDto result = useCase.execute(999);
+
+        assertNotNull(result);
+        assertEquals(true, result.enabled());
+        assertEquals("20:00", result.reminderTime());
+        assertEquals("mon,tue,wed,thu,fri", result.daysOfWeek());
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveReminderSettingUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/SaveReminderSettingUseCaseTest.java
@@ -1,0 +1,83 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.ReminderSettingDto;
+import com.example.FreStyle.entity.ReminderSetting;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.ReminderSettingForm;
+import com.example.FreStyle.repository.ReminderSettingRepository;
+import com.example.FreStyle.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SaveReminderSettingUseCaseTest {
+
+    @Mock
+    private ReminderSettingRepository reminderSettingRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private SaveReminderSettingUseCase useCase;
+
+    @Test
+    @DisplayName("既存設定を更新する")
+    void execute_updatesExistingSetting() {
+        User user = new User();
+        user.setId(1);
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
+
+        ReminderSetting existing = new ReminderSetting();
+        existing.setUser(user);
+        existing.setEnabled(true);
+        existing.setReminderTime("20:00");
+        existing.setDaysOfWeek("mon,tue,wed,thu,fri");
+        when(reminderSettingRepository.findByUserId(1)).thenReturn(Optional.of(existing));
+
+        ReminderSettingForm form = new ReminderSettingForm(false, "18:30", "mon,wed,fri");
+
+        ReminderSettingDto result = useCase.execute(1, form);
+
+        verify(reminderSettingRepository).save(argThat(s ->
+                !s.getEnabled() &&
+                s.getReminderTime().equals("18:30") &&
+                s.getDaysOfWeek().equals("mon,wed,fri")));
+        assertEquals(false, result.enabled());
+        assertEquals("18:30", result.reminderTime());
+        assertEquals("mon,wed,fri", result.daysOfWeek());
+    }
+
+    @Test
+    @DisplayName("新規設定を作成する")
+    void execute_createsNewSetting() {
+        User user = new User();
+        user.setId(1);
+        when(userRepository.findById(1)).thenReturn(Optional.of(user));
+        when(reminderSettingRepository.findByUserId(1)).thenReturn(Optional.empty());
+
+        ReminderSettingForm form = new ReminderSettingForm(true, "21:00", "sat,sun");
+
+        ReminderSettingDto result = useCase.execute(1, form);
+
+        verify(reminderSettingRepository).save(argThat(s ->
+                s.getUser().equals(user) &&
+                s.getEnabled() &&
+                s.getReminderTime().equals("21:00") &&
+                s.getDaysOfWeek().equals("sat,sun")));
+        assertEquals(true, result.enabled());
+        assertEquals("21:00", result.reminderTime());
+        assertEquals("sat,sun", result.daysOfWeek());
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ const LearningReportPage = lazy(() => import('./pages/LearningReportPage'));
 const FriendshipPage = lazy(() => import('./pages/FriendshipPage'));
 const RankingPage = lazy(() => import('./pages/RankingPage'));
 const TemplatePage = lazy(() => import('./pages/TemplatePage'));
+const ReminderPage = lazy(() => import('./pages/ReminderPage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -93,6 +94,7 @@ export default function App() {
         <Route path="/friends" element={<FriendshipPage />} />
         <Route path="/ranking" element={<RankingPage />} />
         <Route path="/templates" element={<TemplatePage />} />
+        <Route path="/reminder" element={<ReminderPage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -6,6 +6,7 @@ import {
   ChartBarIcon,
   TrophyIcon,
   DocumentTextIcon,
+  BellAlertIcon,
 } from '@heroicons/react/24/outline';
 import Card from './Card';
 
@@ -55,6 +56,13 @@ const MENU_ITEMS = [
     label: '会話テンプレート',
     description: 'シーン別の会話テンプレートで練習',
     to: '/templates',
+    badgeKey: null,
+  },
+  {
+    icon: BellAlertIcon,
+    label: '練習リマインダー',
+    description: '練習の通知時間・曜日を設定',
+    to: '/reminder',
     badgeKey: null,
   },
 ];

--- a/frontend/src/hooks/__tests__/useReminder.test.ts
+++ b/frontend/src/hooks/__tests__/useReminder.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useReminder } from '../useReminder';
+import { ReminderRepository } from '../../repositories/ReminderRepository';
+
+vi.mock('../../repositories/ReminderRepository');
+const mockedRepo = vi.mocked(ReminderRepository);
+
+describe('useReminder', () => {
+  const mockSetting = { enabled: true, reminderTime: '20:00', daysOfWeek: 'mon,tue,wed,thu,fri' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchSetting.mockResolvedValue(mockSetting);
+    mockedRepo.saveSetting.mockResolvedValue(mockSetting);
+  });
+
+  it('初期ロード時に設定を取得する', async () => {
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.setting).toEqual(mockSetting);
+  });
+
+  it('有効/無効を切り替える', async () => {
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.toggleEnabled());
+    expect(result.current.setting.enabled).toBe(false);
+  });
+
+  it('時間を変更する', async () => {
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.setTime('19:30'));
+    expect(result.current.setting.reminderTime).toBe('19:30');
+  });
+
+  it('曜日を切り替える', async () => {
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.toggleDay('sat'));
+    expect(result.current.selectedDays).toContain('sat');
+  });
+
+  it('設定を保存する', async () => {
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => { await result.current.save(); });
+    expect(mockedRepo.saveSetting).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useReminder.ts
+++ b/frontend/src/hooks/useReminder.ts
@@ -1,0 +1,78 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ReminderRepository } from '../repositories/ReminderRepository';
+import { ReminderSetting } from '../types';
+
+const DAY_OPTIONS = [
+  { key: 'mon', label: '月' },
+  { key: 'tue', label: '火' },
+  { key: 'wed', label: '水' },
+  { key: 'thu', label: '木' },
+  { key: 'fri', label: '金' },
+  { key: 'sat', label: '土' },
+  { key: 'sun', label: '日' },
+];
+
+export function useReminder() {
+  const [setting, setSetting] = useState<ReminderSetting>({
+    enabled: true,
+    reminderTime: '20:00',
+    daysOfWeek: 'mon,tue,wed,thu,fri',
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    ReminderRepository.fetchSetting()
+      .then((data) => {
+        if (!cancelled) setSetting(data);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const toggleEnabled = useCallback(() => {
+    setSetting((prev) => ({ ...prev, enabled: !prev.enabled }));
+  }, []);
+
+  const setTime = useCallback((time: string) => {
+    setSetting((prev) => ({ ...prev, reminderTime: time }));
+  }, []);
+
+  const toggleDay = useCallback((day: string) => {
+    setSetting((prev) => {
+      const days = prev.daysOfWeek.split(',').filter(Boolean);
+      const newDays = days.includes(day)
+        ? days.filter((d) => d !== day)
+        : [...days, day];
+      return { ...prev, daysOfWeek: newDays.join(',') };
+    });
+  }, []);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    try {
+      const saved = await ReminderRepository.saveSetting(setting);
+      setSetting(saved);
+    } finally {
+      setSaving(false);
+    }
+  }, [setting]);
+
+  const selectedDays = setting.daysOfWeek.split(',').filter(Boolean);
+
+  return {
+    setting,
+    loading,
+    saving,
+    toggleEnabled,
+    setTime,
+    toggleDay,
+    save,
+    dayOptions: DAY_OPTIONS,
+    selectedDays,
+  };
+}

--- a/frontend/src/pages/ReminderPage.tsx
+++ b/frontend/src/pages/ReminderPage.tsx
@@ -1,0 +1,86 @@
+import { useReminder } from '../hooks/useReminder';
+import Loading from '../components/Loading';
+import { useToast } from '../hooks/useToast';
+
+export default function ReminderPage() {
+  const { setting, loading, saving, toggleEnabled, setTime, toggleDay, save, dayOptions, selectedDays } = useReminder();
+  const { showToast } = useToast();
+
+  const handleSave = async () => {
+    await save();
+    showToast('success', 'リマインダー設定を保存しました');
+  };
+
+  if (loading) return <Loading message="設定を読み込み中..." />;
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-6">
+      <h1 className="text-xl font-bold">練習リマインダー</h1>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-4">
+        {/* 有効/無効 */}
+        <div className="flex items-center justify-between">
+          <span className="font-medium">リマインダー</span>
+          <button
+            onClick={toggleEnabled}
+            className={`relative w-12 h-6 rounded-full transition-colors ${
+              setting.enabled ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'
+            }`}
+            data-testid="toggle-enabled"
+            role="switch"
+            aria-checked={setting.enabled}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                setting.enabled ? 'translate-x-6' : ''
+              }`}
+            />
+          </button>
+        </div>
+
+        {/* 時間設定 */}
+        <div className="space-y-1">
+          <label className="text-sm text-gray-500">通知時間</label>
+          <input
+            type="time"
+            value={setting.reminderTime}
+            onChange={(e) => setTime(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700"
+            data-testid="time-input"
+          />
+        </div>
+
+        {/* 曜日設定 */}
+        <div className="space-y-1">
+          <label className="text-sm text-gray-500">通知する曜日</label>
+          <div className="flex gap-2">
+            {dayOptions.map((day) => (
+              <button
+                key={day.key}
+                onClick={() => toggleDay(day.key)}
+                className={`w-9 h-9 rounded-full text-sm font-medium transition-colors ${
+                  selectedDays.includes(day.key)
+                    ? 'bg-blue-500 text-white'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-500'
+                }`}
+                data-testid={`day-${day.key}`}
+              >
+                {day.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 保存ボタン */}
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className="w-full px-4 py-2 bg-blue-500 text-white rounded-lg font-medium hover:bg-blue-600 disabled:opacity-50 transition-colors"
+          data-testid="save-button"
+        >
+          {saving ? '保存中...' : '設定を保存'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/ReminderPage.test.tsx
+++ b/frontend/src/pages/__tests__/ReminderPage.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ReminderPage from '../ReminderPage';
+import { useReminder } from '../../hooks/useReminder';
+
+vi.mock('../../hooks/useReminder');
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+const mockedUseReminder = vi.mocked(useReminder);
+
+function renderPage() {
+  return render(<MemoryRouter><ReminderPage /></MemoryRouter>);
+}
+
+describe('ReminderPage', () => {
+  const defaultReturn = {
+    setting: { enabled: true, reminderTime: '20:00', daysOfWeek: 'mon,tue,wed,thu,fri' },
+    loading: false,
+    saving: false,
+    toggleEnabled: vi.fn(),
+    setTime: vi.fn(),
+    toggleDay: vi.fn(),
+    save: vi.fn(),
+    dayOptions: [{ key: 'mon', label: '月' }, { key: 'tue', label: '火' }],
+    selectedDays: ['mon', 'tue'],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseReminder.mockReturnValue(defaultReturn);
+  });
+
+  it('タイトルを表示する', () => {
+    renderPage();
+    expect(screen.getByText('練習リマインダー')).toBeInTheDocument();
+  });
+
+  it('トグルスイッチを表示する', () => {
+    renderPage();
+    expect(screen.getByTestId('toggle-enabled')).toBeInTheDocument();
+  });
+
+  it('保存ボタンを表示する', () => {
+    renderPage();
+    expect(screen.getByTestId('save-button')).toBeInTheDocument();
+  });
+
+  it('ローディング中はローディング表示する', () => {
+    mockedUseReminder.mockReturnValue({ ...defaultReturn, loading: true });
+    renderPage();
+    expect(screen.getByText('設定を読み込み中...')).toBeInTheDocument();
+  });
+
+  it('トグルクリックでtoggleEnabledが呼ばれる', () => {
+    renderPage();
+    fireEvent.click(screen.getByTestId('toggle-enabled'));
+    expect(defaultReturn.toggleEnabled).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/repositories/ReminderRepository.ts
+++ b/frontend/src/repositories/ReminderRepository.ts
@@ -1,0 +1,14 @@
+import apiClient from '../lib/axios';
+import { ReminderSetting } from '../types';
+
+export const ReminderRepository = {
+  async fetchSetting(): Promise<ReminderSetting> {
+    const response = await apiClient.get<ReminderSetting>('/api/reminder');
+    return response.data;
+  },
+
+  async saveSetting(setting: ReminderSetting): Promise<ReminderSetting> {
+    const response = await apiClient.put<ReminderSetting>('/api/reminder', setting);
+    return response.data;
+  },
+};

--- a/frontend/src/repositories/__tests__/ReminderRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ReminderRepository.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from '../../lib/axios';
+import { ReminderRepository } from '../ReminderRepository';
+
+vi.mock('../../lib/axios');
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('ReminderRepository', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('設定を取得する', async () => {
+    const mockData = { enabled: true, reminderTime: '20:00', daysOfWeek: 'mon,tue' };
+    mockedApiClient.get.mockResolvedValue({ data: mockData });
+    const result = await ReminderRepository.fetchSetting();
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/reminder');
+    expect(result).toEqual(mockData);
+  });
+
+  it('設定を保存する', async () => {
+    const setting = { enabled: true, reminderTime: '19:00', daysOfWeek: 'mon' };
+    mockedApiClient.put.mockResolvedValue({ data: setting });
+    const result = await ReminderRepository.saveSetting(setting);
+    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/reminder', setting);
+    expect(result).toEqual(setting);
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -233,3 +233,10 @@ export interface ConversationTemplate {
   openingMessage: string;
   difficulty: string;
 }
+
+/** リマインダー設定 */
+export interface ReminderSetting {
+  enabled: boolean;
+  reminderTime: string;
+  daysOfWeek: string;
+}


### PR DESCRIPTION
## 概要
- 練習リマインダーの時間・曜日設定を管理する機能を追加
- 学習の習慣化を支援するためのリマインダー設定UI

## 変更内容
### バックエンド
- `ReminderSetting` エンティティ + DBテーブル
- `ReminderSettingController` - `GET/PUT /api/reminder`
- `GetReminderSettingUseCase` / `SaveReminderSettingUseCase`
- バリデーション付きフォーム（時間フォーマット検証）

### フロントエンド
- `ReminderPage` - トグル・時間入力・曜日選択・保存ボタン
- `useReminder` フック
- `ReminderRepository` - API呼び出し
- メニューにリマインダーへのナビゲーション追加

## テスト
- バックエンド: 7テスト（Controller 3 + UseCase 4）
- フロントエンド: 12テスト（Repository 2 + Hook 5 + Page 5）

Closes #1438