### PR TITLE
fix(menu): MenuPage の useMemo を early return より前に移動（React error #310）

### DIFF
--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -56,13 +56,16 @@ export default function MenuPage() {
   } = useMenuData();
   const { weakestAxis } = useScoreHistory();
   const { scenario: recommendedScenario } = useRecommendedScenario(weakestAxis);
+  // Hooks は条件付きの early return より前に呼ぶ（Rules of Hooks）。
+  // 以前は loading 早期 return 直後に useMemo を置いており、再レンダー時に
+  // フック呼び出し数が変わって React error #310 を引き起こしていた。
+  const overallScores = useMemo(() => allScores.map((s) => s.overallScore), [allScores]);
 
   if (loading) {
     return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
 
   const isFirstTimeUser = totalSessions === 0;
-  const overallScores = useMemo(() => allScores.map((s) => s.overallScore), [allScores]);
 
   return (
     <div className="p-6 max-w-2xl mx-auto space-y-6">


### PR DESCRIPTION
## 概要

ホーム画面 (https://normanblog.com/) で React error #310 (\"Rendered more hooks than during the previous render\") が発生して画面が表示されない問題を修正。

## 原因

\`MenuPage\` で \`if (loading) return <Loading />\` の **後** に \`useMemo\` を呼んでいたため、初回レンダー（loading=true）と完了後レンダー（loading=false）でフック呼び出し数が変わり Rules of Hooks 違反になっていた。

## 修正

\`useMemo(...)\` を loading チェックより前に移動。これで loading 状態にかかわらず常に同じ順序でフックが呼ばれる。

## テスト

- [x] \`npm test src/pages/__tests__/MenuPage.test.tsx\` グリーン (7/7 pass)
- [x] 他ページに同パターンが無いか自動 sweep 実施 → 該当なし