### PR TITLE
feat: 本番スモーク E2E テスト基盤を Playwright + GitHub Actions で追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,84 @@
+name: E2E - Playwright Smoke
+
+# 目的: 本番 (https://normanblog.com / https://api.normanblog.com) に対する
+# 認証前スモーク E2E を Playwright + Chromium で実行する。
+# 失敗時は html report / trace / screenshot / video を artifact に残す。
+#
+# トリガー:
+#   - main への push（cd-frontend / cd-backend が走った後の確認）
+#   - PR (frontend / 主要 workflow / E2E 自体への変更)
+#   - workflow_dispatch（任意のタイミングで実行）
+#
+# CodeBuild ではなく Actions に統一する判断:
+#   - API は public ALB 経由でアクセス可能で VPC 内疎通は不要
+#   - OIDC AssumeRole は今回 不要（外形監視）
+#   - 既存 cd-* / scheduled-* と同 platform に集約してログ・通知を一元管理
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/e2e.yml'
+      - '.github/workflows/cd-frontend.yml'
+      - '.github/workflows/cd-backend.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/e2e.yml'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'PLAYWRIGHT_BASE_URL（既定 https://normanblog.com）'
+        required: false
+        default: 'https://normanblog.com'
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Playwright Smoke (Chromium)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url || 'https://normanblog.com' }}
+        run: npx playwright test --project=chromium
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Upload trace / screenshots / video on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: frontend/test-results/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -113,30 +113,44 @@
   <img src="https://skillicons.dev/icons?i=githubactions&theme=light" alt="CI/CD">
 </a>
 
+<h3>Testing</h3>
+<a href="https://skillicons.dev">
+  <img src="https://skillicons.dev/icons?i=vitest,playwright&theme=light" alt="Testing">
+</a>
+
+> Vitest + React Testing Library（フロントエンド単体）/ `go test`（バックエンド単体）/ Playwright（本番 E2E スモーク、Chromium）
+
 ### AWS サービス詳細
+
+実際にプロビジョン済みのリソースのみ記載しています（CFn テンプレートは [`norman6464/frestyle-infrastructure`](https://github.com/norman6464/frestyle-infrastructure) で管理）。
 
 | カテゴリ | サービス | 用途 |
 |---------|----------|------|
-| **Compute** | ECS (Fargate), ECR | コンテナ実行・イメージ管理 |
-| **Networking** | CloudFront, ALB, Route 53 | CDN・ロードバランシング・DNS |
-| **Database** | RDS (PostgreSQL 16), DynamoDB | リレーショナルDB（GORM 経由）・NoSQL |
-| **Storage** | S3 | フロントエンドホスティング・画像保存 |
-| **Auth** | Cognito | JWT認証 (HttpOnly Cookie) |
-| **AI** | Bedrock | AIチャット（コミュニケーションスコア評価） |
-| **Messaging** | SQS | 非同期レポート生成 |
-| **Security** | WAF | XSS・SQLi・DDoS防御・レート制限 |
-| **Monitoring** | CloudWatch, X-Ray, SNS | メトリクス・分散トレーシング・エラー通知 |
-| **CI/CD** | GitHub Actions | 自動テスト・デプロイ |
+| **Compute** | ECS Fargate, ECR | Go (Gin) backend のコンテナ実行・イメージ管理 |
+| **Networking** | CloudFront, ALB, Route 53, ACM | CDN（フロント SPA + セキュリティヘッダー）・ロードバランシング・DNS（旧 Cloudflare から移管）・TLS 証明書 |
+| **Database** | RDS PostgreSQL 16, DynamoDB | リレーショナル DB（GORM 経由）・チャットメッセージ NoSQL |
+| **Storage** | S3 | フロントエンド静的ホスティング・ノート画像 |
+| **Auth** | Cognito | OAuth 2.0 / OIDC + JWT (HttpOnly Cookie)・SRP / Hosted UI |
+| **Secrets** | Secrets Manager | RDS マスターパスワード（`ManageMasterUserPassword` で自動ローテーション） |
+| **Messaging** | SQS (+ DLQ) | 非同期レポート生成キュー（Spring Boot 時代の遺産、Go 移行後は段階的に整理予定） |
+| **Identity** | IAM (OIDC Provider) | GitHub Actions の AssumeRole（長期キー廃止、一時クレデンシャル運用） |
+| **Monitoring** | CloudWatch Logs | ECS Task / RDS のログ集約 |
+| **CI/CD** | GitHub Actions | 自動テスト・E2E (Playwright) ・cd-frontend / cd-backend |
+
+> **未使用のサービス（過去の README に記載があったもの）**: API Gateway / Lambda / WAF / X-Ray / SNS / Bedrock。
+> WebSocket は API Gateway + Lambda 構成ではなく、**ECS 上の Go backend が `gorilla/websocket` で直接 upgrade** する単一経路に統一しています。Bedrock 連携と AI スコアリングは現状ハンドラのスケルトンのみで、本番投入は後続 PR で行います。
 
 ---
 
 ## Architecture Highlights（工夫した点）
 
-### ① WebSocket と HTTP API の構成を用途別に完全分離
-- **WebSocket**：API Gateway + Lambda + DynamoDB
-- **HTTP（Rest API）**：ECS（Fargate） + Go (Gin)
+### ① HTTP / WebSocket を ECS + Go で単一経路化
+- **HTTP API / WebSocket** ともに **ECS Fargate 上の Go (Gin)** に集約
+- WebSocket は `gorilla/websocket` で ALB → ECS Task に直接 upgrade（Sticky Session 不要・stateless 化）
+- 旧構成（Spring Boot 時代）の **API Gateway + Lambda + DynamoDB** のサーバレス WS は廃止し、ALB を 1 本にまとめてコスト・運用・可観測性を一元化
+- フロントエンドは `wss://api.normanblog.com/api/v2/ws/...` で接続、Cognito JWT (HttpOnly Cookie) を Origin チェックと併用して認証
 
-リアルタイム性と低コストを優先した WebSocket と、安定稼働・複雑処理に適した HTTP API を分離し、性能・コスト・可用性の最適化を実現。
+> 旧 Lambda + API Gateway 構成を廃止した理由は本 README 末尾の「なぜアーキテクチャーを変えたのか」を参照。
 
 ### ② JWT（HttpOnly Cookie）× Cognito の安全な認証設計
 - JWT を HttpOnly Cookie に保存（XSS 対策）
@@ -302,11 +316,12 @@ sequenceDiagram
 ---
 
 ## 苦労した点・学び
-- WebSocket を ECS で保持するか、サーバーレスにするかの検討 → コスト / 工数削減 / レイテンシから Lambda + APIGW に決定
-- Spring Security の JWT / JWK / Cookie 設計（Go 移行後は Gin middleware で再実装）
-- ALB の TLS Termination と ECS の Backend 構成
-- Spring Boot の JVM オーバーヘッドにより Fargate 2 vCPU / 4 GB を要し、ランニングコストが嵩んでいた → Go (Gin + GORM) に置き換えて 0.25 vCPU / 0.5 GB へ縮退する設計に切替
-- 既存資産を捨てない移行戦略の設計（path-based routing による Spring Boot / Go 並行運用）
+- **WebSocket の構成方針転換**: 当初は Lambda + API Gateway のサーバレス WebSocket でコスト最適化していたが、トラフィック増加時のスケール特性とコネクション管理（DynamoDB の `connectionId` テーブル）の運用負荷が嵩み、最終的に **ECS + `gorilla/websocket` の単一経路** に統一
+- Spring Security の JWT / JWK / Cookie 設計を Go 移行後は **Gin middleware（`golang-jwt/jwt` + Cognito JWKS キャッシュ）** で再実装
+- ALB の TLS Termination（ACM 証明書）と ECS Backend 間は HTTP（VPC 内）で割り切り、外向き HTTPS 強制は CloudFront の ResponseHeadersPolicy + HSTS で多層化
+- Spring Boot の JVM オーバーヘッドにより Fargate 2 vCPU / 4 GB を要し、ランニングコストが嵩んでいた → Go (Gin + GORM) に置き換えて **0.25 vCPU / 0.5 GB へ縮退（約 80% コスト削減）**
+- 既存資産を捨てない移行戦略の設計（path-based routing による Spring Boot / Go 並行運用 → 全機能 cutover 後に Spring Boot を完全削除）
+- RDS マスターパスワードを **Secrets Manager の自動ローテーション**（`ManageMasterUserPassword=true`）に切替えて、`.env` での平文保管を撤廃
 
 ---
 
@@ -332,18 +347,18 @@ sequenceDiagram
 
 ---
 
-## 技術選定理由（WebSocket / サーバーレス構成）
+## 技術選定理由（WebSocket / ECS 一本化）
 
-1. コスト最適化（従量課金）  
-   ECS 常時稼働より大幅に低コスト。
+旧構成（API Gateway + Lambda + DynamoDB）を廃止し、**ECS + Go (`gorilla/websocket`) の単一経路** に統一した理由:
 
-2. 低レイテンシ & シンプルな処理  
-   Lambda → DynamoDB の最短経路。
-
-3. サーバーレスで構成統一
-   - フルマネージド
-   - 自動スケーリング
-   - 運用負荷最小
+1. **複雑なクエリの直行性**  
+   AI フィードバックでユーザの過去スコア・性格傾向・チャット履歴を組み合わせる必要があり、DynamoDB だけだと application 側の join が肥大化。RDS（PostgreSQL）+ DynamoDB のハイブリッドにし、ECS 上の Go から両方を直接叩く方が単純。
+2. **トラフィック増加時のスケール**  
+   Lambda 同時実行数の上限・cold start・WS 切断時の再接続コスト（API Gateway の billing 単位）が運用上のリスクになっていた。ECS Fargate なら `desired count` で水平スケールでき、ALB のヘルスチェックで自己修復可能。
+3. **可観測性とデプロイ単位の統一**  
+   HTTP / WebSocket を 1 つの ECS Service に同居させると、ログ・メトリクス・デプロイ単位が 1 本化されて運用が楽（CloudWatch Logs Group を分けずに済む）。
+4. **コスト**  
+   Go バイナリは 0.25 vCPU / 0.5 GB Fargate で常時稼働しても月 $9 前後。WS のコネクション課金が無くなる分、トラフィックが伸びるほど ECS の方が有利。
 
 ---
 
@@ -530,6 +545,19 @@ npm test
 
 - Vitest + React Testing Library
 - 慣習: `vi.stubGlobal('localStorage', createMockStorage())` で localStorage をスタブ、`fireEvent` でイベント発火
+
+#### E2E (Playwright)
+
+```bash
+cd frontend
+npm run e2e:install   # 初回のみ（Chromium + OS deps）
+npm run e2e            # 本番に対してスモーク 6 ケース
+npm run e2e:ui         # UI モードでデバッグ
+PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run e2e   # ローカル dev server 経由
+```
+
+- 認証前スモーク（SPA ロード / セキュリティヘッダー / CSP / API health / 認証 401 / SockJS 廃止確認）を **GitHub Actions の `E2E - Playwright Smoke` workflow** で push to main / PR / `workflow_dispatch` 時に実行
+- 詳細・運用手順・将来の認証付き E2E への拡張ガイドは [`norman6464/frestyle-infrastructure` の docs/17-e2e-playwright-runbook.md](https://github.com/norman6464/frestyle-infrastructure/blob/main/docs/17-e2e-playwright-runbook.md) を参照
 
 ---
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -14,6 +14,12 @@ dist-ssr
 .env
 .env.production
 
+# Playwright E2E artifacts
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * スモーク E2E: 認証前でも検証可能な「サイトが生きているか」を網羅的に確認する。
+ *
+ * - 公開 SPA がレンダリングできる
+ * - CloudFront 経由のセキュリティヘッダーが正しく配信されている
+ * - API ヘルスチェックが 200 を返す
+ * - 認証必須エンドポイントが Cookie 無しで 401 を返す
+ *
+ * 認証付きフロー (ログイン後の管理画面 / ノート CRUD 等) は Cognito Hosted UI に
+ * 依存するため、別 spec で `storageState` 経由の事前認証パターンを使う想定。
+ */
+
+const API_BASE = 'https://api.normanblog.com';
+
+test.describe('FreStyle smoke', () => {
+  test('SPA がロードされ FreStyle ロゴ / ログイン誘導が見える', async ({ page }) => {
+    await page.goto('/');
+    await expect(page).toHaveTitle(/FreStyle/);
+    // SPA の root が描画されるまで待つ
+    await page.waitForLoadState('networkidle');
+    // ログイン前は LoginPage か Landing が出る。'fre' / 'login' のどちらかが見える前提
+    const visibleText = (await page.locator('body').innerText()).toLowerCase();
+    expect(visibleText.length).toBeGreaterThan(0);
+  });
+
+  test('CloudFront セキュリティヘッダーが配信される', async ({ request }) => {
+    const res = await request.get('/');
+    const headers = res.headers();
+    expect(headers['strict-transport-security']).toMatch(/max-age=\d+/);
+    expect(headers['x-frame-options']).toBe('DENY');
+    expect(headers['x-content-type-options']).toBe('nosniff');
+    expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+    expect(headers['permissions-policy']).toContain('camera=()');
+  });
+
+  test('CSP meta タグが index.html に含まれている', async ({ request }) => {
+    const res = await request.get('/');
+    const html = await res.text();
+    expect(html).toMatch(/<meta http-equiv="Content-Security-Policy"/);
+    expect(html).toContain("script-src 'self'");
+    expect(html).toContain('upgrade-insecure-requests');
+  });
+
+  test('API /api/v2/health は 200 を返す', async ({ request }) => {
+    const res = await request.get(`${API_BASE}/api/v2/health`);
+    expect(res.status()).toBe(200);
+  });
+
+  test('認証必須エンドポイントは Cookie 無で 401 を返す', async ({ request }) => {
+    for (const path of [
+      '/api/v2/auth/me',
+      '/api/v2/notes',
+      '/api/v2/profile/me',
+      '/api/v2/score-goals',
+      '/api/v2/notifications',
+    ]) {
+      const res = await request.get(`${API_BASE}${path}`);
+      expect.soft(res.status(), `${path} should be 401`).toBe(401);
+    }
+  });
+
+  test('SockJS フォールバック路は廃止済（404 / 401）', async ({ request }) => {
+    // PR #1557 で sockJSInfo handler を廃止したので /info 系は 404 になる。
+    const ws = await request.get(`${API_BASE}/api/v2/ws/ai-chat/info`);
+    expect([401, 404]).toContain(ws.status());
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.1.16",
@@ -1402,6 +1403,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5415,6 +5432,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:install": "playwright install --with-deps chromium",
     "tailwind:init": "tailwindcss init -p"
   },
   "dependencies": {
@@ -52,6 +55,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.1.16",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E config
+ *
+ * - 既定 baseURL は production (https://normanblog.com)。
+ *   ローカルや Preview 環境を狙うときは PLAYWRIGHT_BASE_URL を上書きする。
+ * - CI では retries=2 + workers=2、ローカルは retries=0 で速く回す。
+ * - 失敗時は trace + screenshot + video を artifact として残す。
+ *
+ * 参考:
+ *   npx playwright test                       # 全 E2E
+ *   npx playwright test e2e/smoke.spec.ts     # 単一 spec
+ *   PLAYWRIGHT_BASE_URL=http://localhost:5173 npx playwright test
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['html', { open: 'never' }], ['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://normanblog.com',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    extraHTTPHeaders: {
+      // Bot 判定避けに UA 文字列を素直に送る（Playwright 既定でも入るが明示）。
+      'User-Agent': 'Mozilla/5.0 (FreStyle E2E / Playwright)',
+    },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -7,5 +7,9 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './src/test/setup.ts',
+    // Playwright E2E は別 runner（npm run e2e）で実行する。
+    // Vitest が e2e/*.spec.ts を拾うと @playwright/test の test.describe が
+    // 「configuration から呼ばれた」扱いになって落ちるので明示的に除外する。
+    exclude: ['node_modules', 'dist', 'e2e/**', '**/playwright-report/**'],
   },
 });


### PR DESCRIPTION
## 概要

本番（`https://normanblog.com` / `https://api.normanblog.com`）に対する **認証前スモーク E2E テスト基盤** を Playwright + GitHub Actions で追加します。`cd-frontend` / `cd-backend` 完走後に自動回帰し、`workflow_dispatch` で手動疎通確認も可能です。設計・運用手順・将来の認証付き E2E への拡張ガイドは [`norman6464/frestyle-infrastructure` の docs/17-e2e-playwright-runbook.md（PR #39）](https://github.com/norman6464/frestyle-infrastructure/pull/39) に記録しています。

## 変更内容

### E2E 基盤
- `frontend/playwright.config.ts`：Chromium / 本番 baseURL / `retries=2 in CI` / `trace: on-first-retry`
- `frontend/e2e/smoke.spec.ts`：6 ケースのスモーク
  - SPA ロード（`<title>FreStyle</title>`）
  - CloudFront セキュリティヘッダー（HSTS / X-Frame-Options / X-Content-Type-Options / Referrer-Policy / Permissions-Policy）
  - CSP meta タグ（`script-src 'self'` / `upgrade-insecure-requests`）
  - `GET /api/v2/health` が 200
  - 認証必須エンドポイント（`/auth/me`, `/notes`, `/profile/me`, `/score-goals`, `/notifications`）が Cookie 無で 401
  - SockJS フォールバック路の廃止確認（401 / 404）
- `.github/workflows/e2e.yml`：push to main / PR (frontend / 主要 workflow / E2E 自体への変更) / `workflow_dispatch`
  - `permissions: contents: read` のみ（OIDC AssumeRole 不要 = 外部公開 ALB のみ叩く）
  - HTML report は常時、trace / screenshot / video は失敗時のみ artifact（retention 7 日）

### README 現状反映
- AWS サービス一覧を **実プロビジョン状況** に更新
  - 削除（未使用）: API Gateway / Lambda / WAF / X-Ray / SNS / Bedrock（handler スケルトンのみのため）
  - 追記: Secrets Manager（RDS マスターパスワード自動ローテ）/ ACM / IAM OIDC Provider
- 「Architecture Highlights ①」を **WebSocket = ECS + gorilla/websocket** に修正（旧 Lambda + APIGW 構成を廃止）
- 「技術選定理由（WebSocket / サーバーレス構成）」を **「WebSocket / ECS 一本化」** に書き換え
- 「Testing」スキルアイコン（Vitest + Playwright）と E2E 実行手順を追加

## テスト

- [x] ローカル実行：`cd frontend && npx playwright install --with-deps chromium && npm run e2e` → 6 passed (7.2s)
- [x] `package.json` の e2e / e2e:ui / e2e:install scripts が動作
- [x] `.gitignore` に Playwright artifact パスを追加し、誤コミットを防止
- [ ] PR 作成後 GitHub Actions の `E2E - Playwright Smoke` がグリーンであること
- [ ] `workflow_dispatch` から手動実行でグリーンであること

## 関連

- 設計ドキュメント: [`norman6464/frestyle-infrastructure` の docs/17-e2e-playwright-runbook.md（PR #39）](https://github.com/norman6464/frestyle-infrastructure/pull/39)
- セキュリティヘッダー定義: `frestyle-infrastructure/infrastructure/cloudformation/templates/runtime/cloudfront-security-headers.yml`
- SockJS 廃止経緯: `frestyle-infrastructure/docs/15-go-backend-cutover-runbook.md`