### PR TITLE
fix: スクロールバー二重化とサイドバー縦線途切れを修正、招待アイコンを変更

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,6 +8,14 @@ html {
   scroll-behavior: smooth;
 }
 
+/* AppShell が h-screen で内部スクロールするため、ページ外側の body / html はスクロール禁止
+   （これがないと縦スクロールバーが二本表示される） */
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -49,7 +49,7 @@ export default function AppShell() {
     <div className="h-screen flex bg-surface">
       <SkipLink targetId="main-content" />
       {/* デスクトップサイドバー */}
-      <div className="hidden md:block">
+      <div className="hidden md:block h-full">
         <Sidebar />
       </div>
 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   SunIcon,
   MoonIcon,
   Cog6ToothIcon,
+  UserPlusIcon,
 } from '@heroicons/react/24/outline';
 
 const navItems = [
@@ -113,7 +114,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
               onClick={onNavigate}
             />
             <SidebarItem
-              icon={Cog6ToothIcon}
+              icon={UserPlusIcon}
               label="管理: 招待"
               to="/admin/invitations"
               active={location.pathname.startsWith('/admin/invitations')}


### PR DESCRIPTION
## 概要

サイドバーまわりの 3 つの UI 不具合を修正:

1. ホーム画面で縦スクロールバーが 2 本表示される
2. サイドバーの右側縦罫線が下まで届かず途中で途切れる
3. 「管理: 招待」のアイコンが「管理: シナリオ」と同じ歯車で見分けがつかない

## 変更内容

- `frontend/src/App.css`: `html, body` に `overflow: hidden` + `height: 100%` を追加。AppShell が `h-screen + overflow-auto` で内部スクロールする構成なので、外側 body のスクロールはロック
- `frontend/src/components/layout/AppShell.tsx`: デスクトップサイドバー親ラッパー `<div className="hidden md:block">` に `h-full` を追加。これにより `<aside className="... h-full">` の `border-r` が下まで伸びる
- `frontend/src/components/layout/Sidebar.tsx`: 「管理: 招待」のアイコンを `Cog6ToothIcon` → `UserPlusIcon`（heroicons）に変更。招待＝ユーザー追加なのでセマンティクスも一致

## テスト

- [x] `npx tsc --noEmit` 既存の型エラー以外、新規エラーなし
- [ ] ローカルで `npm run dev` し、ホーム画面でスクロールバー 1 本のみ・サイドバー縦罫線が下端まで届くこと・招待アイコンが人＋プラスマークになっていることを確認

## 関連 Issue

なし（細かい UI 修正）