### PR TITLE
fix(frontend): NoteRepository で backend id を noteId へ正規化（削除が動かない問題）

### DIFF
--- a/frontend/src/repositories/NoteRepository.ts
+++ b/frontend/src/repositories/NoteRepository.ts
@@ -1,19 +1,54 @@
 import apiClient from '../lib/axios';
 import type { Note } from '../types';
 
+// Go バックエンドの Note レスポンスは { id, userId, title, content, isPublic, createdAt, updatedAt }。
+// フロント Note 型は { noteId: string, ..., isPinned: boolean, createdAt: number(ms), updatedAt: number(ms) } を期待するため
+// Repository 層で正規化する（CLAUDE.md の Mapper 集約方針に準拠）。
+interface ApiNote {
+  id: number;
+  userId: number;
+  title?: string;
+  content?: string;
+  isPublic?: boolean;
+  isPinned?: boolean;
+  createdAt?: string | number;
+  updatedAt?: string | number;
+}
+
+function toMillis(value: string | number | undefined): number {
+  if (value == null) return Date.now();
+  if (typeof value === 'number') return value;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Date.now() : parsed;
+}
+
+function toNote(api: ApiNote): Note {
+  return {
+    noteId: String(api.id),
+    userId: api.userId,
+    title: api.title ?? '',
+    content: api.content ?? '',
+    isPinned: api.isPinned ?? api.isPublic ?? false,
+    createdAt: toMillis(api.createdAt),
+    updatedAt: toMillis(api.updatedAt),
+  };
+}
+
 const NoteRepository = {
   async fetchNotes(): Promise<Note[]> {
-    const res = await apiClient.get('/api/v2/notes');
-    return res.data;
+    const res = await apiClient.get<ApiNote[]>('/api/v2/notes');
+    const list = Array.isArray(res.data) ? res.data : [];
+    return list.map(toNote);
   },
 
   async createNote(title: string): Promise<Note> {
-    const res = await apiClient.post('/api/v2/notes', { title });
-    return res.data;
+    const res = await apiClient.post<ApiNote>('/api/v2/notes', { title });
+    return toNote(res.data);
   },
 
   async updateNote(noteId: string, data: { title: string; content: string; isPinned: boolean }): Promise<void> {
-    await apiClient.put(`/api/v2/notes/${noteId}`, data);
+    // backend の domain は isPublic フィールドを持つ。互換のため両方送る。
+    await apiClient.put(`/api/v2/notes/${noteId}`, { ...data, isPublic: data.isPinned });
   },
 
   async deleteNote(noteId: string): Promise<void> {

--- a/frontend/src/repositories/__tests__/NoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteRepository.test.ts
@@ -9,41 +9,74 @@ describe('NoteRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('fetchNotesがGETリクエストを送信する', async () => {
-    const mockNotes = [
-      { noteId: 'note-1', userId: 1, title: 'テスト', content: '', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+  it('fetchNotes は backend の id (number) を noteId (string) に正規化する', async () => {
+    const apiResponse = [
+      {
+        id: 21,
+        userId: 1,
+        title: 'テスト',
+        content: '',
+        isPublic: false,
+        createdAt: '2026-04-28T08:00:00Z',
+        updatedAt: '2026-04-28T09:00:00Z',
+      },
     ];
-    vi.mocked(apiClient.get).mockResolvedValue({ data: mockNotes });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: apiResponse });
 
     const result = await NoteRepository.fetchNotes();
 
     expect(apiClient.get).toHaveBeenCalledWith('/api/v2/notes');
-    expect(result).toEqual(mockNotes);
+    expect(result).toHaveLength(1);
+    expect(result[0].noteId).toBe('21');
+    expect(result[0].title).toBe('テスト');
+    expect(result[0].isPinned).toBe(false);
+    expect(typeof result[0].createdAt).toBe('number');
   });
 
-  it('createNoteがPOSTリクエストを送信する', async () => {
-    const mockNote = { noteId: 'note-new', userId: 1, title: '新しいノート', content: '', isPinned: false, createdAt: 1000, updatedAt: 1000 };
-    vi.mocked(apiClient.post).mockResolvedValue({ data: mockNote });
+  it('fetchNotes は配列以外のレスポンスを空配列にフォールバックする', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: null });
+    const result = await NoteRepository.fetchNotes();
+    expect(result).toEqual([]);
+  });
+
+  it('createNote は backend レスポンスの id を noteId に変換した Note を返す', async () => {
+    const apiResponse = {
+      id: 99,
+      userId: 1,
+      title: '新しいノート',
+      content: '',
+      isPublic: true,
+      createdAt: '2026-04-28T00:00:00Z',
+      updatedAt: '2026-04-28T00:00:00Z',
+    };
+    vi.mocked(apiClient.post).mockResolvedValue({ data: apiResponse });
 
     const result = await NoteRepository.createNote('新しいノート');
 
     expect(apiClient.post).toHaveBeenCalledWith('/api/v2/notes', { title: '新しいノート' });
+    expect(result.noteId).toBe('99');
     expect(result.title).toBe('新しいノート');
+    expect(result.isPinned).toBe(true);
   });
 
-  it('updateNoteがPUTリクエストを送信する', async () => {
+  it('updateNote は noteId を URL に埋め込み isPublic も互換で送信する', async () => {
     vi.mocked(apiClient.put).mockResolvedValue({ data: undefined });
 
-    await NoteRepository.updateNote('note-1', { title: '更新', content: '内容', isPinned: false });
+    await NoteRepository.updateNote('21', { title: '更新', content: '内容', isPinned: true });
 
-    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/notes/note-1', { title: '更新', content: '内容', isPinned: false });
+    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/notes/21', {
+      title: '更新',
+      content: '内容',
+      isPinned: true,
+      isPublic: true,
+    });
   });
 
-  it('deleteNoteがDELETEリクエストを送信する', async () => {
+  it('deleteNote は noteId を URL に埋め込んで DELETE を投げる', async () => {
     vi.mocked(apiClient.delete).mockResolvedValue({ data: undefined });
 
-    await NoteRepository.deleteNote('note-1');
+    await NoteRepository.deleteNote('21');
 
-    expect(apiClient.delete).toHaveBeenCalledWith('/api/v2/notes/note-1');
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/v2/notes/21');
   });
 });


### PR DESCRIPTION
## 概要

本番でノート一覧の削除モーダルで「削除」を押しても何も起きない原因は、バックエンド (Go) が \`{ id: number, isPublic: bool, createdAt: RFC3339 string }\` を返すのにフロント \`Note\` 型は \`{ noteId: string, isPinned: bool, createdAt: number }\` を期待しており、Repository でそのまま cast していたため \`noteId === undefined\` になっていたこと。

\`useNotes.confirmDelete\` の \`if (!deleteTargetId) return;\` で undefined が早期 return され、削除リクエストが飛ばないという挙動。

これは「フロント／バックエンド整合性」の問題の一例で、本 PR では NoteRepository だけ最小修正する（Repository 層で吸収するパターン）。広範囲の DOP 視点リファクタは別 PR で別途実施。

## 変更内容
- NoteRepository に ApiNote → Note のマッパー (\`toNote\` / \`toMillis\`) を追加
  - id (number) → noteId (string)
  - isPublic (bool) → isPinned (bool) にフォールバック
  - createdAt / updatedAt の RFC3339 string → epoch ms (number)
- updateNote で isPinned に加えて isPublic も互換で送信

## TDD 追加・更新テスト
- fetchNotes: id → noteId 正規化、配列以外のレスポンス時は空配列フォールバック
- createNote: 新仕様レスポンスから Note を生成
- updateNote: noteId を URL に埋め込み、isPublic 互換送信
- deleteNote: noteId を URL に埋め込み

## テスト

- [x] \`npx vitest run\` 2361 tests 全 green
- [x] \`npm run build\` 成功

## 関連

#1555-#1559 のフォローアップ。本番ノート削除復旧。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data normalization to ensure notes are properly formatted when retrieved from and sent to the server.

* **Refactor**
  * Enhanced backend response handling to maintain data consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->