### PR TITLE
feat(backend): Phase 3 - AiChat (sessions) を Go で実装

### DIFF
--- a/backend/internal/domain/ai_chat.go
+++ b/backend/internal/domain/ai_chat.go
@@ -1,0 +1,36 @@
+package domain
+
+import "time"
+
+// AiChatSession は AI チャットの 1 セッション。Spring Boot の entity.AiChatSession に相当。
+type AiChatSession struct {
+	ID          uint64    `gorm:"primaryKey" json:"id"`
+	UserID      uint64    `gorm:"column:user_id;index" json:"userId"`
+	Title       string    `gorm:"column:title" json:"title"`
+	SessionType string    `gorm:"column:session_type" json:"sessionType"`
+	ScenarioID  *uint64   `gorm:"column:scenario_id" json:"scenarioId,omitempty"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt   time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (AiChatSession) TableName() string { return "ai_chat_sessions" }
+
+const (
+	AiChatSessionTypeFree     = "free"
+	AiChatSessionTypePractice = "practice"
+)
+
+// AiChatMessage は AI チャットの 1 メッセージ。実体は DynamoDB に保存されるが、
+// API ではこの形で返却する。
+type AiChatMessage struct {
+	SessionID uint64    `json:"sessionId"`
+	MessageID string    `json:"messageId"`
+	Role      string    `json:"role"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+const (
+	AiChatRoleUser      = "user"
+	AiChatRoleAssistant = "assistant"
+)

--- a/backend/internal/handler/ai_chat_handler.go
+++ b/backend/internal/handler/ai_chat_handler.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AiChatHandler は AI チャット関連のエンドポイントを提供する。
+// Spring Boot の AiChatController に相当。
+type AiChatHandler struct {
+	getSessions   *usecase.GetAiChatSessionsByUserIDUseCase
+	createSession *usecase.CreateAiChatSessionUseCase
+}
+
+func NewAiChatHandler(
+	getSessions *usecase.GetAiChatSessionsByUserIDUseCase,
+	createSession *usecase.CreateAiChatSessionUseCase,
+) *AiChatHandler {
+	return &AiChatHandler{getSessions: getSessions, createSession: createSession}
+}
+
+// GetSessions は GET /ai-chat/sessions
+func (h *AiChatHandler) GetSessions(c *gin.Context) {
+	userIDStr := c.Query("userId")
+	userID, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil || userID == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "userId is required"})
+		return
+	}
+	rows, err := h.getSessions.Execute(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+type createSessionReq struct {
+	UserID      uint64  `json:"userId"`
+	Title       string  `json:"title" binding:"required"`
+	SessionType string  `json:"sessionType"`
+	ScenarioID  *uint64 `json:"scenarioId"`
+}
+
+// CreateSession は POST /ai-chat/sessions
+func (h *AiChatHandler) CreateSession(c *gin.Context) {
+	var req createSessionReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	created, err := h.createSession.Execute(c.Request.Context(), usecase.CreateAiChatSessionInput{
+		UserID:      req.UserID,
+		Title:       req.Title,
+		SessionType: req.SessionType,
+		ScenarioID:  req.ScenarioID,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, created)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -37,5 +37,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.Use(middleware.JWTAuth())
 	authed.GET("/auth/me", authHandler.Me)
 
+	// Phase 3: AI チャット
+	aiSessionRepo := repository.NewAiChatSessionRepository(db)
+	aiHandler := NewAiChatHandler(
+		usecase.NewGetAiChatSessionsByUserIDUseCase(aiSessionRepo),
+		usecase.NewCreateAiChatSessionUseCase(aiSessionRepo),
+	)
+	authed.GET("/ai-chat/sessions", aiHandler.GetSessions)
+	authed.POST("/ai-chat/sessions", aiHandler.CreateSession)
+
 	return r
 }

--- a/backend/internal/repository/ai_chat_session_repository.go
+++ b/backend/internal/repository/ai_chat_session_repository.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// AiChatSessionRepository は ai_chat_sessions テーブルへのアクセスを提供する。
+type AiChatSessionRepository interface {
+	ListByUserID(ctx context.Context, userID uint64) ([]domain.AiChatSession, error)
+	FindByID(ctx context.Context, id uint64) (*domain.AiChatSession, error)
+	Create(ctx context.Context, s *domain.AiChatSession) error
+	UpdateTitle(ctx context.Context, id uint64, title string) error
+}
+
+type aiChatSessionRepository struct{ db *gorm.DB }
+
+func NewAiChatSessionRepository(db *gorm.DB) AiChatSessionRepository {
+	return &aiChatSessionRepository{db: db}
+}
+
+func (r *aiChatSessionRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.AiChatSession, error) {
+	var rows []domain.AiChatSession
+	err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *aiChatSessionRepository) FindByID(ctx context.Context, id uint64) (*domain.AiChatSession, error) {
+	var s domain.AiChatSession
+	if err := r.db.WithContext(ctx).First(&s, id).Error; err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *aiChatSessionRepository) Create(ctx context.Context, s *domain.AiChatSession) error {
+	return r.db.WithContext(ctx).Create(s).Error
+}
+
+func (r *aiChatSessionRepository) UpdateTitle(ctx context.Context, id uint64, title string) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.AiChatSession{}).
+		Where("id = ?", id).
+		Update("title", title).Error
+}

--- a/backend/internal/usecase/ai_chat_usecase.go
+++ b/backend/internal/usecase/ai_chat_usecase.go
@@ -1,0 +1,57 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// GetAiChatSessionsByUserIDUseCase は指定ユーザーの AI チャットセッション一覧を返す。
+type GetAiChatSessionsByUserIDUseCase struct {
+	sessions repository.AiChatSessionRepository
+}
+
+func NewGetAiChatSessionsByUserIDUseCase(s repository.AiChatSessionRepository) *GetAiChatSessionsByUserIDUseCase {
+	return &GetAiChatSessionsByUserIDUseCase{sessions: s}
+}
+
+func (u *GetAiChatSessionsByUserIDUseCase) Execute(ctx context.Context, userID uint64) ([]domain.AiChatSession, error) {
+	return u.sessions.ListByUserID(ctx, userID)
+}
+
+// CreateAiChatSessionUseCase は新規セッションを作成する。
+type CreateAiChatSessionUseCase struct {
+	sessions repository.AiChatSessionRepository
+}
+
+func NewCreateAiChatSessionUseCase(s repository.AiChatSessionRepository) *CreateAiChatSessionUseCase {
+	return &CreateAiChatSessionUseCase{sessions: s}
+}
+
+type CreateAiChatSessionInput struct {
+	UserID      uint64
+	Title       string
+	SessionType string
+	ScenarioID  *uint64
+}
+
+func (u *CreateAiChatSessionUseCase) Execute(ctx context.Context, in CreateAiChatSessionInput) (*domain.AiChatSession, error) {
+	if in.Title == "" {
+		return nil, errors.New("title is required")
+	}
+	if in.SessionType == "" {
+		in.SessionType = domain.AiChatSessionTypeFree
+	}
+	s := &domain.AiChatSession{
+		UserID:      in.UserID,
+		Title:       in.Title,
+		SessionType: in.SessionType,
+		ScenarioID:  in.ScenarioID,
+	}
+	if err := u.sessions.Create(ctx, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/backend/internal/usecase/ai_chat_usecase_test.go
+++ b/backend/internal/usecase/ai_chat_usecase_test.go
@@ -1,0 +1,64 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubAiChatSessionRepo struct {
+	rows []domain.AiChatSession
+	err  error
+}
+
+func (s *stubAiChatSessionRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.AiChatSession, error) {
+	return s.rows, s.err
+}
+func (s *stubAiChatSessionRepo) FindByID(_ context.Context, _ uint64) (*domain.AiChatSession, error) {
+	return nil, nil
+}
+func (s *stubAiChatSessionRepo) Create(_ context.Context, sess *domain.AiChatSession) error {
+	if s.err != nil {
+		return s.err
+	}
+	sess.ID = 42
+	return nil
+}
+func (s *stubAiChatSessionRepo) UpdateTitle(_ context.Context, _ uint64, _ string) error {
+	return s.err
+}
+
+func TestGetAiChatSessionsByUserID(t *testing.T) {
+	repo := &stubAiChatSessionRepo{rows: []domain.AiChatSession{{ID: 1, UserID: 7, Title: "a"}}}
+	uc := NewGetAiChatSessionsByUserIDUseCase(repo)
+	got, err := uc.Execute(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 session, got %d", len(got))
+	}
+}
+
+func TestCreateAiChatSession_RequiresTitle(t *testing.T) {
+	uc := NewCreateAiChatSessionUseCase(&stubAiChatSessionRepo{})
+	_, err := uc.Execute(context.Background(), CreateAiChatSessionInput{UserID: 1})
+	if err == nil {
+		t.Fatal("expected error for empty title")
+	}
+}
+
+func TestCreateAiChatSession_DefaultsTypeToFree(t *testing.T) {
+	uc := NewCreateAiChatSessionUseCase(&stubAiChatSessionRepo{})
+	got, err := uc.Execute(context.Background(), CreateAiChatSessionInput{UserID: 1, Title: "x"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.SessionType != domain.AiChatSessionTypeFree {
+		t.Fatalf("want type=free, got %s", got.SessionType)
+	}
+	if got.ID != 42 {
+		t.Fatalf("expected stub-assigned id 42, got %d", got.ID)
+	}
+}


### PR DESCRIPTION
Phase 3: AI チャットセッションの基本 CRUD を Go で実装。

## 変更内容
- domain.AiChatSession (GORM)
- AiChatSessionRepository
- GetAiChatSessionsByUserIDUseCase / CreateAiChatSessionUseCase
- AiChatHandler (GET/POST /ai-chat/sessions)
- /api/v2/ai-chat/* ルーティング

## TODO（後続 PR）
- メッセージ送受信 (DynamoDB) と Bedrock 連携は Phase 3.1 で別 PR 化

Closes #1489