### PR TITLE
feat(backend): Phase 16 - Ranking を Go で実装

### DIFF
--- a/backend/internal/domain/ranking.go
+++ b/backend/internal/domain/ranking.go
@@ -1,0 +1,9 @@
+package domain
+
+// RankingEntry はランキング 1 行。
+type RankingEntry struct {
+	UserID       uint64  `json:"userId"`
+	DisplayName  string  `json:"displayName"`
+	AverageScore float64 `json:"averageScore"`
+	Rank         int     `json:"rank"`
+}

--- a/backend/internal/handler/ranking_handler.go
+++ b/backend/internal/handler/ranking_handler.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type RankingHandler struct {
+	get *usecase.GetRankingUseCase
+}
+
+func NewRankingHandler(g *usecase.GetRankingUseCase) *RankingHandler {
+	return &RankingHandler{get: g}
+}
+
+func (h *RankingHandler) Get(c *gin.Context) {
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	entries, err := h.get.Execute(c.Request.Context(), limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, entries)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -153,5 +153,11 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	)
 	authed.GET("/score-trends/:userId", scoreTrendHandler.Get)
 
+	// Phase 16: Ranking
+	rankingHandler := NewRankingHandler(
+		usecase.NewGetRankingUseCase(repository.NewRankingRepository(db)),
+	)
+	authed.GET("/rankings", rankingHandler.Get)
+
 	return r
 }

--- a/backend/internal/repository/ranking_repository.go
+++ b/backend/internal/repository/ranking_repository.go
@@ -1,0 +1,48 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type RankingRepository interface {
+	TopByAverageScore(ctx context.Context, limit int) ([]domain.RankingEntry, error)
+}
+
+type rankingRepository struct{ db *gorm.DB }
+
+func NewRankingRepository(db *gorm.DB) RankingRepository { return &rankingRepository{db: db} }
+
+func (r *rankingRepository) TopByAverageScore(ctx context.Context, limit int) ([]domain.RankingEntry, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	rows, err := r.db.WithContext(ctx).Raw(`
+		SELECT u.id, u.display_name, COALESCE(AVG(sc.overall_score), 0) AS avg_score
+		FROM users u
+		LEFT JOIN score_cards sc ON sc.user_id = u.id
+		WHERE u.deleted_at IS NULL
+		GROUP BY u.id, u.display_name
+		ORDER BY avg_score DESC
+		LIMIT ?
+	`, limit).Rows()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []domain.RankingEntry
+	rank := 1
+	for rows.Next() {
+		var e domain.RankingEntry
+		if err := rows.Scan(&e.UserID, &e.DisplayName, &e.AverageScore); err != nil {
+			return nil, err
+		}
+		e.Rank = rank
+		rank++
+		entries = append(entries, e)
+	}
+	return entries, nil
+}

--- a/backend/internal/usecase/ranking_usecase.go
+++ b/backend/internal/usecase/ranking_usecase.go
@@ -1,0 +1,18 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type GetRankingUseCase struct{ repo repository.RankingRepository }
+
+func NewGetRankingUseCase(r repository.RankingRepository) *GetRankingUseCase {
+	return &GetRankingUseCase{repo: r}
+}
+
+func (u *GetRankingUseCase) Execute(ctx context.Context, limit int) ([]domain.RankingEntry, error) {
+	return u.repo.TopByAverageScore(ctx, limit)
+}

--- a/backend/internal/usecase/ranking_usecase_test.go
+++ b/backend/internal/usecase/ranking_usecase_test.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubRankingRepo struct {
+	rows []domain.RankingEntry
+	err  error
+}
+
+func (s *stubRankingRepo) TopByAverageScore(_ context.Context, _ int) ([]domain.RankingEntry, error) {
+	return s.rows, s.err
+}
+
+func TestGetRanking_Returns(t *testing.T) {
+	uc := NewGetRankingUseCase(&stubRankingRepo{rows: []domain.RankingEntry{{UserID: 1, Rank: 1}}})
+	got, err := uc.Execute(context.Background(), 20)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}
+
+func TestGetRanking_PropagatesError(t *testing.T) {
+	uc := NewGetRankingUseCase(&stubRankingRepo{err: errors.New("db")})
+	if _, err := uc.Execute(context.Background(), 20); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
Phase 16: ユーザーランキング (平均スコア降順) API を Go で実装。Closes #1502