### PR TITLE
refactor: Note 系を backend domain と整合 (DOP, closes #1562)

### DIFF
--- a/backend/internal/domain/note.go
+++ b/backend/internal/domain/note.go
@@ -2,13 +2,17 @@ package domain
 
 import "time"
 
-// Note は学習メモを表す。Spring Boot の entity.Note に相当。
+// Note は学習メモを表す。フロント NotesPage / SessionNote 機能のドメインモデル。
+//
+// IsPinned はユーザーがピン留めしたかどうか（ピン留めは並び順で先頭に固定する用途）。
+// IsPublic は他ユーザーに公開するかどうか。両者は独立した属性。
 type Note struct {
 	ID        uint64    `gorm:"primaryKey" json:"id"`
 	UserID    uint64    `gorm:"column:user_id;index" json:"userId"`
 	Title     string    `gorm:"column:title" json:"title"`
 	Content   string    `gorm:"column:content" json:"content"`
 	IsPublic  bool      `gorm:"column:is_public" json:"isPublic"`
+	IsPinned  bool      `gorm:"column:is_pinned;default:false" json:"isPinned"`
 	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
 	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }

--- a/backend/internal/handler/note_handler.go
+++ b/backend/internal/handler/note_handler.go
@@ -46,6 +46,7 @@ type noteCreateReq struct {
 	Title    string `json:"title" binding:"required"`
 	Content  string `json:"content"`
 	IsPublic bool   `json:"isPublic"`
+	IsPinned bool   `json:"isPinned"`
 }
 
 // Create は current user 名義で note を作る。userId は受け取らず固定する。
@@ -61,7 +62,8 @@ func (h *NoteHandler) Create(c *gin.Context) {
 		return
 	}
 	got, err := h.create.Execute(c.Request.Context(), usecase.CreateNoteInput{
-		UserID: uid, Title: req.Title, Content: req.Content, IsPublic: req.IsPublic,
+		UserID: uid, Title: req.Title, Content: req.Content,
+		IsPublic: req.IsPublic, IsPinned: req.IsPinned,
 	})
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -74,6 +76,7 @@ type noteUpdateReq struct {
 	Title    string `json:"title" binding:"required"`
 	Content  string `json:"content"`
 	IsPublic bool   `json:"isPublic"`
+	IsPinned bool   `json:"isPinned"`
 }
 
 // Update は current user 所有の note のみ更新可能。usecase 側で所有者検証する。
@@ -90,7 +93,8 @@ func (h *NoteHandler) Update(c *gin.Context) {
 		return
 	}
 	got, err := h.update.Execute(c.Request.Context(), usecase.UpdateNoteInput{
-		UserID: uid, ID: id, Title: req.Title, Content: req.Content, IsPublic: req.IsPublic,
+		UserID: uid, ID: id, Title: req.Title, Content: req.Content,
+		IsPublic: req.IsPublic, IsPinned: req.IsPinned,
 	})
 	if err != nil {
 		if errors.Is(err, usecase.ErrNoteForbidden) {

--- a/backend/internal/usecase/note_usecase.go
+++ b/backend/internal/usecase/note_usecase.go
@@ -34,6 +34,7 @@ type CreateNoteInput struct {
 	Title    string
 	Content  string
 	IsPublic bool
+	IsPinned bool
 }
 
 func (u *CreateNoteUseCase) Execute(ctx context.Context, in CreateNoteInput) (*domain.Note, error) {
@@ -43,7 +44,13 @@ func (u *CreateNoteUseCase) Execute(ctx context.Context, in CreateNoteInput) (*d
 	if in.Title == "" {
 		return nil, errors.New("title is required")
 	}
-	n := &domain.Note{UserID: in.UserID, Title: in.Title, Content: in.Content, IsPublic: in.IsPublic}
+	n := &domain.Note{
+		UserID:   in.UserID,
+		Title:    in.Title,
+		Content:  in.Content,
+		IsPublic: in.IsPublic,
+		IsPinned: in.IsPinned,
+	}
 	if err := u.repo.Create(ctx, n); err != nil {
 		return nil, err
 	}
@@ -62,6 +69,7 @@ type UpdateNoteInput struct {
 	Title    string
 	Content  string
 	IsPublic bool
+	IsPinned bool
 }
 
 // Execute は所有者検証込みで note を更新する。
@@ -83,6 +91,7 @@ func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*d
 	existing.Title = in.Title
 	existing.Content = in.Content
 	existing.IsPublic = in.IsPublic
+	existing.IsPinned = in.IsPinned
 	if err := u.repo.Update(ctx, existing); err != nil {
 		return nil, err
 	}

--- a/frontend/src/components/BlockEditor.tsx
+++ b/frontend/src/components/BlockEditor.tsx
@@ -20,7 +20,7 @@ export interface BlockEditorHandle {
 interface BlockEditorProps {
   content: string;
   onChange: (jsonString: string) => void;
-  noteId: string | null;
+  noteId: number | null;
   onBackspaceAtStart?: () => void;
 }
 

--- a/frontend/src/components/NoteEditor.tsx
+++ b/frontend/src/components/NoteEditor.tsx
@@ -15,7 +15,7 @@ import LineCount from './LineCount';
 interface NoteEditorProps {
   title: string;
   content: string;
-  noteId: string | null;
+  noteId: number | null;
   saveStatus: SaveStatus;
   onTitleChange: (title: string) => void;
   onContentChange: (content: string) => void;

--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -8,15 +8,16 @@ import { getNoteStats } from '../utils/noteStats';
 import ReadingTime from './ReadingTime';
 
 interface NoteListItemProps {
-  noteId: string;
+  noteId: number;
   title: string;
   content: string;
-  updatedAt: number;
+  // backend は RFC3339 string を返す（formatMonthDay は string / number / Date を受け付ける）。
+  updatedAt: string;
   isPinned: boolean;
   isActive: boolean;
-  onSelect: (noteId: string) => void;
-  onDelete: (noteId: string) => void;
-  onTogglePin: (noteId: string) => void;
+  onSelect: (noteId: number) => void;
+  onDelete: (noteId: number) => void;
+  onTogglePin: (noteId: number) => void;
 }
 
 export default memo(function NoteListItem({

--- a/frontend/src/hooks/__tests__/useNotes.test.ts
+++ b/frontend/src/hooks/__tests__/useNotes.test.ts
@@ -1,13 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useNotes } from '../useNotes';
 import NoteRepository from '../../repositories/NoteRepository';
+import type { Note } from '../../types';
 
 vi.mock('../../repositories/NoteRepository');
 
-const mockNotes = [
-  { noteId: 'note-1', userId: 1, title: 'ノート1', content: '内容1', isPinned: true, createdAt: 1000, updatedAt: 3000 },
-  { noteId: 'note-2', userId: 1, title: 'ノート2', content: '内容2', isPinned: false, createdAt: 2000, updatedAt: 2000 },
+// backend `domain.Note` と 1:1。createdAt / updatedAt は RFC3339 string。
+const mockNotes: Note[] = [
+  {
+    id: 1,
+    userId: 1,
+    title: 'ノート1',
+    content: '内容1',
+    isPublic: false,
+    isPinned: true,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-03T00:00:00Z',
+  },
+  {
+    id: 2,
+    userId: 1,
+    title: 'ノート2',
+    content: '内容2',
+    isPublic: false,
+    isPinned: false,
+    createdAt: '2026-01-02T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+  },
 ];
 
 describe('useNotes', () => {
@@ -33,7 +53,16 @@ describe('useNotes', () => {
   });
 
   it('createNoteで新しいノートを作成しローカル追加する', async () => {
-    const newNote = { noteId: 'note-3', userId: 1, title: '新規', content: '', isPinned: false, createdAt: 4000, updatedAt: 4000 };
+    const newNote: Note = {
+      id: 3,
+      userId: 1,
+      title: '新規',
+      content: '',
+      isPublic: false,
+      isPinned: false,
+      createdAt: '2026-01-04T00:00:00Z',
+      updatedAt: '2026-01-04T00:00:00Z',
+    };
     vi.mocked(NoteRepository.createNote).mockResolvedValue(newNote);
 
     const { result } = renderHook(() => useNotes());
@@ -44,7 +73,7 @@ describe('useNotes', () => {
 
     expect(NoteRepository.createNote).toHaveBeenCalledWith('新規');
     expect(result.current.notes).toHaveLength(1);
-    expect(result.current.notes[0].noteId).toBe('note-3');
+    expect(result.current.notes[0].id).toBe(3);
   });
 
   it('deleteNoteでノートを削除しローカル除外する', async () => {
@@ -58,12 +87,12 @@ describe('useNotes', () => {
     expect(result.current.notes).toHaveLength(2);
 
     await act(async () => {
-      await result.current.deleteNote('note-1');
+      await result.current.deleteNote(1);
     });
 
-    expect(NoteRepository.deleteNote).toHaveBeenCalledWith('note-1');
+    expect(NoteRepository.deleteNote).toHaveBeenCalledWith(1);
     expect(result.current.notes).toHaveLength(1);
-    expect(result.current.notes[0].noteId).toBe('note-2');
+    expect(result.current.notes[0].id).toBe(2);
   });
 
   it('selectedNoteIdの初期値がnullである', () => {
@@ -71,17 +100,15 @@ describe('useNotes', () => {
     expect(result.current.selectedNoteId).toBeNull();
   });
 
-  it('selectNoteでノートを選択できる', async () => {
+  it('selectNoteでノートを選択できる', () => {
     const { result } = renderHook(() => useNotes());
 
-    await act(async () => {
-      result.current.selectNote('note-1');
+    act(() => {
+      result.current.selectNote(1);
     });
 
-    expect(result.current.selectedNoteId).toBe('note-1');
+    expect(result.current.selectedNoteId).toBe(1);
   });
-
-  // エッジケーステスト
 
   it('fetchNotesエラー時にnotesが空のまま', async () => {
     vi.mocked(NoteRepository.fetchNotes).mockRejectedValue(new Error('ネットワークエラー'));
@@ -110,7 +137,16 @@ describe('useNotes', () => {
   });
 
   it('createNote成功後にselectedNoteIdが更新される', async () => {
-    const newNote = { noteId: 'new-id', userId: 1, title: 'テスト', content: '', isPinned: false, createdAt: 5000, updatedAt: 5000 };
+    const newNote: Note = {
+      id: 99,
+      userId: 1,
+      title: 'テスト',
+      content: '',
+      isPublic: false,
+      isPinned: false,
+      createdAt: '2026-01-05T00:00:00Z',
+      updatedAt: '2026-01-05T00:00:00Z',
+    };
     vi.mocked(NoteRepository.createNote).mockResolvedValue(newNote);
 
     const { result } = renderHook(() => useNotes());
@@ -119,12 +155,11 @@ describe('useNotes', () => {
       await result.current.createNote('テスト');
     });
 
-    expect(result.current.selectedNoteId).toBe('new-id');
+    expect(result.current.selectedNoteId).toBe(99);
   });
 
   it('updateNoteでnotes配列がローカル更新される', async () => {
     vi.mocked(NoteRepository.updateNote).mockResolvedValue(undefined);
-    vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(mockNotes);
 
     const { result } = renderHook(() => useNotes());
 
@@ -133,11 +168,11 @@ describe('useNotes', () => {
     });
 
     await act(async () => {
-      await result.current.updateNote('note-1', { title: '更新済み', content: '新内容', isPinned: false });
+      await result.current.updateNote(1, { title: '更新済み', content: '新内容', isPinned: false });
     });
 
-    expect(result.current.notes.find(n => n.noteId === 'note-1')?.title).toBe('更新済み');
-    expect(result.current.notes.find(n => n.noteId === 'note-1')?.content).toBe('新内容');
+    expect(result.current.notes.find((n) => n.id === 1)?.title).toBe('更新済み');
+    expect(result.current.notes.find((n) => n.id === 1)?.content).toBe('新内容');
   });
 
   it('選択中のノートを削除するとselectedNoteIdがnullになる', async () => {
@@ -149,27 +184,27 @@ describe('useNotes', () => {
       await result.current.fetchNotes();
     });
 
-    await act(async () => {
-      result.current.selectNote('note-1');
+    act(() => {
+      result.current.selectNote(1);
     });
 
     await act(async () => {
-      await result.current.deleteNote('note-1');
+      await result.current.deleteNote(1);
     });
 
     expect(result.current.selectedNoteId).toBeNull();
     expect(result.current.notes).toHaveLength(1);
   });
 
-  it('selectNoteにnullを渡すと選択解除される', async () => {
+  it('selectNoteにnullを渡すと選択解除される', () => {
     const { result } = renderHook(() => useNotes());
 
-    await act(async () => {
-      result.current.selectNote('note-1');
+    act(() => {
+      result.current.selectNote(1);
     });
-    expect(result.current.selectedNoteId).toBe('note-1');
+    expect(result.current.selectedNoteId).toBe(1);
 
-    await act(async () => {
+    act(() => {
       result.current.selectNote(null);
     });
     expect(result.current.selectedNoteId).toBeNull();
@@ -199,8 +234,6 @@ describe('useNotes', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  // 検索・ピン留め機能テスト
-
   it('searchQueryの初期値が空文字である', () => {
     const { result } = renderHook(() => useNotes());
     expect(result.current.searchQuery).toBe('');
@@ -223,8 +256,7 @@ describe('useNotes', () => {
       await result.current.fetchNotes();
     });
 
-    // mockNotes: note-1(pinned, updatedAt:3000), note-2(unpinned, updatedAt:2000)
-    expect(result.current.filteredNotes[0].noteId).toBe('note-1');
+    expect(result.current.filteredNotes[0].id).toBe(1);
     expect(result.current.filteredNotes[0].isPinned).toBe(true);
   });
 
@@ -255,7 +287,7 @@ describe('useNotes', () => {
     });
 
     expect(result.current.filteredNotes).toHaveLength(1);
-    expect(result.current.filteredNotes[0].noteId).toBe('note-2');
+    expect(result.current.filteredNotes[0].id).toBe(2);
   });
 
   it('togglePinでノートのピン留め状態をトグルする', async () => {
@@ -267,14 +299,13 @@ describe('useNotes', () => {
       await result.current.fetchNotes();
     });
 
-    // note-2はisPinned: false → trueにトグル
     await act(async () => {
-      await result.current.togglePin('note-2');
+      await result.current.togglePin(2);
     });
 
-    const note2 = result.current.notes.find(n => n.noteId === 'note-2');
+    const note2 = result.current.notes.find((n) => n.id === 2);
     expect(note2?.isPinned).toBe(true);
-    expect(NoteRepository.updateNote).toHaveBeenCalledWith('note-2', {
+    expect(NoteRepository.updateNote).toHaveBeenCalledWith(2, {
       title: 'ノート2',
       content: '内容2',
       isPinned: true,
@@ -282,10 +313,10 @@ describe('useNotes', () => {
   });
 
   it('filteredNotesはピン留め内でも更新日時降順でソートされる', async () => {
-    const threeNotes = [
-      { noteId: 'n1', userId: 1, title: 'A', content: '', isPinned: true, createdAt: 1000, updatedAt: 1000 },
-      { noteId: 'n2', userId: 1, title: 'B', content: '', isPinned: true, createdAt: 2000, updatedAt: 3000 },
-      { noteId: 'n3', userId: 1, title: 'C', content: '', isPinned: false, createdAt: 3000, updatedAt: 5000 },
+    const threeNotes: Note[] = [
+      { id: 1, userId: 1, title: 'A', content: '', isPublic: false, isPinned: true, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 2, userId: 1, title: 'B', content: '', isPublic: false, isPinned: true, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
+      { id: 3, userId: 1, title: 'C', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-05T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(threeNotes);
 
@@ -295,15 +326,14 @@ describe('useNotes', () => {
       await result.current.fetchNotes();
     });
 
-    // ピン留め優先: n2(pin,3000), n1(pin,1000), n3(unpin,5000)
-    expect(result.current.filteredNotes[0].noteId).toBe('n2');
-    expect(result.current.filteredNotes[1].noteId).toBe('n1');
-    expect(result.current.filteredNotes[2].noteId).toBe('n3');
+    expect(result.current.filteredNotes[0].id).toBe(2);
+    expect(result.current.filteredNotes[1].id).toBe(1);
+    expect(result.current.filteredNotes[2].id).toBe(3);
   });
 
   it('検索クエリが大文字小文字を区別しない', async () => {
-    const mixedNotes = [
-      { noteId: 'n1', userId: 1, title: 'Hello World', content: '', isPinned: false, createdAt: 1000, updatedAt: 2000 },
+    const mixedNotes: Note[] = [
+      { id: 1, userId: 1, title: 'Hello World', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(mixedNotes);
 
@@ -323,20 +353,20 @@ describe('useNotes', () => {
     const { result } = renderHook(() => useNotes());
     await act(async () => { await result.current.fetchNotes(); });
 
-    const originalPinState = result.current.notes.find(n => n.noteId === 'note-2')?.isPinned;
+    const originalPinState = result.current.notes.find((n) => n.id === 2)?.isPinned;
 
-    await act(async () => { await result.current.togglePin('note-2'); });
+    await act(async () => { await result.current.togglePin(2); });
 
-    expect(result.current.notes.find(n => n.noteId === 'note-2')?.isPinned).toBe(originalPinState);
+    expect(result.current.notes.find((n) => n.id === 2)?.isPinned).toBe(originalPinState);
   });
 
-  it('togglePinで存在しないnoteIdの場合何も起こらない', async () => {
+  it('togglePinで存在しないIDの場合何も起こらない', async () => {
     vi.mocked(NoteRepository.updateNote).mockResolvedValue(undefined);
 
     const { result } = renderHook(() => useNotes());
     await act(async () => { await result.current.fetchNotes(); });
 
-    await act(async () => { await result.current.togglePin('nonexistent'); });
+    await act(async () => { await result.current.togglePin(9999); });
 
     expect(NoteRepository.updateNote).not.toHaveBeenCalled();
     expect(result.current.notes).toHaveLength(2);
@@ -361,14 +391,12 @@ describe('useNotes', () => {
     expect(result.current.filteredNotes).toHaveLength(0);
   });
 
-  // selectedNote テスト
-
   it('selectedNoteが選択中のノートオブジェクトを返す', async () => {
     const { result } = renderHook(() => useNotes());
     await act(async () => { await result.current.fetchNotes(); });
 
-    act(() => { result.current.selectNote('note-1'); });
-    expect(result.current.selectedNote?.noteId).toBe('note-1');
+    act(() => { result.current.selectNote(1); });
+    expect(result.current.selectedNote?.id).toBe(1);
     expect(result.current.selectedNote?.title).toBe('ノート1');
   });
 
@@ -379,8 +407,6 @@ describe('useNotes', () => {
     expect(result.current.selectedNote).toBeNull();
   });
 
-  // 削除確認テスト
-
   it('deleteTargetIdの初期値がnullである', () => {
     const { result } = renderHook(() => useNotes());
     expect(result.current.deleteTargetId).toBeNull();
@@ -389,8 +415,8 @@ describe('useNotes', () => {
   it('requestDeleteでdeleteTargetIdが設定される', () => {
     const { result } = renderHook(() => useNotes());
 
-    act(() => { result.current.requestDelete('note-1'); });
-    expect(result.current.deleteTargetId).toBe('note-1');
+    act(() => { result.current.requestDelete(1); });
+    expect(result.current.deleteTargetId).toBe(1);
   });
 
   it('confirmDeleteでノートが削除されdeleteTargetIdがリセットされる', async () => {
@@ -399,31 +425,31 @@ describe('useNotes', () => {
     const { result } = renderHook(() => useNotes());
     await act(async () => { await result.current.fetchNotes(); });
 
-    act(() => { result.current.requestDelete('note-1'); });
-    expect(result.current.deleteTargetId).toBe('note-1');
+    act(() => { result.current.requestDelete(1); });
+    expect(result.current.deleteTargetId).toBe(1);
 
     await act(async () => { await result.current.confirmDelete(); });
 
     expect(result.current.deleteTargetId).toBeNull();
-    expect(NoteRepository.deleteNote).toHaveBeenCalledWith('note-1');
+    expect(NoteRepository.deleteNote).toHaveBeenCalledWith(1);
     expect(result.current.notes).toHaveLength(1);
   });
 
   it('cancelDeleteでdeleteTargetIdがリセットされる', () => {
     const { result } = renderHook(() => useNotes());
 
-    act(() => { result.current.requestDelete('note-1'); });
-    expect(result.current.deleteTargetId).toBe('note-1');
+    act(() => { result.current.requestDelete(1); });
+    expect(result.current.deleteTargetId).toBe(1);
 
     act(() => { result.current.cancelDelete(); });
     expect(result.current.deleteTargetId).toBeNull();
   });
 
   it('confirmDeleteで選択中ノート削除後に次のノートが自動選択される', async () => {
-    const threeNotes = [
-      { noteId: 'n1', userId: 1, title: 'A', content: '', isPinned: false, createdAt: 1000, updatedAt: 3000 },
-      { noteId: 'n2', userId: 1, title: 'B', content: '', isPinned: false, createdAt: 2000, updatedAt: 2000 },
-      { noteId: 'n3', userId: 1, title: 'C', content: '', isPinned: false, createdAt: 3000, updatedAt: 1000 },
+    const threeNotes: Note[] = [
+      { id: 11, userId: 1, title: 'A', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
+      { id: 12, userId: 1, title: 'B', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+      { id: 13, userId: 1, title: 'C', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(threeNotes);
     vi.mocked(NoteRepository.deleteNote).mockResolvedValue(undefined);
@@ -431,20 +457,19 @@ describe('useNotes', () => {
     const { result } = renderHook(() => useNotes());
     await act(async () => { await result.current.fetchNotes(); });
 
-    // n1を選択 → 削除 → n2（次のノート）が自動選択
-    act(() => { result.current.selectNote('n1'); });
-    act(() => { result.current.requestDelete('n1'); });
+    act(() => { result.current.selectNote(11); });
+    act(() => { result.current.requestDelete(11); });
 
     await act(async () => { await result.current.confirmDelete(); });
 
-    expect(result.current.selectedNoteId).toBe('n2');
+    expect(result.current.selectedNoteId).toBe(12);
   });
 
   it('confirmDeleteで最後のノート削除後に前のノートが自動選択される', async () => {
-    const threeNotes = [
-      { noteId: 'n1', userId: 1, title: 'A', content: '', isPinned: false, createdAt: 1000, updatedAt: 3000 },
-      { noteId: 'n2', userId: 1, title: 'B', content: '', isPinned: false, createdAt: 2000, updatedAt: 2000 },
-      { noteId: 'n3', userId: 1, title: 'C', content: '', isPinned: false, createdAt: 3000, updatedAt: 1000 },
+    const threeNotes: Note[] = [
+      { id: 11, userId: 1, title: 'A', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
+      { id: 12, userId: 1, title: 'B', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+      { id: 13, userId: 1, title: 'C', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(threeNotes);
     vi.mocked(NoteRepository.deleteNote).mockResolvedValue(undefined);
@@ -452,14 +477,12 @@ describe('useNotes', () => {
     const { result } = renderHook(() => useNotes());
     await act(async () => { await result.current.fetchNotes(); });
 
-    // filteredNotes: n1(updatedAt:3000), n2(2000), n3(1000)
-    // n3を選択 → 削除 → n2（前のノート）が自動選択
-    act(() => { result.current.selectNote('n3'); });
-    act(() => { result.current.requestDelete('n3'); });
+    act(() => { result.current.selectNote(13); });
+    act(() => { result.current.requestDelete(13); });
 
     await act(async () => { await result.current.confirmDelete(); });
 
-    expect(result.current.selectedNoteId).toBe('n2');
+    expect(result.current.selectedNoteId).toBe(12);
   });
 
   it('deleteTargetIdがnullのときconfirmDeleteは何もしない', async () => {
@@ -468,8 +491,6 @@ describe('useNotes', () => {
     await act(async () => { await result.current.confirmDelete(); });
     expect(NoteRepository.deleteNote).not.toHaveBeenCalled();
   });
-
-  // ソートオプションテスト
 
   it('noteSortの初期値がdefaultである', () => {
     const { result } = renderHook(() => useNotes());
@@ -484,10 +505,10 @@ describe('useNotes', () => {
   });
 
   it('noteSortがupdated-ascの場合、更新日時昇順でソートされる', async () => {
-    const notes = [
-      { noteId: 'n1', userId: 1, title: 'A', content: '', isPinned: false, createdAt: 1000, updatedAt: 3000 },
-      { noteId: 'n2', userId: 1, title: 'B', content: '', isPinned: false, createdAt: 2000, updatedAt: 1000 },
-      { noteId: 'n3', userId: 1, title: 'C', content: '', isPinned: false, createdAt: 3000, updatedAt: 2000 },
+    const notes: Note[] = [
+      { id: 1, userId: 1, title: 'A', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
+      { id: 2, userId: 1, title: 'B', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 3, userId: 1, title: 'C', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(notes);
 
@@ -496,16 +517,16 @@ describe('useNotes', () => {
 
     act(() => { result.current.setNoteSort('updated-asc'); });
 
-    expect(result.current.filteredNotes[0].noteId).toBe('n2');
-    expect(result.current.filteredNotes[1].noteId).toBe('n3');
-    expect(result.current.filteredNotes[2].noteId).toBe('n1');
+    expect(result.current.filteredNotes[0].id).toBe(2);
+    expect(result.current.filteredNotes[1].id).toBe(3);
+    expect(result.current.filteredNotes[2].id).toBe(1);
   });
 
   it('noteSortがtitleの場合、タイトル順でソートされる', async () => {
-    const notes = [
-      { noteId: 'n1', userId: 1, title: 'バナナ', content: '', isPinned: false, createdAt: 1000, updatedAt: 1000 },
-      { noteId: 'n2', userId: 1, title: 'アップル', content: '', isPinned: false, createdAt: 2000, updatedAt: 2000 },
-      { noteId: 'n3', userId: 1, title: 'チェリー', content: '', isPinned: false, createdAt: 3000, updatedAt: 3000 },
+    const notes: Note[] = [
+      { id: 1, userId: 1, title: 'バナナ', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 2, userId: 1, title: 'アップル', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+      { id: 3, userId: 1, title: 'チェリー', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(notes);
 
@@ -520,10 +541,10 @@ describe('useNotes', () => {
   });
 
   it('noteSortがcreated-descの場合、作成日時降順でソートされる', async () => {
-    const notes = [
-      { noteId: 'n1', userId: 1, title: 'A', content: '', isPinned: false, createdAt: 1000, updatedAt: 3000 },
-      { noteId: 'n2', userId: 1, title: 'B', content: '', isPinned: false, createdAt: 3000, updatedAt: 1000 },
-      { noteId: 'n3', userId: 1, title: 'C', content: '', isPinned: false, createdAt: 2000, updatedAt: 2000 },
+    const notes: Note[] = [
+      { id: 1, userId: 1, title: 'A', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
+      { id: 2, userId: 1, title: 'B', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
+      { id: 3, userId: 1, title: 'C', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(notes);
 
@@ -532,17 +553,17 @@ describe('useNotes', () => {
 
     act(() => { result.current.setNoteSort('created-desc'); });
 
-    expect(result.current.filteredNotes[0].noteId).toBe('n2');
-    expect(result.current.filteredNotes[1].noteId).toBe('n3');
-    expect(result.current.filteredNotes[2].noteId).toBe('n1');
+    expect(result.current.filteredNotes[0].id).toBe(2);
+    expect(result.current.filteredNotes[1].id).toBe(3);
+    expect(result.current.filteredNotes[2].id).toBe(1);
   });
 
   it('noteSortを変更してもピン留めされたノートが常に先頭に来る', async () => {
-    const notes = [
-      { noteId: 'p1', userId: 1, title: 'バナナ', content: '', isPinned: true, createdAt: 1000, updatedAt: 4000 },
-      { noteId: 'u1', userId: 1, title: 'アップル', content: '', isPinned: false, createdAt: 2000, updatedAt: 3000 },
-      { noteId: 'p2', userId: 1, title: 'チェリー', content: '', isPinned: true, createdAt: 3000, updatedAt: 2000 },
-      { noteId: 'u2', userId: 1, title: 'オレンジ', content: '', isPinned: false, createdAt: 4000, updatedAt: 1000 },
+    const notes: Note[] = [
+      { id: 1, userId: 1, title: 'バナナ', content: '', isPublic: false, isPinned: true, createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-01-04T00:00:00Z' },
+      { id: 2, userId: 1, title: 'アップル', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-02T00:00:00Z', updatedAt: '2026-01-03T00:00:00Z' },
+      { id: 3, userId: 1, title: 'チェリー', content: '', isPublic: false, isPinned: true, createdAt: '2026-01-03T00:00:00Z', updatedAt: '2026-01-02T00:00:00Z' },
+      { id: 4, userId: 1, title: 'オレンジ', content: '', isPublic: false, isPinned: false, createdAt: '2026-01-04T00:00:00Z', updatedAt: '2026-01-01T00:00:00Z' },
     ];
     vi.mocked(NoteRepository.fetchNotes).mockResolvedValue(notes);
 
@@ -590,7 +611,7 @@ describe('useNotes', () => {
     });
 
     await act(async () => {
-      await result.current.updateNote('note-1', { title: '更新', content: '内容', isPinned: false });
+      await result.current.updateNote(1, { title: '更新', content: '内容', isPinned: false });
     });
 
     expect(result.current.error).toBe('ノートの更新に失敗しました');
@@ -606,7 +627,7 @@ describe('useNotes', () => {
     });
 
     await act(async () => {
-      await result.current.deleteNote('note-1');
+      await result.current.deleteNote(1);
     });
 
     expect(result.current.error).toBe('ノートの削除に失敗しました');

--- a/frontend/src/hooks/useImageUpload.ts
+++ b/frontend/src/hooks/useImageUpload.ts
@@ -4,12 +4,12 @@ import NoteImageRepository from '../repositories/NoteImageRepository';
 
 const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/svg+xml'];
 
-export function useImageUpload(noteId: string | null, editor: Editor | null) {
+export function useImageUpload(noteId: number | null, editor: Editor | null) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   const uploadAndInsert = useCallback(async (file: File) => {
-    if (!noteId || !editor) return;
+    if (noteId == null || !editor) return;
     if (!ALLOWED_TYPES.includes(file.type)) return;
     setUploadError(null);
 

--- a/frontend/src/hooks/useNoteEditor.ts
+++ b/frontend/src/hooks/useNoteEditor.ts
@@ -4,9 +4,9 @@ import type { Note } from '../types';
 export type SaveStatus = 'idle' | 'unsaved' | 'saving' | 'saved';
 
 export function useNoteEditor(
-  selectedNoteId: string | null,
+  selectedNoteId: number | null,
   selectedNote: Note | null,
-  updateNote: (noteId: string, data: { title: string; content: string; isPinned: boolean }) => Promise<void>
+  updateNote: (noteId: number, data: { title: string; content: string; isPinned: boolean }) => Promise<void>
 ) {
   const [editTitle, setEditTitle] = useState('');
   const [editContent, setEditContent] = useState('');
@@ -35,7 +35,7 @@ export function useNoteEditor(
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       setSaveStatus('unsaved');
       saveTimerRef.current = setTimeout(async () => {
-        if (selectedNoteId) {
+        if (selectedNoteId != null) {
           setSaveStatus('saving');
           try {
             await updateNote(selectedNoteId, {
@@ -70,7 +70,7 @@ export function useNoteEditor(
   );
 
   const forceSave = useCallback(async () => {
-    if (!selectedNoteId) return;
+    if (selectedNoteId == null) return;
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setSaveStatus('saving');
     try {

--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -3,13 +3,19 @@ import type { Note } from '../types';
 import type { NoteSortOption } from '../constants/sortOptions';
 import NoteRepository from '../repositories/NoteRepository';
 
+/**
+ * useNotes — Note の一覧取得・選択・並び替え・CRUD を担う hook。
+ *
+ * Note 型は backend `domain.Note` と 1:1 なので、id は number、
+ * createdAt / updatedAt は RFC3339 string として扱う。
+ */
 export function useNotes() {
   const [notes, setNotes] = useState<Note[]>([]);
-  const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
+  const [selectedNoteId, setSelectedNoteId] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
   const [noteSort, setNoteSort] = useState<NoteSortOption>('default');
   const notesRef = useRef<Note[]>(notes);
   notesRef.current = notes;
@@ -31,36 +37,36 @@ export function useNotes() {
     try {
       const note = await NoteRepository.createNote(title);
       setNotes((prev) => [note, ...prev]);
-      setSelectedNoteId(note.noteId);
+      setSelectedNoteId(note.id);
       return note;
     } catch {
       return null;
     }
   }, []);
 
-  const updateNote = useCallback(async (noteId: string, data: { title: string; content: string; isPinned: boolean }) => {
+  const updateNote = useCallback(async (noteId: number, data: { title: string; content: string; isPinned: boolean }) => {
     try {
       await NoteRepository.updateNote(noteId, data);
       setNotes((prev) =>
-        prev.map((n) => (n.noteId === noteId ? { ...n, ...data, updatedAt: Date.now() } : n))
+        prev.map((n) => (n.id === noteId ? { ...n, ...data, updatedAt: new Date().toISOString() } : n))
       );
     } catch {
       setError('ノートの更新に失敗しました');
     }
   }, []);
 
-  const deleteNote = useCallback(async (noteId: string) => {
+  const deleteNote = useCallback(async (noteId: number) => {
     try {
       await NoteRepository.deleteNote(noteId);
-      setNotes((prev) => prev.filter((n) => n.noteId !== noteId));
+      setNotes((prev) => prev.filter((n) => n.id !== noteId));
       setSelectedNoteId((prev) => (prev === noteId ? null : prev));
     } catch {
       setError('ノートの削除に失敗しました');
     }
   }, []);
 
-  const togglePin = useCallback(async (noteId: string) => {
-    const note = notesRef.current.find((n) => n.noteId === noteId);
+  const togglePin = useCallback(async (noteId: number) => {
+    const note = notesRef.current.find((n) => n.id === noteId);
     if (!note) return;
     const newPinned = !note.isPinned;
     try {
@@ -70,19 +76,19 @@ export function useNotes() {
         isPinned: newPinned,
       });
       setNotes((prev) =>
-        prev.map((n) => (n.noteId === noteId ? { ...n, isPinned: newPinned } : n))
+        prev.map((n) => (n.id === noteId ? { ...n, isPinned: newPinned } : n))
       );
     } catch {
       setError('ピン留めの変更に失敗しました');
     }
   }, []);
 
-  const selectNote = useCallback((noteId: string | null) => {
+  const selectNote = useCallback((noteId: number | null) => {
     setSelectedNoteId(noteId);
   }, []);
 
   const selectedNote = useMemo(() => {
-    return notes.find((n) => n.noteId === selectedNoteId) || null;
+    return notes.find((n) => n.id === selectedNoteId) || null;
   }, [notes, selectedNoteId]);
 
   const filteredNotes = useMemo(() => {
@@ -90,24 +96,26 @@ export function useNotes() {
     const filtered = query
       ? notes.filter((n) => n.title.toLowerCase().includes(query) || n.content.toLowerCase().includes(query))
       : notes;
+    // 並び替え用に RFC3339 string を ms に解釈する。
+    const ms = (s: string) => Date.parse(s) || 0;
     return [...filtered].sort((a, b) => {
       if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
-      if (noteSort === 'updated-asc') return a.updatedAt - b.updatedAt;
+      if (noteSort === 'updated-asc') return ms(a.updatedAt) - ms(b.updatedAt);
       if (noteSort === 'title') return a.title.localeCompare(b.title, 'ja');
-      if (noteSort === 'created-desc') return b.createdAt - a.createdAt;
-      return b.updatedAt - a.updatedAt;
+      if (noteSort === 'created-desc') return ms(b.createdAt) - ms(a.createdAt);
+      return ms(b.updatedAt) - ms(a.updatedAt);
     });
   }, [notes, searchQuery, noteSort]);
 
-  const requestDelete = useCallback((noteId: string) => {
+  const requestDelete = useCallback((noteId: number) => {
     setDeleteTargetId(noteId);
   }, []);
 
   const confirmDelete = useCallback(async () => {
-    if (!deleteTargetId) return;
+    if (deleteTargetId == null) return;
 
-    // 削除前に次の選択候補を決定（filteredNotesの順序で次→前）
-    const idx = filteredNotes.findIndex((n) => n.noteId === deleteTargetId);
+    // 削除前に次の選択候補を決定（filteredNotes の順序で次→前）
+    const idx = filteredNotes.findIndex((n) => n.id === deleteTargetId);
     const nextNote = idx >= 0
       ? filteredNotes[idx + 1] || filteredNotes[idx - 1] || null
       : null;
@@ -115,7 +123,7 @@ export function useNotes() {
     await deleteNote(deleteTargetId);
 
     if (selectedNoteId === deleteTargetId && nextNote) {
-      setSelectedNoteId(nextNote.noteId);
+      setSelectedNoteId(nextNote.id);
     }
 
     setDeleteTargetId(null);

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -65,7 +65,7 @@ export default function NotesPage() {
     onForceSave: forceSave,
   });
 
-  const handleSelectNote = (noteId: string) => {
+  const handleSelectNote = (noteId: number) => {
     selectNote(noteId);
     closeMobilePanel();
   };
@@ -120,13 +120,13 @@ export default function NotesPage() {
           ) : (
             filteredNotes.map((note) => (
               <NoteListItem
-                key={note.noteId}
-                noteId={note.noteId}
+                key={note.id}
+                noteId={note.id}
                 title={note.title}
                 content={note.content}
                 updatedAt={note.updatedAt}
                 isPinned={note.isPinned}
-                isActive={selectedNoteId === note.noteId}
+                isActive={selectedNoteId === note.id}
                 onSelect={handleSelectNote}
                 onDelete={requestDelete}
                 onTogglePin={togglePin}

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import NotesPage from '../NotesPage';
 import { useNotes } from '../../hooks/useNotes';
+import type { Note } from '../../types';
 
 vi.mock('../../hooks/useNotes');
 vi.mock('../../hooks/useBlockEditor', () => ({
@@ -12,12 +13,26 @@ vi.mock('../../hooks/useToast', () => ({
   useToast: () => ({ showToast: mockShowToast, toasts: [], removeToast: vi.fn() }),
 }));
 
+function makeNote(partial: Partial<Note> & { id: number }): Note {
+  return {
+    id: partial.id,
+    userId: partial.userId ?? 1,
+    title: partial.title ?? `ノート${partial.id}`,
+    content: partial.content ?? '',
+    isPublic: partial.isPublic ?? false,
+    isPinned: partial.isPinned ?? false,
+    createdAt: partial.createdAt ?? '2026-01-01T00:00:00Z',
+    updatedAt: partial.updatedAt ?? '2026-01-02T00:00:00Z',
+  };
+}
+
 const mockUseNotes = {
-  notes: [] as any[],
-  filteredNotes: [] as any[],
-  selectedNoteId: null as string | null,
-  selectedNote: null as any,
+  notes: [] as Note[],
+  filteredNotes: [] as Note[],
+  selectedNoteId: null as number | null,
+  selectedNote: null as Note | null,
   loading: false,
+  error: null as string | null,
   searchQuery: '',
   setSearchQuery: vi.fn(),
   fetchNotes: vi.fn(),
@@ -26,10 +41,12 @@ const mockUseNotes = {
   deleteNote: vi.fn(),
   selectNote: vi.fn(),
   togglePin: vi.fn(),
-  deleteTargetId: null as string | null,
+  deleteTargetId: null as number | null,
   requestDelete: vi.fn(),
   confirmDelete: vi.fn(),
   cancelDelete: vi.fn(),
+  noteSort: 'default' as const,
+  setNoteSort: vi.fn(),
 };
 
 describe('NotesPage', () => {
@@ -66,8 +83,8 @@ describe('NotesPage', () => {
 
   it('ノート一覧を表示する', () => {
     const noteList = [
-      { noteId: 'n1', userId: 1, title: 'テスト1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-      { noteId: 'n2', userId: 1, title: 'テスト2', content: '内容2', isPinned: true, createdAt: 1500, updatedAt: 3000 },
+      makeNote({ id: 1, title: 'テスト1', content: '内容1' }),
+      makeNote({ id: 2, title: 'テスト2', content: '内容2', isPinned: true }),
     ];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
@@ -80,11 +97,11 @@ describe('NotesPage', () => {
   });
 
   it('ノート選択時にエディタが表示される', () => {
-    const note = { noteId: 'n1', userId: 1, title: '選択ノート', content: '選択内容', isPinned: false, createdAt: 1000, updatedAt: 2000 };
+    const note = makeNote({ id: 1, title: '選択ノート', content: '選択内容' });
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: [note],
-      selectedNoteId: 'n1',
+      selectedNoteId: 1,
       selectedNote: note,
     });
     render(<NotesPage />);
@@ -104,12 +121,12 @@ describe('NotesPage', () => {
     expect(mockUseNotes.createNote).toHaveBeenCalledWith('無題');
   });
 
-  it('タイトル変更で自動保存が800ms後に呼ばれる', async () => {
-    const note = { noteId: 'n1', userId: 1, title: '元タイトル', content: '', isPinned: false, createdAt: 1000, updatedAt: 2000 };
+  it('タイトル変更で自動保存が800ms後に呼ばれる', () => {
+    const note = makeNote({ id: 1, title: '元タイトル' });
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: [note],
-      selectedNoteId: 'n1',
+      selectedNoteId: 1,
       selectedNote: note,
     });
     render(<NotesPage />);
@@ -123,18 +140,18 @@ describe('NotesPage', () => {
       vi.advanceTimersByTime(800);
     });
 
-    expect(mockUseNotes.updateNote).toHaveBeenCalledWith('n1', expect.objectContaining({
+    expect(mockUseNotes.updateNote).toHaveBeenCalledWith(1, expect.objectContaining({
       title: '新タイトル',
       isPinned: false,
     }));
   });
 
-  it('タイトル変更でデバウンス後にupdateNoteが呼ばれる', async () => {
-    const note = { noteId: 'n1', userId: 1, title: 'タイトル', content: '', isPinned: false, createdAt: 1000, updatedAt: 2000 };
+  it('タイトル変更でデバウンス後にupdateNoteが呼ばれる', () => {
+    const note = makeNote({ id: 1, title: 'タイトル' });
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: [note],
-      selectedNoteId: 'n1',
+      selectedNoteId: 1,
       selectedNote: note,
     });
     render(<NotesPage />);
@@ -145,7 +162,7 @@ describe('NotesPage', () => {
     act(() => { vi.advanceTimersByTime(800); });
 
     expect(mockUseNotes.updateNote).toHaveBeenCalledTimes(1);
-    expect(mockUseNotes.updateNote).toHaveBeenCalledWith('n1', {
+    expect(mockUseNotes.updateNote).toHaveBeenCalledWith(1, {
       title: 'ABC',
       content: '',
       isPinned: false,
@@ -156,8 +173,6 @@ describe('NotesPage', () => {
     render(<NotesPage />);
     expect(screen.getByLabelText('ノート一覧を開く')).toBeInTheDocument();
   });
-
-  // 検索・ピン留め機能テスト
 
   it('検索入力欄が表示される', () => {
     render(<NotesPage />);
@@ -173,8 +188,8 @@ describe('NotesPage', () => {
 
   it('filteredNotesを使ってノート一覧を表示する', () => {
     const allNotes = [
-      { noteId: 'n1', userId: 1, title: 'テスト1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-      { noteId: 'n2', userId: 1, title: 'テスト2', content: '内容2', isPinned: true, createdAt: 1500, updatedAt: 3000 },
+      makeNote({ id: 1, title: 'テスト1', content: '内容1' }),
+      makeNote({ id: 2, title: 'テスト2', content: '内容2', isPinned: true }),
     ];
     const filtered = [allNotes[0]];
     vi.mocked(useNotes).mockReturnValue({
@@ -187,10 +202,8 @@ describe('NotesPage', () => {
     expect(screen.getAllByText('テスト1').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('ピン留めトグルでtogglePinが呼ばれる', async () => {
-    const noteList = [
-      { noteId: 'n1', userId: 1, title: 'ピンテスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-    ];
+  it('ピン留めトグルでtogglePinが呼ばれる', () => {
+    const noteList = [makeNote({ id: 1, title: 'ピンテスト', content: '内容' })];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: noteList,
@@ -199,13 +212,11 @@ describe('NotesPage', () => {
     render(<NotesPage />);
     const pinButtons = screen.getAllByLabelText('ピン留め');
     fireEvent.click(pinButtons[0]);
-    expect(mockUseNotes.togglePin).toHaveBeenCalledWith('n1');
+    expect(mockUseNotes.togglePin).toHaveBeenCalledWith(1);
   });
 
   it('削除ボタンクリックでrequestDeleteが呼ばれる', () => {
-    const noteList = [
-      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-    ];
+    const noteList = [makeNote({ id: 1, title: '削除テスト', content: '内容' })];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: noteList,
@@ -214,32 +225,28 @@ describe('NotesPage', () => {
     render(<NotesPage />);
     const deleteButtons = screen.getAllByLabelText('ノートを削除');
     fireEvent.click(deleteButtons[0]);
-    expect(mockUseNotes.requestDelete).toHaveBeenCalledWith('n1');
+    expect(mockUseNotes.requestDelete).toHaveBeenCalledWith(1);
   });
 
   it('deleteTargetIdがセットされると確認ダイアログが表示される', () => {
-    const noteList = [
-      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-    ];
+    const noteList = [makeNote({ id: 1, title: '削除テスト', content: '内容' })];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: noteList,
       filteredNotes: noteList,
-      deleteTargetId: 'n1',
+      deleteTargetId: 1,
     });
     render(<NotesPage />);
     expect(screen.getByText('このノートを削除しますか？')).toBeInTheDocument();
   });
 
   it('確認ダイアログで削除を実行するとconfirmDeleteが呼ばれる', async () => {
-    const noteList = [
-      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-    ];
+    const noteList = [makeNote({ id: 1, title: '削除テスト', content: '内容' })];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: noteList,
       filteredNotes: noteList,
-      deleteTargetId: 'n1',
+      deleteTargetId: 1,
     });
     render(<NotesPage />);
     await act(async () => {
@@ -249,14 +256,12 @@ describe('NotesPage', () => {
   });
 
   it('確認ダイアログでキャンセルするとcancelDeleteが呼ばれる', () => {
-    const noteList = [
-      { noteId: 'n1', userId: 1, title: '削除テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-    ];
+    const noteList = [makeNote({ id: 1, title: '削除テスト', content: '内容' })];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: noteList,
       filteredNotes: noteList,
-      deleteTargetId: 'n1',
+      deleteTargetId: 1,
     });
     render(<NotesPage />);
     fireEvent.click(screen.getByText('キャンセル'));
@@ -264,9 +269,7 @@ describe('NotesPage', () => {
   });
 
   it('deleteTargetIdがnullのとき確認ダイアログが非表示', () => {
-    const noteList = [
-      { noteId: 'n1', userId: 1, title: 'テスト', content: '内容', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-    ];
+    const noteList = [makeNote({ id: 1, title: 'テスト', content: '内容' })];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
       notes: noteList,
@@ -277,10 +280,8 @@ describe('NotesPage', () => {
     expect(screen.queryByText('このノートを削除しますか？')).not.toBeInTheDocument();
   });
 
-  // トースト通知テスト
-
   it('ノート作成成功時にトーストが表示される', async () => {
-    mockUseNotes.createNote.mockResolvedValue({ noteId: 'n1', title: '無題' });
+    mockUseNotes.createNote.mockResolvedValue(makeNote({ id: 1, title: '無題' }));
     render(<NotesPage />);
 
     const createButtons = screen.getAllByText('新しいノート');
@@ -307,7 +308,7 @@ describe('NotesPage', () => {
     mockUseNotes.confirmDelete.mockResolvedValue(undefined);
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
-      deleteTargetId: 'n1',
+      deleteTargetId: 1,
     });
     render(<NotesPage />);
 
@@ -320,9 +321,9 @@ describe('NotesPage', () => {
 
   it('ノートがある場合、件数が表示される', () => {
     const noteList = [
-      { noteId: 'n1', userId: 1, title: 'テスト1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-      { noteId: 'n2', userId: 1, title: 'テスト2', content: '内容2', isPinned: false, createdAt: 1500, updatedAt: 3000 },
-      { noteId: 'n3', userId: 1, title: 'テスト3', content: '内容3', isPinned: false, createdAt: 2000, updatedAt: 4000 },
+      makeNote({ id: 1, title: 'テスト1', content: '内容1' }),
+      makeNote({ id: 2, title: 'テスト2', content: '内容2' }),
+      makeNote({ id: 3, title: 'テスト3', content: '内容3' }),
     ];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
@@ -340,8 +341,8 @@ describe('NotesPage', () => {
 
   it('複数ノートがある場合、正しいノートのrequestDeleteが呼ばれる', () => {
     const noteList = [
-      { noteId: 'n1', userId: 1, title: 'ノート1', content: '内容1', isPinned: false, createdAt: 1000, updatedAt: 2000 },
-      { noteId: 'n2', userId: 1, title: 'ノート2', content: '内容2', isPinned: false, createdAt: 1500, updatedAt: 3000 },
+      makeNote({ id: 1, title: 'ノート1', content: '内容1' }),
+      makeNote({ id: 2, title: 'ノート2', content: '内容2' }),
     ];
     vi.mocked(useNotes).mockReturnValue({
       ...mockUseNotes,
@@ -351,6 +352,6 @@ describe('NotesPage', () => {
     render(<NotesPage />);
     const deleteButtons = screen.getAllByLabelText('ノートを削除');
     fireEvent.click(deleteButtons[1]);
-    expect(mockUseNotes.requestDelete).toHaveBeenCalledWith('n2');
+    expect(mockUseNotes.requestDelete).toHaveBeenCalledWith(2);
   });
 });

--- a/frontend/src/repositories/NoteImageRepository.ts
+++ b/frontend/src/repositories/NoteImageRepository.ts
@@ -7,7 +7,7 @@ interface PresignedUrlResponse {
 }
 
 const NoteImageRepository = {
-  async getPresignedUrl(noteId: string, fileName: string, contentType: string): Promise<PresignedUrlResponse> {
+  async getPresignedUrl(noteId: number, fileName: string, contentType: string): Promise<PresignedUrlResponse> {
     const res = await apiClient.post(`/api/v2/notes/${noteId}/images/presigned-url`, {
       fileName,
       contentType,

--- a/frontend/src/repositories/NoteRepository.ts
+++ b/frontend/src/repositories/NoteRepository.ts
@@ -1,57 +1,26 @@
 import apiClient from '../lib/axios';
 import type { Note } from '../types';
 
-// Go バックエンドの Note レスポンスは { id, userId, title, content, isPublic, createdAt, updatedAt }。
-// フロント Note 型は { noteId: string, ..., isPinned: boolean, createdAt: number(ms), updatedAt: number(ms) } を期待するため
-// Repository 層で正規化する（CLAUDE.md の Mapper 集約方針に準拠）。
-interface ApiNote {
-  id: number;
-  userId: number;
-  title?: string;
-  content?: string;
-  isPublic?: boolean;
-  isPinned?: boolean;
-  createdAt?: string | number;
-  updatedAt?: string | number;
-}
-
-function toMillis(value: string | number | undefined): number {
-  if (value == null) return Date.now();
-  if (typeof value === 'number') return value;
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? Date.now() : parsed;
-}
-
-function toNote(api: ApiNote): Note {
-  return {
-    noteId: String(api.id),
-    userId: api.userId,
-    title: api.title ?? '',
-    content: api.content ?? '',
-    isPinned: api.isPinned ?? api.isPublic ?? false,
-    createdAt: toMillis(api.createdAt),
-    updatedAt: toMillis(api.updatedAt),
-  };
-}
-
+/**
+ * Note 関連 API の薄いラッパ。
+ * フロント Note 型は backend domain.Note と 1:1 なのでマッパーは不要（DOP 整合性方針）。
+ */
 const NoteRepository = {
   async fetchNotes(): Promise<Note[]> {
-    const res = await apiClient.get<ApiNote[]>('/api/v2/notes');
-    const list = Array.isArray(res.data) ? res.data : [];
-    return list.map(toNote);
+    const res = await apiClient.get<Note[]>('/api/v2/notes');
+    return Array.isArray(res.data) ? res.data : [];
   },
 
   async createNote(title: string): Promise<Note> {
-    const res = await apiClient.post<ApiNote>('/api/v2/notes', { title });
-    return toNote(res.data);
+    const res = await apiClient.post<Note>('/api/v2/notes', { title });
+    return res.data;
   },
 
-  async updateNote(noteId: string, data: { title: string; content: string; isPinned: boolean }): Promise<void> {
-    // backend の domain は isPublic フィールドを持つ。互換のため両方送る。
-    await apiClient.put(`/api/v2/notes/${noteId}`, { ...data, isPublic: data.isPinned });
+  async updateNote(noteId: number, data: { title: string; content: string; isPinned: boolean }): Promise<void> {
+    await apiClient.put(`/api/v2/notes/${noteId}`, data);
   },
 
-  async deleteNote(noteId: string): Promise<void> {
+  async deleteNote(noteId: number): Promise<void> {
     await apiClient.delete(`/api/v2/notes/${noteId}`);
   },
 };

--- a/frontend/src/repositories/__tests__/NoteRepository.test.ts
+++ b/frontend/src/repositories/__tests__/NoteRepository.test.ts
@@ -9,74 +9,43 @@ describe('NoteRepository', () => {
     vi.clearAllMocks();
   });
 
-  it('fetchNotes は backend の id (number) を noteId (string) に正規化する', async () => {
+  it('fetchNotes は backend のレスポンス配列をそのまま返す', async () => {
     const apiResponse = [
-      {
-        id: 21,
-        userId: 1,
-        title: 'テスト',
-        content: '',
-        isPublic: false,
-        createdAt: '2026-04-28T08:00:00Z',
-        updatedAt: '2026-04-28T09:00:00Z',
-      },
+      { id: 21, userId: 1, title: 'テスト', content: '', isPublic: false, isPinned: false, createdAt: '2026-04-28T08:00:00Z', updatedAt: '2026-04-28T09:00:00Z' },
     ];
     vi.mocked(apiClient.get).mockResolvedValue({ data: apiResponse });
 
     const result = await NoteRepository.fetchNotes();
-
     expect(apiClient.get).toHaveBeenCalledWith('/api/v2/notes');
-    expect(result).toHaveLength(1);
-    expect(result[0].noteId).toBe('21');
-    expect(result[0].title).toBe('テスト');
-    expect(result[0].isPinned).toBe(false);
-    expect(typeof result[0].createdAt).toBe('number');
+    expect(result).toEqual(apiResponse);
   });
 
   it('fetchNotes は配列以外のレスポンスを空配列にフォールバックする', async () => {
     vi.mocked(apiClient.get).mockResolvedValue({ data: null });
-    const result = await NoteRepository.fetchNotes();
-    expect(result).toEqual([]);
+    expect(await NoteRepository.fetchNotes()).toEqual([]);
   });
 
-  it('createNote は backend レスポンスの id を noteId に変換した Note を返す', async () => {
-    const apiResponse = {
-      id: 99,
-      userId: 1,
-      title: '新しいノート',
-      content: '',
-      isPublic: true,
-      createdAt: '2026-04-28T00:00:00Z',
-      updatedAt: '2026-04-28T00:00:00Z',
-    };
+  it('createNote は POST し backend レスポンスをそのまま返す', async () => {
+    const apiResponse = { id: 99, userId: 1, title: '新規', content: '', isPublic: false, isPinned: false, createdAt: '2026-04-28T00:00:00Z', updatedAt: '2026-04-28T00:00:00Z' };
     vi.mocked(apiClient.post).mockResolvedValue({ data: apiResponse });
 
-    const result = await NoteRepository.createNote('新しいノート');
-
-    expect(apiClient.post).toHaveBeenCalledWith('/api/v2/notes', { title: '新しいノート' });
-    expect(result.noteId).toBe('99');
-    expect(result.title).toBe('新しいノート');
-    expect(result.isPinned).toBe(true);
+    const result = await NoteRepository.createNote('新規');
+    expect(apiClient.post).toHaveBeenCalledWith('/api/v2/notes', { title: '新規' });
+    expect(result).toEqual(apiResponse);
   });
 
-  it('updateNote は noteId を URL に埋め込み isPublic も互換で送信する', async () => {
+  it('updateNote は noteId(number) を URL に埋め込んで PUT する', async () => {
     vi.mocked(apiClient.put).mockResolvedValue({ data: undefined });
 
-    await NoteRepository.updateNote('21', { title: '更新', content: '内容', isPinned: true });
+    await NoteRepository.updateNote(21, { title: '更新', content: '内容', isPinned: true });
 
-    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/notes/21', {
-      title: '更新',
-      content: '内容',
-      isPinned: true,
-      isPublic: true,
-    });
+    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/notes/21', { title: '更新', content: '内容', isPinned: true });
   });
 
-  it('deleteNote は noteId を URL に埋め込んで DELETE を投げる', async () => {
+  it('deleteNote は noteId(number) を URL に埋め込んで DELETE する', async () => {
     vi.mocked(apiClient.delete).mockResolvedValue({ data: undefined });
 
-    await NoteRepository.deleteNote('21');
-
+    await NoteRepository.deleteNote(21);
     expect(apiClient.delete).toHaveBeenCalledWith('/api/v2/notes/21');
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -138,14 +138,21 @@ export interface SessionNote {
 }
 
 /** ノート */
+/**
+ * Note は Go backend `domain.Note` と 1:1 で対応する。
+ * - id / userId は number
+ * - createdAt / updatedAt は RFC3339 string（ISO）
+ * - isPublic = 公開フラグ、isPinned = ピン留めフラグ（独立した属性）
+ */
 export interface Note {
-  noteId: string;
+  id: number;
   userId: number;
   title: string;
   content: string;
+  isPublic: boolean;
   isPinned: boolean;
-  createdAt: number;
-  updatedAt: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 /** スコア履歴 */

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -28,7 +28,7 @@ export function formatHourMinute(dateString?: string | number): string {
   return new Date(dateString).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' });
 }
 
-export function formatMonthDay(timestamp: number): string {
+export function formatMonthDay(timestamp: number | string): string {
   const date = new Date(timestamp);
   return `${date.getMonth() + 1}/${date.getDate()}`;
 }


### PR DESCRIPTION
## 概要

Issue #1562 対応。Note のフロント型・hook・page・component を Go backend \`domain.Note\` と 1:1 で揃え、Repository のマッパーを撤廃する。

## 変更内容

### バックエンド
- \`domain.Note\` に \`IsPinned bool\` カラム追加（AutoMigrate で自動追加）
- \`usecase.CreateNoteInput\` / \`usecase.UpdateNoteInput\` に \`IsPinned\` を流す
- \`noteCreateReq\` / \`noteUpdateReq\` に \`isPinned\` JSON フィールドを追加

### フロントエンド
- \`types/index.ts\` の \`Note\` を backend と 1:1 化
  - \`noteId: string\` → \`id: number\`
  - \`isPinned: boolean\` 維持、\`isPublic: boolean\` を新規追加
  - \`createdAt: number(ms)\` → \`string(RFC3339)\`
  - \`updatedAt\` も同様
- \`NoteRepository\`: マッパー撤廃、backend レスポンス素通し
- \`useNotes\` / \`useNoteEditor\` / \`useImageUpload\`: 引数型を \`number\` に
- \`NotesPage\` / \`NoteEditor\` / \`BlockEditor\` / \`NoteListItem\`: prop 型を新型に
- \`formatters.formatMonthDay\` を \`number | string\` 受付に拡張
- ソートは \`Date.parse(updatedAt)\` で ms 比較

### TDD で更新したテスト
- \`useNotes.test\` (44 件)
- \`NoteRepository.test\` (5 件)
- \`NotesPage.test\` (25 件)

## テスト

- [x] \`go build ./... && go test ./...\` 全 green
- [x] \`npx vitest run --environment jsdom\` 2361 tests 全 green
- [x] \`npm run build\` 成功

## 関連

Closes #1562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to pin and unpin notes individually to highlight important items and organize your workspace more effectively. Pinning is independent of note sharing settings.

* **Improvements**
  * Enhanced system stability and data consistency with improved timestamp handling and more reliable identifier management throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->