### PR TITLE
feat(backend): Phase 27 - AiChat WebSocket (echo skeleton) を Go で実装

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -30,6 +30,8 @@ github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/internal/handler/ai_chat_ws_handler.go
+++ b/backend/internal/handler/ai_chat_ws_handler.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+// AiChatWsHandler は AI チャット用 WebSocket。
+// Spring Boot の AiChatWebSocketController に相当。
+// Phase 27 ではエコーサーバ + 接続管理のスケルトンのみ。
+// Bedrock 連携は Phase 27.1 で別 PR。
+type AiChatWsHandler struct {
+	upgrader websocket.Upgrader
+}
+
+func NewAiChatWsHandler() *AiChatWsHandler {
+	return &AiChatWsHandler{
+		upgrader: websocket.Upgrader{
+			// 本番では origin チェックを有効化する。
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+	}
+}
+
+func (h *AiChatWsHandler) Handle(c *gin.Context) {
+	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		log.Printf("AiChat ws upgrade failed: %v", err)
+		return
+	}
+	defer conn.Close()
+
+	for {
+		mt, msg, err := conn.ReadMessage()
+		if err != nil {
+			break
+		}
+		// 暫定: クライアントから受け取ったメッセージをそのまま返す（接続疎通確認用）
+		if err := conn.WriteMessage(mt, msg); err != nil {
+			break
+		}
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -256,5 +256,9 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 	authed.PUT("/admin/scenarios/:id", adminScenarioHandler.Update)
 	authed.DELETE("/admin/scenarios/:id", adminScenarioHandler.Delete)
 
+	// Phase 27: AiChat WebSocket (echo skeleton, Bedrock 連携は Phase 27.1)
+	aiChatWsHandler := NewAiChatWsHandler()
+	authed.GET("/ws/ai-chat", aiChatWsHandler.Handle)
+
 	return r
 }


### PR DESCRIPTION
Phase 27: AI チャット WebSocket (echo) を Gorilla WebSocket で実装。Bedrock/DynamoDB 連携は別 PR。Closes #1513