### PR TITLE
test: HelloController 統合テスト + テスト用 application-test.properties

### DIFF
--- a/FreStyle/src/test/java/com/example/FreStyle/controller/HelloControllerTest.java
+++ b/FreStyle/src/test/java/com/example/FreStyle/controller/HelloControllerTest.java
@@ -1,20 +1,63 @@
 package com.example.FreStyle.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
 
-@DisplayName("HelloController テスト")
+/**
+ * HelloController のテスト。
+ *
+ * <p>下記 2 段構えで Phase 1 の統合テストパターンを示す:</p>
+ * <ul>
+ *   <li>{@link Unit} — Controller を直接 new して戻り値を検証（軽量・高速）</li>
+ *   <li>{@link Integration} — {@link MockMvc} で HTTP レイヤを通す（Security フィルタ含む）</li>
+ * </ul>
+ *
+ * <p>Issue #1462 の Phase 1 開始テストとして、他 Controller も同パターンで追加していく。</p>
+ */
 class HelloControllerTest {
 
-    private final HelloController helloController = new HelloController();
+    @Nested
+    @DisplayName("HelloController（Unit）")
+    class Unit {
 
-    @Test
-    @DisplayName("helloエンドポイントが'hello'を返す")
-    void hello_ReturnsHelloString() {
-        String result = helloController.hello();
+        private final HelloController helloController = new HelloController();
 
-        assertEquals("hello", result);
+        @Test
+        @DisplayName("hello() は 'hello' を返す")
+        void hello_returnsHelloString() {
+            String result = helloController.hello();
+
+            assertEquals("hello", result);
+        }
+    }
+
+    @Nested
+    @DisplayName("HelloController（Integration: MockMvc）")
+    @SpringBootTest
+    @AutoConfigureMockMvc
+    @TestPropertySource(locations = "classpath:application-test.properties")
+    class Integration {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        @DisplayName("GET /api/hello は 200 + 'hello' を返す（permitAll なので認証不要）")
+        void getHello_returns200() throws Exception {
+            mockMvc.perform(get("/api/hello"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("hello"));
+        }
     }
 }

--- a/FreStyle/src/test/resources/application-test.properties
+++ b/FreStyle/src/test/resources/application-test.properties
@@ -1,0 +1,28 @@
+# 統合テスト用プロパティ
+# 本番 application.properties が要求する環境変数のフォールバック値を H2 / ダミーで埋める。
+
+# DB は H2 inMemory（Phase 2 で Testcontainers MariaDB に差し替え可）
+spring.datasource.url=jdbc:h2:mem:frestyle_test;MODE=MySQL;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driver-class-name=org.h2.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+# 本番 schema.sql は MariaDB 構文を含むのでテスト時はスキップ
+spring.sql.init.mode=never
+
+# Cognito（テスト時は実際の検証はしないが、起動に必要なプロパティを埋める）
+cognito.client-id=test-client-id
+cognito.client-secret=test-client-secret
+cognito.redirect-uri=http://localhost/callback
+cognito.token-uri=http://localhost/token
+cognito.jwk-set-uri=http://localhost/.well-known/jwks.json
+
+# AWS（テスト時は実 API を呼ばないがプロパティは必要）
+aws.region=ap-northeast-1
+aws.s3.note-images-bucket=test-bucket
+aws.s3.note-images-cdn-url=https://test.cloudfront.net
+aws.sqs.report-queue-url=
+
+# CloudWatch / X-Ray は無効化（テスト中の外部呼び出し抑止）
+management.cloudwatch.metrics.export.enabled=false

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -443,6 +443,27 @@ sequenceDiagram
 - 新規追加コード: **80% 以上**
 - 全体: 段階的に引き上げる（既存は除外可）
 
+### 6.5 統合テスト導入の進捗
+
+統合テストの整備は Issue [#1462](https://github.com/norman6464/FreStyle/issues/1462) で追跡。
+
+- Phase 1（H2 ベース、当面は外部依存をモック化）
+  - [x] HelloController（テンプレート確立）
+  - [ ] CognitoAuthController / ProfileController / PracticeController / NoteController / LearningReportController
+- Phase 2（外部依存を含む）
+  - [ ] DynamoDB / S3 / SQS を LocalStack 化
+  - [ ] Bedrock を WireMock 化
+
+統合テストの起点は [`FreStyle/src/test/resources/application-test.properties`](../FreStyle/src/test/resources/application-test.properties) 。
+H2 inMemory + ダミー Cognito / AWS 設定で `@SpringBootTest` を起動できる。
+
+```java
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.properties")
+class XxxControllerTest { ... }
+```
+
 ---
 
 ## 7. ディレクトリマップ


### PR DESCRIPTION
## 概要

Issue #1462 の Phase 1 開始テスト。`@SpringBootTest + MockMvc` の統合テストパターンを HelloController に確立し、他 Controller も同じパターンで Phase 1 を進められるようにする。

## 変更内容

- `FreStyle/src/test/java/.../controller/HelloControllerTest.java`: `@Nested` で Unit / Integration を分離
- `FreStyle/src/test/resources/application-test.properties`（新規）: H2 inMemory + ダミー Cognito/AWS 設定
- `docs/ARCHITECTURE.md` §6.5 に統合テスト方針と進捗チェックリストを追記

## なぜ

- 現状は UseCase 単体テストのみで Controller → Repository を貫通する自動テストが薄い
- 本 PR でテンプレートを確立すれば Phase 1 の他 Controller（CognitoAuth / Profile / Practice / Note / LearningReport）も短時間で追加可能

## テスト

- [x] `./gradlew test --tests HelloControllerTest` がグリーン（Unit + Integration の 2 ケース）
- [x] 既存テストへの影響なし

## 関連 Issue

- Refs #1462