### PR TITLE
refactor(backend): gofmt 全体適用 + README から未使用 AWS サービス記述を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,6 @@
 | **Monitoring** | CloudWatch Logs | ECS Task / RDS のログ集約 |
 | **CI/CD** | GitHub Actions | 自動テスト・E2E (Playwright) ・cd-frontend / cd-backend |
 
-> **未使用のサービス（過去の README に記載があったもの）**: API Gateway / Lambda / WAF / X-Ray / SNS / Bedrock。
-> WebSocket は API Gateway + Lambda 構成ではなく、**ECS 上の Go backend が `gorilla/websocket` で直接 upgrade** する単一経路に統一しています。Bedrock 連携と AI スコアリングは現状ハンドラのスケルトンのみで、本番投入は後続 PR で行います。
-
 ---
 
 ## Architecture Highlights（工夫した点）

--- a/backend/internal/domain/chat.go
+++ b/backend/internal/domain/chat.go
@@ -14,9 +14,9 @@ func (ChatRoom) TableName() string { return "chat_rooms" }
 
 // ChatRoomMember はルームに所属するユーザー。
 type ChatRoomMember struct {
-	ID       uint64 `gorm:"primaryKey" json:"id"`
-	RoomID   uint64 `gorm:"column:room_id;index" json:"roomId"`
-	UserID   uint64 `gorm:"column:user_id;index" json:"userId"`
+	ID       uint64    `gorm:"primaryKey" json:"id"`
+	RoomID   uint64    `gorm:"column:room_id;index" json:"roomId"`
+	UserID   uint64    `gorm:"column:user_id;index" json:"userId"`
 	JoinedAt time.Time `gorm:"column:joined_at" json:"joinedAt"`
 }
 

--- a/backend/internal/domain/health.go
+++ b/backend/internal/domain/health.go
@@ -3,8 +3,8 @@ package domain
 // Health はバックエンドの稼働状態を表すドメインモデル。
 // Spring Boot 側の /actuator/health 相当。
 type Health struct {
-	Status     string `json:"status"`
-	DBStatus   string `json:"db"`
+	Status   string `json:"status"`
+	DBStatus string `json:"db"`
 }
 
 const (

--- a/backend/internal/domain/score_card.go
+++ b/backend/internal/domain/score_card.go
@@ -4,17 +4,17 @@ import "time"
 
 // ScoreCard は AI が評価したスコア結果。
 type ScoreCard struct {
-	ID                uint64    `gorm:"primaryKey" json:"id"`
-	UserID            uint64    `gorm:"column:user_id;index" json:"userId"`
-	SessionID         uint64    `gorm:"column:session_id;index" json:"sessionId"`
-	OverallScore      float64   `gorm:"column:overall_score" json:"overallScore"`
-	LogicalScore      float64   `gorm:"column:logical_score" json:"logicalScore"`
-	ConsiderationScore float64  `gorm:"column:consideration_score" json:"considerationScore"`
-	SummaryScore      float64   `gorm:"column:summary_score" json:"summaryScore"`
-	ProposalScore     float64   `gorm:"column:proposal_score" json:"proposalScore"`
-	ListeningScore    float64   `gorm:"column:listening_score" json:"listeningScore"`
-	Feedback          string    `gorm:"column:feedback" json:"feedback"`
-	CreatedAt         time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID                 uint64    `gorm:"primaryKey" json:"id"`
+	UserID             uint64    `gorm:"column:user_id;index" json:"userId"`
+	SessionID          uint64    `gorm:"column:session_id;index" json:"sessionId"`
+	OverallScore       float64   `gorm:"column:overall_score" json:"overallScore"`
+	LogicalScore       float64   `gorm:"column:logical_score" json:"logicalScore"`
+	ConsiderationScore float64   `gorm:"column:consideration_score" json:"considerationScore"`
+	SummaryScore       float64   `gorm:"column:summary_score" json:"summaryScore"`
+	ProposalScore      float64   `gorm:"column:proposal_score" json:"proposalScore"`
+	ListeningScore     float64   `gorm:"column:listening_score" json:"listeningScore"`
+	Feedback           string    `gorm:"column:feedback" json:"feedback"`
+	CreatedAt          time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (ScoreCard) TableName() string { return "score_cards" }

--- a/backend/internal/domain/shared_session.go
+++ b/backend/internal/domain/shared_session.go
@@ -4,13 +4,13 @@ import "time"
 
 // SharedSession はコミュニティに共有された AI 会話セッションのメタデータ。
 type SharedSession struct {
-	ID            uint64    `gorm:"primaryKey" json:"id"`
-	OwnerID       uint64    `gorm:"column:owner_id;index" json:"ownerId"`
-	SessionID     uint64    `gorm:"column:session_id;index" json:"sessionId"`
-	Title         string    `gorm:"column:title" json:"title"`
-	Description   string    `gorm:"column:description" json:"description"`
-	IsPublic      bool      `gorm:"column:is_public" json:"isPublic"`
-	CreatedAt     time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID          uint64    `gorm:"primaryKey" json:"id"`
+	OwnerID     uint64    `gorm:"column:owner_id;index" json:"ownerId"`
+	SessionID   uint64    `gorm:"column:session_id;index" json:"sessionId"`
+	Title       string    `gorm:"column:title" json:"title"`
+	Description string    `gorm:"column:description" json:"description"`
+	IsPublic    bool      `gorm:"column:is_public" json:"isPublic"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (SharedSession) TableName() string { return "shared_sessions" }

--- a/backend/internal/domain/user_stats.go
+++ b/backend/internal/domain/user_stats.go
@@ -3,9 +3,9 @@ package domain
 // UserStats は集計済みのユーザー統計。テーブル直結ではなく
 // セッション・スコアからの計算結果として扱う。
 type UserStats struct {
-	UserID         uint64  `json:"userId"`
-	TotalSessions  int     `json:"totalSessions"`
-	AverageScore   float64 `json:"averageScore"`
-	StreakDays     int     `json:"streakDays"`
-	LongestStreak  int     `json:"longestStreak"`
+	UserID        uint64  `json:"userId"`
+	TotalSessions int     `json:"totalSessions"`
+	AverageScore  float64 `json:"averageScore"`
+	StreakDays    int     `json:"streakDays"`
+	LongestStreak int     `json:"longestStreak"`
 }

--- a/backend/internal/domain/weekly_challenge.go
+++ b/backend/internal/domain/weekly_challenge.go
@@ -3,12 +3,12 @@ package domain
 import "time"
 
 type WeeklyChallenge struct {
-	ID         uint64    `gorm:"primaryKey" json:"id"`
-	WeekStart  time.Time `gorm:"column:week_start;type:date" json:"weekStart"`
-	Title      string    `gorm:"column:title" json:"title"`
-	Description string   `gorm:"column:description" json:"description"`
-	IsActive   bool      `gorm:"column:is_active" json:"isActive"`
-	CreatedAt  time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID          uint64    `gorm:"primaryKey" json:"id"`
+	WeekStart   time.Time `gorm:"column:week_start;type:date" json:"weekStart"`
+	Title       string    `gorm:"column:title" json:"title"`
+	Description string    `gorm:"column:description" json:"description"`
+	IsActive    bool      `gorm:"column:is_active" json:"isActive"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (WeeklyChallenge) TableName() string { return "weekly_challenges" }

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -41,8 +41,9 @@ func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, users reposit
 // Me は現在ログイン中のユーザー情報を返す。
 // レスポンスは domain.User の各フィールド + 派生 `isAdmin` / `groups` を含める。
 // isAdmin の判定:
-//   1) Cognito の `cognito:groups` claim に "ADMIN" が含まれている (Spring Boot 時代と同等)
-//   2) または DB users.role が super_admin / company_admin
+//  1. Cognito の `cognito:groups` claim に "ADMIN" が含まれている (Spring Boot 時代と同等)
+//  2. または DB users.role が super_admin / company_admin
+//
 // 上記いずれかで true。フロントは `isAdmin` を見て管理画面の表示可否を決める。
 func (h *AuthHandler) Me(c *gin.Context) {
 	sub, ok := c.Get(middleware.ContextKeyCognitoSub)

--- a/backend/internal/handler/middleware/cors.go
+++ b/backend/internal/handler/middleware/cors.go
@@ -8,10 +8,10 @@ import (
 
 // 許可するオリジン。Spring Boot の CorsConfig と同じ値を Go 側でも維持する。
 var allowedOrigins = map[string]struct{}{
-	"https://normanblog.com":      {},
-	"http://normanblog.com":       {},
-	"http://localhost:5173":       {},
-	"https://dcd3m6lwt0z8u.cloudfront.net": {},
+	"https://normanblog.com":                                          {},
+	"http://normanblog.com":                                           {},
+	"http://localhost:5173":                                           {},
+	"https://dcd3m6lwt0z8u.cloudfront.net":                            {},
 	"http://fre-style-bucket.s3-website-ap-northeast-1.amazonaws.com": {},
 }
 

--- a/backend/internal/repository/notification_repository.go
+++ b/backend/internal/repository/notification_repository.go
@@ -20,7 +20,9 @@ type NotificationRepository interface {
 
 type notificationRepository struct{ db *gorm.DB }
 
-func NewNotificationRepository(db *gorm.DB) NotificationRepository { return &notificationRepository{db: db} }
+func NewNotificationRepository(db *gorm.DB) NotificationRepository {
+	return &notificationRepository{db: db}
+}
 
 func (r *notificationRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error) {
 	var rows []domain.Notification

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -9,7 +9,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListAdminInvitationsUseCase struct{ repo repository.AdminInvitationRepository }
+type ListAdminInvitationsUseCase struct {
+	repo repository.AdminInvitationRepository
+}
 
 func NewListAdminInvitationsUseCase(r repository.AdminInvitationRepository) *ListAdminInvitationsUseCase {
 	return &ListAdminInvitationsUseCase{repo: r}
@@ -56,7 +58,9 @@ func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdm
 	return inv, nil
 }
 
-type CancelAdminInvitationUseCase struct{ repo repository.AdminInvitationRepository }
+type CancelAdminInvitationUseCase struct {
+	repo repository.AdminInvitationRepository
+}
 
 func NewCancelAdminInvitationUseCase(r repository.AdminInvitationRepository) *CancelAdminInvitationUseCase {
 	return &CancelAdminInvitationUseCase{repo: r}

--- a/backend/internal/usecase/admin_scenario_usecase.go
+++ b/backend/internal/usecase/admin_scenario_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListAdminScenariosUseCase struct{ repo repository.AdminScenarioRepository }
+type ListAdminScenariosUseCase struct {
+	repo repository.AdminScenarioRepository
+}
 
 func NewListAdminScenariosUseCase(r repository.AdminScenarioRepository) *ListAdminScenariosUseCase {
 	return &ListAdminScenariosUseCase{repo: r}
@@ -18,7 +20,9 @@ func (u *ListAdminScenariosUseCase) Execute(ctx context.Context) ([]domain.Pract
 	return u.repo.List(ctx)
 }
 
-type CreateAdminScenarioUseCase struct{ repo repository.AdminScenarioRepository }
+type CreateAdminScenarioUseCase struct {
+	repo repository.AdminScenarioRepository
+}
 
 func NewCreateAdminScenarioUseCase(r repository.AdminScenarioRepository) *CreateAdminScenarioUseCase {
 	return &CreateAdminScenarioUseCase{repo: r}
@@ -34,7 +38,9 @@ func (u *CreateAdminScenarioUseCase) Execute(ctx context.Context, s *domain.Prac
 	return s, nil
 }
 
-type UpdateAdminScenarioUseCase struct{ repo repository.AdminScenarioRepository }
+type UpdateAdminScenarioUseCase struct {
+	repo repository.AdminScenarioRepository
+}
 
 func NewUpdateAdminScenarioUseCase(r repository.AdminScenarioRepository) *UpdateAdminScenarioUseCase {
 	return &UpdateAdminScenarioUseCase{repo: r}
@@ -50,7 +56,9 @@ func (u *UpdateAdminScenarioUseCase) Execute(ctx context.Context, s *domain.Prac
 	return s, nil
 }
 
-type DeleteAdminScenarioUseCase struct{ repo repository.AdminScenarioRepository }
+type DeleteAdminScenarioUseCase struct {
+	repo repository.AdminScenarioRepository
+}
 
 func NewDeleteAdminScenarioUseCase(r repository.AdminScenarioRepository) *DeleteAdminScenarioUseCase {
 	return &DeleteAdminScenarioUseCase{repo: r}

--- a/backend/internal/usecase/conversation_template_usecase.go
+++ b/backend/internal/usecase/conversation_template_usecase.go
@@ -7,7 +7,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListConversationTemplatesUseCase struct{ repo repository.ConversationTemplateRepository }
+type ListConversationTemplatesUseCase struct {
+	repo repository.ConversationTemplateRepository
+}
 
 func NewListConversationTemplatesUseCase(r repository.ConversationTemplateRepository) *ListConversationTemplatesUseCase {
 	return &ListConversationTemplatesUseCase{repo: r}

--- a/backend/internal/usecase/daily_goal_usecase.go
+++ b/backend/internal/usecase/daily_goal_usecase.go
@@ -9,7 +9,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type GetDailyGoalUseCase struct{ repo repository.DailyGoalRepository }
+type GetDailyGoalUseCase struct {
+	repo repository.DailyGoalRepository
+}
 
 func NewGetDailyGoalUseCase(r repository.DailyGoalRepository) *GetDailyGoalUseCase {
 	return &GetDailyGoalUseCase{repo: r}
@@ -22,7 +24,9 @@ func (u *GetDailyGoalUseCase) Execute(ctx context.Context, userID uint64, date t
 	return u.repo.FindByUserAndDate(ctx, userID, date)
 }
 
-type UpsertDailyGoalUseCase struct{ repo repository.DailyGoalRepository }
+type UpsertDailyGoalUseCase struct {
+	repo repository.DailyGoalRepository
+}
 
 func NewUpsertDailyGoalUseCase(r repository.DailyGoalRepository) *UpsertDailyGoalUseCase {
 	return &UpsertDailyGoalUseCase{repo: r}

--- a/backend/internal/usecase/favorite_phrase_usecase.go
+++ b/backend/internal/usecase/favorite_phrase_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListFavoritePhrasesUseCase struct{ repo repository.FavoritePhraseRepository }
+type ListFavoritePhrasesUseCase struct {
+	repo repository.FavoritePhraseRepository
+}
 
 func NewListFavoritePhrasesUseCase(r repository.FavoritePhraseRepository) *ListFavoritePhrasesUseCase {
 	return &ListFavoritePhrasesUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *ListFavoritePhrasesUseCase) Execute(ctx context.Context, userID uint64)
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-type AddFavoritePhraseUseCase struct{ repo repository.FavoritePhraseRepository }
+type AddFavoritePhraseUseCase struct {
+	repo repository.FavoritePhraseRepository
+}
 
 func NewAddFavoritePhraseUseCase(r repository.FavoritePhraseRepository) *AddFavoritePhraseUseCase {
 	return &AddFavoritePhraseUseCase{repo: r}
@@ -38,7 +42,9 @@ func (u *AddFavoritePhraseUseCase) Execute(ctx context.Context, userID uint64, p
 	return p, nil
 }
 
-type DeleteFavoritePhraseUseCase struct{ repo repository.FavoritePhraseRepository }
+type DeleteFavoritePhraseUseCase struct {
+	repo repository.FavoritePhraseRepository
+}
 
 func NewDeleteFavoritePhraseUseCase(r repository.FavoritePhraseRepository) *DeleteFavoritePhraseUseCase {
 	return &DeleteFavoritePhraseUseCase{repo: r}

--- a/backend/internal/usecase/favorite_phrase_usecase_test.go
+++ b/backend/internal/usecase/favorite_phrase_usecase_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 type stubFavPhraseRepo struct {
-	rows           []domain.FavoritePhrase
-	err            error
-	deletedUserID  uint64
-	deletedID      uint64
+	rows          []domain.FavoritePhrase
+	err           error
+	deletedUserID uint64
+	deletedID     uint64
 }
 
 func (s *stubFavPhraseRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.FavoritePhrase, error) {

--- a/backend/internal/usecase/friendship_usecase.go
+++ b/backend/internal/usecase/friendship_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListFriendshipsUseCase struct{ repo repository.FriendshipRepository }
+type ListFriendshipsUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewListFriendshipsUseCase(r repository.FriendshipRepository) *ListFriendshipsUseCase {
 	return &ListFriendshipsUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *ListFriendshipsUseCase) Execute(ctx context.Context, userID uint64) ([]
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-type RequestFriendshipUseCase struct{ repo repository.FriendshipRepository }
+type RequestFriendshipUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewRequestFriendshipUseCase(r repository.FriendshipRepository) *RequestFriendshipUseCase {
 	return &RequestFriendshipUseCase{repo: r}
@@ -41,7 +45,9 @@ func (u *RequestFriendshipUseCase) Execute(ctx context.Context, requesterID, add
 	return f, nil
 }
 
-type RespondFriendshipUseCase struct{ repo repository.FriendshipRepository }
+type RespondFriendshipUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewRespondFriendshipUseCase(r repository.FriendshipRepository) *RespondFriendshipUseCase {
 	return &RespondFriendshipUseCase{repo: r}
@@ -60,7 +66,9 @@ func (u *RespondFriendshipUseCase) Execute(ctx context.Context, id uint64, accep
 
 // FollowUserUseCase は単方向フォロー（accepted の Friendship を即時作成）。
 // フロントの follow ボタンが確認なしで完了する仕様に合わせる。
-type FollowUserUseCase struct{ repo repository.FriendshipRepository }
+type FollowUserUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewFollowUserUseCase(r repository.FriendshipRepository) *FollowUserUseCase {
 	return &FollowUserUseCase{repo: r}
@@ -89,7 +97,9 @@ func (u *FollowUserUseCase) Execute(ctx context.Context, followerID, targetID ui
 	return f, nil
 }
 
-type UnfollowUserUseCase struct{ repo repository.FriendshipRepository }
+type UnfollowUserUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewUnfollowUserUseCase(r repository.FriendshipRepository) *UnfollowUserUseCase {
 	return &UnfollowUserUseCase{repo: r}
@@ -102,7 +112,9 @@ func (u *UnfollowUserUseCase) Execute(ctx context.Context, followerID, targetID 
 	return u.repo.DeleteBetween(ctx, followerID, targetID)
 }
 
-type ListFollowingUseCase struct{ repo repository.FriendshipRepository }
+type ListFollowingUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewListFollowingUseCase(r repository.FriendshipRepository) *ListFollowingUseCase {
 	return &ListFollowingUseCase{repo: r}
@@ -115,7 +127,9 @@ func (u *ListFollowingUseCase) Execute(ctx context.Context, userID uint64) ([]do
 	return u.repo.ListAcceptedFollowing(ctx, userID)
 }
 
-type ListFollowersUseCase struct{ repo repository.FriendshipRepository }
+type ListFollowersUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewListFollowersUseCase(r repository.FriendshipRepository) *ListFollowersUseCase {
 	return &ListFollowersUseCase{repo: r}
@@ -134,7 +148,9 @@ type FollowStatus struct {
 	IsFollowedBy bool `json:"isFollowedBy"`
 }
 
-type GetFollowStatusUseCase struct{ repo repository.FriendshipRepository }
+type GetFollowStatusUseCase struct {
+	repo repository.FriendshipRepository
+}
 
 func NewGetFollowStatusUseCase(r repository.FriendshipRepository) *GetFollowStatusUseCase {
 	return &GetFollowStatusUseCase{repo: r}

--- a/backend/internal/usecase/learning_report_usecase.go
+++ b/backend/internal/usecase/learning_report_usecase.go
@@ -9,7 +9,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListLearningReportsUseCase struct{ repo repository.LearningReportRepository }
+type ListLearningReportsUseCase struct {
+	repo repository.LearningReportRepository
+}
 
 func NewListLearningReportsUseCase(r repository.LearningReportRepository) *ListLearningReportsUseCase {
 	return &ListLearningReportsUseCase{repo: r}

--- a/backend/internal/usecase/note_usecase_test.go
+++ b/backend/internal/usecase/note_usecase_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 type stubNoteRepo struct {
-	rows           []domain.Note
-	one            *domain.Note
-	err            error
-	deletedUserID  uint64
-	deletedID      uint64
-	updatedNote    *domain.Note
+	rows          []domain.Note
+	one           *domain.Note
+	err           error
+	deletedUserID uint64
+	deletedID     uint64
+	updatedNote   *domain.Note
 }
 
 func (s *stubNoteRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.Note, error) {

--- a/backend/internal/usecase/notification_usecase.go
+++ b/backend/internal/usecase/notification_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListNotificationsUseCase struct{ repo repository.NotificationRepository }
+type ListNotificationsUseCase struct {
+	repo repository.NotificationRepository
+}
 
 func NewListNotificationsUseCase(r repository.NotificationRepository) *ListNotificationsUseCase {
 	return &ListNotificationsUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *ListNotificationsUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-type MarkNotificationReadUseCase struct{ repo repository.NotificationRepository }
+type MarkNotificationReadUseCase struct {
+	repo repository.NotificationRepository
+}
 
 func NewMarkNotificationReadUseCase(r repository.NotificationRepository) *MarkNotificationReadUseCase {
 	return &MarkNotificationReadUseCase{repo: r}
@@ -37,7 +41,9 @@ func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, userID, id ui
 	return u.repo.MarkRead(ctx, userID, id)
 }
 
-type MarkAllNotificationsReadUseCase struct{ repo repository.NotificationRepository }
+type MarkAllNotificationsReadUseCase struct {
+	repo repository.NotificationRepository
+}
 
 func NewMarkAllNotificationsReadUseCase(r repository.NotificationRepository) *MarkAllNotificationsReadUseCase {
 	return &MarkAllNotificationsReadUseCase{repo: r}
@@ -50,7 +56,9 @@ func (u *MarkAllNotificationsReadUseCase) Execute(ctx context.Context, userID ui
 	return u.repo.MarkAllRead(ctx, userID)
 }
 
-type CountUnreadNotificationsUseCase struct{ repo repository.NotificationRepository }
+type CountUnreadNotificationsUseCase struct {
+	repo repository.NotificationRepository
+}
 
 func NewCountUnreadNotificationsUseCase(r repository.NotificationRepository) *CountUnreadNotificationsUseCase {
 	return &CountUnreadNotificationsUseCase{repo: r}

--- a/backend/internal/usecase/notification_usecase_test.go
+++ b/backend/internal/usecase/notification_usecase_test.go
@@ -16,7 +16,7 @@ func (s *stubNotificationRepo) ListByUserID(_ context.Context, _ uint64) ([]doma
 	return s.rows, s.err
 }
 func (s *stubNotificationRepo) MarkRead(_ context.Context, _, _ uint64) error { return s.err }
-func (s *stubNotificationRepo) MarkAllRead(_ context.Context, _ uint64) error  { return s.err }
+func (s *stubNotificationRepo) MarkAllRead(_ context.Context, _ uint64) error { return s.err }
 func (s *stubNotificationRepo) CountUnread(_ context.Context, _ uint64) (int64, error) {
 	return int64(len(s.rows)), s.err
 }

--- a/backend/internal/usecase/reminder_setting_usecase.go
+++ b/backend/internal/usecase/reminder_setting_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type GetReminderSettingUseCase struct{ repo repository.ReminderSettingRepository }
+type GetReminderSettingUseCase struct {
+	repo repository.ReminderSettingRepository
+}
 
 func NewGetReminderSettingUseCase(r repository.ReminderSettingRepository) *GetReminderSettingUseCase {
 	return &GetReminderSettingUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *GetReminderSettingUseCase) Execute(ctx context.Context, userID uint64) 
 	return u.repo.FindByUserID(ctx, userID)
 }
 
-type UpsertReminderSettingUseCase struct{ repo repository.ReminderSettingRepository }
+type UpsertReminderSettingUseCase struct {
+	repo repository.ReminderSettingRepository
+}
 
 func NewUpsertReminderSettingUseCase(r repository.ReminderSettingRepository) *UpsertReminderSettingUseCase {
 	return &UpsertReminderSettingUseCase{repo: r}

--- a/backend/internal/usecase/score_card_usecase.go
+++ b/backend/internal/usecase/score_card_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type ListScoreCardsByUserIDUseCase struct{ repo repository.ScoreCardRepository }
+type ListScoreCardsByUserIDUseCase struct {
+	repo repository.ScoreCardRepository
+}
 
 func NewListScoreCardsByUserIDUseCase(r repository.ScoreCardRepository) *ListScoreCardsByUserIDUseCase {
 	return &ListScoreCardsByUserIDUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *ListScoreCardsByUserIDUseCase) Execute(ctx context.Context, userID uint
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-type CreateScoreCardUseCase struct{ repo repository.ScoreCardRepository }
+type CreateScoreCardUseCase struct {
+	repo repository.ScoreCardRepository
+}
 
 func NewCreateScoreCardUseCase(r repository.ScoreCardRepository) *CreateScoreCardUseCase {
 	return &CreateScoreCardUseCase{repo: r}

--- a/backend/internal/usecase/score_goal_usecase.go
+++ b/backend/internal/usecase/score_goal_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type GetScoreGoalUseCase struct{ repo repository.ScoreGoalRepository }
+type GetScoreGoalUseCase struct {
+	repo repository.ScoreGoalRepository
+}
 
 func NewGetScoreGoalUseCase(r repository.ScoreGoalRepository) *GetScoreGoalUseCase {
 	return &GetScoreGoalUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *GetScoreGoalUseCase) Execute(ctx context.Context, userID uint64) (*doma
 	return u.repo.FindByUserID(ctx, userID)
 }
 
-type UpsertScoreGoalUseCase struct{ repo repository.ScoreGoalRepository }
+type UpsertScoreGoalUseCase struct {
+	repo repository.ScoreGoalRepository
+}
 
 func NewUpsertScoreGoalUseCase(r repository.ScoreGoalRepository) *UpsertScoreGoalUseCase {
 	return &UpsertScoreGoalUseCase{repo: r}

--- a/backend/internal/usecase/score_trend_usecase.go
+++ b/backend/internal/usecase/score_trend_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type GetScoreTrendUseCase struct{ repo repository.ScoreTrendRepository }
+type GetScoreTrendUseCase struct {
+	repo repository.ScoreTrendRepository
+}
 
 func NewGetScoreTrendUseCase(r repository.ScoreTrendRepository) *GetScoreTrendUseCase {
 	return &GetScoreTrendUseCase{repo: r}

--- a/backend/internal/usecase/session_note_usecase.go
+++ b/backend/internal/usecase/session_note_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type GetSessionNoteUseCase struct{ repo repository.SessionNoteRepository }
+type GetSessionNoteUseCase struct {
+	repo repository.SessionNoteRepository
+}
 
 func NewGetSessionNoteUseCase(r repository.SessionNoteRepository) *GetSessionNoteUseCase {
 	return &GetSessionNoteUseCase{repo: r}
@@ -21,7 +23,9 @@ func (u *GetSessionNoteUseCase) Execute(ctx context.Context, sessionID uint64) (
 	return u.repo.FindBySessionID(ctx, sessionID)
 }
 
-type UpsertSessionNoteUseCase struct{ repo repository.SessionNoteRepository }
+type UpsertSessionNoteUseCase struct {
+	repo repository.SessionNoteRepository
+}
 
 func NewUpsertSessionNoteUseCase(r repository.SessionNoteRepository) *UpsertSessionNoteUseCase {
 	return &UpsertSessionNoteUseCase{repo: r}

--- a/backend/internal/usecase/weekly_challenge_usecase.go
+++ b/backend/internal/usecase/weekly_challenge_usecase.go
@@ -8,7 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-type GetCurrentWeeklyChallengeUseCase struct{ repo repository.WeeklyChallengeRepository }
+type GetCurrentWeeklyChallengeUseCase struct {
+	repo repository.WeeklyChallengeRepository
+}
 
 func NewGetCurrentWeeklyChallengeUseCase(r repository.WeeklyChallengeRepository) *GetCurrentWeeklyChallengeUseCase {
 	return &GetCurrentWeeklyChallengeUseCase{repo: r}
@@ -18,7 +20,9 @@ func (u *GetCurrentWeeklyChallengeUseCase) Execute(ctx context.Context) (*domain
 	return u.repo.CurrentChallenge(ctx)
 }
 
-type CompleteWeeklyChallengeUseCase struct{ repo repository.WeeklyChallengeRepository }
+type CompleteWeeklyChallengeUseCase struct {
+	repo repository.WeeklyChallengeRepository
+}
 
 func NewCompleteWeeklyChallengeUseCase(r repository.WeeklyChallengeRepository) *CompleteWeeklyChallengeUseCase {
 	return &CompleteWeeklyChallengeUseCase{repo: r}


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#1 (gofmt cleanup)**。Effective Go の "gofmt'd code is the standard" 原則に従い、未整形だった 26 ファイルを `gofmt -w` で正規化します。機能変更ゼロ。あわせて README の AWS サービス節から「未使用サービス」記述を削除しました（user 指示：実プロビジョン済のもののみ列挙）。

## 変更内容

### backend (gofmt 整形 26 ファイル)
- `internal/domain/`: chat.go / health.go / score_card.go / shared_session.go / user_stats.go / weekly_challenge.go
- `internal/handler/auth_handler.go`, `internal/handler/middleware/cors.go`
- `internal/repository/notification_repository.go`
- `internal/usecase/`: admin_invitation / admin_scenario / conversation_template / daily_goal / favorite_phrase / friendship / learning_report / note / notification / reminder_setting / score_card / score_goal / score_trend / session_note / weekly_challenge usecases (＋ tests)

### docs
- `README.md`: AWS サービス節の「未使用のサービス（過去に記載があったもの）」note 段落を削除

## テスト

- [x] `gofmt -l backend/` → 0 件
- [x] `go vet ./...` → 警告なし
- [x] `go test ./...` → 全 pass（usecase / handler / middleware の既存テスト全て）

## 後続 PR

| # | テーマ |
|---|---|
| 2 | JWT claim デコード重複（middleware/jwt.go ↔ auth_handler.go）の共通化 |
| 3 | Cookie 定数（`refresh_token` の文字列直書きを定数化）+ `SetAuthCookies` / `ClearAuthCookies` helper |
| 4 | Cognito token 交換（Callback / Refresh の重複 ~140 行）を `internal/infra/cognito/` に service 抽出 |
| 5 | `router.go` (315 行) をドメインごとに `register*Routes` 関数へ分割 |
| 6 | `cmd/server/main.go` の Cognito secret 末尾 4 文字診断ログを削除（解消済み） |
| 7 | backend CI に `gofmt -l` / `go vet` チェックを追加して将来のドリフト防止 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated AWS service references from README.

* **Style**
  * Standardized code formatting and whitespace alignment throughout backend modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->