### PR TITLE
feat(backend): Phase 17 - LearningReport を Go で実装

### DIFF
--- a/backend/internal/domain/learning_report.go
+++ b/backend/internal/domain/learning_report.go
@@ -1,0 +1,22 @@
+package domain
+
+import "time"
+
+// LearningReport はユーザーの学習レポート (週次・月次集計を非同期で生成)。
+type LearningReport struct {
+	ID         uint64    `gorm:"primaryKey" json:"id"`
+	UserID     uint64    `gorm:"column:user_id;index" json:"userId"`
+	PeriodFrom time.Time `gorm:"column:period_from" json:"periodFrom"`
+	PeriodTo   time.Time `gorm:"column:period_to" json:"periodTo"`
+	Status     string    `gorm:"column:status" json:"status"`
+	S3Key      string    `gorm:"column:s3_key" json:"s3Key,omitempty"`
+	CreatedAt  time.Time `gorm:"column:created_at" json:"createdAt"`
+}
+
+func (LearningReport) TableName() string { return "learning_reports" }
+
+const (
+	LearningReportStatusPending = "pending"
+	LearningReportStatusReady   = "ready"
+	LearningReportStatusFailed  = "failed"
+)

--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type LearningReportHandler struct {
+	list    *usecase.ListLearningReportsUseCase
+	request *usecase.RequestLearningReportUseCase
+}
+
+func NewLearningReportHandler(l *usecase.ListLearningReportsUseCase, r *usecase.RequestLearningReportUseCase) *LearningReportHandler {
+	return &LearningReportHandler{list: l, request: r}
+}
+
+func (h *LearningReportHandler) List(c *gin.Context) {
+	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	rows, err := h.list.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+type requestReportReq struct {
+	UserID     uint64 `json:"userId" binding:"required"`
+	PeriodFrom string `json:"periodFrom" binding:"required"`
+	PeriodTo   string `json:"periodTo" binding:"required"`
+}
+
+func (h *LearningReportHandler) Request(c *gin.Context) {
+	var req requestReportReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	from, err := time.Parse(time.RFC3339, req.PeriodFrom)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "periodFrom must be RFC3339"})
+		return
+	}
+	to, err := time.Parse(time.RFC3339, req.PeriodTo)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "periodTo must be RFC3339"})
+		return
+	}
+	got, err := h.request.Execute(c.Request.Context(), usecase.RequestLearningReportInput{
+		UserID: req.UserID, PeriodFrom: from, PeriodTo: to,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, got)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -159,5 +159,14 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	)
 	authed.GET("/rankings", rankingHandler.Get)
 
+	// Phase 17: LearningReport (非同期生成)
+	learningReportRepo := repository.NewLearningReportRepository(db)
+	learningReportHandler := NewLearningReportHandler(
+		usecase.NewListLearningReportsUseCase(learningReportRepo),
+		usecase.NewRequestLearningReportUseCase(learningReportRepo, repository.NewStubSqsEnqueuer()),
+	)
+	authed.GET("/learning-reports", learningReportHandler.List)
+	authed.POST("/learning-reports", learningReportHandler.Request)
+
 	return r
 }

--- a/backend/internal/repository/learning_report_repository.go
+++ b/backend/internal/repository/learning_report_repository.go
@@ -1,0 +1,41 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+type LearningReportRepository interface {
+	ListByUserID(ctx context.Context, userID uint64) ([]domain.LearningReport, error)
+	Create(ctx context.Context, r *domain.LearningReport) error
+}
+
+type learningReportRepository struct{ db *gorm.DB }
+
+func NewLearningReportRepository(db *gorm.DB) LearningReportRepository {
+	return &learningReportRepository{db: db}
+}
+
+func (r *learningReportRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.LearningReport, error) {
+	var rows []domain.LearningReport
+	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("period_to DESC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *learningReportRepository) Create(ctx context.Context, lr *domain.LearningReport) error {
+	return r.db.WithContext(ctx).Create(lr).Error
+}
+
+// SqsEnqueuer はレポート生成ジョブを SQS にキューする interface。
+// 実装は AWS SDK 連携で Phase 17.1 に分離。
+type SqsEnqueuer interface {
+	Enqueue(ctx context.Context, reportID uint64) error
+}
+
+type stubEnqueuer struct{}
+
+func NewStubSqsEnqueuer() SqsEnqueuer { return &stubEnqueuer{} }
+
+func (e *stubEnqueuer) Enqueue(_ context.Context, _ uint64) error { return nil }

--- a/backend/internal/usecase/learning_report_usecase.go
+++ b/backend/internal/usecase/learning_report_usecase.go
@@ -1,0 +1,58 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type ListLearningReportsUseCase struct{ repo repository.LearningReportRepository }
+
+func NewListLearningReportsUseCase(r repository.LearningReportRepository) *ListLearningReportsUseCase {
+	return &ListLearningReportsUseCase{repo: r}
+}
+
+func (u *ListLearningReportsUseCase) Execute(ctx context.Context, userID uint64) ([]domain.LearningReport, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.repo.ListByUserID(ctx, userID)
+}
+
+type RequestLearningReportUseCase struct {
+	repo  repository.LearningReportRepository
+	queue repository.SqsEnqueuer
+}
+
+func NewRequestLearningReportUseCase(r repository.LearningReportRepository, q repository.SqsEnqueuer) *RequestLearningReportUseCase {
+	return &RequestLearningReportUseCase{repo: r, queue: q}
+}
+
+type RequestLearningReportInput struct {
+	UserID     uint64
+	PeriodFrom time.Time
+	PeriodTo   time.Time
+}
+
+func (u *RequestLearningReportUseCase) Execute(ctx context.Context, in RequestLearningReportInput) (*domain.LearningReport, error) {
+	if in.UserID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	if !in.PeriodTo.After(in.PeriodFrom) {
+		return nil, errors.New("periodTo must be after periodFrom")
+	}
+	r := &domain.LearningReport{
+		UserID: in.UserID, PeriodFrom: in.PeriodFrom, PeriodTo: in.PeriodTo,
+		Status: domain.LearningReportStatusPending,
+	}
+	if err := u.repo.Create(ctx, r); err != nil {
+		return nil, err
+	}
+	if err := u.queue.Enqueue(ctx, r.ID); err != nil {
+		return nil, err
+	}
+	return r, nil
+}

--- a/backend/internal/usecase/learning_report_usecase_test.go
+++ b/backend/internal/usecase/learning_report_usecase_test.go
@@ -1,0 +1,66 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubLearningReportRepo struct {
+	rows []domain.LearningReport
+	err  error
+}
+
+func (s *stubLearningReportRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.LearningReport, error) {
+	return s.rows, s.err
+}
+func (s *stubLearningReportRepo) Create(_ context.Context, r *domain.LearningReport) error {
+	if s.err != nil {
+		return s.err
+	}
+	r.ID = 51
+	return nil
+}
+
+type stubEnqueuer struct{ err error }
+
+func (s *stubEnqueuer) Enqueue(_ context.Context, _ uint64) error { return s.err }
+
+func TestListLearningReports_RequiresUserID(t *testing.T) {
+	uc := NewListLearningReportsUseCase(&stubLearningReportRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRequestLearningReport_Validates(t *testing.T) {
+	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{})
+	now := time.Now()
+	if _, err := uc.Execute(context.Background(), RequestLearningReportInput{UserID: 1, PeriodFrom: now, PeriodTo: now}); err == nil {
+		t.Fatal("expected error for equal periods")
+	}
+}
+
+func TestRequestLearningReport_OK(t *testing.T) {
+	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{})
+	now := time.Now()
+	got, err := uc.Execute(context.Background(), RequestLearningReportInput{
+		UserID: 1, PeriodFrom: now.Add(-24 * time.Hour), PeriodTo: now,
+	})
+	if err != nil || got.Status != domain.LearningReportStatusPending {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}
+
+func TestRequestLearningReport_EnqueueError(t *testing.T) {
+	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{err: errors.New("sqs")})
+	now := time.Now()
+	if _, err := uc.Execute(context.Background(), RequestLearningReportInput{
+		UserID: 1, PeriodFrom: now.Add(-24 * time.Hour), PeriodTo: now,
+	}); err == nil {
+		t.Fatal("expected error")
+	}
+}


### PR DESCRIPTION
Phase 17: 学習レポート非同期生成リクエスト + 一覧 API。SQS 実連携は別 PR。Closes #1503