### PR TITLE
refactor: Profile / User 系を backend domain と整合 (DOP, closes #1563)

### DIFF
--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -3,11 +3,27 @@ package domain
 import "time"
 
 // Profile は users テーブルとは別管理のプロフィール拡張情報。
+//
+// Status はユーザーが任意で公開できるショートメッセージ（例: 「学習中」「取り込み中」）。
+// users.display_name は別テーブル管理だが、フロントは「プロフィール表示」で両者を
+// 合わせて使うため、handler 層で join して返す前提。
 type Profile struct {
-	UserID         uint64    `gorm:"primaryKey;column:user_id" json:"userId"`
-	Bio            string    `gorm:"column:bio" json:"bio"`
-	AvatarURL      string    `gorm:"column:avatar_url" json:"avatarUrl"`
-	UpdatedAt      time.Time `gorm:"column:updated_at" json:"updatedAt"`
+	UserID    uint64    `gorm:"primaryKey;column:user_id" json:"userId"`
+	Bio       string    `gorm:"column:bio" json:"bio"`
+	AvatarURL string    `gorm:"column:avatar_url" json:"avatarUrl"`
+	Status    string    `gorm:"column:status;default:''" json:"status"`
+	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
 func (Profile) TableName() string { return "profiles" }
+
+// ProfileView は handler 層で users.display_name と Profile を合成した DTO。
+// フロントの「プロフィール表示」が期待する単一オブジェクトの形。
+type ProfileView struct {
+	UserID      uint64    `json:"userId"`
+	DisplayName string    `json:"displayName"`
+	Bio         string    `json:"bio"`
+	AvatarURL   string    `json:"avatarUrl"`
+	Status      string    `json:"status"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -6,17 +6,28 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
+// ProfileHandler は GET / PUT /profile/:userId(or "me") を提供する。
+//
+// 返却 DTO `domain.ProfileView` は users.display_name と profiles テーブルを合成したもの
+// （フロントは displayName / bio / avatarUrl / status を 1 つの object で扱う）。
 type ProfileHandler struct {
 	get    *usecase.GetProfileUseCase
 	update *usecase.UpdateProfileUseCase
+	users  repository.UserRepository
 }
 
-func NewProfileHandler(g *usecase.GetProfileUseCase, u *usecase.UpdateProfileUseCase) *ProfileHandler {
-	return &ProfileHandler{get: g, update: u}
+func NewProfileHandler(
+	g *usecase.GetProfileUseCase,
+	u *usecase.UpdateProfileUseCase,
+	users repository.UserRepository,
+) *ProfileHandler {
+	return &ProfileHandler{get: g, update: u, users: users}
 }
 
 var (
@@ -53,22 +64,23 @@ func (h *ProfileHandler) Get(c *gin.Context) {
 		writeProfileError(c, err)
 		return
 	}
-	p, err := h.get.Execute(c.Request.Context(), uid)
+	view, err := h.buildView(c, uid)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if p == nil {
-		// 未登録ユーザーでも UI が落ちないよう最小デフォルトを返す。
-		c.JSON(http.StatusOK, gin.H{"userId": uid, "bio": "", "avatarUrl": "", "name": "", "iconUrl": "", "status": ""})
-		return
-	}
-	c.JSON(http.StatusOK, p)
+	c.JSON(http.StatusOK, view)
 }
 
 type updateProfileReq struct {
-	Bio       string `json:"bio"`
-	AvatarURL string `json:"avatarUrl"`
+	// `name` は旧フロント実装の互換のため受け付け、`displayName` を優先する。
+	DisplayName string `json:"displayName"`
+	Name        string `json:"name"`
+	Bio         string `json:"bio"`
+	AvatarURL   string `json:"avatarUrl"`
+	// 旧フロント実装が `iconUrl` で送ってきた場合の互換。
+	IconURL string `json:"iconUrl"`
+	Status  string `json:"status"`
 }
 
 func (h *ProfileHandler) Update(c *gin.Context) {
@@ -82,14 +94,56 @@ func (h *ProfileHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	updated, err := h.update.Execute(c.Request.Context(), usecase.UpdateProfileInput{
-		UserID: uid, Bio: req.Bio, AvatarURL: req.AvatarURL,
-	})
-	if err != nil {
+	displayName := req.DisplayName
+	if displayName == "" {
+		displayName = req.Name
+	}
+	avatarURL := req.AvatarURL
+	if avatarURL == "" {
+		avatarURL = req.IconURL
+	}
+	if displayName != "" {
+		if err := h.users.UpdateDisplayName(c.Request.Context(), uid, displayName); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if _, err := h.update.Execute(c.Request.Context(), usecase.UpdateProfileInput{
+		UserID:    uid,
+		Bio:       req.Bio,
+		AvatarURL: avatarURL,
+		Status:    req.Status,
+	}); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, updated)
+	view, err := h.buildView(c, uid)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"success": "プロフィールを更新しました"})
+		return
+	}
+	c.JSON(http.StatusOK, view)
+}
+
+// buildView は users.display_name と profiles を合成して ProfileView を返す。
+// 未登録ユーザーでも UI が落ちないよう、欠損時は空文字フィールドで埋める。
+func (h *ProfileHandler) buildView(c *gin.Context, uid uint64) (*domain.ProfileView, error) {
+	p, err := h.get.Execute(c.Request.Context(), uid)
+	if err != nil {
+		return nil, err
+	}
+	view := &domain.ProfileView{UserID: uid}
+	if p != nil {
+		view.Bio = p.Bio
+		view.AvatarURL = p.AvatarURL
+		view.Status = p.Status
+		view.UpdatedAt = p.UpdatedAt
+	}
+	user, _ := h.users.FindByID(c.Request.Context(), uid)
+	if user != nil {
+		view.DisplayName = user.DisplayName
+	}
+	return view, nil
 }
 
 func writeProfileError(c *gin.Context, err error) {

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -68,6 +68,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	profileHandler := NewProfileHandler(
 		usecase.NewGetProfileUseCase(profileRepo),
 		usecase.NewUpdateProfileUseCase(profileRepo),
+		userRepo,
 	)
 	// /profile/:userId は数字 / "me" の両方を受ける（handler.resolveUserID で current user 解決）。
 	// フロント互換のため /profile/:userId/update PUT / /profile/:userId/image/presigned-url POST も提供する。

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -11,7 +11,10 @@ import (
 // UserRepository は users テーブルへのアクセスを提供する。
 type UserRepository interface {
 	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
+	FindByID(ctx context.Context, id uint64) (*domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
+	// UpdateDisplayName は ProfilePage の「ニックネーム」変更で呼ばれる。
+	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
 }
 
 type userRepository struct {
@@ -34,6 +37,25 @@ func (r *userRepository) FindByCognitoSub(ctx context.Context, sub string) (*dom
 	return &u, nil
 }
 
+func (r *userRepository) FindByID(ctx context.Context, id uint64) (*domain.User, error) {
+	var u domain.User
+	err := r.db.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", id).First(&u).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
 func (r *userRepository) Create(ctx context.Context, user *domain.User) error {
 	return r.db.WithContext(ctx).Create(user).Error
+}
+
+func (r *userRepository) UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ?", userID).
+		Update("display_name", displayName).Error
 }

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -16,7 +16,13 @@ type stubUserRepo struct {
 func (s *stubUserRepo) FindByCognitoSub(_ context.Context, _ string) (*domain.User, error) {
 	return s.user, s.err
 }
+func (s *stubUserRepo) FindByID(_ context.Context, _ uint64) (*domain.User, error) {
+	return s.user, s.err
+}
 func (s *stubUserRepo) Create(_ context.Context, _ *domain.User) error { return s.err }
+func (s *stubUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error {
+	return s.err
+}
 
 func TestGetCurrentUserUseCase_Found(t *testing.T) {
 	want := &domain.User{ID: 1, CognitoSub: "abc", Email: "u@example.com"}

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -35,13 +35,19 @@ type UpdateProfileInput struct {
 	UserID    uint64
 	Bio       string
 	AvatarURL string
+	Status    string
 }
 
 func (u *UpdateProfileUseCase) Execute(ctx context.Context, in UpdateProfileInput) (*domain.Profile, error) {
 	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
 	}
-	p := &domain.Profile{UserID: in.UserID, Bio: in.Bio, AvatarURL: in.AvatarURL}
+	p := &domain.Profile{
+		UserID:    in.UserID,
+		Bio:       in.Bio,
+		AvatarURL: in.AvatarURL,
+		Status:    in.Status,
+	}
 	if err := u.profiles.Upsert(ctx, p); err != nil {
 		return nil, err
 	}

--- a/frontend/src/hooks/__tests__/useProfileEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileEdit.test.ts
@@ -12,11 +12,20 @@ vi.mock('../../repositories/ProfileRepository', () => ({
   },
 }));
 
+const fixtureProfile = {
+  userId: 1,
+  displayName: 'テスト太郎',
+  bio: '自己紹介文',
+  avatarUrl: '',
+  status: '学習中',
+  updatedAt: '2026-04-28T00:00:00Z',
+};
+
 describe('useProfileEdit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFetchProfile.mockResolvedValue({ name: 'テスト太郎', bio: '自己紹介文', status: '学習中' });
-    mockUpdateProfile.mockResolvedValue({ success: '更新しました' });
+    mockFetchProfile.mockResolvedValue({ ...fixtureProfile });
+    mockUpdateProfile.mockResolvedValue({ ...fixtureProfile });
   });
 
   it('プロフィール取得成功時にフォームに値がセットされる', async () => {
@@ -26,7 +35,7 @@ describe('useProfileEdit', () => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(result.current.form.name).toBe('テスト太郎');
+    expect(result.current.form.displayName).toBe('テスト太郎');
     expect(result.current.form.bio).toBe('自己紹介文');
     expect(result.current.form.status).toBe('学習中');
   });
@@ -52,10 +61,10 @@ describe('useProfileEdit', () => {
     });
 
     act(() => {
-      result.current.updateField('name', '新しい名前');
+      result.current.updateField('displayName', '新しい名前');
     });
 
-    expect(result.current.form.name).toBe('新しい名前');
+    expect(result.current.form.displayName).toBe('新しい名前');
   });
 
   it('handleUpdate成功時に成功メッセージが表示される', async () => {
@@ -70,7 +79,7 @@ describe('useProfileEdit', () => {
     });
 
     expect(result.current.message?.type).toBe('success');
-    expect(result.current.message?.text).toBe('更新しました');
+    expect(result.current.message?.text).toBe('プロフィールを更新しました。');
   });
 
   it('handleUpdate失敗時にエラーメッセージが表示される', async () => {
@@ -92,8 +101,6 @@ describe('useProfileEdit', () => {
 
   it('loading状態が初期trueからfalseに変化する', async () => {
     const { result } = renderHook(() => useProfileEdit());
-
-    // 初期状態はloading true
     expect(result.current.loading).toBe(true);
 
     await waitFor(() => {
@@ -113,12 +120,11 @@ describe('useProfileEdit', () => {
     });
 
     expect(result.current.form.bio).toBe('新しい自己紹介');
-    // nameは変更されていないこと
-    expect(result.current.form.name).toBe('テスト太郎');
+    expect(result.current.form.displayName).toBe('テスト太郎');
   });
 
   it('handleUpdate中はsubmittingがtrueになる', async () => {
-    let resolveUpdate: (value: any) => void;
+    let resolveUpdate: (value: unknown) => void;
     mockUpdateProfile.mockImplementation(
       () => new Promise((resolve) => { resolveUpdate = resolve; })
     );
@@ -139,7 +145,7 @@ describe('useProfileEdit', () => {
     expect(result.current.submitting).toBe(true);
 
     await act(async () => {
-      resolveUpdate!({ success: 'OK' });
+      resolveUpdate!({ ...fixtureProfile });
       await updatePromise!;
     });
 
@@ -154,14 +160,19 @@ describe('useProfileEdit', () => {
     });
 
     act(() => {
-      result.current.updateField('name', '更新太郎');
+      result.current.updateField('displayName', '更新太郎');
     });
 
     await act(async () => {
       await result.current.handleUpdate();
     });
 
-    expect(mockUpdateProfile).toHaveBeenCalledWith({ name: '更新太郎', bio: '自己紹介文', iconUrl: '', status: '学習中' });
+    expect(mockUpdateProfile).toHaveBeenCalledWith({
+      displayName: '更新太郎',
+      bio: '自己紹介文',
+      avatarUrl: '',
+      status: '学習中',
+    });
   });
 
   it('ニックネームが空の場合エラーメッセージが表示されAPIが呼ばれない', async () => {
@@ -172,7 +183,7 @@ describe('useProfileEdit', () => {
     });
 
     act(() => {
-      result.current.updateField('name', '');
+      result.current.updateField('displayName', '');
     });
 
     await act(async () => {
@@ -192,7 +203,7 @@ describe('useProfileEdit', () => {
     });
 
     act(() => {
-      result.current.updateField('name', '   ');
+      result.current.updateField('displayName', '   ');
     });
 
     await act(async () => {

--- a/frontend/src/hooks/useProfileEdit.ts
+++ b/frontend/src/hooks/useProfileEdit.ts
@@ -1,9 +1,22 @@
 import { useState, useEffect, useCallback } from 'react';
 import ProfileRepository from '../repositories/ProfileRepository';
-import type { FormMessage } from '../types';
+import type { FormMessage, Profile } from '../types';
+
+/**
+ * useProfileEdit — ProfilePage で「ニックネーム / 自己紹介 / アイコン / ステータス」
+ * の編集を扱う。フォーム形は backend `domain.ProfileView` のサブセット。
+ */
+type ProfileForm = Pick<Profile, 'displayName' | 'bio' | 'avatarUrl' | 'status'>;
+
+const EMPTY_FORM: ProfileForm = {
+  displayName: '',
+  bio: '',
+  avatarUrl: '',
+  status: '',
+};
 
 export function useProfileEdit() {
-  const [form, setForm] = useState({ name: '', bio: '', iconUrl: '', status: '' });
+  const [form, setForm] = useState<ProfileForm>(EMPTY_FORM);
   const [message, setMessage] = useState<FormMessage | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -12,7 +25,12 @@ export function useProfileEdit() {
     const loadProfile = async () => {
       try {
         const data = await ProfileRepository.fetchProfile();
-        setForm({ name: data.name || '', bio: data.bio || '', iconUrl: data.iconUrl || '', status: data.status || '' });
+        setForm({
+          displayName: data.displayName ?? '',
+          bio: data.bio ?? '',
+          avatarUrl: data.avatarUrl ?? '',
+          status: data.status ?? '',
+        });
       } catch {
         setMessage({ type: 'error', text: 'プロフィール取得に失敗しました。' });
       } finally {
@@ -22,20 +40,19 @@ export function useProfileEdit() {
     loadProfile();
   }, []);
 
-  const updateField = useCallback((field: 'name' | 'bio' | 'iconUrl' | 'status', value: string) => {
+  const updateField = useCallback(<K extends keyof ProfileForm>(field: K, value: ProfileForm[K]) => {
     setForm((prev) => ({ ...prev, [field]: value }));
   }, []);
 
   const handleUpdate = useCallback(async () => {
-    if (!form.name.trim()) {
+    if (!form.displayName.trim()) {
       setMessage({ type: 'error', text: 'ニックネームを入力してください。' });
       return;
     }
-
     setSubmitting(true);
     try {
-      const data = await ProfileRepository.updateProfile(form);
-      setMessage({ type: 'success', text: data.success || 'プロフィールを更新しました。' });
+      await ProfileRepository.updateProfile(form);
+      setMessage({ type: 'success', text: 'プロフィールを更新しました。' });
     } catch {
       setMessage({ type: 'error', text: '通信エラーが発生しました。' });
     } finally {

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -30,7 +30,7 @@ export default function ProfilePage() {
 
     const imageUrl = await upload(file);
     if (imageUrl) {
-      updateField('iconUrl', imageUrl);
+      updateField('avatarUrl', imageUrl);
     } else {
       setMessage({ type: 'error', text: '画像のアップロードに失敗しました。' });
     }
@@ -52,7 +52,7 @@ export default function ProfilePage() {
       <div className="bg-surface-1 rounded-lg border border-surface-3 p-6">
         <div className="flex items-center gap-4 mb-6">
           <div className="relative">
-            <Avatar name={form.name || 'U'} src={form.iconUrl || undefined} size="xl" />
+            <Avatar name={form.displayName || 'U'} src={form.avatarUrl || undefined} size="xl" />
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
@@ -88,9 +88,9 @@ export default function ProfilePage() {
         >
           <InputField
             label="ニックネーム"
-            name="name"
-            value={form.name}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateField('name', e.target.value)}
+            name="displayName"
+            value={form.displayName}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateField('displayName', e.target.value)}
           />
           <TextareaField
             label="自己紹介"

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -42,7 +42,7 @@ describe('ProfilePage', () => {
   });
 
   it('プロファイル取得後にフォームが表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テストユーザー', bio: '自己紹介文' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テストユーザー', bio: '自己紹介文', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 
@@ -63,7 +63,7 @@ describe('ProfilePage', () => {
   });
 
   it('プロファイル取得後にニックネーム欄が表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テストユーザー', bio: '自己紹介文' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テストユーザー', bio: '自己紹介文', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 
@@ -73,7 +73,7 @@ describe('ProfilePage', () => {
   });
 
   it('プロファイル取得後に自己紹介欄が表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: 'テスト自己紹介' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: 'テスト自己紹介', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 
@@ -83,7 +83,7 @@ describe('ProfilePage', () => {
   });
 
   it('送信中はボタンが「更新中...」になり無効化される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: '', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
     mockedRepo.updateProfile.mockReturnValue(new Promise(() => {}));
 
     render(<ProfilePage />);
@@ -101,7 +101,7 @@ describe('ProfilePage', () => {
   });
 
   it('アバターのイニシャルが表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テストユーザー', bio: '' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テストユーザー', bio: '', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 
@@ -111,7 +111,7 @@ describe('ProfilePage', () => {
   });
 
   it('カメラボタンが表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: '', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 
@@ -121,7 +121,7 @@ describe('ProfilePage', () => {
   });
 
   it('画像アップロード成功時にアバターが更新される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: '', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
     mockUpload.mockResolvedValue('https://cdn.example.com/profiles/1/avatar.png');
 
     render(<ProfilePage />);
@@ -140,7 +140,7 @@ describe('ProfilePage', () => {
   });
 
   it('画像アップロード失敗時にエラーメッセージが表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: '', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
     mockUpload.mockResolvedValue(null);
 
     render(<ProfilePage />);
@@ -159,7 +159,7 @@ describe('ProfilePage', () => {
   });
 
   it('ステータス入力フィールドが表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '', status: '学習中' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: '', avatarUrl: '', status: '学習中', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 
@@ -169,7 +169,7 @@ describe('ProfilePage', () => {
   });
 
   it('学習統計セクションが表示される', async () => {
-    mockedRepo.fetchProfile.mockResolvedValue({ name: 'テスト', bio: '' });
+    mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テスト', bio: '', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);
 

--- a/frontend/src/repositories/ProfileRepository.ts
+++ b/frontend/src/repositories/ProfileRepository.ts
@@ -1,18 +1,17 @@
 import apiClient from '../lib/axios';
 import axios from 'axios';
+import type { Profile } from '../types';
 
 /**
- * プロフィールリポジトリ
- *
- * プロフィール関連のAPI呼び出しを抽象化し、
- * axiosインターセプターによる自動トークンリフレッシュを活用する。
+ * Profile 関連 API の薄いラッパ。
+ * フロント `Profile` 型は backend `domain.ProfileView` と 1:1 なのでマッパー不要。
  */
 
-export interface ProfileData {
-  name: string;
+export interface UpdateProfileRequest {
+  displayName: string;
   bio: string;
-  iconUrl?: string;
-  status?: string;
+  avatarUrl: string;
+  status: string;
 }
 
 interface PresignedUrlResponse {
@@ -21,18 +20,18 @@ interface PresignedUrlResponse {
 }
 
 const ProfileRepository = {
-  async fetchProfile(): Promise<ProfileData> {
-    const res = await apiClient.get('/api/v2/profile/me');
+  async fetchProfile(): Promise<Profile> {
+    const res = await apiClient.get<Profile>('/api/v2/profile/me');
     return res.data;
   },
 
-  async updateProfile(data: ProfileData): Promise<{ success: string }> {
-    const res = await apiClient.put('/api/v2/profile/me/update', data);
+  async updateProfile(data: UpdateProfileRequest): Promise<Profile> {
+    const res = await apiClient.put<Profile>('/api/v2/profile/me/update', data);
     return res.data;
   },
 
   async getImagePresignedUrl(fileName: string, contentType: string): Promise<PresignedUrlResponse> {
-    const res = await apiClient.post('/api/v2/profile/me/image/presigned-url', {
+    const res = await apiClient.post<PresignedUrlResponse>('/api/v2/profile/me/image/presigned-url', {
       fileName,
       contentType,
     });

--- a/frontend/src/repositories/__tests__/ProfileRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ProfileRepository.test.ts
@@ -17,29 +17,45 @@ vi.mock('axios', () => ({
   },
 }));
 
+const fixtureProfile = {
+  userId: 1,
+  displayName: 'テスト',
+  bio: '自己紹介',
+  avatarUrl: '',
+  status: '',
+  updatedAt: '2026-04-28T00:00:00Z',
+};
+
 describe('ProfileRepository', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('fetchProfile: プロフィールを取得できる', async () => {
-    const mockData = { name: 'テスト', bio: '自己紹介' };
-    vi.mocked(apiClient.get).mockResolvedValue({ data: mockData });
-
+    vi.mocked(apiClient.get).mockResolvedValue({ data: fixtureProfile });
     const result = await ProfileRepository.fetchProfile();
-
     expect(apiClient.get).toHaveBeenCalledWith('/api/v2/profile/me');
-    expect(result).toEqual(mockData);
+    expect(result).toEqual(fixtureProfile);
   });
 
   it('updateProfile: プロフィールを更新できる', async () => {
-    const mockData = { success: 'プロフィールを更新しました。' };
-    vi.mocked(apiClient.put).mockResolvedValue({ data: mockData });
+    const updated = { ...fixtureProfile, bio: '更新' };
+    vi.mocked(apiClient.put).mockResolvedValue({ data: updated });
 
-    const result = await ProfileRepository.updateProfile({ name: 'テスト', bio: '更新' });
+    const result = await ProfileRepository.updateProfile({
+      displayName: 'テスト',
+      bio: '更新',
+      avatarUrl: '',
+      status: '',
+    });
 
-    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/profile/me/update', { name: 'テスト', bio: '更新' });
-    expect(result).toEqual(mockData);
+    expect(apiClient.put).toHaveBeenCalledWith('/api/v2/profile/me/update', {
+      displayName: 'テスト',
+      bio: '更新',
+      avatarUrl: '',
+      status: '',
+    });
+    expect(result).toEqual(updated);
   });
 
   it('getImagePresignedUrl: Presigned URLを取得できる', async () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -155,6 +155,35 @@ export interface Note {
   updatedAt: string;
 }
 
+/**
+ * Profile は Go backend `domain.ProfileView` と 1:1 で対応する。
+ * users.display_name と profiles を合成した「プロフィール表示」用 DTO。
+ */
+export interface Profile {
+  userId: number;
+  displayName: string;
+  bio: string;
+  avatarUrl: string;
+  status: string;
+  updatedAt: string;
+}
+
+/**
+ * User は Go backend `domain.User` と 1:1 で対応する。
+ * 認証フローおよび admin 操作で利用する。
+ */
+export interface User {
+  id: number;
+  cognitoSub: string;
+  email: string;
+  displayName: string;
+  companyId?: number | null;
+  role: string;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt?: string | null;
+}
+
 /** スコア履歴 */
 export interface ScoreHistory {
   sessionId: number;


### PR DESCRIPTION
## 概要

Issue #1563 対応。Profile 関連のフロント型・hook・page を Go backend \`domain.Profile\` + \`domain.User\` と整合させる。

## 変更内容

### バックエンド
- \`domain.Profile\` に \`Status\` カラム追加
- \`domain.ProfileView\` を新設（users.display_name + profiles の合成 DTO）
- \`UserRepository\` に \`FindByID\` / \`UpdateDisplayName\` を追加
- \`UpdateProfileInput\` に \`Status\` を追加
- \`ProfileHandler\`:
  - \`Get\`: \`ProfileView\` を返す
  - \`Update\`: \`displayName\` を user テーブル更新 / \`bio\` / \`avatarUrl\` / \`status\` を profile upsert
  - 旧フロント互換のため \`name\` / \`iconUrl\` も受け付け

### フロントエンド
- \`types\` に \`Profile\` / \`User\` を新設（backend と 1:1）
- \`ProfileRepository\`: マッパー撤廃、返却型を \`Profile\`
- \`useProfileEdit\`: form 形を \`Pick<Profile, ...>\` に
- \`ProfilePage\`: \`form.name\` → \`form.displayName\`、\`form.iconUrl\` → \`form.avatarUrl\`

### TDD 更新テスト
- \`useProfileEdit.test\` (12 件)
- \`ProfileRepository.test\` (4 件)
- \`ProfilePage.test\` (12 件)

## テスト
- [x] \`go build ./... && go test ./...\` 全 green
- [x] \`npx vitest run --environment jsdom\` 2361 tests 全 green
- [x] \`npm run build\` 成功

Closes #1563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status field to user profiles enabling users to display additional information about themselves.

* **Refactor**
  * Updated profile display to combine user display name with profile information for a unified view.
  * Renamed profile image URL field from icon URL to avatar URL for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->