### PR TITLE
feat(ui): サイドバーヘッダーを統合ロゴ SVG に置換

### DIFF
--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,9 @@
+<svg width="400" height="100" viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="10" y="15" width="70" height="70" rx="12" fill="#c1a35f" />
+  
+  <text x="26" y="68" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="52" fill="#ffffff">F</text>
+  
+  <text x="95" y="70" font-family="Verdana, Geneva, sans-serif" font-weight="bold" font-size="55" fill="#c1a35f" letter-spacing="-2">fre</text>
+  
+  <text x="185" y="70" font-family="Verdana, Geneva, sans-serif" font-weight="bold" font-size="55" fill="#919191" letter-spacing="-1">Style</text>
+</svg>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -71,9 +71,8 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
     {loggingOut && <Loading fullscreen message="ログアウト中..." />}
     <aside className="flex flex-col w-56 h-full bg-surface-1 border-r border-surface-3 flex-shrink-0">
       {/* ロゴ */}
-      <div className="h-14 flex items-center px-4 border-b border-surface-3 gap-2.5">
-        <img src="/logo.webp" alt="FreStyle" className="w-11 h-11 rounded-xl object-contain" />
-        <span className="text-base font-bold text-[var(--color-text-primary)] tracking-tight">FreStyle</span>
+      <div className="h-14 flex items-center px-3 border-b border-surface-3">
+        <img src="/logo.svg" alt="FreStyle" className="h-9 w-auto" />
       </div>
 
       {/* メインナビ */}

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -62,17 +62,11 @@ describe('Sidebar', () => {
     expect(screen.getByText('ログアウト')).toBeDefined();
   });
 
-  it('FreStyleロゴ画像を角丸で表示する', () => {
+  it('FreStyle ロゴ SVG を表示する（F アイコン + テキストを 1 つの SVG に統合）', () => {
     renderSidebar();
     const logo = screen.getByAltText('FreStyle');
     expect(logo).toBeDefined();
-    expect(logo.getAttribute('src')).toBe('/logo.webp');
-    expect(logo.className).toContain('rounded-xl');
-  });
-
-  it('FreStyleテキストがロゴ横に表示される', () => {
-    renderSidebar();
-    expect(screen.getByText('FreStyle')).toBeInTheDocument();
+    expect(logo.getAttribute('src')).toBe('/logo.svg');
   });
 
   it('ホームルートでホームがアクティブになる', () => {


### PR DESCRIPTION
サイドバー左上の F アイコン + FreStyle テキストの 2 要素を、1 枚の SVG ロゴに統合。

## 変更
- frontend/public/logo.svg 追加（F アイコン + fre/Style ワードマーク）
- Sidebar.tsx: img src を /logo.svg に、テキスト要素を削除
- Sidebar.test.tsx を新ロゴ src に追従

## テスト
- npm test Sidebar.test.tsx 9/9 pass