### PR TITLE
feat(admin): 管理者専用シナリオ CRUD + ActivityHeatmap 月ラベル修正

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/auth/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/hello","/api/hello/**","/api/auth/info","/ws/chat/**","/api/auth/**","/actuator/**").permitAll()
                         // OpenAPI / Swagger UI（API 仕様書は認証不要で公開）
                         .requestMatchers("/v3/api-docs","/v3/api-docs/**","/swagger-ui.html","/swagger-ui/**").permitAll()
+                        // 管理者専用エンドポイント（Cognito の cognito:groups に "admin" を含むユーザーのみ）
+                        .requestMatchers("/api/admin/**").hasRole("admin")
                         .anyRequest().authenticated())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AdminScenarioController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AdminScenarioController.java
@@ -1,0 +1,87 @@
+package com.example.FreStyle.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.PracticeScenarioDto;
+import com.example.FreStyle.entity.PracticeScenario;
+import com.example.FreStyle.form.PracticeScenarioForm;
+import com.example.FreStyle.repository.PracticeScenarioRepository;
+import com.example.FreStyle.usecase.CreatePracticeScenarioUseCase;
+import com.example.FreStyle.usecase.DeletePracticeScenarioUseCase;
+import com.example.FreStyle.usecase.UpdatePracticeScenarioUseCase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 管理者専用のシナリオ CRUD API。
+ *
+ * <p>Spring Security により {@code /api/admin/**} は Cognito の {@code cognito:groups} に
+ * "admin" を含むユーザーのみアクセス可能。</p>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/scenarios")
+@Slf4j
+@Tag(name = "Admin Scenarios", description = "管理者専用: 練習シナリオの作成・更新・削除")
+public class AdminScenarioController {
+
+    private final CreatePracticeScenarioUseCase createUseCase;
+    private final UpdatePracticeScenarioUseCase updateUseCase;
+    private final DeletePracticeScenarioUseCase deleteUseCase;
+    private final PracticeScenarioRepository repository;
+
+    @GetMapping
+    public ResponseEntity<List<PracticeScenarioDto>> list() {
+        List<PracticeScenarioDto> scenarios = repository.findAll().stream()
+                .map(this::toDto)
+                .toList();
+        return ResponseEntity.ok(scenarios);
+    }
+
+    @PostMapping
+    public ResponseEntity<PracticeScenarioDto> create(@Valid @RequestBody PracticeScenarioForm form) {
+        log.info("[AdminScenarioController] create scenario name={}", form.name());
+        return ResponseEntity.ok(createUseCase.execute(form));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<PracticeScenarioDto> update(
+            @PathVariable Integer id,
+            @Valid @RequestBody PracticeScenarioForm form
+    ) {
+        log.info("[AdminScenarioController] update scenario id={}", id);
+        return ResponseEntity.ok(updateUseCase.execute(id, form));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Integer id) {
+        log.info("[AdminScenarioController] delete scenario id={}", id);
+        deleteUseCase.execute(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    private PracticeScenarioDto toDto(PracticeScenario s) {
+        return new PracticeScenarioDto(
+                s.getId(),
+                s.getName(),
+                s.getDescription(),
+                s.getCategory(),
+                s.getRoleName(),
+                s.getDifficulty(),
+                s.getSystemPrompt()
+        );
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -247,7 +247,17 @@ public class CognitoAuthController {
                     .body(Map.of("error", "認証されていません"));
         }
         Integer id = userIdentityService.findUserBySub(jwt.getSubject()).getId();
-        log.info("GET /api/auth/cognito/me - userId={}", id);
-        return ResponseEntity.ok(Map.of("id", id));
+        // Cognito の cognito:groups クレームを抽出（フロント側で admin 判定に使う）
+        java.util.List<String> groups = jwt.getClaimAsStringList("cognito:groups");
+        if (groups == null) {
+            groups = java.util.Collections.emptyList();
+        }
+        boolean isAdmin = groups.contains("admin");
+        log.info("GET /api/auth/cognito/me - userId={}, groups={}", id, groups);
+        return ResponseEntity.ok(Map.of(
+                "id", id,
+                "groups", groups,
+                "isAdmin", isAdmin
+        ));
     }
 }

--- a/FreStyle/src/main/java/com/example/FreStyle/form/PracticeScenarioForm.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/form/PracticeScenarioForm.java
@@ -1,0 +1,16 @@
+package com.example.FreStyle.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 管理者によるシナリオ作成・更新時の入力フォーム。
+ */
+public record PracticeScenarioForm(
+        @NotBlank @Size(max = 100) String name,
+        @Size(max = 1000) String description,
+        @Size(max = 50) String category,
+        @NotBlank @Size(max = 100) String roleName,
+        @Size(max = 20) String difficulty,
+        @NotBlank String systemPrompt
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CreatePracticeScenarioUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CreatePracticeScenarioUseCase.java
@@ -1,0 +1,43 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.PracticeScenarioDto;
+import com.example.FreStyle.entity.PracticeScenario;
+import com.example.FreStyle.form.PracticeScenarioForm;
+import com.example.FreStyle.repository.PracticeScenarioRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 管理者がシナリオを新規作成するユースケース。
+ */
+@Service
+@RequiredArgsConstructor
+public class CreatePracticeScenarioUseCase {
+
+    private final PracticeScenarioRepository repository;
+
+    @Transactional
+    public PracticeScenarioDto execute(PracticeScenarioForm form) {
+        PracticeScenario entity = new PracticeScenario();
+        entity.setName(form.name());
+        entity.setDescription(form.description());
+        entity.setCategory(form.category());
+        entity.setRoleName(form.roleName());
+        entity.setDifficulty(form.difficulty());
+        entity.setSystemPrompt(form.systemPrompt());
+
+        PracticeScenario saved = repository.save(entity);
+        return new PracticeScenarioDto(
+                saved.getId(),
+                saved.getName(),
+                saved.getDescription(),
+                saved.getCategory(),
+                saved.getRoleName(),
+                saved.getDifficulty(),
+                saved.getSystemPrompt()
+        );
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/DeletePracticeScenarioUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/DeletePracticeScenarioUseCase.java
@@ -1,0 +1,27 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.PracticeScenarioRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 管理者がシナリオを削除するユースケース。
+ */
+@Service
+@RequiredArgsConstructor
+public class DeletePracticeScenarioUseCase {
+
+    private final PracticeScenarioRepository repository;
+
+    @Transactional
+    public void execute(Integer id) {
+        if (!repository.existsById(id)) {
+            throw new ResourceNotFoundException("シナリオ id=" + id + " が見つかりません");
+        }
+        repository.deleteById(id);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdatePracticeScenarioUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/UpdatePracticeScenarioUseCase.java
@@ -1,0 +1,46 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.PracticeScenarioDto;
+import com.example.FreStyle.entity.PracticeScenario;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.form.PracticeScenarioForm;
+import com.example.FreStyle.repository.PracticeScenarioRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 管理者がシナリオを更新するユースケース。
+ */
+@Service
+@RequiredArgsConstructor
+public class UpdatePracticeScenarioUseCase {
+
+    private final PracticeScenarioRepository repository;
+
+    @Transactional
+    public PracticeScenarioDto execute(Integer id, PracticeScenarioForm form) {
+        PracticeScenario entity = repository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("シナリオ id=" + id + " が見つかりません"));
+
+        entity.setName(form.name());
+        entity.setDescription(form.description());
+        entity.setCategory(form.category());
+        entity.setRoleName(form.roleName());
+        entity.setDifficulty(form.difficulty());
+        entity.setSystemPrompt(form.systemPrompt());
+
+        PracticeScenario saved = repository.save(entity);
+        return new PracticeScenarioDto(
+                saved.getId(),
+                saved.getName(),
+                saved.getDescription(),
+                saved.getCategory(),
+                saved.getRoleName(),
+                saved.getDifficulty(),
+                saved.getSystemPrompt()
+        );
+    }
+}

--- a/docs/admin/admin-feature.md
+++ b/docs/admin/admin-feature.md
@@ -1,0 +1,108 @@
+# 管理者機能（Admin）
+
+## 概要
+
+Cognito の `cognito:groups` クレームに `admin` を含むユーザーのみアクセス可能な管理機能。今回はまず **練習シナリオの CRUD** を提供する。
+
+## 認可フロー
+
+```
+ブラウザ
+  └─ Cookie (Cognito JWT)
+      └─ Spring Security / JwtCookieFilter
+          └─ JwtAuthenticationConverter
+              setAuthoritiesClaimName("cognito:groups")
+              setAuthorityPrefix("ROLE_")
+                ↓
+              ユーザーが Cognito group "admin" 所属なら
+              Spring Security に "ROLE_admin" 権限が付与される
+                ↓
+              SecurityConfig.requestMatchers("/api/admin/**").hasRole("admin")
+              で /api/admin/** へのアクセスを制御
+```
+
+## バックエンド
+
+### `SecurityConfig`
+
+```java
+.authorizeHttpRequests(auth -> auth
+    .requestMatchers(...).permitAll()
+    .requestMatchers("/api/admin/**").hasRole("admin")  // ← これ
+    .anyRequest().authenticated())
+```
+
+### `/api/admin/scenarios`（[`AdminScenarioController`](../../FreStyle/src/main/java/com/example/FreStyle/controller/AdminScenarioController.java)）
+
+| メソッド | パス | 用途 |
+|---|---|---|
+| GET | `/api/admin/scenarios` | 全シナリオ一覧 |
+| POST | `/api/admin/scenarios` | 新規作成 |
+| PUT | `/api/admin/scenarios/{id}` | 更新 |
+| DELETE | `/api/admin/scenarios/{id}` | 削除 |
+
+UseCase（クリーンアーキテクチャ）:
+- [`CreatePracticeScenarioUseCase`](../../FreStyle/src/main/java/com/example/FreStyle/usecase/CreatePracticeScenarioUseCase.java)
+- [`UpdatePracticeScenarioUseCase`](../../FreStyle/src/main/java/com/example/FreStyle/usecase/UpdatePracticeScenarioUseCase.java)
+- [`DeletePracticeScenarioUseCase`](../../FreStyle/src/main/java/com/example/FreStyle/usecase/DeletePracticeScenarioUseCase.java)
+
+### `/api/auth/cognito/me` の拡張
+
+レスポンスに `groups: string[]` と `isAdmin: boolean` を追加。フロントエンドの ServerInitializer がこれを Redux store の `auth.isAdmin` に伝播し、サイドバーの管理メニューを出し分ける。
+
+## フロントエンド
+
+| 場所 | 変更点 |
+|---|---|
+| `src/types/index.ts` | `AuthState.isAdmin: boolean` を追加 |
+| `src/store/authSlice.ts` | `setAuthData` / `setAuthenticated` が `{ isAdmin?: boolean }` を受け取る |
+| `src/utils/AuthInitializer.tsx` | `/me` の `isAdmin` を store に伝播 |
+| `src/components/layout/Sidebar.tsx` | `isAdmin` のときだけ「管理: シナリオ」メニュー表示 |
+| `src/pages/AdminScenariosPage.tsx` | 管理画面本体（一覧・作成・編集・削除フォーム） |
+| `src/repositories/AdminScenarioRepository.ts` | `/api/admin/scenarios` クライアント |
+| `src/App.tsx` | `/admin/scenarios` ルート追加 |
+
+非 admin が `/admin/scenarios` を直接叩いても `<Navigate to="/" replace />` でホームへリダイレクト + バックエンド側で 403。
+
+## Cognito で admin グループを作る手順
+
+```bash
+USER_POOL_ID=ap-northeast-1_TkRen4lyD   # oauth-cource-user-pool（本番）
+
+# 1) admin グループを作成（一度だけ）
+aws cognito-idp create-group --region ap-northeast-1 \
+  --user-pool-id $USER_POOL_ID \
+  --group-name admin \
+  --description "FreStyle の管理者グループ"
+
+# 2) 自分のユーザー名を確認
+aws cognito-idp list-users --region ap-northeast-1 --user-pool-id $USER_POOL_ID \
+  --query 'Users[].[Username,Attributes[?Name==`email`].Value | [0]]' --output table
+
+# 3) 自分を admin グループに追加
+aws cognito-idp admin-add-user-to-group --region ap-northeast-1 \
+  --user-pool-id $USER_POOL_ID \
+  --username <ステップ 2 で確認した username> \
+  --group-name admin
+
+# 4) いったんログアウト → 再ログインで JWT に cognito:groups: ["admin"] が乗る
+```
+
+## 動作確認
+
+1. ログイン
+2. サイドバーに「管理: シナリオ」メニューが表示される
+3. クリックして `/admin/scenarios` に遷移、シナリオ一覧が表示される
+4. 「新規シナリオを作成」フォームから作成・編集・削除できる
+
+非 admin ユーザーで:
+- サイドバーには「管理: シナリオ」が**表示されない**
+- 直接 URL `/admin/scenarios` に行くと **/ にリダイレクト**
+- 万一 API を直接叩いても **403 Forbidden**
+
+## 拡張ポイント
+
+- ユーザー管理（一覧・凍結・admin 付与）
+- シナリオの公開フラグ管理
+- レポートの集計（システム全体）
+- 監査ログ

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ const ReminderPage = lazy(() => import('./pages/ReminderPage'));
 const SharedSessionsPage = lazy(() => import('./pages/SharedSessionsPage'));
 const WeeklyChallengePage = lazy(() => import('./pages/WeeklyChallengePage'));
 const HelpPage = lazy(() => import('./pages/HelpPage'));
+const AdminScenariosPage = lazy(() => import('./pages/AdminScenariosPage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -101,6 +102,8 @@ export default function App() {
         <Route path="/shared-sessions" element={<SharedSessionsPage />} />
         <Route path="/weekly-challenge" element={<WeeklyChallengePage />} />
         <Route path="/help" element={<HelpPage />} />
+        {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
+        <Route path="/admin/scenarios" element={<AdminScenariosPage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/ActivityHeatmap.tsx
+++ b/frontend/src/components/ActivityHeatmap.tsx
@@ -86,44 +86,45 @@ export default function ActivityHeatmap({ practiceDates }: ActivityHeatmapProps)
         </p>
       </div>
 
-      {/* 月ラベル */}
-      <div className="flex mb-1 text-[9px] text-[var(--color-text-faint)]" style={{ paddingLeft: '0px' }}>
-        {monthPositions.map((pos, i) => (
-          <span
-            key={i}
-            style={{
-              position: 'relative',
-              left: `${pos.weekIndex * 11}px`,
-              marginRight: i < monthPositions.length - 1
-                ? `${Math.max(0, (monthPositions[i + 1]?.weekIndex - pos.weekIndex) * 11 - 20)}px`
-                : '0px',
-            }}
-          >
-            {pos.label}
-          </span>
-        ))}
-      </div>
-
-      {/* ヒートマップグリッド */}
-      <div className="flex gap-[2px] overflow-x-auto">
-        {weeks.map((week, weekIndex) => (
-          <div key={weekIndex} className="flex flex-col gap-[2px]">
-            {week.map((day, dayIndex) => {
-              if (!day) {
-                return <div key={dayIndex} className="w-[9px] h-[9px]" />;
-              }
-              const dateStr = formatDate(day);
-              const count = dateCountMap.get(dateStr) || 0;
-              return (
-                <div
-                  key={dayIndex}
-                  title={dateStr}
-                  className={`w-[9px] h-[9px] rounded-[2px] ${getIntensityClass(count)}`}
-                />
-              );
-            })}
+      {/* 月ラベル + ヒートマップグリッドを横スクロール可能な単一コンテナに収める */}
+      <div className="overflow-x-auto">
+        {/* グリッド総幅: weeks * (cell 9px + gap 2px) = weeks * 11px。月ラベルとグリッドで同じ幅を共有 */}
+        <div style={{ width: `${weeks.length * 11}px` }}>
+          {/* 月ラベル: 各ラベルを weekIndex に対して absolute 配置することではみ出しを防ぐ */}
+          <div className="relative h-3 mb-1 text-[9px] text-[var(--color-text-faint)]">
+            {monthPositions.map((pos) => (
+              <span
+                key={`${pos.label}-${pos.weekIndex}`}
+                className="absolute top-0"
+                style={{ left: `${pos.weekIndex * 11}px` }}
+              >
+                {pos.label}
+              </span>
+            ))}
           </div>
-        ))}
+
+          {/* ヒートマップグリッド本体 */}
+          <div className="flex gap-[2px]">
+            {weeks.map((week, weekIndex) => (
+              <div key={weekIndex} className="flex flex-col gap-[2px]">
+                {week.map((day, dayIndex) => {
+                  if (!day) {
+                    return <div key={dayIndex} className="w-[9px] h-[9px]" />;
+                  }
+                  const dateStr = formatDate(day);
+                  const count = dateCountMap.get(dateStr) || 0;
+                  return (
+                    <div
+                      key={dayIndex}
+                      title={dateStr}
+                      className={`w-[9px] h-[9px] rounded-[2px] ${getIntensityClass(count)}`}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </Card>
   );

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,8 +1,10 @@
 import { useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import SidebarItem from './SidebarItem';
 import Loading from '../Loading';
 import { useSidebar } from '../../hooks/useSidebar';
 import { useTheme } from '../../hooks/useTheme';
+import type { RootState } from '../../store';
 import {
   HomeIcon,
   ChatBubbleLeftRightIcon,
@@ -19,6 +21,7 @@ import {
   ArrowLeftOnRectangleIcon,
   SunIcon,
   MoonIcon,
+  Cog6ToothIcon,
 } from '@heroicons/react/24/outline';
 
 const navItems = [
@@ -47,6 +50,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   const location = useLocation();
   const { totalUnread, handleLogout, loggingOut } = useSidebar();
   const { theme, toggleTheme } = useTheme();
+  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
 
   const isActive = (item: typeof navItems[0]) => {
     if (item.matchExact) {
@@ -98,6 +102,19 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
             onClick={onNavigate}
           />
         ))}
+
+        {isAdmin && (
+          <>
+            <div className="my-3 border-t border-surface-3" />
+            <SidebarItem
+              icon={Cog6ToothIcon}
+              label="管理: シナリオ"
+              to="/admin/scenarios"
+              active={location.pathname.startsWith('/admin/scenarios')}
+              onClick={onNavigate}
+            />
+          </>
+        )}
       </nav>
 
       {/* テーマ切り替え・ログアウト */}

--- a/frontend/src/pages/AdminScenariosPage.tsx
+++ b/frontend/src/pages/AdminScenariosPage.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import AdminScenarioRepository, {
+  AdminScenario,
+  AdminScenarioForm,
+} from '../repositories/AdminScenarioRepository';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+
+const EMPTY_FORM: AdminScenarioForm = {
+  name: '',
+  description: '',
+  category: '',
+  roleName: '',
+  difficulty: '',
+  systemPrompt: '',
+};
+
+/**
+ * 管理者専用: 練習シナリオ管理ページ。
+ *
+ * <p>Cognito の admin グループに所属しているユーザーのみアクセス可能。
+ * 非 admin は /（ホーム）にリダイレクト。バックエンドも /api/admin/** で 403 を返すため二重防御。</p>
+ */
+export default function AdminScenariosPage() {
+  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
+  const authLoading = useSelector((state: RootState) => state.auth.loading);
+
+  const [scenarios, setScenarios] = useState<AdminScenario[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [form, setForm] = useState<AdminScenarioForm>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await AdminScenarioRepository.list();
+      setScenarios(data);
+      setError(null);
+    } catch (e) {
+      setError('シナリオの取得に失敗しました');
+      // eslint-disable-next-line no-console
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) {
+      fetchAll();
+    }
+  }, [isAdmin, fetchAll]);
+
+  // 認証ロード待ち
+  if (authLoading) return <Loading message="認証情報を確認中..." />;
+  // admin でなければホームへ
+  if (!isAdmin) return <Navigate to="/" replace />;
+
+  const startEdit = (s: AdminScenario) => {
+    setEditingId(s.id);
+    setForm({
+      name: s.name,
+      description: s.description ?? '',
+      category: s.category ?? '',
+      roleName: s.roleName,
+      difficulty: s.difficulty ?? '',
+      systemPrompt: s.systemPrompt,
+    });
+  };
+
+  const reset = () => {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      if (editingId) {
+        await AdminScenarioRepository.update(editingId, form);
+      } else {
+        await AdminScenarioRepository.create(form);
+      }
+      reset();
+      await fetchAll();
+    } catch (err) {
+      setError('保存に失敗しました');
+      // eslint-disable-next-line no-console
+      console.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const remove = async (id: number) => {
+    if (!confirm('このシナリオを削除しますか？')) return;
+    try {
+      await AdminScenarioRepository.remove(id);
+      await fetchAll();
+    } catch (err) {
+      setError('削除に失敗しました');
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-6">
+      <PageIntro
+        title="管理: 練習シナリオ"
+        description={<>新規作成・編集・削除ができます。一般ユーザーには表示されません。</>}
+      />
+
+      {error && (
+        <div role="alert" className="p-3 rounded border border-red-300 bg-red-50 text-red-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={submit} className="space-y-3 p-4 border rounded-lg bg-[var(--color-surface-1)]">
+        <h2 className="text-base font-bold">{editingId ? `シナリオ #${editingId} を編集` : '新規シナリオを作成'}</h2>
+
+        <label className="block text-sm">
+          <span className="block mb-1">名前 *</span>
+          <input
+            required
+            maxLength={100}
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            className="w-full border rounded px-2 py-1"
+          />
+        </label>
+
+        <label className="block text-sm">
+          <span className="block mb-1">役割名 *</span>
+          <input
+            required
+            maxLength={100}
+            value={form.roleName}
+            onChange={(e) => setForm({ ...form, roleName: e.target.value })}
+            className="w-full border rounded px-2 py-1"
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block text-sm">
+            <span className="block mb-1">カテゴリ</span>
+            <input
+              maxLength={50}
+              value={form.category ?? ''}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              className="w-full border rounded px-2 py-1"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="block mb-1">難易度</span>
+            <input
+              maxLength={20}
+              value={form.difficulty ?? ''}
+              onChange={(e) => setForm({ ...form, difficulty: e.target.value })}
+              className="w-full border rounded px-2 py-1"
+            />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="block mb-1">説明</span>
+          <textarea
+            rows={2}
+            value={form.description ?? ''}
+            onChange={(e) => setForm({ ...form, description: e.target.value })}
+            className="w-full border rounded px-2 py-1"
+          />
+        </label>
+
+        <label className="block text-sm">
+          <span className="block mb-1">System プロンプト *</span>
+          <textarea
+            required
+            rows={6}
+            value={form.systemPrompt}
+            onChange={(e) => setForm({ ...form, systemPrompt: e.target.value })}
+            className="w-full border rounded px-2 py-1 font-mono text-xs"
+          />
+        </label>
+
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="px-4 py-2 rounded bg-emerald-600 text-white disabled:opacity-50"
+          >
+            {editingId ? '更新' : '作成'}
+          </button>
+          {editingId && (
+            <button type="button" onClick={reset} className="px-4 py-2 rounded border">
+              キャンセル
+            </button>
+          )}
+        </div>
+      </form>
+
+      <section>
+        <h2 className="text-base font-bold mb-3">登録済みシナリオ ({scenarios.length})</h2>
+        {loading ? (
+          <Loading message="読み込み中..." />
+        ) : scenarios.length === 0 ? (
+          <p className="text-sm text-[var(--color-text-muted)]">まだ登録されていません</p>
+        ) : (
+          <ul className="space-y-2">
+            {scenarios.map((s) => (
+              <li
+                key={s.id}
+                className="p-3 border rounded flex items-start justify-between gap-3 bg-[var(--color-surface-1)]"
+              >
+                <div className="flex-1 text-sm">
+                  <p className="font-bold">
+                    #{s.id} {s.name} <span className="text-xs text-[var(--color-text-muted)]">({s.roleName})</span>
+                  </p>
+                  <p className="text-xs text-[var(--color-text-muted)]">
+                    {s.category ?? '-'} / {s.difficulty ?? '-'}
+                  </p>
+                  {s.description && <p className="text-xs mt-1">{s.description}</p>}
+                </div>
+                <div className="flex flex-col gap-1">
+                  <button onClick={() => startEdit(s)} className="text-xs px-2 py-1 border rounded">
+                    編集
+                  </button>
+                  <button onClick={() => remove(s.id)} className="text-xs px-2 py-1 border border-red-300 rounded text-red-700">
+                    削除
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/repositories/AdminScenarioRepository.ts
+++ b/frontend/src/repositories/AdminScenarioRepository.ts
@@ -1,0 +1,47 @@
+import apiClient from '../lib/axios';
+
+export interface AdminScenario {
+  id: number;
+  name: string;
+  description: string | null;
+  category: string | null;
+  roleName: string;
+  difficulty: string | null;
+  systemPrompt: string;
+}
+
+export interface AdminScenarioForm {
+  name: string;
+  description?: string;
+  category?: string;
+  roleName: string;
+  difficulty?: string;
+  systemPrompt: string;
+}
+
+/**
+ * 管理者専用: 練習シナリオ CRUD。
+ * 403 が返る場合は admin 権限なし（Cognito の admin グループ未所属）。
+ */
+class AdminScenarioRepository {
+  async list(): Promise<AdminScenario[]> {
+    const res = await apiClient.get<AdminScenario[]>('/api/admin/scenarios');
+    return res.data;
+  }
+
+  async create(form: AdminScenarioForm): Promise<AdminScenario> {
+    const res = await apiClient.post<AdminScenario>('/api/admin/scenarios', form);
+    return res.data;
+  }
+
+  async update(id: number, form: AdminScenarioForm): Promise<AdminScenario> {
+    const res = await apiClient.put<AdminScenario>(`/api/admin/scenarios/${id}`, form);
+    return res.data;
+  }
+
+  async remove(id: number): Promise<void> {
+    await apiClient.delete(`/api/admin/scenarios/${id}`);
+  }
+}
+
+export default new AdminScenarioRepository();

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -44,9 +44,11 @@ export interface ConfirmForgotPasswordRequest {
 
 export interface UserInfo {
   id: number;
-  email: string;
-  name: string;
-  sub: string;
+  email?: string;
+  name?: string;
+  sub?: string;
+  groups?: string[];
+  isAdmin?: boolean;
 }
 
 class AuthRepository {

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -1,28 +1,32 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import type { AuthState } from '../types';
 
 const initialState: AuthState = {
   isAuthenticated: false,
   loading: true,
+  isAdmin: false,
 };
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setAuthData(state) {
+    setAuthData(state, action: PayloadAction<{ isAdmin?: boolean } | undefined>) {
       state.isAuthenticated = true;
       state.loading = false;
+      state.isAdmin = action.payload?.isAdmin ?? false;
     },
 
-    setAuthenticated(state) {
+    setAuthenticated(state, action: PayloadAction<{ isAdmin?: boolean } | undefined>) {
       state.isAuthenticated = true;
       state.loading = false;
+      state.isAdmin = action.payload?.isAdmin ?? false;
     },
 
     clearAuth(state) {
       state.isAuthenticated = false;
       state.loading = false;
+      state.isAdmin = false;
     },
 
     finishLoading(state) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,6 +85,7 @@ export interface FormMessage {
 export interface AuthState {
   isAuthenticated: boolean;
   loading: boolean;
+  isAdmin: boolean;
 }
 
 /** 言い換え提案結果 */

--- a/frontend/src/utils/AuthInitializer.tsx
+++ b/frontend/src/utils/AuthInitializer.tsx
@@ -16,8 +16,8 @@ export default function AuthInitializer({ children }: AuthInitializerProps) {
   useEffect(() => {
     const checkAuth = async () => {
       try {
-        await authRepository.getCurrentUser();
-        dispatch(setAuthData());
+        const me = await authRepository.getCurrentUser();
+        dispatch(setAuthData({ isAdmin: !!me.isAdmin }));
       } catch {
         dispatch(clearAuth());
       } finally {


### PR DESCRIPTION
## 概要

1. ActivityHeatmap の月ラベルがグリッド外にはみ出す問題を修正
2. Cognito の admin グループ所属者だけがアクセスできる **練習シナリオ管理画面** を新規追加

## 変更点

### ActivityHeatmap

月ラベル各々を `weekIndex × 11px + marginRight` で relative 配置していたため、累積幅が画面外まで伸びる問題があった。グリッド総幅と同じ width のコンテナ内で各ラベルを `absolute` 配置に変更し収まるよう修正。

### Admin 機能（新規）

| 場所 | 内容 |
|---|---|
| `SecurityConfig` | `/api/admin/**` を `hasRole("admin")` に制限（Cognito の \`cognito:groups\` から `ROLE_admin` 付与） |
| `AdminScenarioController` | GET/POST/PUT/DELETE `/api/admin/scenarios` |
| 3 UseCase | Create / Update / Delete（クリーンアーキテクチャ） |
| `/api/auth/cognito/me` | `groups: string[]` と `isAdmin: boolean` をレスポンスに追加 |
| Frontend `AuthState.isAdmin` | Redux store に追加し `AuthInitializer` で伝播 |
| `Sidebar` | `isAdmin` のときだけ「管理: シナリオ」メニューを表示 |
| `AdminScenariosPage` | 一覧・作成・編集・削除フォーム（admin 以外は `<Navigate to=/>` でリダイレクト） |
| docs | `docs/admin/admin-feature.md` に認可フローと Cognito 設定手順 |

## 二重防御

- フロント: `Sidebar` に admin リンクは admin のみ表示。直接 URL アクセスも `Navigate to=/` でリダイレクト
- バック: `/api/admin/**` は `hasRole("admin")` で 403

## テスト

- [x] `./gradlew compileJava` 通過
- [x] `npm run build` 通過
- [x] `npm test ActivityHeatmap` グリーン (6/6)
- [ ] Cognito で admin グループ作成 + 自ユーザー追加（マージ後にコマンド実行）
- [ ] 本番でサイドバーに「管理: シナリオ」が出る + シナリオ作成できる

## Cognito 設定（マージ後のコマンド）

\`\`\`bash
USER_POOL_ID=ap-northeast-1_TkRen4lyD
aws cognito-idp create-group --region ap-northeast-1 \\
  --user-pool-id \$USER_POOL_ID --group-name admin
aws cognito-idp admin-add-user-to-group --region ap-northeast-1 \\
  --user-pool-id \$USER_POOL_ID --username <自分の username> --group-name admin
# ログアウト → 再ログインで cognito:groups に admin が付く
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin dashboard for managing practice scenarios with full CRUD operations (create, read, update, delete).
  * Role-based access control for admin users authenticated through Cognito groups.
  * Enhanced user information endpoint returning admin status and group memberships.
  * Conditional admin menu navigation for authorized users.

* **Improvements**
  * Optimized activity heatmap layout with synchronized month labels and improved scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->