### PR TITLE
refactor: AWS SDK を DefaultCredentialsProvider に切り替え (Step 1 セキュリティ改善)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/config/S3Config.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/S3Config.java
@@ -3,19 +3,25 @@ package com.example.FreStyle.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
+/**
+ * S3 Presigner 設定。
+ *
+ * <p>credentialsProvider を明示指定しないことで、AWS SDK の標準
+ * クレデンシャルチェーンが以下の順に自動解決する:
+ * <ol>
+ *   <li>環境変数 AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY（ローカル開発・既存運用）</li>
+ *   <li>~/.aws/credentials</li>
+ *   <li>ECS Task Role（本番運用、推奨）</li>
+ *   <li>EC2 Instance Profile</li>
+ * </ol>
+ * これにより、ローカル開発時は env vars、ECS 本番では Task Role と
+ * 同一コードでシームレスに切り替わる。
+ */
 @Configuration
 public class S3Config {
-
-    @Value("${aws.access-key}")
-    private String accessKey;
-
-    @Value("${aws.secret-key}")
-    private String secretKey;
 
     @Value("${aws.region}")
     private String region;
@@ -24,11 +30,6 @@ public class S3Config {
     public S3Presigner s3Presigner() {
         return S3Presigner.builder()
                 .region(Region.of(region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(accessKey, secretKey)
-                        )
-                )
                 .build();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/config/SqsConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/SqsConfig.java
@@ -5,20 +5,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
+/**
+ * SQS Client 設定。
+ *
+ * <p>credentialsProvider を明示指定しないことで AWS SDK の標準
+ * クレデンシャルチェーンが env vars → ~/.aws/credentials → ECS Task Role
+ * → EC2 Instance Profile の順に自動解決する。S3Config と同方針。
+ */
 @Configuration
 @EnableScheduling
 public class SqsConfig {
-
-    @Value("${aws.access-key}")
-    private String accessKey;
-
-    @Value("${aws.secret-key}")
-    private String secretKey;
 
     @Value("${aws.region}")
     private String region;
@@ -27,11 +26,6 @@ public class SqsConfig {
     public SqsClient sqsClient() {
         return SqsClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(accessKey, secretKey)
-                        )
-                )
                 .build();
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/service/AiChatMessageDynamoService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/AiChatMessageDynamoService.java
@@ -14,8 +14,6 @@ import com.example.FreStyle.dto.AiChatMessageResponseDto;
 import com.example.FreStyle.repository.AiChatMessageDynamoRepository;
 
 import jakarta.annotation.PostConstruct;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -42,12 +40,6 @@ public class AiChatMessageDynamoService implements AiChatMessageDynamoRepository
     private DynamoDbClient dynamoDbClient;
     private String tableName;
 
-    @Value("${aws.access-key:}")
-    private String accessKey;
-
-    @Value("${aws.secret-key:}")
-    private String secretKey;
-
     @Value("${aws.region:}")
     private String region;
 
@@ -65,14 +57,11 @@ public class AiChatMessageDynamoService implements AiChatMessageDynamoRepository
 
     @PostConstruct
     public void init() {
-        if (dynamoDbClient == null && !accessKey.isEmpty()) {
+        // credentialsProvider は明示指定せず、AWS SDK の標準クレデンシャルチェーンに委譲。
+        // env vars → ~/.aws/credentials → ECS Task Role → EC2 Instance Profile の順に解決される。
+        if (dynamoDbClient == null && region != null && !region.isEmpty()) {
             dynamoDbClient = DynamoDbClient.builder()
                     .region(Region.of(region))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(
-                                    AwsBasicCredentials.create(accessKey, secretKey)
-                            )
-                    )
                     .build();
         }
         if (tableName == null) {

--- a/FreStyle/src/main/java/com/example/FreStyle/service/AiChatService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/AiChatService.java
@@ -10,8 +10,6 @@ import org.springframework.stereotype.Service;
 import com.example.FreStyle.dto.AiChatMessageDto;
 
 import jakarta.annotation.PostConstruct;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -22,31 +20,21 @@ import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 // AIとのやり取りをするためのSDKの設定
 @Service
 public class AiChatService {
-    @Value("${aws.access-key}")
-    private String accessKey;
-    
-    @Value("${aws.secret-key}")
-    private String secretKey;
-    
     @Value("${aws.region}")
     private String region;
-    
+
     @Value("${aws.dynamodb.table-name.ai-chat}")
     private String tableName;
-    
+
     private DynamoDbClient dynamoDbClient;
-    
-    // PostConstructではBeanが生成されて依存性注入（DI）が完了した直後に実行されるメソッドを定義
+
+    // PostConstructではBeanが生成されて依存性注入（DI）が完了した直後に実行されるメソッドを定義。
+    // credentialsProvider は明示指定せず、AWS SDK の標準クレデンシャルチェーンに委譲する。
+    // env vars → ~/.aws/credentials → ECS Task Role → EC2 Instance Profile の順で解決される。
     @PostConstruct
-    
     public void init() {
       dynamoDbClient = DynamoDbClient.builder()
               .region(Region.of(region))
-              .credentialsProvider(
-                  StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(accessKey, secretKey) 
-                  )
-              )
               .build();
     }
     

--- a/FreStyle/src/main/java/com/example/FreStyle/service/BedrockService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/BedrockService.java
@@ -10,8 +10,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
@@ -21,12 +19,6 @@ import software.amazon.awssdk.services.bedrockruntime.model.InvokeModelResponse;
 @Service
 @Slf4j
 public class BedrockService {
-
-    @Value("${aws.access-key}")
-    private String accessKey;
-
-    @Value("${aws.secret-key}")
-    private String secretKey;
 
     @Value("${aws.region}")
     private String region;
@@ -45,13 +37,10 @@ public class BedrockService {
     @PostConstruct
     public void init() {
         log.info("🚀 Bedrock Runtime Client を初期化中...");
+        // credentialsProvider は明示指定せず、AWS SDK の標準クレデンシャルチェーンに委譲。
+        // env vars → ~/.aws/credentials → ECS Task Role → EC2 Instance Profile の順で解決。
         bedrockClient = BedrockRuntimeClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(accessKey, secretKey)
-                        )
-                )
                 .build();
         log.info("✅ Bedrock Runtime Client 初期化完了 - Region: {}", region);
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/service/ChatMessageDynamoService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/ChatMessageDynamoService.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
@@ -14,8 +13,6 @@ import com.example.FreStyle.dto.ChatMessageDto;
 import com.example.FreStyle.repository.ChatMessageDynamoRepository;
 
 import jakarta.annotation.PostConstruct;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -36,12 +33,6 @@ public class ChatMessageDynamoService implements ChatMessageDynamoRepository {
     private DynamoDbClient dynamoDbClient;
     private String tableName;
 
-    @Value("${aws.access-key:}")
-    private String accessKey;
-
-    @Value("${aws.secret-key:}")
-    private String secretKey;
-
     @Value("${aws.region:}")
     private String region;
 
@@ -59,14 +50,11 @@ public class ChatMessageDynamoService implements ChatMessageDynamoRepository {
 
     @PostConstruct
     public void init() {
-        if (dynamoDbClient == null && !accessKey.isEmpty()) {
+        // credentialsProvider は明示指定せず、AWS SDK の標準クレデンシャルチェーンに委譲。
+        // env vars → ~/.aws/credentials → ECS Task Role → EC2 Instance Profile の順に解決される。
+        if (dynamoDbClient == null && region != null && !region.isEmpty()) {
             dynamoDbClient = DynamoDbClient.builder()
                     .region(Region.of(region))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(
-                                    AwsBasicCredentials.create(accessKey, secretKey)
-                            )
-                    )
                     .build();
         }
         if (tableName == null) {

--- a/FreStyle/src/main/java/com/example/FreStyle/service/CognitoAuthService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/CognitoAuthService.java
@@ -14,8 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
@@ -38,14 +36,10 @@ public class CognitoAuthService {
     @Value("${cognito.client-secret}")
     private String clientSecret;
 
-    public CognitoAuthService(
-            @Value("${aws.access-key}") String accessKey,
-            @Value("${aws.secret-key}") String secretKey,
-            @Value("${aws.region}") String region) {
-
+    public CognitoAuthService(@Value("${aws.region}") String region) {
+        // credentialsProvider は明示指定せず、AWS SDK の標準クレデンシャルチェーンに委譲。
+        // env vars → ~/.aws/credentials → ECS Task Role → EC2 Instance Profile の順で解決。
         this.cognitoClient = CognitoIdentityProviderClient.builder()
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)))
                 .region(Region.of(region))
                 .build();
     }

--- a/FreStyle/src/main/java/com/example/FreStyle/service/NoteService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/NoteService.java
@@ -5,8 +5,6 @@ import com.example.FreStyle.repository.NoteRepository;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.*;
@@ -28,12 +26,6 @@ public class NoteService implements NoteRepository {
     private DynamoDbClient dynamoDbClient;
     private String tableName;
 
-    @Value("${aws.access-key:}")
-    private String accessKey;
-
-    @Value("${aws.secret-key:}")
-    private String secretKey;
-
     @Value("${aws.region:}")
     private String region;
 
@@ -50,14 +42,11 @@ public class NoteService implements NoteRepository {
 
     @PostConstruct
     public void init() {
-        if (dynamoDbClient == null && !accessKey.isEmpty()) {
+        // credentialsProvider は明示指定せず、AWS SDK の標準クレデンシャルチェーンに委譲。
+        // env vars → ~/.aws/credentials → ECS Task Role → EC2 Instance Profile の順で解決。
+        if (dynamoDbClient == null && region != null && !region.isEmpty()) {
             dynamoDbClient = DynamoDbClient.builder()
                     .region(Region.of(region))
-                    .credentialsProvider(
-                            StaticCredentialsProvider.create(
-                                    AwsBasicCredentials.create(accessKey, secretKey)
-                            )
-                    )
                     .build();
         }
         if (tableName == null) {

--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -32,8 +32,9 @@ cognito.redirect-uri=${COGNITO_REDIRECT_URI}
 cognito.token-uri=${COGNITO_TOKEN_URI}
 cognito.jwk-set-uri=${COGNITO_JWK_SET_URI}
 
-aws.access-key=${AWS_ACCESS_KEY}
-aws.secret-key=${AWS_SECRET_KEY}
+# AWS SDK は標準クレデンシャルチェーン (env vars / ~/.aws/credentials / ECS Task Role / EC2 Instance Profile)
+# で自動解決するため、access-key / secret-key の Spring プロパティ参照は廃止。
+# ローカル開発時は AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY を環境変数で渡す。
 aws.region=${AWS_REGION}
 
 aws.dynamodb.table-name.ai-chat=fre_style_ai_chat

--- a/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/service/CognitoAuthServiceTest.java
@@ -22,7 +22,7 @@ class CognitoAuthServiceTest {
     @BeforeEach
     void setUp() {
         cognitoClient = mock(CognitoIdentityProviderClient.class);
-        service = new CognitoAuthService("dummyAccessKey", "dummySecretKey", "ap-northeast-1");
+        service = new CognitoAuthService("ap-northeast-1");
         ReflectionTestUtils.setField(service, "cognitoClient", cognitoClient);
         ReflectionTestUtils.setField(service, "clientId", "testClientId");
         ReflectionTestUtils.setField(service, "clientSecret", "testClientSecret");

--- a/docs/security/01-aws-sdk-default-credentials.md
+++ b/docs/security/01-aws-sdk-default-credentials.md
@@ -1,0 +1,85 @@
+# AWS SDK の標準クレデンシャルチェーン採用
+
+## 背景
+
+旧実装では Spring Boot 起動時に `application.properties` の `aws.access-key` / `aws.secret-key` を読み、各 AWS Client（S3 / SQS / DynamoDB / Bedrock / Cognito）の builder に `StaticCredentialsProvider.create(AwsBasicCredentials.create(...))` で明示注入していた。
+
+これは以下の問題があった:
+
+1. **長寿命のアクセスキー** が ECS タスクの環境変数経由で注入されており、漏洩リスクが大きい
+2. **ローテーションが手動** — キー変更時に Task Definition / Secret / 環境変数 を全て更新する必要がある
+3. **ECS Task Role への移行が阻害される** — IAM Role を使うときも明示クレデンシャルが優先されるため、Task Role に切り替えてもアクセスキーが残っている限り Role は使われない
+
+## 変更内容
+
+8 ファイル全てで `credentialsProvider` の明示指定を削除し、AWS SDK builder に委譲する形に変更:
+
+| ファイル | 変更前 | 変更後 |
+|---|---|---|
+| `config/S3Config.java` | `.credentialsProvider(StaticCredentialsProvider.create(...))` | builder に渡さない |
+| `config/SqsConfig.java` | 同上 | 同上 |
+| `service/AiChatMessageDynamoService.java` | 同上 | 同上 |
+| `service/AiChatService.java` | 同上 | 同上 |
+| `service/BedrockService.java` | 同上 | 同上 |
+| `service/ChatMessageDynamoService.java` | 同上 | 同上 |
+| `service/CognitoAuthService.java` | コンストラクタで access/secret 受け取り | region のみ受け取る |
+| `service/NoteService.java` | 同 PostConstruct パターン | 同上 |
+
+## なぜ「明示しない」が正解か
+
+AWS SDK v2 の builder は `credentialsProvider` を呼ばないと **`DefaultCredentialsProvider`** を自動的に使用する。これは以下を順に試すクレデンシャルチェーン:
+
+1. **環境変数** `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`
+2. Java システムプロパティ `aws.accessKeyId` / `aws.secretAccessKey`
+3. **Web Identity Token File**（GitHub Actions OIDC など）
+4. AWS SSO（プロファイル設定）
+5. `~/.aws/credentials` のプロファイル
+6. `~/.aws/config` のプロファイル
+7. **ECS コンテナクレデンシャル**（Task Role）
+8. **EC2 Instance Profile**
+
+これにより:
+- **ローカル開発**: 環境変数 or `~/.aws/credentials` で動く
+- **ECS 本番**: Task Role が自動採用される（環境変数を消すだけで切り替わる）
+- **GitHub Actions**: OIDC を使えば `Web Identity Token File` 経由で短期トークンが取れる
+
+つまり **同一コードでローカル / 本番 / CI のいずれでも動く** 上、本番では IAM Role により credentials が短命化される。
+
+## アプリ側の動作確認
+
+```bash
+# ローカル: 環境変数から取得（後方互換）
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=ap-northeast-1
+./gradlew bootRun
+
+# ECS 本番: Task Role が自動的に効く（次の IaC PR でセットアップ）
+```
+
+## `application.properties` の変更
+
+```diff
+- aws.access-key=${AWS_ACCESS_KEY}
+- aws.secret-key=${AWS_SECRET_KEY}
+  aws.region=${AWS_REGION}
+```
+
+`AWS_ACCESS_KEY` / `AWS_SECRET_KEY` 環境変数は ECS Task Definition から削除する（次のインフラ PR で対応）。AWS SDK は標準環境変数 `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` を直接読むので Spring 経由の中継は不要。
+
+## テスト
+
+- 新たな failing は発生していない（既存の 3 件 = `FreStyleApplicationTests.contextLoads`, `AiChatWebSocketController.rephraseMessage` × 2 は本変更前から失敗中）
+- `CognitoAuthServiceTest` のコンストラクタ呼び出しを 3 引数 → 1 引数に更新
+
+## 関連リソース
+
+- 次に予定している IaC 変更: `frestyle-infrastructure` 側で
+  - ECS Task Role を新設し、Bedrock / DynamoDB / S3 / SQS / Secrets Manager の最小権限を付与
+  - Task Definition の `Environment` から `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` を削除
+  - DB パスワードや Cognito Client Secret は `Secrets:` フィールドで Secrets Manager から直接 inject
+
+## 参考
+
+- [AWS SDK for Java v2 - Default Credentials Provider Chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html)
+- [Amazon ECS Task IAM Roles](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)


### PR DESCRIPTION
## 概要
セキュリティ改善 4 ステップのうち **Step 1 の前準備**: アプリ側で長寿命のアクセスキー (\`AWS_ACCESS_KEY\` / \`AWS_SECRET_KEY\` を環境変数経由で注入) を使うのを止め、AWS SDK の **標準クレデンシャルチェーン** に切り替える。

これにより:
- ローカル開発: 環境変数 \`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\` で動く（後方互換）
- ECS 本番: Task Role が自動採用される（次の IaC PR で対応）
- GitHub Actions: OIDC で Web Identity Token File が使える

## 変更内容

### 8 ファイルで \`credentialsProvider\` を builder から削除

| ファイル | 変更 |
|---|---|
| \`config/S3Config.java\` | StaticCredentialsProvider 削除 |
| \`config/SqsConfig.java\` | 同上 |
| \`service/AiChatMessageDynamoService.java\` | 同 PostConstruct パターン |
| \`service/AiChatService.java\` | 同上 |
| \`service/BedrockService.java\` | 同上 |
| \`service/ChatMessageDynamoService.java\` | 同上 |
| \`service/CognitoAuthService.java\` | コンストラクタを region のみに簡素化 |
| \`service/NoteService.java\` | 同 PostConstruct パターン |

### application.properties

\`aws.access-key\` / \`aws.secret-key\` の Spring プロパティ参照を削除。AWS SDK は標準環境変数 \`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\` を直接読むので Spring 経由の中継は不要。

### テスト

\`CognitoAuthServiceTest\` のコンストラクタ呼び出しを 3 引数 → 1 引数に更新。

### ドキュメント
- \`docs/security/01-aws-sdk-default-credentials.md\` 新設（背景、移行効果、チェーン優先順位、後方互換）

## テスト結果
- 新たな failing 0 件
- 既存 failing 3 件（\`FreStyleApplicationTests.contextLoads\`, \`AiChatWebSocketController.rephraseMessage\` × 2）は本 PR 前から発生中で無関係

## 次のステップ
本 PR がマージされると、frestyle-infrastructure 側で:
- ECS Task Role を新設し最小権限を付与
- Task Definition の \`Environment\` から \`AWS_ACCESS_KEY\` / \`AWS_SECRET_KEY\` を削除
- DB パスワードや Cognito Client Secret は \`Secrets:\` フィールドで Secrets Manager から直接 inject

を別 PR で実施する（Step 1 + Step 2 の組）。

## 関連
- セキュリティ改善 4 ステップの Step 1
- 次: frestyle-infrastructure リポでの Task Role + Secrets Manager 統合 PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Enhancement**
  * Application now uses AWS SDK's default credential provider chain instead of hardcoded credentials in configuration. Credentials are resolved automatically from environment variables, AWS profiles, ECS Task Roles, and EC2 instance profiles.

* **Configuration Changes**
  * AWS access and secret keys are no longer required in configuration files. Only the AWS region setting is needed.

* **Documentation**
  * Added security documentation on credential resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->