### PR TITLE
feat(ui): タブ favicon を統合ロゴ SVG に置換

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/image.png" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>FreStyle</title>
     <script>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="90" height="90" rx="18" fill="#c1a35f" />
+  
+  <text x="50" y="72" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="65" fill="#ffffff" text-anchor="middle">F</text>
+</svg>


### PR DESCRIPTION
ブラウザタブの favicon を新ロゴ (F アイコン正方形 SVG) に置き換え。

旧 href=/image.png は存在しないファイルだったため 404、デフォルトアイコン表示になっていた。新 /favicon.svg をブランドカラー (#c1a35f) で配置。