### PR TITLE
feat(backend): Phase 12 - SessionNote を Go で実装

### DIFF
--- a/backend/internal/domain/session_note.go
+++ b/backend/internal/domain/session_note.go
@@ -1,0 +1,15 @@
+package domain
+
+import "time"
+
+// SessionNote は AI チャットセッション固有のメモ。
+type SessionNote struct {
+	ID        uint64    `gorm:"primaryKey" json:"id"`
+	SessionID uint64    `gorm:"column:session_id;index" json:"sessionId"`
+	UserID    uint64    `gorm:"column:user_id;index" json:"userId"`
+	Content   string    `gorm:"column:content" json:"content"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (SessionNote) TableName() string { return "session_notes" }

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -120,5 +120,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	)
 	authed.POST("/notes/images/upload-url", noteImageHandler.IssueUploadURL)
 
+	// Phase 12: SessionNote (セッション固有ノート)
+	sessionNoteRepo := repository.NewSessionNoteRepository(db)
+	sessionNoteHandler := NewSessionNoteHandler(
+		usecase.NewGetSessionNoteUseCase(sessionNoteRepo),
+		usecase.NewUpsertSessionNoteUseCase(sessionNoteRepo),
+	)
+	authed.GET("/sessions/:sessionId/note", sessionNoteHandler.Get)
+	authed.PUT("/sessions/:sessionId/note", sessionNoteHandler.Upsert)
+
 	return r
 }

--- a/backend/internal/handler/session_note_handler.go
+++ b/backend/internal/handler/session_note_handler.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type SessionNoteHandler struct {
+	get    *usecase.GetSessionNoteUseCase
+	upsert *usecase.UpsertSessionNoteUseCase
+}
+
+func NewSessionNoteHandler(g *usecase.GetSessionNoteUseCase, u *usecase.UpsertSessionNoteUseCase) *SessionNoteHandler {
+	return &SessionNoteHandler{get: g, upsert: u}
+}
+
+func (h *SessionNoteHandler) Get(c *gin.Context) {
+	sid, _ := strconv.ParseUint(c.Param("sessionId"), 10, 64)
+	n, err := h.get.Execute(c.Request.Context(), sid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if n == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		return
+	}
+	c.JSON(http.StatusOK, n)
+}
+
+type sessionNoteUpsertReq struct {
+	UserID  uint64 `json:"userId" binding:"required"`
+	Content string `json:"content"`
+}
+
+func (h *SessionNoteHandler) Upsert(c *gin.Context) {
+	sid, _ := strconv.ParseUint(c.Param("sessionId"), 10, 64)
+	var req sessionNoteUpsertReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	got, err := h.upsert.Execute(c.Request.Context(), usecase.UpsertSessionNoteInput{
+		SessionID: sid, UserID: req.UserID, Content: req.Content,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, got)
+}

--- a/backend/internal/repository/session_note_repository.go
+++ b/backend/internal/repository/session_note_repository.go
@@ -1,0 +1,36 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type SessionNoteRepository interface {
+	FindBySessionID(ctx context.Context, sessionID uint64) (*domain.SessionNote, error)
+	Upsert(ctx context.Context, n *domain.SessionNote) error
+}
+
+type sessionNoteRepository struct{ db *gorm.DB }
+
+func NewSessionNoteRepository(db *gorm.DB) SessionNoteRepository {
+	return &sessionNoteRepository{db: db}
+}
+
+func (r *sessionNoteRepository) FindBySessionID(ctx context.Context, sessionID uint64) (*domain.SessionNote, error) {
+	var n domain.SessionNote
+	err := r.db.WithContext(ctx).Where("session_id = ?", sessionID).First(&n).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &n, nil
+}
+
+func (r *sessionNoteRepository) Upsert(ctx context.Context, n *domain.SessionNote) error {
+	return r.db.WithContext(ctx).Save(n).Error
+}

--- a/backend/internal/usecase/session_note_usecase.go
+++ b/backend/internal/usecase/session_note_usecase.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type GetSessionNoteUseCase struct{ repo repository.SessionNoteRepository }
+
+func NewGetSessionNoteUseCase(r repository.SessionNoteRepository) *GetSessionNoteUseCase {
+	return &GetSessionNoteUseCase{repo: r}
+}
+
+func (u *GetSessionNoteUseCase) Execute(ctx context.Context, sessionID uint64) (*domain.SessionNote, error) {
+	if sessionID == 0 {
+		return nil, errors.New("sessionID is required")
+	}
+	return u.repo.FindBySessionID(ctx, sessionID)
+}
+
+type UpsertSessionNoteUseCase struct{ repo repository.SessionNoteRepository }
+
+func NewUpsertSessionNoteUseCase(r repository.SessionNoteRepository) *UpsertSessionNoteUseCase {
+	return &UpsertSessionNoteUseCase{repo: r}
+}
+
+type UpsertSessionNoteInput struct {
+	SessionID uint64
+	UserID    uint64
+	Content   string
+}
+
+func (u *UpsertSessionNoteUseCase) Execute(ctx context.Context, in UpsertSessionNoteInput) (*domain.SessionNote, error) {
+	if in.SessionID == 0 || in.UserID == 0 {
+		return nil, errors.New("sessionID and userID are required")
+	}
+	n := &domain.SessionNote{SessionID: in.SessionID, UserID: in.UserID, Content: in.Content}
+	if err := u.repo.Upsert(ctx, n); err != nil {
+		return nil, err
+	}
+	return n, nil
+}

--- a/backend/internal/usecase/session_note_usecase_test.go
+++ b/backend/internal/usecase/session_note_usecase_test.go
@@ -1,0 +1,47 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubSessionNoteRepo struct {
+	n   *domain.SessionNote
+	err error
+}
+
+func (s *stubSessionNoteRepo) FindBySessionID(_ context.Context, _ uint64) (*domain.SessionNote, error) {
+	return s.n, s.err
+}
+func (s *stubSessionNoteRepo) Upsert(_ context.Context, n *domain.SessionNote) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.n = n
+	return nil
+}
+
+func TestGetSessionNote_RequiresSessionID(t *testing.T) {
+	uc := NewGetSessionNoteUseCase(&stubSessionNoteRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpsertSessionNote_Validates(t *testing.T) {
+	uc := NewUpsertSessionNoteUseCase(&stubSessionNoteRepo{})
+	if _, err := uc.Execute(context.Background(), UpsertSessionNoteInput{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUpsertSessionNote_Persists(t *testing.T) {
+	repo := &stubSessionNoteRepo{}
+	uc := NewUpsertSessionNoteUseCase(repo)
+	got, err := uc.Execute(context.Background(), UpsertSessionNoteInput{SessionID: 1, UserID: 2, Content: "hello"})
+	if err != nil || got.Content != "hello" {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 12: AI チャットセッション固有メモの GET/Upsert API を Go で実装。Closes #1498