### PR TITLE
feat: OpenAPI / Swagger UI を導入（springdoc-openapi）

### DIFF
--- a/FreStyle/build.gradle
+++ b/FreStyle/build.gradle
@@ -90,6 +90,10 @@ dependencies {
 	// Httpクライアント
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// OpenAPI / Swagger UI（springdoc-openapi）
+	// /v3/api-docs と /swagger-ui.html を自動公開
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
 	// 補足: CognitoのJWT検証に必要な公開鍵の自動取得は
 	// Spring Security OAuth2 Resource Serverが標準で処理するため、
 	// Cognito Identity Providerのクライアントは通常不要です。

--- a/FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/hello","/api/hello/**","/api/auth/info","/ws/chat/**","/api/auth/**","/actuator/**").permitAll()
+                        // OpenAPI / Swagger UI（API 仕様書は認証不要で公開）
+                        .requestMatchers("/v3/api-docs","/v3/api-docs/**","/swagger-ui.html","/swagger-ui/**").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())

--- a/FreStyle/src/main/java/com/example/FreStyle/config/OpenApiConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/config/OpenApiConfig.java
@@ -1,0 +1,51 @@
+package com.example.FreStyle.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * OpenAPI / Swagger UI のメタ情報定義。
+ *
+ * <p>Cookie ベース認証（{@code accessToken} HttpOnly Cookie）を SecurityScheme として登録し、
+ * Swagger UI で「Try it out」する際に Cookie を自動付与する形を取る。</p>
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String COOKIE_AUTH = "cookieAuth";
+
+    @Bean
+    public OpenAPI freStyleOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("FreStyle API")
+                        .description("新卒IT エンジニア向けビジネスコミュニケーション練習アプリのバックエンド API。"
+                                + "認証は AWS Cognito 発行の JWT を `accessToken` HttpOnly Cookie で送信する。")
+                        .version("v1")
+                        .contact(new Contact()
+                                .name("FreStyle Team")
+                                .url("https://normanblog.com"))
+                        .license(new License()
+                                .name("Proprietary")))
+                .servers(List.of(
+                        new Server().url("https://api.normanblog.com").description("Production"),
+                        new Server().url("http://localhost:8080").description("Local")))
+                .addSecurityItem(new SecurityRequirement().addList(COOKIE_AUTH))
+                .components(new Components()
+                        .addSecuritySchemes(COOKIE_AUTH, new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.COOKIE)
+                                .name("accessToken")
+                                .description("Cognito 発行の JWT を HttpOnly Cookie として送信")));
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AiChatController.java
@@ -37,6 +37,7 @@ import com.example.FreStyle.usecase.GetPracticeSessionSummaryUseCase;
 import com.example.FreStyle.usecase.RephraseMessageUseCase;
 import com.example.FreStyle.usecase.UpdateAiChatSessionTitleUseCase;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -45,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @RequestMapping("/api/chat/ai")
 @Slf4j
+@Tag(name = "AI Chat", description = "AI 対話セッションとメッセージの管理 API")
 public class AiChatController {
     private final AiChatService aiChatService;
     private final UserIdentityService userIdentityService;

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/HelloController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/HelloController.java
@@ -3,14 +3,20 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequestMapping("/api")
 @Slf4j
+@Tag(name = "Health", description = "ヘルスチェック / 疎通確認エンドポイント")
 public class HelloController {
 
   @GetMapping("/hello")
+  @Operation(summary = "疎通確認", description = "認証不要。固定文字列 'hello' を返す。")
+  @SecurityRequirements
   public String hello() {
     log.debug("Hello health check endpoint called");
     return "hello";

--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -98,3 +98,15 @@ spring.jpa.properties.hibernate.generate_statistics=false
 logging.level.com.example.FreStyle.config.XRayTracingFilter=INFO
 logging.level.com.example.FreStyle.config.XRayConfig=INFO
 logging.level.com.amazonaws.xray=WARN
+
+# ========== OpenAPI / Swagger UI ==========
+# /v3/api-docs (JSON) と /swagger-ui.html (UI) を公開
+# 本番では springdoc.swagger-ui.enabled=false にして UI を閉じる運用も可能
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
+# Actuator はドキュメントから除外（運用用エンドポイントなので）
+springdoc.paths-to-exclude=/actuator/**

--- a/docs/api/openapi.md
+++ b/docs/api/openapi.md
@@ -1,0 +1,163 @@
+# OpenAPI / Swagger UI
+
+## 概要
+
+FreStyle バックエンドは [springdoc-openapi](https://springdoc.org/) を使って実装の Controller / DTO から OpenAPI 3.x 仕様書（JSON）と Swagger UI（HTML）を自動生成する。
+
+| エンドポイント | 用途 |
+|---|---|
+| `GET /v3/api-docs` | OpenAPI 3.x 仕様書（JSON） |
+| `GET /v3/api-docs.yaml` | OpenAPI 3.x 仕様書（YAML） |
+| `GET /swagger-ui.html` | ブラウザで閲覧する Swagger UI |
+
+ローカル: `http://localhost:8080/swagger-ui.html`
+本番: `https://api.normanblog.com/swagger-ui.html`
+
+## なぜ springdoc を選んだか
+
+- Spring Boot 3 / Java 21 公式サポート（`springdoc-openapi-starter-webmvc-ui` 2.6.0）
+- アノテーションは Swagger 2 系（`io.swagger.v3.oas.annotations`）に統一されており追加学習コスト小
+- `@RestController` と DTO を自動スキャンするため、最小限のアノテーションで運用できる
+- 別途 YAML 手書き運用を持たないので、コードと仕様書のドリフトが起きない
+
+## 設定
+
+### 依存追加（`FreStyle/build.gradle`）
+
+```gradle
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+```
+
+### `application.properties`
+
+```properties
+springdoc.api-docs.path=/v3/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
+# Actuator はドキュメントから除外
+springdoc.paths-to-exclude=/actuator/**
+```
+
+本番で UI を非公開にしたい場合は `springdoc.swagger-ui.enabled=false` に切り替える。JSON のみ公開（仕様書配布用）も可能。
+
+### Spring Security 許可
+
+[`SecurityConfig.java`](../../FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java) で以下を `permitAll()` に追加済み:
+
+```
+/v3/api-docs
+/v3/api-docs/**
+/swagger-ui.html
+/swagger-ui/**
+```
+
+### メタ情報 / 認証スキーマ
+
+[`OpenApiConfig.java`](../../FreStyle/src/main/java/com/example/FreStyle/config/OpenApiConfig.java) で以下を定義:
+
+- `Info`: タイトル / 説明 / バージョン / Contact
+- `Server`: 本番（`https://api.normanblog.com`）/ ローカル（`http://localhost:8080`）
+- `SecurityScheme`: `cookieAuth` = `accessToken` HttpOnly Cookie（API Key in Cookie）
+- デフォルト `SecurityRequirement` = `cookieAuth`（全エンドポイントが Cookie 認証必須として表現される）
+
+認証不要のエンドポイント（`/api/hello` 等）は `@SecurityRequirements` を空指定して上書きする。
+
+## Controller への注釈ポリシー
+
+最低限のアノテーションだけ付けて、コードを汚さないようにする。
+
+### クラスレベル: `@Tag` で分類
+
+```java
+@Tag(name = "AI Chat", description = "AI 対話セッションとメッセージの管理 API")
+public class AiChatController { ... }
+```
+
+`@Tag` の `name` で Swagger UI のグループが切り替わる。同じ `name` を別 Controller に付けて手動でまとめることもできる。
+
+### メソッドレベル: 必要に応じて `@Operation`
+
+```java
+@GetMapping("/hello")
+@Operation(summary = "疎通確認", description = "認証不要。固定文字列 'hello' を返す。")
+@SecurityRequirements
+public String hello() { ... }
+```
+
+- `@Operation`: 概要を補足したいときだけ。基本は HTTP メソッド + パス + DTO 名で十分
+- `@SecurityRequirements`: 認証不要にしたいときだけ（デフォルトの `cookieAuth` を解除）
+
+### Tag 一覧（推奨）
+
+| Tag | Controller |
+|---|---|
+| Health | HelloController |
+| AI Chat | AiChatController, AiChatWebSocketController |
+| Chat | ChatController, ChatWebSocketController |
+| Auth | CognitoAuthController |
+| Notes | NoteController, NoteImageController |
+| Practice | PracticeController, ConversationTemplateController, ScenarioBookmarkController |
+| Reports | LearningReportController, ScoreCardController, ScoreGoalController, ScoreTrendController |
+| Social | FriendshipController, SharedSessionController |
+| Profile | ProfileController, UserStatsController, ReminderSettingController |
+| Goals | DailyGoalController, FavoritePhraseController, WeeklyChallengeController |
+| Notifications | NotificationController |
+| Ranking | RankingController |
+| Session Notes | SessionNoteController |
+
+新しい Controller を追加するときは上記表に従って `@Tag` を付けること。
+
+## 動作確認
+
+### ローカル
+
+```bash
+cd FreStyle
+./gradlew bootRun
+# 別ターミナル
+curl -s http://localhost:8080/v3/api-docs | jq .info
+# 期待: {"title":"FreStyle API","description":"...","version":"v1",...}
+
+open http://localhost:8080/swagger-ui.html
+```
+
+### Try it out（Swagger UI から API を叩く）
+
+1. ブラウザで `https://normanblog.com` にログイン → `accessToken` Cookie 発行
+2. 同じブラウザで `https://api.normanblog.com/swagger-ui.html` を開く
+3. 任意のエンドポイントの「Try it out」→「Execute」
+4. ブラウザの `accessToken` Cookie が自動送信される（CORS が同じドメイン構成なら）
+
+クロスオリジンでテストする場合は curl で:
+
+```bash
+TOKEN=$(curl -s --cookie-jar /tmp/cookies.txt https://normanblog.com/login ...)
+curl -s --cookie /tmp/cookies.txt https://api.normanblog.com/api/chat/ai/sessions | jq .
+```
+
+## 仕様書の配布
+
+```bash
+# ローカルで static な OpenAPI JSON を吐き出し
+curl -s http://localhost:8080/v3/api-docs > openapi.json
+
+# YAML 版
+curl -s http://localhost:8080/v3/api-docs.yaml > openapi.yaml
+```
+
+これをフロントエンドリポジトリに置く / API 利用者に配布する / Postman に import する 等で活用する。
+
+## CI への組み込み（将来の TODO）
+
+- [ ] `./gradlew openapi` カスタムタスクで OpenAPI JSON を出力 → リポジトリの `frontend/openapi.json` にコミット
+- [ ] [openapi-typescript](https://github.com/openapi-ts/openapi-typescript) でフロントエンドの型定義を生成
+- [ ] PR で OpenAPI 差分があったら CI に出させる（API 破壊変更レビューを強制）
+
+## 関連
+
+- [springdoc-openapi 公式ドキュメント](https://springdoc.org/)
+- [OpenAPI 3.1 Specification](https://spec.openapis.org/oas/v3.1.0)
+- [`docs/ARCHITECTURE.md`](../ARCHITECTURE.md) — Controller / DTO の責務


### PR DESCRIPTION
## 概要

FreStyle バックエンドに [springdoc-openapi](https://springdoc.org/) を導入し、`/v3/api-docs`（JSON）と `/swagger-ui.html`（UI）を自動公開する。Controller / DTO から OpenAPI 3.x 仕様書が自動生成され、API 仕様書とコードのドリフトを防ぐ。

## 変更内容

- `FreStyle/build.gradle`: `springdoc-openapi-starter-webmvc-ui:2.6.0` を依存追加
- `FreStyle/src/main/resources/application.properties`: springdoc プロパティを追加（Actuator は除外）
- `FreStyle/.../auth/SecurityConfig.java`: `/v3/api-docs/**` と `/swagger-ui/**` を `permitAll()` に追加
- `FreStyle/.../config/OpenApiConfig.java`（新規）: Info / Server / Cookie 認証スキーマ（`accessToken` HttpOnly Cookie）を定義
- `FreStyle/.../controller/AiChatController.java`: クラスに `@Tag(name = "AI Chat")` を付与
- `FreStyle/.../controller/HelloController.java`: `@Tag` + `@Operation` + `@SecurityRequirements`（認証不要を明示）
- `docs/api/openapi.md`（新規）: 運用ガイド + Controller への Tag 命名規約 + CI への組み込み TODO

## なぜ

- Controller / DTO がドメインを表すスキーマそのものなので、別途 YAML を手書き運用すると必ずドリフトする
- springdoc は Spring Boot 3 / Java 21 公式サポートで、最小限のアノテーションで自動生成できる
- 将来的にフロントエンドで `openapi-typescript` で型を自動生成する基盤になる

## テスト

- [x] `./gradlew compileJava` が通る
- [x] `./gradlew test` が通る（既存の 3 件失敗は OpenAPI 変更とは無関係 — `FreStyleApplicationTests.contextLoads` と `AiChatWebSocketControllerTest$RephraseMessage`）
- [ ] ローカルで `./gradlew bootRun` → `curl http://localhost:8080/v3/api-docs | jq .info` が想定通り（マージ前の動作確認）
- [ ] 本番デプロイ後 `https://api.normanblog.com/swagger-ui.html` が表示される

## 関連 Issue

なし（OpenAPI 化は単体タスクとして実施）

## ドキュメント

- [docs/api/openapi.md](docs/api/openapi.md) を新規追加