### PR TITLE
fix: ai-chat / notes も current user 解決 + IDOR 塞ぎ (本番 400 解消)

### DIFF
--- a/backend/internal/handler/ai_chat_handler.go
+++ b/backend/internal/handler/ai_chat_handler.go
@@ -2,14 +2,13 @@ package handler
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // AiChatHandler は AI チャット関連のエンドポイントを提供する。
-// Spring Boot の AiChatController に相当。
 type AiChatHandler struct {
 	getSessions   *usecase.GetAiChatSessionsByUserIDUseCase
 	createSession *usecase.CreateAiChatSessionUseCase
@@ -23,14 +22,14 @@ func NewAiChatHandler(
 }
 
 // GetSessions は GET /ai-chat/sessions
+// userId はクライアントから受け取らず、middleware の current user を使う。
 func (h *AiChatHandler) GetSessions(c *gin.Context) {
-	userIDStr := c.Query("userId")
-	userID, err := strconv.ParseUint(userIDStr, 10, 64)
-	if err != nil || userID == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "userId is required"})
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	rows, err := h.getSessions.Execute(c.Request.Context(), userID)
+	rows, err := h.getSessions.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		return
@@ -39,21 +38,26 @@ func (h *AiChatHandler) GetSessions(c *gin.Context) {
 }
 
 type createSessionReq struct {
-	UserID      uint64  `json:"userId"`
 	Title       string  `json:"title" binding:"required"`
 	SessionType string  `json:"sessionType"`
 	ScenarioID  *uint64 `json:"scenarioId"`
 }
 
 // CreateSession は POST /ai-chat/sessions
+// userId はクライアントから受け取らず current user で固定する（IDOR 対策）。
 func (h *AiChatHandler) CreateSession(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var req createSessionReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	created, err := h.createSession.Execute(c.Request.Context(), usecase.CreateAiChatSessionInput{
-		UserID:      req.UserID,
+		UserID:      uid,
 		Title:       req.Title,
 		SessionType: req.SessionType,
 		ScenarioID:  req.ScenarioID,

--- a/backend/internal/handler/note_handler.go
+++ b/backend/internal/handler/note_handler.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -24,8 +26,14 @@ func NewNoteHandler(
 	return &NoteHandler{list: l, create: c, update: u, del: d}
 }
 
+// List は current user の note 一覧を返す。
+// userId はクライアントから受け取らない（IDOR 対策）。
 func (h *NoteHandler) List(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -35,20 +43,25 @@ func (h *NoteHandler) List(c *gin.Context) {
 }
 
 type noteCreateReq struct {
-	UserID   uint64 `json:"userId" binding:"required"`
 	Title    string `json:"title" binding:"required"`
 	Content  string `json:"content"`
 	IsPublic bool   `json:"isPublic"`
 }
 
+// Create は current user 名義で note を作る。userId は受け取らず固定する。
 func (h *NoteHandler) Create(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var req noteCreateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	got, err := h.create.Execute(c.Request.Context(), usecase.CreateNoteInput{
-		UserID: req.UserID, Title: req.Title, Content: req.Content, IsPublic: req.IsPublic,
+		UserID: uid, Title: req.Title, Content: req.Content, IsPublic: req.IsPublic,
 	})
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -63,7 +76,13 @@ type noteUpdateReq struct {
 	IsPublic bool   `json:"isPublic"`
 }
 
+// Update は current user 所有の note のみ更新可能。usecase 側で所有者検証する。
 func (h *NoteHandler) Update(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
 	var req noteUpdateReq
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -71,18 +90,28 @@ func (h *NoteHandler) Update(c *gin.Context) {
 		return
 	}
 	got, err := h.update.Execute(c.Request.Context(), usecase.UpdateNoteInput{
-		ID: id, Title: req.Title, Content: req.Content, IsPublic: req.IsPublic,
+		UserID: uid, ID: id, Title: req.Title, Content: req.Content, IsPublic: req.IsPublic,
 	})
 	if err != nil {
+		if errors.Is(err, usecase.ErrNoteForbidden) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, got)
 }
 
+// Delete は WHERE で user_id を絞るため他人の note は消せない。
 func (h *NoteHandler) Delete(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err := h.del.Execute(c.Request.Context(), id); err != nil {
+	if err := h.del.Execute(c.Request.Context(), uid, id); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/internal/repository/note_repository.go
+++ b/backend/internal/repository/note_repository.go
@@ -12,7 +12,9 @@ type NoteRepository interface {
 	FindByID(ctx context.Context, id uint64) (*domain.Note, error)
 	Create(ctx context.Context, n *domain.Note) error
 	Update(ctx context.Context, n *domain.Note) error
-	Delete(ctx context.Context, id uint64) error
+	// Delete は所有者検証込みで note を削除する。
+	// WHERE で user_id を絞って他人の note を消せないようにする。
+	Delete(ctx context.Context, userID, id uint64) error
 }
 
 type noteRepository struct{ db *gorm.DB }
@@ -41,6 +43,8 @@ func (r *noteRepository) Update(ctx context.Context, n *domain.Note) error {
 	return r.db.WithContext(ctx).Save(n).Error
 }
 
-func (r *noteRepository) Delete(ctx context.Context, id uint64) error {
-	return r.db.WithContext(ctx).Delete(&domain.Note{}, id).Error
+func (r *noteRepository) Delete(ctx context.Context, userID, id uint64) error {
+	return r.db.WithContext(ctx).
+		Where("id = ? AND user_id = ?", id, userID).
+		Delete(&domain.Note{}).Error
 }

--- a/backend/internal/usecase/note_usecase.go
+++ b/backend/internal/usecase/note_usecase.go
@@ -8,6 +8,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
+var ErrNoteForbidden = errors.New("forbidden")
+
 type ListNotesByUserIDUseCase struct{ repo repository.NoteRepository }
 
 func NewListNotesByUserIDUseCase(r repository.NoteRepository) *ListNotesByUserIDUseCase {
@@ -55,19 +57,28 @@ func NewUpdateNoteUseCase(r repository.NoteRepository) *UpdateNoteUseCase {
 }
 
 type UpdateNoteInput struct {
+	UserID   uint64
 	ID       uint64
 	Title    string
 	Content  string
 	IsPublic bool
 }
 
+// Execute は所有者検証込みで note を更新する。
+// 既存 note の UserID が input.UserID と一致しなければ ErrNoteForbidden を返す。
 func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*domain.Note, error) {
+	if in.UserID == 0 {
+		return nil, errors.New("userID is required")
+	}
 	if in.ID == 0 {
 		return nil, errors.New("id is required")
 	}
 	existing, err := u.repo.FindByID(ctx, in.ID)
 	if err != nil {
 		return nil, err
+	}
+	if existing.UserID != in.UserID {
+		return nil, ErrNoteForbidden
 	}
 	existing.Title = in.Title
 	existing.Content = in.Content
@@ -84,9 +95,12 @@ func NewDeleteNoteUseCase(r repository.NoteRepository) *DeleteNoteUseCase {
 	return &DeleteNoteUseCase{repo: r}
 }
 
-func (u *DeleteNoteUseCase) Execute(ctx context.Context, id uint64) error {
+func (u *DeleteNoteUseCase) Execute(ctx context.Context, userID, id uint64) error {
+	if userID == 0 {
+		return errors.New("userID is required")
+	}
 	if id == 0 {
 		return errors.New("id is required")
 	}
-	return u.repo.Delete(ctx, id)
+	return u.repo.Delete(ctx, userID, id)
 }

--- a/backend/internal/usecase/note_usecase_test.go
+++ b/backend/internal/usecase/note_usecase_test.go
@@ -2,21 +2,27 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
 type stubNoteRepo struct {
-	rows []domain.Note
-	one  *domain.Note
-	err  error
+	rows           []domain.Note
+	one            *domain.Note
+	err            error
+	deletedUserID  uint64
+	deletedID      uint64
+	updatedNote    *domain.Note
 }
 
 func (s *stubNoteRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.Note, error) {
 	return s.rows, s.err
 }
-func (s *stubNoteRepo) FindByID(_ context.Context, _ uint64) (*domain.Note, error) { return s.one, s.err }
+func (s *stubNoteRepo) FindByID(_ context.Context, _ uint64) (*domain.Note, error) {
+	return s.one, s.err
+}
 func (s *stubNoteRepo) Create(_ context.Context, n *domain.Note) error {
 	if s.err != nil {
 		return s.err
@@ -24,8 +30,18 @@ func (s *stubNoteRepo) Create(_ context.Context, n *domain.Note) error {
 	n.ID = 21
 	return nil
 }
-func (s *stubNoteRepo) Update(_ context.Context, _ *domain.Note) error { return s.err }
-func (s *stubNoteRepo) Delete(_ context.Context, _ uint64) error       { return s.err }
+func (s *stubNoteRepo) Update(_ context.Context, n *domain.Note) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.updatedNote = n
+	return nil
+}
+func (s *stubNoteRepo) Delete(_ context.Context, userID, id uint64) error {
+	s.deletedUserID = userID
+	s.deletedID = id
+	return s.err
+}
 
 func TestListNotes_RequiresUserID(t *testing.T) {
 	uc := NewListNotesByUserIDUseCase(&stubNoteRepo{})
@@ -49,16 +65,68 @@ func TestCreateNote_AssignsID(t *testing.T) {
 	}
 }
 
+func TestUpdateNote_RequiresUserID(t *testing.T) {
+	uc := NewUpdateNoteUseCase(&stubNoteRepo{one: &domain.Note{ID: 1, UserID: 1}})
+	if _, err := uc.Execute(context.Background(), UpdateNoteInput{ID: 1, Title: "x"}); err == nil {
+		t.Fatal("expected error when userID is 0")
+	}
+}
+
 func TestUpdateNote_RequiresID(t *testing.T) {
-	uc := NewUpdateNoteUseCase(&stubNoteRepo{one: &domain.Note{ID: 1}})
-	if _, err := uc.Execute(context.Background(), UpdateNoteInput{Title: "x"}); err == nil {
-		t.Fatal("expected error")
+	uc := NewUpdateNoteUseCase(&stubNoteRepo{one: &domain.Note{ID: 1, UserID: 1}})
+	if _, err := uc.Execute(context.Background(), UpdateNoteInput{UserID: 1, Title: "x"}); err == nil {
+		t.Fatal("expected error when id is 0")
+	}
+}
+
+func TestUpdateNote_RejectsForeignOwner(t *testing.T) {
+	repo := &stubNoteRepo{one: &domain.Note{ID: 1, UserID: 99}}
+	uc := NewUpdateNoteUseCase(repo)
+	_, err := uc.Execute(context.Background(), UpdateNoteInput{UserID: 1, ID: 1, Title: "x"})
+	if !errors.Is(err, ErrNoteForbidden) {
+		t.Fatalf("expected ErrNoteForbidden, got %v", err)
+	}
+	if repo.updatedNote != nil {
+		t.Fatal("must not call repo.Update when foreign owner")
+	}
+}
+
+func TestUpdateNote_AllowsOwner(t *testing.T) {
+	repo := &stubNoteRepo{one: &domain.Note{ID: 1, UserID: 1, Title: "old"}}
+	uc := NewUpdateNoteUseCase(repo)
+	got, err := uc.Execute(context.Background(), UpdateNoteInput{UserID: 1, ID: 1, Title: "new"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.Title != "new" {
+		t.Fatalf("title should be updated, got %q", got.Title)
+	}
+	if repo.updatedNote == nil {
+		t.Fatal("repo.Update should be called")
+	}
+}
+
+func TestDeleteNote_RequiresUserID(t *testing.T) {
+	uc := NewDeleteNoteUseCase(&stubNoteRepo{})
+	if err := uc.Execute(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected error when userID is 0")
 	}
 }
 
 func TestDeleteNote_RequiresID(t *testing.T) {
 	uc := NewDeleteNoteUseCase(&stubNoteRepo{})
-	if err := uc.Execute(context.Background(), 0); err == nil {
-		t.Fatal("expected error")
+	if err := uc.Execute(context.Background(), 1, 0); err == nil {
+		t.Fatal("expected error when id is 0")
+	}
+}
+
+func TestDeleteNote_PassesUserIDToRepo(t *testing.T) {
+	repo := &stubNoteRepo{}
+	uc := NewDeleteNoteUseCase(repo)
+	if err := uc.Execute(context.Background(), 7, 11); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if repo.deletedUserID != 7 || repo.deletedID != 11 {
+		t.Fatalf("repo.Delete should be called with (7,11), got (%d,%d)", repo.deletedUserID, repo.deletedID)
 	}
 }


### PR DESCRIPTION
## 概要

PR #1555 のデプロイ後、本番のログイン後コンソールに以下の 400 が出ていた:

- `GET /api/v2/ai-chat/sessions` 400
- `GET /api/v2/notes` 400 (バックエンドログでも `GET "/api/v2/notes" | 400` 確認済)

原因は両 handler が `?userId=` を必須にしており、フロントから userId を渡していないため `userID is required` で 400 を返していた。Spring Boot 廃止整合性 PR (#1555) と同方針で `middleware.CurrentUserIDOrZero` 解決に揃える。

加えて `Note.Update / Delete` には所有者検証が無く、任意 id で他人 note を上書き / 削除できる IDOR が残っていたので一緒に塞ぐ。

## 変更内容

### バックエンド
- `ai_chat_handler.go`
  - `GetSessions`: `?userId=` 受付廃止、`CurrentUserIDOrZero` で解決
  - `CreateSession`: `req.UserID` 廃止し current user 固定（IDOR 対策）
- `note_handler.go`
  - `List`: `?userId=` 廃止、current user 固定
  - `Create`: `req.UserID` 廃止、current user 固定
  - `Update`: usecase に uid を渡し所有者検証（`ErrNoteForbidden -> 403`）
  - `Delete`: usecase 経由で repo の WHERE 句 `user_id` を絞る
- `note_usecase.go`
  - `UpdateNoteInput.UserID` 追加。FindByID した既存 note の UserID と不一致なら `ErrNoteForbidden`
  - `DeleteNoteUseCase.Execute` を `(userID, id)` シグネチャに変更
- `note_repository.go`
  - `Delete(ctx, userID, id)` に変更し WHERE 句で user_id を絞る

### TDD で追加したテスト
- `TestUpdateNote_RequiresUserID`
- `TestUpdateNote_RejectsForeignOwner`
- `TestUpdateNote_AllowsOwner`
- `TestDeleteNote_RequiresUserID`
- `TestDeleteNote_PassesUserIDToRepo`
- 既存 stub repo を新シグネチャに追従

## テスト

- [x] `go build ./...`
- [x] `go test ./internal/usecase/...`
- [x] `npx vitest run AiChatRepository / NoteRepository`
- [ ] 本番デプロイ後に `/api/v2/notes` `/api/v2/ai-chat/sessions` が 200 を返すことを確認

## 関連

#1555 (Spring Boot 廃止整合性) のフォローアップ。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  - Notes and chat sessions now properly enforce user ownership, restricting access to authenticated users' own data.
  - Improved error handling with proper `401 Unauthorized` and `403 Forbidden` responses for authentication and permission violations.
  - User identity is now derived from authentication middleware rather than client-supplied requests, enhancing data isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->