### PR TITLE
debug(backend): Cognito 環境変数を起動ログに出す（一時診断、解消後 revert）

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -21,7 +21,15 @@ func main() {
 
 	r := handler.NewRouter(db, cfg)
 	addr := ":" + cfg.ServerPort
-	log.Printf("FreStyle Go backend listening on %s (env=%s)", addr, cfg.AppEnv)
+	// Cognito secret 不一致の診断用一時ログ。値そのものは出さず長さと末尾 4 文字のみ。
+	// 解消後に削除する。
+	csLen := len(cfg.Cognito.ClientSecret)
+	csTail := ""
+	if csLen >= 4 {
+		csTail = cfg.Cognito.ClientSecret[csLen-4:]
+	}
+	log.Printf("FreStyle Go backend listening on %s (env=%s) cognito_client_id=%s cognito_secret_len=%d cognito_secret_tail=...%s cognito_token_uri=%s",
+		addr, cfg.AppEnv, cfg.Cognito.ClientID, csLen, csTail, cfg.Cognito.TokenURI)
 	if err := r.Run(addr); err != nil {
 		log.Fatalf("server stopped: %v", err)
 	}


### PR DESCRIPTION
invalid_client_secret エラーの真因切り分け用。secret 値そのものは出さず長さ・末尾4文字のみ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced server startup logging to include additional authentication service diagnostics for improved deployment visibility and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->