### PR TITLE
feat(backend): Phase 2 - CognitoAuth (JWT middleware + /me + /logout)

### DIFF
--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -1,0 +1,25 @@
+package domain
+
+import "time"
+
+// User はアプリケーション利用者のドメインモデル。
+// Spring Boot 側の entity.User と同じカラム構造を踏襲する。
+type User struct {
+	ID          uint64     `gorm:"primaryKey" json:"id"`
+	CognitoSub  string     `gorm:"column:cognito_sub;uniqueIndex" json:"cognitoSub"`
+	Email       string     `gorm:"column:email" json:"email"`
+	DisplayName string     `gorm:"column:display_name" json:"displayName"`
+	CompanyID   *uint64    `gorm:"column:company_id" json:"companyId,omitempty"`
+	Role        string     `gorm:"column:role" json:"role"`
+	CreatedAt   time.Time  `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt   time.Time  `gorm:"column:updated_at" json:"updatedAt"`
+	DeletedAt   *time.Time `gorm:"column:deleted_at" json:"deletedAt,omitempty"`
+}
+
+func (User) TableName() string { return "users" }
+
+const (
+	RoleSuperAdmin   = "super_admin"
+	RoleCompanyAdmin = "company_admin"
+	RoleTrainee      = "trainee"
+)

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AuthHandler は Cognito 関連の認証エンドポイントを提供する。
+// Spring Boot の CognitoAuthController に相当。
+type AuthHandler struct {
+	getCurrentUser *usecase.GetCurrentUserUseCase
+}
+
+func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase) *AuthHandler {
+	return &AuthHandler{getCurrentUser: getCurrentUser}
+}
+
+// Me は現在ログイン中のユーザー情報を返す。
+func (h *AuthHandler) Me(c *gin.Context) {
+	sub, ok := c.Get(middleware.ContextKeyCognitoSub)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	user, err := h.getCurrentUser.Execute(c.Request.Context(), sub.(string))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	if user == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user_not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, user)
+}
+
+// Logout はリフレッシュ・アクセストークンの Cookie を消去する。
+func (h *AuthHandler) Logout(c *gin.Context) {
+	c.SetCookie(middleware.CookieAccessToken, "", -1, "/", "", true, true)
+	c.SetCookie("refresh_token", "", -1, "/", "", true, true)
+	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました。"})
+}

--- a/backend/internal/handler/middleware/jwt.go
+++ b/backend/internal/handler/middleware/jwt.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	ContextKeyCognitoSub = "cognitoSub"
+	ContextKeyEmail      = "email"
+	CookieAccessToken    = "access_token"
+)
+
+// JWTAuth は HttpOnly Cookie の access_token を検証する Gin middleware。
+// Phase 2 ではトークン存在チェックのみ行い、JWKS 検証は Phase 2.1 (別 PR) で実装する。
+// TODO: AWS Cognito JWKS から公開鍵を取得して署名検証する。
+func JWTAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		token, err := c.Cookie(CookieAccessToken)
+		if err != nil || token == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		// プレースホルダ: 実際の検証は後続 PR で実装する
+		c.Set(ContextKeyCognitoSub, "placeholder-sub")
+		c.Next()
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
@@ -19,12 +20,22 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	})
 
 	v2 := r.Group("/api/v2")
-	{
-		healthHandler := NewHealthHandler(
-			usecase.NewCheckHealthUseCase(repository.NewHealthRepository(db)),
-		)
-		v2.GET("/health", healthHandler.Get)
-	}
+
+	// Phase 1: 認証不要のヘルスチェック
+	healthHandler := NewHealthHandler(
+		usecase.NewCheckHealthUseCase(repository.NewHealthRepository(db)),
+	)
+	v2.GET("/health", healthHandler.Get)
+
+	// Phase 2: 認証 (Cognito)
+	userRepo := repository.NewUserRepository(db)
+	authHandler := NewAuthHandler(usecase.NewGetCurrentUserUseCase(userRepo))
+	v2.POST("/auth/cognito/logout", authHandler.Logout)
+
+	// 認証必須グループ
+	authed := v2.Group("")
+	authed.Use(middleware.JWTAuth())
+	authed.GET("/auth/me", authHandler.Me)
 
 	return r
 }

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -1,0 +1,39 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// UserRepository は users テーブルへのアクセスを提供する。
+type UserRepository interface {
+	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
+	Create(ctx context.Context, user *domain.User) error
+}
+
+type userRepository struct {
+	db *gorm.DB
+}
+
+func NewUserRepository(db *gorm.DB) UserRepository {
+	return &userRepository{db: db}
+}
+
+func (r *userRepository) FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error) {
+	var u domain.User
+	err := r.db.WithContext(ctx).Where("cognito_sub = ? AND deleted_at IS NULL", sub).First(&u).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *userRepository) Create(ctx context.Context, user *domain.User) error {
+	return r.db.WithContext(ctx).Create(user).Error
+}

--- a/backend/internal/usecase/get_current_user_usecase.go
+++ b/backend/internal/usecase/get_current_user_usecase.go
@@ -1,0 +1,21 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// GetCurrentUserUseCase は Cognito sub から現在のユーザー情報を引く。
+type GetCurrentUserUseCase struct {
+	users repository.UserRepository
+}
+
+func NewGetCurrentUserUseCase(users repository.UserRepository) *GetCurrentUserUseCase {
+	return &GetCurrentUserUseCase{users: users}
+}
+
+func (u *GetCurrentUserUseCase) Execute(ctx context.Context, cognitoSub string) (*domain.User, error) {
+	return u.users.FindByCognitoSub(ctx, cognitoSub)
+}

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -1,0 +1,49 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubUserRepo struct {
+	user *domain.User
+	err  error
+}
+
+func (s *stubUserRepo) FindByCognitoSub(_ context.Context, _ string) (*domain.User, error) {
+	return s.user, s.err
+}
+func (s *stubUserRepo) Create(_ context.Context, _ *domain.User) error { return s.err }
+
+func TestGetCurrentUserUseCase_Found(t *testing.T) {
+	want := &domain.User{ID: 1, CognitoSub: "abc", Email: "u@example.com"}
+	uc := NewGetCurrentUserUseCase(&stubUserRepo{user: want})
+	got, err := uc.Execute(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got == nil || got.ID != 1 {
+		t.Fatalf("want %+v, got %+v", want, got)
+	}
+}
+
+func TestGetCurrentUserUseCase_NotFound(t *testing.T) {
+	uc := NewGetCurrentUserUseCase(&stubUserRepo{user: nil})
+	got, err := uc.Execute(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestGetCurrentUserUseCase_Error(t *testing.T) {
+	uc := NewGetCurrentUserUseCase(&stubUserRepo{err: errors.New("db down")})
+	if _, err := uc.Execute(context.Background(), "x"); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
Phase 2: 認証関連エンドポイントの Go 移植。

## 変更内容
- domain.User (Spring Boot entity.User と同等)
- UserRepository (FindByCognitoSub / Create)
- middleware.JWTAuth (HttpOnly Cookie 経由のトークン抽出)
- GetCurrentUserUseCase
- AuthHandler (GET /auth/me, POST /auth/cognito/logout)
- /api/v2/auth/* ルーティング

## 既知の TODO
- JWKS 公開鍵による署名検証は次の PR (Phase 2.1) で実装

Closes #1488