### PR TITLE
feat(frontend): API パスを /api/v2/* に一括切替 (Go バックエンド統合)

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -93,9 +93,14 @@ jobs:
         run: |
           echo "image_tag=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
-      - name: Build production image
-        working-directory: FreStyle
-        run: docker image build --target production -t temp_api_image_name:latest .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build production image (Go backend)
+        working-directory: backend
+        run: |
+          docker buildx build --platform linux/amd64 \
+            -t temp_api_image_name:latest --load .
 
       - name: Tag and push to ECR
         env:
@@ -168,7 +173,9 @@ jobs:
 
           echo "ecs_sg=$ECS_SG" >> "$GITHUB_OUTPUT"
           echo "tg_arn=$TG_ARN" >> "$GITHUB_OUTPUT"
-          echo "db_url=jdbc:postgresql://$DB_HOST:$DB_PORT/$DB_NAME" >> "$GITHUB_OUTPUT"
+          echo "db_host=$DB_HOST" >> "$GITHUB_OUTPUT"
+          echo "db_port=$DB_PORT" >> "$GITHUB_OUTPUT"
+          echo "db_name=$DB_NAME" >> "$GITHUB_OUTPUT"
           echo "s3_bucket=$S3_BUCKET" >> "$GITHUB_OUTPUT"
           echo "sqs_url=$SQS_URL" >> "$GITHUB_OUTPUT"
           echo "exec_role=$EXEC_ROLE" >> "$GITHUB_OUTPUT"
@@ -180,7 +187,9 @@ jobs:
         env:
           ECS_SG: ${{ steps.deps.outputs.ecs_sg }}
           TG_ARN: ${{ steps.deps.outputs.tg_arn }}
-          DB_URL: ${{ steps.deps.outputs.db_url }}
+          DB_HOST: ${{ steps.deps.outputs.db_host }}
+          DB_PORT: ${{ steps.deps.outputs.db_port }}
+          DB_NAME: ${{ steps.deps.outputs.db_name }}
           S3_BUCKET: ${{ steps.deps.outputs.s3_bucket }}
           SQS_URL: ${{ steps.deps.outputs.sqs_url }}
           EXEC_ROLE: ${{ steps.deps.outputs.exec_role }}
@@ -195,7 +204,9 @@ jobs:
               Environment=$ENV \
               EcsServiceSecurityGroupId="$ECS_SG" \
               TargetGroupArn="$TG_ARN" \
-              DBUrl="$DB_URL" \
+              DBHost="$DB_HOST" \
+              DBPort="$DB_PORT" \
+              DBName="$DB_NAME" \
               DBUser=postgres \
               DBPasswordSecretArn="$DB_PWD_ARN" \
               CognitoClientId="${{ secrets.COGNITO_CLIENT_ID }}" \

--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -146,7 +146,9 @@ jobs:
           {
             echo "ecs_sg=$ECS_SG"
             echo "tg_arn=$TG_ARN"
-            echo "db_url=jdbc:postgresql://$DB_HOST:$DB_PORT/$DB_NAME"
+            echo "db_host=$DB_HOST"
+            echo "db_port=$DB_PORT"
+            echo "db_name=$DB_NAME"
             echo "s3_bucket=$S3_BUCKET"
             echo "sqs_url=$SQS_URL"
             echo "exec_role=$EXEC_ROLE"
@@ -161,7 +163,9 @@ jobs:
         env:
           ECS_SG: ${{ steps.deps.outputs.ecs_sg }}
           TG_ARN: ${{ steps.deps.outputs.tg_arn }}
-          DB_URL: ${{ steps.deps.outputs.db_url }}
+          DB_HOST: ${{ steps.deps.outputs.db_host }}
+          DB_PORT: ${{ steps.deps.outputs.db_port }}
+          DB_NAME: ${{ steps.deps.outputs.db_name }}
           S3_BUCKET: ${{ steps.deps.outputs.s3_bucket }}
           SQS_URL: ${{ steps.deps.outputs.sqs_url }}
           EXEC_ROLE: ${{ steps.deps.outputs.exec_role }}
@@ -176,7 +180,9 @@ jobs:
               Environment=prod \
               EcsServiceSecurityGroupId="$ECS_SG" \
               TargetGroupArn="$TG_ARN" \
-              DBUrl="$DB_URL" \
+              DBHost="$DB_HOST" \
+              DBPort="$DB_PORT" \
+              DBName="$DB_NAME" \
               DBUser=postgres \
               DBPasswordSecretArn="$DB_PWD_ARN" \
               CognitoClientId="${{ secrets.COGNITO_CLIENT_ID }}" \

--- a/frontend/src/hooks/__tests__/useScoreGoal.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreGoal.test.ts
@@ -43,7 +43,7 @@ describe('useScoreGoal', () => {
       expect(result.current.loading).toBe(false);
     });
     expect(result.current.goal).toBe(9.0);
-    expect(mockGet).toHaveBeenCalledWith('/api/score-goal');
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/score-goal');
   });
 
   it('APIエラー時はlocalStorageのデフォルト値を使用する', async () => {
@@ -72,7 +72,7 @@ describe('useScoreGoal', () => {
     });
 
     expect(result.current.goal).toBe(9.5);
-    expect(mockPut).toHaveBeenCalledWith('/api/score-goal', { goalScore: 9.5 });
+    expect(mockPut).toHaveBeenCalledWith('/api/v2/score-goal', { goalScore: 9.5 });
     expect(localStorage.setItem).toHaveBeenCalledWith('scoreGoal', '9.5');
   });
 

--- a/frontend/src/repositories/AdminInvitationRepository.ts
+++ b/frontend/src/repositories/AdminInvitationRepository.ts
@@ -21,17 +21,17 @@ export interface CreateInvitationForm {
 /** 管理者専用: メール招待 CRUD */
 class AdminInvitationRepository {
   async list(): Promise<AdminInvitation[]> {
-    const res = await apiClient.get<AdminInvitation[]>('/api/admin/invitations');
+    const res = await apiClient.get<AdminInvitation[]>('/api/v2/admin/invitations');
     return res.data;
   }
 
   async create(form: CreateInvitationForm): Promise<AdminInvitation> {
-    const res = await apiClient.post<AdminInvitation>('/api/admin/invitations', form);
+    const res = await apiClient.post<AdminInvitation>('/api/v2/admin/invitations', form);
     return res.data;
   }
 
   async cancel(id: number): Promise<void> {
-    await apiClient.delete(`/api/admin/invitations/${id}`);
+    await apiClient.delete(`/api/v2/admin/invitations/${id}`);
   }
 }
 

--- a/frontend/src/repositories/AdminScenarioRepository.ts
+++ b/frontend/src/repositories/AdminScenarioRepository.ts
@@ -25,22 +25,22 @@ export interface AdminScenarioForm {
  */
 class AdminScenarioRepository {
   async list(): Promise<AdminScenario[]> {
-    const res = await apiClient.get<AdminScenario[]>('/api/admin/scenarios');
+    const res = await apiClient.get<AdminScenario[]>('/api/v2/admin/scenarios');
     return res.data;
   }
 
   async create(form: AdminScenarioForm): Promise<AdminScenario> {
-    const res = await apiClient.post<AdminScenario>('/api/admin/scenarios', form);
+    const res = await apiClient.post<AdminScenario>('/api/v2/admin/scenarios', form);
     return res.data;
   }
 
   async update(id: number, form: AdminScenarioForm): Promise<AdminScenario> {
-    const res = await apiClient.put<AdminScenario>(`/api/admin/scenarios/${id}`, form);
+    const res = await apiClient.put<AdminScenario>(`/api/v2/admin/scenarios/${id}`, form);
     return res.data;
   }
 
   async remove(id: number): Promise<void> {
-    await apiClient.delete(`/api/admin/scenarios/${id}`);
+    await apiClient.delete(`/api/v2/admin/scenarios/${id}`);
   }
 }
 

--- a/frontend/src/repositories/AiChatRepository.ts
+++ b/frontend/src/repositories/AiChatRepository.ts
@@ -40,7 +40,7 @@ class AiChatRepository {
    * セッション一覧を取得
    */
   async getSessions(): Promise<AiSession[]> {
-    const response = await apiClient.get('/api/chat/ai/sessions');
+    const response = await apiClient.get('/api/v2/chat/ai/sessions');
     return response.data;
   }
 
@@ -48,7 +48,7 @@ class AiChatRepository {
    * セッション詳細を取得
    */
   async getSession(sessionId: number): Promise<AiSession> {
-    const response = await apiClient.get(`/api/chat/ai/sessions/${sessionId}`);
+    const response = await apiClient.get(`/api/v2/chat/ai/sessions/${sessionId}`);
     return response.data;
   }
 
@@ -56,7 +56,7 @@ class AiChatRepository {
    * 新規セッションを作成
    */
   async createSession(request: CreateSessionRequest): Promise<AiSession> {
-    const response = await apiClient.post('/api/chat/ai/sessions', request);
+    const response = await apiClient.post('/api/v2/chat/ai/sessions', request);
     return response.data;
   }
 
@@ -64,7 +64,7 @@ class AiChatRepository {
    * セッションタイトルを更新
    */
   async updateSessionTitle(sessionId: number, request: UpdateSessionTitleRequest): Promise<AiSession> {
-    const response = await apiClient.put(`/api/chat/ai/sessions/${sessionId}`, request);
+    const response = await apiClient.put(`/api/v2/chat/ai/sessions/${sessionId}`, request);
     return response.data;
   }
 
@@ -72,14 +72,14 @@ class AiChatRepository {
    * セッションを削除
    */
   async deleteSession(sessionId: number): Promise<void> {
-    await apiClient.delete(`/api/chat/ai/sessions/${sessionId}`);
+    await apiClient.delete(`/api/v2/chat/ai/sessions/${sessionId}`);
   }
 
   /**
    * セッション内のメッセージ一覧を取得
    */
   async getMessages(sessionId: number): Promise<AiMessage[]> {
-    const response = await apiClient.get(`/api/chat/ai/sessions/${sessionId}/messages`);
+    const response = await apiClient.get(`/api/v2/chat/ai/sessions/${sessionId}/messages`);
     return response.data;
   }
 
@@ -87,7 +87,7 @@ class AiChatRepository {
    * メッセージを追加
    */
   async addMessage(sessionId: number, request: AddMessageRequest): Promise<AiMessage> {
-    const response = await apiClient.post(`/api/chat/ai/sessions/${sessionId}/messages`, request);
+    const response = await apiClient.post(`/api/v2/chat/ai/sessions/${sessionId}/messages`, request);
     return response.data;
   }
 
@@ -95,7 +95,7 @@ class AiChatRepository {
    * メッセージの言い換え提案を取得
    */
   async rephrase(request: RephraseRequest): Promise<{ result: string }> {
-    const response = await apiClient.post('/api/chat/ai/rephrase', request);
+    const response = await apiClient.post('/api/v2/chat/ai/rephrase', request);
     return response.data;
   }
 
@@ -103,7 +103,7 @@ class AiChatRepository {
    * セッションのスコアカードを取得
    */
   async getScoreCard(sessionId: number): Promise<ScoreCard> {
-    const response = await apiClient.get(`/api/scores/sessions/${sessionId}`);
+    const response = await apiClient.get(`/api/v2/scores/sessions/${sessionId}`);
     return response.data;
   }
 
@@ -111,7 +111,7 @@ class AiChatRepository {
    * スコア履歴を取得
    */
   async getScoreHistory(): Promise<ScoreHistoryItem[]> {
-    const response = await apiClient.get('/api/scores/history');
+    const response = await apiClient.get('/api/v2/scores/history');
     return response.data;
   }
 }

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -56,7 +56,7 @@ class AuthRepository {
    * ログイン
    */
   async login(request: LoginRequest): Promise<UserInfo> {
-    const response = await apiClient.post('/api/auth/cognito/login', request);
+    const response = await apiClient.post('/api/v2/auth/cognito/login', request);
     return response.data;
   }
 
@@ -64,14 +64,14 @@ class AuthRepository {
    * サインアップ
    */
   async signup(request: SignupRequest): Promise<void> {
-    await apiClient.post('/api/auth/cognito/signup', request);
+    await apiClient.post('/api/v2/auth/cognito/signup', request);
   }
 
   /**
    * サインアップ確認
    */
   async confirmSignup(request: ConfirmSignupRequest): Promise<{ message: string }> {
-    const response = await apiClient.post('/api/auth/cognito/confirm', request);
+    const response = await apiClient.post('/api/v2/auth/cognito/confirm', request);
     return response.data;
   }
 
@@ -79,7 +79,7 @@ class AuthRepository {
    * OAuthコールバック
    */
   async callback(code: string): Promise<{ success: string }> {
-    const response = await apiClient.post('/api/auth/cognito/callback', { code });
+    const response = await apiClient.post('/api/v2/auth/cognito/callback', { code });
     return response.data;
   }
 
@@ -87,7 +87,7 @@ class AuthRepository {
    * パスワード再設定リクエスト
    */
   async forgotPassword(request: ForgotPasswordRequest): Promise<{ message: string }> {
-    const response = await apiClient.post('/api/auth/cognito/forgot-password', request);
+    const response = await apiClient.post('/api/v2/auth/cognito/forgot-password', request);
     return response.data;
   }
 
@@ -95,7 +95,7 @@ class AuthRepository {
    * パスワード再設定確認
    */
   async confirmForgotPassword(request: ConfirmForgotPasswordRequest): Promise<{ message: string }> {
-    const response = await apiClient.post('/api/auth/cognito/confirm-forgot-password', request);
+    const response = await apiClient.post('/api/v2/auth/cognito/confirm-forgot-password', request);
     return response.data;
   }
 
@@ -103,14 +103,14 @@ class AuthRepository {
    * ログアウト
    */
   async logout(): Promise<void> {
-    await apiClient.post('/api/auth/cognito/logout');
+    await apiClient.post('/api/v2/auth/cognito/logout');
   }
 
   /**
    * 現在のユーザー情報取得
    */
   async getCurrentUser(): Promise<UserInfo> {
-    const response = await apiClient.get('/api/auth/cognito/me');
+    const response = await apiClient.get('/api/v2/auth/cognito/me');
     return response.data;
   }
 
@@ -118,7 +118,7 @@ class AuthRepository {
    * トークンリフレッシュ
    */
   async refreshToken(): Promise<void> {
-    await apiClient.post('/api/auth/cognito/refresh-token');
+    await apiClient.post('/api/v2/auth/cognito/refresh-token');
   }
 }
 

--- a/frontend/src/repositories/BookmarkRepository.ts
+++ b/frontend/src/repositories/BookmarkRepository.ts
@@ -20,7 +20,7 @@ function saveLocalBookmarks(ids: number[]): void {
 export const BookmarkRepository = {
   async getAll(): Promise<number[]> {
     try {
-      const response = await apiClient.get<number[]>('/api/bookmarks');
+      const response = await apiClient.get<number[]>('/api/v2/bookmarks');
       return response.data;
     } catch {
       return getLocalBookmarks();
@@ -29,7 +29,7 @@ export const BookmarkRepository = {
 
   async add(scenarioId: number): Promise<void> {
     try {
-      await apiClient.post(`/api/bookmarks/${scenarioId}`);
+      await apiClient.post(`/api/v2/bookmarks/${scenarioId}`);
     } catch {
       const ids = getLocalBookmarks();
       if (!ids.includes(scenarioId)) {
@@ -41,7 +41,7 @@ export const BookmarkRepository = {
 
   async remove(scenarioId: number): Promise<void> {
     try {
-      await apiClient.delete(`/api/bookmarks/${scenarioId}`);
+      await apiClient.delete(`/api/v2/bookmarks/${scenarioId}`);
     } catch {
       const ids = getLocalBookmarks().filter(id => id !== scenarioId);
       saveLocalBookmarks(ids);

--- a/frontend/src/repositories/ChatRepository.ts
+++ b/frontend/src/repositories/ChatRepository.ts
@@ -12,31 +12,31 @@ const ChatRepository = {
   async fetchChatUsers(query?: string): Promise<ChatUser[]> {
     const params: Record<string, string> = {};
     if (query) params.query = query;
-    const res = await apiClient.get('/api/chat/rooms', { params });
+    const res = await apiClient.get('/api/v2/chat/rooms', { params });
     return res.data.chatUsers || [];
   },
 
   async fetchCurrentUser(): Promise<{ id: number; name: string }> {
-    const res = await apiClient.get('/api/auth/cognito/me');
+    const res = await apiClient.get('/api/v2/auth/cognito/me');
     return res.data;
   },
 
   async createRoom(userId: number): Promise<{ roomId: number }> {
-    const res = await apiClient.post(`/api/chat/users/${userId}/create`);
+    const res = await apiClient.post(`/api/v2/chat/users/${userId}/create`);
     return res.data;
   },
 
   async markAsRead(roomId: string): Promise<void> {
-    await apiClient.post(`/api/chat/rooms/${roomId}/read`);
+    await apiClient.post(`/api/v2/chat/rooms/${roomId}/read`);
   },
 
   async fetchHistory(roomId: string): Promise<ChatMessage[]> {
-    const res = await apiClient.get(`/api/chat/users/${roomId}/history`);
+    const res = await apiClient.get(`/api/v2/chat/users/${roomId}/history`);
     return res.data;
   },
 
   async rephrase(originalMessage: string, scene: string | null): Promise<{ result: string }> {
-    const res = await apiClient.post('/api/chat/ai/rephrase', { originalMessage, scene });
+    const res = await apiClient.post('/api/v2/chat/ai/rephrase', { originalMessage, scene });
     return res.data;
   },
 };

--- a/frontend/src/repositories/DailyGoalRepository.ts
+++ b/frontend/src/repositories/DailyGoalRepository.ts
@@ -30,7 +30,7 @@ function saveLocalGoal(goal: DailyGoal): void {
 export const DailyGoalRepository = {
   async getToday(): Promise<DailyGoal> {
     try {
-      const response = await apiClient.get<DailyGoal>('/api/daily-goals/today');
+      const response = await apiClient.get<DailyGoal>('/api/v2/daily-goals/today');
       return response.data;
     } catch {
       return getLocalGoal();
@@ -39,7 +39,7 @@ export const DailyGoalRepository = {
 
   async setTarget(target: number): Promise<void> {
     try {
-      await apiClient.put('/api/daily-goals/target', { target });
+      await apiClient.put('/api/v2/daily-goals/target', { target });
     } catch {
       const goal = getLocalGoal();
       goal.target = target;
@@ -49,7 +49,7 @@ export const DailyGoalRepository = {
 
   async incrementCompleted(): Promise<DailyGoal> {
     try {
-      const response = await apiClient.post<DailyGoal>('/api/daily-goals/increment');
+      const response = await apiClient.post<DailyGoal>('/api/v2/daily-goals/increment');
       return response.data;
     } catch {
       const goal = getLocalGoal();

--- a/frontend/src/repositories/FavoritePhraseRepository.ts
+++ b/frontend/src/repositories/FavoritePhraseRepository.ts
@@ -40,7 +40,7 @@ function toFavoritePhrase(dto: ApiFavoritePhraseDto): FavoritePhrase {
 export const FavoritePhraseRepository = {
   async getAll(): Promise<FavoritePhrase[]> {
     try {
-      const response = await apiClient.get<ApiFavoritePhraseDto[]>('/api/favorite-phrases');
+      const response = await apiClient.get<ApiFavoritePhraseDto[]>('/api/v2/favorite-phrases');
       return response.data.map(toFavoritePhrase);
     } catch {
       return getLocalPhrases();
@@ -49,7 +49,7 @@ export const FavoritePhraseRepository = {
 
   async save(phrase: Omit<FavoritePhrase, 'id' | 'createdAt'>): Promise<void> {
     try {
-      await apiClient.post('/api/favorite-phrases', {
+      await apiClient.post('/api/v2/favorite-phrases', {
         originalText: phrase.originalText,
         rephrasedText: phrase.rephrasedText,
         pattern: phrase.pattern,
@@ -68,7 +68,7 @@ export const FavoritePhraseRepository = {
 
   async remove(id: string): Promise<void> {
     try {
-      await apiClient.delete(`/api/favorite-phrases/${id}`);
+      await apiClient.delete(`/api/v2/favorite-phrases/${id}`);
     } catch {
       const all = getLocalPhrases().filter((p) => p.id !== id);
       saveLocalPhrases(all);

--- a/frontend/src/repositories/FriendshipRepository.ts
+++ b/frontend/src/repositories/FriendshipRepository.ts
@@ -3,26 +3,26 @@ import type { FriendshipUser, FollowStatus } from '../types';
 
 export const FriendshipRepository = {
   async getFollowing(): Promise<FriendshipUser[]> {
-    const response = await apiClient.get<FriendshipUser[]>('/api/friendships/following');
+    const response = await apiClient.get<FriendshipUser[]>('/api/v2/friendships/following');
     return response.data;
   },
 
   async getFollowers(): Promise<FriendshipUser[]> {
-    const response = await apiClient.get<FriendshipUser[]>('/api/friendships/followers');
+    const response = await apiClient.get<FriendshipUser[]>('/api/v2/friendships/followers');
     return response.data;
   },
 
   async follow(userId: number): Promise<FriendshipUser> {
-    const response = await apiClient.post<FriendshipUser>(`/api/friendships/${userId}/follow`);
+    const response = await apiClient.post<FriendshipUser>(`/api/v2/friendships/${userId}/follow`);
     return response.data;
   },
 
   async unfollow(userId: number): Promise<void> {
-    await apiClient.delete(`/api/friendships/${userId}/follow`);
+    await apiClient.delete(`/api/v2/friendships/${userId}/follow`);
   },
 
   async checkStatus(userId: number): Promise<FollowStatus> {
-    const response = await apiClient.get<FollowStatus>(`/api/friendships/${userId}/status`);
+    const response = await apiClient.get<FollowStatus>(`/api/v2/friendships/${userId}/status`);
     return response.data;
   },
 };

--- a/frontend/src/repositories/LearningReportRepository.ts
+++ b/frontend/src/repositories/LearningReportRepository.ts
@@ -3,13 +3,13 @@ import type { LearningReport } from '../types';
 
 export const LearningReportRepository = {
   async getAll(): Promise<LearningReport[]> {
-    const response = await apiClient.get<LearningReport[]>('/api/reports');
+    const response = await apiClient.get<LearningReport[]>('/api/v2/reports');
     return response.data;
   },
 
   async getMonthly(year: number, month: number): Promise<LearningReport | null> {
     try {
-      const response = await apiClient.get<LearningReport>(`/api/reports/${year}/${month}`);
+      const response = await apiClient.get<LearningReport>(`/api/v2/reports/${year}/${month}`);
       return response.data;
     } catch {
       return null;
@@ -17,7 +17,7 @@ export const LearningReportRepository = {
   },
 
   async generate(year: number, month: number): Promise<{ status: string }> {
-    const response = await apiClient.post<{ status: string }>('/api/reports/generate', { year, month });
+    const response = await apiClient.post<{ status: string }>('/api/v2/reports/generate', { year, month });
     return response.data;
   },
 };

--- a/frontend/src/repositories/MenuRepository.ts
+++ b/frontend/src/repositories/MenuRepository.ts
@@ -11,17 +11,17 @@ interface ChatRoomsResponse {
 
 export const MenuRepository = {
   async fetchChatStats(): Promise<ChatStats> {
-    const { data } = await apiClient.get('/api/chat/stats');
+    const { data } = await apiClient.get('/api/v2/chat/stats');
     return data;
   },
 
   async fetchChatRooms(): Promise<ChatRoomsResponse> {
-    const { data } = await apiClient.get('/api/chat/rooms');
+    const { data } = await apiClient.get('/api/v2/chat/rooms');
     return data;
   },
 
   async fetchScoreHistory(): Promise<ScoreHistory[]> {
-    const { data } = await apiClient.get('/api/scores/history');
+    const { data } = await apiClient.get('/api/v2/scores/history');
     return data;
   },
 };

--- a/frontend/src/repositories/NoteImageRepository.ts
+++ b/frontend/src/repositories/NoteImageRepository.ts
@@ -8,7 +8,7 @@ interface PresignedUrlResponse {
 
 const NoteImageRepository = {
   async getPresignedUrl(noteId: string, fileName: string, contentType: string): Promise<PresignedUrlResponse> {
-    const res = await apiClient.post(`/api/notes/${noteId}/images/presigned-url`, {
+    const res = await apiClient.post(`/api/v2/notes/${noteId}/images/presigned-url`, {
       fileName,
       contentType,
     });

--- a/frontend/src/repositories/NoteRepository.ts
+++ b/frontend/src/repositories/NoteRepository.ts
@@ -3,21 +3,21 @@ import type { Note } from '../types';
 
 const NoteRepository = {
   async fetchNotes(): Promise<Note[]> {
-    const res = await apiClient.get('/api/notes');
+    const res = await apiClient.get('/api/v2/notes');
     return res.data;
   },
 
   async createNote(title: string): Promise<Note> {
-    const res = await apiClient.post('/api/notes', { title });
+    const res = await apiClient.post('/api/v2/notes', { title });
     return res.data;
   },
 
   async updateNote(noteId: string, data: { title: string; content: string; isPinned: boolean }): Promise<void> {
-    await apiClient.put(`/api/notes/${noteId}`, data);
+    await apiClient.put(`/api/v2/notes/${noteId}`, data);
   },
 
   async deleteNote(noteId: string): Promise<void> {
-    await apiClient.delete(`/api/notes/${noteId}`);
+    await apiClient.delete(`/api/v2/notes/${noteId}`);
   },
 };
 

--- a/frontend/src/repositories/NotificationRepository.ts
+++ b/frontend/src/repositories/NotificationRepository.ts
@@ -3,20 +3,20 @@ import type { Notification } from '../types';
 
 export const NotificationRepository = {
   async getAll(): Promise<Notification[]> {
-    const response = await apiClient.get<Notification[]>('/api/notifications');
+    const response = await apiClient.get<Notification[]>('/api/v2/notifications');
     return response.data;
   },
 
   async markAsRead(notificationId: number): Promise<void> {
-    await apiClient.put(`/api/notifications/${notificationId}/read`);
+    await apiClient.put(`/api/v2/notifications/${notificationId}/read`);
   },
 
   async markAllAsRead(): Promise<void> {
-    await apiClient.put('/api/notifications/read-all');
+    await apiClient.put('/api/v2/notifications/read-all');
   },
 
   async getUnreadCount(): Promise<number> {
-    const response = await apiClient.get<number>('/api/notifications/unread-count');
+    const response = await apiClient.get<number>('/api/v2/notifications/unread-count');
     return response.data;
   },
 };

--- a/frontend/src/repositories/PracticeRepository.ts
+++ b/frontend/src/repositories/PracticeRepository.ts
@@ -39,7 +39,7 @@ class PracticeRepository {
    * シナリオ一覧を取得
    */
   async getScenarios(): Promise<PracticeScenario[]> {
-    const response = await apiClient.get('/api/practice/scenarios');
+    const response = await apiClient.get('/api/v2/practice/scenarios');
     return response.data;
   }
 
@@ -47,7 +47,7 @@ class PracticeRepository {
    * シナリオ詳細を取得
    */
   async getScenario(scenarioId: number): Promise<PracticeScenario> {
-    const response = await apiClient.get(`/api/practice/scenarios/${scenarioId}`);
+    const response = await apiClient.get(`/api/v2/practice/scenarios/${scenarioId}`);
     return response.data;
   }
 
@@ -55,7 +55,7 @@ class PracticeRepository {
    * 練習セッションを作成
    */
   async createPracticeSession(request: CreatePracticeSessionRequest): Promise<PracticeSession> {
-    const response = await apiClient.post('/api/practice/sessions', request);
+    const response = await apiClient.post('/api/v2/practice/sessions', request);
     return response.data;
   }
 }

--- a/frontend/src/repositories/ProfileRepository.ts
+++ b/frontend/src/repositories/ProfileRepository.ts
@@ -22,17 +22,17 @@ interface PresignedUrlResponse {
 
 const ProfileRepository = {
   async fetchProfile(): Promise<ProfileData> {
-    const res = await apiClient.get('/api/profile/me');
+    const res = await apiClient.get('/api/v2/profile/me');
     return res.data;
   },
 
   async updateProfile(data: ProfileData): Promise<{ success: string }> {
-    const res = await apiClient.put('/api/profile/me/update', data);
+    const res = await apiClient.put('/api/v2/profile/me/update', data);
     return res.data;
   },
 
   async getImagePresignedUrl(fileName: string, contentType: string): Promise<PresignedUrlResponse> {
-    const res = await apiClient.post('/api/profile/me/image/presigned-url', {
+    const res = await apiClient.post('/api/v2/profile/me/image/presigned-url', {
       fileName,
       contentType,
     });

--- a/frontend/src/repositories/ProfileStatsRepository.ts
+++ b/frontend/src/repositories/ProfileStatsRepository.ts
@@ -13,8 +13,8 @@ export interface ProfileStats {
 const ProfileStatsRepository = {
   async fetchStats(): Promise<ProfileStats> {
     const [statsRes, streakRes] = await Promise.all([
-      apiClient.get('/api/users/me/stats'),
-      apiClient.get('/api/daily-goals/streak'),
+      apiClient.get('/api/v2/users/me/stats'),
+      apiClient.get('/api/v2/daily-goals/streak'),
     ]);
     return {
       totalSessions: statsRes.data.totalSessions ?? 0,

--- a/frontend/src/repositories/RankingRepository.ts
+++ b/frontend/src/repositories/RankingRepository.ts
@@ -3,7 +3,7 @@ import { Ranking } from '../types';
 
 export const RankingRepository = {
   async fetchRanking(period: string = 'weekly'): Promise<Ranking> {
-    const response = await apiClient.get<Ranking>('/api/ranking', {
+    const response = await apiClient.get<Ranking>('/api/v2/ranking', {
       params: { period },
     });
     return response.data;

--- a/frontend/src/repositories/ReminderRepository.ts
+++ b/frontend/src/repositories/ReminderRepository.ts
@@ -3,12 +3,12 @@ import { ReminderSetting } from '../types';
 
 export const ReminderRepository = {
   async fetchSetting(): Promise<ReminderSetting> {
-    const response = await apiClient.get<ReminderSetting>('/api/reminder');
+    const response = await apiClient.get<ReminderSetting>('/api/v2/reminder');
     return response.data;
   },
 
   async saveSetting(setting: ReminderSetting): Promise<ReminderSetting> {
-    const response = await apiClient.put<ReminderSetting>('/api/reminder', setting);
+    const response = await apiClient.put<ReminderSetting>('/api/v2/reminder', setting);
     return response.data;
   },
 };

--- a/frontend/src/repositories/ScoreGoalRepository.ts
+++ b/frontend/src/repositories/ScoreGoalRepository.ts
@@ -3,7 +3,7 @@ import apiClient from '../lib/axios';
 export const ScoreGoalRepository = {
   async fetchGoal(): Promise<number | null> {
     try {
-      const response = await apiClient.get<{ goalScore: number }>('/api/score-goal');
+      const response = await apiClient.get<{ goalScore: number }>('/api/v2/score-goal');
       return response.data?.goalScore ?? null;
     } catch {
       return null;
@@ -12,7 +12,7 @@ export const ScoreGoalRepository = {
 
   async saveGoal(goalScore: number): Promise<void> {
     try {
-      await apiClient.put('/api/score-goal', { goalScore });
+      await apiClient.put('/api/v2/score-goal', { goalScore });
     } catch {
       // API失敗時は呼び出し元でlocalStorage保存済み
     }

--- a/frontend/src/repositories/SessionNoteRepository.ts
+++ b/frontend/src/repositories/SessionNoteRepository.ts
@@ -31,7 +31,7 @@ export const SessionNoteRepository = {
 
   async get(sessionId: number): Promise<SessionNote | null> {
     try {
-      const response = await apiClient.get<SessionNote>(`/api/session-notes/${sessionId}`);
+      const response = await apiClient.get<SessionNote>(`/api/v2/session-notes/${sessionId}`);
       return response.data;
     } catch {
       const notes = getAllLocalNotes();
@@ -41,7 +41,7 @@ export const SessionNoteRepository = {
 
   async save(sessionId: number, note: string): Promise<void> {
     try {
-      await apiClient.put(`/api/session-notes/${sessionId}`, { note });
+      await apiClient.put(`/api/v2/session-notes/${sessionId}`, { note });
     } catch {
       saveLocalNote(sessionId, note);
     }

--- a/frontend/src/repositories/SharedSessionRepository.ts
+++ b/frontend/src/repositories/SharedSessionRepository.ts
@@ -3,12 +3,12 @@ import { SharedSession } from '../types';
 
 export const SharedSessionRepository = {
   async fetchPublicSessions(): Promise<SharedSession[]> {
-    const response = await apiClient.get<SharedSession[]>('/api/shared-sessions');
+    const response = await apiClient.get<SharedSession[]>('/api/v2/shared-sessions');
     return response.data;
   },
 
   async shareSession(sessionId: number, description?: string): Promise<SharedSession> {
-    const response = await apiClient.post<SharedSession>('/api/shared-sessions', {
+    const response = await apiClient.post<SharedSession>('/api/v2/shared-sessions', {
       sessionId,
       description,
     });
@@ -16,6 +16,6 @@ export const SharedSessionRepository = {
   },
 
   async unshareSession(sessionId: number): Promise<void> {
-    await apiClient.delete(`/api/shared-sessions/${sessionId}`);
+    await apiClient.delete(`/api/v2/shared-sessions/${sessionId}`);
   },
 };

--- a/frontend/src/repositories/TemplateRepository.ts
+++ b/frontend/src/repositories/TemplateRepository.ts
@@ -3,14 +3,14 @@ import { ConversationTemplate } from '../types';
 
 export const TemplateRepository = {
   async fetchTemplates(category?: string): Promise<ConversationTemplate[]> {
-    const response = await apiClient.get<ConversationTemplate[]>('/api/templates', {
+    const response = await apiClient.get<ConversationTemplate[]>('/api/v2/templates', {
       params: category ? { category } : {},
     });
     return response.data;
   },
 
   async fetchTemplateById(id: number): Promise<ConversationTemplate> {
-    const response = await apiClient.get<ConversationTemplate>(`/api/templates/${id}`);
+    const response = await apiClient.get<ConversationTemplate>(`/api/v2/templates/${id}`);
     return response.data;
   },
 };

--- a/frontend/src/repositories/UserSearchRepository.ts
+++ b/frontend/src/repositories/UserSearchRepository.ts
@@ -5,7 +5,7 @@ const UserSearchRepository = {
   async searchUsers(query?: string): Promise<MemberUser[]> {
     const params: Record<string, string> = {};
     if (query) params.query = query;
-    const res = await apiClient.get('/api/chat/users', { params });
+    const res = await apiClient.get('/api/v2/chat/users', { params });
     return res.data.users || [];
   },
 };

--- a/frontend/src/repositories/WeeklyChallengeRepository.ts
+++ b/frontend/src/repositories/WeeklyChallengeRepository.ts
@@ -4,7 +4,7 @@ import { WeeklyChallenge } from '../types';
 export const WeeklyChallengeRepository = {
   async fetchCurrentChallenge(): Promise<WeeklyChallenge | null> {
     try {
-      const response = await apiClient.get<WeeklyChallenge>('/api/weekly-challenge');
+      const response = await apiClient.get<WeeklyChallenge>('/api/v2/weekly-challenge');
       return response.data;
     } catch {
       return null;
@@ -13,7 +13,7 @@ export const WeeklyChallengeRepository = {
 
   async incrementProgress(): Promise<WeeklyChallenge | null> {
     try {
-      const response = await apiClient.post<WeeklyChallenge>('/api/weekly-challenge/progress');
+      const response = await apiClient.post<WeeklyChallenge>('/api/v2/weekly-challenge/progress');
       return response.data;
     } catch {
       return null;

--- a/frontend/src/repositories/__tests__/AiChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AiChatRepository.test.ts
@@ -17,7 +17,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getSessions();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/ai/sessions');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/ai/sessions');
     expect(result).toEqual(mockSessions);
   });
 
@@ -27,7 +27,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getSession(1);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/ai/sessions/1');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1');
     expect(result).toEqual(mockSession);
   });
 
@@ -37,7 +37,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.createSession({ title: '新しいセッション' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/sessions', { title: '新しいセッション' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/ai/sessions', { title: '新しいセッション' });
     expect(result).toEqual(mockSession);
   });
 
@@ -47,7 +47,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.updateSessionTitle(1, { title: '更新タイトル' });
 
-    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/chat/ai/sessions/1', { title: '更新タイトル' });
+    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1', { title: '更新タイトル' });
     expect(result).toEqual(mockSession);
   });
 
@@ -56,7 +56,7 @@ describe('AiChatRepository', () => {
 
     await aiChatRepository.deleteSession(1);
 
-    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/chat/ai/sessions/1');
+    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1');
   });
 
   it('getMessages: メッセージ一覧を取得できる', async () => {
@@ -65,7 +65,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getMessages(1);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/ai/sessions/1/messages');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1/messages');
     expect(result).toEqual(mockMessages);
   });
 
@@ -75,7 +75,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.addMessage(1, { content: '新しいメッセージ', role: 'user' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/sessions/1/messages', { content: '新しいメッセージ', role: 'user' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1/messages', { content: '新しいメッセージ', role: 'user' });
     expect(result).toEqual(mockMessage);
   });
 
@@ -85,7 +85,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.rephrase({ originalMessage: '元のメッセージ', scene: 'meeting' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/rephrase', { originalMessage: '元のメッセージ', scene: 'meeting' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/ai/rephrase', { originalMessage: '元のメッセージ', scene: 'meeting' });
     expect(result).toEqual(mockResult);
   });
 
@@ -95,7 +95,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getScoreCard(1);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/scores/sessions/1');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/scores/sessions/1');
     expect(result).toEqual(mockScoreCard);
   });
 
@@ -105,7 +105,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getScoreHistory();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/scores/history');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/scores/history');
     expect(result).toEqual(mockHistory);
   });
 });

--- a/frontend/src/repositories/__tests__/AuthRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AuthRepository.test.ts
@@ -17,7 +17,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.login({ email: 'test@example.com', password: 'password123' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/login', { email: 'test@example.com', password: 'password123' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/login', { email: 'test@example.com', password: 'password123' });
     expect(result).toEqual(mockUser);
   });
 
@@ -26,7 +26,7 @@ describe('AuthRepository', () => {
 
     await authRepository.signup({ email: 'test@example.com', password: 'password123', name: 'テスト' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/signup', { email: 'test@example.com', password: 'password123', name: 'テスト' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/signup', { email: 'test@example.com', password: 'password123', name: 'テスト' });
   });
 
   it('confirmSignup: サインアップ確認ができる', async () => {
@@ -34,7 +34,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.confirmSignup({ email: 'test@example.com', code: '123456' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/confirm', { email: 'test@example.com', code: '123456' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/confirm', { email: 'test@example.com', code: '123456' });
     expect(result).toEqual({ message: '確認成功' });
   });
 
@@ -44,7 +44,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.callback('auth-code-123');
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/callback', { code: 'auth-code-123' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/callback', { code: 'auth-code-123' });
     expect(result).toEqual(mockData);
   });
 
@@ -53,7 +53,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.forgotPassword({ email: 'test@example.com' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/forgot-password', { email: 'test@example.com' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/forgot-password', { email: 'test@example.com' });
     expect(result).toEqual({ message: '確認コードを送信しました' });
   });
 
@@ -66,7 +66,7 @@ describe('AuthRepository', () => {
       newPassword: 'newPassword123',
     });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/confirm-forgot-password', {
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/confirm-forgot-password', {
       email: 'test@example.com',
       confirmationCode: '123456',
       newPassword: 'newPassword123',
@@ -79,7 +79,7 @@ describe('AuthRepository', () => {
 
     await authRepository.logout();
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/logout');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/logout');
   });
 
   it('getCurrentUser: 現在のユーザー情報を取得できる', async () => {
@@ -88,7 +88,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.getCurrentUser();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/auth/cognito/me');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/auth/cognito/me');
     expect(result).toEqual(mockUser);
   });
 
@@ -97,6 +97,6 @@ describe('AuthRepository', () => {
 
     await authRepository.refreshToken();
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/auth/cognito/refresh-token');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/refresh-token');
   });
 });

--- a/frontend/src/repositories/__tests__/BookmarkRepository.test.ts
+++ b/frontend/src/repositories/__tests__/BookmarkRepository.test.ts
@@ -42,7 +42,7 @@ describe('BookmarkRepository', () => {
       const ids = await BookmarkRepository.getAll();
 
       expect(ids).toEqual([1, 3, 5]);
-      expect(mockGet).toHaveBeenCalledWith('/api/bookmarks');
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/bookmarks');
     });
 
     it('add: APIでブックマークを追加できる', async () => {
@@ -50,7 +50,7 @@ describe('BookmarkRepository', () => {
 
       await BookmarkRepository.add(1);
 
-      expect(mockPost).toHaveBeenCalledWith('/api/bookmarks/1');
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/bookmarks/1');
     });
 
     it('remove: APIでブックマークを削除できる', async () => {
@@ -58,7 +58,7 @@ describe('BookmarkRepository', () => {
 
       await BookmarkRepository.remove(1);
 
-      expect(mockDelete).toHaveBeenCalledWith('/api/bookmarks/1');
+      expect(mockDelete).toHaveBeenCalledWith('/api/v2/bookmarks/1');
     });
 
     it('isBookmarked: ブックマーク済みか判定できる', async () => {

--- a/frontend/src/repositories/__tests__/ChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ChatRepository.test.ts
@@ -21,7 +21,7 @@ describe('ChatRepository', () => {
 
     const result = await ChatRepository.fetchChatUsers();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/rooms', { params: {} });
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/rooms', { params: {} });
     expect(result).toEqual(mockData.chatUsers);
   });
 
@@ -31,7 +31,7 @@ describe('ChatRepository', () => {
 
     await ChatRepository.fetchChatUsers('テスト');
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/rooms', { params: { query: 'テスト' } });
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/rooms', { params: { query: 'テスト' } });
   });
 
   it('fetchCurrentUser: 現在のユーザー情報を取得できる', async () => {
@@ -40,7 +40,7 @@ describe('ChatRepository', () => {
 
     const result = await ChatRepository.fetchCurrentUser();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/auth/cognito/me');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/auth/cognito/me');
     expect(result).toEqual(mockUser);
   });
 
@@ -50,7 +50,7 @@ describe('ChatRepository', () => {
 
     const result = await ChatRepository.createRoom(5);
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/users/5/create');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/users/5/create');
     expect(result).toEqual(mockData);
   });
 
@@ -59,7 +59,7 @@ describe('ChatRepository', () => {
 
     await ChatRepository.markAsRead('10');
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/rooms/10/read');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/rooms/10/read');
   });
 
   it('fetchHistory: チャット履歴を取得できる', async () => {
@@ -71,7 +71,7 @@ describe('ChatRepository', () => {
 
     const result = await ChatRepository.fetchHistory('5');
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/users/5/history');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/users/5/history');
     expect(result).toEqual(mockMessages);
   });
 
@@ -81,7 +81,7 @@ describe('ChatRepository', () => {
 
     const result = await ChatRepository.rephrase('テスト文', null);
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/chat/ai/rephrase', {
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/ai/rephrase', {
       originalMessage: 'テスト文',
       scene: null,
     });

--- a/frontend/src/repositories/__tests__/DailyGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/DailyGoalRepository.test.ts
@@ -43,7 +43,7 @@ describe('DailyGoalRepository', () => {
 
       expect(result.target).toBe(5);
       expect(result.completed).toBe(2);
-      expect(mockGet).toHaveBeenCalledWith('/api/daily-goals/today');
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/daily-goals/today');
     });
 
     it('setTarget: APIで目標回数を設定する', async () => {
@@ -51,7 +51,7 @@ describe('DailyGoalRepository', () => {
 
       await DailyGoalRepository.setTarget(7);
 
-      expect(mockPut).toHaveBeenCalledWith('/api/daily-goals/target', { target: 7 });
+      expect(mockPut).toHaveBeenCalledWith('/api/v2/daily-goals/target', { target: 7 });
     });
 
     it('incrementCompleted: APIで完了数をインクリメントする', async () => {
@@ -60,7 +60,7 @@ describe('DailyGoalRepository', () => {
       const result = await DailyGoalRepository.incrementCompleted();
 
       expect(result.completed).toBe(1);
-      expect(mockPost).toHaveBeenCalledWith('/api/daily-goals/increment');
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/daily-goals/increment');
     });
   });
 

--- a/frontend/src/repositories/__tests__/FavoritePhraseRepository.test.ts
+++ b/frontend/src/repositories/__tests__/FavoritePhraseRepository.test.ts
@@ -48,7 +48,7 @@ describe('FavoritePhraseRepository', () => {
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('1');
       expect(result[0].originalText).toBe('元文');
-      expect(mockGet).toHaveBeenCalledWith('/api/favorite-phrases');
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/favorite-phrases');
     });
 
     it('save: APIでフレーズを保存できる', async () => {
@@ -60,7 +60,7 @@ describe('FavoritePhraseRepository', () => {
         pattern: 'フォーマル版',
       });
 
-      expect(mockPost).toHaveBeenCalledWith('/api/favorite-phrases', {
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/favorite-phrases', {
         originalText: '確認お願い',
         rephrasedText: 'ご確認ください',
         pattern: 'フォーマル版',
@@ -72,7 +72,7 @@ describe('FavoritePhraseRepository', () => {
 
       await FavoritePhraseRepository.remove('5');
 
-      expect(mockDelete).toHaveBeenCalledWith('/api/favorite-phrases/5');
+      expect(mockDelete).toHaveBeenCalledWith('/api/v2/favorite-phrases/5');
     });
 
     it('exists: フレーズの存在判定ができる', async () => {

--- a/frontend/src/repositories/__tests__/FriendshipRepository.test.ts
+++ b/frontend/src/repositories/__tests__/FriendshipRepository.test.ts
@@ -26,7 +26,7 @@ describe('FriendshipRepository', () => {
 
     const result = await FriendshipRepository.getFollowing();
     expect(result).toEqual(users);
-    expect(mockedGet).toHaveBeenCalledWith('/api/friendships/following');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/friendships/following');
   });
 
   it('getFollowers: フォロワー一覧を取得する', async () => {
@@ -35,7 +35,7 @@ describe('FriendshipRepository', () => {
 
     const result = await FriendshipRepository.getFollowers();
     expect(result).toEqual(users);
-    expect(mockedGet).toHaveBeenCalledWith('/api/friendships/followers');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/friendships/followers');
   });
 
   it('follow: フォローリクエストを送る', async () => {
@@ -44,14 +44,14 @@ describe('FriendshipRepository', () => {
 
     const result = await FriendshipRepository.follow(30);
     expect(result).toEqual(user);
-    expect(mockedPost).toHaveBeenCalledWith('/api/friendships/30/follow');
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/friendships/30/follow');
   });
 
   it('unfollow: フォロー解除する', async () => {
     mockedDelete.mockResolvedValue({});
 
     await FriendshipRepository.unfollow(30);
-    expect(mockedDelete).toHaveBeenCalledWith('/api/friendships/30/follow');
+    expect(mockedDelete).toHaveBeenCalledWith('/api/v2/friendships/30/follow');
   });
 
   it('checkStatus: フォロー状態を確認する', async () => {
@@ -60,6 +60,6 @@ describe('FriendshipRepository', () => {
 
     const result = await FriendshipRepository.checkStatus(30);
     expect(result).toEqual(status);
-    expect(mockedGet).toHaveBeenCalledWith('/api/friendships/30/status');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/friendships/30/status');
   });
 });

--- a/frontend/src/repositories/__tests__/LearningReportRepository.test.ts
+++ b/frontend/src/repositories/__tests__/LearningReportRepository.test.ts
@@ -26,7 +26,7 @@ describe('LearningReportRepository', () => {
 
     const result = await LearningReportRepository.getAll();
     expect(result).toEqual(reports);
-    expect(mockedGet).toHaveBeenCalledWith('/api/reports');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/reports');
   });
 
   it('getMonthly: 指定月のレポートを取得する', async () => {
@@ -35,7 +35,7 @@ describe('LearningReportRepository', () => {
 
     const result = await LearningReportRepository.getMonthly(2024, 6);
     expect(result).toEqual(report);
-    expect(mockedGet).toHaveBeenCalledWith('/api/reports/2024/6');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/reports/2024/6');
   });
 
   it('getMonthly: 該当レポートがない場合はnullを返す', async () => {
@@ -50,6 +50,6 @@ describe('LearningReportRepository', () => {
 
     const result = await LearningReportRepository.generate(2024, 6);
     expect(result).toEqual({ status: 'generated' });
-    expect(mockedPost).toHaveBeenCalledWith('/api/reports/generate', { year: 2024, month: 6 });
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/reports/generate', { year: 2024, month: 6 });
   });
 });

--- a/frontend/src/repositories/__tests__/MenuRepository.test.ts
+++ b/frontend/src/repositories/__tests__/MenuRepository.test.ts
@@ -16,7 +16,7 @@ describe('MenuRepository', () => {
 
     const result = await MenuRepository.fetchChatStats();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/stats');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/stats');
     expect(result).toEqual({ chatPartnerCount: 5 });
   });
 
@@ -26,7 +26,7 @@ describe('MenuRepository', () => {
 
     const result = await MenuRepository.fetchChatRooms();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/chat/rooms');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/rooms');
     expect(result).toEqual(mockRooms);
   });
 
@@ -36,7 +36,7 @@ describe('MenuRepository', () => {
 
     const result = await MenuRepository.fetchScoreHistory();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/scores/history');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/scores/history');
     expect(result).toEqual(mockScores);
   });
 

--- a/frontend/src/repositories/__tests__/NoteImageRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteImageRepository.test.ts
@@ -32,7 +32,7 @@ describe('NoteImageRepository', () => {
 
       const result = await NoteImageRepository.getPresignedUrl('note1', 'image.png', 'image/png');
 
-      expect(apiClient.post).toHaveBeenCalledWith('/api/notes/note1/images/presigned-url', {
+      expect(apiClient.post).toHaveBeenCalledWith('/api/v2/notes/note1/images/presigned-url', {
         fileName: 'image.png',
         contentType: 'image/png',
       });

--- a/frontend/src/repositories/__tests__/NoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteRepository.test.ts
@@ -17,7 +17,7 @@ describe('NoteRepository', () => {
 
     const result = await NoteRepository.fetchNotes();
 
-    expect(apiClient.get).toHaveBeenCalledWith('/api/notes');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v2/notes');
     expect(result).toEqual(mockNotes);
   });
 
@@ -27,7 +27,7 @@ describe('NoteRepository', () => {
 
     const result = await NoteRepository.createNote('新しいノート');
 
-    expect(apiClient.post).toHaveBeenCalledWith('/api/notes', { title: '新しいノート' });
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v2/notes', { title: '新しいノート' });
     expect(result.title).toBe('新しいノート');
   });
 
@@ -36,7 +36,7 @@ describe('NoteRepository', () => {
 
     await NoteRepository.updateNote('note-1', { title: '更新', content: '内容', isPinned: false });
 
-    expect(apiClient.put).toHaveBeenCalledWith('/api/notes/note-1', { title: '更新', content: '内容', isPinned: false });
+    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/notes/note-1', { title: '更新', content: '内容', isPinned: false });
   });
 
   it('deleteNoteがDELETEリクエストを送信する', async () => {
@@ -44,6 +44,6 @@ describe('NoteRepository', () => {
 
     await NoteRepository.deleteNote('note-1');
 
-    expect(apiClient.delete).toHaveBeenCalledWith('/api/notes/note-1');
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v2/notes/note-1');
   });
 });

--- a/frontend/src/repositories/__tests__/NotificationRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NotificationRepository.test.ts
@@ -26,21 +26,21 @@ describe('NotificationRepository', () => {
 
     const result = await NotificationRepository.getAll();
     expect(result).toEqual(notifications);
-    expect(mockedGet).toHaveBeenCalledWith('/api/notifications');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/notifications');
   });
 
   it('markAsRead: 指定IDの通知を既読にする', async () => {
     mockedPut.mockResolvedValue({});
 
     await NotificationRepository.markAsRead(5);
-    expect(mockedPut).toHaveBeenCalledWith('/api/notifications/5/read');
+    expect(mockedPut).toHaveBeenCalledWith('/api/v2/notifications/5/read');
   });
 
   it('markAllAsRead: 全通知を既読にする', async () => {
     mockedPut.mockResolvedValue({});
 
     await NotificationRepository.markAllAsRead();
-    expect(mockedPut).toHaveBeenCalledWith('/api/notifications/read-all');
+    expect(mockedPut).toHaveBeenCalledWith('/api/v2/notifications/read-all');
   });
 
   it('getUnreadCount: 未読数を取得する', async () => {
@@ -48,6 +48,6 @@ describe('NotificationRepository', () => {
 
     const result = await NotificationRepository.getUnreadCount();
     expect(result).toBe(3);
-    expect(mockedGet).toHaveBeenCalledWith('/api/notifications/unread-count');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/notifications/unread-count');
   });
 });

--- a/frontend/src/repositories/__tests__/PracticeRepository.test.ts
+++ b/frontend/src/repositories/__tests__/PracticeRepository.test.ts
@@ -19,7 +19,7 @@ describe('PracticeRepository', () => {
 
     const result = await practiceRepository.getScenarios();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/practice/scenarios');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/practice/scenarios');
     expect(result).toEqual(mockScenarios);
   });
 
@@ -29,7 +29,7 @@ describe('PracticeRepository', () => {
 
     const result = await practiceRepository.getScenario(1);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/practice/scenarios/1');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/practice/scenarios/1');
     expect(result).toEqual(mockScenario);
   });
 
@@ -39,7 +39,7 @@ describe('PracticeRepository', () => {
 
     const result = await practiceRepository.createPracticeSession({ scenarioId: 1 });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/practice/sessions', { scenarioId: 1 });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/practice/sessions', { scenarioId: 1 });
     expect(result).toEqual(mockSession);
   });
 
@@ -55,7 +55,7 @@ describe('PracticeRepository', () => {
 
     const result = await practiceRepository.getScenario(99);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/practice/scenarios/99');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/practice/scenarios/99');
     expect(result).toEqual(mockScenario);
   });
 });

--- a/frontend/src/repositories/__tests__/ProfileRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ProfileRepository.test.ts
@@ -28,7 +28,7 @@ describe('ProfileRepository', () => {
 
     const result = await ProfileRepository.fetchProfile();
 
-    expect(apiClient.get).toHaveBeenCalledWith('/api/profile/me');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v2/profile/me');
     expect(result).toEqual(mockData);
   });
 
@@ -38,7 +38,7 @@ describe('ProfileRepository', () => {
 
     const result = await ProfileRepository.updateProfile({ name: 'テスト', bio: '更新' });
 
-    expect(apiClient.put).toHaveBeenCalledWith('/api/profile/me/update', { name: 'テスト', bio: '更新' });
+    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/profile/me/update', { name: 'テスト', bio: '更新' });
     expect(result).toEqual(mockData);
   });
 
@@ -48,7 +48,7 @@ describe('ProfileRepository', () => {
 
     const result = await ProfileRepository.getImagePresignedUrl('avatar.png', 'image/png');
 
-    expect(apiClient.post).toHaveBeenCalledWith('/api/profile/me/image/presigned-url', {
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v2/profile/me/image/presigned-url', {
       fileName: 'avatar.png',
       contentType: 'image/png',
     });

--- a/frontend/src/repositories/__tests__/ProfileStatsRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ProfileStatsRepository.test.ts
@@ -22,8 +22,8 @@ describe('ProfileStatsRepository', () => {
 
     const stats = await ProfileStatsRepository.fetchStats();
 
-    expect(mockGet).toHaveBeenCalledWith('/api/users/me/stats');
-    expect(mockGet).toHaveBeenCalledWith('/api/daily-goals/streak');
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/users/me/stats');
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/daily-goals/streak');
     expect(stats).toEqual({
       totalSessions: 10,
       averageScore: 75.5,

--- a/frontend/src/repositories/__tests__/RankingRepository.test.ts
+++ b/frontend/src/repositories/__tests__/RankingRepository.test.ts
@@ -17,7 +17,7 @@ describe('RankingRepository', () => {
 
       const result = await RankingRepository.fetchRanking();
 
-      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/ranking', {
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/ranking', {
         params: { period: 'weekly' },
       });
       expect(result).toEqual(mockData);
@@ -29,7 +29,7 @@ describe('RankingRepository', () => {
 
       await RankingRepository.fetchRanking('monthly');
 
-      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/ranking', {
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/ranking', {
         params: { period: 'monthly' },
       });
     });

--- a/frontend/src/repositories/__tests__/ReminderRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ReminderRepository.test.ts
@@ -12,7 +12,7 @@ describe('ReminderRepository', () => {
     const mockData = { enabled: true, reminderTime: '20:00', daysOfWeek: 'mon,tue' };
     mockedApiClient.get.mockResolvedValue({ data: mockData });
     const result = await ReminderRepository.fetchSetting();
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/reminder');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/reminder');
     expect(result).toEqual(mockData);
   });
 
@@ -20,7 +20,7 @@ describe('ReminderRepository', () => {
     const setting = { enabled: true, reminderTime: '19:00', daysOfWeek: 'mon' };
     mockedApiClient.put.mockResolvedValue({ data: setting });
     const result = await ReminderRepository.saveSetting(setting);
-    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/reminder', setting);
+    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/v2/reminder', setting);
     expect(result).toEqual(setting);
   });
 });

--- a/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
@@ -22,7 +22,7 @@ describe('ScoreGoalRepository', () => {
     const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
     const result = await ScoreGoalRepository.fetchGoal();
     expect(result).toBe(9.0);
-    expect(mockedGet).toHaveBeenCalledWith('/api/score-goal');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/score-goal');
   });
 
   it('fetchGoal: API失敗時にnullを返す', async () => {
@@ -36,7 +36,7 @@ describe('ScoreGoalRepository', () => {
     mockedPut.mockResolvedValue({ data: {} });
     const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
     await ScoreGoalRepository.saveGoal(7.5);
-    expect(mockedPut).toHaveBeenCalledWith('/api/score-goal', { goalScore: 7.5 });
+    expect(mockedPut).toHaveBeenCalledWith('/api/v2/score-goal', { goalScore: 7.5 });
   });
 
   it('saveGoal: API失敗時にエラーをスローしない', async () => {

--- a/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/SessionNoteRepository.test.ts
@@ -41,7 +41,7 @@ describe('SessionNoteRepository', () => {
 
       expect(result).not.toBeNull();
       expect(result!.note).toBe('APIメモ');
-      expect(mockGet).toHaveBeenCalledWith('/api/session-notes/1');
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/session-notes/1');
     });
 
     it('save: APIでメモを保存する', async () => {
@@ -49,7 +49,7 @@ describe('SessionNoteRepository', () => {
 
       await SessionNoteRepository.save(1, '保存メモ');
 
-      expect(mockPut).toHaveBeenCalledWith('/api/session-notes/1', { note: '保存メモ' });
+      expect(mockPut).toHaveBeenCalledWith('/api/v2/session-notes/1', { note: '保存メモ' });
     });
   });
 

--- a/frontend/src/repositories/__tests__/SharedSessionRepository.test.ts
+++ b/frontend/src/repositories/__tests__/SharedSessionRepository.test.ts
@@ -11,7 +11,7 @@ describe('SharedSessionRepository', () => {
   it('公開セッション一覧を取得する', async () => {
     mockedApiClient.get.mockResolvedValue({ data: [] });
     const result = await SharedSessionRepository.fetchPublicSessions();
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/shared-sessions');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/shared-sessions');
     expect(result).toEqual([]);
   });
 
@@ -19,13 +19,13 @@ describe('SharedSessionRepository', () => {
     const mockShared = { id: 1, sessionId: 10, sessionTitle: 'test' };
     mockedApiClient.post.mockResolvedValue({ data: mockShared });
     const result = await SharedSessionRepository.shareSession(10, 'desc');
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/shared-sessions', { sessionId: 10, description: 'desc' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/shared-sessions', { sessionId: 10, description: 'desc' });
     expect(result).toEqual(mockShared);
   });
 
   it('セッション共有を解除する', async () => {
     mockedApiClient.delete.mockResolvedValue({});
     await SharedSessionRepository.unshareSession(10);
-    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/shared-sessions/10');
+    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/v2/shared-sessions/10');
   });
 });

--- a/frontend/src/repositories/__tests__/TemplateRepository.test.ts
+++ b/frontend/src/repositories/__tests__/TemplateRepository.test.ts
@@ -12,13 +12,13 @@ describe('TemplateRepository', () => {
     it('カテゴリなしで全テンプレートを取得する', async () => {
       mockedApiClient.get.mockResolvedValue({ data: [] });
       await TemplateRepository.fetchTemplates();
-      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/templates', { params: {} });
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/templates', { params: {} });
     });
 
     it('カテゴリ指定でテンプレートを取得する', async () => {
       mockedApiClient.get.mockResolvedValue({ data: [] });
       await TemplateRepository.fetchTemplates('meeting');
-      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/templates', { params: { category: 'meeting' } });
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/templates', { params: { category: 'meeting' } });
     });
   });
 
@@ -27,7 +27,7 @@ describe('TemplateRepository', () => {
       const mockTemplate = { id: 1, title: 'Test', description: '', category: 'meeting', openingMessage: 'Hello', difficulty: 'beginner' };
       mockedApiClient.get.mockResolvedValue({ data: mockTemplate });
       const result = await TemplateRepository.fetchTemplateById(1);
-      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/templates/1');
+      expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/templates/1');
       expect(result).toEqual(mockTemplate);
     });
   });

--- a/frontend/src/repositories/__tests__/UserSearchRepository.test.ts
+++ b/frontend/src/repositories/__tests__/UserSearchRepository.test.ts
@@ -17,7 +17,7 @@ describe('UserSearchRepository', () => {
 
     const result = await UserSearchRepository.searchUsers('山田');
 
-    expect(apiClient.get).toHaveBeenCalledWith('/api/chat/users', { params: { query: '山田' } });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v2/chat/users', { params: { query: '山田' } });
     expect(result).toEqual(mockUsers);
   });
 
@@ -26,7 +26,7 @@ describe('UserSearchRepository', () => {
 
     const result = await UserSearchRepository.searchUsers();
 
-    expect(apiClient.get).toHaveBeenCalledWith('/api/chat/users', { params: {} });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/v2/chat/users', { params: {} });
     expect(result).toEqual([]);
   });
 

--- a/frontend/src/repositories/__tests__/WeeklyChallengeRepository.test.ts
+++ b/frontend/src/repositories/__tests__/WeeklyChallengeRepository.test.ts
@@ -12,7 +12,7 @@ describe('WeeklyChallengeRepository', () => {
     const mockData = { id: 1, title: 'Test', targetSessions: 3, completedSessions: 0, isCompleted: false };
     mockedApiClient.get.mockResolvedValue({ data: mockData });
     const result = await WeeklyChallengeRepository.fetchCurrentChallenge();
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/weekly-challenge');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/weekly-challenge');
     expect(result).toEqual(mockData);
   });
 
@@ -20,7 +20,7 @@ describe('WeeklyChallengeRepository', () => {
     const mockData = { id: 1, completedSessions: 1 };
     mockedApiClient.post.mockResolvedValue({ data: mockData });
     const result = await WeeklyChallengeRepository.incrementProgress();
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/weekly-challenge/progress');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/weekly-challenge/progress');
     expect(result).toEqual(mockData);
   });
 


### PR DESCRIPTION
Spring Boot 完全廃止に伴い、フロントエンドの全 API 呼び出しを Go バックエンド (/api/v2/*) に切替。

## 変更内容
- 47 リポジトリファイルで '/api/foo' → '/api/v2/foo'
- 対応するテストの expect URL も /api/v2 に追従
- バッククォート (template literal) 内のパスも置換

## テスト
- [x] Vitest 全 293 files / 2361 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated backend API endpoints to v2 versioning for improved system stability and compatibility.
  * Enhanced production deployment process with updated containerization workflow.
  * Refactored database configuration parameters for improved deployment flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->