### PR TITLE
feat(backend): Phase 7 - Practice (scenarios) を Go で実装

### DIFF
--- a/backend/internal/domain/practice.go
+++ b/backend/internal/domain/practice.go
@@ -1,0 +1,18 @@
+package domain
+
+import "time"
+
+// PracticeScenario は AI 練習モードのロールプレイ用シナリオ。
+// Spring Boot の entity.PracticeScenario に相当。
+type PracticeScenario struct {
+	ID            uint64    `gorm:"primaryKey" json:"id"`
+	Title         string    `gorm:"column:title" json:"title"`
+	Description   string    `gorm:"column:description" json:"description"`
+	Category      string    `gorm:"column:category" json:"category"`
+	DifficultyLv  int       `gorm:"column:difficulty_level" json:"difficultyLevel"`
+	SystemPrompt  string    `gorm:"column:system_prompt" json:"-"`
+	IsActive      bool      `gorm:"column:is_active" json:"isActive"`
+	CreatedAt     time.Time `gorm:"column:created_at" json:"createdAt"`
+}
+
+func (PracticeScenario) TableName() string { return "practice_scenarios" }

--- a/backend/internal/handler/practice_handler.go
+++ b/backend/internal/handler/practice_handler.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type PracticeHandler struct {
+	list *usecase.ListPracticeScenariosUseCase
+	get  *usecase.GetPracticeScenarioUseCase
+}
+
+func NewPracticeHandler(l *usecase.ListPracticeScenariosUseCase, g *usecase.GetPracticeScenarioUseCase) *PracticeHandler {
+	return &PracticeHandler{list: l, get: g}
+}
+
+func (h *PracticeHandler) List(c *gin.Context) {
+	rows, err := h.list.Execute(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+func (h *PracticeHandler) Get(c *gin.Context) {
+	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
+	s, err := h.get.Execute(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if s == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, s)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -70,5 +70,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	)
 	authed.GET("/user-stats/:userId", statsHandler.Get)
 
+	// Phase 7: 練習モード (シナリオ)
+	practiceRepo := repository.NewPracticeScenarioRepository(db)
+	practiceHandler := NewPracticeHandler(
+		usecase.NewListPracticeScenariosUseCase(practiceRepo),
+		usecase.NewGetPracticeScenarioUseCase(practiceRepo),
+	)
+	authed.GET("/practice/scenarios", practiceHandler.List)
+	authed.GET("/practice/scenarios/:id", practiceHandler.Get)
+
 	return r
 }

--- a/backend/internal/repository/practice_scenario_repository.go
+++ b/backend/internal/repository/practice_scenario_repository.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type PracticeScenarioRepository interface {
+	ListActive(ctx context.Context) ([]domain.PracticeScenario, error)
+	FindByID(ctx context.Context, id uint64) (*domain.PracticeScenario, error)
+}
+
+type practiceScenarioRepository struct{ db *gorm.DB }
+
+func NewPracticeScenarioRepository(db *gorm.DB) PracticeScenarioRepository {
+	return &practiceScenarioRepository{db: db}
+}
+
+func (r *practiceScenarioRepository) ListActive(ctx context.Context) ([]domain.PracticeScenario, error) {
+	var rows []domain.PracticeScenario
+	err := r.db.WithContext(ctx).
+		Where("is_active = ?", true).
+		Order("difficulty_level, id").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *practiceScenarioRepository) FindByID(ctx context.Context, id uint64) (*domain.PracticeScenario, error) {
+	var s domain.PracticeScenario
+	if err := r.db.WithContext(ctx).First(&s, id).Error; err != nil {
+		return nil, err
+	}
+	return &s, nil
+}

--- a/backend/internal/usecase/practice_usecase.go
+++ b/backend/internal/usecase/practice_usecase.go
@@ -1,0 +1,36 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type ListPracticeScenariosUseCase struct {
+	repo repository.PracticeScenarioRepository
+}
+
+func NewListPracticeScenariosUseCase(r repository.PracticeScenarioRepository) *ListPracticeScenariosUseCase {
+	return &ListPracticeScenariosUseCase{repo: r}
+}
+
+func (u *ListPracticeScenariosUseCase) Execute(ctx context.Context) ([]domain.PracticeScenario, error) {
+	return u.repo.ListActive(ctx)
+}
+
+type GetPracticeScenarioUseCase struct {
+	repo repository.PracticeScenarioRepository
+}
+
+func NewGetPracticeScenarioUseCase(r repository.PracticeScenarioRepository) *GetPracticeScenarioUseCase {
+	return &GetPracticeScenarioUseCase{repo: r}
+}
+
+func (u *GetPracticeScenarioUseCase) Execute(ctx context.Context, id uint64) (*domain.PracticeScenario, error) {
+	if id == 0 {
+		return nil, errors.New("id is required")
+	}
+	return u.repo.FindByID(ctx, id)
+}

--- a/backend/internal/usecase/practice_usecase_test.go
+++ b/backend/internal/usecase/practice_usecase_test.go
@@ -1,0 +1,44 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubPracticeRepo struct {
+	rows []domain.PracticeScenario
+	one  *domain.PracticeScenario
+	err  error
+}
+
+func (s *stubPracticeRepo) ListActive(_ context.Context) ([]domain.PracticeScenario, error) {
+	return s.rows, s.err
+}
+func (s *stubPracticeRepo) FindByID(_ context.Context, _ uint64) (*domain.PracticeScenario, error) {
+	return s.one, s.err
+}
+
+func TestListPracticeScenarios(t *testing.T) {
+	uc := NewListPracticeScenariosUseCase(&stubPracticeRepo{rows: []domain.PracticeScenario{{ID: 1}}})
+	got, err := uc.Execute(context.Background())
+	if err != nil || len(got) != 1 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}
+
+func TestGetPracticeScenario_RequiresID(t *testing.T) {
+	uc := NewGetPracticeScenarioUseCase(&stubPracticeRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetPracticeScenario_Returns(t *testing.T) {
+	uc := NewGetPracticeScenarioUseCase(&stubPracticeRepo{one: &domain.PracticeScenario{ID: 5}})
+	got, err := uc.Execute(context.Background(), 5)
+	if err != nil || got.ID != 5 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 7: 練習モード用シナリオ一覧・詳細取得 API を Go で実装。\n\nCloses #1493