### PR TITLE
fix(post-login): フロント旧 path 修正 + Go alias/stub + users 自動 upsert

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -10,8 +12,10 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -19,13 +23,15 @@ import (
 // Spring Boot の CognitoAuthController に相当。
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
+	users          repository.UserRepository
 	cognito        *config.CognitoConfig
 	httpClient     *http.Client
 }
 
-func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, cognito *config.CognitoConfig) *AuthHandler {
+func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, users repository.UserRepository, cognito *config.CognitoConfig) *AuthHandler {
 	return &AuthHandler{
 		getCurrentUser: getCurrentUser,
+		users:          users,
 		cognito:        cognito,
 		// Cognito token endpoint への通信が無限待ちにならないよう必ず timeout を設定する
 		httpClient: &http.Client{Timeout: 10 * time.Second},
@@ -137,7 +143,56 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	if tok.RefreshToken != "" {
 		c.SetCookie("refresh_token", tok.RefreshToken, 30*24*3600, "/", "", true, true)
 	}
+
+	// 初回ログインで users 行が無いと /auth/me が 404 になるため自動で upsert する。
+	// id_token の payload から sub / email を取り出して、未登録なら trainee として作成。
+	if claims, err := decodeJWTClaims(tok.IDToken); err == nil {
+		sub, _ := claims["sub"].(string)
+		email, _ := claims["email"].(string)
+		if sub != "" && h.users != nil {
+			existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
+			if existing == nil {
+				_ = h.users.Create(c.Request.Context(), &domain.User{
+					CognitoSub:  sub,
+					Email:       email,
+					DisplayName: email,
+					Role:        domain.RoleTrainee,
+				})
+			}
+		}
+	}
+
 	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
+}
+
+// decodeJWTClaims は JWT (3 セグメント、署名検証なし) の payload 部だけ base64 デコードする。
+// callback 直後に Cognito 発行 token から sub / email を取り出して users 自動作成するためだけに使う。
+// 認証 middleware の本格的な署名検証 (JWKS) は別 issue。
+func decodeJWTClaims(idToken string) (map[string]any, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid jwt format")
+	}
+	payload, err := base64URLDecode(parts[1])
+	if err != nil {
+		return nil, err
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+func base64URLDecode(s string) ([]byte, error) {
+	switch len(s) % 4 {
+	case 2:
+		s += "=="
+	case 3:
+		s += "="
+	}
+	s = strings.NewReplacer("-", "+", "_", "/").Replace(s)
+	return base64.StdEncoding.DecodeString(s)
 }
 
 // Refresh は HttpOnly Cookie の refresh_token を使ってアクセストークンを再発行する。

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -32,7 +32,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 
 	// Phase 2: 認証 (Cognito)
 	userRepo := repository.NewUserRepository(db)
-	authHandler := NewAuthHandler(usecase.NewGetCurrentUserUseCase(userRepo), &cfg.Cognito)
+	authHandler := NewAuthHandler(usecase.NewGetCurrentUserUseCase(userRepo), userRepo, &cfg.Cognito)
 	v2.POST("/auth/cognito/logout", authHandler.Logout)
 	// callback は code を受け取って token に交換するので認証不要
 	v2.POST("/auth/cognito/callback", authHandler.Callback)
@@ -63,6 +63,11 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/chat/rooms", chatHandler.GetRooms)
 	authed.POST("/chat/rooms", chatHandler.CreateRoom)
+	// /chat/stats はフロント MenuPage が叩いていた旧 Spring Boot path。
+	// Go では未実装なので暫定 stub で空オブジェクトを返す（フロントは PR で chat/rooms 由来に切替済）。
+	authed.GET("/chat/stats", func(c *gin.Context) {
+		c.JSON(200, gin.H{"chatPartnerCount": 0})
+	})
 
 	// Phase 5: プロフィール
 	profileRepo := repository.NewProfileRepository(db)
@@ -146,6 +151,8 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/score-cards", scoreCardHandler.List)
 	authed.POST("/score-cards", scoreCardHandler.Create)
+	// 旧 Spring Boot 互換 path の alias
+	authed.GET("/scores/history", scoreCardHandler.List)
 
 	// Phase 14: ScoreGoal
 	scoreGoalRepo := repository.NewScoreGoalRepository(db)

--- a/frontend/src/repositories/AiChatRepository.ts
+++ b/frontend/src/repositories/AiChatRepository.ts
@@ -111,7 +111,7 @@ class AiChatRepository {
    * スコア履歴を取得
    */
   async getScoreHistory(): Promise<ScoreHistoryItem[]> {
-    const response = await apiClient.get('/api/v2/scores/history');
+    const response = await apiClient.get('/api/v2/score-cards');
     return response.data;
   }
 }

--- a/frontend/src/repositories/MenuRepository.ts
+++ b/frontend/src/repositories/MenuRepository.ts
@@ -10,9 +10,15 @@ interface ChatRoomsResponse {
 }
 
 export const MenuRepository = {
+  // /chat/stats は Go バックエンドに未実装。chat/rooms から件数を計算する暫定実装。
   async fetchChatStats(): Promise<ChatStats> {
-    const { data } = await apiClient.get('/api/v2/chat/stats');
-    return data;
+    try {
+      const { data } = await apiClient.get<ChatRoomsResponse>('/api/v2/chat/rooms');
+      const count = Array.isArray(data?.chatUsers) ? data.chatUsers.length : 0;
+      return { chatPartnerCount: count };
+    } catch {
+      return { chatPartnerCount: 0 };
+    }
   },
 
   async fetchChatRooms(): Promise<ChatRoomsResponse> {
@@ -21,7 +27,7 @@ export const MenuRepository = {
   },
 
   async fetchScoreHistory(): Promise<ScoreHistory[]> {
-    const { data } = await apiClient.get('/api/v2/scores/history');
+    const { data } = await apiClient.get('/api/v2/score-cards');
     return data;
   },
 };

--- a/frontend/src/repositories/__tests__/AiChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AiChatRepository.test.ts
@@ -105,7 +105,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getScoreHistory();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/scores/history');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/score-cards');
     expect(result).toEqual(mockHistory);
   });
 });

--- a/frontend/src/repositories/__tests__/MenuRepository.test.ts
+++ b/frontend/src/repositories/__tests__/MenuRepository.test.ts
@@ -11,13 +11,13 @@ describe('MenuRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('チャット統計を取得できる', async () => {
-    mockedApiClient.get.mockResolvedValue({ data: { chatPartnerCount: 5 } });
+  it('チャット統計は chat/rooms の件数から導出する', async () => {
+    mockedApiClient.get.mockResolvedValue({ data: { chatUsers: [{ roomId: 1, unreadCount: 0 }, { roomId: 2, unreadCount: 1 }] } });
 
     const result = await MenuRepository.fetchChatStats();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/stats');
-    expect(result).toEqual({ chatPartnerCount: 5 });
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/rooms');
+    expect(result).toEqual({ chatPartnerCount: 2 });
   });
 
   it('チャットルーム一覧を取得できる', async () => {
@@ -36,13 +36,13 @@ describe('MenuRepository', () => {
 
     const result = await MenuRepository.fetchScoreHistory();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/scores/history');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/score-cards');
     expect(result).toEqual(mockScores);
   });
 
-  it('fetchChatStats: APIエラーが呼び出し元に伝播する', async () => {
+  it('fetchChatStats: API エラーは握りつぶして 0 を返す（暫定対応）', async () => {
     mockedApiClient.get.mockRejectedValue(new Error('Network Error'));
 
-    await expect(MenuRepository.fetchChatStats()).rejects.toThrow('Network Error');
+    await expect(MenuRepository.fetchChatStats()).resolves.toEqual({ chatPartnerCount: 0 });
   });
 });


### PR DESCRIPTION
ログイン後の 404 / 401 を一括修正。
- /scores/history を /score-cards に置換 (FE) / alias 追加 (Go)
- /chat/stats は Go 未実装のため /chat/rooms 由来に変更 (FE) / stub 追加 (Go)
- Callback で users 行を自動 upsert (AutoMigrate 直後のクリーン DB でも 404 にならない)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User accounts are now automatically created and provisioned on first sign-in via authentication, with email information pre-populated for account identification.

* **Refactor**
  * Internal API improvements for retrieving score history and chat statistics to enhance system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->