### PR TITLE
refactor: Spring Boot 廃止整合性 — 旧 path alias 削除 + current user 解決 middleware

### DIFF
--- a/backend/internal/handler/chat_handler.go
+++ b/backend/internal/handler/chat_handler.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -20,12 +21,14 @@ func NewChatHandler(g *usecase.GetChatRoomsByUserIDUseCase, c *usecase.CreateCha
 func (h *ChatHandler) GetRooms(c *gin.Context) {
 	// userId クエリが無い場合は空配列を返す（本来は認証 middleware から current user を取り出すべきだが、
 	// JWKS 検証が Phase 2.1 待ちのため暫定対応）。
-	uidStr := c.Query("userId")
-	if uidStr == "" {
+	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	if uid == 0 {
+		uid = middleware.MustCurrentUserID(c)
+	}
+	if uid == 0 {
 		c.JSON(http.StatusOK, []struct{}{})
 		return
 	}
-	uid, _ := strconv.ParseUint(uidStr, 10, 64)
 	rows, err := h.getRooms.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/chat_handler.go
+++ b/backend/internal/handler/chat_handler.go
@@ -19,11 +19,11 @@ func NewChatHandler(g *usecase.GetChatRoomsByUserIDUseCase, c *usecase.CreateCha
 }
 
 func (h *ChatHandler) GetRooms(c *gin.Context) {
-	// userId クエリが無い場合は空配列を返す（本来は認証 middleware から current user を取り出すべきだが、
-	// JWKS 検証が Phase 2.1 待ちのため暫定対応）。
+	// `?userId=` が指定されていれば優先し、無ければ middleware.CurrentUser がセットした
+	// 認証済 user を使う。フロントは current user 用に userId 無しで叩いてくるのが正規 path。
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
 	if uid == 0 {
-		uid = middleware.MustCurrentUserID(c)
+		uid = middleware.CurrentUserIDOrZero(c)
 	}
 	if uid == 0 {
 		c.JSON(http.StatusOK, []struct{}{})

--- a/backend/internal/handler/daily_goal_handler.go
+++ b/backend/internal/handler/daily_goal_handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -18,8 +19,22 @@ func NewDailyGoalHandler(g *usecase.GetDailyGoalUseCase, u *usecase.UpsertDailyG
 	return &DailyGoalHandler{get: g, upsert: u}
 }
 
+// resolveUserID は path の :userId が "today" や空文字なら current user を返す。
+// フロントが /api/v2/daily-goals/today を叩くケースに対応。
+func (h *DailyGoalHandler) resolveUserID(c *gin.Context) uint64 {
+	param := c.Param("userId")
+	if uid, err := strconv.ParseUint(param, 10, 64); err == nil && uid > 0 {
+		return uid
+	}
+	return middleware.MustCurrentUserID(c)
+}
+
 func (h *DailyGoalHandler) Get(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid := h.resolveUserID(c)
+	if uid == 0 {
+		c.JSON(http.StatusOK, gin.H{"date": "", "targetMinutes": 0, "actualMinutes": 0, "isAchieved": false})
+		return
+	}
 	dateStr := c.DefaultQuery("date", time.Now().UTC().Format("2006-01-02"))
 	date, err := time.Parse("2006-01-02", dateStr)
 	if err != nil {
@@ -32,7 +47,7 @@ func (h *DailyGoalHandler) Get(c *gin.Context) {
 		return
 	}
 	if got == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		c.JSON(http.StatusOK, gin.H{"userId": uid, "date": dateStr, "targetMinutes": 0, "actualMinutes": 0, "isAchieved": false})
 		return
 	}
 	c.JSON(http.StatusOK, got)

--- a/backend/internal/handler/daily_goal_handler.go
+++ b/backend/internal/handler/daily_goal_handler.go
@@ -26,7 +26,7 @@ func (h *DailyGoalHandler) resolveUserID(c *gin.Context) uint64 {
 	if uid, err := strconv.ParseUint(param, 10, 64); err == nil && uid > 0 {
 		return uid
 	}
-	return middleware.MustCurrentUserID(c)
+	return middleware.CurrentUserIDOrZero(c)
 }
 
 func (h *DailyGoalHandler) Get(c *gin.Context) {

--- a/backend/internal/handler/daily_goal_handler.go
+++ b/backend/internal/handler/daily_goal_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -19,20 +20,43 @@ func NewDailyGoalHandler(g *usecase.GetDailyGoalUseCase, u *usecase.UpsertDailyG
 	return &DailyGoalHandler{get: g, upsert: u}
 }
 
-// resolveUserID は path の :userId が "today" や空文字なら current user を返す。
-// フロントが /api/v2/daily-goals/today を叩くケースに対応。
-func (h *DailyGoalHandler) resolveUserID(c *gin.Context) uint64 {
-	param := c.Param("userId")
-	if uid, err := strconv.ParseUint(param, 10, 64); err == nil && uid > 0 {
-		return uid
+var (
+	errDailyGoalForbidden    = errors.New("forbidden")
+	errDailyGoalUnauthorized = errors.New("unauthorized")
+)
+
+// resolveUserID は path :userId を current user と突き合わせる。
+//   - "today" / 空文字 / 数値以外 → current user (フロントの /daily-goals/today に対応)
+//   - 数値 0 → 不正
+//   - 数値が current user 以外 → forbidden（IDOR 対策）
+//   - 数値が current user と一致 → そのまま返す
+func (h *DailyGoalHandler) resolveUserID(c *gin.Context) (uint64, error) {
+	cur := middleware.CurrentUserIDOrZero(c)
+	if cur == 0 {
+		return 0, errDailyGoalUnauthorized
 	}
-	return middleware.CurrentUserIDOrZero(c)
+	param := c.Param("userId")
+	if param == "" || param == "today" {
+		return cur, nil
+	}
+	uid, err := strconv.ParseUint(param, 10, 64)
+	if err != nil {
+		// 数字でない path リテラル（例 "today" 以外の文字列）も current user として扱う。
+		return cur, nil
+	}
+	if uid == 0 {
+		return 0, errDailyGoalForbidden
+	}
+	if uid != cur {
+		return 0, errDailyGoalForbidden
+	}
+	return uid, nil
 }
 
 func (h *DailyGoalHandler) Get(c *gin.Context) {
-	uid := h.resolveUserID(c)
-	if uid == 0 {
-		c.JSON(http.StatusOK, gin.H{"date": "", "targetMinutes": 0, "actualMinutes": 0, "isAchieved": false})
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		writeDailyGoalError(c, err)
 		return
 	}
 	dateStr := c.DefaultQuery("date", time.Now().UTC().Format("2006-01-02"))
@@ -47,6 +71,7 @@ func (h *DailyGoalHandler) Get(c *gin.Context) {
 		return
 	}
 	if got == nil {
+		// 未設定でも success と同形 (userId / date / targetMinutes / actualMinutes / isAchieved) を返す。
 		c.JSON(http.StatusOK, gin.H{"userId": uid, "date": dateStr, "targetMinutes": 0, "actualMinutes": 0, "isAchieved": false})
 		return
 	}
@@ -60,7 +85,11 @@ type dailyGoalReq struct {
 }
 
 func (h *DailyGoalHandler) Upsert(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		writeDailyGoalError(c, err)
+		return
+	}
 	var req dailyGoalReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -79,4 +108,15 @@ func (h *DailyGoalHandler) Upsert(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, got)
+}
+
+func writeDailyGoalError(c *gin.Context, err error) {
+	switch err {
+	case errDailyGoalUnauthorized:
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	case errDailyGoalForbidden:
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	default:
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	}
 }

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+const ContextKeyCurrentUserID = "currentUserID"
+
+// CurrentUser は JWTAuth の後段で動く middleware。
+// JWTAuth が context に詰めた cognito sub から users 行を引き、
+// `currentUserID` を context にセットする。
+//
+// これにより handler は `c.Get(ContextKeyCurrentUserID)` で
+// 認証済みユーザーの users.id を取り出せる。
+// 個別 handler が `:userId` path / `?userId=` クエリを要求しなくても済む。
+func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		raw, ok := c.Get(ContextKeyCognitoSub)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		sub, _ := raw.(string)
+		user, err := users.FindByCognitoSub(c.Request.Context(), sub)
+		if err != nil || user == nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "user_not_found"})
+			return
+		}
+		c.Set(ContextKeyCurrentUserID, user.ID)
+		c.Next()
+	}
+}
+
+// MustCurrentUserID は middleware.CurrentUser が必須の handler 内で使うヘルパ。
+// 設定されていなければ 0 を返す（呼び出し側でガードする）。
+func MustCurrentUserID(c *gin.Context) uint64 {
+	v, ok := c.Get(ContextKeyCurrentUserID)
+	if !ok {
+		return 0
+	}
+	id, _ := v.(uint64)
+	return id
+}

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -13,7 +13,7 @@ const ContextKeyCurrentUserID = "currentUserID"
 // JWTAuth が context に詰めた cognito sub から users 行を引き、
 // `currentUserID` を context にセットする。
 //
-// これにより handler は `c.Get(ContextKeyCurrentUserID)` で
+// これにより handler は `middleware.CurrentUserIDOrZero(c)` で
 // 認証済みユーザーの users.id を取り出せる。
 // 個別 handler が `:userId` path / `?userId=` クエリを要求しなくても済む。
 func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
@@ -23,9 +23,18 @@ func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
-		sub, _ := raw.(string)
+		sub, ok := raw.(string)
+		if !ok || sub == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_sub"})
+			return
+		}
 		user, err := users.FindByCognitoSub(c.Request.Context(), sub)
-		if err != nil || user == nil {
+		if err != nil {
+			// repo / DB エラーは認証問題ではなくサーバ側障害なので 500。
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "user_lookup_failed"})
+			return
+		}
+		if user == nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "user_not_found"})
 			return
 		}
@@ -34,9 +43,11 @@ func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
 	}
 }
 
-// MustCurrentUserID は middleware.CurrentUser が必須の handler 内で使うヘルパ。
+// CurrentUserIDOrZero は middleware.CurrentUser がセットした users.id を取り出す。
 // 設定されていなければ 0 を返す（呼び出し側でガードする）。
-func MustCurrentUserID(c *gin.Context) uint64 {
+// 名前で「未設定なら 0」と明示することで、Must プレフィックスから連想される
+// 「不在なら panic / abort」挙動と取り違えないようにする意図。
+func CurrentUserIDOrZero(c *gin.Context) uint64 {
 	v, ok := c.Get(ContextKeyCurrentUserID)
 	if !ok {
 		return 0

--- a/backend/internal/handler/notification_handler.go
+++ b/backend/internal/handler/notification_handler.go
@@ -18,13 +18,13 @@ func NewNotificationHandler(l *usecase.ListNotificationsUseCase, m *usecase.Mark
 	return &NotificationHandler{list: l, markRead: m}
 }
 
+// List は常に認証済 current user の通知を返す。
+// 過去は ?userId= クエリを受け付けていたが、authz 機構が無いため任意の userId を
+// クエリで指定できると IDOR になる。admin 機構が入るまでは current user 固定にする。
 func (h *NotificationHandler) List(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
-		uid = middleware.MustCurrentUserID(c)
-	}
-	if uid == 0 {
-		c.JSON(http.StatusOK, []struct{}{})
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)

--- a/backend/internal/handler/notification_handler.go
+++ b/backend/internal/handler/notification_handler.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -19,6 +20,13 @@ func NewNotificationHandler(l *usecase.ListNotificationsUseCase, m *usecase.Mark
 
 func (h *NotificationHandler) List(c *gin.Context) {
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	if uid == 0 {
+		uid = middleware.MustCurrentUserID(c)
+	}
+	if uid == 0 {
+		c.JSON(http.StatusOK, []struct{}{})
+		return
+	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/notification_handler.go
+++ b/backend/internal/handler/notification_handler.go
@@ -35,9 +35,17 @@ func (h *NotificationHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
+// MarkRead は所有者検証つきで通知を既読化する。
+// 自分の通知 id でなければ DB の WHERE 句で何もマッチしないので、
+// 任意 id を渡されても他人の既読化は起きない。
 func (h *NotificationHandler) MarkRead(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err := h.markRead.Execute(c.Request.Context(), id); err != nil {
+	if err := h.markRead.Execute(c.Request.Context(), uid, id); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -94,9 +94,11 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		usecase.NewAddScenarioBookmarkUseCase(bookmarkRepo),
 		usecase.NewRemoveScenarioBookmarkUseCase(bookmarkRepo),
 	)
+	// scenario-bookmarks は current user の所有物のみ操作可能（IDOR 対策で userId は受けない）。
+	// フロントは /scenario-bookmarks/:scenarioId に POST/DELETE を投げる。
 	authed.GET("/scenario-bookmarks", bookmarkHandler.List)
-	authed.POST("/scenario-bookmarks", bookmarkHandler.Add)
-	authed.DELETE("/scenario-bookmarks/:userId/:scenarioId", bookmarkHandler.Remove)
+	authed.POST("/scenario-bookmarks/:scenarioId", bookmarkHandler.Add)
+	authed.DELETE("/scenario-bookmarks/:scenarioId", bookmarkHandler.Remove)
 
 	// Phase 9: 共有 AI 会話セッション
 	sharedRepo := repository.NewSharedSessionRepository(db)

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -39,12 +39,11 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	// refresh-token は HttpOnly Cookie の refresh_token を読むため認証 middleware の対象外
 	v2.POST("/auth/cognito/refresh-token", authHandler.Refresh)
 
-	// 認証必須グループ
+	// 認証必須グループ。JWTAuth で sub を context に詰めた後、CurrentUser で users.id を解決する。
 	authed := v2.Group("")
 	authed.Use(middleware.JWTAuth())
+	authed.Use(middleware.CurrentUser(userRepo))
 	authed.GET("/auth/me", authHandler.Me)
-	// フロントが旧 Spring Boot 互換パス /api/v2/auth/cognito/me を叩く場合の alias
-	authed.GET("/auth/cognito/me", authHandler.Me)
 
 	// Phase 3: AI チャット
 	aiSessionRepo := repository.NewAiChatSessionRepository(db)
@@ -54,9 +53,6 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/ai-chat/sessions", aiHandler.GetSessions)
 	authed.POST("/ai-chat/sessions", aiHandler.CreateSession)
-	// 旧 Spring Boot 互換 path: フロントは /chat/ai/sessions を叩く
-	authed.GET("/chat/ai/sessions", aiHandler.GetSessions)
-	authed.POST("/chat/ai/sessions", aiHandler.CreateSession)
 
 	// Phase 4: ユーザー間チャット (ルーム CRUD)
 	chatRoomRepo := repository.NewChatRoomRepository(db)
@@ -66,11 +62,6 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/chat/rooms", chatHandler.GetRooms)
 	authed.POST("/chat/rooms", chatHandler.CreateRoom)
-	// /chat/stats はフロント MenuPage が叩いていた旧 Spring Boot path。
-	// Go では未実装なので暫定 stub で空オブジェクトを返す（フロントは PR で chat/rooms 由来に切替済）。
-	authed.GET("/chat/stats", func(c *gin.Context) {
-		c.JSON(200, gin.H{"chatPartnerCount": 0})
-	})
 
 	// Phase 5: プロフィール
 	profileRepo := repository.NewProfileRepository(db)
@@ -106,8 +97,6 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	authed.GET("/scenario-bookmarks", bookmarkHandler.List)
 	authed.POST("/scenario-bookmarks", bookmarkHandler.Add)
 	authed.DELETE("/scenario-bookmarks/:userId/:scenarioId", bookmarkHandler.Remove)
-	// 旧 Spring Boot 互換 path のための alias（フロントが /api/v2/bookmarks を叩くケース）
-	authed.GET("/bookmarks", bookmarkHandler.List)
 
 	// Phase 9: 共有 AI 会話セッション
 	sharedRepo := repository.NewSharedSessionRepository(db)
@@ -156,8 +145,6 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	)
 	authed.GET("/score-cards", scoreCardHandler.List)
 	authed.POST("/score-cards", scoreCardHandler.Create)
-	// 旧 Spring Boot 互換 path の alias
-	authed.GET("/scores/history", scoreCardHandler.List)
 
 	// Phase 14: ScoreGoal
 	scoreGoalRepo := repository.NewScoreGoalRepository(db)
@@ -165,12 +152,11 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		usecase.NewGetScoreGoalUseCase(scoreGoalRepo),
 		usecase.NewUpsertScoreGoalUseCase(scoreGoalRepo),
 	)
+	// /score-goals は current user 解決、/score-goals/:userId は管理者用 path
+	authed.GET("/score-goals", scoreGoalHandler.Get)
+	authed.PUT("/score-goals", scoreGoalHandler.Upsert)
 	authed.GET("/score-goals/:userId", scoreGoalHandler.Get)
 	authed.PUT("/score-goals/:userId", scoreGoalHandler.Upsert)
-	// 旧 Spring Boot 互換 path（単数形）: フロントが /score-goal を叩く
-	authed.GET("/score-goal", func(c *gin.Context) {
-		c.JSON(200, gin.H{"targetScore": 0})
-	})
 
 	// Phase 15: ScoreTrend
 	scoreTrendHandler := NewScoreTrendHandler(
@@ -245,13 +231,10 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		usecase.NewGetDailyGoalUseCase(dailyGoalRepo),
 		usecase.NewUpsertDailyGoalUseCase(dailyGoalRepo),
 	)
+	// /daily-goals/today はフロント MenuPage が呼ぶ。handler 側で path の :userId が "today" や数値以外なら
+	// current user に解決する仕組みを入れている (see daily_goal_handler.go resolveUserID)。
 	authed.GET("/daily-goals/:userId", dailyGoalHandler.Get)
 	authed.PUT("/daily-goals/:userId", dailyGoalHandler.Upsert)
-	// /daily-goals/today は Spring Boot 時代の path。Go では :userId 解析されて 400 になっていた。
-	// 暫定で 200 + 空オブジェクトを返す stub。本来は current user の今日の goal を返すべきだが別 issue。
-	authed.GET("/daily-goals/today", func(c *gin.Context) {
-		c.JSON(200, gin.H{"date": "", "targetMinutes": 0, "actualMinutes": 0, "isAchieved": false})
-	})
 
 	// Phase 24: WeeklyChallenge
 	weeklyRepo := repository.NewWeeklyChallengeRepository(db)

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -152,11 +152,11 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		usecase.NewGetScoreGoalUseCase(scoreGoalRepo),
 		usecase.NewUpsertScoreGoalUseCase(scoreGoalRepo),
 	)
-	// /score-goals は current user 解決、/score-goals/:userId は管理者用 path
+	// 認証済 current user の score goal のみを返す。
+	// 旧 `/score-goals/:userId` 系は admin 認可機構が無く IDOR になるため廃止。
+	// admin 用の他ユーザー閲覧/変更が必要になったら別途 /admin/users/:id/score-goal として追加する。
 	authed.GET("/score-goals", scoreGoalHandler.Get)
 	authed.PUT("/score-goals", scoreGoalHandler.Upsert)
-	authed.GET("/score-goals/:userId", scoreGoalHandler.Get)
-	authed.PUT("/score-goals/:userId", scoreGoalHandler.Upsert)
 
 	// Phase 15: ScoreTrend
 	scoreTrendHandler := NewScoreTrendHandler(

--- a/backend/internal/handler/scenario_bookmark_handler.go
+++ b/backend/internal/handler/scenario_bookmark_handler.go
@@ -26,7 +26,7 @@ func NewScenarioBookmarkHandler(
 func (h *ScenarioBookmarkHandler) List(c *gin.Context) {
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
 	if uid == 0 {
-		uid = middleware.MustCurrentUserID(c)
+		uid = middleware.CurrentUserIDOrZero(c)
 	}
 	if uid == 0 {
 		c.JSON(http.StatusOK, []struct{}{})

--- a/backend/internal/handler/scenario_bookmark_handler.go
+++ b/backend/internal/handler/scenario_bookmark_handler.go
@@ -24,12 +24,9 @@ func NewScenarioBookmarkHandler(
 }
 
 func (h *ScenarioBookmarkHandler) List(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
-		uid = middleware.CurrentUserIDOrZero(c)
-	}
-	if uid == 0 {
-		c.JSON(http.StatusOK, []struct{}{})
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
@@ -40,18 +37,20 @@ func (h *ScenarioBookmarkHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
-type addBookmarkReq struct {
-	UserID     uint64 `json:"userId" binding:"required"`
-	ScenarioID uint64 `json:"scenarioId" binding:"required"`
-}
-
+// Add は path :scenarioId を current user の bookmark として登録する。
+// userId はクライアントから受け取らずサーバ側で current user に固定する（IDOR 対策）。
 func (h *ScenarioBookmarkHandler) Add(c *gin.Context) {
-	var req addBookmarkReq
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	got, err := h.add.Execute(c.Request.Context(), req.UserID, req.ScenarioID)
+	sid, err := strconv.ParseUint(c.Param("scenarioId"), 10, 64)
+	if err != nil || sid == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scenarioId"})
+		return
+	}
+	got, err := h.add.Execute(c.Request.Context(), uid, sid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -59,9 +58,19 @@ func (h *ScenarioBookmarkHandler) Add(c *gin.Context) {
 	c.JSON(http.StatusCreated, got)
 }
 
+// Remove は path :scenarioId を current user の bookmark として削除する。
+// 他人の bookmark を消せないように DB の WHERE 句で user_id を絞る。
 func (h *ScenarioBookmarkHandler) Remove(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
-	sid, _ := strconv.ParseUint(c.Param("scenarioId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	sid, err := strconv.ParseUint(c.Param("scenarioId"), 10, 64)
+	if err != nil || sid == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scenarioId"})
+		return
+	}
 	if err := h.remove.Execute(c.Request.Context(), uid, sid); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handler/scenario_bookmark_handler.go
+++ b/backend/internal/handler/scenario_bookmark_handler.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -24,6 +25,9 @@ func NewScenarioBookmarkHandler(
 
 func (h *ScenarioBookmarkHandler) List(c *gin.Context) {
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	if uid == 0 {
+		uid = middleware.MustCurrentUserID(c)
+	}
 	if uid == 0 {
 		c.JSON(http.StatusOK, []struct{}{})
 		return

--- a/backend/internal/handler/score_card_handler.go
+++ b/backend/internal/handler/score_card_handler.go
@@ -19,18 +19,22 @@ func NewScoreCardHandler(l *usecase.ListScoreCardsByUserIDUseCase, c *usecase.Cr
 	return &ScoreCardHandler{list: l, create: c}
 }
 
+// List は ?userId= が指定されていても current user と一致しなければ 403。
+// フロントは /api/v2/score-cards だけ叩けば current user の一覧が返る。
 func (h *ScoreCardHandler) List(c *gin.Context) {
-	// userId は (1) クエリ → (2) middleware の current user の順で解決する。
-	// フロントは /api/v2/score-cards だけ叩けば良く、認証済 user の score-card 一覧が返る。
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
-	if uid == 0 {
-		uid = middleware.CurrentUserIDOrZero(c)
-	}
-	if uid == 0 {
-		c.JSON(http.StatusOK, []struct{}{})
+	cur := middleware.CurrentUserIDOrZero(c)
+	if cur == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	rows, err := h.list.Execute(c.Request.Context(), uid)
+	if q := c.Query("userId"); q != "" {
+		qUID, _ := strconv.ParseUint(q, 10, 64)
+		if qUID != 0 && qUID != cur {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+	}
+	rows, err := h.list.Execute(c.Request.Context(), cur)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -38,12 +42,20 @@ func (h *ScoreCardHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
+// Create はクライアント値の card.UserID を信用せず current user で必ず上書きする（IDOR 対策）。
+// クライアントが他 userId を指定して投げてきても、保存される行は必ず current user 名義になる。
 func (h *ScoreCardHandler) Create(c *gin.Context) {
+	cur := middleware.CurrentUserIDOrZero(c)
+	if cur == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var card domain.ScoreCard
 	if err := c.ShouldBindJSON(&card); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	card.UserID = cur
 	got, err := h.create.Execute(c.Request.Context(), &card)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/score_card_handler.go
+++ b/backend/internal/handler/score_card_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -19,9 +20,12 @@ func NewScoreCardHandler(l *usecase.ListScoreCardsByUserIDUseCase, c *usecase.Cr
 }
 
 func (h *ScoreCardHandler) List(c *gin.Context) {
-	// userId クエリ未指定 / parse 失敗時は空配列で返す（フロント未連携時の暫定対応）。
-	// 本来は middleware で current user を解決して付与すべきだが、別 issue に分離。
+	// userId は (1) クエリ → (2) middleware の current user の順で解決する。
+	// フロントは /api/v2/score-cards だけ叩けば良く、認証済 user の score-card 一覧が返る。
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	if uid == 0 {
+		uid = middleware.MustCurrentUserID(c)
+	}
 	if uid == 0 {
 		c.JSON(http.StatusOK, []struct{}{})
 		return

--- a/backend/internal/handler/score_card_handler.go
+++ b/backend/internal/handler/score_card_handler.go
@@ -24,7 +24,7 @@ func (h *ScoreCardHandler) List(c *gin.Context) {
 	// フロントは /api/v2/score-cards だけ叩けば良く、認証済 user の score-card 一覧が返る。
 	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
 	if uid == 0 {
-		uid = middleware.MustCurrentUserID(c)
+		uid = middleware.CurrentUserIDOrZero(c)
 	}
 	if uid == 0 {
 		c.JSON(http.StatusOK, []struct{}{})

--- a/backend/internal/handler/score_goal_handler.go
+++ b/backend/internal/handler/score_goal_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -18,18 +19,28 @@ func NewScoreGoalHandler(g *usecase.GetScoreGoalUseCase, u *usecase.UpsertScoreG
 	return &ScoreGoalHandler{get: g, upsert: u}
 }
 
-// resolveUserID は path :userId か、未指定なら current user の users.id を返す。
-func (h *ScoreGoalHandler) resolveUserID(c *gin.Context) uint64 {
+var errInvalidUserID = errors.New("invalid userId")
+
+// resolveUserID は path :userId が指定されていれば解析し、未指定なら current user を返す。
+// 不正な :userId （非数値・0）は黙って current user にフォールバックさせず error を返す。
+// これにより handler 側で 400 を返せる（IDOR 風の意図しない挙動を防ぐ）。
+func (h *ScoreGoalHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	if v := c.Param("userId"); v != "" {
-		if uid, err := strconv.ParseUint(v, 10, 64); err == nil {
-			return uid
+		uid, err := strconv.ParseUint(v, 10, 64)
+		if err != nil || uid == 0 {
+			return 0, errInvalidUserID
 		}
+		return uid, nil
 	}
-	return middleware.MustCurrentUserID(c)
+	return middleware.CurrentUserIDOrZero(c), nil
 }
 
 func (h *ScoreGoalHandler) Get(c *gin.Context) {
-	uid := h.resolveUserID(c)
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	if uid == 0 {
 		c.JSON(http.StatusOK, gin.H{"targetScore": 0})
 		return
@@ -52,7 +63,11 @@ type scoreGoalUpsertReq struct {
 }
 
 func (h *ScoreGoalHandler) Upsert(c *gin.Context) {
-	uid := h.resolveUserID(c)
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	if uid == 0 {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return

--- a/backend/internal/handler/score_goal_handler.go
+++ b/backend/internal/handler/score_goal_handler.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -17,15 +18,30 @@ func NewScoreGoalHandler(g *usecase.GetScoreGoalUseCase, u *usecase.UpsertScoreG
 	return &ScoreGoalHandler{get: g, upsert: u}
 }
 
+// resolveUserID は path :userId か、未指定なら current user の users.id を返す。
+func (h *ScoreGoalHandler) resolveUserID(c *gin.Context) uint64 {
+	if v := c.Param("userId"); v != "" {
+		if uid, err := strconv.ParseUint(v, 10, 64); err == nil {
+			return uid
+		}
+	}
+	return middleware.MustCurrentUserID(c)
+}
+
 func (h *ScoreGoalHandler) Get(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid := h.resolveUserID(c)
+	if uid == 0 {
+		c.JSON(http.StatusOK, gin.H{"targetScore": 0})
+		return
+	}
 	g, err := h.get.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if g == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+		// 未設定でも 0 で返す（フロントが落ちないようにする）。
+		c.JSON(http.StatusOK, gin.H{"userId": uid, "targetScore": 0})
 		return
 	}
 	c.JSON(http.StatusOK, g)
@@ -36,7 +52,11 @@ type scoreGoalUpsertReq struct {
 }
 
 func (h *ScoreGoalHandler) Upsert(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid := h.resolveUserID(c)
+	if uid == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var req scoreGoalUpsertReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/repository/notification_repository.go
+++ b/backend/internal/repository/notification_repository.go
@@ -9,7 +9,9 @@ import (
 
 type NotificationRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error)
-	MarkRead(ctx context.Context, id uint64) error
+	// MarkRead は所有者検証込みで is_read を立てる。
+	// 自分以外の通知を既読化できないように、必ず WHERE で user_id を絞る。
+	MarkRead(ctx context.Context, userID, id uint64) error
 }
 
 type notificationRepository struct{ db *gorm.DB }
@@ -22,8 +24,11 @@ func (r *notificationRepository) ListByUserID(ctx context.Context, userID uint64
 	return rows, err
 }
 
-func (r *notificationRepository) MarkRead(ctx context.Context, id uint64) error {
-	return r.db.WithContext(ctx).Model(&domain.Notification{}).Where("id = ?", id).Update("is_read", true).Error
+func (r *notificationRepository) MarkRead(ctx context.Context, userID, id uint64) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.Notification{}).
+		Where("id = ? AND user_id = ?", id, userID).
+		Update("is_read", true).Error
 }
 
 // SnsPublisher は通知 push 用の interface（実装は AWS SDK 連携で別 PR）。

--- a/backend/internal/usecase/notification_usecase.go
+++ b/backend/internal/usecase/notification_usecase.go
@@ -27,9 +27,12 @@ func NewMarkNotificationReadUseCase(r repository.NotificationRepository) *MarkNo
 	return &MarkNotificationReadUseCase{repo: r}
 }
 
-func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, id uint64) error {
+func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, userID, id uint64) error {
+	if userID == 0 {
+		return errors.New("userID is required")
+	}
 	if id == 0 {
 		return errors.New("id is required")
 	}
-	return u.repo.MarkRead(ctx, id)
+	return u.repo.MarkRead(ctx, userID, id)
 }

--- a/backend/internal/usecase/notification_usecase_test.go
+++ b/backend/internal/usecase/notification_usecase_test.go
@@ -15,7 +15,7 @@ type stubNotificationRepo struct {
 func (s *stubNotificationRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.Notification, error) {
 	return s.rows, s.err
 }
-func (s *stubNotificationRepo) MarkRead(_ context.Context, _ uint64) error { return s.err }
+func (s *stubNotificationRepo) MarkRead(_ context.Context, _, _ uint64) error { return s.err }
 
 func TestListNotifications_RequiresUserID(t *testing.T) {
 	uc := NewListNotificationsUseCase(&stubNotificationRepo{})
@@ -24,9 +24,16 @@ func TestListNotifications_RequiresUserID(t *testing.T) {
 	}
 }
 
+func TestMarkRead_RequiresUserID(t *testing.T) {
+	uc := NewMarkNotificationReadUseCase(&stubNotificationRepo{})
+	if err := uc.Execute(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestMarkRead_RequiresID(t *testing.T) {
 	uc := NewMarkNotificationReadUseCase(&stubNotificationRepo{})
-	if err := uc.Execute(context.Background(), 0); err == nil {
+	if err := uc.Execute(context.Background(), 1, 0); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/frontend/src/hooks/__tests__/useScoreGoal.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreGoal.test.ts
@@ -35,7 +35,7 @@ describe('useScoreGoal', () => {
   });
 
   it('APIから目標スコアを取得する', async () => {
-    mockGet.mockResolvedValue({ data: { goalScore: 9.0 } });
+    mockGet.mockResolvedValue({ data: { targetScore: 9.0 } });
 
     const { result } = renderHook(() => useScoreGoal());
 
@@ -58,7 +58,7 @@ describe('useScoreGoal', () => {
   });
 
   it('目標スコアを保存できる', async () => {
-    mockGet.mockResolvedValue({ data: { goalScore: 8.0 } });
+    mockGet.mockResolvedValue({ data: { targetScore: 8.0 } });
     mockPut.mockResolvedValue({});
 
     const { result } = renderHook(() => useScoreGoal());
@@ -72,12 +72,12 @@ describe('useScoreGoal', () => {
     });
 
     expect(result.current.goal).toBe(9.5);
-    expect(mockPut).toHaveBeenCalledWith('/api/v2/score-goals', { goalScore: 9.5 });
+    expect(mockPut).toHaveBeenCalledWith('/api/v2/score-goals', { targetScore: 9.5 });
     expect(localStorage.setItem).toHaveBeenCalledWith('scoreGoal', '9.5');
   });
 
   it('API保存失敗時もlocalStorageには保存される', async () => {
-    mockGet.mockResolvedValue({ data: { goalScore: 8.0 } });
+    mockGet.mockResolvedValue({ data: { targetScore: 8.0 } });
     mockPut.mockRejectedValue(new Error('Network Error'));
 
     const { result } = renderHook(() => useScoreGoal());
@@ -95,7 +95,7 @@ describe('useScoreGoal', () => {
   });
 
   it('読み込み中はloadingがtrueになる', async () => {
-    mockGet.mockResolvedValue({ data: { goalScore: 8.5 } });
+    mockGet.mockResolvedValue({ data: { targetScore: 8.5 } });
 
     const { result } = renderHook(() => useScoreGoal());
 

--- a/frontend/src/hooks/__tests__/useScoreGoal.test.ts
+++ b/frontend/src/hooks/__tests__/useScoreGoal.test.ts
@@ -43,7 +43,7 @@ describe('useScoreGoal', () => {
       expect(result.current.loading).toBe(false);
     });
     expect(result.current.goal).toBe(9.0);
-    expect(mockGet).toHaveBeenCalledWith('/api/v2/score-goal');
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/score-goals');
   });
 
   it('APIエラー時はlocalStorageのデフォルト値を使用する', async () => {
@@ -72,7 +72,7 @@ describe('useScoreGoal', () => {
     });
 
     expect(result.current.goal).toBe(9.5);
-    expect(mockPut).toHaveBeenCalledWith('/api/v2/score-goal', { goalScore: 9.5 });
+    expect(mockPut).toHaveBeenCalledWith('/api/v2/score-goals', { goalScore: 9.5 });
     expect(localStorage.setItem).toHaveBeenCalledWith('scoreGoal', '9.5');
   });
 

--- a/frontend/src/repositories/AiChatRepository.ts
+++ b/frontend/src/repositories/AiChatRepository.ts
@@ -40,7 +40,7 @@ class AiChatRepository {
    * セッション一覧を取得
    */
   async getSessions(): Promise<AiSession[]> {
-    const response = await apiClient.get('/api/v2/chat/ai/sessions');
+    const response = await apiClient.get('/api/v2/ai-chat/sessions');
     return response.data;
   }
 
@@ -48,7 +48,7 @@ class AiChatRepository {
    * セッション詳細を取得
    */
   async getSession(sessionId: number): Promise<AiSession> {
-    const response = await apiClient.get(`/api/v2/chat/ai/sessions/${sessionId}`);
+    const response = await apiClient.get(`/api/v2/ai-chat/sessions/${sessionId}`);
     return response.data;
   }
 
@@ -56,7 +56,7 @@ class AiChatRepository {
    * 新規セッションを作成
    */
   async createSession(request: CreateSessionRequest): Promise<AiSession> {
-    const response = await apiClient.post('/api/v2/chat/ai/sessions', request);
+    const response = await apiClient.post('/api/v2/ai-chat/sessions', request);
     return response.data;
   }
 
@@ -64,7 +64,7 @@ class AiChatRepository {
    * セッションタイトルを更新
    */
   async updateSessionTitle(sessionId: number, request: UpdateSessionTitleRequest): Promise<AiSession> {
-    const response = await apiClient.put(`/api/v2/chat/ai/sessions/${sessionId}`, request);
+    const response = await apiClient.put(`/api/v2/ai-chat/sessions/${sessionId}`, request);
     return response.data;
   }
 
@@ -72,14 +72,14 @@ class AiChatRepository {
    * セッションを削除
    */
   async deleteSession(sessionId: number): Promise<void> {
-    await apiClient.delete(`/api/v2/chat/ai/sessions/${sessionId}`);
+    await apiClient.delete(`/api/v2/ai-chat/sessions/${sessionId}`);
   }
 
   /**
    * セッション内のメッセージ一覧を取得
    */
   async getMessages(sessionId: number): Promise<AiMessage[]> {
-    const response = await apiClient.get(`/api/v2/chat/ai/sessions/${sessionId}/messages`);
+    const response = await apiClient.get(`/api/v2/ai-chat/sessions/${sessionId}/messages`);
     return response.data;
   }
 
@@ -87,7 +87,7 @@ class AiChatRepository {
    * メッセージを追加
    */
   async addMessage(sessionId: number, request: AddMessageRequest): Promise<AiMessage> {
-    const response = await apiClient.post(`/api/v2/chat/ai/sessions/${sessionId}/messages`, request);
+    const response = await apiClient.post(`/api/v2/ai-chat/sessions/${sessionId}/messages`, request);
     return response.data;
   }
 

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -110,7 +110,7 @@ class AuthRepository {
    * 現在のユーザー情報取得
    */
   async getCurrentUser(): Promise<UserInfo> {
-    const response = await apiClient.get('/api/v2/auth/cognito/me');
+    const response = await apiClient.get('/api/v2/auth/me');
     return response.data;
   }
 

--- a/frontend/src/repositories/BookmarkRepository.ts
+++ b/frontend/src/repositories/BookmarkRepository.ts
@@ -20,7 +20,7 @@ function saveLocalBookmarks(ids: number[]): void {
 export const BookmarkRepository = {
   async getAll(): Promise<number[]> {
     try {
-      const response = await apiClient.get<number[]>('/api/v2/bookmarks');
+      const response = await apiClient.get<number[]>('/api/v2/scenario-bookmarks');
       return response.data;
     } catch {
       return getLocalBookmarks();
@@ -29,7 +29,7 @@ export const BookmarkRepository = {
 
   async add(scenarioId: number): Promise<void> {
     try {
-      await apiClient.post(`/api/v2/bookmarks/${scenarioId}`);
+      await apiClient.post(`/api/v2/scenario-bookmarks/${scenarioId}`);
     } catch {
       const ids = getLocalBookmarks();
       if (!ids.includes(scenarioId)) {
@@ -41,7 +41,7 @@ export const BookmarkRepository = {
 
   async remove(scenarioId: number): Promise<void> {
     try {
-      await apiClient.delete(`/api/v2/bookmarks/${scenarioId}`);
+      await apiClient.delete(`/api/v2/scenario-bookmarks/${scenarioId}`);
     } catch {
       const ids = getLocalBookmarks().filter(id => id !== scenarioId);
       saveLocalBookmarks(ids);

--- a/frontend/src/repositories/ChatRepository.ts
+++ b/frontend/src/repositories/ChatRepository.ts
@@ -17,7 +17,7 @@ const ChatRepository = {
   },
 
   async fetchCurrentUser(): Promise<{ id: number; name: string }> {
-    const res = await apiClient.get('/api/v2/auth/cognito/me');
+    const res = await apiClient.get('/api/v2/auth/me');
     return res.data;
   },
 

--- a/frontend/src/repositories/ScoreGoalRepository.ts
+++ b/frontend/src/repositories/ScoreGoalRepository.ts
@@ -3,7 +3,7 @@ import apiClient from '../lib/axios';
 export const ScoreGoalRepository = {
   async fetchGoal(): Promise<number | null> {
     try {
-      const response = await apiClient.get<{ goalScore: number }>('/api/v2/score-goal');
+      const response = await apiClient.get<{ goalScore: number }>('/api/v2/score-goals');
       return response.data?.goalScore ?? null;
     } catch {
       return null;
@@ -12,7 +12,7 @@ export const ScoreGoalRepository = {
 
   async saveGoal(goalScore: number): Promise<void> {
     try {
-      await apiClient.put('/api/v2/score-goal', { goalScore });
+      await apiClient.put('/api/v2/score-goals', { goalScore });
     } catch {
       // API失敗時は呼び出し元でlocalStorage保存済み
     }

--- a/frontend/src/repositories/ScoreGoalRepository.ts
+++ b/frontend/src/repositories/ScoreGoalRepository.ts
@@ -1,18 +1,20 @@
 import apiClient from '../lib/axios';
 
+// Go バックエンドの ScoreGoalHandler は { targetScore: number } を bind/return する。
+// 旧 Spring Boot 時代の goalScore は廃止済み。
 export const ScoreGoalRepository = {
   async fetchGoal(): Promise<number | null> {
     try {
-      const response = await apiClient.get<{ goalScore: number }>('/api/v2/score-goals');
-      return response.data?.goalScore ?? null;
+      const response = await apiClient.get<{ targetScore: number }>('/api/v2/score-goals');
+      return response.data?.targetScore ?? null;
     } catch {
       return null;
     }
   },
 
-  async saveGoal(goalScore: number): Promise<void> {
+  async saveGoal(targetScore: number): Promise<void> {
     try {
-      await apiClient.put('/api/v2/score-goals', { goalScore });
+      await apiClient.put('/api/v2/score-goals', { targetScore });
     } catch {
       // API失敗時は呼び出し元でlocalStorage保存済み
     }

--- a/frontend/src/repositories/__tests__/AiChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AiChatRepository.test.ts
@@ -17,7 +17,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getSessions();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/ai/sessions');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/ai-chat/sessions');
     expect(result).toEqual(mockSessions);
   });
 
@@ -27,7 +27,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getSession(1);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/ai-chat/sessions/1');
     expect(result).toEqual(mockSession);
   });
 
@@ -37,7 +37,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.createSession({ title: '新しいセッション' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/ai/sessions', { title: '新しいセッション' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/ai-chat/sessions', { title: '新しいセッション' });
     expect(result).toEqual(mockSession);
   });
 
@@ -47,7 +47,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.updateSessionTitle(1, { title: '更新タイトル' });
 
-    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1', { title: '更新タイトル' });
+    expect(mockedApiClient.put).toHaveBeenCalledWith('/api/v2/ai-chat/sessions/1', { title: '更新タイトル' });
     expect(result).toEqual(mockSession);
   });
 
@@ -56,7 +56,7 @@ describe('AiChatRepository', () => {
 
     await aiChatRepository.deleteSession(1);
 
-    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1');
+    expect(mockedApiClient.delete).toHaveBeenCalledWith('/api/v2/ai-chat/sessions/1');
   });
 
   it('getMessages: メッセージ一覧を取得できる', async () => {
@@ -65,7 +65,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.getMessages(1);
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1/messages');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/ai-chat/sessions/1/messages');
     expect(result).toEqual(mockMessages);
   });
 
@@ -75,7 +75,7 @@ describe('AiChatRepository', () => {
 
     const result = await aiChatRepository.addMessage(1, { content: '新しいメッセージ', role: 'user' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/chat/ai/sessions/1/messages', { content: '新しいメッセージ', role: 'user' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/ai-chat/sessions/1/messages', { content: '新しいメッセージ', role: 'user' });
     expect(result).toEqual(mockMessage);
   });
 

--- a/frontend/src/repositories/__tests__/AuthRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AuthRepository.test.ts
@@ -88,7 +88,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.getCurrentUser();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/auth/cognito/me');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/auth/me');
     expect(result).toEqual(mockUser);
   });
 

--- a/frontend/src/repositories/__tests__/BookmarkRepository.test.ts
+++ b/frontend/src/repositories/__tests__/BookmarkRepository.test.ts
@@ -42,7 +42,7 @@ describe('BookmarkRepository', () => {
       const ids = await BookmarkRepository.getAll();
 
       expect(ids).toEqual([1, 3, 5]);
-      expect(mockGet).toHaveBeenCalledWith('/api/v2/bookmarks');
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/scenario-bookmarks');
     });
 
     it('add: APIでブックマークを追加できる', async () => {
@@ -50,7 +50,7 @@ describe('BookmarkRepository', () => {
 
       await BookmarkRepository.add(1);
 
-      expect(mockPost).toHaveBeenCalledWith('/api/v2/bookmarks/1');
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/scenario-bookmarks/1');
     });
 
     it('remove: APIでブックマークを削除できる', async () => {
@@ -58,7 +58,7 @@ describe('BookmarkRepository', () => {
 
       await BookmarkRepository.remove(1);
 
-      expect(mockDelete).toHaveBeenCalledWith('/api/v2/bookmarks/1');
+      expect(mockDelete).toHaveBeenCalledWith('/api/v2/scenario-bookmarks/1');
     });
 
     it('isBookmarked: ブックマーク済みか判定できる', async () => {

--- a/frontend/src/repositories/__tests__/ChatRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ChatRepository.test.ts
@@ -40,7 +40,7 @@ describe('ChatRepository', () => {
 
     const result = await ChatRepository.fetchCurrentUser();
 
-    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/auth/cognito/me');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/auth/me');
     expect(result).toEqual(mockUser);
   });
 

--- a/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
@@ -17,8 +17,8 @@ describe('ScoreGoalRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('fetchGoal: API成功時にgoalScoreを返す', async () => {
-    mockedGet.mockResolvedValue({ data: { goalScore: 9.0 } });
+  it('fetchGoal: API成功時にtargetScoreを返す', async () => {
+    mockedGet.mockResolvedValue({ data: { targetScore: 9.0 } });
     const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
     const result = await ScoreGoalRepository.fetchGoal();
     expect(result).toBe(9.0);
@@ -36,7 +36,7 @@ describe('ScoreGoalRepository', () => {
     mockedPut.mockResolvedValue({ data: {} });
     const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
     await ScoreGoalRepository.saveGoal(7.5);
-    expect(mockedPut).toHaveBeenCalledWith('/api/v2/score-goals', { goalScore: 7.5 });
+    expect(mockedPut).toHaveBeenCalledWith('/api/v2/score-goals', { targetScore: 7.5 });
   });
 
   it('saveGoal: API失敗時にエラーをスローしない', async () => {

--- a/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ScoreGoalRepository.test.ts
@@ -22,7 +22,7 @@ describe('ScoreGoalRepository', () => {
     const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
     const result = await ScoreGoalRepository.fetchGoal();
     expect(result).toBe(9.0);
-    expect(mockedGet).toHaveBeenCalledWith('/api/v2/score-goal');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/score-goals');
   });
 
   it('fetchGoal: API失敗時にnullを返す', async () => {
@@ -36,7 +36,7 @@ describe('ScoreGoalRepository', () => {
     mockedPut.mockResolvedValue({ data: {} });
     const { ScoreGoalRepository } = await import('../ScoreGoalRepository');
     await ScoreGoalRepository.saveGoal(7.5);
-    expect(mockedPut).toHaveBeenCalledWith('/api/v2/score-goal', { goalScore: 7.5 });
+    expect(mockedPut).toHaveBeenCalledWith('/api/v2/score-goals', { goalScore: 7.5 });
   });
 
   it('saveGoal: API失敗時にエラーをスローしない', async () => {


### PR DESCRIPTION
## 概要

Spring Boot 時代の path / 旧 frontend path との互換 alias を全廃し、Go バックエンドの正規 path（`/api/v2/...` の Go 側採用形）にフロントエンドを揃えました。あわせて `:userId` を path に持たない handler が増えたため、Cognito sub から `users.id` を解決する `CurrentUser` middleware を導入しています。

「Spring Boot の資産はもう無い」という前提で、暫定 alias / 旧 path に依存していた箇所を一掃するのが目的です。

## 変更内容

### バックエンド
- `internal/handler/middleware/current_user.go` を新規追加
  - JWT (cognito sub) → `users` 行を引き、context に `currentUserID` をセット
  - `MustCurrentUserID(c)` ヘルパで handler から認証済 user の `users.id` を取得
- `router.go` から旧 path alias を削除
  - 削除: `/auth/cognito/me` / `/chat/ai/sessions` / `/chat/stats` / `/bookmarks` / `/scores/history` / `/score-goal` / `/daily-goals/today`
  - 認証必須グループに `middleware.CurrentUser(userRepo)` を装着
- `score_goal_handler.go` / `daily_goal_handler.go` / `score_card_handler.go` / `scenario_bookmark_handler.go` / `chat_handler.go` / `notification_handler.go`
  - `:userId` / `?userId=` 未指定時に `MustCurrentUserID(c)` でフォールバック
  - 該当データなしのとき 404 ではなく初期値 (`targetScore: 0` 等) を返すよう統一

### フロントエンド
- `repositories/*.ts` の旧 path を Go 正規 path へ全置換
  - `/api/v2/auth/cognito/me` → `/api/v2/auth/me`
  - `/api/v2/chat/ai/sessions` → `/api/v2/ai-chat/sessions`
  - `/api/v2/bookmarks` → `/api/v2/scenario-bookmarks`
  - `/api/v2/score-goal` → `/api/v2/score-goals`
- `repositories/__tests__/*.test.ts` も新 path に追従
- `hooks/__tests__/useScoreGoal.test.ts` 期待値更新

## テスト

- [ ] `cd backend && go build ./...`
- [ ] `cd frontend && npm test -- --run`
- [ ] 手動: ログイン → `/api/v2/auth/me`、`/api/v2/score-goals`、`/api/v2/daily-goals/today`、`/api/v2/scenario-bookmarks`、`/api/v2/ai-chat/sessions` の 200 応答確認

## 関連 Issue

ログイン後の 404 系エラー (`/api/v2/score-goal` 404 等) の恒久対応。PR #1552〜#1554 で入れた path alias / 暫定 stub の整理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added middleware to reliably resolve the authenticated current user.

* **Bug Fixes**
  * Handlers now return consistent 200 default/empty responses instead of 404 for missing data.
  * Improved user-ID resolution to fall back to the authenticated user when appropriate; invalid IDs produce clearer errors.

* **Refactor**
  * Renamed and consolidated several API routes (pluralized endpoints, reorganized chat/bookmark paths); removed legacy endpoints.

* **Tests**
  * Updated unit tests to match new endpoint paths and payload field names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->