### PR TITLE
fix(ci): scheduled-stop の Summary step を非クリティカル化

### DIFF
--- a/.github/workflows/scheduled-stop.yml
+++ b/.github/workflows/scheduled-stop.yml
@@ -72,9 +72,13 @@ jobs:
             echo "ALB stack already absent, skip"
           fi
 
+      # Summary は非クリティカル。GitHub Actions IAM Role に
+      # cloudformation:ListStacks 権限が無くても本筋 (ECS / ALB destroy) は完了済み。
+      # 失敗で workflow 全体を red にしないため continue-on-error / `|| true` で吸収する。
       - name: Summary
+        continue-on-error: true
         run: |
           echo "🌙 Cost-saving stop complete at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           aws cloudformation list-stacks --region $AWS_REGION \
             --query 'StackSummaries[?starts_with(StackName, `frestyle-prod-`) && StackStatus != `DELETE_COMPLETE`].[StackName,StackStatus]' \
-            --output table
+            --output table || echo "(ListStacks denied; not fatal)"


### PR DESCRIPTION
## 概要

\`Scheduled - Stop (destroy ECS + ALB at night)\` workflow が「destroy 完了 → Summary step で IAM 権限不足エラー」で failure になる問題を修正する。

## 原因

最後の Summary step で \`aws cloudformation list-stacks\` を実行する際、GitHub Actions OIDC Role に \`cloudformation:ListStacks\` 権限が無く exit code 254 で落ちていた。ECS / ALB の destroy 自体は成功している。

## 変更内容

- Summary step に \`continue-on-error: true\`
- \`list-stacks\` 末尾に \`|| echo "(ListStacks denied; not fatal)"\` フォールバック

## 関連

IAM Role への \`cloudformation:ListStacks\` 付与は frestyle-infrastructure リポで別途対応予定。

## テスト
- workflow yaml のみの変更、ローカルテスト不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow robustness by making the summary step non-critical, allowing graceful handling of potential access errors while preserving core stack deletion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->