### PR TITLE
feat: ウィークリーチャレンジ機能を追加 (#1442)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/WeeklyChallengeController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/WeeklyChallengeController.java
@@ -1,0 +1,49 @@
+package com.example.FreStyle.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.WeeklyChallengeDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetCurrentChallengeUseCase;
+import com.example.FreStyle.usecase.IncrementChallengeProgressUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weekly-challenge")
+@Slf4j
+public class WeeklyChallengeController {
+
+    private final GetCurrentChallengeUseCase getCurrentChallengeUseCase;
+    private final IncrementChallengeProgressUseCase incrementChallengeProgressUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping
+    public ResponseEntity<WeeklyChallengeDto> getCurrentChallenge(@AuthenticationPrincipal Jwt jwt) {
+        User user = resolveUser(jwt);
+        log.info("ウィークリーチャレンジ取得: userId={}", user.getId());
+        WeeklyChallengeDto dto = getCurrentChallengeUseCase.execute(user.getId());
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping("/progress")
+    public ResponseEntity<WeeklyChallengeDto> incrementProgress(@AuthenticationPrincipal Jwt jwt) {
+        User user = resolveUser(jwt);
+        log.info("ウィークリーチャレンジ進捗インクリメント: userId={}", user.getId());
+        WeeklyChallengeDto dto = incrementChallengeProgressUseCase.execute(user.getId());
+        return ResponseEntity.ok(dto);
+    }
+
+    private User resolveUser(Jwt jwt) {
+        return userIdentityService.findUserBySub(jwt.getSubject());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/WeeklyChallengeDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/WeeklyChallengeDto.java
@@ -1,0 +1,13 @@
+package com.example.FreStyle.dto;
+
+public record WeeklyChallengeDto(
+    Integer id,
+    String title,
+    String description,
+    String category,
+    int targetSessions,
+    int completedSessions,
+    boolean isCompleted,
+    String weekStart,
+    String weekEnd
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/UserChallengeProgress.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/UserChallengeProgress.java
@@ -1,0 +1,33 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Timestamp;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_challenge_progress")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserChallengeProgress {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id", nullable = false)
+    private WeeklyChallenge challenge;
+
+    @Column(name = "completed_sessions", nullable = false)
+    private Integer completedSessions;
+
+    @Column(name = "is_completed", nullable = false)
+    private Boolean isCompleted;
+
+    @Column(name = "updated_at", insertable = false, updatable = false)
+    private Timestamp updatedAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/WeeklyChallenge.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/WeeklyChallenge.java
@@ -1,0 +1,38 @@
+package com.example.FreStyle.entity;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "weekly_challenges")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeeklyChallenge {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(length = 100, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    @Column(length = 50, nullable = false)
+    private String category;
+
+    @Column(name = "target_sessions", nullable = false)
+    private Integer targetSessions;
+
+    @Column(name = "week_start", nullable = false)
+    private Date weekStart;
+
+    @Column(name = "week_end", nullable = false)
+    private Date weekEnd;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Timestamp createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/UserChallengeProgressRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/UserChallengeProgressRepository.java
@@ -1,0 +1,11 @@
+package com.example.FreStyle.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.FreStyle.entity.UserChallengeProgress;
+
+public interface UserChallengeProgressRepository extends JpaRepository<UserChallengeProgress, Integer> {
+    Optional<UserChallengeProgress> findByUserIdAndChallengeId(Integer userId, Integer challengeId);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/WeeklyChallengeRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/WeeklyChallengeRepository.java
@@ -1,0 +1,12 @@
+package com.example.FreStyle.repository;
+
+import java.sql.Date;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.FreStyle.entity.WeeklyChallenge;
+
+public interface WeeklyChallengeRepository extends JpaRepository<WeeklyChallenge, Integer> {
+    Optional<WeeklyChallenge> findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(Date date, Date date2);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetCurrentChallengeUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetCurrentChallengeUseCase.java
@@ -1,0 +1,50 @@
+package com.example.FreStyle.usecase;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.WeeklyChallengeDto;
+import com.example.FreStyle.entity.WeeklyChallenge;
+import com.example.FreStyle.repository.UserChallengeProgressRepository;
+import com.example.FreStyle.repository.WeeklyChallengeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetCurrentChallengeUseCase {
+
+    private final WeeklyChallengeRepository weeklyChallengeRepository;
+    private final UserChallengeProgressRepository userChallengeProgressRepository;
+
+    @Transactional(readOnly = true)
+    public WeeklyChallengeDto execute(Integer userId) {
+        Date today = Date.valueOf(LocalDate.now());
+        return weeklyChallengeRepository
+                .findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(today, today)
+                .map(challenge -> {
+                    var progress = userChallengeProgressRepository
+                            .findByUserIdAndChallengeId(userId, challenge.getId());
+                    int completedSessions = progress.map(p -> p.getCompletedSessions()).orElse(0);
+                    boolean isCompleted = progress.map(p -> p.getIsCompleted()).orElse(false);
+                    return toDto(challenge, completedSessions, isCompleted);
+                })
+                .orElse(null);
+    }
+
+    private WeeklyChallengeDto toDto(WeeklyChallenge challenge, int completedSessions, boolean isCompleted) {
+        return new WeeklyChallengeDto(
+                challenge.getId(),
+                challenge.getTitle(),
+                challenge.getDescription(),
+                challenge.getCategory(),
+                challenge.getTargetSessions(),
+                completedSessions,
+                isCompleted,
+                challenge.getWeekStart().toString(),
+                challenge.getWeekEnd().toString());
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/IncrementChallengeProgressUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/IncrementChallengeProgressUseCase.java
@@ -1,0 +1,58 @@
+package com.example.FreStyle.usecase;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.WeeklyChallengeDto;
+import com.example.FreStyle.entity.UserChallengeProgress;
+import com.example.FreStyle.entity.WeeklyChallenge;
+import com.example.FreStyle.repository.UserChallengeProgressRepository;
+import com.example.FreStyle.repository.WeeklyChallengeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IncrementChallengeProgressUseCase {
+
+    private final WeeklyChallengeRepository weeklyChallengeRepository;
+    private final UserChallengeProgressRepository userChallengeProgressRepository;
+
+    @Transactional
+    public WeeklyChallengeDto execute(Integer userId) {
+        Date today = Date.valueOf(LocalDate.now());
+        WeeklyChallenge challenge = weeklyChallengeRepository
+                .findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(today, today)
+                .orElseThrow(() -> new RuntimeException("今週のチャレンジが見つかりません"));
+
+        UserChallengeProgress progress = userChallengeProgressRepository
+                .findByUserIdAndChallengeId(userId, challenge.getId())
+                .orElseGet(() -> {
+                    UserChallengeProgress newProgress = new UserChallengeProgress();
+                    newProgress.setChallenge(challenge);
+                    newProgress.setCompletedSessions(0);
+                    newProgress.setIsCompleted(false);
+                    return newProgress;
+                });
+
+        progress.setCompletedSessions(progress.getCompletedSessions() + 1);
+        if (progress.getCompletedSessions() >= challenge.getTargetSessions()) {
+            progress.setIsCompleted(true);
+        }
+        userChallengeProgressRepository.save(progress);
+
+        return new WeeklyChallengeDto(
+                challenge.getId(),
+                challenge.getTitle(),
+                challenge.getDescription(),
+                challenge.getCategory(),
+                challenge.getTargetSessions(),
+                progress.getCompletedSessions(),
+                progress.getIsCompleted(),
+                challenge.getWeekStart().toString(),
+                challenge.getWeekEnd().toString());
+    }
+}

--- a/FreStyle/src/main/resources/schema.sql
+++ b/FreStyle/src/main/resources/schema.sql
@@ -321,6 +321,34 @@ CREATE TABLE IF NOT EXISTS shared_sessions (
     INDEX idx_public_created (is_public, created_at DESC)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
+-- ウィークリーチャレンジ
+CREATE TABLE IF NOT EXISTS weekly_challenges (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    title VARCHAR(100) NOT NULL,
+    description TEXT NOT NULL,
+    category VARCHAR(50) NOT NULL,
+    target_sessions INT NOT NULL DEFAULT 3,
+    week_start DATE NOT NULL,
+    week_end DATE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_week_start (week_start)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- ユーザーチャレンジ進捗
+CREATE TABLE IF NOT EXISTS user_challenge_progress (
+    id INT PRIMARY KEY AUTO_INCREMENT,
+    user_id INT NOT NULL,
+    challenge_id INT NOT NULL,
+    completed_sessions INT NOT NULL DEFAULT 0,
+    is_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    UNIQUE KEY uk_user_challenge (user_id, challenge_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (challenge_id) REFERENCES weekly_challenges(id) ON DELETE CASCADE
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
 -- ┌─────────────────┐     ┌──────────────────────┐
 -- │     users       │────→│   ai_chat_sessions   │
 -- └─────────────────┘     └──────────────────────┘

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/WeeklyChallengeControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/WeeklyChallengeControllerTest.java
@@ -1,0 +1,82 @@
+package com.example.FreStyle.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import com.example.FreStyle.dto.WeeklyChallengeDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.GetCurrentChallengeUseCase;
+import com.example.FreStyle.usecase.IncrementChallengeProgressUseCase;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WeeklyChallengeController テスト")
+class WeeklyChallengeControllerTest {
+
+    @Mock
+    private GetCurrentChallengeUseCase getCurrentChallengeUseCase;
+
+    @Mock
+    private IncrementChallengeProgressUseCase incrementChallengeProgressUseCase;
+
+    @Mock
+    private UserIdentityService userIdentityService;
+
+    @InjectMocks
+    private WeeklyChallengeController weeklyChallengeController;
+
+    private Jwt createMockJwt() {
+        Jwt jwt = mock(Jwt.class);
+        when(jwt.getSubject()).thenReturn("cognito-sub-123");
+        return jwt;
+    }
+
+    @Test
+    @DisplayName("getCurrentChallenge: 今週のチャレンジとユーザー進捗を取得できる")
+    void getCurrentChallenge_returnsChallengeWithProgress() {
+        Jwt jwt = createMockJwt();
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(user);
+        WeeklyChallengeDto dto = new WeeklyChallengeDto(
+                1, "今週のチャレンジ", "説明文", "communication",
+                3, 1, false, "2026-03-02", "2026-03-08");
+        when(getCurrentChallengeUseCase.execute(1)).thenReturn(dto);
+
+        ResponseEntity<WeeklyChallengeDto> response = weeklyChallengeController.getCurrentChallenge(jwt);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("今週のチャレンジ", response.getBody().title());
+        assertEquals(1, response.getBody().completedSessions());
+        assertFalse(response.getBody().isCompleted());
+    }
+
+    @Test
+    @DisplayName("incrementProgress: チャレンジ進捗をインクリメントできる")
+    void incrementProgress_incrementsAndReturnsUpdated() {
+        Jwt jwt = createMockJwt();
+        User user = new User();
+        user.setId(1);
+        when(userIdentityService.findUserBySub("cognito-sub-123")).thenReturn(user);
+        WeeklyChallengeDto dto = new WeeklyChallengeDto(
+                1, "今週のチャレンジ", "説明文", "communication",
+                3, 2, false, "2026-03-02", "2026-03-08");
+        when(incrementChallengeProgressUseCase.execute(1)).thenReturn(dto);
+
+        ResponseEntity<WeeklyChallengeDto> response = weeklyChallengeController.incrementProgress(jwt);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(2, response.getBody().completedSessions());
+        verify(incrementChallengeProgressUseCase).execute(1);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetCurrentChallengeUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetCurrentChallengeUseCaseTest.java
@@ -1,0 +1,77 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.WeeklyChallengeDto;
+import com.example.FreStyle.entity.UserChallengeProgress;
+import com.example.FreStyle.entity.WeeklyChallenge;
+import com.example.FreStyle.repository.UserChallengeProgressRepository;
+import com.example.FreStyle.repository.WeeklyChallengeRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetCurrentChallengeUseCase テスト")
+class GetCurrentChallengeUseCaseTest {
+
+    @Mock
+    private WeeklyChallengeRepository weeklyChallengeRepository;
+
+    @Mock
+    private UserChallengeProgressRepository userChallengeProgressRepository;
+
+    @InjectMocks
+    private GetCurrentChallengeUseCase getCurrentChallengeUseCase;
+
+    @Test
+    @DisplayName("今週のチャレンジが存在する場合、ユーザー進捗と合わせて返す")
+    void execute_withExistingChallenge_returnsChallengeWithProgress() {
+        WeeklyChallenge challenge = new WeeklyChallenge();
+        challenge.setId(1);
+        challenge.setTitle("コミュニケーション強化週間");
+        challenge.setDescription("今週は3回練習しよう");
+        challenge.setCategory("communication");
+        challenge.setTargetSessions(3);
+        challenge.setWeekStart(Date.valueOf("2026-03-02"));
+        challenge.setWeekEnd(Date.valueOf("2026-03-08"));
+
+        when(weeklyChallengeRepository.findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(
+                any(Date.class), any(Date.class)))
+                .thenReturn(Optional.of(challenge));
+
+        UserChallengeProgress progress = new UserChallengeProgress();
+        progress.setCompletedSessions(2);
+        progress.setIsCompleted(false);
+        when(userChallengeProgressRepository.findByUserIdAndChallengeId(1, 1))
+                .thenReturn(Optional.of(progress));
+
+        WeeklyChallengeDto result = getCurrentChallengeUseCase.execute(1);
+
+        assertNotNull(result);
+        assertEquals("コミュニケーション強化週間", result.title());
+        assertEquals(2, result.completedSessions());
+        assertFalse(result.isCompleted());
+        assertEquals(3, result.targetSessions());
+    }
+
+    @Test
+    @DisplayName("今週のチャレンジが存在しない場合、nullを返す")
+    void execute_withoutChallenge_returnsNull() {
+        when(weeklyChallengeRepository.findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(
+                any(Date.class), any(Date.class)))
+                .thenReturn(Optional.empty());
+
+        WeeklyChallengeDto result = getCurrentChallengeUseCase.execute(1);
+
+        assertNull(result);
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/IncrementChallengeProgressUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/IncrementChallengeProgressUseCaseTest.java
@@ -1,0 +1,92 @@
+package com.example.FreStyle.usecase;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.dto.WeeklyChallengeDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.entity.UserChallengeProgress;
+import com.example.FreStyle.entity.WeeklyChallenge;
+import com.example.FreStyle.repository.UserChallengeProgressRepository;
+import com.example.FreStyle.repository.WeeklyChallengeRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("IncrementChallengeProgressUseCase テスト")
+class IncrementChallengeProgressUseCaseTest {
+
+    @Mock
+    private WeeklyChallengeRepository weeklyChallengeRepository;
+
+    @Mock
+    private UserChallengeProgressRepository userChallengeProgressRepository;
+
+    @InjectMocks
+    private IncrementChallengeProgressUseCase incrementChallengeProgressUseCase;
+
+    @Test
+    @DisplayName("既存の進捗がある場合、セッション数をインクリメントする")
+    void execute_existingProgress_incrementsCompletedSessions() {
+        WeeklyChallenge challenge = new WeeklyChallenge();
+        challenge.setId(1);
+        challenge.setTitle("チャレンジ");
+        challenge.setDescription("説明");
+        challenge.setCategory("communication");
+        challenge.setTargetSessions(3);
+        challenge.setWeekStart(Date.valueOf("2026-03-02"));
+        challenge.setWeekEnd(Date.valueOf("2026-03-08"));
+
+        when(weeklyChallengeRepository.findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(
+                any(Date.class), any(Date.class)))
+                .thenReturn(Optional.of(challenge));
+
+        UserChallengeProgress progress = new UserChallengeProgress();
+        progress.setCompletedSessions(1);
+        progress.setIsCompleted(false);
+        progress.setChallenge(challenge);
+        when(userChallengeProgressRepository.findByUserIdAndChallengeId(1, 1))
+                .thenReturn(Optional.of(progress));
+
+        WeeklyChallengeDto result = incrementChallengeProgressUseCase.execute(1);
+
+        assertEquals(2, result.completedSessions());
+        assertFalse(result.isCompleted());
+        verify(userChallengeProgressRepository).save(argThat(p -> p.getCompletedSessions() == 2));
+    }
+
+    @Test
+    @DisplayName("進捗が存在しない場合、新規作成してインクリメントする")
+    void execute_noProgress_createsNewAndIncrements() {
+        WeeklyChallenge challenge = new WeeklyChallenge();
+        challenge.setId(1);
+        challenge.setTitle("チャレンジ");
+        challenge.setDescription("説明");
+        challenge.setCategory("communication");
+        challenge.setTargetSessions(3);
+        challenge.setWeekStart(Date.valueOf("2026-03-02"));
+        challenge.setWeekEnd(Date.valueOf("2026-03-08"));
+
+        when(weeklyChallengeRepository.findByWeekStartLessThanEqualAndWeekEndGreaterThanEqual(
+                any(Date.class), any(Date.class)))
+                .thenReturn(Optional.of(challenge));
+
+        when(userChallengeProgressRepository.findByUserIdAndChallengeId(1, 1))
+                .thenReturn(Optional.empty());
+
+        WeeklyChallengeDto result = incrementChallengeProgressUseCase.execute(1);
+
+        assertEquals(1, result.completedSessions());
+        assertFalse(result.isCompleted());
+        verify(userChallengeProgressRepository).save(argThat(p ->
+                p.getCompletedSessions() == 1 && !p.getIsCompleted()));
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ const RankingPage = lazy(() => import('./pages/RankingPage'));
 const TemplatePage = lazy(() => import('./pages/TemplatePage'));
 const ReminderPage = lazy(() => import('./pages/ReminderPage'));
 const SharedSessionsPage = lazy(() => import('./pages/SharedSessionsPage'));
+const WeeklyChallengePage = lazy(() => import('./pages/WeeklyChallengePage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -97,6 +98,7 @@ export default function App() {
         <Route path="/templates" element={<TemplatePage />} />
         <Route path="/reminder" element={<ReminderPage />} />
         <Route path="/shared-sessions" element={<SharedSessionsPage />} />
+        <Route path="/weekly-challenge" element={<WeeklyChallengePage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/MenuNavigationCard.tsx
+++ b/frontend/src/components/MenuNavigationCard.tsx
@@ -8,6 +8,7 @@ import {
   DocumentTextIcon,
   BellAlertIcon,
   ShareIcon,
+  FireIcon,
 } from '@heroicons/react/24/outline';
 import Card from './Card';
 
@@ -71,6 +72,13 @@ const MENU_ITEMS = [
     label: 'みんなの会話',
     description: 'コミュニティで共有されたAI会話セッション',
     to: '/shared-sessions',
+    badgeKey: null,
+  },
+  {
+    icon: FireIcon,
+    label: 'ウィークリーチャレンジ',
+    description: '今週のチャレンジに挑戦しよう',
+    to: '/weekly-challenge',
     badgeKey: null,
   },
 ];

--- a/frontend/src/hooks/__tests__/useWeeklyChallenge.test.ts
+++ b/frontend/src/hooks/__tests__/useWeeklyChallenge.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useWeeklyChallenge } from '../useWeeklyChallenge';
+import { WeeklyChallengeRepository } from '../../repositories/WeeklyChallengeRepository';
+
+vi.mock('../../repositories/WeeklyChallengeRepository');
+const mockedRepo = vi.mocked(WeeklyChallengeRepository);
+
+describe('useWeeklyChallenge', () => {
+  const mockChallenge = { id: 1, title: 'Test', description: 'desc', category: 'meeting', targetSessions: 3, completedSessions: 1, isCompleted: false, weekStart: '2024-01-01', weekEnd: '2024-01-07' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedRepo.fetchCurrentChallenge.mockResolvedValue(mockChallenge);
+    mockedRepo.incrementProgress.mockResolvedValue({ ...mockChallenge, completedSessions: 2 });
+  });
+
+  it('チャレンジを取得する', async () => {
+    const { result } = renderHook(() => useWeeklyChallenge());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.challenge).toEqual(mockChallenge);
+  });
+
+  it('進捗をインクリメントする', async () => {
+    const { result } = renderHook(() => useWeeklyChallenge());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => { await result.current.incrementProgress(); });
+    expect(result.current.challenge?.completedSessions).toBe(2);
+  });
+
+  it('チャレンジがない場合はnullを返す', async () => {
+    mockedRepo.fetchCurrentChallenge.mockResolvedValue(null);
+    const { result } = renderHook(() => useWeeklyChallenge());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.challenge).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useWeeklyChallenge.ts
+++ b/frontend/src/hooks/useWeeklyChallenge.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useCallback } from 'react';
+import { WeeklyChallengeRepository } from '../repositories/WeeklyChallengeRepository';
+import { WeeklyChallenge } from '../types';
+
+export function useWeeklyChallenge() {
+  const [challenge, setChallenge] = useState<WeeklyChallenge | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    WeeklyChallengeRepository.fetchCurrentChallenge()
+      .then((data) => {
+        if (!cancelled) setChallenge(data);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const incrementProgress = useCallback(async () => {
+    const updated = await WeeklyChallengeRepository.incrementProgress();
+    if (updated) setChallenge(updated);
+  }, []);
+
+  return { challenge, loading, incrementProgress };
+}

--- a/frontend/src/pages/WeeklyChallengePage.tsx
+++ b/frontend/src/pages/WeeklyChallengePage.tsx
@@ -1,0 +1,58 @@
+import { useWeeklyChallenge } from '../hooks/useWeeklyChallenge';
+import Loading from '../components/Loading';
+
+export default function WeeklyChallengePage() {
+  const { challenge, loading } = useWeeklyChallenge();
+
+  if (loading) return <Loading message="チャレンジを読み込み中..." />;
+
+  if (!challenge) {
+    return (
+      <div className="max-w-lg mx-auto px-4 py-6">
+        <h1 className="text-xl font-bold mb-4">ウィークリーチャレンジ</h1>
+        <p className="text-gray-400 text-center py-8">今週のチャレンジはまだ設定されていません</p>
+      </div>
+    );
+  }
+
+  const progress = Math.min((challenge.completedSessions / challenge.targetSessions) * 100, 100);
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-6 space-y-4">
+      <h1 className="text-xl font-bold">ウィークリーチャレンジ</h1>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-gray-400">
+            {new Date(challenge.weekStart).toLocaleDateString('ja-JP')} 〜 {new Date(challenge.weekEnd).toLocaleDateString('ja-JP')}
+          </span>
+          {challenge.isCompleted && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400" data-testid="completed-badge">
+              達成！
+            </span>
+          )}
+        </div>
+
+        <h2 className="text-lg font-bold">{challenge.title}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{challenge.description}</p>
+
+        {/* プログレスバー */}
+        <div className="space-y-1">
+          <div className="flex justify-between text-sm">
+            <span>{challenge.completedSessions} / {challenge.targetSessions} セッション</span>
+            <span className="text-gray-400">{Math.round(progress)}%</span>
+          </div>
+          <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3">
+            <div
+              className={`h-3 rounded-full transition-all ${
+                challenge.isCompleted ? 'bg-green-500' : 'bg-blue-500'
+              }`}
+              style={{ width: `${progress}%` }}
+              data-testid="progress-bar"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/WeeklyChallengePage.test.tsx
+++ b/frontend/src/pages/__tests__/WeeklyChallengePage.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import WeeklyChallengePage from '../WeeklyChallengePage';
+import { useWeeklyChallenge } from '../../hooks/useWeeklyChallenge';
+
+vi.mock('../../hooks/useWeeklyChallenge');
+const mockedUseWeeklyChallenge = vi.mocked(useWeeklyChallenge);
+
+function renderPage() {
+  return render(<MemoryRouter><WeeklyChallengePage /></MemoryRouter>);
+}
+
+describe('WeeklyChallengePage', () => {
+  const mockChallenge = { id: 1, title: '会議スキル強化週間', description: '会議関連のシナリオを3回練習', category: 'meeting', targetSessions: 3, completedSessions: 1, isCompleted: false, weekStart: '2024-01-01', weekEnd: '2024-01-07' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseWeeklyChallenge.mockReturnValue({ challenge: mockChallenge, loading: false, incrementProgress: vi.fn() });
+  });
+
+  it('タイトルを表示する', () => {
+    renderPage();
+    expect(screen.getByText('ウィークリーチャレンジ')).toBeInTheDocument();
+  });
+
+  it('チャレンジ名を表示する', () => {
+    renderPage();
+    expect(screen.getByText('会議スキル強化週間')).toBeInTheDocument();
+  });
+
+  it('進捗を表示する', () => {
+    renderPage();
+    expect(screen.getByText('1 / 3 セッション')).toBeInTheDocument();
+  });
+
+  it('ローディング中はローディング表示する', () => {
+    mockedUseWeeklyChallenge.mockReturnValue({ challenge: null, loading: true, incrementProgress: vi.fn() });
+    renderPage();
+    expect(screen.getByText('チャレンジを読み込み中...')).toBeInTheDocument();
+  });
+
+  it('チャレンジがない場合は空メッセージを表示する', () => {
+    mockedUseWeeklyChallenge.mockReturnValue({ challenge: null, loading: false, incrementProgress: vi.fn() });
+    renderPage();
+    expect(screen.getByText('今週のチャレンジはまだ設定されていません')).toBeInTheDocument();
+  });
+
+  it('達成時にバッジを表示する', () => {
+    mockedUseWeeklyChallenge.mockReturnValue({ challenge: { ...mockChallenge, isCompleted: true, completedSessions: 3 }, loading: false, incrementProgress: vi.fn() });
+    renderPage();
+    expect(screen.getByTestId('completed-badge')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/WeeklyChallengeRepository.ts
+++ b/frontend/src/repositories/WeeklyChallengeRepository.ts
@@ -1,0 +1,22 @@
+import apiClient from '../lib/axios';
+import { WeeklyChallenge } from '../types';
+
+export const WeeklyChallengeRepository = {
+  async fetchCurrentChallenge(): Promise<WeeklyChallenge | null> {
+    try {
+      const response = await apiClient.get<WeeklyChallenge>('/api/weekly-challenge');
+      return response.data;
+    } catch {
+      return null;
+    }
+  },
+
+  async incrementProgress(): Promise<WeeklyChallenge | null> {
+    try {
+      const response = await apiClient.post<WeeklyChallenge>('/api/weekly-challenge/progress');
+      return response.data;
+    } catch {
+      return null;
+    }
+  },
+};

--- a/frontend/src/repositories/__tests__/WeeklyChallengeRepository.test.ts
+++ b/frontend/src/repositories/__tests__/WeeklyChallengeRepository.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import apiClient from '../../lib/axios';
+import { WeeklyChallengeRepository } from '../WeeklyChallengeRepository';
+
+vi.mock('../../lib/axios');
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('WeeklyChallengeRepository', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('今週のチャレンジを取得する', async () => {
+    const mockData = { id: 1, title: 'Test', targetSessions: 3, completedSessions: 0, isCompleted: false };
+    mockedApiClient.get.mockResolvedValue({ data: mockData });
+    const result = await WeeklyChallengeRepository.fetchCurrentChallenge();
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/weekly-challenge');
+    expect(result).toEqual(mockData);
+  });
+
+  it('進捗をインクリメントする', async () => {
+    const mockData = { id: 1, completedSessions: 1 };
+    mockedApiClient.post.mockResolvedValue({ data: mockData });
+    const result = await WeeklyChallengeRepository.incrementProgress();
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/weekly-challenge/progress');
+    expect(result).toEqual(mockData);
+  });
+
+  it('エラー時にnullを返す', async () => {
+    mockedApiClient.get.mockRejectedValue(new Error('fail'));
+    const result = await WeeklyChallengeRepository.fetchCurrentChallenge();
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -252,3 +252,16 @@ export interface SharedSession {
   description: string | null;
   createdAt: string;
 }
+
+/** ウィークリーチャレンジ */
+export interface WeeklyChallenge {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  targetSessions: number;
+  completedSessions: number;
+  isCompleted: boolean;
+  weekStart: string;
+  weekEnd: string;
+}


### PR DESCRIPTION
## 概要
- 週替わりテーマ付きチャレンジでユーザーの継続的な学習を促進
- プログレスバーで進捗を可視化、達成時にバッジ表示

## 変更内容
### バックエンド
- `WeeklyChallenge` / `UserChallengeProgress` エンティティ + DBテーブル
- `WeeklyChallengeController` - `GET /api/weekly-challenge`, `POST /api/weekly-challenge/progress`
- `GetCurrentChallengeUseCase` / `IncrementChallengeProgressUseCase`

### フロントエンド
- `WeeklyChallengePage` - チャレンジ表示（プログレスバー・達成バッジ）
- `useWeeklyChallenge` フック
- `WeeklyChallengeRepository` - API呼び出し
- メニューにナビゲーション追加

## テスト
- バックエンド: 6テスト（Controller 2 + UseCase 4）
- フロントエンド: 12テスト（Repository 3 + Hook 3 + Page 6）

Closes #1442