### PR TITLE
fix(backend): 旧 path alias + bookmarks 空対応 + SockJS info stub

### DIFF
--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -54,6 +54,9 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/ai-chat/sessions", aiHandler.GetSessions)
 	authed.POST("/ai-chat/sessions", aiHandler.CreateSession)
+	// 旧 Spring Boot 互換 path: フロントは /chat/ai/sessions を叩く
+	authed.GET("/chat/ai/sessions", aiHandler.GetSessions)
+	authed.POST("/chat/ai/sessions", aiHandler.CreateSession)
 
 	// Phase 4: ユーザー間チャット (ルーム CRUD)
 	chatRoomRepo := repository.NewChatRoomRepository(db)
@@ -164,6 +167,10 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/score-goals/:userId", scoreGoalHandler.Get)
 	authed.PUT("/score-goals/:userId", scoreGoalHandler.Upsert)
+	// 旧 Spring Boot 互換 path（単数形）: フロントが /score-goal を叩く
+	authed.GET("/score-goal", func(c *gin.Context) {
+		c.JSON(200, gin.H{"targetScore": 0})
+	})
 
 	// Phase 15: ScoreTrend
 	scoreTrendHandler := NewScoreTrendHandler(
@@ -282,10 +289,30 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	// Phase 27: AiChat WebSocket (echo skeleton, Bedrock 連携は Phase 27.1)
 	aiChatWsHandler := NewAiChatWsHandler()
 	authed.GET("/ws/ai-chat", aiChatWsHandler.Handle)
+	// SockJS 互換 info endpoint。フロント (@stomp/stompjs + sockjs-client) は接続前に
+	// /ws/.../info?t=... を叩く。Go は raw WebSocket なので websocket=false で返して
+	// SockJS の reconnect ループを早期終了させる。本格的な WS 統合は別 issue。
+	v2.GET("/ws/ai-chat/info", sockJSInfo)
+	v2.GET("/ws/chat/info", sockJSInfo)
+	// /ws/... (api/v2 プレフィックス無し) でも叩かれているので root にも登録
+	r.GET("/ws/ai-chat/info", sockJSInfo)
+	r.GET("/ws/chat/info", sockJSInfo)
 
 	// Phase 28: Chat WebSocket (ルームごとブロードキャスト)
 	chatWsHandler := NewChatWsHandler()
 	authed.GET("/ws/chat/:roomId", chatWsHandler.Handle)
 
 	return r
+}
+
+// sockJSInfo は SockJS 互換の /info レスポンスを返す。
+// websocket=false を返すことで sockjs-client が WS 試行をスキップし、
+// 全 transport 失敗 → 早期に諦めるようになる（本格的な WS 統合は別 issue）。
+func sockJSInfo(c *gin.Context) {
+	c.JSON(200, gin.H{
+		"entropy":       0,
+		"origins":       []string{"*:*"},
+		"cookie_needed": false,
+		"websocket":     false,
+	})
 }

--- a/backend/internal/handler/scenario_bookmark_handler.go
+++ b/backend/internal/handler/scenario_bookmark_handler.go
@@ -24,6 +24,10 @@ func NewScenarioBookmarkHandler(
 
 func (h *ScenarioBookmarkHandler) List(c *gin.Context) {
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	if uid == 0 {
+		c.JSON(http.StatusOK, []struct{}{})
+		return
+	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})


### PR DESCRIPTION
ホーム画面到達後の 404/400 を一括解消。/chat/ai/sessions, /score-goal, /bookmarks userId 未指定, /ws/.../info の stub を追加。