### PR TITLE
feat(security): フロントに CSP meta タグ + theme-init 外部ファイル化

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,17 +1,31 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!--
+      Content-Security-Policy:
+        - default-src 'self'                            : 既定で同一オリジン以外を遮断
+        - script-src 'self'                             : インラインスクリプト禁止（Self-XSS / 注入対策）
+        - style-src 'self' 'unsafe-inline'              : Tailwind / React の inline style 用
+        - img-src 'self' data: https:                   : avatar / CDN 経由画像 / data URL
+        - font-src 'self' data:                         : ローカルフォント + base64 埋め込み
+        - connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com
+                                                         : API / WebSocket / Cognito callback
+        - form-action 'self' https://*.amazoncognito.com: ログイン flow が Cognito Hosted UI へ POST
+        - frame-ancestors 'none'                        : Clickjacking 対策（任意ページからの iframe 禁止）
+        - base-uri 'self'                               : <base> 注入対策
+        - object-src 'none'                             : <object>/<embed>/<applet> 禁止
+        - upgrade-insecure-requests                     : http リソース参照を https に強制
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com; form-action 'self' https://*.amazoncognito.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
+
     <title>FreStyle</title>
-    <script>
-      try {
-        if (localStorage.getItem('theme') === 'light') {
-          document.documentElement.classList.add('light');
-        }
-      } catch (e) {}
-    </script>
+    <!-- theme 初期化は public/theme-init.js に外出し（CSP: script-src 'self' を満たすため） -->
+    <script src="/theme-init.js"></script>
   </head>
   <body style="background-color: var(--color-surface, #1A1A1A);">
     <div id="root"></div>

--- a/frontend/public/theme-init.js
+++ b/frontend/public/theme-init.js
@@ -1,0 +1,10 @@
+// 起動時に localStorage の theme を反映する。
+// FOUC を防ぐため <script src> で head 同期実行する想定。
+// inline script を外出ししたのは Content-Security-Policy: script-src 'self' を有効にするため。
+try {
+  if (localStorage.getItem('theme') === 'light') {
+    document.documentElement.classList.add('light');
+  }
+} catch (e) {
+  // localStorage 不可な環境ではデフォルトテーマで起動。
+}


### PR DESCRIPTION
## 概要

Self-XSS リスクの根本対応として、フロントに Content-Security-Policy を導入する。インライン \`<script>\` を排除し \`script-src 'self'\` を厳守。

## 変更内容
- 新規 \`frontend/public/theme-init.js\`（旧 index.html inline script の外部ファイル化）
- \`frontend/index.html\`:
  - \`<meta http-equiv=\"Content-Security-Policy\">\` を追加
  - \`<meta name=\"referrer\" content=\"strict-origin-when-cross-origin\">\`
  - inline script を外部参照に置換

## CSP 値の設計
- \`script-src 'self'\`        インラインスクリプト全面禁止
- \`style-src 'self' 'unsafe-inline'\`  Tailwind / React の inline style 互換
- \`connect-src\`              API / WebSocket / Cognito
- \`frame-ancestors 'none'\`   Clickjacking 対策
- \`upgrade-insecure-requests\` http リソース参照を https 強制

## 関連
- frestyle-infrastructure PR #38（HSTS / X-Frame-Options 等は CloudFront 経由）

## テスト
- [x] \`npm run build\` 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Japanese language support is now available.
* **Security**
  * Strengthened security posture with enhanced Content-Security-Policy and referrer policy controls to improve protection against certain web-based attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->