### PR TITLE
chore: infrastructure/ を .gitignore に追加（IaCは別リポジトリで管理）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .env
 .claude/
 CLAUDE.md
+
+# IaC（CloudFormation）はプライベートリポジトリ frestyle-infrastructure
+# で別管理しているため、本リポジトリには含めない。
+# 詳細はリポジトリ管理者に問い合わせてください。
+infrastructure/


### PR DESCRIPTION
## 概要
CloudFormation など IaC コードは本リポジトリではなくプライベートリポジトリ \`frestyle-infrastructure\` で管理する方針に変更したため、本リポジトリに混入しないよう \`.gitignore\` に \`infrastructure/\` を追加します。

Closes #1455 の方針変更に伴う対応。

## 変更内容
- \`.gitignore\` に \`infrastructure/\` を追加
- 過去に push されていた \`feat/cloudformation-iac-phase1\` ブランチは別リポジトリ運用方針に伴い削除済み

## 運用方針
- **CloudFormation テンプレート / デプロイスクリプト** はプライベートリポジトリ \`frestyle-infrastructure\` で管理
- 本リポジトリには「IaC は別リポジトリで管理する」という事実だけを残す
- 関連する作業（環境変数化など）が本リポジトリに発生した場合は別途 Issue/PR で扱う

## 関連
- Issue: #1455