### PR TITLE
fix(auth): admin group 名を小文字 'admin' に修正

### DIFF
--- a/backend/internal/handler/middleware/jwt.go
+++ b/backend/internal/handler/middleware/jwt.go
@@ -19,8 +19,9 @@ const (
 
 // AdminGroupName は Cognito User Pool 上の admin グループ名。
 // resjimkalto89890@gmail.com など管理者ユーザーが所属する。
-// Spring Boot 時代と同じく "ADMIN" を採用。
-const AdminGroupName = "ADMIN"
+// AWS Cognito の group 名は case-sensitive。Pool 2 (ap-northeast-1_TkRen4lyD) の
+// 既存 group `admin` (小文字) を Spring Boot 時代から踏襲している。
+const AdminGroupName = "admin"
 
 // JWTAuth は HttpOnly Cookie の access_token を検証する Gin middleware。
 // 現状は payload (claims) の base64 デコードのみで、署名 (JWKS) 検証は別 issue で実装する。


### PR DESCRIPTION
PR #1579 で AdminGroupName を 'ADMIN' としていたが、Cognito Pool 2 の既存 group は 'admin' (小文字)。Cognito group 名は case-sensitive なので合わせる。