### PR TITLE
feat: 夜間コスト節約スケジュール (22時destroy / 7時recreate)

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -1,0 +1,207 @@
+name: Scheduled - Start (recreate ALB + ECS at morning)
+
+# 目的: 毎日 07:00 JST (22:00 UTC) に ALB と ECS を再作成して稼働開始。
+# scheduled-stop.yml と対になる。
+#
+# 流れ:
+#   1) ALB を CFn deploy（新しい AWS DNS 名が払い出される）
+#   2) ECS を CFn deploy（IAM Role / Secrets Manager は前夜から残置）
+#   3) Cloudflare DNS で api.normanblog.com の CNAME を新 ALB に更新
+#   4) services-stable wait + ヘルスチェック
+#
+# 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+
+on:
+  schedule:
+    # 07:00 JST = 22:00 UTC（前日）、毎日
+    - cron: '0 22 * * *'
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '手動実行時は "start" と入力'
+        required: true
+        type: string
+
+env:
+  AWS_REGION: ap-northeast-1
+  STACK_PFX: frestyle-prod
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+  IAC_REPO: norman6464/frestyle-infrastructure
+  CF_API_RECORD_NAME: api.normanblog.com
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  start:
+    name: Recreate ALB + ECS
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Verify input (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm }}" != "start" ]; then
+            echo "ERROR: confirm に 'start' と入力されていません"
+            exit 1
+          fi
+
+      - name: Checkout frestyle-infrastructure
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.IAC_REPO }}
+          token: ${{ secrets.IAC_REPO_TOKEN }}
+          path: iac
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: frestyle-scheduled-start
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy ALB stack
+        run: |
+          ALB_SG=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sg \
+            --query 'Stacks[0].Outputs[?OutputKey==`AlbSecurityGroupId`].OutputValue' --output text)
+          aws cloudformation deploy --region $AWS_REGION \
+            --stack-name $STACK_PFX-alb \
+            --template-file iac/infrastructure/cloudformation/templates/runtime/alb.yml \
+            --parameter-overrides Environment=prod AlbSecurityGroupId=$ALB_SG \
+            --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
+            --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
+
+      - name: Resolve dependent stack outputs
+        id: deps
+        run: |
+          ECS_SG=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sg \
+            --query 'Stacks[0].Outputs[?OutputKey==`EcsServiceSecurityGroupId`].OutputValue' --output text)
+          TG_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-alb \
+            --query 'Stacks[0].Outputs[?OutputKey==`TargetGroupArn`].OutputValue' --output text)
+          DB_HOST=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-rds \
+            --query 'Stacks[0].Outputs[?OutputKey==`DBEndpoint`].OutputValue' --output text)
+          DB_PORT=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-rds \
+            --query 'Stacks[0].Outputs[?OutputKey==`DBPort`].OutputValue' --output text)
+          DB_NAME=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-rds \
+            --query 'Stacks[0].Outputs[?OutputKey==`DBName`].OutputValue' --output text)
+          S3_BUCKET=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-s3 \
+            --query 'Stacks[0].Outputs[?OutputKey==`NoteImagesBucketName`].OutputValue' --output text)
+          SQS_URL=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sqs \
+            --query 'Stacks[0].Outputs[?OutputKey==`ReportQueueUrl`].OutputValue' --output text)
+          EXEC_ROLE=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-iam \
+            --query 'Stacks[0].Outputs[?OutputKey==`TaskExecutionRoleArn`].OutputValue' --output text)
+          TASK_ROLE=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-iam \
+            --query 'Stacks[0].Outputs[?OutputKey==`TaskRoleArn`].OutputValue' --output text)
+          DB_PWD_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
+            --secret-id $STACK_PFX/db-master-password --query 'ARN' --output text)
+          COG_SEC_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
+            --secret-id $STACK_PFX/cognito-client-secret --query 'ARN' --output text)
+          ALB_DNS=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-alb \
+            --query 'Stacks[0].Outputs[?OutputKey==`LoadBalancerDnsName`].OutputValue' --output text)
+
+          {
+            echo "ecs_sg=$ECS_SG"
+            echo "tg_arn=$TG_ARN"
+            echo "db_url=jdbc:mysql://$DB_HOST:$DB_PORT/$DB_NAME"
+            echo "s3_bucket=$S3_BUCKET"
+            echo "sqs_url=$SQS_URL"
+            echo "exec_role=$EXEC_ROLE"
+            echo "task_role=$TASK_ROLE"
+            echo "db_pwd_arn=$DB_PWD_ARN"
+            echo "cog_sec_arn=$COG_SEC_ARN"
+            echo "alb_dns=$ALB_DNS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Deploy ECS stack
+        env:
+          ECS_SG: ${{ steps.deps.outputs.ecs_sg }}
+          TG_ARN: ${{ steps.deps.outputs.tg_arn }}
+          DB_URL: ${{ steps.deps.outputs.db_url }}
+          S3_BUCKET: ${{ steps.deps.outputs.s3_bucket }}
+          SQS_URL: ${{ steps.deps.outputs.sqs_url }}
+          EXEC_ROLE: ${{ steps.deps.outputs.exec_role }}
+          TASK_ROLE: ${{ steps.deps.outputs.task_role }}
+          DB_PWD_ARN: ${{ steps.deps.outputs.db_pwd_arn }}
+          COG_SEC_ARN: ${{ steps.deps.outputs.cog_sec_arn }}
+        run: |
+          aws cloudformation deploy --region $AWS_REGION \
+            --stack-name $STACK_PFX-ecs \
+            --template-file iac/infrastructure/cloudformation/templates/runtime/ecs.yml \
+            --parameter-overrides \
+              Environment=prod \
+              EcsServiceSecurityGroupId="$ECS_SG" \
+              TargetGroupArn="$TG_ARN" \
+              DBUrl="$DB_URL" \
+              DBUser=admin \
+              DBPasswordSecretArn="$DB_PWD_ARN" \
+              CognitoClientId="${{ secrets.COGNITO_CLIENT_ID }}" \
+              CognitoClientSecretArn="$COG_SEC_ARN" \
+              CognitoRedirectUri="${{ secrets.COGNITO_REDIRECT_URI }}" \
+              CognitoTokenUri="${{ secrets.COGNITO_TOKEN_URI }}" \
+              CognitoJwkSetUri="${{ secrets.COGNITO_JWK_SET_URI }}" \
+              NoteImagesBucket="$S3_BUCKET" \
+              SqsReportQueueUrl="$SQS_URL" \
+              ExecutionRoleArn="$EXEC_ROLE" \
+              TaskRoleArn="$TASK_ROLE" \
+            --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
+            --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
+
+      - name: Update Cloudflare DNS to new ALB
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          ALB_DNS: ${{ steps.deps.outputs.alb_dns }}
+        run: |
+          REC_ID=$(curl -s -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records?type=CNAME&name=$CF_API_RECORD_NAME" | \
+            jq -r '.result[0].id // ""')
+          BODY=$(jq -n --arg name "$CF_API_RECORD_NAME" --arg content "$ALB_DNS" \
+            '{type:"CNAME", name:$name, content:$content, ttl:1, proxied:true}')
+          if [ -n "$REC_ID" ]; then
+            echo "Updating existing record id=$REC_ID -> $ALB_DNS"
+            curl -s -X PUT -H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json" \
+              --data "$BODY" \
+              "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records/$REC_ID" | jq '.success, .result.content'
+          else
+            echo "Creating new record -> $ALB_DNS"
+            curl -s -X POST -H "Authorization: Bearer $CF_API_TOKEN" -H "Content-Type: application/json" \
+              --data "$BODY" \
+              "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" | jq '.success, .result.content'
+          fi
+
+      - name: Wait for ECS service to stabilize
+        run: |
+          aws ecs wait services-stable --region $AWS_REGION \
+            --cluster $STACK_PFX --services $STACK_PFX-svc
+
+      - name: Health check via ALB DNS (Cloudflare 伝播前でも確認可)
+        env:
+          ALB_DNS: ${{ steps.deps.outputs.alb_dns }}
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -fsS "http://$ALB_DNS/actuator/health"; then
+              echo "✅ Healthy"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "❌ Health check failed after 5 attempts"
+          exit 1
+
+      - name: Summary
+        run: |
+          echo "☀️ Morning start complete at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/.github/workflows/scheduled-stop.yml
+++ b/.github/workflows/scheduled-stop.yml
@@ -1,0 +1,80 @@
+name: Scheduled - Stop (destroy ECS + ALB at night)
+
+# 目的: 毎日 22:00 JST (13:00 UTC) に ECS + ALB を destroy してコスト節約。
+# RDS / DynamoDB / S3 / SQS / IAM / SG / ECR / Cognito は対象外（データ保護 or 課金影響小）。
+#
+# 復旧は scheduled-start.yml が翌日 07:00 JST に自動実行。
+# 緊急で起こしたい場合は手動で gh workflow run scheduled-start.yml を叩く。
+#
+# 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+
+on:
+  schedule:
+    # 22:00 JST = 13:00 UTC、毎日
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '手動実行時は "stop" と入力'
+        required: true
+        type: string
+
+env:
+  AWS_REGION: ap-northeast-1
+  STACK_PFX: frestyle-prod
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  stop:
+    name: Destroy ECS + ALB
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Verify input (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm }}" != "stop" ]; then
+            echo "ERROR: confirm に 'stop' と入力されていません"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: frestyle-scheduled-stop
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Destroy ECS stack
+        run: |
+          if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $STACK_PFX-ecs >/dev/null 2>&1; then
+            echo "Deleting $STACK_PFX-ecs ..."
+            aws cloudformation delete-stack --region $AWS_REGION --stack-name $STACK_PFX-ecs
+            aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $STACK_PFX-ecs
+            echo "✅ ECS deleted"
+          else
+            echo "ECS stack already absent, skip"
+          fi
+
+      - name: Destroy ALB stack
+        run: |
+          if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $STACK_PFX-alb >/dev/null 2>&1; then
+            echo "Deleting $STACK_PFX-alb ..."
+            aws cloudformation delete-stack --region $AWS_REGION --stack-name $STACK_PFX-alb
+            aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $STACK_PFX-alb
+            echo "✅ ALB deleted"
+          else
+            echo "ALB stack already absent, skip"
+          fi
+
+      - name: Summary
+        run: |
+          echo "🌙 Cost-saving stop complete at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          aws cloudformation list-stacks --region $AWS_REGION \
+            --query 'StackSummaries[?starts_with(StackName, `frestyle-prod-`) && StackStatus != `DELETE_COMPLETE`].[StackName,StackStatus]' \
+            --output table

--- a/docs/operations/scheduled-cost-savings.md
+++ b/docs/operations/scheduled-cost-savings.md
@@ -1,0 +1,140 @@
+# 夜間コスト節約スケジュール
+
+## 概要
+
+毎日 22:00 JST に ECS + ALB を destroy、翌日 07:00 JST に再作成して Cloudflare DNS を新 ALB に更新する自動スケジュールジョブです。
+
+## 効果
+
+| リソース | 24/7 月額目安 | 9 時間/日停止での節約 |
+|---|---|---|
+| ECS Fargate (2 vCPU/4GB) | ~$50 | ~$19 (37.5%) |
+| ALB (時間課金) | ~$22 | ~$8 |
+| **合計** | **~$72** | **~$27/月** |
+
+RDS / DynamoDB / S3 / SQS / IAM / SG / ECR / Cognito は対象外（データ保護 or 課金影響小）。
+
+## 仕組み
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ GitHub Actions Scheduled Workflow                            │
+│                                                              │
+│ 22:00 JST (13:00 UTC) ─┐  scheduled-stop.yml                │
+│                        ▼                                     │
+│   1. CFn delete-stack  frestyle-prod-ecs                     │
+│   2. CFn delete-stack  frestyle-prod-alb                     │
+│                                                              │
+│ 07:00 JST (22:00 UTC) ─┐  scheduled-start.yml               │
+│                        ▼                                     │
+│   1. CFn deploy        frestyle-prod-alb（新 DNS 払い出し）   │
+│   2. CFn deploy        frestyle-prod-ecs                     │
+│   3. Cloudflare API    api.normanblog.com → 新 ALB DNS       │
+│   4. ECS services-stable wait + ヘルスチェック                │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## ワークフロー
+
+| ファイル | トリガー | 処理 |
+|---|---|---|
+| [`.github/workflows/scheduled-stop.yml`](../../.github/workflows/scheduled-stop.yml) | `cron: '0 13 * * *'` (22:00 JST) | ECS + ALB destroy |
+| [`.github/workflows/scheduled-start.yml`](../../.github/workflows/scheduled-start.yml) | `cron: '0 22 * * *'` (07:00 JST) | ALB + ECS deploy + Cloudflare DNS 更新 |
+
+両方とも `workflow_dispatch` で手動起動も可能（`stop` / `start` を confirm 入力）。
+
+## 認証
+
+GitHub OIDC で `frestyle-prod-github-actions-role` を AssumeRole（Step 3 で導入）。`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` 等の長寿命 Secret は不要。
+
+## 必要な GitHub Secrets
+
+`scheduled-start.yml` が Cloudflare DNS を更新するため、以下が必要:
+
+| Secret | 用途 |
+|---|---|
+| `IAC_REPO_TOKEN` | frestyle-infrastructure (private) を clone する PAT |
+| `CF_API_TOKEN` | Cloudflare API トークン（Zone:DNS:Edit 権限） |
+| `CF_ZONE_ID` | normanblog.com の Zone ID |
+| `COGNITO_CLIENT_ID` | ECS Task Definition のパラメータ用 |
+| `COGNITO_REDIRECT_URI` / `COGNITO_TOKEN_URI` / `COGNITO_JWK_SET_URI` | 同上 |
+
+CF_API_TOKEN / CF_ZONE_ID 未登録の場合の登録方法:
+
+```bash
+# .env から読み込む例
+source .env
+echo "$CF_API_TOKEN" | gh secret set CF_API_TOKEN -R norman6464/FreStyle
+echo "$CF_ZONE_ID"   | gh secret set CF_ZONE_ID   -R norman6464/FreStyle
+```
+
+## 手動実行
+
+スケジュールを待たず即時に実行する:
+
+```bash
+# 即時 stop
+gh workflow run scheduled-stop.yml --ref main -f confirm=stop
+
+# 即時 start
+gh workflow run scheduled-start.yml --ref main -f confirm=start
+
+# 進捗確認
+gh run watch
+```
+
+## 一時的に停止スケジュールを無効にする
+
+旅行中など、ずっと起動状態にしておきたい場合:
+
+```bash
+# scheduled-stop.yml を無効化
+gh workflow disable "Scheduled - Stop (destroy ECS + ALB at night)" -R norman6464/FreStyle
+
+# 再有効化
+gh workflow enable "Scheduled - Stop (destroy ECS + ALB at night)" -R norman6464/FreStyle
+```
+
+## ロールバック / 緊急対応
+
+### 朝の自動起動が失敗した
+
+```bash
+gh run list --workflow=scheduled-start.yml --limit 3
+gh run view <run-id> --log-failed
+
+# 手動で再実行
+gh workflow run scheduled-start.yml --ref main -f confirm=start
+```
+
+### スケジュールごと止めたい（廃止）
+
+両方の workflow ファイルを `git rm` して PR → マージ。
+
+## 制約と注意
+
+1. **RDS は停止しない**: データ保護のため。RDS インスタンスは 24/7 課金（db.t4g.micro なら ~$13/月）
+2. **Cloudflare DNS 伝播**: 1〜数分は新 ALB DNS が浸透するまでアクセス不可になる場合あり（proxied=true でキャッシュ駆動）
+3. **GitHub Actions 課金**: 1 日 2 実行 × 平均 5 分 = 月 ~5 時間。Free 枠（月 2,000 分）の範囲内
+4. **OIDC Role の Trust Policy**: `refs/heads/main` のみ許可。スケジュール実行も main から発火するので OK
+5. **ECR fre-style:latest**: ECS は常に最新タグを pull するため、毎朝 fresh なイメージで起動。古いタグに固定したい場合は `cd-backend.yml` で `:${sha}` タグを使う
+
+## 観測
+
+CloudWatch Logs `/ecs/frestyle-prod` で毎朝の起動ログを確認:
+
+```bash
+make logs   # frestyle-infrastructure リポで実行
+```
+
+GitHub Actions の実行履歴:
+
+```bash
+gh run list --workflow=scheduled-stop.yml -R norman6464/FreStyle
+gh run list --workflow=scheduled-start.yml -R norman6464/FreStyle
+```
+
+## 関連
+
+- [`docs/security/02-github-oidc.md`](../../../frestyle-infrastructure/docs/security/02-github-oidc.md) — OIDC 認証の設計
+- frestyle-infrastructure リポ `Makefile` — 同等の `make destroy-ecs` / `make destroy-alb` / `make deploy-alb` / `make deploy-ecs` で手元から同じ操作可能


### PR DESCRIPTION
毎日 22:00 JST に ECS + ALB destroy、翌 07:00 JST に再作成 + Cloudflare DNS 更新する GitHub Actions スケジュール。OIDC 認証経由（Step 3 の IAM Role 利用）。詳細は docs/operations/scheduled-cost-savings.md。