### PR TITLE
feat(backend): Phase 15 - ScoreTrend を Go で実装

### DIFF
--- a/backend/internal/domain/score_trend.go
+++ b/backend/internal/domain/score_trend.go
@@ -1,0 +1,13 @@
+package domain
+
+// ScoreTrendPoint は時系列でのスコア推移 1 ポイント。
+type ScoreTrendPoint struct {
+	Date         string  `json:"date"`
+	OverallScore float64 `json:"overallScore"`
+}
+
+// ScoreTrend はユーザーのスコア推移。
+type ScoreTrend struct {
+	UserID uint64            `json:"userId"`
+	Points []ScoreTrendPoint `json:"points"`
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -147,5 +147,11 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.GET("/score-goals/:userId", scoreGoalHandler.Get)
 	authed.PUT("/score-goals/:userId", scoreGoalHandler.Upsert)
 
+	// Phase 15: ScoreTrend
+	scoreTrendHandler := NewScoreTrendHandler(
+		usecase.NewGetScoreTrendUseCase(repository.NewScoreTrendRepository(db)),
+	)
+	authed.GET("/score-trends/:userId", scoreTrendHandler.Get)
+
 	return r
 }

--- a/backend/internal/handler/score_trend_handler.go
+++ b/backend/internal/handler/score_trend_handler.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type ScoreTrendHandler struct {
+	get *usecase.GetScoreTrendUseCase
+}
+
+func NewScoreTrendHandler(g *usecase.GetScoreTrendUseCase) *ScoreTrendHandler {
+	return &ScoreTrendHandler{get: g}
+}
+
+func (h *ScoreTrendHandler) Get(c *gin.Context) {
+	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	days, _ := strconv.Atoi(c.DefaultQuery("days", "30"))
+	trend, err := h.get.Execute(c.Request.Context(), uid, days)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, trend)
+}

--- a/backend/internal/repository/score_trend_repository.go
+++ b/backend/internal/repository/score_trend_repository.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type ScoreTrendRepository interface {
+	AggregateDaily(ctx context.Context, userID uint64, days int) ([]domain.ScoreTrendPoint, error)
+}
+
+type scoreTrendRepository struct{ db *gorm.DB }
+
+func NewScoreTrendRepository(db *gorm.DB) ScoreTrendRepository { return &scoreTrendRepository{db: db} }
+
+func (r *scoreTrendRepository) AggregateDaily(ctx context.Context, userID uint64, days int) ([]domain.ScoreTrendPoint, error) {
+	if days <= 0 || days > 365 {
+		days = 30
+	}
+	rows, err := r.db.WithContext(ctx).Raw(`
+		SELECT to_char(created_at, 'YYYY-MM-DD') AS d, AVG(overall_score) AS avg_score
+		FROM score_cards
+		WHERE user_id = ? AND created_at >= NOW() - INTERVAL '1 day' * ?
+		GROUP BY d
+		ORDER BY d
+	`, userID, days).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var points []domain.ScoreTrendPoint
+	for rows.Next() {
+		var p domain.ScoreTrendPoint
+		if err := rows.Scan(&p.Date, &p.OverallScore); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, nil
+}

--- a/backend/internal/usecase/score_trend_usecase.go
+++ b/backend/internal/usecase/score_trend_usecase.go
@@ -1,0 +1,26 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type GetScoreTrendUseCase struct{ repo repository.ScoreTrendRepository }
+
+func NewGetScoreTrendUseCase(r repository.ScoreTrendRepository) *GetScoreTrendUseCase {
+	return &GetScoreTrendUseCase{repo: r}
+}
+
+func (u *GetScoreTrendUseCase) Execute(ctx context.Context, userID uint64, days int) (*domain.ScoreTrend, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	points, err := u.repo.AggregateDaily(ctx, userID, days)
+	if err != nil {
+		return nil, err
+	}
+	return &domain.ScoreTrend{UserID: userID, Points: points}, nil
+}

--- a/backend/internal/usecase/score_trend_usecase_test.go
+++ b/backend/internal/usecase/score_trend_usecase_test.go
@@ -1,0 +1,34 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubScoreTrendRepo struct {
+	pts []domain.ScoreTrendPoint
+	err error
+}
+
+func (s *stubScoreTrendRepo) AggregateDaily(_ context.Context, _ uint64, _ int) ([]domain.ScoreTrendPoint, error) {
+	return s.pts, s.err
+}
+
+func TestGetScoreTrend_RequiresUserID(t *testing.T) {
+	uc := NewGetScoreTrendUseCase(&stubScoreTrendRepo{})
+	if _, err := uc.Execute(context.Background(), 0, 30); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGetScoreTrend_Wraps(t *testing.T) {
+	uc := NewGetScoreTrendUseCase(&stubScoreTrendRepo{
+		pts: []domain.ScoreTrendPoint{{Date: "2026-04-26", OverallScore: 7.5}},
+	})
+	got, err := uc.Execute(context.Background(), 1, 30)
+	if err != nil || len(got.Points) != 1 || got.UserID != 1 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}


### PR DESCRIPTION
Phase 15: スコア推移 (日次集計) API を Go で実装。Closes #1501