### PR TITLE
feat(backend): Phase 4 - Chat (rooms) を Go で実装

### DIFF
--- a/backend/internal/domain/chat.go
+++ b/backend/internal/domain/chat.go
@@ -1,0 +1,32 @@
+package domain
+
+import "time"
+
+// ChatRoom は 1 対 1 / グループのチャットルーム。
+type ChatRoom struct {
+	ID        uint64    `gorm:"primaryKey" json:"id"`
+	Name      string    `gorm:"column:name" json:"name"`
+	IsGroup   bool      `gorm:"column:is_group" json:"isGroup"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
+}
+
+func (ChatRoom) TableName() string { return "chat_rooms" }
+
+// ChatRoomMember はルームに所属するユーザー。
+type ChatRoomMember struct {
+	ID       uint64 `gorm:"primaryKey" json:"id"`
+	RoomID   uint64 `gorm:"column:room_id;index" json:"roomId"`
+	UserID   uint64 `gorm:"column:user_id;index" json:"userId"`
+	JoinedAt time.Time `gorm:"column:joined_at" json:"joinedAt"`
+}
+
+func (ChatRoomMember) TableName() string { return "chat_room_members" }
+
+// ChatMessage は DynamoDB に保存されるユーザー間メッセージ。
+type ChatMessage struct {
+	RoomID    uint64    `json:"roomId"`
+	MessageID string    `json:"messageId"`
+	SenderID  uint64    `json:"senderId"`
+	Content   string    `json:"content"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/backend/internal/handler/chat_handler.go
+++ b/backend/internal/handler/chat_handler.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type ChatHandler struct {
+	getRooms   *usecase.GetChatRoomsByUserIDUseCase
+	createRoom *usecase.CreateChatRoomUseCase
+}
+
+func NewChatHandler(g *usecase.GetChatRoomsByUserIDUseCase, c *usecase.CreateChatRoomUseCase) *ChatHandler {
+	return &ChatHandler{getRooms: g, createRoom: c}
+}
+
+func (h *ChatHandler) GetRooms(c *gin.Context) {
+	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	rows, err := h.getRooms.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+type createRoomReq struct {
+	Name    string `json:"name" binding:"required"`
+	IsGroup bool   `json:"isGroup"`
+}
+
+func (h *ChatHandler) CreateRoom(c *gin.Context) {
+	var req createRoomReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	created, err := h.createRoom.Execute(c.Request.Context(), req.Name, req.IsGroup)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, created)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -46,5 +46,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.GET("/ai-chat/sessions", aiHandler.GetSessions)
 	authed.POST("/ai-chat/sessions", aiHandler.CreateSession)
 
+	// Phase 4: ユーザー間チャット (ルーム CRUD)
+	chatRoomRepo := repository.NewChatRoomRepository(db)
+	chatHandler := NewChatHandler(
+		usecase.NewGetChatRoomsByUserIDUseCase(chatRoomRepo),
+		usecase.NewCreateChatRoomUseCase(chatRoomRepo),
+	)
+	authed.GET("/chat/rooms", chatHandler.GetRooms)
+	authed.POST("/chat/rooms", chatHandler.CreateRoom)
+
 	return r
 }

--- a/backend/internal/repository/chat_room_repository.go
+++ b/backend/internal/repository/chat_room_repository.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type ChatRoomRepository interface {
+	ListByUserID(ctx context.Context, userID uint64) ([]domain.ChatRoom, error)
+	Create(ctx context.Context, r *domain.ChatRoom) error
+}
+
+type chatRoomRepository struct{ db *gorm.DB }
+
+func NewChatRoomRepository(db *gorm.DB) ChatRoomRepository {
+	return &chatRoomRepository{db: db}
+}
+
+func (r *chatRoomRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.ChatRoom, error) {
+	var rows []domain.ChatRoom
+	err := r.db.WithContext(ctx).
+		Joins("JOIN chat_room_members m ON m.room_id = chat_rooms.id").
+		Where("m.user_id = ?", userID).
+		Order("chat_rooms.created_at DESC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *chatRoomRepository) Create(ctx context.Context, room *domain.ChatRoom) error {
+	return r.db.WithContext(ctx).Create(room).Error
+}

--- a/backend/internal/usecase/chat_usecase.go
+++ b/backend/internal/usecase/chat_usecase.go
@@ -1,0 +1,43 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type GetChatRoomsByUserIDUseCase struct {
+	rooms repository.ChatRoomRepository
+}
+
+func NewGetChatRoomsByUserIDUseCase(r repository.ChatRoomRepository) *GetChatRoomsByUserIDUseCase {
+	return &GetChatRoomsByUserIDUseCase{rooms: r}
+}
+
+func (u *GetChatRoomsByUserIDUseCase) Execute(ctx context.Context, userID uint64) ([]domain.ChatRoom, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.rooms.ListByUserID(ctx, userID)
+}
+
+type CreateChatRoomUseCase struct {
+	rooms repository.ChatRoomRepository
+}
+
+func NewCreateChatRoomUseCase(r repository.ChatRoomRepository) *CreateChatRoomUseCase {
+	return &CreateChatRoomUseCase{rooms: r}
+}
+
+func (u *CreateChatRoomUseCase) Execute(ctx context.Context, name string, isGroup bool) (*domain.ChatRoom, error) {
+	if name == "" {
+		return nil, errors.New("name is required")
+	}
+	r := &domain.ChatRoom{Name: name, IsGroup: isGroup}
+	if err := u.rooms.Create(ctx, r); err != nil {
+		return nil, err
+	}
+	return r, nil
+}

--- a/backend/internal/usecase/chat_usecase_test.go
+++ b/backend/internal/usecase/chat_usecase_test.go
@@ -1,0 +1,54 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubChatRoomRepo struct {
+	rows []domain.ChatRoom
+	err  error
+}
+
+func (s *stubChatRoomRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.ChatRoom, error) {
+	return s.rows, s.err
+}
+func (s *stubChatRoomRepo) Create(_ context.Context, r *domain.ChatRoom) error {
+	if s.err != nil {
+		return s.err
+	}
+	r.ID = 99
+	return nil
+}
+
+func TestGetChatRoomsByUserID_RequiresUserID(t *testing.T) {
+	uc := NewGetChatRoomsByUserIDUseCase(&stubChatRoomRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetChatRoomsByUserID_Returns(t *testing.T) {
+	uc := NewGetChatRoomsByUserIDUseCase(&stubChatRoomRepo{rows: []domain.ChatRoom{{ID: 1}}})
+	got, err := uc.Execute(context.Background(), 5)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("unexpected: rows=%v err=%v", got, err)
+	}
+}
+
+func TestCreateChatRoom_RequiresName(t *testing.T) {
+	uc := NewCreateChatRoomUseCase(&stubChatRoomRepo{})
+	if _, err := uc.Execute(context.Background(), "", false); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCreateChatRoom_AssignsID(t *testing.T) {
+	uc := NewCreateChatRoomUseCase(&stubChatRoomRepo{})
+	got, err := uc.Execute(context.Background(), "team-a", true)
+	if err != nil || got.ID != 99 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 4: ユーザー間チャットルームの基本 CRUD を Go で実装。

## 変更内容
- domain.ChatRoom / ChatRoomMember (GORM), ChatMessage (DynamoDB 用)
- ChatRoomRepository
- GetChatRoomsByUserIDUseCase / CreateChatRoomUseCase
- ChatHandler (GET/POST /chat/rooms)
- /api/v2/chat/* ルーティング

## TODO
- メッセージ送受信 (DynamoDB) は Phase 4.1 で別 PR

Closes #1490