### PR TITLE
fix(db): postgres profile で spring.sql.init.mode=never

### DIFF
--- a/FreStyle/src/main/resources/application-postgres.properties
+++ b/FreStyle/src/main/resources/application-postgres.properties
@@ -9,6 +9,10 @@ spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 # schema.sql は PostgreSQL 用に置き換える (FreStyle/src/main/resources/schema-postgres.sql)
 # 本番では Flyway 導入後にこの sql.init は disabled にして移行する想定。MVP は schema.sql 直で起動。
 spring.sql.init.platform=postgres
+# schema-postgres.sql は手動で 1 度流し済み (Phase 0b cutover 時)。
+# Spring Boot 起動時に schema.sql (MariaDB 構文) を流すと PostgreSQL でパースエラーになるため
+# 切替後は never で固定。Flyway 導入時に再考。
+spring.sql.init.mode=never
 # CharsetEncoding は不要 (postgres は UTF-8 デフォルト)
 spring.jpa.properties.hibernate.connection.characterEncoding=UTF-8
 


### PR DESCRIPTION
Spring Boot 起動失敗の根本原因。schema.sql (MariaDB 構文) を PostgreSQL に流していた問題を修正。