### PR TITLE
fix: 本番 404 を 4 種解消 — reports / friendships / notifications / favorite-phrases パス整合 + IDOR 対策

### DIFF
--- a/backend/internal/handler/favorite_phrase_handler.go
+++ b/backend/internal/handler/favorite_phrase_handler.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -18,8 +19,14 @@ func NewFavoritePhraseHandler(l *usecase.ListFavoritePhrasesUseCase, a *usecase.
 	return &FavoritePhraseHandler{list: l, add: a, remove: d}
 }
 
+// List は current user の favorite phrase 一覧を返す。
+// userId はクライアントから受け取らない（IDOR 対策）。
 func (h *FavoritePhraseHandler) List(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -28,19 +35,42 @@ func (h *FavoritePhraseHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
+// addPhraseReq は userId を受け取らない（current user 固定）。
+// originalText / rephrasedText / pattern はフロントの言い換え保存 API に合わせるが、
+// backend domain は phrase / note しか持たないため、phrase = rephrasedText, note = originalText で保存する。
 type addPhraseReq struct {
-	UserID uint64 `json:"userId" binding:"required"`
-	Phrase string `json:"phrase" binding:"required"`
+	OriginalText  string `json:"originalText"`
+	RephrasedText string `json:"rephrasedText"`
+	Pattern       string `json:"pattern"`
+	// 旧仕様の互換のため phrase/note も受け付ける。
+	Phrase string `json:"phrase"`
 	Note   string `json:"note"`
 }
 
 func (h *FavoritePhraseHandler) Add(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var req addPhraseReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	got, err := h.add.Execute(c.Request.Context(), req.UserID, req.Phrase, req.Note)
+	phrase := req.RephrasedText
+	if phrase == "" {
+		phrase = req.Phrase
+	}
+	note := req.OriginalText
+	if note == "" {
+		note = req.Note
+	}
+	if phrase == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "phrase is required"})
+		return
+	}
+	got, err := h.add.Execute(c.Request.Context(), uid, phrase, note)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -48,9 +78,15 @@ func (h *FavoritePhraseHandler) Add(c *gin.Context) {
 	c.JSON(http.StatusCreated, got)
 }
 
+// Remove は current user 所有の phrase のみ削除可能（IDOR 対策）。
 func (h *FavoritePhraseHandler) Remove(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err := h.remove.Execute(c.Request.Context(), id); err != nil {
+	if err := h.remove.Execute(c.Request.Context(), uid, id); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/internal/handler/friendship_handler.go
+++ b/backend/internal/handler/friendship_handler.go
@@ -5,21 +5,45 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 type FriendshipHandler struct {
-	list    *usecase.ListFriendshipsUseCase
-	request *usecase.RequestFriendshipUseCase
-	respond *usecase.RespondFriendshipUseCase
+	list      *usecase.ListFriendshipsUseCase
+	request   *usecase.RequestFriendshipUseCase
+	respond   *usecase.RespondFriendshipUseCase
+	follow    *usecase.FollowUserUseCase
+	unfollow  *usecase.UnfollowUserUseCase
+	following *usecase.ListFollowingUseCase
+	followers *usecase.ListFollowersUseCase
+	status    *usecase.GetFollowStatusUseCase
 }
 
-func NewFriendshipHandler(l *usecase.ListFriendshipsUseCase, r *usecase.RequestFriendshipUseCase, p *usecase.RespondFriendshipUseCase) *FriendshipHandler {
-	return &FriendshipHandler{list: l, request: r, respond: p}
+func NewFriendshipHandler(
+	l *usecase.ListFriendshipsUseCase,
+	r *usecase.RequestFriendshipUseCase,
+	p *usecase.RespondFriendshipUseCase,
+	f *usecase.FollowUserUseCase,
+	uf *usecase.UnfollowUserUseCase,
+	lf *usecase.ListFollowingUseCase,
+	lfr *usecase.ListFollowersUseCase,
+	gs *usecase.GetFollowStatusUseCase,
+) *FriendshipHandler {
+	return &FriendshipHandler{
+		list: l, request: r, respond: p,
+		follow: f, unfollow: uf,
+		following: lf, followers: lfr, status: gs,
+	}
 }
 
+// List は current user に紐づく Friendship 全件 (pending 含む) を返す。
 func (h *FriendshipHandler) List(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -29,17 +53,22 @@ func (h *FriendshipHandler) List(c *gin.Context) {
 }
 
 type requestFriendshipReq struct {
-	RequesterID uint64 `json:"requesterId" binding:"required"`
 	AddresseeID uint64 `json:"addresseeId" binding:"required"`
 }
 
+// Request は current user 起点で friendship 申請を作る。
 func (h *FriendshipHandler) Request(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var req requestFriendshipReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	got, err := h.request.Execute(c.Request.Context(), req.RequesterID, req.AddresseeID)
+	got, err := h.request.Execute(c.Request.Context(), uid, req.AddresseeID)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -63,4 +92,81 @@ func (h *FriendshipHandler) Respond(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// Following は current user が follow している相手の Friendship を返す。
+func (h *FriendshipHandler) Following(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	rows, err := h.following.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// Followers は current user を follow している相手の Friendship を返す。
+func (h *FriendshipHandler) Followers(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	rows, err := h.followers.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// Follow は current user → :userId の単方向 follow を成立させる。
+func (h *FriendshipHandler) Follow(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	target, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	got, err := h.follow.Execute(c.Request.Context(), uid, target)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, got)
+}
+
+// Unfollow は current user → :userId の friendship を削除する。
+func (h *FriendshipHandler) Unfollow(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	target, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	if err := h.unfollow.Execute(c.Request.Context(), uid, target); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// Status は current user と :userId の follow 関係を返す。
+func (h *FriendshipHandler) Status(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	target, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	out, err := h.status.Execute(c.Request.Context(), uid, target)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, out)
 }

--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -18,8 +18,14 @@ func NewLearningReportHandler(l *usecase.ListLearningReportsUseCase, r *usecase.
 	return &LearningReportHandler{list: l, request: r}
 }
 
+// List は current user の learning report 一覧を返す。
+// userId はクライアントから受け取らない（IDOR 対策）。
 func (h *LearningReportHandler) List(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Query("userId"), 10, 64)
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -29,12 +35,17 @@ func (h *LearningReportHandler) List(c *gin.Context) {
 }
 
 type requestReportReq struct {
-	UserID     uint64 `json:"userId" binding:"required"`
 	PeriodFrom string `json:"periodFrom" binding:"required"`
 	PeriodTo   string `json:"periodTo" binding:"required"`
 }
 
+// Request は current user で report 生成を要求する。
 func (h *LearningReportHandler) Request(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
 	var req requestReportReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -51,7 +62,7 @@ func (h *LearningReportHandler) Request(c *gin.Context) {
 		return
 	}
 	got, err := h.request.Execute(c.Request.Context(), usecase.RequestLearningReportInput{
-		UserID: req.UserID, PeriodFrom: from, PeriodTo: to,
+		UserID: uid, PeriodFrom: from, PeriodTo: to,
 	})
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/notification_handler.go
+++ b/backend/internal/handler/notification_handler.go
@@ -10,17 +10,22 @@ import (
 )
 
 type NotificationHandler struct {
-	list     *usecase.ListNotificationsUseCase
-	markRead *usecase.MarkNotificationReadUseCase
+	list        *usecase.ListNotificationsUseCase
+	markRead    *usecase.MarkNotificationReadUseCase
+	markAllRead *usecase.MarkAllNotificationsReadUseCase
+	countUnread *usecase.CountUnreadNotificationsUseCase
 }
 
-func NewNotificationHandler(l *usecase.ListNotificationsUseCase, m *usecase.MarkNotificationReadUseCase) *NotificationHandler {
-	return &NotificationHandler{list: l, markRead: m}
+func NewNotificationHandler(
+	l *usecase.ListNotificationsUseCase,
+	m *usecase.MarkNotificationReadUseCase,
+	a *usecase.MarkAllNotificationsReadUseCase,
+	cu *usecase.CountUnreadNotificationsUseCase,
+) *NotificationHandler {
+	return &NotificationHandler{list: l, markRead: m, markAllRead: a, countUnread: cu}
 }
 
 // List は常に認証済 current user の通知を返す。
-// 過去は ?userId= クエリを受け付けていたが、authz 機構が無いため任意の userId を
-// クエリで指定できると IDOR になる。admin 機構が入るまでは current user 固定にする。
 func (h *NotificationHandler) List(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -36,8 +41,6 @@ func (h *NotificationHandler) List(c *gin.Context) {
 }
 
 // MarkRead は所有者検証つきで通知を既読化する。
-// 自分の通知 id でなければ DB の WHERE 句で何もマッチしないので、
-// 任意 id を渡されても他人の既読化は起きない。
 func (h *NotificationHandler) MarkRead(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -50,4 +53,33 @@ func (h *NotificationHandler) MarkRead(c *gin.Context) {
 		return
 	}
 	c.Status(http.StatusNoContent)
+}
+
+// MarkAllRead は current user の全通知をまとめて既読化する。
+func (h *NotificationHandler) MarkAllRead(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	if err := h.markAllRead.Execute(c.Request.Context(), uid); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// UnreadCount は current user の未読通知数を整数で返す。
+func (h *NotificationHandler) UnreadCount(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	n, err := h.countUnread.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, n)
 }

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -198,25 +198,41 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	authed.POST("/favorite-phrases", favHandler.Add)
 	authed.DELETE("/favorite-phrases/:id", favHandler.Remove)
 
-	// Phase 20: Friendship
+	// Phase 20: Friendship + 単方向フォロー（フロントの follow / unfollow / status / following / followers に対応）
 	friendshipRepo := repository.NewFriendshipRepository(db)
 	friendshipHandler := NewFriendshipHandler(
 		usecase.NewListFriendshipsUseCase(friendshipRepo),
 		usecase.NewRequestFriendshipUseCase(friendshipRepo),
 		usecase.NewRespondFriendshipUseCase(friendshipRepo),
+		usecase.NewFollowUserUseCase(friendshipRepo),
+		usecase.NewUnfollowUserUseCase(friendshipRepo),
+		usecase.NewListFollowingUseCase(friendshipRepo),
+		usecase.NewListFollowersUseCase(friendshipRepo),
+		usecase.NewGetFollowStatusUseCase(friendshipRepo),
 	)
 	authed.GET("/friendships", friendshipHandler.List)
 	authed.POST("/friendships", friendshipHandler.Request)
 	authed.PATCH("/friendships/:id", friendshipHandler.Respond)
+	authed.GET("/friendships/following", friendshipHandler.Following)
+	authed.GET("/friendships/followers", friendshipHandler.Followers)
+	authed.POST("/friendships/:userId/follow", friendshipHandler.Follow)
+	authed.DELETE("/friendships/:userId/follow", friendshipHandler.Unfollow)
+	authed.GET("/friendships/:userId/status", friendshipHandler.Status)
 
 	// Phase 21: Notification
 	notificationRepo := repository.NewNotificationRepository(db)
 	notificationHandler := NewNotificationHandler(
 		usecase.NewListNotificationsUseCase(notificationRepo),
 		usecase.NewMarkNotificationReadUseCase(notificationRepo),
+		usecase.NewMarkAllNotificationsReadUseCase(notificationRepo),
+		usecase.NewCountUnreadNotificationsUseCase(notificationRepo),
 	)
 	authed.GET("/notifications", notificationHandler.List)
+	authed.GET("/notifications/unread-count", notificationHandler.UnreadCount)
 	authed.PATCH("/notifications/:id/read", notificationHandler.MarkRead)
+	authed.PUT("/notifications/:id/read", notificationHandler.MarkRead)
+	authed.PATCH("/notifications/read-all", notificationHandler.MarkAllRead)
+	authed.PUT("/notifications/read-all", notificationHandler.MarkAllRead)
 
 	// Phase 22: ReminderSetting
 	reminderRepo := repository.NewReminderSettingRepository(db)

--- a/backend/internal/repository/favorite_phrase_repository.go
+++ b/backend/internal/repository/favorite_phrase_repository.go
@@ -10,7 +10,8 @@ import (
 type FavoritePhraseRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.FavoritePhrase, error)
 	Create(ctx context.Context, p *domain.FavoritePhrase) error
-	Delete(ctx context.Context, id uint64) error
+	// Delete は所有者検証込みで削除する。WHERE で user_id を絞り IDOR を防ぐ。
+	Delete(ctx context.Context, userID, id uint64) error
 }
 
 type favoritePhraseRepository struct{ db *gorm.DB }
@@ -29,6 +30,8 @@ func (r *favoritePhraseRepository) Create(ctx context.Context, p *domain.Favorit
 	return r.db.WithContext(ctx).Create(p).Error
 }
 
-func (r *favoritePhraseRepository) Delete(ctx context.Context, id uint64) error {
-	return r.db.WithContext(ctx).Delete(&domain.FavoritePhrase{}, id).Error
+func (r *favoritePhraseRepository) Delete(ctx context.Context, userID, id uint64) error {
+	return r.db.WithContext(ctx).
+		Where("id = ? AND user_id = ?", id, userID).
+		Delete(&domain.FavoritePhrase{}).Error
 }

--- a/backend/internal/repository/friendship_repository.go
+++ b/backend/internal/repository/friendship_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"gorm.io/gorm"
@@ -11,6 +12,14 @@ type FriendshipRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.Friendship, error)
 	Create(ctx context.Context, f *domain.Friendship) error
 	UpdateStatus(ctx context.Context, id uint64, status string) error
+	// ListAcceptedFollowing は user が requester かつ accepted な相手（フォロー中）を返す。
+	ListAcceptedFollowing(ctx context.Context, userID uint64) ([]domain.Friendship, error)
+	// ListAcceptedFollowers は user が addressee かつ accepted な相手（フォロワー）を返す。
+	ListAcceptedFollowers(ctx context.Context, userID uint64) ([]domain.Friendship, error)
+	// FindBetween は requester→addressee 方向の friendship を 1 件返す（無ければ nil, nil）。
+	FindBetween(ctx context.Context, requesterID, addresseeID uint64) (*domain.Friendship, error)
+	// DeleteBetween は requester→addressee の friendship を削除する。
+	DeleteBetween(ctx context.Context, requesterID, addresseeID uint64) error
 }
 
 type friendshipRepository struct{ db *gorm.DB }
@@ -32,4 +41,42 @@ func (r *friendshipRepository) Create(ctx context.Context, f *domain.Friendship)
 
 func (r *friendshipRepository) UpdateStatus(ctx context.Context, id uint64, status string) error {
 	return r.db.WithContext(ctx).Model(&domain.Friendship{}).Where("id = ?", id).Update("status", status).Error
+}
+
+func (r *friendshipRepository) ListAcceptedFollowing(ctx context.Context, userID uint64) ([]domain.Friendship, error) {
+	var rows []domain.Friendship
+	err := r.db.WithContext(ctx).
+		Where("requester_id = ? AND status = ?", userID, domain.FriendshipStatusAccepted).
+		Order("created_at DESC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *friendshipRepository) ListAcceptedFollowers(ctx context.Context, userID uint64) ([]domain.Friendship, error) {
+	var rows []domain.Friendship
+	err := r.db.WithContext(ctx).
+		Where("addressee_id = ? AND status = ?", userID, domain.FriendshipStatusAccepted).
+		Order("created_at DESC").
+		Find(&rows).Error
+	return rows, err
+}
+
+func (r *friendshipRepository) FindBetween(ctx context.Context, requesterID, addresseeID uint64) (*domain.Friendship, error) {
+	var f domain.Friendship
+	err := r.db.WithContext(ctx).
+		Where("requester_id = ? AND addressee_id = ?", requesterID, addresseeID).
+		First(&f).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+func (r *friendshipRepository) DeleteBetween(ctx context.Context, requesterID, addresseeID uint64) error {
+	return r.db.WithContext(ctx).
+		Where("requester_id = ? AND addressee_id = ?", requesterID, addresseeID).
+		Delete(&domain.Friendship{}).Error
 }

--- a/backend/internal/repository/notification_repository.go
+++ b/backend/internal/repository/notification_repository.go
@@ -12,6 +12,10 @@ type NotificationRepository interface {
 	// MarkRead は所有者検証込みで is_read を立てる。
 	// 自分以外の通知を既読化できないように、必ず WHERE で user_id を絞る。
 	MarkRead(ctx context.Context, userID, id uint64) error
+	// MarkAllRead は current user の全通知を既読化する。
+	MarkAllRead(ctx context.Context, userID uint64) error
+	// CountUnread は current user の未読通知数を返す。
+	CountUnread(ctx context.Context, userID uint64) (int64, error)
 }
 
 type notificationRepository struct{ db *gorm.DB }
@@ -29,6 +33,22 @@ func (r *notificationRepository) MarkRead(ctx context.Context, userID, id uint64
 		Model(&domain.Notification{}).
 		Where("id = ? AND user_id = ?", id, userID).
 		Update("is_read", true).Error
+}
+
+func (r *notificationRepository) MarkAllRead(ctx context.Context, userID uint64) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.Notification{}).
+		Where("user_id = ? AND is_read = ?", userID, false).
+		Update("is_read", true).Error
+}
+
+func (r *notificationRepository) CountUnread(ctx context.Context, userID uint64) (int64, error) {
+	var n int64
+	err := r.db.WithContext(ctx).
+		Model(&domain.Notification{}).
+		Where("user_id = ? AND is_read = ?", userID, false).
+		Count(&n).Error
+	return n, err
 }
 
 // SnsPublisher は通知 push 用の interface（実装は AWS SDK 連携で別 PR）。

--- a/backend/internal/usecase/favorite_phrase_usecase.go
+++ b/backend/internal/usecase/favorite_phrase_usecase.go
@@ -44,9 +44,12 @@ func NewDeleteFavoritePhraseUseCase(r repository.FavoritePhraseRepository) *Dele
 	return &DeleteFavoritePhraseUseCase{repo: r}
 }
 
-func (u *DeleteFavoritePhraseUseCase) Execute(ctx context.Context, id uint64) error {
+func (u *DeleteFavoritePhraseUseCase) Execute(ctx context.Context, userID, id uint64) error {
+	if userID == 0 {
+		return errors.New("userID is required")
+	}
 	if id == 0 {
 		return errors.New("id is required")
 	}
-	return u.repo.Delete(ctx, id)
+	return u.repo.Delete(ctx, userID, id)
 }

--- a/backend/internal/usecase/favorite_phrase_usecase_test.go
+++ b/backend/internal/usecase/favorite_phrase_usecase_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 type stubFavPhraseRepo struct {
-	rows []domain.FavoritePhrase
-	err  error
+	rows           []domain.FavoritePhrase
+	err            error
+	deletedUserID  uint64
+	deletedID      uint64
 }
 
 func (s *stubFavPhraseRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.FavoritePhrase, error) {
@@ -22,7 +24,11 @@ func (s *stubFavPhraseRepo) Create(_ context.Context, p *domain.FavoritePhrase) 
 	p.ID = 71
 	return nil
 }
-func (s *stubFavPhraseRepo) Delete(_ context.Context, _ uint64) error { return s.err }
+func (s *stubFavPhraseRepo) Delete(_ context.Context, userID, id uint64) error {
+	s.deletedUserID = userID
+	s.deletedID = id
+	return s.err
+}
 
 func TestListFavoritePhrases_RequiresUserID(t *testing.T) {
 	uc := NewListFavoritePhrasesUseCase(&stubFavPhraseRepo{})
@@ -46,9 +52,27 @@ func TestAddFavoritePhrase_AssignsID(t *testing.T) {
 	}
 }
 
+func TestDeleteFavoritePhrase_RequiresUserID(t *testing.T) {
+	uc := NewDeleteFavoritePhraseUseCase(&stubFavPhraseRepo{})
+	if err := uc.Execute(context.Background(), 0, 1); err == nil {
+		t.Fatal("expected error when userID is 0")
+	}
+}
+
 func TestDeleteFavoritePhrase_RequiresID(t *testing.T) {
 	uc := NewDeleteFavoritePhraseUseCase(&stubFavPhraseRepo{})
-	if err := uc.Execute(context.Background(), 0); err == nil {
-		t.Fatal("expected error")
+	if err := uc.Execute(context.Background(), 1, 0); err == nil {
+		t.Fatal("expected error when id is 0")
+	}
+}
+
+func TestDeleteFavoritePhrase_PassesUserIDToRepo(t *testing.T) {
+	repo := &stubFavPhraseRepo{}
+	uc := NewDeleteFavoritePhraseUseCase(repo)
+	if err := uc.Execute(context.Background(), 9, 11); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if repo.deletedUserID != 9 || repo.deletedID != 11 {
+		t.Fatalf("Delete should be called with (9,11), got (%d,%d)", repo.deletedUserID, repo.deletedID)
 	}
 }

--- a/backend/internal/usecase/friendship_usecase.go
+++ b/backend/internal/usecase/friendship_usecase.go
@@ -57,3 +57,103 @@ func (u *RespondFriendshipUseCase) Execute(ctx context.Context, id uint64, accep
 	}
 	return u.repo.UpdateStatus(ctx, id, status)
 }
+
+// FollowUserUseCase は単方向フォロー（accepted の Friendship を即時作成）。
+// フロントの follow ボタンが確認なしで完了する仕様に合わせる。
+type FollowUserUseCase struct{ repo repository.FriendshipRepository }
+
+func NewFollowUserUseCase(r repository.FriendshipRepository) *FollowUserUseCase {
+	return &FollowUserUseCase{repo: r}
+}
+
+func (u *FollowUserUseCase) Execute(ctx context.Context, followerID, targetID uint64) (*domain.Friendship, error) {
+	if followerID == 0 || targetID == 0 {
+		return nil, errors.New("followerID and targetID are required")
+	}
+	if followerID == targetID {
+		return nil, errors.New("cannot follow self")
+	}
+	if existing, err := u.repo.FindBetween(ctx, followerID, targetID); err != nil {
+		return nil, err
+	} else if existing != nil {
+		return existing, nil
+	}
+	f := &domain.Friendship{
+		RequesterID: followerID,
+		AddresseeID: targetID,
+		Status:      domain.FriendshipStatusAccepted,
+	}
+	if err := u.repo.Create(ctx, f); err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+type UnfollowUserUseCase struct{ repo repository.FriendshipRepository }
+
+func NewUnfollowUserUseCase(r repository.FriendshipRepository) *UnfollowUserUseCase {
+	return &UnfollowUserUseCase{repo: r}
+}
+
+func (u *UnfollowUserUseCase) Execute(ctx context.Context, followerID, targetID uint64) error {
+	if followerID == 0 || targetID == 0 {
+		return errors.New("followerID and targetID are required")
+	}
+	return u.repo.DeleteBetween(ctx, followerID, targetID)
+}
+
+type ListFollowingUseCase struct{ repo repository.FriendshipRepository }
+
+func NewListFollowingUseCase(r repository.FriendshipRepository) *ListFollowingUseCase {
+	return &ListFollowingUseCase{repo: r}
+}
+
+func (u *ListFollowingUseCase) Execute(ctx context.Context, userID uint64) ([]domain.Friendship, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.repo.ListAcceptedFollowing(ctx, userID)
+}
+
+type ListFollowersUseCase struct{ repo repository.FriendshipRepository }
+
+func NewListFollowersUseCase(r repository.FriendshipRepository) *ListFollowersUseCase {
+	return &ListFollowersUseCase{repo: r}
+}
+
+func (u *ListFollowersUseCase) Execute(ctx context.Context, userID uint64) ([]domain.Friendship, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.repo.ListAcceptedFollowers(ctx, userID)
+}
+
+// FollowStatus は viewer→target、target→viewer の両方向 follow 状態を表す。
+type FollowStatus struct {
+	IsFollowing  bool `json:"isFollowing"`
+	IsFollowedBy bool `json:"isFollowedBy"`
+}
+
+type GetFollowStatusUseCase struct{ repo repository.FriendshipRepository }
+
+func NewGetFollowStatusUseCase(r repository.FriendshipRepository) *GetFollowStatusUseCase {
+	return &GetFollowStatusUseCase{repo: r}
+}
+
+func (u *GetFollowStatusUseCase) Execute(ctx context.Context, viewerID, targetID uint64) (FollowStatus, error) {
+	if viewerID == 0 || targetID == 0 {
+		return FollowStatus{}, errors.New("viewerID and targetID are required")
+	}
+	out := FollowStatus{}
+	if f, err := u.repo.FindBetween(ctx, viewerID, targetID); err != nil {
+		return FollowStatus{}, err
+	} else if f != nil && f.Status == domain.FriendshipStatusAccepted {
+		out.IsFollowing = true
+	}
+	if f, err := u.repo.FindBetween(ctx, targetID, viewerID); err != nil {
+		return FollowStatus{}, err
+	} else if f != nil && f.Status == domain.FriendshipStatusAccepted {
+		out.IsFollowedBy = true
+	}
+	return out, nil
+}

--- a/backend/internal/usecase/friendship_usecase_test.go
+++ b/backend/internal/usecase/friendship_usecase_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 type stubFriendshipRepo struct {
-	rows []domain.Friendship
-	err  error
+	rows      []domain.Friendship
+	err       error
+	between   *domain.Friendship
+	deleteHit struct{ requesterID, addresseeID uint64 }
 }
 
 func (s *stubFriendshipRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.Friendship, error) {
@@ -23,6 +25,20 @@ func (s *stubFriendshipRepo) Create(_ context.Context, f *domain.Friendship) err
 	return nil
 }
 func (s *stubFriendshipRepo) UpdateStatus(_ context.Context, _ uint64, _ string) error {
+	return s.err
+}
+func (s *stubFriendshipRepo) ListAcceptedFollowing(_ context.Context, _ uint64) ([]domain.Friendship, error) {
+	return s.rows, s.err
+}
+func (s *stubFriendshipRepo) ListAcceptedFollowers(_ context.Context, _ uint64) ([]domain.Friendship, error) {
+	return s.rows, s.err
+}
+func (s *stubFriendshipRepo) FindBetween(_ context.Context, _, _ uint64) (*domain.Friendship, error) {
+	return s.between, s.err
+}
+func (s *stubFriendshipRepo) DeleteBetween(_ context.Context, requesterID, addresseeID uint64) error {
+	s.deleteHit.requesterID = requesterID
+	s.deleteHit.addresseeID = addresseeID
 	return s.err
 }
 
@@ -51,6 +67,54 @@ func TestRequestFriendship_AssignsID(t *testing.T) {
 func TestRespondFriendship_RequiresID(t *testing.T) {
 	uc := NewRespondFriendshipUseCase(&stubFriendshipRepo{})
 	if err := uc.Execute(context.Background(), 0, true); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFollowUser_RejectsSelf(t *testing.T) {
+	uc := NewFollowUserUseCase(&stubFriendshipRepo{})
+	if _, err := uc.Execute(context.Background(), 1, 1); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFollowUser_ReturnsExistingIfAlreadyFollowing(t *testing.T) {
+	existing := &domain.Friendship{ID: 99, RequesterID: 1, AddresseeID: 2, Status: domain.FriendshipStatusAccepted}
+	uc := NewFollowUserUseCase(&stubFriendshipRepo{between: existing})
+	got, err := uc.Execute(context.Background(), 1, 2)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.ID != 99 {
+		t.Fatalf("should return existing, got %+v", got)
+	}
+}
+
+func TestFollowUser_CreatesAcceptedFriendship(t *testing.T) {
+	uc := NewFollowUserUseCase(&stubFriendshipRepo{})
+	got, err := uc.Execute(context.Background(), 1, 2)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.Status != domain.FriendshipStatusAccepted {
+		t.Fatalf("status should be accepted, got %s", got.Status)
+	}
+}
+
+func TestUnfollowUser_PassesIDsToRepo(t *testing.T) {
+	repo := &stubFriendshipRepo{}
+	uc := NewUnfollowUserUseCase(repo)
+	if err := uc.Execute(context.Background(), 7, 11); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if repo.deleteHit.requesterID != 7 || repo.deleteHit.addresseeID != 11 {
+		t.Fatalf("Delete called with wrong ids: %+v", repo.deleteHit)
+	}
+}
+
+func TestGetFollowStatus_RequiresIDs(t *testing.T) {
+	uc := NewGetFollowStatusUseCase(&stubFriendshipRepo{})
+	if _, err := uc.Execute(context.Background(), 0, 1); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/backend/internal/usecase/notification_usecase.go
+++ b/backend/internal/usecase/notification_usecase.go
@@ -36,3 +36,29 @@ func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, userID, id ui
 	}
 	return u.repo.MarkRead(ctx, userID, id)
 }
+
+type MarkAllNotificationsReadUseCase struct{ repo repository.NotificationRepository }
+
+func NewMarkAllNotificationsReadUseCase(r repository.NotificationRepository) *MarkAllNotificationsReadUseCase {
+	return &MarkAllNotificationsReadUseCase{repo: r}
+}
+
+func (u *MarkAllNotificationsReadUseCase) Execute(ctx context.Context, userID uint64) error {
+	if userID == 0 {
+		return errors.New("userID is required")
+	}
+	return u.repo.MarkAllRead(ctx, userID)
+}
+
+type CountUnreadNotificationsUseCase struct{ repo repository.NotificationRepository }
+
+func NewCountUnreadNotificationsUseCase(r repository.NotificationRepository) *CountUnreadNotificationsUseCase {
+	return &CountUnreadNotificationsUseCase{repo: r}
+}
+
+func (u *CountUnreadNotificationsUseCase) Execute(ctx context.Context, userID uint64) (int64, error) {
+	if userID == 0 {
+		return 0, errors.New("userID is required")
+	}
+	return u.repo.CountUnread(ctx, userID)
+}

--- a/backend/internal/usecase/notification_usecase_test.go
+++ b/backend/internal/usecase/notification_usecase_test.go
@@ -16,6 +16,10 @@ func (s *stubNotificationRepo) ListByUserID(_ context.Context, _ uint64) ([]doma
 	return s.rows, s.err
 }
 func (s *stubNotificationRepo) MarkRead(_ context.Context, _, _ uint64) error { return s.err }
+func (s *stubNotificationRepo) MarkAllRead(_ context.Context, _ uint64) error  { return s.err }
+func (s *stubNotificationRepo) CountUnread(_ context.Context, _ uint64) (int64, error) {
+	return int64(len(s.rows)), s.err
+}
 
 func TestListNotifications_RequiresUserID(t *testing.T) {
 	uc := NewListNotificationsUseCase(&stubNotificationRepo{})
@@ -34,6 +38,20 @@ func TestMarkRead_RequiresUserID(t *testing.T) {
 func TestMarkRead_RequiresID(t *testing.T) {
 	uc := NewMarkNotificationReadUseCase(&stubNotificationRepo{})
 	if err := uc.Execute(context.Background(), 1, 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestMarkAllNotificationsRead_RequiresUserID(t *testing.T) {
+	uc := NewMarkAllNotificationsReadUseCase(&stubNotificationRepo{})
+	if err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestCountUnreadNotifications_RequiresUserID(t *testing.T) {
+	uc := NewCountUnreadNotificationsUseCase(&stubNotificationRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/frontend/src/repositories/LearningReportRepository.ts
+++ b/frontend/src/repositories/LearningReportRepository.ts
@@ -1,15 +1,16 @@
 import apiClient from '../lib/axios';
 import type { LearningReport } from '../types';
 
+// Go バックエンドの正規パスは /learning-reports（旧 Spring Boot 時代の /reports は廃止）。
 export const LearningReportRepository = {
   async getAll(): Promise<LearningReport[]> {
-    const response = await apiClient.get<LearningReport[]>('/api/v2/reports');
+    const response = await apiClient.get<LearningReport[]>('/api/v2/learning-reports');
     return response.data;
   },
 
   async getMonthly(year: number, month: number): Promise<LearningReport | null> {
     try {
-      const response = await apiClient.get<LearningReport>(`/api/v2/reports/${year}/${month}`);
+      const response = await apiClient.get<LearningReport>(`/api/v2/learning-reports/${year}/${month}`);
       return response.data;
     } catch {
       return null;
@@ -17,7 +18,7 @@ export const LearningReportRepository = {
   },
 
   async generate(year: number, month: number): Promise<{ status: string }> {
-    const response = await apiClient.post<{ status: string }>('/api/v2/reports/generate', { year, month });
+    const response = await apiClient.post<{ status: string }>('/api/v2/learning-reports/generate', { year, month });
     return response.data;
   },
 };

--- a/frontend/src/repositories/NotificationRepository.ts
+++ b/frontend/src/repositories/NotificationRepository.ts
@@ -1,6 +1,7 @@
 import apiClient from '../lib/axios';
 import type { Notification } from '../types';
 
+// Go バックエンドは PATCH を REST 標準として提供する。フロントは PATCH に揃える。
 export const NotificationRepository = {
   async getAll(): Promise<Notification[]> {
     const response = await apiClient.get<Notification[]>('/api/v2/notifications');
@@ -8,11 +9,11 @@ export const NotificationRepository = {
   },
 
   async markAsRead(notificationId: number): Promise<void> {
-    await apiClient.put(`/api/v2/notifications/${notificationId}/read`);
+    await apiClient.patch(`/api/v2/notifications/${notificationId}/read`);
   },
 
   async markAllAsRead(): Promise<void> {
-    await apiClient.put('/api/v2/notifications/read-all');
+    await apiClient.patch('/api/v2/notifications/read-all');
   },
 
   async getUnreadCount(): Promise<number> {

--- a/frontend/src/repositories/__tests__/LearningReportRepository.test.ts
+++ b/frontend/src/repositories/__tests__/LearningReportRepository.test.ts
@@ -26,7 +26,7 @@ describe('LearningReportRepository', () => {
 
     const result = await LearningReportRepository.getAll();
     expect(result).toEqual(reports);
-    expect(mockedGet).toHaveBeenCalledWith('/api/v2/reports');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/learning-reports');
   });
 
   it('getMonthly: 指定月のレポートを取得する', async () => {
@@ -35,7 +35,7 @@ describe('LearningReportRepository', () => {
 
     const result = await LearningReportRepository.getMonthly(2024, 6);
     expect(result).toEqual(report);
-    expect(mockedGet).toHaveBeenCalledWith('/api/v2/reports/2024/6');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/learning-reports/2024/6');
   });
 
   it('getMonthly: 該当レポートがない場合はnullを返す', async () => {
@@ -50,6 +50,6 @@ describe('LearningReportRepository', () => {
 
     const result = await LearningReportRepository.generate(2024, 6);
     expect(result).toEqual({ status: 'generated' });
-    expect(mockedPost).toHaveBeenCalledWith('/api/v2/reports/generate', { year: 2024, month: 6 });
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/learning-reports/generate', { year: 2024, month: 6 });
   });
 });

--- a/frontend/src/repositories/__tests__/NotificationRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NotificationRepository.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../lib/axios', () => ({
   default: {
     get: vi.fn(),
-    put: vi.fn(),
+    patch: vi.fn(),
   },
 }));
 
@@ -11,7 +11,7 @@ import apiClient from '../../lib/axios';
 import { NotificationRepository } from '../NotificationRepository';
 
 const mockedGet = vi.mocked(apiClient.get);
-const mockedPut = vi.mocked(apiClient.put);
+const mockedPatch = vi.mocked(apiClient.patch);
 
 describe('NotificationRepository', () => {
   beforeEach(() => {
@@ -30,17 +30,17 @@ describe('NotificationRepository', () => {
   });
 
   it('markAsRead: 指定IDの通知を既読にする', async () => {
-    mockedPut.mockResolvedValue({});
+    mockedPatch.mockResolvedValue({});
 
     await NotificationRepository.markAsRead(5);
-    expect(mockedPut).toHaveBeenCalledWith('/api/v2/notifications/5/read');
+    expect(mockedPatch).toHaveBeenCalledWith('/api/v2/notifications/5/read');
   });
 
   it('markAllAsRead: 全通知を既読にする', async () => {
-    mockedPut.mockResolvedValue({});
+    mockedPatch.mockResolvedValue({});
 
     await NotificationRepository.markAllAsRead();
-    expect(mockedPut).toHaveBeenCalledWith('/api/v2/notifications/read-all');
+    expect(mockedPatch).toHaveBeenCalledWith('/api/v2/notifications/read-all');
   });
 
   it('getUnreadCount: 未読数を取得する', async () => {


### PR DESCRIPTION
## 概要

PR #1557 デプロイ後、本番でフロントが叩く path とバックエンドの path が不整合で複数の 404 / 400 が発生していた:

- \`GET /api/v2/reports\` 404
- \`GET /api/v2/friendships/following\` 404
- \`GET /api/v2/friendships/followers\` 404
- \`GET /api/v2/notifications/unread-count\` 404
- \`GET /api/v2/favorite-phrases\` 400 (?userId 必須)

Spring Boot 廃止整合性シリーズの最終整理として、フロントが期待する path を Go raw API に対応させる + 残っていた書き込み系 IDOR を塞ぐ。

## 変更内容

### バックエンド

#### favorite_phrase
- handler を current user 固定に（?userId / req.UserID 廃止）
- repository.Delete に userID 引数追加 + WHERE で IDOR 対策

#### notification
- /notifications/unread-count GET と /notifications/read-all PATCH を新設
- /:id/read と /read-all は PATCH を正規だが PUT も alias で受ける（旧クライアント互換）
- repository に MarkAllRead / CountUnread, usecase に対応 UseCase

#### friendship
- /following /followers /:userId/follow (POST/DELETE) /:userId/status を新設
- usecase / repository も既存の双方向 friendship を残しつつ単方向 follow を追加
- Request handler を current user 起点に固定（IDOR 対策）

#### learning_report
- handler を current user 固定に（IDOR 対策）

### フロントエンド
- LearningReportRepository: \`/api/v2/reports\` → \`/api/v2/learning-reports\`
- NotificationRepository: PUT → PATCH に統一

### TDD 追加テスト
- DeleteFavoritePhraseUseCase: RequiresUserID / RequiresID / PassesUserIDToRepo
- MarkAllNotificationsReadUseCase / CountUnreadNotificationsUseCase: RequiresUserID
- FollowUser: RejectsSelf / ReturnsExistingIfAlreadyFollowing / CreatesAcceptedFriendship
- UnfollowUser: PassesIDsToRepo
- GetFollowStatus: RequiresIDs

## テスト

- [x] \`go build ./... && go test ./...\` 全 green
- [x] \`npx vitest run\` 2360 tests 全 green
- [x] \`npm run build\` 成功

## 関連

#1555 / #1556 / #1557 のフォローアップ。本番ログイン後のコンソールエラー解消が目的。