### PR TITLE
feat(ci): scheduled-stop で RDS スナップショット → 削除、scheduled-start で snapshot から復元

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -1,16 +1,27 @@
-name: Scheduled - Start (recreate ALB + ECS at morning)
+name: Scheduled - Start (restore RDS + recreate ALB + ECS at morning)
 
-# 目的: 毎日 07:00 JST (22:00 UTC) に ALB と ECS を再作成して稼働開始。
-# scheduled-stop.yml と対になる。
+# 目的: 毎日 07:00 JST (22:00 UTC) に RDS を昨夜の snapshot から復元し、
+# ALB と ECS を再作成して稼働開始。scheduled-stop.yml と対になる。
 #
 # 流れ:
-#   1) ALB を CFn deploy（新しい AWS DNS 名が払い出される）
-#   2) ECS を CFn deploy（IAM Role / Secrets Manager は前夜から残置）
-#   3) Route 53 で api.normanblog.com の Alias レコードを新 ALB に更新
+#   1) RDS スタックが無ければ最新の `frestyle-prod-nightly-*` snapshot から復元
+#      (CFn deploy with DBSnapshotIdentifier=<latest>)
+#   2) ALB を CFn deploy（新しい AWS DNS 名が払い出される）
+#   3) ECS を CFn deploy（IAM Role / Secrets Manager は前夜から残置）
+#   4) Route 53 で api.normanblog.com の Alias レコードを新 ALB に更新
 #      (normanblog.com の Hosted Zone Z02128031IOUNFFKBRXXE)
-#   4) services-stable wait + ヘルスチェック
+#   5) services-stable wait + ヘルスチェック
 #
 # 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+# 必要な追加 IAM 権限:
+#   - rds:DescribeDBSnapshots
+#   - cloudformation:CreateStack / UpdateStack / DescribeStacks（既存）
+#
+# 前提:
+#   - frestyle-infrastructure 側の rds-postgres.yml が `DBSnapshotIdentifier`
+#     パラメータを受け取る形に対応していること（テンプレ未対応の場合は
+#     scheduled-start 初回実行時に param 不一致で fail するので、その時点で
+#     インフラ側に PR を出す）。
 
 on:
   schedule:
@@ -26,8 +37,11 @@ on:
 env:
   AWS_REGION: ap-northeast-1
   STACK_PFX: frestyle-prod
+  RDS_STACK: frestyle-prod-rds-postgres
   AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
   IAC_REPO: norman6464/frestyle-infrastructure
+  # nightly snapshot の prefix（scheduled-stop 側と一致させる）
+  NIGHTLY_SNAPSHOT_PREFIX: frestyle-prod-nightly
   # Route 53: normanblog.com の権威 Hosted Zone（CloudFront も同ゾーンに紐付いている正規ゾーン）
   R53_HOSTED_ZONE_ID: Z02128031IOUNFFKBRXXE
   R53_RECORD_NAME: api.normanblog.com
@@ -69,7 +83,7 @@ jobs:
         run: |
           # 前夜の scheduled-stop / 前回の cd-backend が ROLLBACK_COMPLETE で残っていると
           # 今回の deploy が "stack cannot be updated" で失敗する。先に削除しておく。
-          for STACK in $STACK_PFX-ecs $STACK_PFX-alb; do
+          for STACK in $STACK_PFX-ecs $STACK_PFX-alb $RDS_STACK; do
             STATUS=$(aws cloudformation describe-stacks --region $AWS_REGION \
               --stack-name $STACK --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "ABSENT")
             case "$STATUS" in
@@ -83,6 +97,37 @@ jobs:
                 ;;
             esac
           done
+
+      - name: Restore RDS from latest nightly snapshot (if RDS stack absent)
+        id: restore_rds
+        run: |
+          # RDS スタックが既に存在すれば、昼間の手動運用 (例: バックアップ確認) などで
+          # 起き上がっているので何もしない。
+          if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $RDS_STACK >/dev/null 2>&1; then
+            echo "$RDS_STACK already exists — skip restore"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # 昨夜 scheduled-stop が作った最新の nightly snapshot を取得。
+          LATEST=$(aws rds describe-db-snapshots --region $AWS_REGION \
+            --snapshot-type manual \
+            --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '${NIGHTLY_SNAPSHOT_PREFIX}-') && Status=='available'] | sort_by(@, &SnapshotCreateTime)[-1].DBSnapshotIdentifier" \
+            --output text)
+          if [ -z "$LATEST" ] || [ "$LATEST" = "None" ]; then
+            echo "::error::No nightly snapshot found for prefix '${NIGHTLY_SNAPSHOT_PREFIX}-'"
+            exit 1
+          fi
+          echo "Restoring from snapshot: $LATEST"
+          # rds-postgres.yml は frestyle-infrastructure 側で `DBSnapshotIdentifier`
+          # パラメータを受け付ける必要がある。受け付ければ snapshot 復元として動作。
+          aws cloudformation deploy --region $AWS_REGION \
+            --stack-name $RDS_STACK \
+            --template-file iac/infrastructure/cloudformation/templates/runtime/rds-postgres.yml \
+            --parameter-overrides Environment=prod DBSnapshotIdentifier="$LATEST" \
+            --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
+            --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
+          echo "✅ RDS restored from $LATEST"
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
 
       - name: Deploy ALB stack
         run: |

--- a/.github/workflows/scheduled-stop.yml
+++ b/.github/workflows/scheduled-stop.yml
@@ -1,12 +1,25 @@
-name: Scheduled - Stop (destroy ECS + ALB at night)
+name: Scheduled - Stop (destroy ECS + ALB + RDS at night)
 
-# 目的: 毎日 22:00 JST (13:00 UTC) に ECS + ALB を destroy してコスト節約。
-# RDS / DynamoDB / S3 / SQS / IAM / SG / ECR / Cognito は対象外（データ保護 or 課金影響小）。
+# 目的: 毎日 22:00 JST (13:00 UTC) に ECS + ALB + RDS を destroy してコスト節約。
+# RDS は事前に手動スナップショットを取ってから削除する。翌朝 scheduled-start.yml が
+# その最新スナップショットから RDS を復元して起動する。
+#
+# 順序:
+#   1) ECS destroy（DB connection を全断するため最初に）
+#   2) ALB destroy
+#   3) RDS の手動スナップショット作成（識別子: frestyle-prod-nightly-YYYYMMDD-HHMMSS）
+#   4) snapshot available まで wait
+#   5) RDS スタック destroy（CFn DeletionPolicy: Snapshot により auto final snapshot も作成される）
+#   6) 古い nightly snapshot を 7 世代だけ残してクリーンアップ
 #
 # 復旧は scheduled-start.yml が翌日 07:00 JST に自動実行。
 # 緊急で起こしたい場合は手動で gh workflow run scheduled-start.yml を叩く。
 #
 # 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+# 必要な IAM 権限:
+#   - cloudformation:DeleteStack / DescribeStacks / DescribeStackResources / ListStackResources
+#   - rds:CreateDBSnapshot / DescribeDBSnapshots / DeleteDBSnapshot
+#   - rds:DescribeDBInstances
 
 on:
   schedule:
@@ -22,7 +35,12 @@ on:
 env:
   AWS_REGION: ap-northeast-1
   STACK_PFX: frestyle-prod
+  RDS_STACK: frestyle-prod-rds-postgres
   AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+  # nightly snapshot 識別子の prefix（scheduled-start 側の検索条件と一致させる）
+  NIGHTLY_SNAPSHOT_PREFIX: frestyle-prod-nightly
+  # 残す nightly snapshot の世代数（古いものは削除して RDS 課金を抑える）
+  NIGHTLY_KEEP: 7
 
 permissions:
   id-token: write
@@ -30,9 +48,9 @@ permissions:
 
 jobs:
   stop:
-    name: Destroy ECS + ALB
+    name: Destroy ECS + ALB + RDS (with snapshot)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
 
     steps:
       - name: Verify input (workflow_dispatch only)
@@ -72,8 +90,91 @@ jobs:
             echo "ALB stack already absent, skip"
           fi
 
+      - name: Resolve RDS instance identifier
+        id: rds
+        run: |
+          # RDS スタックから DBInstance リソースの PhysicalResourceId（=DBInstanceIdentifier）を取得。
+          # CFn が自動採番した識別子を直接拾うのが最も確実。
+          if ! aws cloudformation describe-stacks --region $AWS_REGION --stack-name $RDS_STACK >/dev/null 2>&1; then
+            echo "RDS stack ($RDS_STACK) not found — already destroyed. Skip subsequent steps."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          DB_ID=$(aws cloudformation list-stack-resources --region $AWS_REGION \
+            --stack-name $RDS_STACK \
+            --query "StackResourceSummaries[?ResourceType=='AWS::RDS::DBInstance'].PhysicalResourceId | [0]" \
+            --output text)
+          if [ -z "$DB_ID" ] || [ "$DB_ID" = "None" ]; then
+            echo "::error::Could not resolve DBInstanceIdentifier from $RDS_STACK"
+            exit 1
+          fi
+          echo "Resolved DBInstanceIdentifier: $DB_ID"
+          SNAPSHOT_ID="${NIGHTLY_SNAPSHOT_PREFIX}-$(date -u +%Y%m%d-%H%M%S)"
+          {
+            echo "skip=false"
+            echo "db_id=$DB_ID"
+            echo "snapshot_id=$SNAPSHOT_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create manual snapshot before destroying RDS
+        if: steps.rds.outputs.skip != 'true'
+        env:
+          DB_ID: ${{ steps.rds.outputs.db_id }}
+          SNAPSHOT_ID: ${{ steps.rds.outputs.snapshot_id }}
+        run: |
+          echo "Creating manual snapshot: $SNAPSHOT_ID (from $DB_ID)"
+          aws rds create-db-snapshot --region $AWS_REGION \
+            --db-instance-identifier "$DB_ID" \
+            --db-snapshot-identifier "$SNAPSHOT_ID" \
+            --tags Key=Project,Value=FreStyle Key=Environment,Value=prod Key=ManagedBy,Value=scheduled-stop
+          echo "Waiting for snapshot to become available (this may take a few minutes)..."
+          aws rds wait db-snapshot-available --region $AWS_REGION \
+            --db-snapshot-identifier "$SNAPSHOT_ID"
+          echo "✅ Snapshot $SNAPSHOT_ID is available"
+
+      - name: Destroy RDS stack
+        if: steps.rds.outputs.skip != 'true'
+        run: |
+          # CFn の DeletionPolicy: Snapshot により auto final snapshot も作成されるが、
+          # 我々は事前に予測可能な命名 (frestyle-prod-nightly-*) で manual snapshot を取っているので、
+          # こちらが scheduled-start で参照する正規の世代になる。
+          echo "Deleting $RDS_STACK ..."
+          aws cloudformation delete-stack --region $AWS_REGION --stack-name $RDS_STACK
+          aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $RDS_STACK
+          echo "✅ RDS stack deleted"
+
+      - name: Cleanup old nightly snapshots (keep latest N)
+        if: steps.rds.outputs.skip != 'true'
+        continue-on-error: true
+        run: |
+          # nightly prefix を持つ manual snapshot を新しい順に取得し、
+          # NIGHTLY_KEEP より古いものを削除する。CFn auto final snapshot は
+          # `rds:` で始まる system snapshot なので対象外。
+          ALL=$(aws rds describe-db-snapshots --region $AWS_REGION \
+            --snapshot-type manual \
+            --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '${NIGHTLY_SNAPSHOT_PREFIX}-')] | sort_by(@, &SnapshotCreateTime)[].DBSnapshotIdentifier" \
+            --output text)
+          if [ -z "$ALL" ]; then
+            echo "No nightly snapshots found, skip cleanup"
+            exit 0
+          fi
+          # 新しい順 (sort_by は古い順なので reverse する)
+          REVERSED=$(echo "$ALL" | tr '\t' '\n' | tac)
+          KEEP=$NIGHTLY_KEEP
+          IDX=0
+          for SNAP in $REVERSED; do
+            IDX=$((IDX+1))
+            if [ "$IDX" -le "$KEEP" ]; then
+              echo "Keep: $SNAP"
+              continue
+            fi
+            echo "Delete (older than $KEEP latest): $SNAP"
+            aws rds delete-db-snapshot --region $AWS_REGION \
+              --db-snapshot-identifier "$SNAP" || echo "(failed to delete $SNAP, skip)"
+          done
+
       # Summary は非クリティカル。GitHub Actions IAM Role に
-      # cloudformation:ListStacks 権限が無くても本筋 (ECS / ALB destroy) は完了済み。
+      # cloudformation:ListStacks 権限が無くても本筋 (ECS / ALB / RDS destroy) は完了済み。
       # 失敗で workflow 全体を red にしないため continue-on-error / `|| true` で吸収する。
       - name: Summary
         continue-on-error: true


### PR DESCRIPTION
## 概要

ECS / ALB に加えて **RDS も毎晩 destroy** してコスト最大化、翌朝に nightly snapshot からデータ復元して起動する運用に変更する。

## scheduled-stop.yml

ECS / ALB destroy の後に RDS 関連処理を追加:

1. RDS スタックから DBInstanceIdentifier を取得
2. 識別子 \`frestyle-prod-nightly-YYYYMMDD-HHMMSS\` で manual snapshot 作成
3. snapshot available まで wait
4. RDS スタックを CFn delete-stack
5. \`frestyle-prod-nightly-*\` snapshot を最新 7 世代まで保持、古いものは削除

timeout-minutes を 20 → 60 に延長。

## scheduled-start.yml

ALB / ECS deploy の前に RDS 復元ステップを追加:

1. RDS スタック既存ならスキップ
2. \`frestyle-prod-nightly-*\` の最新 manual snapshot を取得
3. \`cloudformation deploy --parameter-overrides DBSnapshotIdentifier=<latest>\` で復元

## 必要な追加 IAM 権限
- \`rds:CreateDBSnapshot\` / \`DescribeDBSnapshots\` / \`DeleteDBSnapshot\`
- \`rds:DescribeDBInstances\`
- \`cloudformation:DescribeStackResources\` / \`ListStackResources\`

## 前提

\`frestyle-infrastructure\` の \`rds-postgres.yml\` が \`DBSnapshotIdentifier\` パラメータに対応している必要がある。未対応の場合は scheduled-start 初回実行で fail するので、その時点でインフラ側に PR を出す。