### PR TITLE
feat(backend): CORS middleware + Cognito callback を Go で実装

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -19,7 +19,7 @@ func main() {
 		log.Fatalf("database connect failed: %v", err)
 	}
 
-	r := handler.NewRouter(db)
+	r := handler.NewRouter(db, cfg)
 	addr := ":" + cfg.ServerPort
 	log.Printf("FreStyle Go backend listening on %s (env=%s)", addr, cfg.AppEnv)
 	if err := r.Run(addr); err != nil {

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,10 +1,17 @@
 package handler
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -12,10 +19,16 @@ import (
 // Spring Boot の CognitoAuthController に相当。
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
+	cognito        *config.CognitoConfig
+	httpClient     *http.Client
 }
 
-func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase) *AuthHandler {
-	return &AuthHandler{getCurrentUser: getCurrentUser}
+func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, cognito *config.CognitoConfig) *AuthHandler {
+	return &AuthHandler{
+		getCurrentUser: getCurrentUser,
+		cognito:        cognito,
+		httpClient:     &http.Client{},
+	}
 }
 
 // Me は現在ログイン中のユーザー情報を返す。
@@ -42,4 +55,79 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	c.SetCookie(middleware.CookieAccessToken, "", -1, "/", "", true, true)
 	c.SetCookie("refresh_token", "", -1, "/", "", true, true)
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました。"})
+}
+
+type cognitoCallbackReq struct {
+	Code string `json:"code" binding:"required"`
+}
+
+type cognitoTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// Callback は Cognito Hosted UI から戻ってきた認可コードをアクセストークンに交換し、
+// HttpOnly Cookie に格納する。Spring Boot の CognitoAuthController#callback 相当。
+func (h *AuthHandler) Callback(c *gin.Context) {
+	var req cognitoCallbackReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if h.cognito == nil || h.cognito.TokenURI == "" || h.cognito.ClientID == "" {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"})
+		return
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("client_id", h.cognito.ClientID)
+	form.Set("code", req.Code)
+	form.Set("redirect_uri", h.cognito.RedirectURI)
+
+	httpReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost,
+		h.cognito.TokenURI, strings.NewReader(form.Encode()))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "request_build_failed"})
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if h.cognito.ClientSecret != "" {
+		basic := base64.StdEncoding.EncodeToString(
+			[]byte(fmt.Sprintf("%s:%s", h.cognito.ClientID, h.cognito.ClientSecret)))
+		httpReq.Header.Set("Authorization", "Basic "+basic)
+	}
+
+	resp, err := h.httpClient.Do(httpReq)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "cognito_unreachable"})
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "token_exchange_failed", "detail": string(body)})
+		return
+	}
+
+	var tok cognitoTokenResponse
+	if err := json.Unmarshal(body, &tok); err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "invalid_token_response"})
+		return
+	}
+
+	// HttpOnly + Secure + SameSite=None でアプリ全体に Cookie を渡す
+	maxAge := tok.ExpiresIn
+	if maxAge <= 0 {
+		maxAge = 3600
+	}
+	c.SetSameSite(http.SameSiteNoneMode)
+	c.SetCookie(middleware.CookieAccessToken, tok.AccessToken, maxAge, "/", "", true, true)
+	if tok.RefreshToken != "" {
+		c.SetCookie("refresh_token", tok.RefreshToken, 30*24*3600, "/", "", true, true)
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
 }

--- a/backend/internal/handler/middleware/cors.go
+++ b/backend/internal/handler/middleware/cors.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// 許可するオリジン。Spring Boot の CorsConfig と同じ値を Go 側でも維持する。
+var allowedOrigins = map[string]struct{}{
+	"https://normanblog.com":      {},
+	"http://normanblog.com":       {},
+	"http://localhost:5173":       {},
+	"https://dcd3m6lwt0z8u.cloudfront.net": {},
+	"http://fre-style-bucket.s3-website-ap-northeast-1.amazonaws.com": {},
+}
+
+const (
+	allowMethods = "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+	allowHeaders = "Content-Type, Authorization, X-Requested-With"
+	maxAge       = "3600"
+)
+
+// CORS は Gin 用の CORS middleware。
+// 許可リストにある Origin のみ Access-Control-Allow-Origin を返し、
+// allowCredentials=true で動作するようにする。
+// Preflight (OPTIONS) は本 middleware 内で 204 で返して終端する。
+func CORS() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		origin := c.GetHeader("Origin")
+		if _, ok := allowedOrigins[origin]; ok {
+			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Access-Control-Allow-Credentials", "true")
+			c.Header("Access-Control-Allow-Methods", allowMethods)
+			c.Header("Access-Control-Allow-Headers", allowHeaders)
+			c.Header("Access-Control-Max-Age", maxAge)
+			c.Header("Vary", "Origin")
+		}
+
+		if c.Request.Method == http.MethodOptions {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -3,17 +3,20 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
 
 // NewRouter は API ルーティングを組み立てる。
-// /api/v2/* は Spring Boot の /api/* と並行運用する Go 側のエンドポイント。
-func NewRouter(db *gorm.DB) *gin.Engine {
+// /api/v2/* は Go バックエンドの単独エンドポイント（旧 Spring Boot /api/* は廃止済み）。
+func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(gin.Logger())
+	// 全エンドポイントで CORS を許可（normanblog.com など allowlisted origin）
+	r.Use(middleware.CORS())
 
 	r.GET("/", func(c *gin.Context) {
 		c.JSON(200, gin.H{"message": "FreStyle Go backend"})
@@ -29,8 +32,10 @@ func NewRouter(db *gorm.DB) *gin.Engine {
 
 	// Phase 2: 認証 (Cognito)
 	userRepo := repository.NewUserRepository(db)
-	authHandler := NewAuthHandler(usecase.NewGetCurrentUserUseCase(userRepo))
+	authHandler := NewAuthHandler(usecase.NewGetCurrentUserUseCase(userRepo), &cfg.Cognito)
 	v2.POST("/auth/cognito/logout", authHandler.Logout)
+	// callback は code を受け取って token に交換するので認証不要
+	v2.POST("/auth/cognito/callback", authHandler.Callback)
 
 	// 認証必須グループ
 	authed := v2.Group("")

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -14,6 +14,17 @@ type Config struct {
 	DBPassword string
 	DBName     string
 	DBSSLMode  string
+
+	Cognito CognitoConfig
+}
+
+// CognitoConfig は Cognito Hosted UI / OAuth2 token endpoint との通信に必要な設定。
+type CognitoConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	TokenURI     string
+	JwkSetURI    string
 }
 
 func Load() (*Config, error) {
@@ -26,6 +37,13 @@ func Load() (*Config, error) {
 		DBPassword: os.Getenv("DB_PASSWORD"),
 		DBName:     getEnvOrDefault("DB_NAME", "fre_style"),
 		DBSSLMode:  getEnvOrDefault("DB_SSLMODE", "require"),
+		Cognito: CognitoConfig{
+			ClientID:     os.Getenv("COGNITO_CLIENT_ID"),
+			ClientSecret: os.Getenv("COGNITO_CLIENT_SECRET"),
+			RedirectURI:  os.Getenv("COGNITO_REDIRECT_URI"),
+			TokenURI:     os.Getenv("COGNITO_TOKEN_URI"),
+			JwkSetURI:    os.Getenv("COGNITO_JWK_SET_URI"),
+		},
 	}
 	if cfg.DBHost == "" {
 		return nil, fmt.Errorf("DB_HOST is required")


### PR DESCRIPTION
## 報告された問題

`https://api.normanblog.com/api/auth/cognito/callback` で CORS エラーが発生。

## 根本原因（複数）

1. Go 側に **CORS middleware が未実装** だった（Spring Boot の CorsConfig 相当が Phase 2 で省略されていた）
2. Go 側に **Cognito callback エンドポイントが未実装** だった（Phase 2 では /me と /logout だけ実装、/callback はスタブ）
3. 古い JS bundle が CloudFront 経由で配信されていて `/api/auth/...` を叩いている（フロント側は `/api/v2/auth/...` に移行済み）

## 変更

- `handler/middleware/cors.go` 新設（allowlist 方式、normanblog.com / localhost:5173 等を許可）
- `handler/router.go` で全ルートに `r.Use(middleware.CORS())`
- `handler/auth_handler.go` に Callback ハンドラを実装、Cognito token endpoint と通信して HttpOnly Cookie に格納
- `infra/config/config.go` に CognitoConfig を追加
- `cmd/server/main.go` を `NewRouter(db, cfg)` に変更

## 検証
- [x] go vet / go test 全 pass

## マージ後にあなたが実行する手順
1. `make ecr-build-push && make restart` で Go バックエンド再デプロイ
2. CloudFront キャッシュ invalidation か、フロントを再 build & deploy（`/api/auth/...` を叩く古い bundle が残っているため）
3. ブラウザで再ログイン → /api/v2/auth/cognito/callback が 200 を返すことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cognito OAuth 2.0 authentication support with callback-based login
  * Enabled CORS (Cross-Origin Resource Sharing) across all API endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->