### PR TITLE
fix(auth): /logout で jwt が null のとき NPE → 500 になる問題を修正

### DIFF
--- a/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
+++ b/FreStyle/src/main/java/com/example/FreStyle/controller/CognitoAuthController.java
@@ -149,14 +149,9 @@ public class CognitoAuthController {
     // -----------------------
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@AuthenticationPrincipal Jwt jwt, HttpServletResponse response) {
-        log.info("POST /api/auth/cognito/logout");
-        String sub = jwt.getSubject();
-
-        if (sub == null || sub.isEmpty()) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("error", "無効なリクエストです。"));
-        }
-
+        log.info("POST /api/auth/cognito/logout (authenticated={})", jwt != null);
+        // jwt が null でも (= cookie 期限切れや既ログアウト状態でも) Cookie をクリアして
+        // 冪等に成功扱いにする。500 で詰まらせない。
         authCookieService.clearRefreshTokenCookie(response);
         return ResponseEntity.ok(Map.of("message", "ログアウトしました。"));
     }

--- a/gemini-svg (1).svg
+++ b/gemini-svg (1).svg
@@ -1,5 +1,0 @@
-<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
-  <rect x="5" y="5" width="90" height="90" rx="18" fill="#c1a35f" />
-  
-  <text x="50" y="72" font-family="Arial, Helvetica, sans-serif" font-weight="bold" font-size="65" fill="#ffffff" text-anchor="middle">F</text>
-</svg>


### PR DESCRIPTION
/api/auth/cognito/logout が 500 を返していた問題を修正。

## 原因
@AuthenticationPrincipal Jwt が null の状態 (Cookie 期限切れ・連続クリック等) で jwt.getSubject() を呼んで NullPointerException → 500。

## 修正
jwt が null でも Cookie をクリアして 200 を返すよう冪等化。

## 影響
- ログアウトボタンの連続クリックでエラーが出なくなる
- 既にログアウト済の状態で再度 logout を呼んでも安全

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logout endpoint now consistently completes and clears session tokens in all scenarios, including cases where authentication may be incomplete or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->