### PR TITLE
feat(backend): Phase 11 - NoteImage を Go で実装

### DIFF
--- a/backend/internal/domain/note_image.go
+++ b/backend/internal/domain/note_image.go
@@ -1,0 +1,8 @@
+package domain
+
+// NoteImageUploadURL は S3 への直接アップロード用に発行する署名付き URL を表す。
+type NoteImageUploadURL struct {
+	URL       string `json:"url"`
+	Key       string `json:"key"`
+	ExpiresIn int    `json:"expiresIn"`
+}

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type NoteImageHandler struct {
+	issue *usecase.IssueNoteImageUploadURLUseCase
+}
+
+func NewNoteImageHandler(i *usecase.IssueNoteImageUploadURLUseCase) *NoteImageHandler {
+	return &NoteImageHandler{issue: i}
+}
+
+type issueUploadURLReq struct {
+	UserID      uint64 `json:"userId" binding:"required"`
+	ContentType string `json:"contentType"`
+}
+
+func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
+	var req issueUploadURLReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	got, err := h.issue.Execute(c.Request.Context(), req.UserID, req.ContentType)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, got)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -112,5 +112,13 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.PUT("/notes/:id", noteHandler.Update)
 	authed.DELETE("/notes/:id", noteHandler.Delete)
 
+	// Phase 11: Note image (S3 presigned upload)
+	noteImageHandler := NewNoteImageHandler(
+		usecase.NewIssueNoteImageUploadURLUseCase(
+			repository.NewStubNoteImagePresigner("frestyle-prod-note-images"),
+		),
+	)
+	authed.POST("/notes/images/upload-url", noteImageHandler.IssueUploadURL)
+
 	return r
 }

--- a/backend/internal/repository/note_image_repository.go
+++ b/backend/internal/repository/note_image_repository.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// NoteImagePresigner は S3 への PUT 用 presigned URL を発行する。
+// AWS SDK 連携は Phase 11.1 で実装予定。Phase 11 ではモック生成のみ。
+type NoteImagePresigner interface {
+	Generate(ctx context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error)
+}
+
+type stubPresigner struct{ bucket string }
+
+func NewStubNoteImagePresigner(bucket string) NoteImagePresigner {
+	return &stubPresigner{bucket: bucket}
+}
+
+func (p *stubPresigner) Generate(_ context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error) {
+	if userID == 0 {
+		return nil, fmt.Errorf("userID is required")
+	}
+	if contentType == "" {
+		contentType = "image/png"
+	}
+	key := fmt.Sprintf("notes/%d/%d.bin", userID, time.Now().UnixNano())
+	return &domain.NoteImageUploadURL{
+		URL:       fmt.Sprintf("https://%s.s3.amazonaws.com/%s?X-Amz-Stub=1", p.bucket, key),
+		Key:       key,
+		ExpiresIn: 600,
+	}, nil
+}

--- a/backend/internal/usecase/note_image_usecase.go
+++ b/backend/internal/usecase/note_image_usecase.go
@@ -1,0 +1,24 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type IssueNoteImageUploadURLUseCase struct {
+	presigner repository.NoteImagePresigner
+}
+
+func NewIssueNoteImageUploadURLUseCase(p repository.NoteImagePresigner) *IssueNoteImageUploadURLUseCase {
+	return &IssueNoteImageUploadURLUseCase{presigner: p}
+}
+
+func (u *IssueNoteImageUploadURLUseCase) Execute(ctx context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.presigner.Generate(ctx, userID, contentType)
+}

--- a/backend/internal/usecase/note_image_usecase_test.go
+++ b/backend/internal/usecase/note_image_usecase_test.go
@@ -1,0 +1,34 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubPresigner struct {
+	url *domain.NoteImageUploadURL
+	err error
+}
+
+func (s *stubPresigner) Generate(_ context.Context, _ uint64, _ string) (*domain.NoteImageUploadURL, error) {
+	return s.url, s.err
+}
+
+func TestIssueNoteImageUploadURL_RequiresUserID(t *testing.T) {
+	uc := NewIssueNoteImageUploadURLUseCase(&stubPresigner{})
+	if _, err := uc.Execute(context.Background(), 0, "image/png"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIssueNoteImageUploadURL_Returns(t *testing.T) {
+	uc := NewIssueNoteImageUploadURLUseCase(&stubPresigner{
+		url: &domain.NoteImageUploadURL{URL: "https://example", Key: "k", ExpiresIn: 60},
+	})
+	got, err := uc.Execute(context.Background(), 1, "image/png")
+	if err != nil || got.URL == "" {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 11: ノート画像アップロード用の presigned URL 発行 API を Go で実装。実 S3 連携は Phase 11.1 で別 PR 化。Closes #1497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new API endpoint for authenticated users to request presigned upload URLs for note images. These secure URLs include time-limited access and can be used for direct image uploads.

## Tests
* Added unit tests for the note image upload URL generation feature, covering validation scenarios and successful response cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->