### PR TITLE
refactor(frontend): Score / Practice 系の DTO 型を backend domain と整合 (DOP, refs #1565)

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -90,7 +90,8 @@ export interface AiSession {
   createdAt?: string;
 }
 
-/** 練習シナリオ */
+/** 練習シナリオ（フロント表示用 view）。
+ *  backend 1:1 は `PracticeScenarioDto` を参照すること。 */
 export interface PracticeScenario {
   id: number;
   name: string;
@@ -98,6 +99,25 @@ export interface PracticeScenario {
   category: string;
   roleName: string;
   difficulty: string;
+}
+
+/** PracticeScenarioDto は Go backend `domain.PracticeScenario` と 1:1。 */
+export interface PracticeScenarioDto {
+  id: number;
+  title: string;
+  description: string;
+  category: string;
+  difficultyLevel: number;
+  isActive: boolean;
+  createdAt: string;
+}
+
+/** ScenarioBookmark は Go backend `domain.ScenarioBookmark` と 1:1。 */
+export interface ScenarioBookmark {
+  id: number;
+  userId: number;
+  scenarioId: number;
+  createdAt: string;
 }
 
 /**
@@ -168,11 +188,58 @@ export interface AxisScore {
   comment: string;
 }
 
-/** スコアカード */
+/** スコアカード（フロント表示用 view）。
+ *  backend 1:1 は `ScoreCardDto` を参照すること。 */
 export interface ScoreCard {
   sessionId: number;
   scores: AxisScore[];
   overallScore: number;
+}
+
+/**
+ * ScoreCardDto は Go backend `domain.ScoreCard` と 1:1。
+ * 5 軸スコアは個別カラム（logicalScore / considerationScore / summaryScore /
+ * proposalScore / listeningScore）として保持される。
+ */
+export interface ScoreCardDto {
+  id: number;
+  userId: number;
+  sessionId: number;
+  overallScore: number;
+  logicalScore: number;
+  considerationScore: number;
+  summaryScore: number;
+  proposalScore: number;
+  listeningScore: number;
+  feedback: string;
+  createdAt: string;
+}
+
+/** ScoreGoalDto は Go backend `domain.ScoreGoal` と 1:1。 */
+export interface ScoreGoalDto {
+  userId: number;
+  targetScore: number;
+  updatedAt: string;
+}
+
+/** ScoreTrendPoint / ScoreTrend は Go backend `domain.ScoreTrend` と 1:1。 */
+export interface ScoreTrendPoint {
+  date: string;
+  overallScore: number;
+}
+export interface ScoreTrend {
+  userId: number;
+  points: ScoreTrendPoint[];
+}
+
+/** RankingEntryDto は Go backend `domain.RankingEntry` と 1:1。
+ *  既存 `RankingEntry` (UI view) は username / iconUrl / sessionCount を
+ *  別 API から取得して合成しているため、当面 view 型は別に保持する。 */
+export interface RankingEntryDto {
+  userId: number;
+  displayName: string;
+  averageScore: number;
+  rank: number;
 }
 
 /** SNSプロバイダー */


### PR DESCRIPTION
## 概要

Issue #1565 の足がかり。Score / Practice 関連の「真のソース」を frontend types で明示するため、backend domain と 1:1 の DTO 型を追加する。Issue #1564 と同方針。

## 追加した型（backend と 1:1）
- \`PracticeScenarioDto\` ← \`domain.PracticeScenario\`
- \`ScenarioBookmark\` ← \`domain.ScenarioBookmark\`
- \`ScoreCardDto\` ← \`domain.ScoreCard\`（5 軸 + feedback）
- \`ScoreGoalDto\` ← \`domain.ScoreGoal\`
- \`ScoreTrend\` / \`ScoreTrendPoint\` ← \`domain.ScoreTrend\`
- \`RankingEntryDto\` ← \`domain.RankingEntry\`

## 既存 view 型は保持
- \`PracticeScenario\`（UI 表示用）
- \`ScoreCard\`（AxisScore[] にまとめた表示用 view）
- \`RankingEntry\`（username / iconUrl / sessionCount 含む UI view）

DTO への一斉移行は別 issue で実施。

## テスト
- [x] \`npx vitest run --environment jsdom\` 2361 tests 全 green
- [x] \`npm run build\` 成功

Refs #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type definitions to support enhanced data structure handling between frontend and backend systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->