### PR TITLE
test: エッジケーステストの追加によるテスト品質向上 (#1446)

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/service/RankingServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/RankingServiceTest.java
@@ -111,4 +111,75 @@ class RankingServiceTest {
         // Allow 5 seconds tolerance
         assertThat(diffMillis).isBetween(sevenDaysMillis - 5000L, sevenDaysMillis + 5000L);
     }
+
+    @Test
+    @DisplayName("monthlyの場合は1ヶ月前からのデータを取得する")
+    void shouldUseCutoffForMonthlyPeriod() {
+        ArgumentCaptor<Timestamp> cutoffCaptor = ArgumentCaptor.forClass(Timestamp.class);
+        when(communicationScoreRepository.findUserAverageScoresAfter(cutoffCaptor.capture()))
+                .thenReturn(List.of());
+
+        rankingService.getRanking("monthly", 1);
+
+        Timestamp capturedCutoff = cutoffCaptor.getValue();
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        long diffMillis = now.getTime() - capturedCutoff.getTime();
+        // approximately 30 days
+        long thirtyDaysMillis = 30 * 24 * 60 * 60 * 1000L;
+        // Allow range of 28-31 days to account for month length variation
+        long twentyEightDaysMillis = 28 * 24 * 60 * 60 * 1000L;
+        long thirtyOneDaysMillis = 31 * 24 * 60 * 60 * 1000L;
+        assertThat(diffMillis).isBetween(twentyEightDaysMillis - 5000L, thirtyOneDaysMillis + 5000L);
+    }
+
+    @Test
+    @DisplayName("ユーザーが見つからない場合はスキップする")
+    void shouldSkipWhenUserNotFound() {
+        Object[] row1 = new Object[]{1, 8.5, 3L};
+        Object[] row2 = new Object[]{2, 7.0, 2L};
+        when(communicationScoreRepository.findUserAverageScoresAfter(any(Timestamp.class)))
+                .thenReturn(List.of(row1, row2));
+
+        User user1 = new User();
+        user1.setId(1);
+        user1.setName("User1");
+        user1.setIconUrl("icon1.png");
+        when(userRepository.findById(1)).thenReturn(Optional.of(user1));
+        when(userRepository.findById(2)).thenReturn(Optional.empty());
+
+        RankingDto result = rankingService.getRanking("weekly", 99);
+
+        assertThat(result.entries()).hasSize(1);
+        assertThat(result.entries().get(0).username()).isEqualTo("User1");
+    }
+
+    @Test
+    @DisplayName("空の結果の場合は空のリストを返す")
+    void shouldReturnEmptyListWhenNoResults() {
+        when(communicationScoreRepository.findUserAverageScoresAfter(any(Timestamp.class)))
+                .thenReturn(List.of());
+
+        RankingDto result = rankingService.getRanking("weekly", 1);
+
+        assertThat(result.entries()).isEmpty();
+        assertThat(result.myRanking()).isNull();
+    }
+
+    @Test
+    @DisplayName("デフォルトの期間はmonthlyとして扱う")
+    void shouldTreatUnknownPeriodAsMonthly() {
+        ArgumentCaptor<Timestamp> cutoffCaptor = ArgumentCaptor.forClass(Timestamp.class);
+        when(communicationScoreRepository.findUserAverageScoresAfter(cutoffCaptor.capture()))
+                .thenReturn(List.of());
+
+        rankingService.getRanking("unknown_period", 1);
+
+        Timestamp capturedCutoff = cutoffCaptor.getValue();
+        Timestamp now = new Timestamp(System.currentTimeMillis());
+        long diffMillis = now.getTime() - capturedCutoff.getTime();
+        // default falls through to monthly (approximately 28-31 days)
+        long twentyEightDaysMillis = 28 * 24 * 60 * 60 * 1000L;
+        long thirtyOneDaysMillis = 31 * 24 * 60 * 60 * 1000L;
+        assertThat(diffMillis).isBetween(twentyEightDaysMillis - 5000L, thirtyOneDaysMillis + 5000L);
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetPublicSessionsUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetPublicSessionsUseCaseTest.java
@@ -58,4 +58,14 @@ class GetPublicSessionsUseCaseTest {
         assertThat(result.get(0).sessionTitle()).isEqualTo("公開セッション");
         assertThat(result.get(0).username()).isEqualTo("ユーザー1");
     }
+
+    @Test
+    @DisplayName("公開セッションがない場合は空リストを返す")
+    void shouldReturnEmptyListWhenNoPublicSessions() {
+        when(sharedSessionRepository.findPublicSessions()).thenReturn(List.of());
+
+        List<SharedSessionDto> result = useCase.execute();
+
+        assertThat(result).isEmpty();
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/GetRankingUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/GetRankingUseCaseTest.java
@@ -39,4 +39,16 @@ class GetRankingUseCaseTest {
         verify(rankingService).getRanking("weekly", 1);
         assertThat(result).isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("RankingServiceに正しい引数を委譲する")
+    void shouldDelegateCorrectPeriodAndUserId() {
+        RankingDto expected = new RankingDto(List.of(), null);
+        when(rankingService.getRanking("monthly", 42)).thenReturn(expected);
+
+        RankingDto result = useCase.execute("monthly", 42);
+
+        verify(rankingService).getRanking("monthly", 42);
+        assertThat(result).isEqualTo(expected);
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/RephraseMessageUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/RephraseMessageUseCaseTest.java
@@ -33,4 +33,25 @@ class RephraseMessageUseCaseTest {
         assertThat(result).isEqualTo("言い換え結果");
         verify(bedrockService).rephrase("元のメッセージ", "会議");
     }
+
+    @Test
+    @DisplayName("空のメッセージでも処理する")
+    void execute_handlesEmptyMessage() {
+        when(bedrockService.rephrase("", "日常")).thenReturn("空の言い換え結果");
+
+        String result = rephraseMessageUseCase.execute("", "日常");
+
+        assertThat(result).isEqualTo("空の言い換え結果");
+        verify(bedrockService).rephrase("", "日常");
+    }
+
+    @Test
+    @DisplayName("BedrockServiceに正しい引数を渡す")
+    void execute_passesCorrectArgumentsToBedrockService() {
+        when(bedrockService.rephrase("特定のメッセージ", "ビジネス")).thenReturn("結果");
+
+        rephraseMessageUseCase.execute("特定のメッセージ", "ビジネス");
+
+        verify(bedrockService).rephrase("特定のメッセージ", "ビジネス");
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/ShareSessionUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/ShareSessionUseCaseTest.java
@@ -86,4 +86,16 @@ class ShareSessionUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(2, form))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
+
+    @Test
+    @DisplayName("セッションが見つからない場合は例外を投げる")
+    void shouldThrowWhenSessionNotFound() {
+        when(aiChatSessionRepository.findByIdAndUserId(999, 1))
+                .thenReturn(Optional.empty());
+
+        ShareSessionForm form = new ShareSessionForm(999, "説明");
+
+        assertThatThrownBy(() -> useCase.execute(1, form))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
 }

--- a/FreStyle/src/test/java/com/example/FreStyle/usecase/UnshareSessionUseCaseTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/usecase/UnshareSessionUseCaseTest.java
@@ -71,4 +71,13 @@ class UnshareSessionUseCaseTest {
         assertThatThrownBy(() -> useCase.execute(1, 10))
                 .isInstanceOf(ResourceNotFoundException.class);
     }
+
+    @Test
+    @DisplayName("共有セッションが見つからない場合は例外を投げる")
+    void shouldThrowWhenSharedSessionNotFound() {
+        when(sharedSessionRepository.findBySessionId(999)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(1, 999))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
 }

--- a/frontend/src/hooks/__tests__/useRanking.test.ts
+++ b/frontend/src/hooks/__tests__/useRanking.test.ts
@@ -61,4 +61,26 @@ describe('useRanking', () => {
 
     expect(result.current.error).toBe('ランキングの取得に失敗しました');
   });
+
+  it('アンマウント時にデータ更新しない', async () => {
+    let resolvePromise: (value: typeof mockRanking) => void;
+    mockedRepo.fetchRanking.mockImplementation(() => new Promise((resolve) => { resolvePromise = resolve; }));
+
+    const { result, unmount } = renderHook(() => useRanking());
+
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+
+    resolvePromise!(mockRanking);
+
+    // After unmount, state should not have been updated (no error thrown)
+    expect(result.current.ranking).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('期間のデフォルト値はweeklyである', () => {
+    const { result } = renderHook(() => useRanking());
+    expect(result.current.period).toBe('weekly');
+  });
 });

--- a/frontend/src/hooks/__tests__/useReminder.test.ts
+++ b/frontend/src/hooks/__tests__/useReminder.test.ts
@@ -48,4 +48,40 @@ describe('useReminder', () => {
     await act(async () => { await result.current.save(); });
     expect(mockedRepo.saveSetting).toHaveBeenCalled();
   });
+
+  it('曜日をトグルで削除する', async () => {
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // mockSettingのdaysOfWeekは 'mon,tue,wed,thu,fri' なので 'mon' は含まれている
+    expect(result.current.selectedDays).toContain('mon');
+
+    act(() => result.current.toggleDay('mon'));
+
+    expect(result.current.selectedDays).not.toContain('mon');
+    expect(result.current.setting.daysOfWeek).not.toContain('mon');
+  });
+
+  it('保存中フラグが正しく管理される', async () => {
+    let resolveSave: (value: typeof mockSetting) => void;
+    mockedRepo.saveSetting.mockImplementation(() => new Promise((resolve) => { resolveSave = resolve; }));
+
+    const { result } = renderHook(() => useReminder());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.saving).toBe(false);
+
+    let savePromise: Promise<void>;
+    act(() => { savePromise = result.current.save(); });
+
+    // saving should be true while the promise is pending
+    expect(result.current.saving).toBe(true);
+
+    await act(async () => {
+      resolveSave!(mockSetting);
+      await savePromise!;
+    });
+
+    expect(result.current.saving).toBe(false);
+  });
 });

--- a/frontend/src/hooks/__tests__/useSharedSessions.test.ts
+++ b/frontend/src/hooks/__tests__/useSharedSessions.test.ts
@@ -37,4 +37,28 @@ describe('useSharedSessions', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe('共有セッションの取得に失敗しました');
   });
+
+  it('共有解除するとリストから削除される', async () => {
+    mockedRepo.unshareSession.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useSharedSessions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sessions).toHaveLength(1);
+
+    await act(async () => { await result.current.unshareSession(10); });
+    expect(result.current.sessions).toHaveLength(0);
+    expect(mockedRepo.unshareSession).toHaveBeenCalledWith(10);
+  });
+
+  it('共有解除のAPIエラーをスローする', async () => {
+    mockedRepo.unshareSession.mockRejectedValue(new Error('unshare failed'));
+    const { result } = renderHook(() => useSharedSessions());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(
+      act(async () => { await result.current.unshareSession(10); })
+    ).rejects.toThrow('unshare failed');
+
+    // リストは変更されないこと（filterはunshareSession成功後に実行される）
+    expect(result.current.sessions).toHaveLength(1);
+  });
 });

--- a/frontend/src/hooks/__tests__/useTemplates.test.ts
+++ b/frontend/src/hooks/__tests__/useTemplates.test.ts
@@ -36,4 +36,29 @@ describe('useTemplates', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe('テンプレートの取得に失敗しました');
   });
+
+  it('カテゴリリストを提供する', async () => {
+    const { result } = renderHook(() => useTemplates());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.categories).toBeDefined();
+    expect(Array.isArray(result.current.categories)).toBe(true);
+    expect(result.current.categories.length).toBeGreaterThan(0);
+    expect(result.current.categories[0]).toHaveProperty('key');
+    expect(result.current.categories[0]).toHaveProperty('label');
+  });
+
+  it('空文字カテゴリはundefinedとして送信する', async () => {
+    const { result } = renderHook(() => useTemplates());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // 初期状態は空文字 → undefinedで呼ばれる
+    expect(mockedRepo.fetchTemplates).toHaveBeenCalledWith(undefined);
+
+    // カテゴリを設定してから空文字に戻す
+    act(() => result.current.changeCategory('meeting'));
+    await waitFor(() => expect(mockedRepo.fetchTemplates).toHaveBeenCalledWith('meeting'));
+
+    act(() => result.current.changeCategory(''));
+    await waitFor(() => expect(mockedRepo.fetchTemplates).toHaveBeenLastCalledWith(undefined));
+  });
 });

--- a/frontend/src/hooks/__tests__/useWeeklyChallenge.test.ts
+++ b/frontend/src/hooks/__tests__/useWeeklyChallenge.test.ts
@@ -34,4 +34,21 @@ describe('useWeeklyChallenge', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.challenge).toBeNull();
   });
+
+  it('アンマウント時にデータ更新しない', async () => {
+    let resolvePromise: (value: typeof mockChallenge | null) => void;
+    mockedRepo.fetchCurrentChallenge.mockImplementation(() => new Promise((resolve) => { resolvePromise = resolve; }));
+
+    const { result, unmount } = renderHook(() => useWeeklyChallenge());
+
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+
+    resolvePromise!(mockChallenge);
+
+    // After unmount, state should not have been updated
+    expect(result.current.challenge).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
 });


### PR DESCRIPTION
## 概要
エッジケーステスト19件を追加してテスト品質を向上。

## 追加テスト
### バックエンド (10件)
- RankingServiceTest: monthly期間、ユーザー未発見、空結果、デフォルト期間
- ShareSessionUseCaseTest: セッション未発見時の例外
- UnshareSessionUseCaseTest: 共有セッション未発見時の例外
- RephraseMessageUseCaseTest: 空メッセージ処理、引数検証
- GetPublicSessionsUseCaseTest: 空結果
- GetRankingUseCaseTest: 引数委譲検証

### フロントエンド (9件)
- useRanking: アンマウント時の状態更新防止、デフォルト期間
- useSharedSessions: 共有解除後のリスト更新、エラー伝播
- useTemplates: カテゴリリスト提供、空カテゴリ処理
- useWeeklyChallenge: アンマウント時の状態更新防止
- useReminder: 曜日トグル削除、保存中フラグ管理

Closes #1446