### PR TITLE
feat(auth): admin 判定を Cognito group + DB role の両方サポート

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -39,6 +39,11 @@ func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, users reposit
 }
 
 // Me は現在ログイン中のユーザー情報を返す。
+// レスポンスは domain.User の各フィールド + 派生 `isAdmin` / `groups` を含める。
+// isAdmin の判定:
+//   1) Cognito の `cognito:groups` claim に "ADMIN" が含まれている (Spring Boot 時代と同等)
+//   2) または DB users.role が super_admin / company_admin
+// 上記いずれかで true。フロントは `isAdmin` を見て管理画面の表示可否を決める。
 func (h *AuthHandler) Me(c *gin.Context) {
 	sub, ok := c.Get(middleware.ContextKeyCognitoSub)
 	if !ok {
@@ -54,7 +59,22 @@ func (h *AuthHandler) Me(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user_not_found"})
 		return
 	}
-	c.JSON(http.StatusOK, user)
+	groups := middleware.CognitoGroupsFromContext(c)
+	isAdmin := middleware.IsAdminFromGroups(groups) ||
+		user.Role == domain.RoleSuperAdmin ||
+		user.Role == domain.RoleCompanyAdmin
+	c.JSON(http.StatusOK, gin.H{
+		"id":          user.ID,
+		"cognitoSub":  user.CognitoSub,
+		"email":       user.Email,
+		"displayName": user.DisplayName,
+		"companyId":   user.CompanyID,
+		"role":        user.Role,
+		"createdAt":   user.CreatedAt,
+		"updatedAt":   user.UpdatedAt,
+		"groups":      groups,
+		"isAdmin":     isAdmin,
+	})
 }
 
 // Logout はリフレッシュ・アクセストークンの Cookie を消去する。
@@ -145,10 +165,18 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	}
 
 	// 初回ログインで users 行が無いと /auth/me が 404 になるため自動で upsert する。
-	// id_token の payload から sub / email を取り出して、未登録なら trainee として作成。
+	// id_token の payload から sub / email / cognito:groups を取り出して同期する:
+	//   - 未登録なら role = (group に ADMIN なら super_admin / 無ければ trainee) で create
+	//   - 既存ユーザーは Cognito group が変わっていれば role を update する
+	// これで Spring Boot 時代と同じ「Cognito group が真のソース」で運用できる。
 	if claims, err := decodeJWTClaims(tok.IDToken); err == nil {
 		sub, _ := claims["sub"].(string)
 		email, _ := claims["email"].(string)
+		groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
+		desiredRole := domain.RoleTrainee
+		if middleware.IsAdminFromGroups(groups) {
+			desiredRole = domain.RoleSuperAdmin
+		}
 		if sub != "" && h.users != nil {
 			existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
 			if existing == nil {
@@ -156,8 +184,13 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 					CognitoSub:  sub,
 					Email:       email,
 					DisplayName: email,
-					Role:        domain.RoleTrainee,
+					Role:        desiredRole,
 				})
+			} else if existing.Role != desiredRole && desiredRole == domain.RoleSuperAdmin {
+				// Cognito group で admin に昇格された場合のみ DB role を上書きする。
+				// 既に DB で super_admin / company_admin が設定されているケースは触らない
+				// （AdminInvitation 系の手動付与が他にある可能性があるため、降格は手動で）。
+				_ = h.users.UpdateRole(c.Request.Context(), existing.ID, desiredRole)
 			}
 		}
 	}

--- a/backend/internal/handler/middleware/jwt.go
+++ b/backend/internal/handler/middleware/jwt.go
@@ -4,16 +4,23 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/gin-gonic/gin"
 )
 
 const (
-	ContextKeyCognitoSub = "cognitoSub"
-	ContextKeyEmail      = "email"
-	CookieAccessToken    = "access_token"
+	ContextKeyCognitoSub    = "cognitoSub"
+	ContextKeyEmail         = "email"
+	ContextKeyCognitoGroups = "cognitoGroups"
+	CookieAccessToken       = "access_token"
 )
+
+// AdminGroupName は Cognito User Pool 上の admin グループ名。
+// resjimkalto89890@gmail.com など管理者ユーザーが所属する。
+// Spring Boot 時代と同じく "ADMIN" を採用。
+const AdminGroupName = "ADMIN"
 
 // JWTAuth は HttpOnly Cookie の access_token を検証する Gin middleware。
 // 現状は payload (claims) の base64 デコードのみで、署名 (JWKS) 検証は別 issue で実装する。
@@ -39,8 +46,47 @@ func JWTAuth() gin.HandlerFunc {
 		if email, ok := claims["email"].(string); ok {
 			c.Set(ContextKeyEmail, email)
 		}
+		// cognito:groups は []string として claim に入る。Spring Boot 時代と同じ
+		// "ADMIN" group を見て管理者判定する想定。
+		if raw, ok := claims["cognito:groups"]; ok {
+			groups := ToStringSliceFromClaim(raw)
+			c.Set(ContextKeyCognitoGroups, groups)
+		}
 		c.Next()
 	}
+}
+
+// ToStringSliceFromClaim は claim の `cognito:groups` を []string に変換する。
+// JSON unmarshal 結果が []any なので逐次 string assert する。
+// auth_handler 等の外部からも使うため exported。
+func ToStringSliceFromClaim(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// CognitoGroupsFromContext は context にセットされた cognito:groups を返す。
+// 未設定 / 不正型の場合は nil。
+func CognitoGroupsFromContext(c *gin.Context) []string {
+	v, ok := c.Get(ContextKeyCognitoGroups)
+	if !ok {
+		return nil
+	}
+	groups, _ := v.([]string)
+	return groups
+}
+
+// IsAdminFromGroups は groups に AdminGroupName が含まれているかを判定する。
+func IsAdminFromGroups(groups []string) bool {
+	return slices.Contains(groups, AdminGroupName)
 }
 
 func decodeClaims(jwt string) (map[string]any, error) {

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -15,6 +15,8 @@ type UserRepository interface {
 	Create(ctx context.Context, user *domain.User) error
 	// UpdateDisplayName は ProfilePage の「ニックネーム」変更で呼ばれる。
 	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
+	// UpdateRole は Cognito group → DB role 同期で呼ばれる。
+	UpdateRole(ctx context.Context, userID uint64, role string) error
 }
 
 type userRepository struct {
@@ -58,4 +60,11 @@ func (r *userRepository) UpdateDisplayName(ctx context.Context, userID uint64, d
 		Model(&domain.User{}).
 		Where("id = ?", userID).
 		Update("display_name", displayName).Error
+}
+
+func (r *userRepository) UpdateRole(ctx context.Context, userID uint64, role string) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ?", userID).
+		Update("role", role).Error
 }

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -23,6 +23,9 @@ func (s *stubUserRepo) Create(_ context.Context, _ *domain.User) error { return 
 func (s *stubUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error {
 	return s.err
 }
+func (s *stubUserRepo) UpdateRole(_ context.Context, _ uint64, _ string) error {
+	return s.err
+}
 
 func TestGetCurrentUserUseCase_Found(t *testing.T) {
 	want := &domain.User{ID: 1, CognitoSub: "abc", Email: "u@example.com"}


### PR DESCRIPTION
## 概要

Spring Boot 時代の \"Cognito ADMIN group が真のソース\" 運用を Go 側で復元する。

\`isAdmin = (cognito:groups に \"ADMIN\") || (users.role が super_admin / company_admin)\`

## 変更内容
- JWT middleware: cognito:groups を context にセット + ヘルパ export
- Auth.Me: \`groups\` / \`isAdmin\` をレスポンスに含める
- Auth.Callback: ADMIN group の場合 users.role を super_admin に upsert / 昇格
- UserRepository: \`UpdateRole\` 追加

## 運用作業（merge 後）
1. Cognito ADMIN group 作成 + resjimkalto89890@gmail.com を追加
2. DB users.role を super_admin に UPDATE（fallback）

## テスト
- [x] go build ./... && go test ./... 全 green