### PR TITLE
feat(backend): AutoMigrate 導入 + BaseEntity 共通化 (Go domain を DB スキーマの「正」に)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -19,6 +19,14 @@ func main() {
 		log.Fatalf("database connect failed: %v", err)
 	}
 
+	// Go domain を「正」とする AutoMigrate。
+	// RESET_DB=true なら DROP SCHEMA → CREATE SCHEMA で完全リセット後 AutoMigrate。
+	// 詳細は backend/internal/infra/database/migrate.go と
+	// docs/16-go-schema-design.md (frestyle-infrastructure) を参照。
+	if err := database.Migrate(db); err != nil {
+		log.Fatalf("migrate failed: %v", err)
+	}
+
 	r := handler.NewRouter(db, cfg)
 	addr := ":" + cfg.ServerPort
 	// Cognito secret 不一致の診断用一時ログ。値そのものは出さず長さと末尾 4 文字のみ。

--- a/backend/internal/domain/base.go
+++ b/backend/internal/domain/base.go
@@ -1,0 +1,29 @@
+// Package domain は FreStyle の純粋なドメイン構造体・列挙・定数を集める層。
+//
+// クリーンアーキテクチャ的観点:
+//   - domain は他のどの層にも依存しない (純粋なロジックのみ)
+//   - usecase / repository / handler が domain を参照する
+//   - GORM tag は本来 infrastructure 関心ごとだが、本プロジェクトでは
+//     pragmatic な妥協として domain 構造体に直書きする運用にしている
+//     （DTO ↔ DB Entity の二重定義を避け、移行コストを抑えるため）
+//   - DB スキーマは Go domain を「正」として AutoMigrate で構築する
+//     （詳細: docs/16-go-schema-design.md @ frestyle-infrastructure）
+package domain
+
+import "time"
+
+// BaseEntity は全ての永続化ドメイン共通のフィールドをまとめる埋め込み用構造体。
+// 各 entity は無名フィールドとして埋め込んで使う:
+//
+//	type User struct {
+//	    BaseEntity
+//	    ...
+//	}
+//
+// 主キー / タイムスタンプの規約をプロジェクト全体で統一することで、
+// 「テーブルによって id 型が違う」「updated_at がないテーブルがある」のような不揃いを防ぐ。
+type BaseEntity struct {
+	ID        uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime" json:"createdAt"`
+	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime" json:"updatedAt"`
+}

--- a/backend/internal/domain/practice.go
+++ b/backend/internal/domain/practice.go
@@ -5,14 +5,14 @@ import "time"
 // PracticeScenario は AI 練習モードのロールプレイ用シナリオ。
 // Spring Boot の entity.PracticeScenario に相当。
 type PracticeScenario struct {
-	ID            uint64    `gorm:"primaryKey" json:"id"`
-	Title         string    `gorm:"column:title" json:"title"`
-	Description   string    `gorm:"column:description" json:"description"`
-	Category      string    `gorm:"column:category" json:"category"`
-	DifficultyLv  int       `gorm:"column:difficulty_level" json:"difficultyLevel"`
-	SystemPrompt  string    `gorm:"column:system_prompt" json:"-"`
-	IsActive      bool      `gorm:"column:is_active" json:"isActive"`
-	CreatedAt     time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID           uint64    `gorm:"primaryKey" json:"id"`
+	Title        string    `gorm:"column:title" json:"title"`
+	Description  string    `gorm:"column:description" json:"description"`
+	Category     string    `gorm:"column:category" json:"category"`
+	DifficultyLv int       `gorm:"column:difficulty_level" json:"difficultyLevel"`
+	SystemPrompt string    `gorm:"column:system_prompt" json:"-"`
+	IsActive     bool      `gorm:"column:is_active;default:true" json:"isActive"`
+	CreatedAt    time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (PracticeScenario) TableName() string { return "practice_scenarios" }

--- a/backend/internal/handler/chat_handler.go
+++ b/backend/internal/handler/chat_handler.go
@@ -18,7 +18,14 @@ func NewChatHandler(g *usecase.GetChatRoomsByUserIDUseCase, c *usecase.CreateCha
 }
 
 func (h *ChatHandler) GetRooms(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	// userId クエリが無い場合は空配列を返す（本来は認証 middleware から current user を取り出すべきだが、
+	// JWKS 検証が Phase 2.1 待ちのため暫定対応）。
+	uidStr := c.Query("userId")
+	if uidStr == "" {
+		c.JSON(http.StatusOK, []struct{}{})
+		return
+	}
+	uid, _ := strconv.ParseUint(uidStr, 10, 64)
 	rows, err := h.getRooms.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -43,6 +43,8 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	authed := v2.Group("")
 	authed.Use(middleware.JWTAuth())
 	authed.GET("/auth/me", authHandler.Me)
+	// フロントが旧 Spring Boot 互換パス /api/v2/auth/cognito/me を叩く場合の alias
+	authed.GET("/auth/cognito/me", authHandler.Me)
 
 	// Phase 3: AI チャット
 	aiSessionRepo := repository.NewAiChatSessionRepository(db)

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -1,0 +1,62 @@
+package database
+
+import (
+	"log"
+	"os"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// allDomainModels は全 domain 構造体のリスト。
+// AutoMigrate に渡してテーブル作成・列追加を一元管理する。
+// 新しい domain を追加したら必ずここにも追記する。
+func allDomainModels() []any {
+	return []any{
+		&domain.User{},
+		&domain.Profile{},
+		&domain.AiChatSession{},
+		&domain.ChatRoom{},
+		&domain.ChatRoomMember{},
+		&domain.PracticeScenario{},
+		&domain.ScenarioBookmark{},
+		&domain.SharedSession{},
+		&domain.Note{},
+		&domain.SessionNote{},
+		&domain.ScoreCard{},
+		&domain.ScoreGoal{},
+		&domain.LearningReport{},
+		&domain.ConversationTemplate{},
+		&domain.FavoritePhrase{},
+		&domain.Friendship{},
+		&domain.Notification{},
+		&domain.ReminderSetting{},
+		&domain.DailyGoal{},
+		&domain.WeeklyChallenge{},
+		&domain.WeeklyChallengeProgress{},
+		&domain.AdminInvitation{},
+	}
+}
+
+// Migrate は起動時のスキーマ整合チェック。
+//   - RESET_DB=true: DROP SCHEMA public CASCADE → CREATE SCHEMA public で完全 wipe してから AutoMigrate。
+//     リリース前に Go domain を「正」とする初期構築をしたいときの一回限り操作。
+//   - RESET_DB が未指定: AutoMigrate のみ走る（CREATE TABLE IF NOT EXISTS と ADD COLUMN は走るが、
+//     型変更・列削除は GORM の安全側仕様で実行されない）。
+func Migrate(db *gorm.DB) error {
+	if os.Getenv("RESET_DB") == "true" {
+		log.Println("⚠️ RESET_DB=true: dropping public schema and recreating")
+		if err := db.Exec("DROP SCHEMA public CASCADE").Error; err != nil {
+			return err
+		}
+		if err := db.Exec("CREATE SCHEMA public").Error; err != nil {
+			return err
+		}
+	}
+	log.Println("migrate: AutoMigrate start")
+	if err := db.AutoMigrate(allDomainModels()...); err != nil {
+		return err
+	}
+	log.Println("migrate: AutoMigrate done")
+	return nil
+}


### PR DESCRIPTION
## 背景
ログイン後 \`/api/v2/practice/scenarios\` で 500 エラー。原因は DB に \`is_active\` 列が無く Go の WHERE 句で SQLSTATE 42703。
「Go domain を「正」として DB スキーマを管理する」体制に切替える。

## 変更
- AutoMigrate を起動時に走らせる (\`database.Migrate(db)\`)
- 全 domain を \`allDomainModels()\` に列挙
- \`RESET_DB=true\` 環境変数で DROP SCHEMA → CREATE SCHEMA の完全 wipe も可能
- \`BaseEntity\` (ID + CreatedAt + UpdatedAt) を新設し、共通スキーマ規約を docs と package コメントで明文化
- 旧 Spring Boot 互換 path \`/auth/cognito/me\` の alias を追加
- chat_handler の userId 未指定 handling を暫定実装

## 効果
- is_active のような列ズレ事故が起きなくなる
- 「Go domain に追加 → AutoMigrate で DB に反映」の単純フロー
- 完全リセットが必要な時は RESET_DB=true で 1 回起動するだけで wipe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new `/api/v2/auth/cognito/me` endpoint for authentication.

* **Bug Fixes**
  * Fixed chat API to gracefully handle missing user ID parameters by returning an empty response instead of an error.

* **Improvements**
  * Enhanced system startup with automatic database schema initialization and migration.
  * Practice scenarios now default to active status on creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->