### PR TITLE
feat(backend): Phase 9 - SharedSession を Go で実装

### DIFF
--- a/backend/internal/domain/shared_session.go
+++ b/backend/internal/domain/shared_session.go
@@ -1,0 +1,16 @@
+package domain
+
+import "time"
+
+// SharedSession はコミュニティに共有された AI 会話セッションのメタデータ。
+type SharedSession struct {
+	ID            uint64    `gorm:"primaryKey" json:"id"`
+	OwnerID       uint64    `gorm:"column:owner_id;index" json:"ownerId"`
+	SessionID     uint64    `gorm:"column:session_id;index" json:"sessionId"`
+	Title         string    `gorm:"column:title" json:"title"`
+	Description   string    `gorm:"column:description" json:"description"`
+	IsPublic      bool      `gorm:"column:is_public" json:"isPublic"`
+	CreatedAt     time.Time `gorm:"column:created_at" json:"createdAt"`
+}
+
+func (SharedSession) TableName() string { return "shared_sessions" }

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -90,5 +90,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.POST("/scenario-bookmarks", bookmarkHandler.Add)
 	authed.DELETE("/scenario-bookmarks/:userId/:scenarioId", bookmarkHandler.Remove)
 
+	// Phase 9: 共有 AI 会話セッション
+	sharedRepo := repository.NewSharedSessionRepository(db)
+	sharedHandler := NewSharedSessionHandler(
+		usecase.NewListSharedSessionsUseCase(sharedRepo),
+		usecase.NewCreateSharedSessionUseCase(sharedRepo),
+	)
+	authed.GET("/shared-sessions", sharedHandler.List)
+	authed.POST("/shared-sessions", sharedHandler.Create)
+
 	return r
 }

--- a/backend/internal/handler/shared_session_handler.go
+++ b/backend/internal/handler/shared_session_handler.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type SharedSessionHandler struct {
+	list   *usecase.ListSharedSessionsUseCase
+	create *usecase.CreateSharedSessionUseCase
+}
+
+func NewSharedSessionHandler(l *usecase.ListSharedSessionsUseCase, c *usecase.CreateSharedSessionUseCase) *SharedSessionHandler {
+	return &SharedSessionHandler{list: l, create: c}
+}
+
+func (h *SharedSessionHandler) List(c *gin.Context) {
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	rows, err := h.list.Execute(c.Request.Context(), limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+type createSharedReq struct {
+	OwnerID     uint64 `json:"ownerId" binding:"required"`
+	SessionID   uint64 `json:"sessionId" binding:"required"`
+	Title       string `json:"title" binding:"required"`
+	Description string `json:"description"`
+	IsPublic    bool   `json:"isPublic"`
+}
+
+func (h *SharedSessionHandler) Create(c *gin.Context) {
+	var req createSharedReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	got, err := h.create.Execute(c.Request.Context(), usecase.CreateSharedSessionInput{
+		OwnerID: req.OwnerID, SessionID: req.SessionID,
+		Title: req.Title, Description: req.Description, IsPublic: req.IsPublic,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, got)
+}

--- a/backend/internal/repository/shared_session_repository.go
+++ b/backend/internal/repository/shared_session_repository.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type SharedSessionRepository interface {
+	ListPublic(ctx context.Context, limit int) ([]domain.SharedSession, error)
+	Create(ctx context.Context, s *domain.SharedSession) error
+}
+
+type sharedSessionRepository struct{ db *gorm.DB }
+
+func NewSharedSessionRepository(db *gorm.DB) SharedSessionRepository {
+	return &sharedSessionRepository{db: db}
+}
+
+func (r *sharedSessionRepository) ListPublic(ctx context.Context, limit int) ([]domain.SharedSession, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 50
+	}
+	var rows []domain.SharedSession
+	err := r.db.WithContext(ctx).
+		Where("is_public = ?", true).
+		Order("created_at DESC").
+		Limit(limit).
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *sharedSessionRepository) Create(ctx context.Context, s *domain.SharedSession) error {
+	return r.db.WithContext(ctx).Create(s).Error
+}

--- a/backend/internal/usecase/shared_session_usecase.go
+++ b/backend/internal/usecase/shared_session_usecase.go
@@ -1,0 +1,54 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type ListSharedSessionsUseCase struct {
+	repo repository.SharedSessionRepository
+}
+
+func NewListSharedSessionsUseCase(r repository.SharedSessionRepository) *ListSharedSessionsUseCase {
+	return &ListSharedSessionsUseCase{repo: r}
+}
+
+func (u *ListSharedSessionsUseCase) Execute(ctx context.Context, limit int) ([]domain.SharedSession, error) {
+	return u.repo.ListPublic(ctx, limit)
+}
+
+type CreateSharedSessionUseCase struct {
+	repo repository.SharedSessionRepository
+}
+
+func NewCreateSharedSessionUseCase(r repository.SharedSessionRepository) *CreateSharedSessionUseCase {
+	return &CreateSharedSessionUseCase{repo: r}
+}
+
+type CreateSharedSessionInput struct {
+	OwnerID     uint64
+	SessionID   uint64
+	Title       string
+	Description string
+	IsPublic    bool
+}
+
+func (u *CreateSharedSessionUseCase) Execute(ctx context.Context, in CreateSharedSessionInput) (*domain.SharedSession, error) {
+	if in.OwnerID == 0 || in.SessionID == 0 {
+		return nil, errors.New("ownerID and sessionID are required")
+	}
+	if in.Title == "" {
+		return nil, errors.New("title is required")
+	}
+	s := &domain.SharedSession{
+		OwnerID: in.OwnerID, SessionID: in.SessionID,
+		Title: in.Title, Description: in.Description, IsPublic: in.IsPublic,
+	}
+	if err := u.repo.Create(ctx, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}

--- a/backend/internal/usecase/shared_session_usecase_test.go
+++ b/backend/internal/usecase/shared_session_usecase_test.go
@@ -1,0 +1,50 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubSharedRepo struct {
+	rows []domain.SharedSession
+	err  error
+}
+
+func (s *stubSharedRepo) ListPublic(_ context.Context, _ int) ([]domain.SharedSession, error) {
+	return s.rows, s.err
+}
+func (s *stubSharedRepo) Create(_ context.Context, x *domain.SharedSession) error {
+	if s.err != nil {
+		return s.err
+	}
+	x.ID = 11
+	return nil
+}
+
+func TestListSharedSessions(t *testing.T) {
+	uc := NewListSharedSessionsUseCase(&stubSharedRepo{rows: []domain.SharedSession{{ID: 1}}})
+	got, err := uc.Execute(context.Background(), 10)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}
+
+func TestCreateSharedSession_Validates(t *testing.T) {
+	uc := NewCreateSharedSessionUseCase(&stubSharedRepo{})
+	if _, err := uc.Execute(context.Background(), CreateSharedSessionInput{OwnerID: 1, SessionID: 2}); err == nil {
+		t.Fatal("expected error for empty title")
+	}
+	if _, err := uc.Execute(context.Background(), CreateSharedSessionInput{Title: "x"}); err == nil {
+		t.Fatal("expected error for missing IDs")
+	}
+}
+
+func TestCreateSharedSession_AssignsID(t *testing.T) {
+	uc := NewCreateSharedSessionUseCase(&stubSharedRepo{})
+	got, err := uc.Execute(context.Background(), CreateSharedSessionInput{OwnerID: 1, SessionID: 2, Title: "x"})
+	if err != nil || got.ID != 11 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 9: 共有 AI 会話セッションのリスト/作成 API。Closes #1495