### PR TITLE
feat(backend): Phase 5 - Profile を Go で実装

### DIFF
--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -1,0 +1,13 @@
+package domain
+
+import "time"
+
+// Profile は users テーブルとは別管理のプロフィール拡張情報。
+type Profile struct {
+	UserID         uint64    `gorm:"primaryKey;column:user_id" json:"userId"`
+	Bio            string    `gorm:"column:bio" json:"bio"`
+	AvatarURL      string    `gorm:"column:avatar_url" json:"avatarUrl"`
+	UpdatedAt      time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (Profile) TableName() string { return "profiles" }

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type ProfileHandler struct {
+	get    *usecase.GetProfileUseCase
+	update *usecase.UpdateProfileUseCase
+}
+
+func NewProfileHandler(g *usecase.GetProfileUseCase, u *usecase.UpdateProfileUseCase) *ProfileHandler {
+	return &ProfileHandler{get: g, update: u}
+}
+
+func (h *ProfileHandler) Get(c *gin.Context) {
+	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	p, err := h.get.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if p == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "profile_not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, p)
+}
+
+type updateProfileReq struct {
+	Bio       string `json:"bio"`
+	AvatarURL string `json:"avatarUrl"`
+}
+
+func (h *ProfileHandler) Update(c *gin.Context) {
+	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	var req updateProfileReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	updated, err := h.update.Execute(c.Request.Context(), usecase.UpdateProfileInput{
+		UserID: uid, Bio: req.Bio, AvatarURL: req.AvatarURL,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, updated)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -55,5 +55,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.GET("/chat/rooms", chatHandler.GetRooms)
 	authed.POST("/chat/rooms", chatHandler.CreateRoom)
 
+	// Phase 5: プロフィール
+	profileRepo := repository.NewProfileRepository(db)
+	profileHandler := NewProfileHandler(
+		usecase.NewGetProfileUseCase(profileRepo),
+		usecase.NewUpdateProfileUseCase(profileRepo),
+	)
+	authed.GET("/profile/:userId", profileHandler.Get)
+	authed.PUT("/profile/:userId", profileHandler.Update)
+
 	return r
 }

--- a/backend/internal/repository/profile_repository.go
+++ b/backend/internal/repository/profile_repository.go
@@ -1,0 +1,34 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type ProfileRepository interface {
+	FindByUserID(ctx context.Context, userID uint64) (*domain.Profile, error)
+	Upsert(ctx context.Context, p *domain.Profile) error
+}
+
+type profileRepository struct{ db *gorm.DB }
+
+func NewProfileRepository(db *gorm.DB) ProfileRepository { return &profileRepository{db: db} }
+
+func (r *profileRepository) FindByUserID(ctx context.Context, userID uint64) (*domain.Profile, error) {
+	var p domain.Profile
+	err := r.db.WithContext(ctx).Where("user_id = ?", userID).First(&p).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *profileRepository) Upsert(ctx context.Context, p *domain.Profile) error {
+	return r.db.WithContext(ctx).Save(p).Error
+}

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -1,0 +1,49 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type GetProfileUseCase struct {
+	profiles repository.ProfileRepository
+}
+
+func NewGetProfileUseCase(p repository.ProfileRepository) *GetProfileUseCase {
+	return &GetProfileUseCase{profiles: p}
+}
+
+func (u *GetProfileUseCase) Execute(ctx context.Context, userID uint64) (*domain.Profile, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.profiles.FindByUserID(ctx, userID)
+}
+
+type UpdateProfileUseCase struct {
+	profiles repository.ProfileRepository
+}
+
+func NewUpdateProfileUseCase(p repository.ProfileRepository) *UpdateProfileUseCase {
+	return &UpdateProfileUseCase{profiles: p}
+}
+
+type UpdateProfileInput struct {
+	UserID    uint64
+	Bio       string
+	AvatarURL string
+}
+
+func (u *UpdateProfileUseCase) Execute(ctx context.Context, in UpdateProfileInput) (*domain.Profile, error) {
+	if in.UserID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	p := &domain.Profile{UserID: in.UserID, Bio: in.Bio, AvatarURL: in.AvatarURL}
+	if err := u.profiles.Upsert(ctx, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}

--- a/backend/internal/usecase/profile_usecase_test.go
+++ b/backend/internal/usecase/profile_usecase_test.go
@@ -1,0 +1,58 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubProfileRepo struct {
+	p   *domain.Profile
+	err error
+}
+
+func (s *stubProfileRepo) FindByUserID(_ context.Context, _ uint64) (*domain.Profile, error) {
+	return s.p, s.err
+}
+func (s *stubProfileRepo) Upsert(_ context.Context, p *domain.Profile) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.p = p
+	return nil
+}
+
+func TestGetProfile_RequiresUserID(t *testing.T) {
+	uc := NewGetProfileUseCase(&stubProfileRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetProfile_NotFoundReturnsNil(t *testing.T) {
+	uc := NewGetProfileUseCase(&stubProfileRepo{p: nil})
+	got, err := uc.Execute(context.Background(), 1)
+	if err != nil || got != nil {
+		t.Fatalf("expected (nil,nil), got (%v,%v)", got, err)
+	}
+}
+
+func TestUpdateProfile_RequiresUserID(t *testing.T) {
+	uc := NewUpdateProfileUseCase(&stubProfileRepo{})
+	if _, err := uc.Execute(context.Background(), UpdateProfileInput{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpdateProfile_Persists(t *testing.T) {
+	repo := &stubProfileRepo{}
+	uc := NewUpdateProfileUseCase(repo)
+	got, err := uc.Execute(context.Background(), UpdateProfileInput{UserID: 1, Bio: "hi"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got.Bio != "hi" {
+		t.Fatalf("expected bio=hi, got %q", got.Bio)
+	}
+}


### PR DESCRIPTION
Phase 5: プロフィール拡張情報の取得・更新を Go で実装。

## 変更内容
- domain.Profile (GORM)
- ProfileRepository
- GetProfileUseCase / UpdateProfileUseCase
- ProfileHandler (GET/PUT /profile/:userId)

Closes #1491