### PR TITLE
fix(ci): scheduled-start の RDS 復元 parameter 名を SnapshotIdentifier に修正

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -120,10 +120,13 @@ jobs:
           echo "Restoring from snapshot: $LATEST"
           # rds-postgres.yml は frestyle-infrastructure 側で `DBSnapshotIdentifier`
           # パラメータを受け付ける必要がある。受け付ければ snapshot 復元として動作。
+          # rds-postgres.yml の正規パラメータ名は `SnapshotIdentifier`。
+          # 指定すると Conditions.RestoreFromSnapshot が true になり、
+          # DBSnapshotIdentifier として CFn が DB を復元する。
           aws cloudformation deploy --region $AWS_REGION \
             --stack-name $RDS_STACK \
             --template-file iac/infrastructure/cloudformation/templates/runtime/rds-postgres.yml \
-            --parameter-overrides Environment=prod DBSnapshotIdentifier="$LATEST" \
+            --parameter-overrides Environment=prod SnapshotIdentifier="$LATEST" \
             --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
             --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
           echo "✅ RDS restored from $LATEST"


### PR DESCRIPTION
## 概要

PR #1573 で scheduled-start.yml が RDS 復元時に \`DBSnapshotIdentifier\` を渡していたが、frestyle-infrastructure 側の \`rds-postgres.yml\` テンプレは \`SnapshotIdentifier\` という名前で受ける仕様。実テンプレに合わせて修正する。

## 関連

- PR #1573（本体の運用追加）
- frestyle-infrastructure PR #35（IAM Role に RDS 系権限追加）