### PR TITLE
feat(backend): Phase 6 - UserStats を Go で実装

### DIFF
--- a/backend/internal/domain/user_stats.go
+++ b/backend/internal/domain/user_stats.go
@@ -1,0 +1,11 @@
+package domain
+
+// UserStats は集計済みのユーザー統計。テーブル直結ではなく
+// セッション・スコアからの計算結果として扱う。
+type UserStats struct {
+	UserID         uint64  `json:"userId"`
+	TotalSessions  int     `json:"totalSessions"`
+	AverageScore   float64 `json:"averageScore"`
+	StreakDays     int     `json:"streakDays"`
+	LongestStreak  int     `json:"longestStreak"`
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -64,5 +64,11 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.GET("/profile/:userId", profileHandler.Get)
 	authed.PUT("/profile/:userId", profileHandler.Update)
 
+	// Phase 6: ユーザー統計
+	statsHandler := NewUserStatsHandler(
+		usecase.NewGetUserStatsUseCase(repository.NewUserStatsRepository(db)),
+	)
+	authed.GET("/user-stats/:userId", statsHandler.Get)
+
 	return r
 }

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type UserStatsHandler struct {
+	get *usecase.GetUserStatsUseCase
+}
+
+func NewUserStatsHandler(g *usecase.GetUserStatsUseCase) *UserStatsHandler {
+	return &UserStatsHandler{get: g}
+}
+
+func (h *UserStatsHandler) Get(c *gin.Context) {
+	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	stats, err := h.get.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, stats)
+}

--- a/backend/internal/repository/user_stats_repository.go
+++ b/backend/internal/repository/user_stats_repository.go
@@ -1,0 +1,32 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type UserStatsRepository interface {
+	Compute(ctx context.Context, userID uint64) (*domain.UserStats, error)
+}
+
+type userStatsRepository struct{ db *gorm.DB }
+
+func NewUserStatsRepository(db *gorm.DB) UserStatsRepository { return &userStatsRepository{db: db} }
+
+// Compute は ai_chat_sessions と score_cards から集計。
+// SQL は最小限に留め、追加のメトリクスは後続 PR で拡張する。
+func (r *userStatsRepository) Compute(ctx context.Context, userID uint64) (*domain.UserStats, error) {
+	stats := &domain.UserStats{UserID: userID}
+	row := r.db.WithContext(ctx).Raw(
+		"SELECT COUNT(*), COALESCE(AVG(overall_score),0) FROM score_cards WHERE user_id = ?",
+		userID,
+	).Row()
+	var avg float64
+	if err := row.Scan(&stats.TotalSessions, &avg); err != nil {
+		return nil, err
+	}
+	stats.AverageScore = avg
+	return stats, nil
+}

--- a/backend/internal/usecase/user_stats_usecase.go
+++ b/backend/internal/usecase/user_stats_usecase.go
@@ -1,0 +1,24 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type GetUserStatsUseCase struct {
+	stats repository.UserStatsRepository
+}
+
+func NewGetUserStatsUseCase(s repository.UserStatsRepository) *GetUserStatsUseCase {
+	return &GetUserStatsUseCase{stats: s}
+}
+
+func (u *GetUserStatsUseCase) Execute(ctx context.Context, userID uint64) (*domain.UserStats, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.stats.Compute(ctx, userID)
+}

--- a/backend/internal/usecase/user_stats_usecase_test.go
+++ b/backend/internal/usecase/user_stats_usecase_test.go
@@ -1,0 +1,40 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubUserStatsRepo struct {
+	stats *domain.UserStats
+	err   error
+}
+
+func (s *stubUserStatsRepo) Compute(_ context.Context, _ uint64) (*domain.UserStats, error) {
+	return s.stats, s.err
+}
+
+func TestGetUserStats_RequiresUserID(t *testing.T) {
+	uc := NewGetUserStatsUseCase(&stubUserStatsRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetUserStats_PropagatesError(t *testing.T) {
+	uc := NewGetUserStatsUseCase(&stubUserStatsRepo{err: errors.New("db")})
+	if _, err := uc.Execute(context.Background(), 1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetUserStats_Returns(t *testing.T) {
+	uc := NewGetUserStatsUseCase(&stubUserStatsRepo{stats: &domain.UserStats{UserID: 1, TotalSessions: 3}})
+	got, err := uc.Execute(context.Background(), 1)
+	if err != nil || got.TotalSessions != 3 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 6: ユーザー統計集計 API を Go で実装。

## 変更内容
- domain.UserStats / UserStatsRepository.Compute
- GetUserStatsUseCase
- UserStatsHandler GET /api/v2/user-stats/:userId

Closes #1492