### PR TITLE
feat(ci): scheduled-start で RDS Managed Secret (rds!*) を優先利用

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -175,9 +175,22 @@ jobs:
           TASK_ROLE=$(aws cloudformation describe-stacks --region $AWS_REGION \
             --stack-name $STACK_PFX-iam \
             --query 'Stacks[0].Outputs[?OutputKey==`TaskRoleArn`].OutputValue' --output text)
-          # PostgreSQL master password (旧 db-master-password ではなく pg-master-password)
-          DB_PWD_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
-            --secret-id $STACK_PFX/pg-master-password --query 'ARN' --output text)
+          # PostgreSQL master password の Secret ARN を解決する（短期 credential 方針）。
+          # 1) RDS スタックが ManageMasterUserPassword=true で作られていれば、AWS が自動生成した
+          #    `MasterUserSecretArn` を output として export している。これは JSON 形式 Secret なので
+          #    ECS Task で参照するときは `:password::` の jsonField suffix が必要。
+          # 2) 無ければ旧来の手動 Secret `frestyle-prod/pg-master-password` (plain string) を使う。
+          MANAGED_SECRET_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-rds-postgres \
+            --query 'Stacks[0].Outputs[?OutputKey==`MasterUserSecretArn`].OutputValue' --output text 2>/dev/null || true)
+          if [ -n "$MANAGED_SECRET_ARN" ] && [ "$MANAGED_SECRET_ARN" != "None" ]; then
+            echo "Using AWS-managed master user secret: $MANAGED_SECRET_ARN"
+            DB_PWD_ARN="${MANAGED_SECRET_ARN}:password::"
+          else
+            echo "MasterUserSecretArn output not found — fallback to manual Secret pg-master-password"
+            DB_PWD_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
+              --secret-id $STACK_PFX/pg-master-password --query 'ARN' --output text)
+          fi
           COG_SEC_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
             --secret-id $STACK_PFX/cognito-client-secret --query 'ARN' --output text)
           ALB_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \


### PR DESCRIPTION
## 概要

frestyle-infrastructure PR #36 で rds-postgres.yml が \`ManageMasterUserPassword=true\` の AWS 自動管理 Secret に対応したため、scheduled-start 側もそれを優先利用するように追従する。

## 変更内容

\`Resolve dependent stack outputs\` step:
1. \`frestyle-prod-rds-postgres\` の Output \`MasterUserSecretArn\` を取得試行
2. 取得できれば \`:password::\` jsonField suffix を付けた ARN を \`DB_PWD_ARN\` に設定（AWS managed Secret は JSON 形式）
3. 取得できなければ従来の \`frestyle-prod/pg-master-password\` を fallback

## 関連
- frestyle-infrastructure PR #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to prioritize RDS-managed database secrets with automatic fallback to manual secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->