### PR TITLE
refactor(frontend): Engagement 系の DTO 型を backend domain と整合 (DOP, refs #1566)

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -178,7 +178,8 @@ export interface ScoreCard {
 /** SNSプロバイダー */
 export type SnsProvider = 'google' | 'facebook' | 'x';
 
-/** お気に入りフレーズ */
+/** お気に入りフレーズ（フロント表示用 view）。
+ *  backend 1:1 は `FavoritePhraseDto` を参照すること。 */
 export interface FavoritePhrase {
   id: string;
   originalText: string;
@@ -187,11 +188,33 @@ export interface FavoritePhrase {
   createdAt: string;
 }
 
-/** 日次学習目標 */
+/** FavoritePhraseDto は Go backend `domain.FavoritePhrase` と 1:1。 */
+export interface FavoritePhraseDto {
+  id: number;
+  userId: number;
+  phrase: string;
+  note: string;
+  createdAt: string;
+}
+
+/** 日次学習目標（フロント表示用 view）。
+ *  backend 1:1 は `DailyGoalDto` を参照すること。 */
 export interface DailyGoal {
   date: string;
   target: number;
   completed: number;
+}
+
+/** DailyGoalDto は Go backend `domain.DailyGoal` と 1:1。
+ *  date は YYYY-MM-DD で、targetMinutes / actualMinutes / isAchieved を持つ。 */
+export interface DailyGoalDto {
+  id: number;
+  userId: number;
+  date: string;
+  targetMinutes: number;
+  actualMinutes: number;
+  isAchieved: boolean;
+  createdAt: string;
 }
 
 /** セッションメモ */
@@ -266,7 +289,8 @@ export interface ScoreHistoryItem {
   createdAt: string;
 }
 
-/** 学習レポート */
+/** 学習レポート（フロント表示用 view）。
+ *  backend 1:1 は `LearningReportDto` を参照すること。 */
 export interface LearningReport {
   id: number;
   year: number;
@@ -281,7 +305,20 @@ export interface LearningReport {
   createdAt?: string;
 }
 
-/** 通知 */
+/** LearningReportDto は Go backend `domain.LearningReport` と 1:1。
+ *  非同期生成のため status (`pending` / `ready` / `failed`) と s3Key を持つ。 */
+export interface LearningReportDto {
+  id: number;
+  userId: number;
+  periodFrom: string;
+  periodTo: string;
+  status: 'pending' | 'ready' | 'failed';
+  s3Key?: string;
+  createdAt: string;
+}
+
+/** 通知（フロント表示用 view）。
+ *  backend 1:1 は `NotificationDto` を参照すること。 */
 export interface Notification {
   id: number;
   type: string;
@@ -292,6 +329,20 @@ export interface Notification {
   createdAt: string;
 }
 
+/** NotificationDto は Go backend `domain.Notification` と 1:1。
+ *  backend は `body` カラム、フロント view は `message` を使う点が差。 */
+export interface NotificationDto {
+  id: number;
+  userId: number;
+  type: string;
+  title: string;
+  body: string;
+  isRead: boolean;
+  createdAt: string;
+}
+
+/** FriendshipUser はフロント表示用 view（friend list 表示で使う）。
+ *  backend 1:1 は `FriendshipDto`。 */
 export interface FriendshipUser {
   id: number;
   userId: number;
@@ -301,6 +352,16 @@ export interface FriendshipUser {
   mutual: boolean;
   createdAt: string;
   status: string | null;
+}
+
+/** FriendshipDto は Go backend `domain.Friendship` と 1:1。
+ *  status は `pending` / `accepted` / `rejected`。 */
+export interface FriendshipDto {
+  id: number;
+  requesterId: number;
+  addresseeId: number;
+  status: 'pending' | 'accepted' | 'rejected';
+  createdAt: string;
 }
 
 export interface FollowStatus {
@@ -325,7 +386,8 @@ export interface Ranking {
   myRanking: RankingEntry | null;
 }
 
-/** 会話テンプレート */
+/** 会話テンプレート（フロント表示用 view）。
+ *  backend 1:1 は `ConversationTemplateDto` を参照すること。 */
 export interface ConversationTemplate {
   id: number;
   title: string;
@@ -335,11 +397,30 @@ export interface ConversationTemplate {
   difficulty: string;
 }
 
-/** リマインダー設定 */
+/** ConversationTemplateDto は Go backend `domain.ConversationTemplate` と 1:1。 */
+export interface ConversationTemplateDto {
+  id: number;
+  title: string;
+  body: string;
+  category: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
+/** リマインダー設定（フロント表示用 view）。 */
 export interface ReminderSetting {
   enabled: boolean;
   reminderTime: string;
   daysOfWeek: string;
+}
+
+/** ReminderSettingDto は Go backend `domain.ReminderSetting` と 1:1（user 単位の通知設定）。 */
+export interface ReminderSettingDto {
+  userId: number;
+  enabled: boolean;
+  reminderTime: string;
+  daysOfWeek: string;
+  updatedAt: string;
 }
 
 /** 共有セッション */
@@ -354,7 +435,8 @@ export interface SharedSession {
   createdAt: string;
 }
 
-/** ウィークリーチャレンジ */
+/** ウィークリーチャレンジ（フロント表示用 view）。
+ *  backend 1:1 は `WeeklyChallengeDto` / `WeeklyChallengeProgressDto` を参照。 */
 export interface WeeklyChallenge {
   id: number;
   title: string;
@@ -365,4 +447,22 @@ export interface WeeklyChallenge {
   isCompleted: boolean;
   weekStart: string;
   weekEnd: string;
+}
+
+/** WeeklyChallengeDto は Go backend `domain.WeeklyChallenge` と 1:1。 */
+export interface WeeklyChallengeDto {
+  id: number;
+  weekStart: string;
+  title: string;
+  description: string;
+  isActive: boolean;
+  createdAt: string;
+}
+
+/** WeeklyChallengeProgressDto は Go backend `domain.WeeklyChallengeProgress` と 1:1。 */
+export interface WeeklyChallengeProgressDto {
+  userId: number;
+  challengeId: number;
+  completed: boolean;
+  updatedAt: string;
 }


### PR DESCRIPTION
## 概要

Issue #1566 の足がかり。Engagement 関連の「真のソース」を frontend types で明示するため、backend domain と 1:1 の DTO 型を追加する。Issue #1564 / #1565 と同方針。

## 追加した型（backend と 1:1）
- \`NotificationDto\` ← \`domain.Notification\`
- \`FavoritePhraseDto\` ← \`domain.FavoritePhrase\`
- \`FriendshipDto\` ← \`domain.Friendship\`
- \`DailyGoalDto\` ← \`domain.DailyGoal\`
- \`WeeklyChallengeDto\` / \`WeeklyChallengeProgressDto\` ← \`domain.WeeklyChallenge\` 系
- \`LearningReportDto\` ← \`domain.LearningReport\`
- \`ConversationTemplateDto\` ← \`domain.ConversationTemplate\`
- \`ReminderSettingDto\` ← \`domain.ReminderSetting\`

## 既存 view 型は保持
各 UI 用 view 型はフロントが組み立てた集約形として保持。Repository / hook での DTO 移行は後段の別 issue。

## テスト
- [x] \`npx vitest run --environment jsdom\` 2361 tests 全 green
- [x] \`npm run build\` 成功

Refs #1566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal type definitions and documentation for improved data structure consistency across core features including favorites, goals, learning, notifications, friendships, conversation templates, reminders, and challenges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->