### PR TITLE
fix: /profile/me 400 と /users/me/stats 404 を解消 — "me" 許容 + IDOR 対策

### DIFF
--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -17,15 +19,48 @@ func NewProfileHandler(g *usecase.GetProfileUseCase, u *usecase.UpdateProfileUse
 	return &ProfileHandler{get: g, update: u}
 }
 
+var (
+	errProfileForbidden    = errors.New("forbidden")
+	errProfileUnauthorized = errors.New("unauthorized")
+)
+
+// resolveUserID は path :userId を current user と突き合わせる。
+//   - "me" / 空文字 / 数字以外 → current user に解決（フロント /profile/me に対応）
+//   - 数字で current user と一致 → そのまま
+//   - 数字で current user 以外 → 403（IDOR 対策）
+func (h *ProfileHandler) resolveUserID(c *gin.Context) (uint64, error) {
+	cur := middleware.CurrentUserIDOrZero(c)
+	if cur == 0 {
+		return 0, errProfileUnauthorized
+	}
+	param := c.Param("userId")
+	if param == "" || param == "me" {
+		return cur, nil
+	}
+	uid, err := strconv.ParseUint(param, 10, 64)
+	if err != nil {
+		return cur, nil
+	}
+	if uid == 0 || uid != cur {
+		return 0, errProfileForbidden
+	}
+	return uid, nil
+}
+
 func (h *ProfileHandler) Get(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		writeProfileError(c, err)
+		return
+	}
 	p, err := h.get.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if p == nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "profile_not_found"})
+		// 未登録ユーザーでも UI が落ちないよう最小デフォルトを返す。
+		c.JSON(http.StatusOK, gin.H{"userId": uid, "bio": "", "avatarUrl": "", "name": "", "iconUrl": "", "status": ""})
 		return
 	}
 	c.JSON(http.StatusOK, p)
@@ -37,7 +72,11 @@ type updateProfileReq struct {
 }
 
 func (h *ProfileHandler) Update(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		writeProfileError(c, err)
+		return
+	}
 	var req updateProfileReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -51,4 +90,15 @@ func (h *ProfileHandler) Update(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, updated)
+}
+
+func writeProfileError(c *gin.Context, err error) {
+	switch err {
+	case errProfileUnauthorized:
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	case errProfileForbidden:
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	default:
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	}
 }

--- a/backend/internal/handler/profile_handler_test.go
+++ b/backend/internal/handler/profile_handler_test.go
@@ -1,0 +1,62 @@
+package handler
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// makeCtx は gin.Context を生成し、context に current user を埋め込んで返す。
+func makeCtx(currentUserID uint64, paramUserID string) *gin.Context {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	if currentUserID != 0 {
+		c.Set(middleware.ContextKeyCurrentUserID, currentUserID)
+	}
+	c.Params = gin.Params{{Key: "userId", Value: paramUserID}}
+	return c
+}
+
+func TestProfileResolveUserID_MeKeyword(t *testing.T) {
+	h := &ProfileHandler{}
+	uid, err := h.resolveUserID(makeCtx(7, "me"))
+	if err != nil || uid != 7 {
+		t.Fatalf("'me' should resolve to current user; got uid=%d err=%v", uid, err)
+	}
+}
+
+func TestProfileResolveUserID_EmptyParam(t *testing.T) {
+	h := &ProfileHandler{}
+	uid, err := h.resolveUserID(makeCtx(7, ""))
+	if err != nil || uid != 7 {
+		t.Fatalf("empty param should resolve to current user; got uid=%d err=%v", uid, err)
+	}
+}
+
+func TestProfileResolveUserID_MatchingNumeric(t *testing.T) {
+	h := &ProfileHandler{}
+	uid, err := h.resolveUserID(makeCtx(7, "7"))
+	if err != nil || uid != 7 {
+		t.Fatalf("matching numeric should pass; got uid=%d err=%v", uid, err)
+	}
+}
+
+func TestProfileResolveUserID_MismatchNumericIsForbidden(t *testing.T) {
+	h := &ProfileHandler{}
+	if _, err := h.resolveUserID(makeCtx(7, "99")); err != errProfileForbidden {
+		t.Fatalf("mismatch numeric should be forbidden; got %v", err)
+	}
+}
+
+func TestProfileResolveUserID_NoCurrentUserIsUnauthorized(t *testing.T) {
+	h := &ProfileHandler{}
+	if _, err := h.resolveUserID(makeCtx(0, "me")); err != errProfileUnauthorized {
+		t.Fatalf("no current user should be unauthorized; got %v", err)
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -69,14 +69,19 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		usecase.NewGetProfileUseCase(profileRepo),
 		usecase.NewUpdateProfileUseCase(profileRepo),
 	)
+	// /profile/:userId は数字 / "me" の両方を受ける（handler.resolveUserID で current user 解決）。
+	// フロント互換のため /profile/:userId/update PUT / /profile/:userId/image/presigned-url POST も提供する。
 	authed.GET("/profile/:userId", profileHandler.Get)
 	authed.PUT("/profile/:userId", profileHandler.Update)
+	authed.PUT("/profile/:userId/update", profileHandler.Update)
 
 	// Phase 6: ユーザー統計
 	statsHandler := NewUserStatsHandler(
 		usecase.NewGetUserStatsUseCase(repository.NewUserStatsRepository(db)),
 	)
+	// 旧 path /user-stats/:userId と Spring 風 /users/:userId/stats の両方を提供する。
 	authed.GET("/user-stats/:userId", statsHandler.Get)
+	authed.GET("/users/:userId/stats", statsHandler.Get)
 
 	// Phase 7: 練習モード (シナリオ)
 	practiceRepo := repository.NewPracticeScenarioRepository(db)

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -16,8 +18,45 @@ func NewUserStatsHandler(g *usecase.GetUserStatsUseCase) *UserStatsHandler {
 	return &UserStatsHandler{get: g}
 }
 
+var (
+	errUserStatsForbidden    = errors.New("forbidden")
+	errUserStatsUnauthorized = errors.New("unauthorized")
+)
+
+// resolveUserID は profile_handler と同じ規則で path :userId を解決する。
+// "me" / 空文字 → current user、数字は current user と一致した場合のみ通す（IDOR 対策）。
+func (h *UserStatsHandler) resolveUserID(c *gin.Context) (uint64, error) {
+	cur := middleware.CurrentUserIDOrZero(c)
+	if cur == 0 {
+		return 0, errUserStatsUnauthorized
+	}
+	param := c.Param("userId")
+	if param == "" || param == "me" {
+		return cur, nil
+	}
+	uid, err := strconv.ParseUint(param, 10, 64)
+	if err != nil {
+		return cur, nil
+	}
+	if uid == 0 || uid != cur {
+		return 0, errUserStatsForbidden
+	}
+	return uid, nil
+}
+
 func (h *UserStatsHandler) Get(c *gin.Context) {
-	uid, _ := strconv.ParseUint(c.Param("userId"), 10, 64)
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		switch err {
+		case errUserStatsUnauthorized:
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		case errUserStatsForbidden:
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
+		return
+	}
 	stats, err := h.get.Execute(c.Request.Context(), uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/user_stats_handler_test.go
+++ b/backend/internal/handler/user_stats_handler_test.go
@@ -1,0 +1,25 @@
+package handler
+
+import "testing"
+
+func TestUserStatsResolveUserID_MeKeyword(t *testing.T) {
+	h := &UserStatsHandler{}
+	uid, err := h.resolveUserID(makeCtx(7, "me"))
+	if err != nil || uid != 7 {
+		t.Fatalf("'me' should resolve to current user; got uid=%d err=%v", uid, err)
+	}
+}
+
+func TestUserStatsResolveUserID_MismatchNumericIsForbidden(t *testing.T) {
+	h := &UserStatsHandler{}
+	if _, err := h.resolveUserID(makeCtx(7, "99")); err != errUserStatsForbidden {
+		t.Fatalf("mismatch numeric should be forbidden; got %v", err)
+	}
+}
+
+func TestUserStatsResolveUserID_NoCurrentUserIsUnauthorized(t *testing.T) {
+	h := &UserStatsHandler{}
+	if _, err := h.resolveUserID(makeCtx(0, "me")); err != errUserStatsUnauthorized {
+		t.Fatalf("no current user should be unauthorized; got %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

ProfilePage で残っていた本番エラー 2 件を解消する:

- \`GET /api/v2/profile/me\` 400 (\`:userId\` を ParseUint できず uid=0 → 400)
- \`GET /api/v2/users/me/stats\` 404 (backend に該当 route なし)

## 変更内容

### バックエンド
- \`profile_handler.go\` / \`user_stats_handler.go\` に \`resolveUserID\` ヘルパを導入
  - \"me\" / 空文字 / 数字以外 → \`middleware.CurrentUserIDOrZero\` で current user に解決
  - 数字 0 / current user 以外の数字 → 403（IDOR 対策）
  - 数字一致 → そのまま通す
- \`router.go\` に追加:
  - \`PUT /profile/:userId/update\` を既存 Update handler に wire
  - \`GET /users/:userId/stats\` を既存 UserStats handler に wire（旧 \`/user-stats/:userId\` は維持）
- \`profile.Get\` で未登録ユーザー時に 404 ではなく最小デフォルト JSON を返す（初回アクセスで UI が落ちないように）

### TDD 追加テスト
- \`ProfileHandler.resolveUserID\`: \"me\" / 空文字 / 数字一致 / 数字 mismatch / current 不在
- \`UserStatsHandler.resolveUserID\`: 主要ケース 3 種

## テスト

- [x] \`go build ./... && go test ./...\` 全 green

## 関連

#1555-#1558 のフォローアップ。本番コンソール残エラー 2 件のクリア。