### PR TITLE
fix(workflow): scheduled-start の health check パスを /api/v2/health に変更

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -246,7 +246,7 @@ jobs:
           ALB_DNS: ${{ steps.deps.outputs.alb_dns }}
         run: |
           for i in 1 2 3 4 5; do
-            if curl -fsS "http://$ALB_DNS/actuator/health"; then
+            if curl -fsS "http://$ALB_DNS/api/v2/health"; then
               echo "✅ Healthy"
               exit 0
             fi


### PR DESCRIPTION
scheduled-start.yml の最後の health check が旧 Spring Boot の `/actuator/health` を叩いて 404 で workflow 失敗扱いになる問題を修正。