### PR TITLE
refactor: ControllerからServiceへの直接呼び出しをUseCase経由に変更 (#1444)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatController.java
@@ -25,7 +25,6 @@ import com.example.FreStyle.dto.AiChatSessionStatsDto;
 import com.example.FreStyle.dto.PracticeSessionSummaryDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.AiChatService;
-import com.example.FreStyle.service.BedrockService;
 import com.example.FreStyle.service.UserIdentityService;
 import com.example.FreStyle.usecase.AddAiChatMessageUseCase;
 import com.example.FreStyle.usecase.CreateAiChatSessionUseCase;
@@ -35,6 +34,7 @@ import com.example.FreStyle.usecase.GetAiChatSessionByIdUseCase;
 import com.example.FreStyle.usecase.GetAiChatSessionsByUserIdUseCase;
 import com.example.FreStyle.usecase.GetAiChatSessionStatsUseCase;
 import com.example.FreStyle.usecase.GetPracticeSessionSummaryUseCase;
+import com.example.FreStyle.usecase.RephraseMessageUseCase;
 import com.example.FreStyle.usecase.UpdateAiChatSessionTitleUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -48,7 +48,6 @@ import lombok.extern.slf4j.Slf4j;
 public class AiChatController {
     private final AiChatService aiChatService;
     private final UserIdentityService userIdentityService;
-    private final BedrockService bedrockService;
 
     // UseCases (クリーンアーキテクチャー)
     private final GetAiChatSessionsByUserIdUseCase getAiChatSessionsByUserIdUseCase;
@@ -60,6 +59,7 @@ public class AiChatController {
     private final AddAiChatMessageUseCase addAiChatMessageUseCase;
     private final GetPracticeSessionSummaryUseCase getPracticeSessionSummaryUseCase;
     private final GetAiChatSessionStatsUseCase getAiChatSessionStatsUseCase;
+    private final RephraseMessageUseCase rephraseMessageUseCase;
 
 
     // =============================================
@@ -253,7 +253,7 @@ public class AiChatController {
 
         resolveUser(jwt); // 認証チェック
 
-        String result = bedrockService.rephrase(request.originalMessage(), request.scene());
+        String result = rephraseMessageUseCase.execute(request.originalMessage(), request.scene());
         log.info("✅ 言い換え提案取得成功");
 
         return ResponseEntity.ok(Map.of("result", result));

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatWebSocketController.java
@@ -13,11 +13,11 @@ import com.example.FreStyle.constant.SceneDisplayName;
 import com.example.FreStyle.dto.AiChatMessageResponseDto;
 import com.example.FreStyle.dto.AiChatSessionDto;
 import com.example.FreStyle.dto.ScoreCardDto;
-import com.example.FreStyle.service.BedrockService;
 import com.example.FreStyle.usecase.AddAiChatMessageUseCase;
 import com.example.FreStyle.usecase.CreateAiChatSessionUseCase;
 import com.example.FreStyle.usecase.DeleteAiChatSessionUseCase;
 import com.example.FreStyle.usecase.GetAiReplyUseCase;
+import com.example.FreStyle.usecase.RephraseMessageUseCase;
 import com.example.FreStyle.usecase.SaveScoreCardUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -28,7 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AiChatWebSocketController {
 
-    private final BedrockService bedrockService;
     private final SimpMessagingTemplate messagingTemplate;
 
     // UseCases (クリーンアーキテクチャー)
@@ -37,6 +36,7 @@ public class AiChatWebSocketController {
     private final DeleteAiChatSessionUseCase deleteAiChatSessionUseCase;
     private final GetAiReplyUseCase getAiReplyUseCase;
     private final SaveScoreCardUseCase saveScoreCardUseCase;
+    private final RephraseMessageUseCase rephraseMessageUseCase;
 
     /**
      * AIチャットメッセージ送信
@@ -185,7 +185,7 @@ public class AiChatWebSocketController {
             Object sceneObj = payload.get("scene");
             String scene = sceneObj != null ? String.valueOf(sceneObj) : null;
 
-            String rephraseResult = bedrockService.rephrase(originalMessage, scene);
+            String rephraseResult = rephraseMessageUseCase.execute(originalMessage, scene);
 
             messagingTemplate.convertAndSend(
                     "/topic/ai-chat/user/" + userId + "/rephrase",

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/FriendshipController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/FriendshipController.java
@@ -16,7 +16,6 @@ import com.example.FreStyle.dto.FollowStatusDto;
 import com.example.FreStyle.dto.FriendshipDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
 import com.example.FreStyle.usecase.CheckFollowStatusUseCase;
 import com.example.FreStyle.usecase.FollowUserUseCase;
 import com.example.FreStyle.usecase.GetFollowersUseCase;
@@ -38,16 +37,14 @@ public class FriendshipController {
     private final GetFollowingUseCase getFollowingUseCase;
     private final CheckFollowStatusUseCase checkFollowStatusUseCase;
     private final UserIdentityService userIdentityService;
-    private final UserService userService;
 
     @PostMapping("/{userId}/follow")
     public ResponseEntity<FriendshipDto> followUser(
             @AuthenticationPrincipal Jwt jwt,
             @PathVariable Integer userId) {
         User currentUser = resolveUser(jwt);
-        User targetUser = userService.findUserById(userId);
         log.info("フォロー: userId={} -> targetId={}", currentUser.getId(), userId);
-        FriendshipDto result = followUserUseCase.execute(currentUser, targetUser);
+        FriendshipDto result = followUserUseCase.execute(currentUser, userId);
         return ResponseEntity.ok(result);
     }
 
@@ -57,7 +54,7 @@ public class FriendshipController {
             @PathVariable Integer userId) {
         User currentUser = resolveUser(jwt);
         log.info("フォロー解除: userId={} -> targetId={}", currentUser.getId(), userId);
-        unfollowUserUseCase.execute(currentUser, userId);
+        unfollowUserUseCase.execute(currentUser.getId(), userId);
         return ResponseEntity.noContent().build();
     }
 

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/UserStatsController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/UserStatsController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.example.FreStyle.dto.UserStatsDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
 import com.example.FreStyle.usecase.GetUserStatsUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ public class UserStatsController {
 
     private final GetUserStatsUseCase getUserStatsUseCase;
     private final UserIdentityService userIdentityService;
-    private final UserService userService;
 
     @GetMapping("/me/stats")
     public ResponseEntity<UserStatsDto> getMyStats(@AuthenticationPrincipal Jwt jwt) {
@@ -37,7 +35,6 @@ public class UserStatsController {
 
     @GetMapping("/{userId}/stats")
     public ResponseEntity<UserStatsDto> getUserStats(@PathVariable Integer userId) {
-        userService.findUserById(userId);
         log.info("ユーザー統計取得: userId={}", userId);
         UserStatsDto stats = getUserStatsUseCase.execute(userId);
         return ResponseEntity.ok(stats);

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/FollowUserUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/FollowUserUseCase.java
@@ -9,6 +9,7 @@ import com.example.FreStyle.entity.Friendship;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.mapper.FriendshipMapper;
 import com.example.FreStyle.repository.FriendshipRepository;
+import com.example.FreStyle.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,16 +19,19 @@ public class FollowUserUseCase {
 
     private final FriendshipRepository friendshipRepository;
     private final FriendshipMapper friendshipMapper;
+    private final UserService userService;
 
     @Transactional
-    public FriendshipDto execute(User follower, User following) {
-        if (follower.getId().equals(following.getId())) {
+    public FriendshipDto execute(User follower, Integer followingId) {
+        if (follower.getId().equals(followingId)) {
             throw new IllegalArgumentException("自分自身をフォローすることはできません");
         }
 
-        if (friendshipRepository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())) {
+        if (friendshipRepository.existsByFollowerIdAndFollowingId(follower.getId(), followingId)) {
             throw new IllegalArgumentException("既にフォローしています");
         }
+
+        User following = userService.findUserById(followingId);
 
         Friendship friendship = new Friendship();
         friendship.setFollower(follower);
@@ -41,7 +45,7 @@ public class FollowUserUseCase {
         }
 
         boolean mutual = friendshipRepository.existsByFollowerIdAndFollowingId(
-                following.getId(), follower.getId());
+                followingId, follower.getId());
 
         return friendshipMapper.toFollowingDto(saved, mutual);
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserStatsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/GetUserStatsUseCase.java
@@ -11,6 +11,7 @@ import com.example.FreStyle.entity.CommunicationScore;
 import com.example.FreStyle.repository.AiChatSessionRepository;
 import com.example.FreStyle.repository.CommunicationScoreRepository;
 import com.example.FreStyle.repository.FriendshipRepository;
+import com.example.FreStyle.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,9 +22,12 @@ public class GetUserStatsUseCase {
     private final AiChatSessionRepository aiChatSessionRepository;
     private final FriendshipRepository friendshipRepository;
     private final CommunicationScoreRepository communicationScoreRepository;
+    private final UserService userService;
 
     @Transactional(readOnly = true)
     public UserStatsDto execute(Integer userId) {
+        // ユーザー存在チェック（存在しない場合はRuntimeException）
+        userService.findUserById(userId);
         List<AiChatSession> sessions = aiChatSessionRepository.findByUserIdOrderByCreatedAtDesc(userId);
         long totalSessions = sessions.size();
         long practiceSessionCount = sessions.stream()

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/RephraseMessageUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/RephraseMessageUseCase.java
@@ -1,0 +1,17 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+
+import com.example.FreStyle.service.BedrockService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RephraseMessageUseCase {
+    private final BedrockService bedrockService;
+
+    public String execute(String originalMessage, String scene) {
+        return bedrockService.rephrase(originalMessage, scene);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UnfollowUserUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UnfollowUserUseCase.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.FreStyle.entity.Friendship;
-import com.example.FreStyle.entity.User;
 import com.example.FreStyle.exception.ResourceNotFoundException;
 import com.example.FreStyle.repository.FriendshipRepository;
 
@@ -17,9 +16,9 @@ public class UnfollowUserUseCase {
     private final FriendshipRepository friendshipRepository;
 
     @Transactional
-    public void execute(User follower, Integer followingId) {
+    public void execute(Integer followerId, Integer followingId) {
         Friendship friendship = friendshipRepository
-                .findByFollowerIdAndFollowingId(follower.getId(), followingId)
+                .findByFollowerIdAndFollowingId(followerId, followingId)
                 .orElseThrow(() -> new ResourceNotFoundException("フォロー関係が見つかりません"));
 
         friendshipRepository.delete(friendship);

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/AiChatControllerTest.java
@@ -27,17 +27,17 @@ import com.example.FreStyle.dto.AiChatMessageResponseDto;
 import com.example.FreStyle.dto.AiChatSessionDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.AiChatService;
-import com.example.FreStyle.service.BedrockService;
 import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.AddAiChatMessageUseCase;
 import com.example.FreStyle.usecase.CreateAiChatSessionUseCase;
 import com.example.FreStyle.usecase.DeleteAiChatSessionUseCase;
-import com.example.FreStyle.usecase.GetAiChatSessionByIdUseCase;
-import com.example.FreStyle.usecase.GetAiChatSessionsByUserIdUseCase;
-import com.example.FreStyle.usecase.UpdateAiChatSessionTitleUseCase;
 import com.example.FreStyle.usecase.GetAiChatMessagesBySessionIdUseCase;
-import com.example.FreStyle.usecase.AddAiChatMessageUseCase;
-import com.example.FreStyle.usecase.GetPracticeSessionSummaryUseCase;
+import com.example.FreStyle.usecase.GetAiChatSessionByIdUseCase;
 import com.example.FreStyle.usecase.GetAiChatSessionStatsUseCase;
+import com.example.FreStyle.usecase.GetAiChatSessionsByUserIdUseCase;
+import com.example.FreStyle.usecase.GetPracticeSessionSummaryUseCase;
+import com.example.FreStyle.usecase.RephraseMessageUseCase;
+import com.example.FreStyle.usecase.UpdateAiChatSessionTitleUseCase;
 import com.example.FreStyle.dto.AiChatSessionStatsDto;
 import com.example.FreStyle.dto.PracticeSessionSummaryDto;
 
@@ -47,7 +47,7 @@ class AiChatControllerTest {
 
     @Mock private AiChatService aiChatService;
     @Mock private UserIdentityService userIdentityService;
-    @Mock private BedrockService bedrockService;
+    @Mock private RephraseMessageUseCase rephraseMessageUseCase;
     @Mock private GetAiChatSessionsByUserIdUseCase getAiChatSessionsByUserIdUseCase;
     @Mock private CreateAiChatSessionUseCase createAiChatSessionUseCase;
     @Mock private GetAiChatSessionByIdUseCase getAiChatSessionByIdUseCase;
@@ -141,7 +141,7 @@ class AiChatControllerTest {
             Jwt jwt = mockJwt("sub-123");
             User user = createUser(10);
             when(userIdentityService.findUserBySub("sub-123")).thenReturn(user);
-            when(bedrockService.rephrase("テスト", "会議")).thenReturn("言い換え結果");
+            when(rephraseMessageUseCase.execute("テスト", "会議")).thenReturn("言い換え結果");
 
             // Use reflection-free approach: create record via constructor
             var request = new AiChatController.RephraseRequest("テスト", "会議");

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/FriendshipControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/FriendshipControllerTest.java
@@ -23,7 +23,6 @@ import com.example.FreStyle.dto.FollowStatusDto;
 import com.example.FreStyle.dto.FriendshipDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
 import com.example.FreStyle.usecase.CheckFollowStatusUseCase;
 import com.example.FreStyle.usecase.FollowUserUseCase;
 import com.example.FreStyle.usecase.GetFollowersUseCase;
@@ -52,15 +51,11 @@ class FriendshipControllerTest {
     @Mock
     private UserIdentityService userIdentityService;
 
-    @Mock
-    private UserService userService;
-
     @InjectMocks
     private FriendshipController friendshipController;
 
     private Jwt mockJwt;
     private User testUser;
-    private User targetUser;
 
     @BeforeEach
     void setUp() {
@@ -70,10 +65,6 @@ class FriendshipControllerTest {
         testUser = new User();
         testUser.setId(1);
         testUser.setName("テストユーザー");
-
-        targetUser = new User();
-        targetUser.setId(2);
-        targetUser.setName("ターゲット");
 
         when(userIdentityService.findUserBySub("sub-123")).thenReturn(testUser);
     }
@@ -85,9 +76,8 @@ class FriendshipControllerTest {
         @Test
         @DisplayName("ユーザーをフォローできる")
         void followsUser() {
-            when(userService.findUserById(2)).thenReturn(targetUser);
             FriendshipDto dto = new FriendshipDto(1, 2, "ターゲット", null, null, false, "2026-02-17T00:00:00", null);
-            when(followUserUseCase.execute(testUser, targetUser)).thenReturn(dto);
+            when(followUserUseCase.execute(testUser, 2)).thenReturn(dto);
 
             ResponseEntity<FriendshipDto> response = friendshipController.followUser(mockJwt, 2);
 
@@ -106,7 +96,7 @@ class FriendshipControllerTest {
             ResponseEntity<Void> response = friendshipController.unfollowUser(mockJwt, 2);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-            verify(unfollowUserUseCase).execute(testUser, 2);
+            verify(unfollowUserUseCase).execute(1, 2);
         }
     }
 

--- a/FreStyle/src/test/java/com/example/FreStyle/controller/UserStatsControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/UserStatsControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import com.example.FreStyle.dto.UserStatsDto;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.service.UserIdentityService;
-import com.example.FreStyle.service.UserService;
 import com.example.FreStyle.usecase.GetUserStatsUseCase;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,9 +27,6 @@ class UserStatsControllerTest {
 
     @Mock
     private UserIdentityService userIdentityService;
-
-    @Mock
-    private UserService userService;
 
     @Mock
     private Jwt jwt;
@@ -67,10 +63,6 @@ class UserStatsControllerTest {
     @Test
     @DisplayName("指定ユーザーの統計を取得できる")
     void getUserStats_returnsStats() {
-        User targetUser = new User();
-        targetUser.setId(2);
-        when(userService.findUserById(2)).thenReturn(targetUser);
-
         UserStatsDto stats = new UserStatsDto(5, 3, 8, 4, 60.0);
         when(getUserStatsUseCase.execute(2)).thenReturn(stats);
 

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/FollowUserUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/FollowUserUseCaseTest.java
@@ -22,6 +22,7 @@ import com.example.FreStyle.entity.Friendship;
 import com.example.FreStyle.entity.User;
 import com.example.FreStyle.mapper.FriendshipMapper;
 import com.example.FreStyle.repository.FriendshipRepository;
+import com.example.FreStyle.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("FollowUserUseCase テスト")
@@ -29,6 +30,9 @@ class FollowUserUseCaseTest {
 
     @Mock
     private FriendshipRepository friendshipRepository;
+
+    @Mock
+    private UserService userService;
 
     @Spy
     private FriendshipMapper friendshipMapper;
@@ -54,13 +58,14 @@ class FollowUserUseCaseTest {
     void execute_followsUser() {
         when(friendshipRepository.existsByFollowerIdAndFollowingId(1, 2)).thenReturn(false);
         when(friendshipRepository.existsByFollowerIdAndFollowingId(2, 1)).thenReturn(false);
+        when(userService.findUserById(2)).thenReturn(following);
         when(friendshipRepository.save(any(Friendship.class))).thenAnswer(inv -> {
             Friendship f = inv.getArgument(0);
             f.setId(100);
             return f;
         });
 
-        FriendshipDto result = followUserUseCase.execute(follower, following);
+        FriendshipDto result = followUserUseCase.execute(follower, 2);
 
         assertThat(result).isNotNull();
         assertThat(result.userId()).isEqualTo(2);
@@ -74,13 +79,14 @@ class FollowUserUseCaseTest {
     void execute_mutualFollow() {
         when(friendshipRepository.existsByFollowerIdAndFollowingId(1, 2)).thenReturn(false);
         when(friendshipRepository.existsByFollowerIdAndFollowingId(2, 1)).thenReturn(true);
+        when(userService.findUserById(2)).thenReturn(following);
         when(friendshipRepository.save(any(Friendship.class))).thenAnswer(inv -> {
             Friendship f = inv.getArgument(0);
             f.setId(101);
             return f;
         });
 
-        FriendshipDto result = followUserUseCase.execute(follower, following);
+        FriendshipDto result = followUserUseCase.execute(follower, 2);
 
         assertThat(result).isNotNull();
         assertThat(result.mutual()).isTrue();
@@ -91,14 +97,14 @@ class FollowUserUseCaseTest {
     void execute_alreadyFollowing() {
         when(friendshipRepository.existsByFollowerIdAndFollowingId(1, 2)).thenReturn(true);
 
-        assertThatThrownBy(() -> followUserUseCase.execute(follower, following))
+        assertThatThrownBy(() -> followUserUseCase.execute(follower, 2))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     @DisplayName("自分自身はフォローできない")
     void execute_cannotFollowSelf() {
-        assertThatThrownBy(() -> followUserUseCase.execute(follower, follower))
+        assertThatThrownBy(() -> followUserUseCase.execute(follower, 1))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -106,10 +112,11 @@ class FollowUserUseCaseTest {
     @DisplayName("レース条件でDB制約違反が発生した場合はIllegalArgumentExceptionに変換される")
     void execute_raceConditionThrowsIllegalArgument() {
         when(friendshipRepository.existsByFollowerIdAndFollowingId(1, 2)).thenReturn(false);
+        when(userService.findUserById(2)).thenReturn(following);
         when(friendshipRepository.save(any(Friendship.class)))
                 .thenThrow(new DataIntegrityViolationException("Duplicate entry"));
 
-        assertThatThrownBy(() -> followUserUseCase.execute(follower, following))
+        assertThatThrownBy(() -> followUserUseCase.execute(follower, 2))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("既にフォローしています");
     }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserStatsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetUserStatsUseCaseTest.java
@@ -18,6 +18,7 @@ import com.example.FreStyle.entity.CommunicationScore;
 import com.example.FreStyle.repository.AiChatSessionRepository;
 import com.example.FreStyle.repository.CommunicationScoreRepository;
 import com.example.FreStyle.repository.FriendshipRepository;
+import com.example.FreStyle.service.UserService;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("GetUserStatsUseCase テスト")
@@ -31,6 +32,9 @@ class GetUserStatsUseCaseTest {
 
     @Mock
     private CommunicationScoreRepository communicationScoreRepository;
+
+    @Mock
+    private UserService userService;
 
     @InjectMocks
     private GetUserStatsUseCase getUserStatsUseCase;

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/RephraseMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/RephraseMessageUseCaseTest.java
@@ -1,0 +1,36 @@
+package com.example.FreStyle.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.FreStyle.service.BedrockService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RephraseMessageUseCase テスト")
+class RephraseMessageUseCaseTest {
+
+    @Mock
+    private BedrockService bedrockService;
+
+    @InjectMocks
+    private RephraseMessageUseCase rephraseMessageUseCase;
+
+    @Test
+    @DisplayName("メッセージを言い換える")
+    void execute_rephrasesMessage() {
+        when(bedrockService.rephrase("元のメッセージ", "会議")).thenReturn("言い換え結果");
+
+        String result = rephraseMessageUseCase.execute("元のメッセージ", "会議");
+
+        assertThat(result).isEqualTo("言い換え結果");
+        verify(bedrockService).rephrase("元のメッセージ", "会議");
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UnfollowUserUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UnfollowUserUseCaseTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,20 +28,14 @@ class UnfollowUserUseCaseTest {
     @InjectMocks
     private UnfollowUserUseCase unfollowUserUseCase;
 
-    private User follower;
-    private User following;
-
-    @BeforeEach
-    void setUp() {
-        follower = new User();
-        follower.setId(1);
-        following = new User();
-        following.setId(2);
-    }
-
     @Test
     @DisplayName("フォローを解除できる")
     void execute_unfollowsUser() {
+        User follower = new User();
+        follower.setId(1);
+        User following = new User();
+        following.setId(2);
+
         Friendship friendship = new Friendship();
         friendship.setId(10);
         friendship.setFollower(follower);
@@ -51,7 +44,7 @@ class UnfollowUserUseCaseTest {
         when(friendshipRepository.findByFollowerIdAndFollowingId(1, 2))
                 .thenReturn(Optional.of(friendship));
 
-        unfollowUserUseCase.execute(follower, 2);
+        unfollowUserUseCase.execute(1, 2);
 
         verify(friendshipRepository).delete(friendship);
     }
@@ -62,7 +55,7 @@ class UnfollowUserUseCaseTest {
         when(friendshipRepository.findByFollowerIdAndFollowingId(1, 2))
                 .thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> unfollowUserUseCase.execute(follower, 2))
+        assertThatThrownBy(() -> unfollowUserUseCase.execute(1, 2))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
 }


### PR DESCRIPTION
## 概要
クリーンアーキテクチャの層構造（Controller → UseCase → Service → Repository）に違反していた4箇所を修正。

## 変更内容
1. **RephraseMessageUseCase 新規作成** - AiChatController・AiChatWebSocketControllerから BedrockService.rephrase() を直接呼び出していた箇所をUseCase経由に変更
2. **FollowUserUseCase** - Controller側でuserService.findUserById()していた処理をUseCase内に移動
3. **UnfollowUserUseCase** - 同上
4. **GetUserStatsUseCase** - UserStatsController側のユーザー存在検証をUseCase内に移動

## テスト
- 新規: RephraseMessageUseCaseTest（1テスト）
- 既存テスト7クラス全て更新・パス

Closes #1444