### PR TITLE
fix(auth): Cognito token exchange を client_secret_post (body 方式) に統一

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -85,9 +83,15 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 		return
 	}
 
+	// Cognito の OAuth2 token endpoint には「Authorization Basic header 方式」と
+	// 「body 方式 (client_id + client_secret を form に入れる)」があるが、両方送ると
+	// invalid_client を返すケースがある。本実装では body 方式に統一する（AWS docs 推奨）。
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
 	form.Set("client_id", h.cognito.ClientID)
+	if h.cognito.ClientSecret != "" {
+		form.Set("client_secret", h.cognito.ClientSecret)
+	}
 	form.Set("code", req.Code)
 	form.Set("redirect_uri", h.cognito.RedirectURI)
 
@@ -98,11 +102,6 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 		return
 	}
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if h.cognito.ClientSecret != "" {
-		basic := base64.StdEncoding.EncodeToString(
-			[]byte(fmt.Sprintf("%s:%s", h.cognito.ClientID, h.cognito.ClientSecret)))
-		httpReq.Header.Set("Authorization", "Basic "+basic)
-	}
 
 	resp, err := h.httpClient.Do(httpReq)
 	if err != nil {
@@ -153,9 +152,13 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 
+	// Callback と同じく body 方式に統一する。
 	form := url.Values{}
 	form.Set("grant_type", "refresh_token")
 	form.Set("client_id", h.cognito.ClientID)
+	if h.cognito.ClientSecret != "" {
+		form.Set("client_secret", h.cognito.ClientSecret)
+	}
 	form.Set("refresh_token", rt)
 
 	httpReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost,
@@ -165,11 +168,6 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if h.cognito.ClientSecret != "" {
-		basic := base64.StdEncoding.EncodeToString(
-			[]byte(fmt.Sprintf("%s:%s", h.cognito.ClientID, h.cognito.ClientSecret)))
-		httpReq.Header.Set("Authorization", "Basic "+basic)
-	}
 
 	resp, err := h.httpClient.Do(httpReq)
 	if err != nil {


### PR DESCRIPTION
## 背景
本番ログイン時に `POST /api/v2/auth/cognito/callback` が `invalid_client` で 401。
Secrets Manager の値と Cognito の実 ClientSecret は同期済みだが、Authorization header と body の client_id 重複送信が Cognito 側で拒否される可能性。

## Spring Boot 旧実装の確認
client_secret_basic 方式（Authorization Basic header + body の client_id）を採用していた。git log から確認。

## 変更
- Callback / Refresh ハンドラから Authorization header を削除
- body の form に `client_id` と `client_secret` を入れる client_secret_post 方式に統一
- import から encoding/base64 と fmt を削除

## メリット
- Cognito 側のパース挙動が決定的になり invalid_client が解消される見込み
- 全パラメータが body にあるためデバッグしやすい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication mechanisms for token exchange and refresh operations by refining credential transmission methods. Streamlined the authentication flow to enhance security and efficiency while maintaining full compatibility with all authentication services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->