### PR TITLE
fix(ci): cd-backend.yml を GitHub OIDC + IAM Role 認証に切替

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -14,8 +14,10 @@ name: CD - Backend Deploy to ECS
 #      （GitHub Secrets を parameter-overrides 経由で渡す）
 #   3) force-new-deployment でローリング再起動
 #
+# 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+#       Step 3 で導入。長寿命の AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY は廃止。
+#
 # 必要な GitHub Secrets（事前セットアップが必要）:
-#   - AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY  : 管理者用 IAM（後で OIDC Role に移行予定）
 #   - AWS_ECR_API_SERVER_REPOSITORY              : 例 fre-style
 #   - COGNITO_CLIENT_ID / COGNITO_REDIRECT_URI / COGNITO_TOKEN_URI / COGNITO_JWK_SET_URI
 #     ※ COGNITO_CLIENT_SECRET と DB password は AWS Secrets Manager に保管済み（Step 2 で導入）
@@ -40,8 +42,10 @@ env:
   ENV: prod
   STACK_PFX: frestyle-prod
   IAC_REPO: norman6464/frestyle-infrastructure
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -70,11 +74,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: frestyle-cd-backend-build
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Login to Amazon ECR
@@ -118,11 +122,11 @@ jobs:
           token: ${{ secrets.IAC_REPO_TOKEN }}
           path: iac
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: frestyle-cd-backend-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Resolve dependent stack outputs

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 CLAUDE.md
 
 infrastructure/
+
+frestyle-infrastructure/

--- a/docs/operations/cd-backend-oidc.md
+++ b/docs/operations/cd-backend-oidc.md
@@ -1,0 +1,102 @@
+# cd-backend.yml の OIDC Role 認証移行
+
+## 概要
+
+`cd-backend.yml` が AWS にアクセスするとき、長寿命の `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` を GitHub Secrets に保管していた構成から、GitHub OIDC + IAM Role に切り替える。`scheduled-stop.yml` / `scheduled-start.yml` と同じパターン。
+
+## なぜ
+
+- 長寿命キーの漏洩リスク
+- ローテーションが手動で運用負荷が高い
+- Step 3 で OIDC Role (`frestyle-prod-github-actions-role`) を導入済みなのに `cd-backend.yml` だけ取り残されていた
+- 旧 `GitHubActions` IAM User には `secretsmanager:DescribeSecret` が無く、`Resolve dependent stack outputs` ステップで `AccessDeniedException` が出てデプロイが失敗していた
+
+## 変更内容
+
+`.github/workflows/cd-backend.yml`:
+
+```yaml
+env:
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+
+permissions:
+  id-token: write     # OIDC token の取得
+  contents: read
+
+# Build & Push Image / CFn Deploy 両方の job で:
+- name: Configure AWS credentials (OIDC)
+  uses: aws-actions/configure-aws-credentials@v4
+  with:
+    role-to-assume: ${{ env.AWS_ROLE_ARN }}
+    role-session-name: frestyle-cd-backend-build  # / deploy
+    aws-region: ${{ env.AWS_REGION }}
+```
+
+## 廃止する GitHub Secrets
+
+| Secret | 旧用途 | 移行後 |
+|---|---|---|
+| `AWS_ACCESS_KEY_ID` | cd-backend が AWS にアクセスする際の credential | **不要**（OIDC Role） |
+| `AWS_SECRET_ACCESS_KEY` | 同上 | **不要** |
+
+`scheduled-*.yml` も同じ Role を使うため、両 workflow から同様に削除済み。
+
+```bash
+# 削除コマンド（移行確認後に実施）
+gh secret delete AWS_ACCESS_KEY_ID -R norman6464/FreStyle
+gh secret delete AWS_SECRET_ACCESS_KEY -R norman6464/FreStyle
+```
+
+## OIDC Role の権限スコープ
+
+`frestyle-prod-github-actions-role` の trust policy は **main ブランチ** と **`refs/tags/release/*` タグ** からの AssumeRole のみ許可する。PR ブランチや別リポからは AssumeRole 不可。
+
+許可される操作（Inline Policies）:
+- `cloudformation:*` on `frestyle-*` stacks のみ
+- `ecs:UpdateService` / `ecs:DescribeServices` 等
+- `ecr:Get*` / `ecr:Put*`（PowerUser 経由）
+- `secretsmanager:DescribeSecret` / `secretsmanager:GetSecretValue` on `frestyle-prod/*` のみ
+- `iam:PassRole` on `frestyle-prod-ecs-task-execution-role` / `frestyle-prod-ecs-task-role` のみ
+
+詳細: [`frestyle-infrastructure/docs/security/02-github-oidc.md`](../../frestyle-infrastructure/docs/security/02-github-oidc.md)
+
+## OIDC Role のデプロイ確認
+
+```bash
+aws iam get-role --role-name frestyle-prod-github-actions-role --query 'Role.Arn' --output text
+# arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+```
+
+Role が存在しない場合は IaC リポで以下を実行:
+
+```bash
+cd ~/Desktop/FreStyle/frestyle-infrastructure
+# OIDC Provider が既存なら CreateOidcProvider=false が必要
+aws cloudformation deploy --region ap-northeast-1 \
+  --stack-name frestyle-prod-github-oidc \
+  --template-file infrastructure/cloudformation/templates/iam/github-oidc.yml \
+  --parameter-overrides Environment=prod CreateOidcProvider=false \
+  --capabilities CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset
+```
+
+## 動作確認
+
+```bash
+gh workflow run cd-backend.yml --ref main -R norman6464/FreStyle -f confirm=deploy
+gh run watch $(gh run list --workflow=cd-backend.yml -R norman6464/FreStyle --limit 1 --json databaseId -q '.[0].databaseId') -R norman6464/FreStyle
+```
+
+期待:
+1. `Configure AWS credentials (OIDC)` で `Successfully assumed role` ログが出る
+2. `Resolve dependent stack outputs` が DescribeSecret で AccessDenied を出さない
+3. `Deploy ECS stack` → `Wait for service to stabilize` → `Verify health` がグリーン
+
+## ロールバック
+
+問題が起きた場合は当該コミットを revert すれば旧 IAM User 認証に戻せる。
+ただし旧 IAM User `GitHubActions` には `secretsmanager:DescribeSecret` が無いため、戻すなら先に IAM User へ inline policy を追加すること。
+
+## 関連
+
+- [`docs/operations/scheduled-cost-savings.md`](./scheduled-cost-savings.md) — 同じ OIDC Role を使っている
+- [`frestyle-infrastructure/docs/security/02-github-oidc.md`](../../frestyle-infrastructure/docs/security/02-github-oidc.md) — Role / Trust Policy の設計


### PR DESCRIPTION
## 概要

`cd-backend.yml` の AWS 認証を長寿命キー（`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`）から GitHub OIDC + IAM Role (`frestyle-prod-github-actions-role`) に切り替える。

## 背景

- 旧 IAM User `GitHubActions` には `secretsmanager:DescribeSecret` 権限が無く、`Resolve dependent stack outputs` ステップで AccessDenied により本番デプロイが失敗していた（run 24934374423）
- `scheduled-stop.yml` / `scheduled-start.yml` は既に OIDC Role を使っており、`cd-backend.yml` だけが取り残されていた
- Step 3 の OIDC Role には `secretsmanager:DescribeSecret`, `secretsmanager:GetSecretValue`, `cloudformation:*`, `ecs:UpdateService`, ECR PowerUser 等の必要権限を付与済み

## 変更内容

`.github/workflows/cd-backend.yml`:

- `permissions.id-token: write` を追加
- `AWS_ROLE_ARN` を env に追加
- Build & Push Image / CFn Deploy 両方の `Configure AWS credentials` を OIDC 化（`role-to-assume`）
- ヘッダコメントから AWS_ACCESS_KEY_ID/SECRET の言及を削除

その他:
- `.gitignore`: `frestyle-infrastructure/` を追加（FreStyle 配下に IaC を clone する運用）
- `docs/operations/cd-backend-oidc.md`（新規）: 設計・移行手順・ロールバック

## OIDC Role 側の対応

`frestyle-prod-github-actions-role` は本 PR と同期して main にマージしたコミットからのみ AssumeRole 可能（trust policy 制約）。事前に AWS 側で OIDC スタックをデプロイ済み（`make deploy-github-oidc` 相当を実行済み）。

## テスト

- [x] `aws iam get-role --role-name frestyle-prod-github-actions-role` で Role 存在確認
- [ ] 本 PR マージ後 `gh workflow run cd-backend.yml -f confirm=deploy` でグリーン
- [ ] AccessDenied が出ないこと

## 廃止予定の Secrets

動作確認後:
```bash
gh secret delete AWS_ACCESS_KEY_ID -R norman6464/FreStyle
gh secret delete AWS_SECRET_ACCESS_KEY -R norman6464/FreStyle
```

## 関連

- [docs/operations/cd-backend-oidc.md](docs/operations/cd-backend-oidc.md)
- frestyle-infrastructure: [docs/security/02-github-oidc.md](https://github.com/norman6464/frestyle-infrastructure/blob/main/docs/security/02-github-oidc.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment workflow to use enhanced authentication mechanism for cloud infrastructure access.
  * Updated ignore rules for repository directories.

* **Documentation**
  * Added operations guide documenting deployment authentication setup and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->