### PR TITLE
feat(backend): profile アイコン用 S3 presigned URL endpoint を追加

### DIFF
--- a/backend/internal/domain/profile_image.go
+++ b/backend/internal/domain/profile_image.go
@@ -1,0 +1,11 @@
+package domain
+
+// ProfileImageUploadURL は profile アイコン用の S3 直接アップロード URL を表す。
+// フロントの ProfileRepository.getImagePresignedUrl が期待する形式
+// （uploadUrl: PUT 対象、imageUrl: アップロード後に表示する URL）に合わせる。
+type ProfileImageUploadURL struct {
+	UploadURL string `json:"uploadUrl"`
+	ImageURL  string `json:"imageUrl"`
+	Key       string `json:"key"`
+	ExpiresIn int    `json:"expiresIn"`
+}

--- a/backend/internal/handler/profile_image_handler.go
+++ b/backend/internal/handler/profile_image_handler.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// ProfileImageHandler は profile アイコン用 S3 PUT 署名付き URL を発行する。
+// フロント ProfileRepository.getImagePresignedUrl が叩く /profile/:userId/image/presigned-url を提供する。
+type ProfileImageHandler struct {
+	issue *usecase.IssueProfileImageUploadURLUseCase
+}
+
+func NewProfileImageHandler(i *usecase.IssueProfileImageUploadURLUseCase) *ProfileImageHandler {
+	return &ProfileImageHandler{issue: i}
+}
+
+type issueProfileImageReq struct {
+	FileName    string `json:"fileName"`
+	ContentType string `json:"contentType"`
+}
+
+var (
+	errProfileImageForbidden    = errors.New("forbidden")
+	errProfileImageUnauthorized = errors.New("unauthorized")
+)
+
+// resolveUserID は profile_handler と同じ規則で path :userId を解決する（"me" / 数字一致のみ通す）。
+func (h *ProfileImageHandler) resolveUserID(c *gin.Context) (uint64, error) {
+	cur := middleware.CurrentUserIDOrZero(c)
+	if cur == 0 {
+		return 0, errProfileImageUnauthorized
+	}
+	param := c.Param("userId")
+	if param == "" || param == "me" {
+		return cur, nil
+	}
+	uid, err := strconv.ParseUint(param, 10, 64)
+	if err != nil {
+		return cur, nil
+	}
+	if uid == 0 || uid != cur {
+		return 0, errProfileImageForbidden
+	}
+	return uid, nil
+}
+
+// IssueUploadURL は POST /profile/:userId/image/presigned-url。
+// クライアントは { fileName, contentType } を送り、 { uploadUrl, imageUrl, key, expiresIn } を受け取る。
+func (h *ProfileImageHandler) IssueUploadURL(c *gin.Context) {
+	uid, err := h.resolveUserID(c)
+	if err != nil {
+		switch err {
+		case errProfileImageUnauthorized:
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		case errProfileImageForbidden:
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		default:
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	var req issueProfileImageReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// body 無しで叩かれても 400 にせず、デフォルト値で処理を続ける。
+		req = issueProfileImageReq{}
+	}
+	got, err := h.issue.Execute(c.Request.Context(), uid, req.FileName, req.ContentType)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, got)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -75,6 +75,15 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	authed.PUT("/profile/:userId", profileHandler.Update)
 	authed.PUT("/profile/:userId/update", profileHandler.Update)
 
+	// Profile アイコン画像の S3 presigned-url。bucket / CDN は note image と同じインフラを共有する
+	// （別 prefix `profiles/` で分離）。AWS SDK 統合は別 issue。
+	profileImageHandler := NewProfileImageHandler(
+		usecase.NewIssueProfileImageUploadURLUseCase(
+			repository.NewStubProfileImagePresigner("frestyle-prod-note-images", "https://normanblog.com"),
+		),
+	)
+	authed.POST("/profile/:userId/image/presigned-url", profileImageHandler.IssueUploadURL)
+
 	// Phase 6: ユーザー統計
 	statsHandler := NewUserStatsHandler(
 		usecase.NewGetUserStatsUseCase(repository.NewUserStatsRepository(db)),

--- a/backend/internal/repository/profile_image_repository.go
+++ b/backend/internal/repository/profile_image_repository.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// ProfileImagePresigner は profile アイコン用 S3 PUT 署名付き URL を発行する。
+// AWS SDK 実装は別 PR。現状は Stub で形式だけ満たす。
+type ProfileImagePresigner interface {
+	Generate(ctx context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error)
+}
+
+type stubProfileImagePresigner struct {
+	bucket string
+	cdnURL string
+}
+
+// NewStubProfileImagePresigner は CDN URL (例: https://normanblog.com) と
+// S3 bucket name を受け取って stub presigner を返す。
+func NewStubProfileImagePresigner(bucket, cdnURL string) ProfileImagePresigner {
+	return &stubProfileImagePresigner{bucket: bucket, cdnURL: strings.TrimRight(cdnURL, "/")}
+}
+
+func (p *stubProfileImagePresigner) Generate(_ context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error) {
+	if userID == 0 {
+		return nil, fmt.Errorf("userID is required")
+	}
+	if contentType == "" {
+		contentType = "image/png"
+	}
+	ext := guessExt(fileName, contentType)
+	key := fmt.Sprintf("profiles/%d/%d%s", userID, time.Now().UnixNano(), ext)
+	return &domain.ProfileImageUploadURL{
+		UploadURL: fmt.Sprintf("https://%s.s3.amazonaws.com/%s?X-Amz-Stub=1", p.bucket, key),
+		ImageURL:  fmt.Sprintf("%s/%s", p.cdnURL, key),
+		Key:       key,
+		ExpiresIn: 600,
+	}, nil
+}
+
+// guessExt は fileName または contentType から「.png」「.jpg」などの拡張子を返す。
+// 純粋関数化することで usecase 経由で間接的にテストできる。
+func guessExt(fileName, contentType string) string {
+	if i := strings.LastIndex(fileName, "."); i != -1 && i < len(fileName)-1 {
+		return strings.ToLower(fileName[i:])
+	}
+	switch contentType {
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/png":
+		return ".png"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	default:
+		return ".bin"
+	}
+}

--- a/backend/internal/usecase/profile_image_usecase.go
+++ b/backend/internal/usecase/profile_image_usecase.go
@@ -1,0 +1,26 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+type IssueProfileImageUploadURLUseCase struct {
+	presigner repository.ProfileImagePresigner
+}
+
+func NewIssueProfileImageUploadURLUseCase(p repository.ProfileImagePresigner) *IssueProfileImageUploadURLUseCase {
+	return &IssueProfileImageUploadURLUseCase{presigner: p}
+}
+
+// Execute は current user の profile アイコン用 PUT 署名付き URL を発行する。
+// userID は handler 側で middleware 経由 (=current user) で渡す前提。
+func (u *IssueProfileImageUploadURLUseCase) Execute(ctx context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.presigner.Generate(ctx, userID, fileName, contentType)
+}

--- a/backend/internal/usecase/profile_image_usecase_test.go
+++ b/backend/internal/usecase/profile_image_usecase_test.go
@@ -1,0 +1,54 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubProfileImagePresigner struct {
+	called    bool
+	gotUserID uint64
+	gotFile   string
+	gotCType  string
+	err       error
+}
+
+func (s *stubProfileImagePresigner) Generate(_ context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error) {
+	s.called = true
+	s.gotUserID = userID
+	s.gotFile = fileName
+	s.gotCType = contentType
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &domain.ProfileImageUploadURL{
+		UploadURL: "https://stub.example/upload",
+		ImageURL:  "https://stub.example/image",
+		Key:       "profiles/x.png",
+		ExpiresIn: 600,
+	}, nil
+}
+
+func TestIssueProfileImageUploadURL_RequiresUserID(t *testing.T) {
+	uc := NewIssueProfileImageUploadURLUseCase(&stubProfileImagePresigner{})
+	if _, err := uc.Execute(context.Background(), 0, "a.png", "image/png"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIssueProfileImageUploadURL_PassesArgsToPresigner(t *testing.T) {
+	stub := &stubProfileImagePresigner{}
+	uc := NewIssueProfileImageUploadURLUseCase(stub)
+	got, err := uc.Execute(context.Background(), 7, "icon.jpg", "image/jpeg")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.UploadURL == "" || got.ImageURL == "" {
+		t.Errorf("URLs should be set: %+v", got)
+	}
+	if !stub.called || stub.gotUserID != 7 || stub.gotFile != "icon.jpg" || stub.gotCType != "image/jpeg" {
+		t.Errorf("presigner not called with expected args: %+v", stub)
+	}
+}


### PR DESCRIPTION
## 概要

本番 ProfilePage で \`POST /api/v2/profile/me/image/presigned-url\` が 404 になり、プロフィール画像アップロードが動作しない。最小スコープで stub presigner を実装し、フロント既存実装と path 整合させる。

AWS SDK 経由の実 S3 連携は別 issue。本 PR では bucket / key / URL 形式を確定させ、フロントが 404 を踏まないようにすることを目的とする。

## 変更内容

### 新規 domain
- \`ProfileImageUploadURL\` (uploadUrl, imageUrl, key, expiresIn)

### 新規 repository
- \`ProfileImagePresigner\` interface + \`stubProfileImagePresigner\`
- key 形式: \`profiles/{userId}/{epochNs}{ext}\` (拡張子は fileName または contentType から推定)

### 新規 usecase
- \`IssueProfileImageUploadURLUseCase\`

### 新規 handler
- \`ProfileImageHandler.IssueUploadURL\`
- resolveUserID で \"me\" / 数字一致のみ通す（IDOR 対策）

### router
- \`POST /profile/:userId/image/presigned-url\` を wire
- bucket は \`frestyle-prod-note-images\` を共有（prefix \`profiles/\` で分離）

### TDD 追加テスト
- \`IssueProfileImageUploadURL_RequiresUserID\`
- \`IssueProfileImageUploadURL_PassesArgsToPresigner\`

## テスト

- [x] \`go build ./... && go test ./...\` 全 green

## 関連

#1555-#1560 シリーズの最終 path 整合 PR。S3 直アップロードの本実装は別 issue。