### PR TITLE
feat: AI会話の共有機能を追加 (#1440)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/SharedSessionController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/SharedSessionController.java
@@ -1,0 +1,73 @@
+package com.example.FreStyle.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.SharedSessionDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.ShareSessionForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetPublicSessionsUseCase;
+import com.example.FreStyle.usecase.ShareSessionUseCase;
+import com.example.FreStyle.usecase.UnshareSessionUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shared-sessions")
+@Slf4j
+public class SharedSessionController {
+
+    private final GetPublicSessionsUseCase getPublicSessionsUseCase;
+    private final ShareSessionUseCase shareSessionUseCase;
+    private final UnshareSessionUseCase unshareSessionUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping
+    public ResponseEntity<List<SharedSessionDto>> getPublicSessions() {
+        log.info("========== GET /api/shared-sessions ==========");
+        List<SharedSessionDto> sessions = getPublicSessionsUseCase.execute();
+        log.info("公開セッション一覧取得成功 - 件数: {}", sessions.size());
+        return ResponseEntity.ok(sessions);
+    }
+
+    @PostMapping
+    public ResponseEntity<SharedSessionDto> shareSession(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody ShareSessionForm form) {
+        User user = resolveUser(jwt);
+        log.info("========== POST /api/shared-sessions ========== userId={}, sessionId={}", user.getId(), form.sessionId());
+        SharedSessionDto dto = shareSessionUseCase.execute(user.getId(), form);
+        log.info("セッション共有成功 - sharedSessionId: {}", dto.id());
+        return ResponseEntity.ok(dto);
+    }
+
+    @DeleteMapping("/{sessionId}")
+    public ResponseEntity<Void> unshareSession(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Integer sessionId) {
+        User user = resolveUser(jwt);
+        log.info("========== DELETE /api/shared-sessions/{} ========== userId={}", sessionId, user.getId());
+        unshareSessionUseCase.execute(user.getId(), sessionId);
+        log.info("セッション共有解除成功 - sessionId: {}", sessionId);
+        return ResponseEntity.ok().build();
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/SharedSessionDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/SharedSessionDto.java
@@ -1,0 +1,12 @@
+package com.example.FreStyle.dto;
+
+public record SharedSessionDto(
+    Integer id,
+    Integer sessionId,
+    String sessionTitle,
+    Integer userId,
+    String username,
+    String userIconUrl,
+    String description,
+    String createdAt
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/SharedSession.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/SharedSession.java
@@ -1,0 +1,44 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "shared_sessions")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SharedSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private AiChatSession session;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/form/ShareSessionForm.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/form/ShareSessionForm.java
@@ -1,0 +1,8 @@
+package com.example.FreStyle.form;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ShareSessionForm(
+    @NotNull Integer sessionId,
+    String description
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/SharedSessionRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/SharedSessionRepository.java
@@ -1,0 +1,20 @@
+package com.example.FreStyle.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.example.FreStyle.entity.SharedSession;
+
+@Repository
+public interface SharedSessionRepository extends JpaRepository<SharedSession, Integer> {
+    @Query("SELECT ss FROM SharedSession ss WHERE ss.isPublic = true ORDER BY ss.createdAt DESC")
+    List<SharedSession> findPublicSessions();
+
+    Optional<SharedSession> findBySessionId(Integer sessionId);
+
+    List<SharedSession> findByUserIdOrderByCreatedAtDesc(Integer userId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetPublicSessionsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetPublicSessionsUseCase.java
@@ -1,0 +1,34 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.example.FreStyle.dto.SharedSessionDto;
+import com.example.FreStyle.entity.SharedSession;
+import com.example.FreStyle.repository.SharedSessionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetPublicSessionsUseCase {
+
+    private final SharedSessionRepository sharedSessionRepository;
+
+    public List<SharedSessionDto> execute() {
+        List<SharedSession> sessions = sharedSessionRepository.findPublicSessions();
+        return sessions.stream()
+                .map(ss -> new SharedSessionDto(
+                        ss.getId(),
+                        ss.getSession().getId(),
+                        ss.getSession().getTitle(),
+                        ss.getUser().getId(),
+                        ss.getUser().getName(),
+                        ss.getUser().getIconUrl(),
+                        ss.getDescription(),
+                        ss.getCreatedAt() != null ? ss.getCreatedAt().toLocalDateTime().toString() : null
+                ))
+                .toList();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/ShareSessionUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/ShareSessionUseCase.java
@@ -1,0 +1,49 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.SharedSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.SharedSession;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.form.ShareSessionForm;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+import com.example.FreStyle.repository.SharedSessionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShareSessionUseCase {
+
+    private final AiChatSessionRepository aiChatSessionRepository;
+    private final SharedSessionRepository sharedSessionRepository;
+
+    @Transactional
+    public SharedSessionDto execute(Integer userId, ShareSessionForm form) {
+        AiChatSession session = aiChatSessionRepository.findByIdAndUserId(form.sessionId(), userId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                    "セッションが見つからないか、アクセス権限がありません: sessionId=" + form.sessionId() + ", userId=" + userId
+                ));
+
+        SharedSession sharedSession = new SharedSession();
+        sharedSession.setSession(session);
+        sharedSession.setUser(session.getUser());
+        sharedSession.setDescription(form.description());
+        sharedSession.setIsPublic(true);
+
+        SharedSession saved = sharedSessionRepository.save(sharedSession);
+
+        return new SharedSessionDto(
+                saved.getId(),
+                saved.getSession().getId(),
+                saved.getSession().getTitle(),
+                saved.getUser().getId(),
+                saved.getUser().getName(),
+                saved.getUser().getIconUrl(),
+                saved.getDescription(),
+                saved.getCreatedAt() != null ? saved.getCreatedAt().toLocalDateTime().toString() : null
+        );
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UnshareSessionUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UnshareSessionUseCase.java
@@ -1,0 +1,33 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.SharedSession;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.SharedSessionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UnshareSessionUseCase {
+
+    private final SharedSessionRepository sharedSessionRepository;
+
+    @Transactional
+    public void execute(Integer userId, Integer sessionId) {
+        SharedSession sharedSession = sharedSessionRepository.findBySessionId(sessionId)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                    "共有セッションが見つかりません: sessionId=" + sessionId
+                ));
+
+        if (!sharedSession.getUser().getId().equals(userId)) {
+            throw new ResourceNotFoundException(
+                "共有セッションへのアクセス権限がありません: sessionId=" + sessionId + ", userId=" + userId
+            );
+        }
+
+        sharedSessionRepository.delete(sharedSession);
+    }
+}

--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -306,6 +306,21 @@ CREATE TABLE IF NOT EXISTS reminder_settings (
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- 共有セッション
+CREATE TABLE IF NOT EXISTS shared_sessions (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    session_id INT NOT NULL,
+    user_id INT NOT NULL,
+    description TEXT,
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_session_id (session_id),
+    FOREIGN KEY (session_id) REFERENCES ai_chat_sessions(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_public_created (is_public, created_at DESC)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/SharedSessionControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/SharedSessionControllerTest.java
@@ -1,0 +1,101 @@
+package com.example.FreStyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.SharedSessionDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.ShareSessionForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetPublicSessionsUseCase;
+import com.example.FreStyle.usecase.ShareSessionUseCase;
+import com.example.FreStyle.usecase.UnshareSessionUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SharedSessionController")
+class SharedSessionControllerTest {
+
+    @Mock
+    private GetPublicSessionsUseCase getPublicSessionsUseCase;
+
+    @Mock
+    private ShareSessionUseCase shareSessionUseCase;
+
+    @Mock
+    private UnshareSessionUseCase unshareSessionUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private SharedSessionController controller;
+
+    private Jwt jwt;
+    private User user;
+
+    private void setUpAuth() {
+        jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("test-sub");
+
+        user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+
+        when(userIdentityService.findUserBySub("test-sub")).thenReturn(user);
+    }
+
+    @Test
+    @DisplayName("公開セッション一覧を取得する")
+    void shouldReturnPublicSessions() {
+        SharedSessionDto dto = new SharedSessionDto(
+                1, 10, "セッション", 1, "ユーザー", "https://icon.png", "説明", "2026-03-08T10:00:00");
+        when(getPublicSessionsUseCase.execute()).thenReturn(List.of(dto));
+
+        ResponseEntity<List<SharedSessionDto>> response = controller.getPublicSessions();
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).sessionTitle()).isEqualTo("セッション");
+    }
+
+    @Test
+    @DisplayName("セッションを共有する")
+    void shouldShareSession() {
+        setUpAuth();
+        ShareSessionForm form = new ShareSessionForm(10, "説明");
+        SharedSessionDto dto = new SharedSessionDto(
+                1, 10, "セッション", 1, "ユーザー", "https://icon.png", "説明", "2026-03-08T10:00:00");
+        when(shareSessionUseCase.execute(eq(1), any(ShareSessionForm.class))).thenReturn(dto);
+
+        ResponseEntity<SharedSessionDto> response = controller.shareSession(jwt, form);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        assertThat(response.getBody().sessionId()).isEqualTo(10);
+        verify(shareSessionUseCase).execute(1, form);
+    }
+
+    @Test
+    @DisplayName("セッションの共有を解除する")
+    void shouldUnshareSession() {
+        setUpAuth();
+        ResponseEntity<Void> response = controller.unshareSession(jwt, 10);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(200);
+        verify(unshareSessionUseCase).execute(1, 10);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetPublicSessionsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetPublicSessionsUseCaseTest.java
@@ -1,0 +1,61 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.SharedSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.SharedSession;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.repository.SharedSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetPublicSessionsUseCase")
+class GetPublicSessionsUseCaseTest {
+
+    @Mock
+    private SharedSessionRepository sharedSessionRepository;
+
+    @InjectMocks
+    private GetPublicSessionsUseCase useCase;
+
+    @Test
+    @DisplayName("公開セッションを取得する")
+    void shouldReturnPublicSessions() {
+        User user = new User();
+        user.setId(1);
+        user.setName("ユーザー1");
+        user.setIconUrl("https://example.com/icon.png");
+
+        AiChatSession session = new AiChatSession();
+        session.setId(10);
+        session.setUser(user);
+        session.setTitle("公開セッション");
+
+        SharedSession shared = new SharedSession();
+        shared.setId(100);
+        shared.setSession(session);
+        shared.setUser(user);
+        shared.setDescription("説明");
+        shared.setIsPublic(true);
+        shared.setCreatedAt(Timestamp.valueOf("2026-03-08 10:00:00"));
+
+        when(sharedSessionRepository.findPublicSessions()).thenReturn(List.of(shared));
+
+        List<SharedSessionDto> result = useCase.execute();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).sessionTitle()).isEqualTo("公開セッション");
+        assertThat(result.get(0).username()).isEqualTo("ユーザー1");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/ShareSessionUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/ShareSessionUseCaseTest.java
@@ -1,0 +1,89 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.SharedSessionDto;
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.SharedSession;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.form.ShareSessionForm;
+import com.example.FreStyle.repository.AiChatSessionRepository;
+import com.example.FreStyle.repository.SharedSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShareSessionUseCase")
+class ShareSessionUseCaseTest {
+
+    @Mock
+    private AiChatSessionRepository aiChatSessionRepository;
+
+    @Mock
+    private SharedSessionRepository sharedSessionRepository;
+
+    @InjectMocks
+    private ShareSessionUseCase useCase;
+
+    @Test
+    @DisplayName("セッションを共有する")
+    void shouldShareSession() {
+        User user = new User();
+        user.setId(1);
+        user.setName("テストユーザー");
+        user.setIconUrl("https://example.com/icon.png");
+
+        AiChatSession session = new AiChatSession();
+        session.setId(10);
+        session.setUser(user);
+        session.setTitle("テストセッション");
+
+        when(aiChatSessionRepository.findByIdAndUserId(10, 1))
+                .thenReturn(Optional.of(session));
+
+        SharedSession saved = new SharedSession();
+        saved.setId(100);
+        saved.setSession(session);
+        saved.setUser(user);
+        saved.setDescription("共有の説明");
+        saved.setIsPublic(true);
+        saved.setCreatedAt(Timestamp.valueOf("2026-03-08 10:00:00"));
+        when(sharedSessionRepository.save(any(SharedSession.class))).thenReturn(saved);
+
+        ShareSessionForm form = new ShareSessionForm(10, "共有の説明");
+        SharedSessionDto result = useCase.execute(1, form);
+
+        assertThat(result.id()).isEqualTo(100);
+        assertThat(result.sessionId()).isEqualTo(10);
+        assertThat(result.sessionTitle()).isEqualTo("テストセッション");
+        assertThat(result.userId()).isEqualTo(1);
+        assertThat(result.username()).isEqualTo("テストユーザー");
+        assertThat(result.description()).isEqualTo("共有の説明");
+        verify(sharedSessionRepository).save(any(SharedSession.class));
+    }
+
+    @Test
+    @DisplayName("他人のセッションを共有しようとすると例外が発生する")
+    void shouldThrowWhenSharingOthersSession() {
+        when(aiChatSessionRepository.findByIdAndUserId(10, 2))
+                .thenReturn(Optional.empty());
+
+        ShareSessionForm form = new ShareSessionForm(10, "説明");
+
+        assertThatThrownBy(() -> useCase.execute(2, form))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UnshareSessionUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UnshareSessionUseCaseTest.java
@@ -1,0 +1,74 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.entity.AiChatSession;
+import com.example.FreStyle.entity.SharedSession;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.SharedSessionRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UnshareSessionUseCase")
+class UnshareSessionUseCaseTest {
+
+    @Mock
+    private SharedSessionRepository sharedSessionRepository;
+
+    @InjectMocks
+    private UnshareSessionUseCase useCase;
+
+    @Test
+    @DisplayName("共有を解除する")
+    void shouldUnshareSession() {
+        User user = new User();
+        user.setId(1);
+
+        AiChatSession session = new AiChatSession();
+        session.setId(10);
+        session.setUser(user);
+
+        SharedSession shared = new SharedSession();
+        shared.setId(100);
+        shared.setSession(session);
+        shared.setUser(user);
+
+        when(sharedSessionRepository.findBySessionId(10)).thenReturn(Optional.of(shared));
+
+        useCase.execute(1, 10);
+
+        verify(sharedSessionRepository).delete(shared);
+    }
+
+    @Test
+    @DisplayName("他人のセッションの共有は解除できない")
+    void shouldThrowWhenUnsharingOthersSession() {
+        User otherUser = new User();
+        otherUser.setId(2);
+
+        AiChatSession session = new AiChatSession();
+        session.setId(10);
+        session.setUser(otherUser);
+
+        SharedSession shared = new SharedSession();
+        shared.setId(100);
+        shared.setSession(session);
+        shared.setUser(otherUser);
+
+        when(sharedSessionRepository.findBySessionId(10)).thenReturn(Optional.of(shared));
+
+        assertThatThrownBy(() -> useCase.execute(1, 10))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ const FriendshipPage = lazy(() => import('./pages/FriendshipPage'));
 const RankingPage = lazy(() => import('./pages/RankingPage'));
 const TemplatePage = lazy(() => import('./pages/TemplatePage'));
 const ReminderPage = lazy(() => import('./pages/ReminderPage'));
+const SharedSessionsPage = lazy(() => import('./pages/SharedSessionsPage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -95,6 +96,7 @@ export default function App() {
         <Route path="/ranking" element={<RankingPage />} />
         <Route path="/templates" element={<TemplatePage />} />
         <Route path="/reminder" element={<ReminderPage />} />
+        <Route path="/shared-sessions" element={<SharedSessionsPage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -7,6 +7,7 @@ import {
   TrophyIcon,
   DocumentTextIcon,
   BellAlertIcon,
+  ShareIcon,
 } from '@heroicons/react/24/outline';
 import Card from './Card';
 
@@ -63,6 +64,13 @@ const MENU_ITEMS = [
     label: '練習リマインダー',
     description: '練習の通知時間・曜日を設定',
     to: '/reminder',
+    badgeKey: null,
+  },
+  {
+    icon: ShareIcon,
+    label: 'みんなの会話',
+    description: 'コミュニティで共有されたAI会話セッション',
+    to: '/shared-sessions',
     badgeKey: null,
   },
 ];

--- a/frontend/src/hooks/__tests__/useSharedSessions.test.ts
+++ b/frontend/src/hooks/__tests__/useSharedSessions.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useSharedSessions } from '../useSharedSessions';
+import { SharedSessionRepository } from '../../repositories/SharedSessionRepository';
+
+vi.mock('../../repositories/SharedSessionRepository');
+const mockedRepo = vi.mocked(SharedSessionRepository);
+
+describe('useSharedSessions', () => {
+  const mockSessions = [
+    { id: 1, sessionId: 10, sessionTitle: 'Test Session', userId: 1, username: 'user1', userIconUrl: null, description: null, createdAt: '2024-01-01' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchPublicSessions.mockResolvedValue(mockSessions);
+  });
+
+  it('公開セッションを取得する', async () => {
+    const { result } = renderHook(() => useSharedSessions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessions).toEqual(mockSessions);
+  });
+
+  it('セッションを共有する', async () => {
+    const newShared = { ...mockSessions[0], id: 2, sessionId: 20, sessionTitle: 'New' };
+    mockedRepo.shareSession.mockResolvedValue(newShared);
+    const { result } = renderHook(() => useSharedSessions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => { await result.current.shareSession(20); });
+    expect(result.current.sessions).toHaveLength(2);
+  });
+
+  it('エラー時にエラーメッセージを設定する', async () => {
+    mockedRepo.fetchPublicSessions.mockRejectedValue(new Error('fail'));
+    const { result } = renderHook(() => useSharedSessions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('共有セッションの取得に失敗しました');
+  });
+});

--- a/frontend/src/hooks/useSharedSessions.ts
+++ b/frontend/src/hooks/useSharedSessions.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect, useCallback } from 'react';
+import { SharedSessionRepository } from '../repositories/SharedSessionRepository';
+import { SharedSession } from '../types';
+
+export function useSharedSessions() {
+  const [sessions, setSessions] = useState<SharedSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    SharedSessionRepository.fetchPublicSessions()
+      .then((data) => {
+        if (!cancelled) setSessions(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('共有セッションの取得に失敗しました');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const shareSession = useCallback(async (sessionId: number, description?: string) => {
+    const shared = await SharedSessionRepository.shareSession(sessionId, description);
+    setSessions((prev) => [shared, ...prev]);
+    return shared;
+  }, []);
+
+  const unshareSession = useCallback(async (sessionId: number) => {
+    await SharedSessionRepository.unshareSession(sessionId);
+    setSessions((prev) => prev.filter((s) => s.sessionId !== sessionId));
+  }, []);
+
+  return { sessions, loading, error, shareSession, unshareSession };
+}

--- a/frontend/src/pages/SharedSessionsPage.tsx
+++ b/frontend/src/pages/SharedSessionsPage.tsx
@@ -1,0 +1,62 @@
+import { useSharedSessions } from '../hooks/useSharedSessions';
+import { useNavigate } from 'react-router-dom';
+import Loading from '../components/Loading';
+import { SharedSession } from '../types';
+
+function SharedSessionCard({ session }: { session: SharedSession }) {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-2 cursor-pointer hover:border-blue-400 transition-colors"
+      onClick={() => navigate(`/chat/ask-ai/${session.sessionId}`)}
+      data-testid={`shared-session-${session.id}`}
+    >
+      <div className="flex items-center gap-2">
+        <div className="w-7 h-7 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden flex-shrink-0">
+          {session.userIconUrl ? (
+            <img src={session.userIconUrl} alt={session.username} className="w-full h-full object-cover" />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-xs text-gray-500">
+              {session.username.charAt(0)}
+            </div>
+          )}
+        </div>
+        <span className="text-sm font-medium">{session.username}</span>
+        <span className="text-xs text-gray-400 ml-auto">
+          {new Date(session.createdAt).toLocaleDateString('ja-JP')}
+        </span>
+      </div>
+      <h3 className="font-semibold">{session.sessionTitle}</h3>
+      {session.description && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">{session.description}</p>
+      )}
+    </div>
+  );
+}
+
+export default function SharedSessionsPage() {
+  const { sessions, loading, error } = useSharedSessions();
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-xl font-bold">みんなの会話</h1>
+      <p className="text-sm text-gray-500">コミュニティで共有されたAI会話セッション</p>
+
+      {loading && <Loading message="共有セッションを読み込み中..." />}
+      {error && <p className="text-red-500 text-center">{error}</p>}
+
+      {!loading && !error && sessions.length === 0 && (
+        <p className="text-gray-400 text-center py-8">まだ共有されたセッションはありません</p>
+      )}
+
+      {!loading && !error && (
+        <div className="space-y-3">
+          {sessions.map((session) => (
+            <SharedSessionCard key={session.id} session={session} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/SharedSessionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SharedSessionsPage.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import SharedSessionsPage from '../SharedSessionsPage';
+import { useSharedSessions } from '../../hooks/useSharedSessions';
+
+vi.mock('../../hooks/useSharedSessions');
+const mockedUseSharedSessions = vi.mocked(useSharedSessions);
+
+function renderPage() {
+  return render(<MemoryRouter><SharedSessionsPage /></MemoryRouter>);
+}
+
+describe('SharedSessionsPage', () => {
+  const mockSessions = [
+    { id: 1, sessionId: 10, sessionTitle: '会議の練習', userId: 1, username: 'TestUser', userIconUrl: null, description: '良いセッション', createdAt: '2024-01-01' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseSharedSessions.mockReturnValue({
+      sessions: mockSessions,
+      loading: false,
+      error: null,
+      shareSession: vi.fn(),
+      unshareSession: vi.fn(),
+    });
+  });
+
+  it('タイトルを表示する', () => {
+    renderPage();
+    expect(screen.getByText('みんなの会話')).toBeInTheDocument();
+  });
+
+  it('共有セッションを表示する', () => {
+    renderPage();
+    expect(screen.getByText('会議の練習')).toBeInTheDocument();
+    expect(screen.getByText('TestUser')).toBeInTheDocument();
+  });
+
+  it('ローディング中はローディング表示する', () => {
+    mockedUseSharedSessions.mockReturnValue({ sessions: [], loading: true, error: null, shareSession: vi.fn(), unshareSession: vi.fn() });
+    renderPage();
+    expect(screen.getByText('共有セッションを読み込み中...')).toBeInTheDocument();
+  });
+
+  it('セッションがない場合は空メッセージを表示する', () => {
+    mockedUseSharedSessions.mockReturnValue({ sessions: [], loading: false, error: null, shareSession: vi.fn(), unshareSession: vi.fn() });
+    renderPage();
+    expect(screen.getByText('まだ共有されたセッションはありません')).toBeInTheDocument();
+  });
+
+  it('エラー時はエラーメッセージを表示する', () => {
+    mockedUseSharedSessions.mockReturnValue({ sessions: [], loading: false, error: '共有セッションの取得に失敗しました', shareSession: vi.fn(), unshareSession: vi.fn() });
+    renderPage();
+    expect(screen.getByText('共有セッションの取得に失敗しました')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/SharedSessionRepository.ts
+++ b/frontend/src/repositories/SharedSessionRepository.ts
@@ -1,0 +1,21 @@
+import apiClient from '../lib/axios';
+import { SharedSession } from '../types';
+
+export const SharedSessionRepository = {
+  async fetchPublicSessions(): Promise<SharedSession[]> {
+    const response = await apiClient.get<SharedSession[]>('/api/shared-sessions');
+    return response.data;
+  },
+
+  async shareSession(sessionId: number, description?: string): Promise<SharedSession> {
+    const response = await apiClient.post<SharedSession>('/api/shared-sessions', {
+      sessionId,
+      description,
+    });
+    return response.data;
+  },
+
+  async unshareSession(sessionId: number): Promise<void> {
+    await apiClient.delete(`/api/shared-sessions/${sessionId}`);
+  },
+};

--- a/frontend/src/repositories/__tests__/SharedSessionRepository.test.ts
+++ b/frontend/src/repositories/__tests__/SharedSessionRepository.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from '../../lib/axios';
+import { SharedSessionRepository } from '../SharedSessionRepository';
+
+vi.mock('../../lib/axios');
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('SharedSessionRepository', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('公開セッション一覧を取得する', async () => {
+    mockedApiClient.get.mockResolvedValue({ data: [] });
+    const result = await SharedSessionRepository.fetchPublicSessions();
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/shared-sessions');
+    expect(result).toEqual([]);
+  });
+
+  it('セッションを共有する', async () => {
+    const mockShared = { id: 1, sessionId: 10, sessionTitle: 'test' };
+    mockedApiClient.post.mockResolvedValue({ data: mockShared });
+    const result = await SharedSessionRepository.shareSession(10, 'desc');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/shared-sessions', { sessionId: 10, description: 'desc' });
+    expect(result).toEqual(mockShared);
+  });
+
+  it('セッション共有を解除する', async () => {
+    mockedApiClient.delete.mockResolvedValue({});
+    await SharedSessionRepository.unshareSession(10);
+    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/shared-sessions/10');
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -240,3 +240,15 @@ export interface ReminderSetting {
   reminderTime: string;
   daysOfWeek: string;
 }
+
+/** 共有セッション */
+export interface SharedSession {
+  id: number;
+  sessionId: number;
+  sessionTitle: string;
+  userId: number;
+  username: string;
+  userIconUrl: string | null;
+  description: string | null;
+  createdAt: string;
+}


### PR DESCRIPTION
## 概要
- AIチャットセッションをコミュニティに共有できる機能を追加
- 共有セッション一覧の閲覧、セッションの公開・非公開設定

## 変更内容
### バックエンド
- `SharedSession` エンティティ + DBテーブル
- `SharedSessionController` - `GET/POST/DELETE /api/shared-sessions`
- `ShareSessionUseCase` / `GetPublicSessionsUseCase` / `UnshareSessionUseCase`

### フロントエンド
- `SharedSessionsPage` - 共有セッション一覧ページ
- `useSharedSessions` フック
- `SharedSessionRepository` - API呼び出し
- メニューに「みんなの会話」ナビゲーション追加

## テスト
- バックエンド: 8テスト（Controller 3 + UseCase 5）
- フロントエンド: 11テスト（Repository 3 + Hook 3 + Page 5）

Closes #1440