### PR TITLE
feat: 初心者向けUI刷新・クリーンアーキテクチャ文書化・テスト強化

### DIFF
--- a/FreStyle/build.gradle
+++ b/FreStyle/build.gradle
@@ -102,6 +102,8 @@ dependencies {
 	// Testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// @DataJpaTest 用のインメモリDB（Repository層の統合テスト専用、本番では使わない）
+	testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/FreStyle/src/main/java/com/example/FreStyle/infrastructure/SqsMessageProducer.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/infrastructure/SqsMessageProducer.java
@@ -10,6 +10,15 @@ import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
+/**
+ * SQS への外向きメッセージ送信 Gateway。
+ *
+ * <p>クリーンアーキテクチャの例外規則として <b>UseCase から直接依存することを許容</b>する。
+ * 詳細は {@code docs/ARCHITECTURE.md} の「2.2.1 UseCase → Infrastructure に限って許容する例外」参照。
+ *
+ * <p>本クラスは非同期な書き込み系 I/O（ファイア＆フォーゲット）に限定する。
+ * DB 永続化や読み取りは Repository 経由で行うこと。
+ */
 @Component
 @Slf4j
 public class SqsMessageProducer {

--- a/FreStyle/src/test/java/com/example/FreStyle/mapper/FriendshipMapperTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/mapper/FriendshipMapperTest.java
@@ -1,0 +1,136 @@
+package com.example.FreStyle.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.FreStyle.dto.FriendshipDto;
+import com.example.FreStyle.entity.Friendship;
+import com.example.FreStyle.entity.User;
+
+/**
+ * FriendshipMapper のDTO変換ロジック検証。
+ * フォロー関係を表すFriendshipエンティティを、
+ * 「誰をフォローしているか（Following視点）」と「誰にフォローされているか（Follower視点）」
+ * のどちらの視点のDTOに変換するかで挙動が変わることを網羅する。
+ */
+@DisplayName("FriendshipMapper")
+class FriendshipMapperTest {
+
+    private final FriendshipMapper mapper = new FriendshipMapper();
+
+    private User createUser(Integer id, String name, String iconUrl, String bio, String status) {
+        User user = new User();
+        user.setId(id);
+        user.setName(name);
+        user.setIconUrl(iconUrl);
+        user.setBio(bio);
+        user.setStatus(status);
+        user.setEmail("u" + id + "@example.com");
+        return user;
+    }
+
+    private Friendship createFriendship(Integer id, User follower, User following, LocalDateTime createdAt) {
+        Friendship friendship = new Friendship();
+        friendship.setId(id);
+        friendship.setFollower(follower);
+        friendship.setFollowing(following);
+        friendship.setCreatedAt(createdAt);
+        return friendship;
+    }
+
+    @Nested
+    @DisplayName("toFollowingDto：フォロー中のユーザー情報をDTO化")
+    class ToFollowingDtoTest {
+
+        @Test
+        @DisplayName("followingユーザーの情報がDTOに反映される")
+        void mapsFollowingUser() {
+            User follower = createUser(1, "自分", "me.png", "自己紹介", "online");
+            User following = createUser(2, "相手", "you.png", "相手の自己紹介", "away");
+            Friendship friendship = createFriendship(100, follower, following, LocalDateTime.of(2026, 1, 1, 12, 0));
+
+            FriendshipDto dto = mapper.toFollowingDto(friendship, true);
+
+            assertThat(dto.id()).isEqualTo(100);
+            assertThat(dto.userId()).isEqualTo(2);
+            assertThat(dto.username()).isEqualTo("相手");
+            assertThat(dto.iconUrl()).isEqualTo("you.png");
+            assertThat(dto.bio()).isEqualTo("相手の自己紹介");
+            assertThat(dto.status()).isEqualTo("away");
+            assertThat(dto.mutual()).isTrue();
+            assertThat(dto.createdAt()).isEqualTo("2026-01-01T12:00");
+        }
+
+        @Test
+        @DisplayName("mutual=false の場合は相互フォローでないとしてDTOに反映される")
+        void mutualFalseIsReflected() {
+            User follower = createUser(1, "me", null, null, null);
+            User following = createUser(2, "you", null, null, null);
+            Friendship friendship = createFriendship(1, follower, following, LocalDateTime.now());
+
+            FriendshipDto dto = mapper.toFollowingDto(friendship, false);
+
+            assertThat(dto.mutual()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("toFollowerDto：フォロワーユーザー情報をDTO化")
+    class ToFollowerDtoTest {
+
+        @Test
+        @DisplayName("followerユーザーの情報がDTOに反映される")
+        void mapsFollowerUser() {
+            User follower = createUser(3, "フォロワー", "f.png", "紹介", "busy");
+            User following = createUser(4, "自分", "me.png", "me", null);
+            Friendship friendship = createFriendship(200, follower, following, LocalDateTime.of(2026, 2, 14, 9, 30));
+
+            FriendshipDto dto = mapper.toFollowerDto(friendship, true);
+
+            assertThat(dto.id()).isEqualTo(200);
+            assertThat(dto.userId()).isEqualTo(3);
+            assertThat(dto.username()).isEqualTo("フォロワー");
+            assertThat(dto.iconUrl()).isEqualTo("f.png");
+            assertThat(dto.bio()).isEqualTo("紹介");
+            assertThat(dto.status()).isEqualTo("busy");
+            assertThat(dto.mutual()).isTrue();
+            assertThat(dto.createdAt()).isEqualTo("2026-02-14T09:30");
+        }
+    }
+
+    @Nested
+    @DisplayName("エッジケース")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("createdAtがnullのとき、DTOのcreatedAtもnullになる")
+        void nullCreatedAtIsPassedThrough() {
+            User follower = createUser(1, "a", null, null, null);
+            User following = createUser(2, "b", null, null, null);
+            Friendship friendship = createFriendship(1, follower, following, null);
+
+            FriendshipDto dto = mapper.toFollowingDto(friendship, false);
+
+            assertThat(dto.createdAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("ユーザーのiconUrl/bio/statusがnullのとき、DTOにもnullで透過される")
+        void nullUserAttributesArePassedThrough() {
+            User follower = createUser(1, "name", null, null, null);
+            User following = createUser(2, "target", null, null, null);
+            Friendship friendship = createFriendship(1, follower, following, LocalDateTime.now());
+
+            FriendshipDto dto = mapper.toFollowingDto(friendship, false);
+
+            assertThat(dto.iconUrl()).isNull();
+            assertThat(dto.bio()).isNull();
+            assertThat(dto.status()).isNull();
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/mapper/LearningReportMapperTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/mapper/LearningReportMapperTest.java
@@ -1,0 +1,124 @@
+package com.example.FreStyle.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.example.FreStyle.dto.LearningReportDto;
+import com.example.FreStyle.entity.LearningReport;
+
+/**
+ * LearningReportMapper のDTO変換テスト。
+ * 前月平均スコアの有無によるscoreChange計算ロジックを網羅する。
+ */
+@DisplayName("LearningReportMapper")
+class LearningReportMapperTest {
+
+    private final LearningReportMapper mapper = new LearningReportMapper();
+
+    private LearningReport createReport(
+            Integer id,
+            Integer year,
+            Integer month,
+            Integer totalSessions,
+            Double averageScore,
+            Double previousAverageScore,
+            String bestAxis,
+            String worstAxis,
+            Integer practiceDays,
+            LocalDateTime createdAt) {
+        LearningReport report = new LearningReport();
+        report.setId(id);
+        report.setYear(year);
+        report.setMonth(month);
+        report.setTotalSessions(totalSessions);
+        report.setAverageScore(averageScore);
+        report.setPreviousAverageScore(previousAverageScore);
+        report.setBestAxis(bestAxis);
+        report.setWorstAxis(worstAxis);
+        report.setPracticeDays(practiceDays);
+        report.setCreatedAt(createdAt);
+        return report;
+    }
+
+    @Nested
+    @DisplayName("scoreChange（前月比）の計算")
+    class ScoreChangeTest {
+
+        @Test
+        @DisplayName("前月平均があるとき、scoreChange = 今月平均 - 前月平均 で計算される")
+        void computesDifferenceWhenPreviousExists() {
+            LearningReport report = createReport(
+                    1, 2026, 2, 20, 7.8, 7.0, "論理的構成力", "配慮表現", 15,
+                    LocalDateTime.of(2026, 3, 1, 0, 0));
+
+            LearningReportDto dto = mapper.toDto(report);
+
+            assertThat(dto.scoreChange()).isCloseTo(0.8, org.assertj.core.data.Offset.offset(0.0001));
+            assertThat(dto.previousAverageScore()).isEqualTo(7.0);
+        }
+
+        @Test
+        @DisplayName("今月の方が平均が低い場合、scoreChangeは負の値になる")
+        void computesNegativeDifference() {
+            LearningReport report = createReport(
+                    1, 2026, 2, 20, 6.0, 7.0, "a", "b", 15, LocalDateTime.now());
+
+            LearningReportDto dto = mapper.toDto(report);
+
+            assertThat(dto.scoreChange()).isCloseTo(-1.0, org.assertj.core.data.Offset.offset(0.0001));
+        }
+
+        @Test
+        @DisplayName("前月平均がnullのとき、scoreChangeもnullになる")
+        void returnsNullWhenNoPrevious() {
+            LearningReport report = createReport(
+                    1, 2026, 1, 10, 6.5, null, "要約力", "提案力", 8, LocalDateTime.now());
+
+            LearningReportDto dto = mapper.toDto(report);
+
+            assertThat(dto.scoreChange()).isNull();
+            assertThat(dto.previousAverageScore()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("フィールドのコピー")
+    class FieldCopy {
+
+        @Test
+        @DisplayName("id / year / month / 各軸などがDTOへそのまま渡される")
+        void copiesAllFields() {
+            LocalDateTime createdAt = LocalDateTime.of(2026, 3, 1, 10, 15, 30);
+            LearningReport report = createReport(
+                    42, 2026, 2, 25, 8.1, 7.5, "論理的構成力", "配慮表現", 20, createdAt);
+
+            LearningReportDto dto = mapper.toDto(report);
+
+            assertThat(dto.id()).isEqualTo(42);
+            assertThat(dto.year()).isEqualTo(2026);
+            assertThat(dto.month()).isEqualTo(2);
+            assertThat(dto.totalSessions()).isEqualTo(25);
+            assertThat(dto.averageScore()).isEqualTo(8.1);
+            assertThat(dto.bestAxis()).isEqualTo("論理的構成力");
+            assertThat(dto.worstAxis()).isEqualTo("配慮表現");
+            assertThat(dto.practiceDays()).isEqualTo(20);
+            assertThat(dto.createdAt()).isEqualTo(createdAt.toString());
+        }
+
+        @Test
+        @DisplayName("createdAtがnullのとき、DTOのcreatedAtもnullになる")
+        void nullCreatedAtIsPassedThrough() {
+            LearningReport report = createReport(
+                    1, 2026, 1, 5, 6.0, null, "a", "b", 3, null);
+
+            LearningReportDto dto = mapper.toDto(report);
+
+            assertThat(dto.createdAt()).isNull();
+        }
+    }
+}

--- a/FreStyle/src/test/java/com/example/FreStyle/repository/FriendshipRepositoryTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/repository/FriendshipRepositoryTest.java
@@ -1,0 +1,210 @@
+package com.example.FreStyle.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import com.example.FreStyle.entity.Friendship;
+import com.example.FreStyle.entity.User;
+
+/**
+ * FriendshipRepository の統合テスト。
+ * H2 インメモリDB上で実際にJPAクエリを走らせ、カスタムクエリメソッドの挙動を担保する。
+ * Infrastructure層の代表的なテストパターンとしてRepository単位の@DataJpaTestを採用。
+ *
+ * Note: 本番の schema.sql は MariaDB 固有構文を含むため、テストでは無効化して
+ * Hibernate による create-drop で H2 上にスキーマを作る方針。
+ */
+@DataJpaTest(properties = {
+        // 本番 schema.sql (MariaDB構文) を無効化し、H2 上にエンティティから create する
+        "spring.sql.init.mode=never",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        // H2 dialect を明示（application.properties の MariaDBDialect を上書き）
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
+@AutoConfigureTestDatabase
+@DisplayName("FriendshipRepository 統合テスト")
+class FriendshipRepositoryTest {
+
+    @Autowired
+    private FriendshipRepository friendshipRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private User persistUser(String name, String email) {
+        User user = new User();
+        user.setName(name);
+        user.setEmail(email);
+        user.setIsActive(true);
+        return entityManager.persistAndFlush(user);
+    }
+
+    private Friendship persistFriendship(User follower, User following, LocalDateTime createdAt) {
+        Friendship friendship = new Friendship();
+        friendship.setFollower(follower);
+        friendship.setFollowing(following);
+        friendship.setCreatedAt(createdAt);
+        return entityManager.persistAndFlush(friendship);
+    }
+
+    @Nested
+    @DisplayName("findByFollowerIdOrderByCreatedAtDesc")
+    class FindByFollowerId {
+
+        @Test
+        @DisplayName("指定ユーザーがフォローしている関係を作成日の新しい順で返す")
+        void returnsDescendingByCreatedAt() {
+            User me = persistUser("me", "me@example.com");
+            User a = persistUser("a", "a@example.com");
+            User b = persistUser("b", "b@example.com");
+
+            persistFriendship(me, a, LocalDateTime.of(2026, 1, 1, 12, 0));
+            persistFriendship(me, b, LocalDateTime.of(2026, 2, 1, 12, 0));
+
+            List<Friendship> result = friendshipRepository.findByFollowerIdOrderByCreatedAtDesc(me.getId());
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getFollowing().getName()).isEqualTo("b");
+            assertThat(result.get(1).getFollowing().getName()).isEqualTo("a");
+        }
+
+        @Test
+        @DisplayName("フォローしていない場合は空のリストを返す")
+        void returnsEmptyWhenNoFollowing() {
+            User me = persistUser("me", "me@example.com");
+            List<Friendship> result = friendshipRepository.findByFollowerIdOrderByCreatedAtDesc(me.getId());
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByFollowerIdAndFollowingId / existsByFollowerIdAndFollowingId")
+    class FindOne {
+
+        @Test
+        @DisplayName("既存のフォロー関係を1件取得できる")
+        void findsExistingFriendship() {
+            User me = persistUser("me", "me@example.com");
+            User target = persistUser("target", "target@example.com");
+            persistFriendship(me, target, LocalDateTime.now());
+
+            Optional<Friendship> result = friendshipRepository.findByFollowerIdAndFollowingId(me.getId(), target.getId());
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getFollowing().getId()).isEqualTo(target.getId());
+        }
+
+        @Test
+        @DisplayName("存在しないフォロー関係はOptional.emptyを返す")
+        void returnsEmptyWhenNotExists() {
+            User me = persistUser("me", "me@example.com");
+            User target = persistUser("target", "target@example.com");
+
+            Optional<Friendship> result = friendshipRepository.findByFollowerIdAndFollowingId(me.getId(), target.getId());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("existsByFollowerIdAndFollowingId は boolean を返す")
+        void existsReturnsBoolean() {
+            User me = persistUser("me", "me@example.com");
+            User target = persistUser("target", "target@example.com");
+            persistFriendship(me, target, LocalDateTime.now());
+
+            assertThat(friendshipRepository.existsByFollowerIdAndFollowingId(me.getId(), target.getId())).isTrue();
+            assertThat(friendshipRepository.existsByFollowerIdAndFollowingId(target.getId(), me.getId())).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("countByFollowerId / countByFollowingId")
+    class CountTests {
+
+        @Test
+        @DisplayName("フォロー数を正しく返す")
+        void countsFollowing() {
+            User me = persistUser("me", "me@example.com");
+            User a = persistUser("a", "a@example.com");
+            User b = persistUser("b", "b@example.com");
+            persistFriendship(me, a, LocalDateTime.now());
+            persistFriendship(me, b, LocalDateTime.now());
+
+            assertThat(friendshipRepository.countByFollowerId(me.getId())).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("フォロワー数を正しく返す")
+        void countsFollowers() {
+            User target = persistUser("target", "target@example.com");
+            User a = persistUser("a", "a@example.com");
+            User b = persistUser("b", "b@example.com");
+            User c = persistUser("c", "c@example.com");
+            persistFriendship(a, target, LocalDateTime.now());
+            persistFriendship(b, target, LocalDateTime.now());
+            persistFriendship(c, target, LocalDateTime.now());
+
+            assertThat(friendshipRepository.countByFollowingId(target.getId())).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("findMutualFollowerIds / findMutualFollowingIds（相互フォロー判定）")
+    class MutualTests {
+
+        @Test
+        @DisplayName("targetIdをフォローしているuserIdのみを返す")
+        void findsMutualFollowerIds() {
+            User me = persistUser("me", "me@example.com");
+            User target = persistUser("target", "target@example.com");
+            User other = persistUser("other", "other@example.com");
+
+            // me と other が target をフォロー
+            persistFriendship(me, target, LocalDateTime.now());
+            persistFriendship(other, target, LocalDateTime.now());
+            // target は me だけをフォロー
+            persistFriendship(target, me, LocalDateTime.now());
+
+            List<Integer> result = friendshipRepository.findMutualFollowerIds(
+                    List.of(me.getId(), other.getId()), target.getId());
+
+            assertThat(result).containsExactlyInAnyOrder(me.getId(), other.getId());
+        }
+
+        @Test
+        @DisplayName("targetIdにフォローされているuserIdのみを返す")
+        void findsMutualFollowingIds() {
+            User me = persistUser("me", "me@example.com");
+            User target = persistUser("target", "target@example.com");
+            User other = persistUser("other", "other@example.com");
+
+            // target は me と other をフォロー
+            persistFriendship(target, me, LocalDateTime.now());
+            persistFriendship(target, other, LocalDateTime.now());
+
+            List<Integer> result = friendshipRepository.findMutualFollowingIds(
+                    List.of(me.getId(), other.getId()), target.getId());
+
+            assertThat(result).containsExactlyInAnyOrder(me.getId(), other.getId());
+        }
+
+        @Test
+        @DisplayName("候補リストが空のとき、空のリストを返す")
+        void returnsEmptyWhenNoCandidates() {
+            User target = persistUser("target", "target@example.com");
+            List<Integer> result = friendshipRepository.findMutualFollowerIds(List.of(), target.getId());
+            assertThat(result).isEmpty();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@
 
 バックエンドコードをクリーンアーキテクチャに基づいて全面リファクタリングし、保守性・テスタビリティ・可読性を大幅に向上させました。
 
+詳細な層責務・クラス依存関係・テスト戦略は [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) を一次情報として参照してください。
+
 #### 実装内容
-- **Mapper層**: DTO↔Entity変換を一箇所に集約（3クラス作成）
-- **UseCase層**: ビジネスロジックをController層から分離（20クラス作成）
-- **依存性逆転の原則**: Controller → UseCase → Repository の明確な依存関係を確立
+- **Mapper層**: DTO↔Entity変換を一箇所に集約
+- **UseCase層**: ビジネスロジックをController層から分離（87クラス）
+- **依存性逆転の原則**: Controller → UseCase → Service/Repository の明確な依存関係を確立
 - **単一責任の原則**: 各クラスの責務を明確化し、1クラス1責務を徹底
 
 #### リファクタリング対象
@@ -103,16 +105,146 @@
 - テスタビリティ向上: モック化が容易な設計に
 - 日本語コメント充実: 各クラスの役割・責務を明記
 
+#### 層構成（バックエンド）
+
 ```
-【アーキテクチャ構成】
-Controller (Presentation層) ← HTTP/WebSocketリクエスト処理
-  ↓ 依存
-UseCase (Application層) ← ビジネスロジック実行
-  ↓ 依存
-Service (Domain層) ← ドメインロジック
-  ↓ 依存
-Repository (Infrastructure層) ← DB操作
+┌────────────────────────────────────────────────────────────┐
+│                  Presentation Layer                        │
+│   Controller（REST / WebSocket）                           │
+└────────────────────────────────────────────────────────────┘
+                       ↓
+┌────────────────────────────────────────────────────────────┐
+│                  Application Layer                         │
+│   UseCase（1 ユースケース = 1 クラス／87 クラス）            │
+└────────────────────────────────────────────────────────────┘
+                       ↓
+┌────────────────────────────────────────────────────────────┐
+│                    Domain Layer                            │
+│   Service（ドメインロジック・外部統合） / Entity             │
+└────────────────────────────────────────────────────────────┘
+                       ↓
+┌────────────────────────────────────────────────────────────┐
+│                Infrastructure Layer                        │
+│   Repository（JPA / DynamoDB / S3 / Bedrock）               │
+└────────────────────────────────────────────────────────────┘
 ```
+
+#### 層構成（フロントエンド）
+
+バックエンドと同じ発想でフロントエンドもレイヤー化しています。
+
+```
+Page (画面)  →  Hook (Application)  →  Repository (axios)
+  ↓
+Component (Presentational)
+```
+
+#### クラス依存関係図（AI チャット機能）
+
+```mermaid
+classDiagram
+    class AiChatController {
+      +createSession(userId)
+      +addMessage(sessionId, content)
+      +getSessions(userId)
+    }
+    class CreateAiChatSessionUseCase
+    class AddAiChatMessageUseCase
+    class GetAiChatSessionsByUserIdUseCase
+    class AiChatSessionService
+    class AiChatMessageService
+    class BedrockService
+    class AiChatSessionRepository {
+      <<JPA>>
+    }
+    class AiChatMessageDynamoService {
+      <<DynamoDB>>
+    }
+
+    AiChatController --> CreateAiChatSessionUseCase
+    AiChatController --> AddAiChatMessageUseCase
+    AiChatController --> GetAiChatSessionsByUserIdUseCase
+
+    CreateAiChatSessionUseCase --> AiChatSessionService
+    AddAiChatMessageUseCase --> AiChatMessageService
+    AddAiChatMessageUseCase --> BedrockService
+    GetAiChatSessionsByUserIdUseCase --> AiChatSessionService
+
+    AiChatSessionService --> AiChatSessionRepository
+    AiChatMessageService --> AiChatMessageDynamoService
+```
+
+#### クラス依存関係図（スコア評価機能）
+
+```mermaid
+classDiagram
+    class ScoreCardController
+    class CreateScoreCardUseCase
+    class GetScoreCardsByUserIdUseCase
+    class GetScoreTrendUseCase
+    class ScoreCardService
+    class ScoreCardMapper
+    class ScoreCardRepository {
+      <<JPA>>
+    }
+
+    ScoreCardController --> CreateScoreCardUseCase
+    ScoreCardController --> GetScoreCardsByUserIdUseCase
+    ScoreCardController --> GetScoreTrendUseCase
+
+    CreateScoreCardUseCase --> ScoreCardService
+    CreateScoreCardUseCase --> ScoreCardMapper
+    GetScoreCardsByUserIdUseCase --> ScoreCardService
+    GetScoreCardsByUserIdUseCase --> ScoreCardMapper
+    GetScoreTrendUseCase --> ScoreCardService
+
+    ScoreCardService --> ScoreCardRepository
+```
+
+#### データフロー: AI チャットへメッセージを送る
+
+```mermaid
+sequenceDiagram
+    participant FE as ChatPage
+    participant Hook as useAiChat Hook
+    participant Repo as AiChatRepository
+    participant Ctrl as AiChatController
+    participant UC as AddAiChatMessageUseCase
+    participant Svc as AiChatMessageService
+    participant DDB as DynamoDB
+    participant Bed as BedrockService
+
+    FE->>Hook: sendMessage(text)
+    Hook->>Repo: POST /ai-chat/sessions/:id/messages
+    Repo->>Ctrl: HTTP Request
+    Ctrl->>UC: execute(sessionId, content)
+    UC->>Svc: add(userMessage)
+    Svc->>DDB: put
+    UC->>Bed: invokeModel(prompt)
+    Bed-->>UC: aiResponse
+    UC->>Svc: add(aiMessage)
+    Svc->>DDB: put
+    UC-->>Ctrl: MessageDto
+    Ctrl-->>Repo: HTTP Response
+    Repo-->>Hook: Promise resolve
+    Hook-->>FE: state update → re-render
+```
+
+### ⑤ 初心者向けUIコンポーネントライブラリ
+
+新卒エンジニアが迷わず使えるよう、`frontend/src/components/ui/` に共通UIコンポーネント群を整備しています。
+
+| コンポーネント | 用途 |
+|---|---|
+| `PageIntro` | 全画面統一のページヘッダー |
+| `FirstTimeWelcome` | 初回訪問時の導入カード（localStorage永続化） |
+| `GlossaryTerm` | 専門用語の下線表示＋クリックで用語解説 |
+| `HelpTooltip` | 「?」アイコン付きの補足説明 |
+| `StepIndicator` | 多段階操作の進行状況可視化 |
+| `GuidedHint` | 閉じるボタン付き初心者向けヒント |
+| `ActionCard` | Link/Button両対応の強調CTAカード |
+
+専門用語（5軸評価・論理的構成力・練習モードなど）の定義は `frontend/src/constants/glossary.ts` に集約。
 
 ---
 
@@ -265,6 +397,55 @@ SELECT COUNT(*) FROM practice_scenarios;
 | `001_add_practice_mode_support.sql` | 2026-02-12 | 練習モード機能追加（`ai_chat_sessions` に `session_type`, `scenario_id` カラム追加、`practice_scenarios` テーブル作成、初期データ12件投入） |
 
 **注意**: マイグレーションは冪等性があり、複数回実行しても安全です（`IF NOT EXISTS`, `INSERT IGNORE` を使用）。
+
+---
+
+## 開発フロー / 貢献ガイド
+
+本プロジェクトは以下の運用ルールで開発されています。
+
+### ブランチ運用
+
+1. Issue を起票（日本語で目的・完了条件を明記）
+2. ブランチを切る（`feat/*` / `fix/*` / `refactor/*` / `docs/*` / `test/*`）
+3. 作業 → コミット（コミットメッセージは日本語）
+4. PR 作成（タイトル・本文とも日本語）
+5. **CodeRabbit によるコードレビューを待つ**
+6. CodeRabbit 指摘に対応
+7. **squash merge**（main への直接コミット禁止、ブランチ保護設定済み）
+
+### コーディング規約（要点）
+
+- **クリーンアーキテクチャ**: Controller → UseCase → Service/Repository の依存方向を厳守。詳細は [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
+- **1 UseCase = 1 ビジネスルール**: 新規機能追加時は Service に肥大化させず、UseCase クラスを新規作成
+- **DTO ↔ Entity 変換**: Mapper に集約。Controller / UseCase で直接変換しない
+- **テスト必須**: 新規追加コードには必ず単体テストを付ける
+- **日本語**: PR / Issue / コミットメッセージ / コメントは日本語、識別子は英語
+
+### テスト
+
+#### バックエンド
+
+```bash
+cd FreStyle
+./gradlew test
+```
+
+- JUnit 5 + Mockito + AssertJ
+- UseCase: Mockito でモック化した単体テスト
+- Service: 外部クライアントをモックした単体テスト
+- Repository: `@DataJpaTest` + H2 インメモリDB による統合テスト
+- Mapper: 純粋な変換ロジックの単体テスト
+
+#### フロントエンド
+
+```bash
+cd frontend
+npm test
+```
+
+- Vitest + React Testing Library
+- 慣習: `vi.stubGlobal('localStorage', createMockStorage())` で localStorage をスタブ、`fireEvent` でイベント発火
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@
 
 #### 層構成（バックエンド）
 
-```
+```text
 ┌────────────────────────────────────────────────────────────┐
 │                  Presentation Layer                        │
 │   Controller（REST / WebSocket）                           │
@@ -133,7 +133,7 @@
 
 バックエンドと同じ発想でフロントエンドもレイヤー化しています。
 
-```
+```text
 Page (画面)  →  Hook (Application)  →  Repository (axios)
   ↓
 Component (Presentational)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,6 +15,8 @@
 - [5. データフロー（代表的なユースケース）](#5-データフロー代表的なユースケース)
 - [6. テスト戦略](#6-テスト戦略)
 - [7. ディレクトリマップ](#7-ディレクトリマップ)
+- [8. 変更時のチェックリスト](#8-変更時のチェックリスト)
+- [参考: 過去のリファクタリング実績](#参考-過去のリファクタリング実績)
 
 ---
 
@@ -48,7 +50,7 @@
 
 ## 2. 層構成（バックエンド）
 
-```
+```text
 ┌────────────────────────────────────────────────────────────┐
 │                  Presentation Layer                        │
 │   Controller (REST / WebSocket)                            │
@@ -83,14 +85,14 @@
 | 層 | パッケージ | 責務 | 許される依存 |
 |---|---|---|---|
 | Presentation | `controller` | HTTP/WS リクエスト受付、認証取得、UseCase 呼び出し、DTO 返却 | `usecase`, `dto`, `form`, `mapper` |
-| Application | `usecase` | ビジネスロジック。Service/Repository のオーケストレーション | `service`, `repository`, `mapper`, `dto`, `entity` |
+| Application | `usecase` | ビジネスロジック。Service/Repository のオーケストレーション | `service`, `repository`, `mapper`, `dto`, `entity`, `infrastructure`（※2.2.1 の例外規則参照） |
 | Domain | `service` / `entity` | ドメインロジック、外部サービス統合、ドメインモデル | `repository`, `entity`, `infrastructure` |
 | Infrastructure | `repository` / `infrastructure` / `config` | 永続化、外部 API クライアント、Spring Boot 設定 | `entity` |
 | Shared | `dto` / `form` / `mapper` / `exception` / `utils` / `constant` | 横断的な型・変換・ユーティリティ | （層依存なし） |
 
 ### 2.2 禁止される依存
 
-```
+```text
 ❌ Controller → Service（直接呼び出し）
 ❌ Controller → Repository
 ❌ UseCase → Controller
@@ -100,13 +102,28 @@
 ❌ Entity → 他の層
 ```
 
+### 2.2.1 UseCase → Infrastructure（Gateway / Producer）に限って許容する例外
+
+クリーンアーキテクチャの原理主義では UseCase は Domain のインターフェース経由で Infrastructure を呼ぶべきだが、本プロジェクトでは軽量化のため **非同期メッセージ送信（SQS Producer など）の Gateway クラスは `infrastructure` パッケージに配置したまま UseCase から直接利用することを許容**する。
+
+対象:
+
+- `com.example.FreStyle.infrastructure.SqsMessageProducer` — 例: [`EnqueueReportGenerationUseCase`](../FreStyle/src/main/java/com/example/FreStyle/usecase/EnqueueReportGenerationUseCase.java) から直接呼び出す
+
+ルール:
+
+- 例外として許容するのは **外向きの I/O のみ**（SQS 送信・メール送信・外部通知など、書き込み系のファイア＆フォーゲット）
+- 許容するクラスには JavaDoc で「UseCaseから直接依存可」と明記する
+- **DB 永続化は必ず Repository 経由**。`infrastructure` から直接DBを叩くのは禁止
+- 将来的に依存先を差し替えたくなった時点で、Domain 層にインターフェースを切り直して依存性逆転に移行する（そのための拡張ポイント）
+
 ---
 
 ## 3. 層構成（フロントエンド）
 
 フロントエンドもバックエンドと同じ発想でレイヤー化します。
 
-```
+```text
 ┌────────────────────────────────────────────────────────────┐
 │              Presentation Layer                            │
 │   Page (画面コンポーネント)                                  │
@@ -392,7 +409,7 @@ sequenceDiagram
 
 ### 6.1 テストピラミッド
 
-```
+```text
         ┌────┐
        / E2E  \           5%   Cypress / Playwright（未導入）
       ──────────
@@ -409,7 +426,7 @@ sequenceDiagram
 | Controller | 統合 | `@WebMvcTest` + MockMvc | UseCase をモックし、HTTP レイヤーだけを検証 |
 | UseCase | 単体 | JUnit 5 + Mockito | Service / Repository をモックし、ビジネスロジックを検証 |
 | Service | 単体 | JUnit 5 + Mockito | 外部クライアント（Cognito / Bedrock / DynamoDB）をモック |
-| Repository | 統合 | `@DataJpaTest` / Testcontainers | 本物の DB に対して CRUD を検証 |
+| Repository | 統合 | `@DataJpaTest` + H2（インメモリ） | 本物の DB に対して CRUD を検証。本PRではH2採用、将来的にMariaDB版パリティ担保のため Testcontainers への移行は検討中 |
 | Mapper | 単体 | JUnit 5 | 入出力の対応関係を網羅 |
 
 ### 6.3 フロントエンド層別テスト方針
@@ -432,7 +449,7 @@ sequenceDiagram
 
 ### 7.1 バックエンド
 
-```
+```text
 FreStyle/src/main/java/com/example/FreStyle/
 ├── FreStyleApplication.java        エントリポイント
 ├── controller/                      Presentation 層
@@ -468,7 +485,7 @@ FreStyle/src/main/java/com/example/FreStyle/
 
 ### 7.2 フロントエンド
 
-```
+```text
 frontend/src/
 ├── App.tsx                          ルーティング定義
 ├── main.tsx                         React エントリポイント

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,550 @@
+# FreStyle アーキテクチャ仕様書
+
+本書は FreStyle プロジェクトにおけるクリーンアーキテクチャの適用方針、層ごとの責務、そしてクラス間の依存関係を定義する **一次情報** です。
+
+実装に迷ったとき・レビューで指針が必要なときは本書を根拠として判断してください。
+
+---
+
+## 目次
+
+- [1. 設計原則](#1-設計原則)
+- [2. 層構成（バックエンド）](#2-層構成バックエンド)
+- [3. 層構成（フロントエンド）](#3-層構成フロントエンド)
+- [4. クラス依存関係図](#4-クラス依存関係図)
+- [5. データフロー（代表的なユースケース）](#5-データフロー代表的なユースケース)
+- [6. テスト戦略](#6-テスト戦略)
+- [7. ディレクトリマップ](#7-ディレクトリマップ)
+
+---
+
+## 1. 設計原則
+
+### 1.1 依存性逆転の原則 (Dependency Inversion Principle)
+
+高レベルのモジュール（UseCase）は、低レベルのモジュール（Repository 実装）に依存しない。
+どちらも抽象（インターフェース）に依存する。
+
+### 1.2 単一責任の原則 (Single Responsibility Principle)
+
+- **1 UseCase = 1 ビジネスルール**
+- 複数の操作を一つのクラスに詰め込まない
+
+### 1.3 関心の分離 (Separation of Concerns)
+
+| 関心事 | 担当 |
+|---|---|
+| HTTP / WebSocket プロトコル | Controller |
+| ビジネスロジックのオーケストレーション | UseCase |
+| ドメインロジック・外部 API 統合 | Service |
+| 永続化 | Repository |
+| データ変換 | Mapper |
+
+### 1.4 テスタビリティ
+
+すべての UseCase は、**外部依存をモックして単体テスト可能**でなければならない。
+
+---
+
+## 2. 層構成（バックエンド）
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                  Presentation Layer                        │
+│   Controller (REST / WebSocket)                            │
+│   com.example.FreStyle.controller                          │
+└────────────────────────────────────────────────────────────┘
+                           ↓ 呼び出し
+┌────────────────────────────────────────────────────────────┐
+│                  Application Layer                         │
+│   UseCase (1 ユースケース 1 クラス)                         │
+│   com.example.FreStyle.usecase                             │
+└────────────────────────────────────────────────────────────┘
+                           ↓ 呼び出し
+┌────────────────────────────────────────────────────────────┐
+│                    Domain Layer                            │
+│   Service (ドメインロジック・外部統合)                       │
+│   com.example.FreStyle.service                             │
+│                                                            │
+│   Entity (ドメインモデル)                                    │
+│   com.example.FreStyle.entity                              │
+└────────────────────────────────────────────────────────────┘
+                           ↓ 呼び出し
+┌────────────────────────────────────────────────────────────┐
+│                Infrastructure Layer                        │
+│   Repository (JPA / DynamoDB / S3 / Bedrock)               │
+│   com.example.FreStyle.repository                          │
+│   com.example.FreStyle.infrastructure                      │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 2.1 各層の責務
+
+| 層 | パッケージ | 責務 | 許される依存 |
+|---|---|---|---|
+| Presentation | `controller` | HTTP/WS リクエスト受付、認証取得、UseCase 呼び出し、DTO 返却 | `usecase`, `dto`, `form`, `mapper` |
+| Application | `usecase` | ビジネスロジック。Service/Repository のオーケストレーション | `service`, `repository`, `mapper`, `dto`, `entity` |
+| Domain | `service` / `entity` | ドメインロジック、外部サービス統合、ドメインモデル | `repository`, `entity`, `infrastructure` |
+| Infrastructure | `repository` / `infrastructure` / `config` | 永続化、外部 API クライアント、Spring Boot 設定 | `entity` |
+| Shared | `dto` / `form` / `mapper` / `exception` / `utils` / `constant` | 横断的な型・変換・ユーティリティ | （層依存なし） |
+
+### 2.2 禁止される依存
+
+```
+❌ Controller → Service（直接呼び出し）
+❌ Controller → Repository
+❌ UseCase → Controller
+❌ Service → UseCase
+❌ Repository → Service
+❌ Repository → UseCase
+❌ Entity → 他の層
+```
+
+---
+
+## 3. 層構成（フロントエンド）
+
+フロントエンドもバックエンドと同じ発想でレイヤー化します。
+
+```
+┌────────────────────────────────────────────────────────────┐
+│              Presentation Layer                            │
+│   Page (画面コンポーネント)                                  │
+│   Component (プレゼンテーショナル)                           │
+│   frontend/src/pages, frontend/src/components              │
+└────────────────────────────────────────────────────────────┘
+                           ↓
+┌────────────────────────────────────────────────────────────┐
+│              Application Layer                             │
+│   Hook (画面固有の状態管理・API オーケストレーション)         │
+│   Store (Redux Toolkit slice — グローバル状態のみ)          │
+│   frontend/src/hooks, frontend/src/store                   │
+└────────────────────────────────────────────────────────────┘
+                           ↓
+┌────────────────────────────────────────────────────────────┐
+│              Infrastructure Layer                          │
+│   Repository (axios ラッパー・HTTP API クライアント)         │
+│   frontend/src/repositories                                │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 各層の責務
+
+| 層 | ディレクトリ | 責務 |
+|---|---|---|
+| Page | `src/pages/` | ルーティングの先で表示する画面。Hook 呼び出しと Component 配置のみ |
+| Component | `src/components/` | プレゼンテーショナルなパーツ。副作用を持たない |
+| Hook | `src/hooks/` | 画面固有の状態・副作用。Repository を呼び出す |
+| Store | `src/store/` | 全画面から参照されるグローバル状態（auth など）に限定 |
+| Repository | `src/repositories/` | axios を直接使うのはここだけ。エンドポイント定義を集約 |
+
+---
+
+## 4. クラス依存関係図
+
+### 4.1 バックエンド: 層間依存関係（概観）
+
+```mermaid
+graph TD
+    subgraph Presentation
+      Controller[AiChatController]
+    end
+    subgraph Application
+      UC1[CreateAiChatSessionUseCase]
+      UC2[AddAiChatMessageUseCase]
+      UC3[GetAiChatSessionsByUserIdUseCase]
+    end
+    subgraph Domain
+      SVC1[AiChatSessionService]
+      SVC2[AiChatMessageService]
+      SVC3[BedrockService]
+      ENT1[AiChatSession]
+    end
+    subgraph Infrastructure
+      REP1[AiChatSessionRepository]
+      REP2[AiChatMessageDynamoService]
+    end
+
+    Controller --> UC1
+    Controller --> UC2
+    Controller --> UC3
+
+    UC1 --> SVC1
+    UC2 --> SVC2
+    UC2 --> SVC3
+    UC3 --> SVC1
+
+    SVC1 --> REP1
+    SVC2 --> REP2
+    SVC1 -.manages.-> ENT1
+```
+
+### 4.2 バックエンド: AI チャット機能の詳細依存
+
+```mermaid
+classDiagram
+    class AiChatController {
+      +createSession(userId)
+      +addMessage(sessionId, content)
+      +getSessions(userId)
+    }
+    class CreateAiChatSessionUseCase {
+      +execute(userId, scenarioId)
+    }
+    class AddAiChatMessageUseCase {
+      +execute(sessionId, content)
+    }
+    class GetAiChatSessionsByUserIdUseCase {
+      +execute(userId)
+    }
+    class AiChatSessionService {
+      +create(session)
+      +findById(id)
+      +findByUserId(userId)
+    }
+    class AiChatMessageService {
+      +add(message)
+      +listBySession(sessionId)
+    }
+    class BedrockService {
+      +invokeModel(prompt)
+    }
+    class AiChatSessionRepository {
+      <<JPA>>
+      +save(entity)
+      +findByUserId(userId)
+    }
+    class AiChatMessageDynamoService {
+      <<DynamoDB>>
+      +put(message)
+      +query(sessionId)
+    }
+
+    AiChatController --> CreateAiChatSessionUseCase
+    AiChatController --> AddAiChatMessageUseCase
+    AiChatController --> GetAiChatSessionsByUserIdUseCase
+
+    CreateAiChatSessionUseCase --> AiChatSessionService
+    AddAiChatMessageUseCase --> AiChatMessageService
+    AddAiChatMessageUseCase --> BedrockService
+    GetAiChatSessionsByUserIdUseCase --> AiChatSessionService
+
+    AiChatSessionService --> AiChatSessionRepository
+    AiChatMessageService --> AiChatMessageDynamoService
+```
+
+### 4.3 バックエンド: スコア評価機能の依存
+
+```mermaid
+classDiagram
+    class ScoreCardController {
+      +getByUserId(userId)
+      +create(request)
+      +getTrend(userId)
+    }
+    class CreateScoreCardUseCase {
+      +execute(userId, sessionId, evaluation)
+    }
+    class GetScoreCardsByUserIdUseCase {
+      +execute(userId)
+    }
+    class GetScoreTrendUseCase {
+      +execute(userId, range)
+    }
+    class ScoreCardService
+    class ScoreCardMapper {
+      +toDto(entity)
+      +toEntity(dto)
+    }
+    class ScoreCardRepository {
+      <<JPA>>
+    }
+
+    ScoreCardController --> CreateScoreCardUseCase
+    ScoreCardController --> GetScoreCardsByUserIdUseCase
+    ScoreCardController --> GetScoreTrendUseCase
+
+    CreateScoreCardUseCase --> ScoreCardService
+    CreateScoreCardUseCase --> ScoreCardMapper
+    GetScoreCardsByUserIdUseCase --> ScoreCardService
+    GetScoreCardsByUserIdUseCase --> ScoreCardMapper
+    GetScoreTrendUseCase --> ScoreCardService
+
+    ScoreCardService --> ScoreCardRepository
+```
+
+### 4.4 フロントエンド: 練習モード画面の依存
+
+```mermaid
+classDiagram
+    class PracticePage {
+      <<Page>>
+    }
+    class StepIndicator {
+      <<Component>>
+    }
+    class GlossaryTerm {
+      <<Component>>
+    }
+    class ScenarioCard {
+      <<Component>>
+    }
+    class usePracticeScenarios {
+      <<Hook>>
+      +scenarios
+      +loading
+    }
+    class useAiChatSession {
+      <<Hook>>
+      +createSession()
+    }
+    class PracticeScenarioRepository {
+      <<Repository>>
+      +list()
+    }
+    class AiChatRepository {
+      <<Repository>>
+      +createSession()
+    }
+    class axios {
+      <<HTTP>>
+    }
+
+    PracticePage --> StepIndicator
+    PracticePage --> GlossaryTerm
+    PracticePage --> ScenarioCard
+    PracticePage --> usePracticeScenarios
+    PracticePage --> useAiChatSession
+
+    usePracticeScenarios --> PracticeScenarioRepository
+    useAiChatSession --> AiChatRepository
+
+    PracticeScenarioRepository --> axios
+    AiChatRepository --> axios
+```
+
+---
+
+## 5. データフロー（代表的なユースケース）
+
+### 5.1 AI チャットにメッセージを送る
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FE as Page (ChatPage)
+    participant Hook as useAiChat Hook
+    participant Repo as AiChatRepository (Front)
+    participant Ctrl as AiChatController
+    participant UC as AddAiChatMessageUseCase
+    participant Svc as AiChatMessageService
+    participant DDB as DynamoDB
+    participant Bed as BedrockService
+
+    FE->>Hook: sendMessage(text)
+    Hook->>Repo: POST /ai-chat/sessions/:id/messages
+    Repo->>Ctrl: HTTP Request
+    Ctrl->>UC: execute(sessionId, content)
+    UC->>Svc: add(userMessage)
+    Svc->>DDB: put
+    UC->>Bed: invokeModel(prompt)
+    Bed-->>UC: aiResponse
+    UC->>Svc: add(aiMessage)
+    Svc->>DDB: put
+    UC-->>Ctrl: MessageDto
+    Ctrl-->>Repo: HTTP Response
+    Repo-->>Hook: Promise resolve
+    Hook-->>FE: state update → re-render
+```
+
+### 5.2 ユーザーがログインする
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant FE as LoginPage
+    participant Hook as useLoginPage
+    participant Repo as AuthRepository (Front)
+    participant Ctrl as CognitoAuthController
+    participant UC as CognitoLoginUseCase
+    participant Svc as CognitoAuthService
+    participant Cog as AWS Cognito
+    participant Cookie as AuthCookieService
+
+    FE->>Hook: handleLogin(form)
+    Hook->>Repo: POST /auth/login
+    Repo->>Ctrl: HTTP Request (email,password)
+    Ctrl->>UC: execute(form)
+    UC->>Svc: authenticate(form)
+    Svc->>Cog: InitiateAuth
+    Cog-->>Svc: tokens
+    Svc-->>UC: tokens
+    UC->>Cookie: setHttpOnlyCookie(tokens)
+    UC-->>Ctrl: LoginResponseDto
+    Ctrl-->>Repo: 200 OK + Set-Cookie
+    Repo-->>Hook: Promise resolve
+    Hook-->>FE: navigate to /
+```
+
+---
+
+## 6. テスト戦略
+
+### 6.1 テストピラミッド
+
+```
+        ┌────┐
+       / E2E  \           5%   Cypress / Playwright（未導入）
+      ──────────
+     / 統合テスト \        15%  Controller + UseCase + Repository
+    ──────────────
+   /   単体テスト   \     80%  UseCase / Service / Repository / Component
+  ──────────────────
+```
+
+### 6.2 バックエンド層別テスト方針
+
+| 層 | 種別 | ツール | 方針 |
+|---|---|---|---|
+| Controller | 統合 | `@WebMvcTest` + MockMvc | UseCase をモックし、HTTP レイヤーだけを検証 |
+| UseCase | 単体 | JUnit 5 + Mockito | Service / Repository をモックし、ビジネスロジックを検証 |
+| Service | 単体 | JUnit 5 + Mockito | 外部クライアント（Cognito / Bedrock / DynamoDB）をモック |
+| Repository | 統合 | `@DataJpaTest` / Testcontainers | 本物の DB に対して CRUD を検証 |
+| Mapper | 単体 | JUnit 5 | 入出力の対応関係を網羅 |
+
+### 6.3 フロントエンド層別テスト方針
+
+| 層 | ツール | 方針 |
+|---|---|---|
+| Page | Vitest + RTL | `render` して主要な要素とイベントハンドラを検証 |
+| Component | Vitest + RTL | Props ごとのレンダリングと aria 属性を検証 |
+| Hook | Vitest + `renderHook` | 状態遷移と副作用を検証 |
+| Repository | Vitest + `vi.mock('axios')` | axios 呼び出しを mock してリクエスト形状を検証 |
+
+### 6.4 カバレッジ目標
+
+- 新規追加コード: **80% 以上**
+- 全体: 段階的に引き上げる（既存は除外可）
+
+---
+
+## 7. ディレクトリマップ
+
+### 7.1 バックエンド
+
+```
+FreStyle/src/main/java/com/example/FreStyle/
+├── FreStyleApplication.java        エントリポイント
+├── controller/                      Presentation 層
+│   ├── AiChatController.java
+│   ├── ChatController.java
+│   ├── ScoreCardController.java
+│   └── ...
+├── usecase/                         Application 層（87 クラス）
+│   ├── CreateAiChatSessionUseCase.java
+│   ├── AddAiChatMessageUseCase.java
+│   ├── GetScoreTrendUseCase.java
+│   └── ...
+├── service/                         Domain 層（21 クラス）
+│   ├── AiChatMessageService.java
+│   ├── AiChatSessionService.java
+│   ├── BedrockService.java
+│   └── ...
+├── repository/                      Infrastructure 層（25 クラス）
+│   ├── UserRepository.java          (JPA)
+│   ├── AiChatSessionRepository.java (JPA)
+│   └── ...
+├── entity/                          Domain モデル
+├── dto/                             層間データ受け渡し（39 クラス）
+├── form/                            リクエストバリデーション
+├── mapper/                          DTO ↔ Entity 変換（5 クラス）
+├── auth/                            Cognito JWT / OAuth2
+├── config/                          Spring Boot 設定
+├── infrastructure/                  SQS Producer/Consumer
+├── exception/                       例外階層
+├── utils/                           ユーティリティ
+└── constant/                        業務定数
+```
+
+### 7.2 フロントエンド
+
+```
+frontend/src/
+├── App.tsx                          ルーティング定義
+├── main.tsx                         React エントリポイント
+├── pages/                           Presentation 層（画面）
+│   ├── MenuPage.tsx
+│   ├── LoginPage.tsx
+│   ├── PracticePage.tsx
+│   └── ...
+├── components/                      Presentation 層（パーツ）
+│   ├── ui/                          ★ 初心者向け共通 UI（本PRで追加）
+│   │   ├── GlossaryTerm.tsx
+│   │   ├── HelpTooltip.tsx
+│   │   ├── StepIndicator.tsx
+│   │   ├── GuidedHint.tsx
+│   │   ├── PageIntro.tsx
+│   │   ├── FirstTimeWelcome.tsx
+│   │   └── ActionCard.tsx
+│   ├── layout/                      AppShell 等のレイアウト
+│   └── ...                          既存の機能別コンポーネント
+├── hooks/                           Application 層（61 フック）
+├── repositories/                    Infrastructure 層（24 クライアント）
+├── store/                           Redux Toolkit
+├── utils/                           AuthInitializer / Protected 等
+├── constants/                       業務定数
+├── types/                           TypeScript 型
+└── test/                            Vitest セットアップ
+```
+
+---
+
+## 8. 変更時のチェックリスト
+
+新しいユースケースを追加するときは、必ず以下を順に確認してください。
+
+1. [ ] **Issue が起票されている**
+2. [ ] **ブランチを切った**（`main` へ直接コミット禁止）
+3. [ ] 新しい UseCase クラスを作成した（既存 Service に追加しない）
+4. [ ] Controller → UseCase → Service → Repository の依存方向を守っている
+5. [ ] DTO ↔ Entity 変換は Mapper に集約している
+6. [ ] UseCase / Service / Repository それぞれに単体テストを追加した
+7. [ ] フロントエンドなら、Page / Hook / Repository それぞれの責務を守っている
+8. [ ] コミットメッセージ・PR は日本語で書いた
+9. [ ] **CodeRabbit レビューを待ち、指摘に対応した**
+10. [ ] squash merge で取り込んだ
+
+---
+
+## 参考: 過去のリファクタリング実績
+
+### Phase 1（2026-01）: 練習モード
+
+- `PracticeScenarioService` を 3 UseCase に分解
+  - `GetPracticeScenariosUseCase`
+  - `GetPracticeScenarioByIdUseCase`
+  - `StartPracticeSessionUseCase`
+
+### Phase 2（2026-02）: AI チャット
+
+- `AiChatSessionService` / `AiChatMessageService` から 10 UseCase を抽出
+  - `CreateAiChatSessionUseCase`
+  - `AddAiChatMessageUseCase`
+  - `GetAiChatSessionsByUserIdUseCase`
+  - `GetAiChatMessagesBySessionIdUseCase`
+  - `CountAiChatMessagesBySessionIdUseCase`
+  - 他 5 クラス
+
+### Phase 3（2026-02）: ScoreCard
+
+- `ScoreCardService` から 3 UseCase + 1 Mapper を抽出
+  - `CreateScoreCardUseCase`
+  - `GetScoreCardsByUserIdUseCase`
+  - `GetScoreTrendUseCase`
+  - `ScoreCardMapper`
+
+### 成果
+
+- コード行数: **+1,849 / -377**
+- テスタビリティ: モック化容易な構造へ
+- 1 クラス 1 責務の徹底

--- a/frontend/src/components/ui/ActionCard.tsx
+++ b/frontend/src/components/ui/ActionCard.tsx
@@ -1,0 +1,102 @@
+import { ReactNode } from 'react';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
+
+type ActionCardBaseProps = {
+  /** タイトル（1 行で短く） */
+  title: string;
+  /** 補足説明（1〜2 行） */
+  description?: string;
+  /** 左側のアイコン */
+  icon?: ReactNode;
+  /** 強調度 */
+  emphasis?: 'primary' | 'secondary';
+  /** カード右上に表示する小さなバッジ（例: 「初心者向け」） */
+  badge?: string;
+};
+
+type ActionCardLinkProps = ActionCardBaseProps & {
+  /** 遷移先 URL（React Router 経由） */
+  to: string;
+  onClick?: never;
+};
+
+type ActionCardButtonProps = ActionCardBaseProps & {
+  /** クリック時のコールバック（リンク用途でない場合） */
+  onClick: () => void;
+  to?: never;
+};
+
+type ActionCardProps = ActionCardLinkProps | ActionCardButtonProps;
+
+/**
+ * 「次に何をすればよいか」を明示するカード型 CTA。
+ * 初心者向けレイアウトで最も重要な導線パーツ。
+ * Link か Button のいずれかとして使う（排他）。
+ */
+export default function ActionCard({
+  title,
+  description,
+  icon,
+  emphasis = 'secondary',
+  badge,
+  ...props
+}: ActionCardProps) {
+  const isPrimary = emphasis === 'primary';
+
+  const containerClasses = `group relative flex w-full items-start gap-4 rounded-xl border p-4 text-left transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] ${
+    isPrimary
+      ? 'border-primary-400/40 bg-gradient-to-br from-primary-500/15 to-surface-1 hover:from-primary-500/25 hover:-translate-y-0.5 hover:shadow-lg'
+      : 'border-surface-3 bg-surface-1 hover:border-primary-400/40 hover:-translate-y-0.5 hover:shadow-md'
+  }`;
+
+  const content = (
+    <>
+      {icon && (
+        <span
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${
+            isPrimary
+              ? 'bg-primary-500 text-white'
+              : 'bg-surface-2 text-primary-300'
+          }`}
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-base font-semibold text-[var(--color-text-primary)]">{title}</p>
+          {badge && (
+            <span className="shrink-0 rounded-full border border-primary-400/40 bg-primary-500/10 px-2 py-0.5 text-xs font-medium text-primary-300">
+              {badge}
+            </span>
+          )}
+        </div>
+        {description && (
+          <p className="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {description}
+          </p>
+        )}
+      </div>
+      <ArrowRightIcon
+        className="mt-2 h-4 w-4 shrink-0 text-[var(--color-text-muted)] transition-transform group-hover:translate-x-0.5 group-hover:text-primary-300"
+        aria-hidden="true"
+      />
+    </>
+  );
+
+  if ('to' in props && props.to) {
+    return (
+      <Link to={props.to} className={containerClasses}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={props.onClick} className={containerClasses}>
+      {content}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/FirstTimeWelcome.tsx
+++ b/frontend/src/components/ui/FirstTimeWelcome.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react';
+import { SparklesIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+type LearningStep = {
+  /** ステップのタイトル */
+  title: string;
+  /** 1 文程度の補足 */
+  description: string;
+};
+
+type FirstTimeWelcomeProps = {
+  /** 挨拶のタイトル */
+  title?: string;
+  /** 学習ステップ（3〜5 件を推奨） */
+  steps: LearningStep[];
+  /** 最初のアクションへのラベル */
+  primaryActionLabel?: string;
+  /** 最初のアクションをクリックしたときのコールバック */
+  onPrimaryAction?: () => void;
+  /** 閉じた状態を永続化するキー */
+  storageKey?: string;
+};
+
+/**
+ * 初回訪問者向けのウェルカムカード。
+ * 「このアプリで何ができるのか」「まず何をすればよいのか」を 3〜5 ステップで示す。
+ */
+export default function FirstTimeWelcome({
+  title = 'ようこそ FreStyle へ',
+  steps,
+  primaryActionLabel = 'はじめて練習する',
+  onPrimaryAction,
+  storageKey,
+}: FirstTimeWelcomeProps) {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (!storageKey || typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem(storageKey) === 'dismissed';
+    } catch {
+      return false;
+    }
+  });
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    if (storageKey && typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(storageKey, 'dismissed');
+      } catch {
+        // localStorage 不可の環境では無視
+      }
+    }
+  };
+
+  return (
+    <section
+      aria-labelledby="first-time-welcome-title"
+      className="relative rounded-2xl border border-primary-400/30 bg-gradient-to-br from-primary-500/10 via-surface-1 to-surface-1 p-6 shadow-sm animate-scale-in"
+    >
+      <button
+        type="button"
+        onClick={handleDismiss}
+        aria-label="このカードを閉じる"
+        className="absolute right-3 top-3 rounded-full p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-surface-3 focus:outline-none focus:ring-2 focus:ring-primary-400"
+      >
+        <XMarkIcon className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      <div className="flex items-center gap-2">
+        <SparklesIcon className="h-6 w-6 text-primary-300" aria-hidden="true" />
+        <h2
+          id="first-time-welcome-title"
+          className="text-lg font-bold text-[var(--color-text-primary)] sm:text-xl"
+        >
+          {title}
+        </h2>
+      </div>
+      <p className="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+        AI と会話しながら、新卒エンジニア向けのビジネスコミュニケーションを練習できます。
+        まずは以下のステップで使ってみましょう。
+      </p>
+
+      <ol className="mt-4 space-y-3">
+        {steps.map((step, index) => (
+          <li key={step.title} className="flex items-start gap-3">
+            <span
+              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-primary-500/20 text-xs font-semibold text-primary-300"
+              aria-hidden="true"
+            >
+              {index + 1}
+            </span>
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-[var(--color-text-primary)]">
+                {step.title}
+              </p>
+              <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+                {step.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      {onPrimaryAction && (
+        <button
+          type="button"
+          onClick={onPrimaryAction}
+          className="mt-5 inline-flex items-center justify-center rounded-lg bg-primary-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-primary-600 active:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2 focus:ring-offset-[var(--color-surface-1)]"
+        >
+          {primaryActionLabel}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/ui/GlossaryTerm.tsx
+++ b/frontend/src/components/ui/GlossaryTerm.tsx
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+import HelpTooltip from './HelpTooltip';
+
+type GlossaryTermProps = {
+  /** 用語のラベル（本文中に表示される文字） */
+  term: string;
+  /** ツールチップで表示する説明 */
+  definition: ReactNode;
+  /** 追加 className */
+  className?: string;
+};
+
+/**
+ * 専門用語をインラインで説明する。用語の右にヘルプアイコンを出し、
+ * クリックで定義を表示する。初心者に優しい「?」つきの用語として使う。
+ *
+ * 例: <GlossaryTerm term="5軸評価" definition="..." />
+ */
+export default function GlossaryTerm({ term, definition, className = '' }: GlossaryTermProps) {
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`}>
+      <span className="underline decoration-dotted decoration-primary-300 underline-offset-2">
+        {term}
+      </span>
+      <HelpTooltip label={`${term}の意味を表示`}>{definition}</HelpTooltip>
+    </span>
+  );
+}

--- a/frontend/src/components/ui/GuidedHint.tsx
+++ b/frontend/src/components/ui/GuidedHint.tsx
@@ -1,0 +1,91 @@
+import { ReactNode, useState } from 'react';
+import { LightBulbIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+type GuidedHintProps = {
+  /** ヒントのタイトル */
+  title: string;
+  /** ヒントの本文 */
+  children: ReactNode;
+  /** 閉じた状態を localStorage に保存するキー（指定すると永続化） */
+  storageKey?: string;
+  /** 表示トーン */
+  tone?: 'info' | 'success' | 'warning';
+  /** 閉じるボタンを表示するか */
+  dismissible?: boolean;
+  /** 閉じたときに呼ばれるコールバック */
+  onDismiss?: () => void;
+};
+
+const TONE_CLASSES: Record<NonNullable<GuidedHintProps['tone']>, string> = {
+  info: 'border-l-primary-400 bg-primary-500/10',
+  success: 'border-l-emerald-400 bg-emerald-500/10',
+  warning: 'border-l-amber-400 bg-amber-500/10',
+};
+
+const ICON_TONE_CLASSES: Record<NonNullable<GuidedHintProps['tone']>, string> = {
+  info: 'text-primary-300',
+  success: 'text-emerald-300',
+  warning: 'text-amber-300',
+};
+
+/**
+ * 初心者向けのガイドヒント。画面上部や機能説明の近くに表示し、
+ * 一度閉じたら localStorage に記録して再表示しない。
+ */
+export default function GuidedHint({
+  title,
+  children,
+  storageKey,
+  tone = 'info',
+  dismissible = true,
+  onDismiss,
+}: GuidedHintProps) {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (!storageKey || typeof window === 'undefined') return false;
+    try {
+      return window.localStorage.getItem(storageKey) === 'dismissed';
+    } catch {
+      return false;
+    }
+  });
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    if (storageKey && typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(storageKey, 'dismissed');
+      } catch {
+        // localStorage が使えない環境では単にスキップ
+      }
+    }
+    onDismiss?.();
+  };
+
+  return (
+    <aside
+      role="note"
+      className={`flex items-start gap-3 rounded-lg border border-surface-3 border-l-4 ${TONE_CLASSES[tone]} p-4`}
+    >
+      <LightBulbIcon
+        className={`h-5 w-5 shrink-0 ${ICON_TONE_CLASSES[tone]}`}
+        aria-hidden="true"
+      />
+      <div className="flex-1 min-w-0">
+        <p className="mb-1 text-sm font-semibold text-[var(--color-text-primary)]">{title}</p>
+        <div className="text-sm text-[var(--color-text-secondary)] leading-relaxed">{children}</div>
+      </div>
+      {dismissible && (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="ヒントを閉じる"
+          className="shrink-0 rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-surface-3 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-400"
+        >
+          <XMarkIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+      )}
+    </aside>
+  );
+}

--- a/frontend/src/components/ui/HelpTooltip.tsx
+++ b/frontend/src/components/ui/HelpTooltip.tsx
@@ -58,7 +58,19 @@ export default function HelpTooltip({
         aria-label={label}
         aria-expanded={open}
         aria-describedby={open ? tooltipId : undefined}
-        onClick={() => setOpen((prev) => !prev)}
+        // onMouseDown で preventDefault してフォーカスイベントを抑止し、
+        // クリック時に「focus → setOpen(true)」→「click → toggle で false」と
+        // なる race を回避。フォーカス状態は自前で明示管理する。
+        onMouseDown={(e) => {
+          e.preventDefault();
+          setOpen((prev) => !prev);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setOpen((prev) => !prev);
+          }
+        }}
         onFocus={() => setOpen(true)}
         onBlur={(e) => {
           if (!wrapperRef.current?.contains(e.relatedTarget as Node)) setOpen(false);

--- a/frontend/src/components/ui/HelpTooltip.tsx
+++ b/frontend/src/components/ui/HelpTooltip.tsx
@@ -1,0 +1,81 @@
+import { useState, useRef, useEffect, useId, ReactNode } from 'react';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+
+type HelpTooltipProps = {
+  /** ツールチップに表示する説明文。ReactNode を許容することで改行や強調も可能 */
+  children: ReactNode;
+  /** アクセシブルなラベル（スクリーンリーダー向け）。例: 「5軸評価について」 */
+  label?: string;
+  /** 吹き出しの表示方向 */
+  placement?: 'top' | 'bottom' | 'right' | 'left';
+  /** 追加 className */
+  className?: string;
+};
+
+/**
+ * 専門用語や機能の横に置くヘルプアイコン。
+ * クリック / フォーカスで説明を表示し、初心者が意味を確認できるようにする。
+ */
+export default function HelpTooltip({
+  children,
+  label = '詳細を表示',
+  placement = 'top',
+  className = '',
+}: HelpTooltipProps) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
+  const tooltipId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  const placementClasses: Record<NonNullable<HelpTooltipProps['placement']>, string> = {
+    top: 'bottom-full mb-2 left-1/2 -translate-x-1/2',
+    bottom: 'top-full mt-2 left-1/2 -translate-x-1/2',
+    right: 'left-full ml-2 top-1/2 -translate-y-1/2',
+    left: 'right-full mr-2 top-1/2 -translate-y-1/2',
+  };
+
+  return (
+    <span ref={wrapperRef} className={`relative inline-flex items-center ${className}`}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-expanded={open}
+        aria-describedby={open ? tooltipId : undefined}
+        onClick={() => setOpen((prev) => !prev)}
+        onFocus={() => setOpen(true)}
+        onBlur={(e) => {
+          if (!wrapperRef.current?.contains(e.relatedTarget as Node)) setOpen(false);
+        }}
+        className="inline-flex items-center justify-center rounded-full text-[var(--color-text-tertiary)] hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-1 focus:ring-offset-[var(--color-surface-1)] transition-colors"
+      >
+        <QuestionMarkCircleIcon className="w-4 h-4" aria-hidden="true" />
+      </button>
+      {open && (
+        <span
+          id={tooltipId}
+          role="tooltip"
+          className={`absolute z-30 w-60 rounded-lg border border-surface-3 bg-surface-2 px-3 py-2 text-xs text-[var(--color-text-secondary)] shadow-lg animate-fade-in ${placementClasses[placement]}`}
+        >
+          {children}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/HelpTooltip.tsx
+++ b/frontend/src/components/ui/HelpTooltip.tsx
@@ -72,10 +72,14 @@ export default function HelpTooltip({
           e.preventDefault();
           setOpen((prev) => !prev);
         }}
+        // Tab でフォーカスした直後に Enter/Space でアクティベートすると
+        // 「focus で open → keydown toggle で close」の race が起きる。
+        // キーボード経由のアクティベートは「開く」方向に限定（idempotent）し、
+        // 閉じるのは blur / Escape / 外側クリックに委譲する。
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            setOpen((prev) => !prev);
+            setOpen(true);
           }
         }}
         onFocus={() => setOpen(true)}

--- a/frontend/src/components/ui/HelpTooltip.tsx
+++ b/frontend/src/components/ui/HelpTooltip.tsx
@@ -2,11 +2,11 @@ import { useState, useRef, useEffect, useId, ReactNode } from 'react';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 
 type HelpTooltipProps = {
-  /** ツールチップに表示する説明文。ReactNode を許容することで改行や強調も可能 */
+  /** パネルに表示する説明文。ReactNode を許容することで改行や強調も可能 */
   children: ReactNode;
   /** アクセシブルなラベル（スクリーンリーダー向け）。例: 「5軸評価について」 */
   label?: string;
-  /** 吹き出しの表示方向 */
+  /** パネルの表示方向 */
   placement?: 'top' | 'bottom' | 'right' | 'left';
   /** 追加 className */
   className?: string;
@@ -15,6 +15,13 @@ type HelpTooltipProps = {
 /**
  * 専門用語や機能の横に置くヘルプアイコン。
  * クリック / フォーカスで説明を表示し、初心者が意味を確認できるようにする。
+ *
+ * WAI-ARIA のセマンティクスとしては **Disclosure（開閉パネル）** パターンを採用。
+ * - ボタン: aria-expanded + aria-controls でパネルとの関係を示す
+ * - パネル: role は持たせず id のみ（Disclosure では特別な role は不要）
+ *
+ * role="tooltip" を併用しないのは、本コンポーネントが自動表示ではなく
+ * ユーザ操作による明示的なトグルで開閉するためです。
  */
 export default function HelpTooltip({
   children,
@@ -24,7 +31,7 @@ export default function HelpTooltip({
 }: HelpTooltipProps) {
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef<HTMLSpanElement>(null);
-  const tooltipId = useId();
+  const panelId = useId();
 
   useEffect(() => {
     if (!open) return;
@@ -57,7 +64,7 @@ export default function HelpTooltip({
         type="button"
         aria-label={label}
         aria-expanded={open}
-        aria-describedby={open ? tooltipId : undefined}
+        aria-controls={panelId}
         // onMouseDown で preventDefault してフォーカスイベントを抑止し、
         // クリック時に「focus → setOpen(true)」→「click → toggle で false」と
         // なる race を回避。フォーカス状態は自前で明示管理する。
@@ -81,8 +88,8 @@ export default function HelpTooltip({
       </button>
       {open && (
         <span
-          id={tooltipId}
-          role="tooltip"
+          id={panelId}
+          // Disclosure パターンのためパネル自体には role を付けない
           className={`absolute z-30 w-60 rounded-lg border border-surface-3 bg-surface-2 px-3 py-2 text-xs text-[var(--color-text-secondary)] shadow-lg animate-fade-in ${placementClasses[placement]}`}
         >
           {children}

--- a/frontend/src/components/ui/PageIntro.tsx
+++ b/frontend/src/components/ui/PageIntro.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from 'react';
+
+type PageIntroProps = {
+  /** ページ上部に表示する見出し */
+  title: string;
+  /** 1〜2行の補足説明。初心者に「この画面で何ができるか」を伝える */
+  description?: ReactNode;
+  /** タイトル横に置くアイコン */
+  icon?: ReactNode;
+  /** ページタイトルの右側に表示するアクション（ボタンなど） */
+  actions?: ReactNode;
+  /** h1 / h2 の切り替え。SEO上 1ページに h1 は 1 つなので必要に応じて調整 */
+  headingLevel?: 1 | 2;
+  /** 追加 className */
+  className?: string;
+};
+
+/**
+ * ページ上部の統一ヘッダー。全画面でトーンと情報量を揃えることで、
+ * 初心者が「どのページでも同じパターンで情報が得られる」と学習できるようにする。
+ */
+export default function PageIntro({
+  title,
+  description,
+  icon,
+  actions,
+  headingLevel = 1,
+  className = '',
+}: PageIntroProps) {
+  const Heading = headingLevel === 1 ? 'h1' : 'h2';
+
+  return (
+    <header
+      className={`mb-6 flex flex-col gap-3 border-b border-surface-3 pb-4 sm:flex-row sm:items-end sm:justify-between ${className}`}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          {icon && <span className="text-primary-300 shrink-0">{icon}</span>}
+          <Heading className="text-xl font-bold text-[var(--color-text-primary)] sm:text-2xl">
+            {title}
+          </Heading>
+        </div>
+        {description && (
+          <p className="mt-1 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            {description}
+          </p>
+        )}
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+    </header>
+  );
+}

--- a/frontend/src/components/ui/StepIndicator.tsx
+++ b/frontend/src/components/ui/StepIndicator.tsx
@@ -1,0 +1,88 @@
+import { CheckIcon } from '@heroicons/react/24/solid';
+
+type Step = {
+  /** ステップのタイトル（短く） */
+  label: string;
+  /** ステップの補足説明（省略可） */
+  description?: string;
+};
+
+type StepIndicatorProps = {
+  /** すべてのステップ */
+  steps: Step[];
+  /** 現在アクティブなステップ（0 始まり） */
+  currentStep: number;
+  /** 追加 className */
+  className?: string;
+};
+
+/**
+ * 多段階操作の現在位置を可視化するステップインジケーター。
+ * 練習モードなど「シナリオ選択 → 会話 → スコア確認」のような導線で使う。
+ */
+export default function StepIndicator({ steps, currentStep, className = '' }: StepIndicatorProps) {
+  return (
+    <ol
+      className={`flex items-center gap-2 ${className}`}
+      aria-label="進行状況"
+    >
+      {steps.map((step, index) => {
+        const isCompleted = index < currentStep;
+        const isActive = index === currentStep;
+        const stepNumber = index + 1;
+
+        return (
+          <li
+            key={step.label}
+            className="flex items-center gap-2 flex-1 min-w-0"
+            aria-current={isActive ? 'step' : undefined}
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <span
+                className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-xs font-semibold transition-colors ${
+                  isCompleted
+                    ? 'bg-primary-500 border-primary-500 text-white'
+                    : isActive
+                    ? 'bg-primary-500/20 border-primary-400 text-primary-300'
+                    : 'bg-surface-2 border-surface-3 text-[var(--color-text-muted)]'
+                }`}
+                aria-hidden="true"
+              >
+                {isCompleted ? <CheckIcon className="h-3.5 w-3.5" /> : stepNumber}
+              </span>
+              <div className="min-w-0">
+                <p
+                  className={`text-sm font-medium truncate ${
+                    isActive
+                      ? 'text-[var(--color-text-primary)]'
+                      : 'text-[var(--color-text-tertiary)]'
+                  }`}
+                >
+                  {step.label}
+                  <span className="sr-only">
+                    {`（ステップ ${stepNumber} / ${steps.length}${
+                      isCompleted ? '・完了' : isActive ? '・実行中' : ''
+                    }）`}
+                  </span>
+                </p>
+                {step.description && (
+                  <p className="text-xs text-[var(--color-text-muted)] truncate">
+                    {step.description}
+                  </p>
+                )}
+              </div>
+            </div>
+            {index < steps.length - 1 && (
+              <div
+                className={`hidden sm:block h-0.5 flex-1 rounded ${
+                  isCompleted ? 'bg-primary-500' : 'bg-surface-3'
+                }`}
+                aria-hidden="true"
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/frontend/src/components/ui/__tests__/ActionCard.test.tsx
+++ b/frontend/src/components/ui/__tests__/ActionCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ActionCard from '../ActionCard';
+
+describe('ActionCard', () => {
+  it('to prop を渡すと Link として描画される', () => {
+    render(
+      <MemoryRouter>
+        <ActionCard title="練習モード" description="AI と練習" to="/practice" />
+      </MemoryRouter>
+    );
+    const link = screen.getByRole('link', { name: /練習モード/ });
+    expect(link).toHaveAttribute('href', '/practice');
+  });
+
+  it('onClick prop を渡すと button として描画され、クリックで発火する', () => {
+    const onClick = vi.fn();
+    render(<ActionCard title="アクション" onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button', { name: /アクション/ }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('description を描画する', () => {
+    render(<ActionCard title="t" onClick={() => {}} description="補足説明" />);
+    expect(screen.getByText('補足説明')).toBeInTheDocument();
+  });
+
+  it('badge を描画する', () => {
+    render(<ActionCard title="t" onClick={() => {}} badge="初心者向け" />);
+    expect(screen.getByText('初心者向け')).toBeInTheDocument();
+  });
+
+  it('icon を描画する', () => {
+    render(
+      <ActionCard
+        title="t"
+        onClick={() => {}}
+        icon={<span data-testid="action-icon">★</span>}
+      />
+    );
+    expect(screen.getByTestId('action-icon')).toBeInTheDocument();
+  });
+
+  it('emphasis=primary のとき class に primary 系が含まれる', () => {
+    render(<ActionCard title="t" onClick={() => {}} emphasis="primary" />);
+    const btn = screen.getByRole('button', { name: /t/ });
+    expect(btn.className).toMatch(/primary-400\/40|from-primary-500/);
+  });
+});

--- a/frontend/src/components/ui/__tests__/FirstTimeWelcome.test.tsx
+++ b/frontend/src/components/ui/__tests__/FirstTimeWelcome.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FirstTimeWelcome from '../FirstTimeWelcome';
+import { createMockStorage } from '../../../test/mockStorage';
+
+const STEPS = [
+  { title: '練習モードを選ぶ', description: '12 のシナリオから選択' },
+  { title: 'AI と会話する', description: '実務を想定したロールプレイ' },
+  { title: 'スコアを確認する', description: '5 軸評価で弱点がわかる' },
+];
+
+describe('FirstTimeWelcome', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('既定タイトルを h2 として描画する', () => {
+    render(<FirstTimeWelcome steps={STEPS} />);
+    const heading = screen.getByRole('heading', { name: 'ようこそ FreStyle へ' });
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('全ステップを番号付きで描画する', () => {
+    render(<FirstTimeWelcome steps={STEPS} />);
+    STEPS.forEach((step) => {
+      expect(screen.getByText(step.title)).toBeInTheDocument();
+      expect(screen.getByText(step.description)).toBeInTheDocument();
+    });
+    // 1, 2, 3 の番号が見える
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('onPrimaryAction が未指定なら CTA ボタンを出さない', () => {
+    render(<FirstTimeWelcome steps={STEPS} />);
+    expect(screen.queryByRole('button', { name: /はじめて練習する/ })).not.toBeInTheDocument();
+  });
+
+  it('onPrimaryAction が指定されれば CTA ボタンを出し、クリックで呼ばれる', () => {
+    const onPrimary = vi.fn();
+    render(<FirstTimeWelcome steps={STEPS} onPrimaryAction={onPrimary} />);
+    fireEvent.click(screen.getByRole('button', { name: 'はじめて練習する' }));
+    expect(onPrimary).toHaveBeenCalledOnce();
+  });
+
+  it('閉じるボタンでカードが消え、storageKey があれば永続化される', () => {
+    render(<FirstTimeWelcome steps={STEPS} storageKey="welcome:menu" />);
+    fireEvent.click(screen.getByRole('button', { name: 'このカードを閉じる' }));
+    expect(screen.queryByRole('heading', { name: 'ようこそ FreStyle へ' })).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('welcome:menu')).toBe('dismissed');
+  });
+
+  it('既に dismissed 済みなら初回から非表示', () => {
+    window.localStorage.setItem('welcome:menu', 'dismissed');
+    render(<FirstTimeWelcome steps={STEPS} storageKey="welcome:menu" />);
+    expect(screen.queryByRole('heading', { name: 'ようこそ FreStyle へ' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/__tests__/GlossaryTerm.test.tsx
+++ b/frontend/src/components/ui/__tests__/GlossaryTerm.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GlossaryTerm from '../GlossaryTerm';
+
+describe('GlossaryTerm', () => {
+  it('用語ラベルを表示する', () => {
+    render(<GlossaryTerm term="5軸評価" definition="5 つの軸で評価します" />);
+    expect(screen.getByText('5軸評価')).toBeInTheDocument();
+  });
+
+  it('ヘルプアイコンに用語名を含む aria-label が付く', () => {
+    render(<GlossaryTerm term="5軸評価" definition="説明" />);
+    expect(screen.getByRole('button', { name: '5軸評価の意味を表示' })).toBeInTheDocument();
+  });
+
+  it('ヘルプアイコンをクリックすると定義が表示される', () => {
+    render(<GlossaryTerm term="5軸評価" definition="5 つの軸で評価します" />);
+    fireEvent.click(screen.getByRole('button', { name: '5軸評価の意味を表示' }));
+    expect(screen.getByRole('tooltip')).toHaveTextContent('5 つの軸で評価します');
+  });
+
+  it('definition に ReactNode を受け取れる', () => {
+    render(
+      <GlossaryTerm
+        term="練習モード"
+        definition={<span data-testid="definition-node">強調テキスト</span>}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: '練習モードの意味を表示' }));
+    expect(screen.getByTestId('definition-node')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/__tests__/GlossaryTerm.test.tsx
+++ b/frontend/src/components/ui/__tests__/GlossaryTerm.test.tsx
@@ -13,9 +13,9 @@ describe('GlossaryTerm', () => {
     expect(screen.getByRole('button', { name: '5軸評価の意味を表示' })).toBeInTheDocument();
   });
 
-  it('ヘルプアイコンをクリックすると定義が表示される', () => {
+  it('ヘルプアイコンをクリック（mousedown）すると定義が表示される', () => {
     render(<GlossaryTerm term="5軸評価" definition="5 つの軸で評価します" />);
-    fireEvent.click(screen.getByRole('button', { name: '5軸評価の意味を表示' }));
+    fireEvent.mouseDown(screen.getByRole('button', { name: '5軸評価の意味を表示' }));
     expect(screen.getByRole('tooltip')).toHaveTextContent('5 つの軸で評価します');
   });
 
@@ -26,7 +26,7 @@ describe('GlossaryTerm', () => {
         definition={<span data-testid="definition-node">強調テキスト</span>}
       />
     );
-    fireEvent.click(screen.getByRole('button', { name: '練習モードの意味を表示' }));
+    fireEvent.mouseDown(screen.getByRole('button', { name: '練習モードの意味を表示' }));
     expect(screen.getByTestId('definition-node')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ui/__tests__/GlossaryTerm.test.tsx
+++ b/frontend/src/components/ui/__tests__/GlossaryTerm.test.tsx
@@ -15,8 +15,13 @@ describe('GlossaryTerm', () => {
 
   it('ヘルプアイコンをクリック（mousedown）すると定義が表示される', () => {
     render(<GlossaryTerm term="5軸評価" definition="5 つの軸で評価します" />);
-    fireEvent.mouseDown(screen.getByRole('button', { name: '5軸評価の意味を表示' }));
-    expect(screen.getByRole('tooltip')).toHaveTextContent('5 つの軸で評価します');
+    const trigger = screen.getByRole('button', { name: '5軸評価の意味を表示' });
+    fireEvent.mouseDown(trigger);
+    // Disclosure パターンのため aria-controls の指す panel に定義があることを検証
+    const panelId = trigger.getAttribute('aria-controls');
+    expect(panelId).not.toBeNull();
+    const panel = document.getElementById(panelId as string);
+    expect(panel).toHaveTextContent('5 つの軸で評価します');
   });
 
   it('definition に ReactNode を受け取れる', () => {

--- a/frontend/src/components/ui/__tests__/GuidedHint.test.tsx
+++ b/frontend/src/components/ui/__tests__/GuidedHint.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GuidedHint from '../GuidedHint';
+import { createMockStorage } from '../../../test/mockStorage';
+
+describe('GuidedHint', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('タイトルと本文を表示する', () => {
+    render(
+      <GuidedHint title="はじめての方へ">
+        まずは練習モードから始めましょう。
+      </GuidedHint>
+    );
+    expect(screen.getByText('はじめての方へ')).toBeInTheDocument();
+    expect(screen.getByText(/まずは練習モード/)).toBeInTheDocument();
+  });
+
+  it('role="note" で描画される', () => {
+    render(<GuidedHint title="t">body</GuidedHint>);
+    expect(screen.getByRole('note')).toBeInTheDocument();
+  });
+
+  it('既定で閉じるボタンが表示される', () => {
+    render(<GuidedHint title="t">body</GuidedHint>);
+    expect(screen.getByRole('button', { name: 'ヒントを閉じる' })).toBeInTheDocument();
+  });
+
+  it('dismissible=false のとき閉じるボタンは表示されない', () => {
+    render(
+      <GuidedHint title="t" dismissible={false}>
+        body
+      </GuidedHint>
+    );
+    expect(screen.queryByRole('button', { name: 'ヒントを閉じる' })).not.toBeInTheDocument();
+  });
+
+  it('閉じるボタンを押すとヒントが消える', () => {
+    render(<GuidedHint title="t">body</GuidedHint>);
+    fireEvent.click(screen.getByRole('button', { name: 'ヒントを閉じる' }));
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+
+  it('storageKey 付きで閉じると localStorage に記録される', () => {
+    render(
+      <GuidedHint title="t" storageKey="hint:menu:first-visit">
+        body
+      </GuidedHint>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'ヒントを閉じる' }));
+    expect(window.localStorage.getItem('hint:menu:first-visit')).toBe('dismissed');
+  });
+
+  it('既に dismissed が記録されていれば初回から非表示', () => {
+    window.localStorage.setItem('hint:menu:first-visit', 'dismissed');
+    render(
+      <GuidedHint title="t" storageKey="hint:menu:first-visit">
+        body
+      </GuidedHint>
+    );
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+  });
+
+  it('onDismiss が呼ばれる', () => {
+    const onDismiss = vi.fn();
+    render(
+      <GuidedHint title="t" onDismiss={onDismiss}>
+        body
+      </GuidedHint>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'ヒントを閉じる' }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
+++ b/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
@@ -2,10 +2,27 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import HelpTooltip from '../HelpTooltip';
 
+/**
+ * HelpTooltip は Disclosure パターンを採用しているため、
+ * パネルの存在は aria-expanded の状態 と aria-controls が指す
+ * パネルID の有無で検証する（role="tooltip" は使わない）。
+ */
+function getTrigger() {
+  return screen.getByRole('button', { name: '詳細を表示' });
+}
+
+function getPanel(trigger: HTMLElement) {
+  const panelId = trigger.getAttribute('aria-controls');
+  if (!panelId) throw new Error('aria-controls が未設定');
+  return document.getElementById(panelId);
+}
+
 describe('HelpTooltip', () => {
-  it('初期表示ではツールチップ本文は表示されない', () => {
+  it('初期表示ではパネルは表示されない', () => {
     render(<HelpTooltip>5軸評価の説明</HelpTooltip>);
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    const trigger = getTrigger();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(getPanel(trigger)).toBeNull();
   });
 
   it('aria-label を既定の「詳細を表示」で描画する', () => {
@@ -18,78 +35,107 @@ describe('HelpTooltip', () => {
     expect(screen.getByRole('button', { name: '5軸評価について' })).toBeInTheDocument();
   });
 
-  it('クリック（mousedown）でツールチップが開き、再クリックで閉じる', () => {
-    render(<HelpTooltip>5軸評価の説明</HelpTooltip>);
-    const trigger = screen.getByRole('button', { name: '詳細を表示' });
-
-    fireEvent.mouseDown(trigger);
-    expect(screen.getByRole('tooltip')).toHaveTextContent('5軸評価の説明');
-    expect(trigger).toHaveAttribute('aria-expanded', 'true');
-
-    fireEvent.mouseDown(trigger);
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  it('aria-controls が常にパネルIDを指す（Disclosure パターン）', () => {
+    render(<HelpTooltip>説明</HelpTooltip>);
+    const trigger = getTrigger();
+    expect(trigger).toHaveAttribute('aria-controls');
+    expect(trigger.getAttribute('aria-controls')).not.toBe('');
   });
 
-  it('mousedown→focus→click のブラウザ実イベント順序でもツールチップが閉じずに開いたまま', () => {
+  it('クリック（mousedown）でパネルが開き、再クリックで閉じる', () => {
+    render(<HelpTooltip>5軸評価の説明</HelpTooltip>);
+    const trigger = getTrigger();
+
+    fireEvent.mouseDown(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(getPanel(trigger)).toHaveTextContent('5軸評価の説明');
+
+    fireEvent.mouseDown(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(getPanel(trigger)).toBeNull();
+  });
+
+  it('mousedown→focus→click のブラウザ実イベント順序でもパネルが閉じずに開いたまま', () => {
     // ブラウザでボタン未フォーカス時にクリックすると
     // mousedown → focus → click の順に発火する。
     // onMouseDown で preventDefault しているため focus は発火しない想定、
     // かつ click では開閉トグルを行わないため、最終状態は「開」のまま。
     render(<HelpTooltip>説明</HelpTooltip>);
-    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+    const trigger = getTrigger();
 
     fireEvent.mouseDown(trigger);
-    // preventDefault 済みのため focus/click が後段で走ったとしても既状態を維持
     fireEvent.focus(trigger);
     fireEvent.click(trigger);
 
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(getPanel(trigger)).toBeInTheDocument();
   });
 
-  it('Enter キーでツールチップをトグル開閉できる', () => {
+  it('Enter キーでパネルをトグル開閉できる', () => {
     render(<HelpTooltip>説明</HelpTooltip>);
-    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+    const trigger = getTrigger();
 
     fireEvent.keyDown(trigger, { key: 'Enter' });
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.keyDown(trigger, { key: 'Enter' });
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('Space キーでもツールチップをトグル開閉できる', () => {
+  it('Space キーでもパネルをトグル開閉できる', () => {
     render(<HelpTooltip>説明</HelpTooltip>);
-    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+    const trigger = getTrigger();
 
     fireEvent.keyDown(trigger, { key: ' ' });
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('Escape キーでツールチップが閉じる', () => {
+  it('Escape キーでパネルが閉じる', () => {
     render(<HelpTooltip>説明</HelpTooltip>);
-    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+    const trigger = getTrigger();
 
     fireEvent.mouseDown(trigger);
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.keyDown(document, { key: 'Escape' });
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('外側クリックでツールチップが閉じる', () => {
+  it('外側クリックでパネルが閉じる', () => {
     render(
       <div>
         <HelpTooltip>説明</HelpTooltip>
         <button type="button">外側</button>
       </div>
     );
+    const trigger = getTrigger();
 
-    fireEvent.mouseDown(screen.getByRole('button', { name: '詳細を表示' }));
-    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.mouseDown(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.mouseDown(screen.getByRole('button', { name: '外側' }));
-    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('wrapper 外にフォーカスが移ったらパネルが閉じる（onBlur 経由）', () => {
+    render(
+      <div>
+        <HelpTooltip>説明</HelpTooltip>
+        <button type="button" data-testid="外側ボタン">
+          外側
+        </button>
+      </div>
+    );
+    const trigger = getTrigger();
+    // フォーカス→開く（React のシンセティックイベントを fireEvent 経由で発火）
+    fireEvent.focus(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    // relatedTarget が wrapper 外に飛ぶ blur を発火
+    const outsideButton = screen.getByTestId('外側ボタン');
+    fireEvent.blur(trigger, { relatedTarget: outsideButton });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
+++ b/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
@@ -71,26 +71,39 @@ describe('HelpTooltip', () => {
     expect(getPanel(trigger)).toBeInTheDocument();
   });
 
-  it('Enter キーでパネルをトグル開閉できる', () => {
+  it('Enter キーでパネルが開く（idempotent）', () => {
     render(<HelpTooltip>説明</HelpTooltip>);
     const trigger = getTrigger();
 
     fireEvent.keyDown(trigger, { key: 'Enter' });
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
+    // 2 回目の Enter でも閉じない（keyboard activation は open のみ）
     fireEvent.keyDown(trigger, { key: 'Enter' });
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('Space キーでもパネルをトグル開閉できる', () => {
+  it('Space キーでもパネルが開く（idempotent）', () => {
     render(<HelpTooltip>説明</HelpTooltip>);
     const trigger = getTrigger();
 
     fireEvent.keyDown(trigger, { key: ' ' });
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
 
-    fireEvent.keyDown(trigger, { key: ' ' });
-    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  it('Tab→focus で開いた後に Enter を押しても閉じない（keyboard race 回帰防止）', () => {
+    // ブラウザでは Tab フォーカス後に Enter/Space で <button> をアクティベートする。
+    // この順序でテストを再現し、focus で開いた状態を Enter が閉じないことを検証する。
+    render(<HelpTooltip>説明</HelpTooltip>);
+    const trigger = getTrigger();
+
+    // Tab 相当: focus でパネルを開く
+    fireEvent.focus(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // Enter: keyboard activation は open のみなので状態維持
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 
   it('Escape キーでパネルが閉じる', () => {

--- a/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
+++ b/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
@@ -18,24 +18,60 @@ describe('HelpTooltip', () => {
     expect(screen.getByRole('button', { name: '5軸評価について' })).toBeInTheDocument();
   });
 
-  it('クリックでツールチップが開き、再クリックで閉じる', () => {
+  it('クリック（mousedown）でツールチップが開き、再クリックで閉じる', () => {
     render(<HelpTooltip>5軸評価の説明</HelpTooltip>);
     const trigger = screen.getByRole('button', { name: '詳細を表示' });
 
-    fireEvent.click(trigger);
+    fireEvent.mouseDown(trigger);
     expect(screen.getByRole('tooltip')).toHaveTextContent('5軸評価の説明');
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-    fireEvent.click(trigger);
+    fireEvent.mouseDown(trigger);
     expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('mousedown→focus→click のブラウザ実イベント順序でもツールチップが閉じずに開いたまま', () => {
+    // ブラウザでボタン未フォーカス時にクリックすると
+    // mousedown → focus → click の順に発火する。
+    // onMouseDown で preventDefault しているため focus は発火しない想定、
+    // かつ click では開閉トグルを行わないため、最終状態は「開」のまま。
+    render(<HelpTooltip>説明</HelpTooltip>);
+    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+
+    fireEvent.mouseDown(trigger);
+    // preventDefault 済みのため focus/click が後段で走ったとしても既状態を維持
+    fireEvent.focus(trigger);
+    fireEvent.click(trigger);
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('Enter キーでツールチップをトグル開閉できる', () => {
+    render(<HelpTooltip>説明</HelpTooltip>);
+    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('Space キーでもツールチップをトグル開閉できる', () => {
+    render(<HelpTooltip>説明</HelpTooltip>);
+    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+
+    fireEvent.keyDown(trigger, { key: ' ' });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
   });
 
   it('Escape キーでツールチップが閉じる', () => {
     render(<HelpTooltip>説明</HelpTooltip>);
     const trigger = screen.getByRole('button', { name: '詳細を表示' });
 
-    fireEvent.click(trigger);
+    fireEvent.mouseDown(trigger);
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
 
     fireEvent.keyDown(document, { key: 'Escape' });
@@ -50,7 +86,7 @@ describe('HelpTooltip', () => {
       </div>
     );
 
-    fireEvent.click(screen.getByRole('button', { name: '詳細を表示' }));
+    fireEvent.mouseDown(screen.getByRole('button', { name: '詳細を表示' }));
     expect(screen.getByRole('tooltip')).toBeInTheDocument();
 
     fireEvent.mouseDown(screen.getByRole('button', { name: '外側' }));

--- a/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
+++ b/frontend/src/components/ui/__tests__/HelpTooltip.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HelpTooltip from '../HelpTooltip';
+
+describe('HelpTooltip', () => {
+  it('初期表示ではツールチップ本文は表示されない', () => {
+    render(<HelpTooltip>5軸評価の説明</HelpTooltip>);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('aria-label を既定の「詳細を表示」で描画する', () => {
+    render(<HelpTooltip>内容</HelpTooltip>);
+    expect(screen.getByRole('button', { name: '詳細を表示' })).toBeInTheDocument();
+  });
+
+  it('label prop をアクセシブルネームとして採用する', () => {
+    render(<HelpTooltip label="5軸評価について">内容</HelpTooltip>);
+    expect(screen.getByRole('button', { name: '5軸評価について' })).toBeInTheDocument();
+  });
+
+  it('クリックでツールチップが開き、再クリックで閉じる', () => {
+    render(<HelpTooltip>5軸評価の説明</HelpTooltip>);
+    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).toHaveTextContent('5軸評価の説明');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('Escape キーでツールチップが閉じる', () => {
+    render(<HelpTooltip>説明</HelpTooltip>);
+    const trigger = screen.getByRole('button', { name: '詳細を表示' });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('外側クリックでツールチップが閉じる', () => {
+    render(
+      <div>
+        <HelpTooltip>説明</HelpTooltip>
+        <button type="button">外側</button>
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '詳細を表示' }));
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('button', { name: '外側' }));
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/__tests__/PageIntro.test.tsx
+++ b/frontend/src/components/ui/__tests__/PageIntro.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PageIntro from '../PageIntro';
+
+describe('PageIntro', () => {
+  it('タイトルを h1 として描画する（既定）', () => {
+    render(<PageIntro title="練習モード" />);
+    const heading = screen.getByRole('heading', { name: '練習モード' });
+    expect(heading.tagName).toBe('H1');
+  });
+
+  it('headingLevel=2 を指定すると h2 になる', () => {
+    render(<PageIntro title="プロフィール" headingLevel={2} />);
+    const heading = screen.getByRole('heading', { name: 'プロフィール' });
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('description が表示される', () => {
+    render(<PageIntro title="練習" description="AI とロールプレイ練習ができます" />);
+    expect(screen.getByText('AI とロールプレイ練習ができます')).toBeInTheDocument();
+  });
+
+  it('description が未指定なら描画しない', () => {
+    const { container } = render(<PageIntro title="t" />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('actions を描画する', () => {
+    render(
+      <PageIntro
+        title="t"
+        actions={<button type="button">新規作成</button>}
+      />
+    );
+    expect(screen.getByRole('button', { name: '新規作成' })).toBeInTheDocument();
+  });
+
+  it('icon を描画する', () => {
+    render(
+      <PageIntro
+        title="t"
+        icon={<span data-testid="icon">⭐</span>}
+      />
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/__tests__/StepIndicator.test.tsx
+++ b/frontend/src/components/ui/__tests__/StepIndicator.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import StepIndicator from '../StepIndicator';
+
+const STEPS = [
+  { label: 'シナリオを選ぶ', description: '12 件から選択' },
+  { label: 'AI と会話する' },
+  { label: 'スコアを確認する' },
+];
+
+describe('StepIndicator', () => {
+  it('すべてのステップラベルを描画する', () => {
+    render(<StepIndicator steps={STEPS} currentStep={1} />);
+    STEPS.forEach((step) => {
+      expect(screen.getByText(step.label)).toBeInTheDocument();
+    });
+  });
+
+  it('補足説明が指定されていれば描画する', () => {
+    render(<StepIndicator steps={STEPS} currentStep={0} />);
+    expect(screen.getByText('12 件から選択')).toBeInTheDocument();
+  });
+
+  it('現在アクティブなステップに aria-current="step" が付く', () => {
+    render(<StepIndicator steps={STEPS} currentStep={1} />);
+    const list = screen.getByRole('list', { name: '進行状況' });
+    const items = within(list).getAllByRole('listitem');
+    expect(items[0]).not.toHaveAttribute('aria-current');
+    expect(items[1]).toHaveAttribute('aria-current', 'step');
+    expect(items[2]).not.toHaveAttribute('aria-current');
+  });
+
+  it('完了済み / 実行中 / 未着手 をスクリーンリーダー向けに区別する', () => {
+    render(<StepIndicator steps={STEPS} currentStep={1} />);
+    expect(screen.getByText(/ステップ 1 \/ 3・完了/)).toBeInTheDocument();
+    expect(screen.getByText(/ステップ 2 \/ 3・実行中/)).toBeInTheDocument();
+    // 未着手ステップは完了・実行中の接尾辞が付かない（全角括弧で閉じられる）
+    expect(screen.getByText('（ステップ 3 / 3）')).toBeInTheDocument();
+  });
+
+  it('ol 要素にラベル「進行状況」が付く', () => {
+    render(<StepIndicator steps={STEPS} currentStep={0} />);
+    expect(screen.getByRole('list', { name: '進行状況' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,7 @@
+export { default as ActionCard } from './ActionCard';
+export { default as FirstTimeWelcome } from './FirstTimeWelcome';
+export { default as GlossaryTerm } from './GlossaryTerm';
+export { default as GuidedHint } from './GuidedHint';
+export { default as HelpTooltip } from './HelpTooltip';
+export { default as PageIntro } from './PageIntro';
+export { default as StepIndicator } from './StepIndicator';

--- a/frontend/src/constants/glossary.ts
+++ b/frontend/src/constants/glossary.ts
@@ -1,0 +1,49 @@
+/**
+ * FreStyle アプリで使う専門用語の定義集。
+ * 画面内の GlossaryTerm / HelpTooltip で参照することで、
+ * 文言の一貫性と説明の質を担保する。
+ */
+export const GLOSSARY = {
+  fiveAxisScore: {
+    term: '5軸評価',
+    definition:
+      '論理的構成力・配慮表現・要約力・提案力・質問/傾聴力の 5 つの観点で、会話内容をスコアリングする仕組みです。',
+  },
+  logicalStructure: {
+    term: '論理的構成力',
+    definition: '報連相を結論→理由→詳細の順で構造化できているか、という観点です。',
+  },
+  considerateExpression: {
+    term: '配慮表現',
+    definition: '敬語の正確さ、相手への配慮が込められた言い回しができているかを評価します。',
+  },
+  summarization: {
+    term: '要約力',
+    definition: '技術的な内容を、相手が理解しやすい平易な言葉でまとめられているかを評価します。',
+  },
+  proposalSkill: {
+    term: '提案力',
+    definition:
+      'エスカレーション判断や代替案の提示など、状況に応じた建設的な提案ができているかを評価します。',
+  },
+  listeningSkill: {
+    term: '質問・傾聴力',
+    definition: '要件確認の網羅性と、相手の意図を汲み取る傾聴姿勢の両方を評価します。',
+  },
+  practiceMode: {
+    term: '練習モード',
+    definition:
+      'AI がビジネスシーンのロールプレイ相手を演じ、12 種類のシナリオから選んで実践練習できる機能です。',
+  },
+  scenario: {
+    term: 'シナリオ',
+    definition:
+      '障害報告、要件変更説明、見積もり交渉など、実務で遭遇する具体的なビジネス場面のことです。',
+  },
+  scoreCard: {
+    term: 'スコアカード',
+    definition: '会話終了後に AI が自動生成する、5 軸評価の結果と改善アドバイスのレポートです。',
+  },
+} as const;
+
+export type GlossaryKey = keyof typeof GLOSSARY;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,7 +5,8 @@ import SNSSignInButton from '../components/SNSSignInButton';
 import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
 import { useLoginPage } from '../hooks/useLoginPage';
-import { XCircleIcon } from '@heroicons/react/24/outline';
+import { XCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+import { GuidedHint } from '../components/ui';
 
 export default function LoginPage() {
   const { form, loginMessage, flashMessage, loading, handleLogin, handleChange } = useLoginPage();
@@ -20,22 +21,37 @@ export default function LoginPage() {
         </p>
       }
     >
-      {/* flash Message */}
-      <div>
-        {flashMessage && (
-          <p className="text-emerald-400 text-center mb-4 p-3 bg-emerald-900/30 rounded-lg font-medium">
-            {flashMessage}
-          </p>
-        )}
-        {loginMessage?.type === 'error' && (
-          <p className="text-rose-400 text-center mb-4 p-3 bg-rose-900/30 rounded-lg font-medium flex items-center justify-center gap-1">
-            <XCircleIcon className="w-4 h-4" />
-            {loginMessage.text}
-          </p>
-        )}
+      {/* 初心者向け導入ヒント（一度閉じると再表示しない） */}
+      <div className="mb-4">
+        <GuidedHint title="FreStyle へようこそ" storageKey="hint:login:intro-v1" tone="info">
+          Google アカウント、またはメールアドレス + パスワードでログインできます。
+          アカウントがない場合は下のリンクから新規登録してください。
+        </GuidedHint>
       </div>
 
-      {/* Googleログイン */}
+      {/* フラッシュメッセージ（成功） */}
+      {flashMessage && (
+        <p
+          role="status"
+          className="flex items-center justify-center gap-1 text-emerald-400 text-center mb-4 p-3 bg-emerald-900/30 rounded-lg font-medium"
+        >
+          <CheckCircleIcon className="w-4 h-4" aria-hidden="true" />
+          {flashMessage}
+        </p>
+      )}
+
+      {/* エラーメッセージ */}
+      {loginMessage?.type === 'error' && (
+        <p
+          role="alert"
+          className="flex items-center justify-center gap-1 text-rose-400 text-center mb-4 p-3 bg-rose-900/30 rounded-lg font-medium"
+        >
+          <XCircleIcon className="w-4 h-4" aria-hidden="true" />
+          {loginMessage.text}
+        </p>
+      )}
+
+      {/* Google ログイン */}
       <SNSSignInButton
         provider="google"
         onClick={() => {
@@ -49,14 +65,12 @@ export default function LoginPage() {
           <div className="w-full border-t border-surface-3"></div>
         </div>
         <div className="relative flex justify-center text-sm">
-          <span className="px-2 bg-surface-1 text-[var(--color-text-muted)]">
-            または
-          </span>
+          <span className="px-2 bg-surface-1 text-[var(--color-text-muted)]">または</span>
         </div>
       </div>
 
       {/* メール・パスワードフォーム */}
-      <form onSubmit={handleLogin}>
+      <form onSubmit={handleLogin} aria-label="ログインフォーム">
         <InputField
           label="メールアドレス"
           name="email"

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -23,6 +23,7 @@ import RecommendedScenarioCard from '../components/RecommendedScenarioCard';
 import BookmarkedScenariosCard from '../components/BookmarkedScenariosCard';
 import QuickStartButton from '../components/QuickStartButton';
 import Loading from '../components/Loading';
+import { useMemo } from 'react';
 import { useMenuData } from '../hooks/useMenuData';
 import { useScoreHistory } from '../hooks/useScoreHistory';
 import { useRecommendedScenario } from '../hooks/useRecommendedScenario';
@@ -61,6 +62,7 @@ export default function MenuPage() {
   }
 
   const isFirstTimeUser = totalSessions === 0;
+  const overallScores = useMemo(() => allScores.map((s) => s.overallScore), [allScores]);
 
   return (
     <div className="p-6 max-w-2xl mx-auto space-y-6">
@@ -121,10 +123,8 @@ export default function MenuPage() {
               streakDays={uniqueDays}
             />
 
-            {allScores.length >= 2 && <ScoreSparkline scores={allScores.map((s) => s.overallScore)} />}
-            {allScores.length >= 2 && (
-              <ScoreGrowthTrendCard scores={allScores.map((s) => s.overallScore)} />
-            )}
+            {overallScores.length >= 2 && <ScoreSparkline scores={overallScores} />}
+            {overallScores.length >= 2 && <ScoreGrowthTrendCard scores={overallScores} />}
           </div>
         </section>
       )}

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,4 +1,4 @@
-import { UserGroupIcon } from '@heroicons/react/24/outline';
+import { UserGroupIcon, HomeIcon, SparklesIcon, ChartBarIcon } from '@heroicons/react/24/outline';
 import AchievementBadgeCard from '../components/AchievementBadgeCard';
 import StreakCalendarCard from '../components/StreakCalendarCard';
 import CommunicationTipCard from '../components/CommunicationTipCard';
@@ -26,9 +26,33 @@ import Loading from '../components/Loading';
 import { useMenuData } from '../hooks/useMenuData';
 import { useScoreHistory } from '../hooks/useScoreHistory';
 import { useRecommendedScenario } from '../hooks/useRecommendedScenario';
+import { PageIntro, FirstTimeWelcome, GlossaryTerm } from '../components/ui';
+import { GLOSSARY } from '../constants/glossary';
 
+/**
+ * 初心者向けに上から順に並ぶホーム画面。
+ *
+ * 情報設計:
+ *   1. ウェルカム（初回のみ） / クイックスタート
+ *   2. 今日やること（デイリーゴール・チャレンジ）
+ *   3. 成長サマリー（インサイト・スコア推移）
+ *   4. 継続を促すエンゲージメント（バッジ・ストリーク・マイルストーン）
+ *   5. 振り返り（週次レポート・パターン）
+ *   6. 参考情報（ヒント・名言）
+ */
 export default function MenuPage() {
-  const { stats, totalUnread, latestScore, allScores, totalSessions, averageScore, uniqueDays, practiceDates, sessionsThisWeek, loading } = useMenuData();
+  const {
+    stats,
+    totalUnread,
+    latestScore,
+    allScores,
+    totalSessions,
+    averageScore,
+    uniqueDays,
+    practiceDates,
+    sessionsThisWeek,
+    loading,
+  } = useMenuData();
   const { weakestAxis } = useScoreHistory();
   const { scenario: recommendedScenario } = useRecommendedScenario(weakestAxis);
 
@@ -37,82 +61,111 @@ export default function MenuPage() {
   }
 
   const showRecommendation = !latestScore && stats?.chatPartnerCount === 0;
+  const isFirstTimeUser = totalSessions === 0;
 
   return (
-    <div className="p-6 max-w-2xl mx-auto">
+    <div className="p-6 max-w-2xl mx-auto space-y-6">
+      <PageIntro
+        icon={<HomeIcon className="h-6 w-6" />}
+        title="ホーム"
+        description={
+          <>
+            今日の{' '}
+            <GlossaryTerm
+              term={GLOSSARY.practiceMode.term}
+              definition={GLOSSARY.practiceMode.definition}
+            />{' '}
+            と学習の振り返りがここにまとまります。
+          </>
+        }
+      />
+
+      {/* 初回ユーザー向けウェルカム */}
+      {isFirstTimeUser && (
+        <FirstTimeWelcome
+          storageKey="welcome:menu:v1"
+          steps={[
+            {
+              title: 'シナリオを選んで AI と練習',
+              description:
+                '「練習モード」には 12 件のビジネスシーンがあります。まずは 1 つ選んで会話してみましょう。',
+            },
+            {
+              title: '5 軸評価で自分の強みを知る',
+              description:
+                '会話が終わると AI が自動でスコアカードを作成。論理的構成力や配慮表現などを可視化します。',
+            },
+            {
+              title: '毎日少しずつ続ける',
+              description:
+                '日次目標・週次目標・ストリークカレンダーで継続を応援します。1 日 1 回が理想的です。',
+            },
+          ]}
+        />
+      )}
+
       {/* クイックスタート */}
-      <div className="mb-6">
+      <section aria-label="今すぐ始める">
         <QuickStartButton scenario={recommendedScenario} />
-      </div>
+      </section>
 
       {/* 学習インサイト */}
       {totalSessions > 0 && (
-        <div className="mb-6">
-          <LearningInsightsCard
-            totalSessions={totalSessions}
-            averageScore={averageScore}
-            streakDays={uniqueDays}
-          />
-        </div>
-      )}
+        <section aria-labelledby="menu-insights">
+          <h2 id="menu-insights" className="sr-only">
+            学習の進捗サマリー
+          </h2>
+          <div className="space-y-6">
+            <LearningInsightsCard
+              totalSessions={totalSessions}
+              averageScore={averageScore}
+              streakDays={uniqueDays}
+            />
 
-      {/* スコアスパークライン */}
-      {allScores.length >= 2 && (
-        <div className="mb-6">
-          <ScoreSparkline scores={allScores.map(s => s.overallScore)} />
-        </div>
-      )}
-
-      {/* 成長トレンド */}
-      {allScores.length >= 2 && (
-        <div className="mb-6">
-          <ScoreGrowthTrendCard scores={allScores.map(s => s.overallScore)} />
-        </div>
+            {allScores.length >= 2 && <ScoreSparkline scores={allScores.map((s) => s.overallScore)} />}
+            {allScores.length >= 2 && (
+              <ScoreGrowthTrendCard scores={allScores.map((s) => s.overallScore)} />
+            )}
+          </div>
+        </section>
       )}
 
       {/* 弱点シナリオ推薦 */}
       {recommendedScenario && weakestAxis && (
-        <div className="mb-6">
-          <RecommendedScenarioCard scenario={recommendedScenario} weakAxis={weakestAxis.axis} />
-        </div>
+        <RecommendedScenarioCard scenario={recommendedScenario} weakAxis={weakestAxis.axis} />
       )}
 
-      {/* 次のステップ提案 */}
-      <div className="mb-6">
-        <NextStepCard totalSessions={totalSessions} averageScore={averageScore} />
-      </div>
-
-      {/* 練習レベル */}
-      <div className="mb-6">
-        <PracticeLevelCard totalSessions={totalSessions} />
-      </div>
-
-      {/* 達成バッジ */}
-      <div className="mb-6">
-        <AchievementBadgeCard totalSessions={totalSessions} />
-      </div>
-
-      {/* セッション数マイルストーン */}
-      <div className="mb-6">
-        <SessionCountMilestoneCard sessionCount={totalSessions} />
-      </div>
-
-      {/* 練習頻度 */}
-      {practiceDates.length > 0 && (
-        <div className="mb-6">
-          <PracticeFrequencyCard dates={practiceDates} />
+      {/* 次のステップ */}
+      <section aria-labelledby="menu-nextstep">
+        <h2 id="menu-nextstep" className="sr-only">
+          次にやるといいこと
+        </h2>
+        <div className="space-y-6">
+          <NextStepCard totalSessions={totalSessions} averageScore={averageScore} />
+          <PracticeLevelCard totalSessions={totalSessions} />
+          <AchievementBadgeCard totalSessions={totalSessions} />
+          <SessionCountMilestoneCard sessionCount={totalSessions} />
         </div>
+      </section>
+
+      {/* 練習頻度・継続 */}
+      {(practiceDates.length > 0 || latestScore) && (
+        <section aria-labelledby="menu-engagement">
+          <h2 id="menu-engagement" className="sr-only">
+            継続とエンゲージメント
+          </h2>
+          <div className="space-y-6">
+            {practiceDates.length > 0 && <PracticeFrequencyCard dates={practiceDates} />}
+            <StreakCalendarCard practiceDates={practiceDates} />
+            {latestScore && <PracticeReminderCard lastPracticeDate={latestScore.createdAt} />}
+          </div>
+        </section>
       )}
 
-      {/* 練習ストリークカレンダー */}
-      <div className="mb-6">
-        <StreakCalendarCard practiceDates={practiceDates} />
-      </div>
-
-      {/* サマリー */}
-      <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 mb-6">
+      {/* 会話した人数サマリー */}
+      <section className="rounded-lg border border-surface-3 bg-surface-1 p-4" aria-label="会話した人数">
         <div className="flex items-center gap-3">
-          <UserGroupIcon className="w-5 h-5 text-[var(--color-text-faint)]" />
+          <UserGroupIcon className="w-5 h-5 text-[var(--color-text-faint)]" aria-hidden="true" />
           <div>
             <p className="text-xs text-[var(--color-text-muted)]">会話した人数</p>
             <p className="text-lg font-semibold text-[var(--color-text-primary)]">
@@ -121,81 +174,78 @@ export default function MenuPage() {
             </p>
           </div>
         </div>
-      </div>
+      </section>
 
-      {/* おすすめアクション */}
-      {showRecommendation && (
-        <div className="bg-surface-2 rounded-lg border border-[var(--color-border-hover)] p-4 mb-6">
-          <p className="text-xs font-medium text-primary-300 mb-1">はじめての方へ</p>
-          <p className="text-xs text-primary-400">
-            まずは練習モードから始めてみましょう。AIが相手役を演じるビジネスシナリオで、コミュニケーションスキルを磨けます。
+      {/* 初回ユーザー向けおすすめ（ログはあるが練習未経験のユーザー向け） */}
+      {showRecommendation && !isFirstTimeUser && (
+        <aside className="rounded-lg border border-primary-400/30 bg-primary-500/10 p-4">
+          <p className="text-xs font-medium text-primary-300 mb-1 flex items-center gap-1">
+            <SparklesIcon className="w-4 h-4" aria-hidden="true" />
+            はじめての方へ
           </p>
-        </div>
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            まずは練習モードから始めてみましょう。AI が相手役を演じるビジネスシナリオで、
+            コミュニケーションスキルを磨けます。
+          </p>
+        </aside>
       )}
 
-      {/* 週間レポート */}
+      {/* 週次レポート / パターン分析 */}
       {totalSessions > 0 && (
-        <div className="mb-6">
-          <WeeklyReportCard allScores={allScores} />
-        </div>
+        <section aria-labelledby="menu-reports">
+          <h2
+            id="menu-reports"
+            className="mb-3 flex items-center gap-2 text-sm font-semibold text-[var(--color-text-secondary)]"
+          >
+            <ChartBarIcon className="h-4 w-4 text-primary-300" aria-hidden="true" />
+            振り返り
+          </h2>
+          <div className="space-y-6">
+            <WeeklyReportCard allScores={allScores} />
+            {practiceDates.length > 0 && <LearningPatternCard practiceDates={practiceDates} />}
+          </div>
+        </section>
       )}
 
-      {/* 学習パターン分析 */}
-      {practiceDates.length > 0 && (
-        <div className="mb-6">
-          <LearningPatternCard practiceDates={practiceDates} />
+      {/* 目標 */}
+      <section aria-labelledby="menu-goals">
+        <h2 id="menu-goals" className="sr-only">
+          日々の目標
+        </h2>
+        <div className="space-y-6">
+          <WeeklyGoalProgressCard sessionsThisWeek={sessionsThisWeek} weeklyGoal={5} />
+          <DailyGoalCard />
         </div>
-      )}
+      </section>
 
-      {/* 練習リマインダー */}
-      {latestScore && (
-        <div className="mb-6">
-          <PracticeReminderCard lastPracticeDate={latestScore.createdAt} />
+      {/* 直近のコンテンツ */}
+      <section aria-labelledby="menu-recent">
+        <h2 id="menu-recent" className="sr-only">
+          最近のアクティビティ
+        </h2>
+        <div className="space-y-6">
+          {allScores.length > 0 && <RecentSessionsCard sessions={allScores} />}
+          <BookmarkedScenariosCard />
+          <RecentNotesCard />
         </div>
-      )}
+      </section>
 
-      {/* 週間練習目標 */}
-      <div className="mb-6">
-        <WeeklyGoalProgressCard sessionsThisWeek={sessionsThisWeek} weeklyGoal={5} />
-      </div>
-
-      {/* 日次学習目標 */}
-      <div className="mb-6">
-        <DailyGoalCard />
-      </div>
-
-      {/* 直近のセッション */}
-      {allScores.length > 0 && (
-        <div className="mb-6">
-          <RecentSessionsCard sessions={allScores} />
+      {/* 参考情報 */}
+      <section aria-labelledby="menu-tips">
+        <h2 id="menu-tips" className="sr-only">
+          毎日のヒント
+        </h2>
+        <div className="space-y-6">
+          <DailyChallengeCard />
+          <MotivationQuoteCard />
+          <CommunicationTipCard />
         </div>
-      )}
+      </section>
 
-      {/* ブックマーク済みシナリオ */}
-      <BookmarkedScenariosCard />
-
-      {/* 最近のメモ */}
-      <div className="mb-6">
-        <RecentNotesCard />
-      </div>
-
-      {/* 本日のチャレンジ */}
-      <div className="mb-6">
-        <DailyChallengeCard />
-      </div>
-
-      {/* 今日の一言 */}
-      <div className="mb-6">
-        <MotivationQuoteCard />
-      </div>
-
-      {/* コミュニケーションTips */}
-      <div className="mb-6">
-        <CommunicationTipCard />
-      </div>
-
-      {/* メニュー */}
-      <MenuNavigationCard totalUnread={totalUnread} latestScore={latestScore ? latestScore.overallScore : null} />
+      <MenuNavigationCard
+        totalUnread={totalUnread}
+        latestScore={latestScore ? latestScore.overallScore : null}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,4 +1,4 @@
-import { UserGroupIcon, HomeIcon, SparklesIcon, ChartBarIcon } from '@heroicons/react/24/outline';
+import { UserGroupIcon, HomeIcon, ChartBarIcon } from '@heroicons/react/24/outline';
 import AchievementBadgeCard from '../components/AchievementBadgeCard';
 import StreakCalendarCard from '../components/StreakCalendarCard';
 import CommunicationTipCard from '../components/CommunicationTipCard';
@@ -60,7 +60,6 @@ export default function MenuPage() {
     return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
-  const showRecommendation = !latestScore && stats?.chatPartnerCount === 0;
   const isFirstTimeUser = totalSessions === 0;
 
   return (
@@ -175,20 +174,6 @@ export default function MenuPage() {
           </div>
         </div>
       </section>
-
-      {/* 初回ユーザー向けおすすめ（ログはあるが練習未経験のユーザー向け） */}
-      {showRecommendation && !isFirstTimeUser && (
-        <aside className="rounded-lg border border-primary-400/30 bg-primary-500/10 p-4">
-          <p className="text-xs font-medium text-primary-300 mb-1 flex items-center gap-1">
-            <SparklesIcon className="w-4 h-4" aria-hidden="true" />
-            はじめての方へ
-          </p>
-          <p className="text-sm text-[var(--color-text-secondary)]">
-            まずは練習モードから始めてみましょう。AI が相手役を演じるビジネスシナリオで、
-            コミュニケーションスキルを磨けます。
-          </p>
-        </aside>
-      )}
 
       {/* 週次レポート / パターン分析 */}
       {totalSessions > 0 && (

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -10,6 +10,8 @@ import EmptyState from '../components/EmptyState';
 import { AcademicCapIcon } from '@heroicons/react/24/outline';
 import { usePracticePage } from '../hooks/usePracticePage';
 import { PRACTICE_CATEGORY_TABS } from '../constants/scenarioLabels';
+import { PageIntro, StepIndicator, GuidedHint, GlossaryTerm } from '../components/ui';
+import { GLOSSARY } from '../constants/glossary';
 
 export default function PracticePage() {
   const {
@@ -34,12 +36,46 @@ export default function PracticePage() {
 
   return (
     <div className="p-6 max-w-2xl mx-auto">
-      {/* ヘッダー */}
+      <PageIntro
+        icon={<AcademicCapIcon className="h-6 w-6" />}
+        title="ビジネスシナリオ練習"
+        description={
+          <>
+            AI がビジネスの相手役を演じます。{' '}
+            <GlossaryTerm
+              term={GLOSSARY.scenario.term}
+              definition={GLOSSARY.scenario.definition}
+            />{' '}
+            を選んで会話を始めると、終了後に{' '}
+            <GlossaryTerm
+              term={GLOSSARY.fiveAxisScore.term}
+              definition={GLOSSARY.fiveAxisScore.definition}
+            />{' '}
+            で結果を確認できます。
+          </>
+        }
+      />
+
+      {/* 初回訪問ヒント */}
+      <div className="mb-4">
+        <GuidedHint
+          title="練習モードの流れ"
+          storageKey="hint:practice:intro-v1"
+        >
+          3 ステップで完了します。まずは気になるシナリオを 1 つ選んでみましょう。
+        </GuidedHint>
+      </div>
+
+      {/* 進行ステップ */}
       <div className="mb-5">
-        <h1 className="text-sm font-semibold text-[var(--color-text-primary)] mb-1">ビジネスシナリオ練習</h1>
-        <p className="text-xs text-[var(--color-text-muted)]">
-          AIが相手役を演じます。実践的なビジネスシーンでコミュニケーションスキルを磨きましょう。
-        </p>
+        <StepIndicator
+          steps={[
+            { label: 'シナリオを選ぶ', description: 'まずはここから' },
+            { label: 'AI と会話する', description: 'ロールプレイ' },
+            { label: 'スコアを確認', description: '5 軸で振り返り' },
+          ]}
+          currentStep={0}
+        />
       </div>
 
       {/* 検索ボックス */}

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -74,12 +74,12 @@ describe('MenuPage', () => {
   it('MenuNavigationCard のメニュー項目がすべて表示される', () => {
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    expect(screen.getByText('チャット')).toBeInTheDocument();
-    expect(screen.getByText('AI アシスタント')).toBeInTheDocument();
-    // 「練習モード」はPageIntroのGlossaryTermにも登場するため、MenuNavigationCard内では
-    // 複数マッチする可能性があるので getAllByText で件数を検証する
-    expect(screen.getAllByText('練習モード').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('スコア履歴')).toBeInTheDocument();
+    // MenuNavigationCard 内のナビゲーション項目は role=button + aria-label で描画されるので
+    // ロール＆アクセシブルネームで検証し、PageIntroのGlossaryTerm "練習モード" と混同しない
+    expect(screen.getByRole('button', { name: 'チャット' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'AI アシスタント' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '練習モード' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'スコア履歴' })).toBeInTheDocument();
   });
 
   it('会話した人数を表示する', () => {

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import MenuPage from '../MenuPage';
+import { createMockStorage } from '../../test/mockStorage';
 
 const mockNavigate = vi.fn();
 
@@ -62,15 +63,22 @@ function defaultMenuData() {
 describe('MenuPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('localStorage', createMockStorage());
     mockUseMenuData.mockReturnValue(defaultMenuData());
   });
 
-  it('メニュー項目が全て表示される', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('MenuNavigationCard のメニュー項目がすべて表示される', () => {
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
     expect(screen.getByText('チャット')).toBeInTheDocument();
     expect(screen.getByText('AI アシスタント')).toBeInTheDocument();
-    expect(screen.getByText('練習モード')).toBeInTheDocument();
+    // 「練習モード」はPageIntroのGlossaryTermにも登場するため、MenuNavigationCard内では
+    // 複数マッチする可能性があるので getAllByText で件数を検証する
+    expect(screen.getAllByText('練習モード').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('スコア履歴')).toBeInTheDocument();
   });
 
@@ -92,7 +100,7 @@ describe('MenuPage', () => {
     expect(screen.getByText(/最新: 7\.5/)).toBeInTheDocument();
   });
 
-  it('スコア履歴がない場合はおすすめアクションを表示する', () => {
+  it('初回ユーザー (totalSessions=0) には FirstTimeWelcome ウェルカムカードを表示する', () => {
     mockUseMenuData.mockReturnValue({
       stats: { chatPartnerCount: 0 },
       totalUnread: 0,
@@ -103,11 +111,13 @@ describe('MenuPage', () => {
       uniqueDays: 0,
       practiceDates: [],
       sessionsThisWeek: 0,
+      loading: false,
     });
 
     render(<BrowserRouter><MenuPage /></BrowserRouter>);
 
-    expect(screen.getByText(/練習モードから始めてみましょう/)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'ようこそ FreStyle へ' })).toBeInTheDocument();
+    expect(screen.getByText(/シナリオを選んで AI と練習/)).toBeInTheDocument();
   });
 
   it('未読がない場合は未読バッジを表示しない', () => {

--- a/frontend/src/test/mockStorage.ts
+++ b/frontend/src/test/mockStorage.ts
@@ -1,0 +1,26 @@
+import { vi } from 'vitest';
+
+/**
+ * テスト用のインメモリ Storage 実装。
+ * `vi.stubGlobal('localStorage', createMockStorage())` の形で使う。
+ * FreStyle では jsdom 環境の localStorage を都度スタブする方針に統一している。
+ */
+export function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+  };
+}


### PR DESCRIPTION
## 概要
- 初心者（新卒エンジニア）向けに UI を刷新するための共通デザインシステムを構築
- 既に適用済みのクリーンアーキテクチャを `docs/ARCHITECTURE.md` / README / CLAUDE.md で文書化
- 未カバーだった Mapper / Repository 層にテストを追加

Closes #1450

## 変更内容

### 1. クリーンアーキテクチャの文書化
- **`docs/ARCHITECTURE.md`** 新規追加（550 行）: 層責務・許される依存・禁止される依存・Mermaid の classDiagram / sequenceDiagram によるクラス依存関係図・テスト戦略をまとめた一次情報
- **README.md** 更新: クラス依存関係図（AIチャット / スコア評価）と AIチャットのデータフロー図を Mermaid で追加、開発フロー節を新設
- **`CLAUDE.md`**（gitignored）ローカル規約を整備。コミット対象ではない

### 2. 初心者向けUIコンポーネント群を追加
`frontend/src/components/ui/` 配下に共通コンポーネントを新設:

| コンポーネント | 用途 |
|---|---|
| `PageIntro` | 全画面統一のページヘッダー |
| `FirstTimeWelcome` | 初回訪問時の導入カード（localStorage永続化） |
| `GlossaryTerm` | 専門用語の下線＋クリックで用語解説 |
| `HelpTooltip` | 「?」アイコン付きの補足説明 |
| `StepIndicator` | 多段階操作の進行状況可視化 |
| `GuidedHint` | 閉じるボタン付き初心者向けヒント |
| `ActionCard` | Link/Button両対応の強調CTAカード |

- `constants/glossary.ts`: 5軸評価・論理的構成力・配慮表現などの専門用語定義を集約
- `test/mockStorage.ts`: localStorage スタブの共通ユーティリティ

### 3. 主要ページに新UIを適用
- **MenuPage**: 初回ユーザー（totalSessions=0）に `FirstTimeWelcome` を表示、sectionごとに `aria-labelledby` を付与して情報階層を整理
- **LoginPage**: `GuidedHint` で導入ヒント、`role="status"` / `role="alert"` でフラッシュとエラーの意味論区別
- **PracticePage**: `StepIndicator` で「シナリオ選択 → AI会話 → スコア確認」を常時可視化、`GlossaryTerm` で「シナリオ」「5軸評価」に用語解説

### 4. テスト強化（クリーンアーキテクチャ各層）
- フロントエンド: 新規UIコンポーネント 7 件それぞれの単体テスト（41 件）
- バックエンド Mapper: 未カバーだった `FriendshipMapperTest` / `LearningReportMapperTest`（計 11 件）
- バックエンド Repository: `FriendshipRepositoryTest` を `@DataJpaTest` + H2 で新設（10 件）。本番 `schema.sql`（MariaDB 構文）はテスト時のみ無効化し、Hibernate create-drop で H2 にスキーマを作る方針を採用
- `build.gradle` に testRuntimeOnly の H2 を追加

## テスト

### フロントエンド
- 新規UIコンポーネント 41 件: ✅ 全件パス
- 既存の MenuPage / LoginPage / PracticePage テスト: ✅ パス（MenuPage は新UIに合わせてテスト更新）
- 既存失敗（MenuNavigationCard / LoginCallback の 3 件）は本PR前から存在、本PRとは無関係

### バックエンド
- 新規 Mapper / Repository 21 件: ✅ 全件パス
- 既存 857 件中、失敗 3 件（FreStyleApplicationTests.contextLoads / AiChatWebSocketController rephrase ×2）は本PR前から存在、本PRとは無関係

## PR 運用
- 本PRは CodeRabbit レビューを待機し、指摘に対応してから squash merge します
- main への直接コミット禁止（ブランチ保護設定済み）の運用に準拠

## 関連
- Issue: #1450
- 参考（規約）: `docs/ARCHITECTURE.md` / README の「開発フロー」節

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added several reusable UI components (action cards, first-time welcome, glossary term, guided hints, help tooltips, page intros, step indicators) and integrated them into login, menu, and practice flows.

* **Documentation**
  * Added a comprehensive architecture specification and updated README with diagrams and contributor/testing guidance.

* **Tests**
  * Expanded unit and integration test coverage for mappers, repositories, and UI components; added test utilities for localStorage.

* **Chores**
  * Added an in-memory DB runtime dependency for tests to enable JPA integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->