### PR TITLE
feat(admin): メール招待機能 (CompanyAdmin → Trainee)

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/AdminInvitationController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/AdminInvitationController.java
@@ -1,0 +1,91 @@
+package com.example.FreStyle.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.FreStyle.dto.InvitationDto;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.form.CreateInvitationForm;
+import com.example.FreStyle.service.UserIdentityService;
+import com.example.FreStyle.usecase.CancelInvitationUseCase;
+import com.example.FreStyle.usecase.CreateInvitationUseCase;
+import com.example.FreStyle.usecase.ListInvitationsUseCase;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 管理者専用: 招待管理 API。
+ *
+ * <p>{@code /api/admin/**} は SecurityConfig で {@code hasRole("admin")} 制限済み。</p>
+ *
+ * <p>招待作成時に Cognito Admin Create User で標準の招待メール（一時パスワード付き）が
+ * 招待先に送信される。受信者は Hosted UI でパスワードを変更してログインすると、
+ * 既に DB 側で会社マッピング (company_id, role=trainee) が設定されているため、
+ * そのまま自社のコース・教材にアクセスできる。</p>
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/invitations")
+@Slf4j
+@Tag(name = "Admin Invitations", description = "管理者専用: 招待メール送信とトラッキング")
+public class AdminInvitationController {
+
+    private final CreateInvitationUseCase createUseCase;
+    private final ListInvitationsUseCase listUseCase;
+    private final CancelInvitationUseCase cancelUseCase;
+    private final UserIdentityService userIdentityService;
+
+    @GetMapping
+    public ResponseEntity<List<InvitationDto>> list(@AuthenticationPrincipal Jwt jwt) {
+        Long companyId = resolveCompanyId(jwt);
+        return ResponseEntity.ok(listUseCase.execute(companyId));
+    }
+
+    @PostMapping
+    public ResponseEntity<InvitationDto> create(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody CreateInvitationForm form
+    ) {
+        User inviter = userIdentityService.findUserBySub(jwt.getSubject());
+        Long companyId = inviter.getCompanyId();
+        if (companyId == null) {
+            // super_admin は company_id NULL なので、明示的に form 経由で指定する設計に
+            // 拡張する必要がある。MVP では company_admin (自社) のみサポート。
+            throw new IllegalStateException("会社に所属していないユーザーは招待を発行できません");
+        }
+        log.info("[AdminInvitationController] create invitation companyId={} email={} by userId={}",
+                companyId, form.email(), inviter.getId());
+        return ResponseEntity.ok(createUseCase.execute(companyId, inviter.getId().longValue(), form));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> cancel(
+            @AuthenticationPrincipal Jwt jwt,
+            @PathVariable Long id
+    ) {
+        Long companyId = resolveCompanyId(jwt);
+        cancelUseCase.execute(companyId, id);
+        return ResponseEntity.noContent().build();
+    }
+
+    private Long resolveCompanyId(Jwt jwt) {
+        User user = userIdentityService.findUserBySub(jwt.getSubject());
+        if (user.getCompanyId() == null) {
+            throw new IllegalStateException("会社に所属していないユーザー");
+        }
+        return user.getCompanyId();
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/dto/InvitationDto.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/dto/InvitationDto.java
@@ -1,0 +1,15 @@
+package com.example.FreStyle.dto;
+
+import java.time.LocalDateTime;
+
+public record InvitationDto(
+        Long id,
+        Long companyId,
+        String email,
+        String role,
+        Long invitedBy,
+        LocalDateTime expiresAt,
+        LocalDateTime acceptedAt,
+        Long acceptedUserId,
+        LocalDateTime createdAt
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/Invitation.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/Invitation.java
@@ -1,0 +1,56 @@
+package com.example.FreStyle.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 招待トークン。
+ * CompanyAdmin が Trainee を招待する際に作成される。
+ */
+@Entity
+@Table(name = "invitations")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Invitation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "company_id", nullable = false)
+    private Long companyId;
+
+    @Column(nullable = false, length = 254)
+    private String email;
+
+    @Column(nullable = false, length = 30)
+    private String role;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String token;
+
+    @Column(name = "invited_by")
+    private Long invitedBy;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
+    @Column(name = "accepted_user_id")
+    private Long acceptedUserId;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/entity/User.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/entity/User.java
@@ -33,7 +33,7 @@ public class User {
 
     @Column(length = 254, nullable = false, unique = true)
     private String email;
-    
+
     @Column(name = "icon_url", length = 255)
     private String iconUrl;
 
@@ -45,6 +45,18 @@ public class User {
 
     @Column(name = "is_active")
     private Boolean isActive = false;
+
+    /** マルチテナント: 所属会社 (super_admin は NULL) */
+    @Column(name = "company_id")
+    private Long companyId;
+
+    /** ロール: super_admin / company_admin / trainee */
+    @Column(length = 30, nullable = false)
+    private String role;
+
+    /** 論理削除タイムスタンプ */
+    @Column(name = "deleted_at")
+    private java.time.LocalDateTime deletedAt;
 
     @Column(name = "created_at", insertable = false, updatable = false)
     private Timestamp createdAt;

--- a/FreStyle/src/main/java/com/example/FreStyle/form/CreateInvitationForm.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/form/CreateInvitationForm.java
@@ -1,0 +1,21 @@
+package com.example.FreStyle.form;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 招待作成リクエストの入力フォーム。
+ *
+ * @param email 招待先メールアドレス
+ * @param role  招待後のロール (trainee / company_admin)
+ * @param displayName 任意の表示名（無ければ email から推定）
+ */
+public record CreateInvitationForm(
+        @NotBlank @Email @Size(max = 254) String email,
+        @NotBlank @Pattern(regexp = "trainee|company_admin",
+                message = "role は trainee または company_admin")
+        String role,
+        @Size(max = 100) String displayName
+) {}

--- a/FreStyle/src/main/java/com/example/FreStyle/repository/InvitationRepository.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/repository/InvitationRepository.java
@@ -1,0 +1,22 @@
+package com.example.FreStyle.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.FreStyle.entity.Invitation;
+
+@Repository
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+    /** 会社別の未承諾招待を新しい順で取得 */
+    List<Invitation> findByCompanyIdAndAcceptedAtIsNullOrderByCreatedAtDesc(Long companyId);
+
+    /** トークンから招待を取得 */
+    Optional<Invitation> findByToken(String token);
+
+    /** 同一会社・同一メールの未承諾招待が存在するか */
+    Optional<Invitation> findByCompanyIdAndEmailAndAcceptedAtIsNull(Long companyId, String email);
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/service/CognitoAdminService.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/service/CognitoAdminService.java
@@ -1,0 +1,93 @@
+package com.example.FreStyle.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminAddUserToGroupRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminCreateUserRequest;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminCreateUserResponse;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.AttributeType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.DeliveryMediumType;
+import software.amazon.awssdk.services.cognitoidentityprovider.model.UsernameExistsException;
+
+/**
+ * Cognito の管理 API（招待・グループ追加・パスワードリセット等）。
+ * 通常の認証フロー (CognitoAuthService) とは別に、CompanyAdmin / SuperAdmin
+ * からの管理操作用に分離する。
+ */
+@Service
+@Slf4j
+public class CognitoAdminService {
+
+    private final CognitoIdentityProviderClient cognitoClient;
+    private final String userPoolId;
+
+    public CognitoAdminService(
+            @Value("${aws.region}") String region,
+            @Value("${cognito.user-pool-id}") String userPoolId
+    ) {
+        this.userPoolId = userPoolId;
+        this.cognitoClient = CognitoIdentityProviderClient.builder()
+                .region(Region.of(region))
+                .build();
+    }
+
+    public record AdminCreatedUser(String username, String sub, boolean alreadyExisted) {}
+
+    /**
+     * Cognito にユーザーを管理者作成し、招待メール（Cognito 標準）を送信する。
+     * - 既に同一 email で登録済みなら何もせず alreadyExisted=true を返す
+     * - 一時パスワードは Cognito が自動生成、メール送信に乗る
+     * - ユーザーは初回ログイン時に必ずパスワード変更を要求される
+     *
+     * @param email      招待先メールアドレス
+     * @param displayName ユーザー表示名（name 属性）
+     * @return 作成された Cognito Username と sub
+     */
+    public AdminCreatedUser inviteUser(String email, String displayName) {
+        try {
+            AdminCreateUserRequest req = AdminCreateUserRequest.builder()
+                    .userPoolId(userPoolId)
+                    .username(email)
+                    .userAttributes(
+                            AttributeType.builder().name("email").value(email).build(),
+                            AttributeType.builder().name("email_verified").value("true").build(),
+                            AttributeType.builder().name("name").value(displayName != null ? displayName : email).build()
+                    )
+                    .desiredDeliveryMediums(DeliveryMediumType.EMAIL)
+                    // MessageAction を未指定にすると Cognito 標準の招待メール (一時パスワード付き) が送信される
+                    .build();
+            AdminCreateUserResponse resp = cognitoClient.adminCreateUser(req);
+            String sub = resp.user().attributes().stream()
+                    .filter(a -> "sub".equals(a.name()))
+                    .map(AttributeType::value)
+                    .findFirst()
+                    .orElse(resp.user().username());
+            log.info("[CognitoAdminService] invited user email={} sub={} status={}",
+                    email, sub, resp.user().userStatusAsString());
+            return new AdminCreatedUser(resp.user().username(), sub, false);
+        } catch (UsernameExistsException e) {
+            log.warn("[CognitoAdminService] user already exists email={}", email);
+            // 既存ユーザーの sub を取得するため admin-get-user を呼ぶこともできるが、
+            // ここでは alreadyExisted=true で返してアプリ側に判断させる
+            return new AdminCreatedUser(email, null, true);
+        }
+    }
+
+    /**
+     * 任意の Cognito Group にユーザーを追加（admin / company-admin / trainee 等）。
+     * Group が存在しなければ事前に AWS CLI で create-group しておくこと。
+     */
+    public void addUserToGroup(String username, String groupName) {
+        AdminAddUserToGroupRequest req = AdminAddUserToGroupRequest.builder()
+                .userPoolId(userPoolId)
+                .username(username)
+                .groupName(groupName)
+                .build();
+        cognitoClient.adminAddUserToGroup(req);
+        log.info("[CognitoAdminService] added user to group username={} group={}", username, groupName);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CancelInvitationUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CancelInvitationUseCase.java
@@ -1,0 +1,31 @@
+package com.example.FreStyle.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.entity.Invitation;
+import com.example.FreStyle.exception.ResourceNotFoundException;
+import com.example.FreStyle.repository.InvitationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 自社の招待をキャンセルするユースケース（DB から物理削除）。
+ * 自社所有でない場合は ResourceNotFoundException を投げる。
+ */
+@Service
+@RequiredArgsConstructor
+public class CancelInvitationUseCase {
+
+    private final InvitationRepository repository;
+
+    @Transactional
+    public void execute(Long companyId, Long invitationId) {
+        Invitation inv = repository.findById(invitationId)
+                .orElseThrow(() -> new ResourceNotFoundException("招待 id=" + invitationId + " が見つかりません"));
+        if (!inv.getCompanyId().equals(companyId)) {
+            throw new ResourceNotFoundException("招待 id=" + invitationId + " は自社所有ではありません");
+        }
+        repository.delete(inv);
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateInvitationUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/CreateInvitationUseCase.java
@@ -1,0 +1,122 @@
+package com.example.FreStyle.usecase;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.InvitationDto;
+import com.example.FreStyle.entity.Invitation;
+import com.example.FreStyle.entity.User;
+import com.example.FreStyle.entity.UserIdentity;
+import com.example.FreStyle.form.CreateInvitationForm;
+import com.example.FreStyle.repository.InvitationRepository;
+import com.example.FreStyle.repository.UserIdentityRepository;
+import com.example.FreStyle.repository.UserRepository;
+import com.example.FreStyle.service.CognitoAdminService;
+import com.example.FreStyle.service.CognitoAdminService.AdminCreatedUser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * CompanyAdmin が Trainee を招待するユースケース。
+ *
+ * <p>処理の流れ:</p>
+ * <ol>
+ *   <li>Cognito にユーザーを管理者作成（標準の招待メールが送信される）</li>
+ *   <li>users テーブルに Trainee を INSERT (既存なら role / company_id 上書き)</li>
+ *   <li>user_identities に Cognito sub をマッピング</li>
+ *   <li>invitations テーブルに招待トークンと有効期限を記録</li>
+ * </ol>
+ *
+ * <p>SES で独自テンプレ送信に置き換える場合は CognitoAdminService の MessageAction を SUPPRESS
+ * にし、本 UseCase で別途メール送信する設計に拡張する（Phase 2）。</p>
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CreateInvitationUseCase {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int EXPIRES_IN_DAYS = 14;
+
+    private final InvitationRepository invitationRepository;
+    private final UserRepository userRepository;
+    private final UserIdentityRepository userIdentityRepository;
+    private final CognitoAdminService cognitoAdminService;
+
+    @Transactional
+    public InvitationDto execute(Long companyId, Long inviterUserId, CreateInvitationForm form) {
+        String email = form.email().trim().toLowerCase();
+        String role = form.role();
+        String displayName = form.displayName() != null && !form.displayName().isBlank()
+                ? form.displayName()
+                : email.substring(0, email.indexOf('@'));
+
+        // 1) Cognito 招待 (既存ユーザーは alreadyExisted=true で返るので冪等)
+        AdminCreatedUser cognitoUser = cognitoAdminService.inviteUser(email, displayName);
+
+        // 2) users INSERT or UPDATE
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    User u = new User();
+                    u.setEmail(email);
+                    u.setName(displayName);
+                    u.setIsActive(true);
+                    return u;
+                });
+        user.setCompanyId(companyId);
+        user.setRole(role);
+        if (user.getName() == null || user.getName().isBlank()) {
+            user.setName(displayName);
+        }
+        user = userRepository.save(user);
+
+        // 3) Cognito sub のマッピング (既に存在しない場合のみ)
+        if (cognitoUser.sub() != null) {
+            boolean exists = userIdentityRepository
+                    .findByProviderAndProviderSub("cognito", cognitoUser.sub())
+                    .isPresent();
+            if (!exists) {
+                UserIdentity identity = new UserIdentity();
+                identity.setUser(user);
+                identity.setProvider("cognito");
+                identity.setProviderSub(cognitoUser.sub());
+                userIdentityRepository.save(identity);
+            }
+        }
+
+        // 4) invitations 記録
+        String token = generateToken();
+        Invitation invitation = new Invitation();
+        invitation.setCompanyId(companyId);
+        invitation.setEmail(email);
+        invitation.setRole(role);
+        invitation.setToken(token);
+        invitation.setInvitedBy(inviterUserId);
+        invitation.setExpiresAt(LocalDateTime.now().plusDays(EXPIRES_IN_DAYS));
+        invitation = invitationRepository.save(invitation);
+
+        log.info("[CreateInvitationUseCase] companyId={} email={} role={} cognitoExists={}",
+                companyId, email, role, cognitoUser.alreadyExisted());
+
+        return toDto(invitation);
+    }
+
+    private static String generateToken() {
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private static InvitationDto toDto(Invitation i) {
+        return new InvitationDto(
+                i.getId(), i.getCompanyId(), i.getEmail(), i.getRole(),
+                i.getInvitedBy(), i.getExpiresAt(), i.getAcceptedAt(),
+                i.getAcceptedUserId(), i.getCreatedAt()
+        );
+    }
+}

--- a/FreStyle/src/main/java/com/example/FreStyle/usecase/ListInvitationsUseCase.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/usecase/ListInvitationsUseCase.java
@@ -1,0 +1,36 @@
+package com.example.FreStyle.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.example.FreStyle.dto.InvitationDto;
+import com.example.FreStyle.entity.Invitation;
+import com.example.FreStyle.repository.InvitationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 自社の未承諾招待を一覧取得するユースケース。
+ */
+@Service
+@RequiredArgsConstructor
+public class ListInvitationsUseCase {
+
+    private final InvitationRepository repository;
+
+    @Transactional(readOnly = true)
+    public List<InvitationDto> execute(Long companyId) {
+        return repository.findByCompanyIdAndAcceptedAtIsNullOrderByCreatedAtDesc(companyId)
+                .stream().map(this::toDto).toList();
+    }
+
+    private InvitationDto toDto(Invitation i) {
+        return new InvitationDto(
+                i.getId(), i.getCompanyId(), i.getEmail(), i.getRole(),
+                i.getInvitedBy(), i.getExpiresAt(), i.getAcceptedAt(),
+                i.getAcceptedUserId(), i.getCreatedAt()
+        );
+    }
+}

--- a/FreStyle/src/main/resources/application.properties
+++ b/FreStyle/src/main/resources/application.properties
@@ -31,6 +31,8 @@ cognito.client-secret=${COGNITO_CLIENT_SECRET}
 cognito.redirect-uri=${COGNITO_REDIRECT_URI}
 cognito.token-uri=${COGNITO_TOKEN_URI}
 cognito.jwk-set-uri=${COGNITO_JWK_SET_URI}
+# Admin 操作 (招待・グループ管理) 用の User Pool ID。本番は oauth-cource-user-pool。
+cognito.user-pool-id=${COGNITO_USER_POOL_ID:ap-northeast-1_TkRen4lyD}
 
 # AWS SDK は標準クレデンシャルチェーン (env vars / ~/.aws/credentials / ECS Task Role / EC2 Instance Profile)
 # で自動解決するため、access-key / secret-key の Spring プロパティ参照は廃止。

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ const SharedSessionsPage = lazy(() => import('./pages/SharedSessionsPage'));
 const WeeklyChallengePage = lazy(() => import('./pages/WeeklyChallengePage'));
 const HelpPage = lazy(() => import('./pages/HelpPage'));
 const AdminScenariosPage = lazy(() => import('./pages/AdminScenariosPage'));
+const AdminInvitationsPage = lazy(() => import('./pages/AdminInvitationsPage'));
 
 function NavigationToast() {
   const location = useLocation();
@@ -104,6 +105,7 @@ export default function App() {
         <Route path="/help" element={<HelpPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/scenarios" element={<AdminScenariosPage />} />
+        <Route path="/admin/invitations" element={<AdminInvitationsPage />} />
       </Route>
     </Routes>
     </Suspense>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -112,6 +112,13 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
               active={location.pathname.startsWith('/admin/scenarios')}
               onClick={onNavigate}
             />
+            <SidebarItem
+              icon={Cog6ToothIcon}
+              label="管理: 招待"
+              to="/admin/invitations"
+              active={location.pathname.startsWith('/admin/invitations')}
+              onClick={onNavigate}
+            />
           </>
         )}
       </nav>

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import AdminInvitationRepository, {
+  AdminInvitation,
+  CreateInvitationForm,
+} from '../repositories/AdminInvitationRepository';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+
+const EMPTY_FORM: CreateInvitationForm = {
+  email: '',
+  role: 'trainee',
+  displayName: '',
+};
+
+/**
+ * 管理者専用: メール招待管理ページ。
+ *
+ * <p>CompanyAdmin が新卒研修対象者のメールアドレスを入力 → Cognito 経由で
+ * 一時パスワード付きの招待メールが送信される。受信者は Hosted UI でログインし、
+ * パスワード変更後に自社のコース・教材にアクセスできる。</p>
+ */
+export default function AdminInvitationsPage() {
+  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
+  const authLoading = useSelector((state: RootState) => state.auth.loading);
+
+  const [invitations, setInvitations] = useState<AdminInvitation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<CreateInvitationForm>(EMPTY_FORM);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await AdminInvitationRepository.list();
+      setInvitations(data);
+      setError(null);
+    } catch (e) {
+      setError('招待一覧の取得に失敗しました');
+      // eslint-disable-next-line no-console
+      console.error(e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAdmin) fetchAll();
+  }, [isAdmin, fetchAll]);
+
+  if (authLoading) return <Loading message="認証情報を確認中..." />;
+  if (!isAdmin) return <Navigate to="/" replace />;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const created = await AdminInvitationRepository.create(form);
+      setSuccess(
+        `${created.email} 宛に招待メールを送信しました。受信者は Cognito Hosted UI で初回パスワードを変更してログインしてください。`
+      );
+      setForm(EMPTY_FORM);
+      await fetchAll();
+    } catch (err: unknown) {
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+        '招待の作成に失敗しました';
+      setError(msg);
+      // eslint-disable-next-line no-console
+      console.error(err);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const cancel = async (id: number) => {
+    if (!confirm('この招待をキャンセルしますか？')) return;
+    try {
+      await AdminInvitationRepository.cancel(id);
+      await fetchAll();
+    } catch (err) {
+      setError('招待のキャンセルに失敗しました');
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  };
+
+  const formatDate = (iso: string) => new Date(iso).toLocaleString('ja-JP');
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto space-y-6">
+      <PageIntro
+        title="管理: メンバー招待"
+        description={
+          <>
+            メールアドレスを入力すると、Cognito 経由で一時パスワード付きの招待メールが送信されます。
+            受信者は初回ログイン時にパスワード変更を要求されます。
+          </>
+        }
+      />
+
+      {error && (
+        <div role="alert" className="p-3 rounded border border-red-300 bg-red-50 text-red-800 text-sm">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div role="status" className="p-3 rounded border border-emerald-300 bg-emerald-50 text-emerald-800 text-sm">
+          {success}
+        </div>
+      )}
+
+      <form onSubmit={submit} className="space-y-3 p-4 border rounded-lg bg-[var(--color-surface-1)]">
+        <h2 className="text-base font-bold">新規招待</h2>
+
+        <label className="block text-sm">
+          <span className="block mb-1">メールアドレス *</span>
+          <input
+            required
+            type="email"
+            maxLength={254}
+            value={form.email}
+            onChange={(e) => setForm({ ...form, email: e.target.value })}
+            placeholder="newmember@example.com"
+            className="w-full border rounded px-2 py-1"
+          />
+        </label>
+
+        <label className="block text-sm">
+          <span className="block mb-1">ロール *</span>
+          <select
+            required
+            value={form.role}
+            onChange={(e) =>
+              setForm({ ...form, role: e.target.value as CreateInvitationForm['role'] })
+            }
+            className="w-full border rounded px-2 py-1"
+          >
+            <option value="trainee">Trainee（新卒研修対象）</option>
+            <option value="company_admin">CompanyAdmin（メンター）</option>
+          </select>
+        </label>
+
+        <label className="block text-sm">
+          <span className="block mb-1">表示名（任意）</span>
+          <input
+            maxLength={100}
+            value={form.displayName ?? ''}
+            onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+            placeholder="例: 山田太郎"
+            className="w-full border rounded px-2 py-1"
+          />
+          <span className="block mt-1 text-xs text-[var(--color-text-muted)]">
+            未入力の場合はメールアドレスのローカル部から自動生成されます。
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="px-4 py-2 rounded bg-emerald-600 text-white disabled:opacity-50"
+        >
+          {submitting ? '送信中...' : '招待メールを送信'}
+        </button>
+      </form>
+
+      <section>
+        <h2 className="text-base font-bold mb-3">未承諾の招待 ({invitations.length})</h2>
+        {loading ? (
+          <Loading message="読み込み中..." />
+        ) : invitations.length === 0 ? (
+          <p className="text-sm text-[var(--color-text-muted)]">未承諾の招待はありません</p>
+        ) : (
+          <ul className="space-y-2">
+            {invitations.map((inv) => (
+              <li
+                key={inv.id}
+                className="p-3 border rounded flex items-start justify-between gap-3 bg-[var(--color-surface-1)]"
+              >
+                <div className="flex-1 text-sm">
+                  <p className="font-bold">
+                    {inv.email}{' '}
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-surface-3">{inv.role}</span>
+                  </p>
+                  <p className="text-xs text-[var(--color-text-muted)]">
+                    招待日: {formatDate(inv.createdAt)} / 有効期限: {formatDate(inv.expiresAt)}
+                  </p>
+                </div>
+                <button
+                  onClick={() => cancel(inv.id)}
+                  className="text-xs px-2 py-1 border border-red-300 rounded text-red-700"
+                >
+                  取り消し
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/repositories/AdminInvitationRepository.ts
+++ b/frontend/src/repositories/AdminInvitationRepository.ts
@@ -1,0 +1,38 @@
+import apiClient from '../lib/axios';
+
+export interface AdminInvitation {
+  id: number;
+  companyId: number;
+  email: string;
+  role: 'trainee' | 'company_admin';
+  invitedBy: number | null;
+  expiresAt: string;
+  acceptedAt: string | null;
+  acceptedUserId: number | null;
+  createdAt: string;
+}
+
+export interface CreateInvitationForm {
+  email: string;
+  role: 'trainee' | 'company_admin';
+  displayName?: string;
+}
+
+/** 管理者専用: メール招待 CRUD */
+class AdminInvitationRepository {
+  async list(): Promise<AdminInvitation[]> {
+    const res = await apiClient.get<AdminInvitation[]>('/api/admin/invitations');
+    return res.data;
+  }
+
+  async create(form: CreateInvitationForm): Promise<AdminInvitation> {
+    const res = await apiClient.post<AdminInvitation>('/api/admin/invitations', form);
+    return res.data;
+  }
+
+  async cancel(id: number): Promise<void> {
+    await apiClient.delete(`/api/admin/invitations/${id}`);
+  }
+}
+
+export default new AdminInvitationRepository();

--- a/gemini-svg (1).svg
+++ b/gemini-svg (1).svg
@@ -1,0 +1,5 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="90" height="90" rx="18" fill="#c1a35f" />
+  
+  <text x="50" y="72" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="65" fill="#ffffff" text-anchor="middle">F</text>
+</svg>


### PR DESCRIPTION
## 概要

CompanyAdmin がメールアドレスを入力すると、Cognito 経由で一時パスワード付きの招待メールが送信される機能。受信者は Hosted UI でログインしパスワードを変更すれば、自社のコース・教材に即座にアクセスできる。

## エンドポイント
- POST /api/admin/invitations { email, role, displayName? }
- GET /api/admin/invitations
- DELETE /api/admin/invitations/{id}

## 流れ
1. POST → Cognito AdminCreateUser (一時パスワード生成 + Cognito 標準メール送信)
2. users INSERT (company_id=自社, role=trainee/company_admin)
3. user_identities INSERT (Cognito sub マッピング)
4. invitations INSERT (token + 14日有効期限)

## ロール
hasRole(admin) で保護。MVP では admin Cognito Group にいるユーザー (super_admin / company_admin 兼任) が招待発行可能。

## 関連 PR
- frestyle-infrastructure #23: Task Role に cognito-idp Admin 系権限追加