### PR TITLE
refactor(backend): JWT claim デコードを middleware.DecodeClaims に集約

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -170,7 +168,7 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	//   - 未登録なら role = (group に ADMIN なら super_admin / 無ければ trainee) で create
 	//   - 既存ユーザーは Cognito group が変わっていれば role を update する
 	// これで Spring Boot 時代と同じ「Cognito group が真のソース」で運用できる。
-	if claims, err := decodeJWTClaims(tok.IDToken); err == nil {
+	if claims, err := middleware.DecodeClaims(tok.IDToken); err == nil {
 		sub, _ := claims["sub"].(string)
 		email, _ := claims["email"].(string)
 		groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
@@ -197,36 +195,6 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
-}
-
-// decodeJWTClaims は JWT (3 セグメント、署名検証なし) の payload 部だけ base64 デコードする。
-// callback 直後に Cognito 発行 token から sub / email を取り出して users 自動作成するためだけに使う。
-// 認証 middleware の本格的な署名検証 (JWKS) は別 issue。
-func decodeJWTClaims(idToken string) (map[string]any, error) {
-	parts := strings.Split(idToken, ".")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("invalid jwt format")
-	}
-	payload, err := base64URLDecode(parts[1])
-	if err != nil {
-		return nil, err
-	}
-	var claims map[string]any
-	if err := json.Unmarshal(payload, &claims); err != nil {
-		return nil, err
-	}
-	return claims, nil
-}
-
-func base64URLDecode(s string) ([]byte, error) {
-	switch len(s) % 4 {
-	case 2:
-		s += "=="
-	case 3:
-		s += "="
-	}
-	s = strings.NewReplacer("-", "+", "_", "/").Replace(s)
-	return base64.StdEncoding.DecodeString(s)
 }
 
 // Refresh は HttpOnly Cookie の refresh_token を使ってアクセストークンを再発行する。

--- a/backend/internal/handler/middleware/jwt.go
+++ b/backend/internal/handler/middleware/jwt.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"slices"
 	"strings"
@@ -33,7 +34,7 @@ func JWTAuth() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
-		claims, err := decodeClaims(token)
+		claims, err := DecodeClaims(token)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
 			return
@@ -90,10 +91,15 @@ func IsAdminFromGroups(groups []string) bool {
 	return slices.Contains(groups, AdminGroupName)
 }
 
-func decodeClaims(jwt string) (map[string]any, error) {
-	parts := strings.Split(jwt, ".")
+// DecodeClaims は JWT (3 セグメント) の payload 部だけを base64url デコードして
+// claim マップに変換する。署名検証は行わない（JWKS 検証は別 issue）。
+//
+// middleware.JWTAuth と auth_handler.Callback の両方で利用される共通ヘルパー。
+// 以前は各所に同等実装が複製されていたが DRY 化のため 1 箇所に集約。
+func DecodeClaims(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
-		return nil, errInvalidJWT
+		return nil, ErrInvalidJWT
 	}
 	payload, err := base64URLDecode(parts[1])
 	if err != nil {
@@ -106,6 +112,7 @@ func decodeClaims(jwt string) (map[string]any, error) {
 	return claims, nil
 }
 
+// base64URLDecode は JWT で使われる URL-safe base64 (パディング省略) を復元してデコードする。
 func base64URLDecode(s string) ([]byte, error) {
 	switch len(s) % 4 {
 	case 2:
@@ -117,8 +124,5 @@ func base64URLDecode(s string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(s)
 }
 
-type jwtError string
-
-func (e jwtError) Error() string { return string(e) }
-
-const errInvalidJWT = jwtError("invalid jwt format")
+// ErrInvalidJWT は token の形式 (3 セグメント) が壊れているときに返る。
+var ErrInvalidJWT = errors.New("middleware: invalid jwt format")

--- a/backend/internal/handler/middleware/jwt_test.go
+++ b/backend/internal/handler/middleware/jwt_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// makeJWT は header.payload.signature 形式のダミー JWT を組み立てる。
+// 署名検証はしないので signature 部はプレースホルダで良い。
+func makeJWT(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	header := encodeSegment(t, map[string]any{"alg": "RS256", "typ": "JWT"})
+	body := encodeSegment(t, payload)
+	return header + "." + body + ".sig"
+}
+
+func encodeSegment(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// base64URL (パディング省略) で encode
+	s := base64.StdEncoding.EncodeToString(b)
+	s = strings.TrimRight(s, "=")
+	s = strings.NewReplacer("+", "-", "/", "_").Replace(s)
+	return s
+}
+
+func TestDecodeClaims_Success(t *testing.T) {
+	want := map[string]any{
+		"sub":            "abc-123",
+		"email":          "u@example.com",
+		"cognito:groups": []any{"admin"},
+	}
+	tok := makeJWT(t, want)
+	got, err := DecodeClaims(tok)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got["sub"] != "abc-123" || got["email"] != "u@example.com" {
+		t.Fatalf("unexpected claims: %+v", got)
+	}
+	if groups := ToStringSliceFromClaim(got["cognito:groups"]); len(groups) != 1 || groups[0] != "admin" {
+		t.Fatalf("groups: %+v", groups)
+	}
+}
+
+func TestDecodeClaims_InvalidFormat(t *testing.T) {
+	cases := []string{"", "only.two", "a.b.c.d"}
+	for _, c := range cases {
+		if _, err := DecodeClaims(c); !errors.Is(err, ErrInvalidJWT) {
+			t.Errorf("token=%q want ErrInvalidJWT, got %v", c, err)
+		}
+	}
+}
+
+func TestDecodeClaims_InvalidBase64(t *testing.T) {
+	tok := "header.!!!notbase64!!!.sig"
+	if _, err := DecodeClaims(tok); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestDecodeClaims_InvalidJSON(t *testing.T) {
+	header := encodeSegment(t, map[string]any{"alg": "RS256"})
+	bogus := strings.NewReplacer("+", "-", "/", "_").Replace(
+		strings.TrimRight(base64.StdEncoding.EncodeToString([]byte("not-json")), "="),
+	)
+	tok := header + "." + bogus + ".sig"
+	if _, err := DecodeClaims(tok); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestIsAdminFromGroups(t *testing.T) {
+	if !IsAdminFromGroups([]string{"trainee", "admin"}) {
+		t.Fatal("admin should be detected")
+	}
+	if IsAdminFromGroups([]string{"trainee"}) {
+		t.Fatal("non-admin should not be detected")
+	}
+	if IsAdminFromGroups(nil) {
+		t.Fatal("nil should not be detected")
+	}
+}
+
+func TestToStringSliceFromClaim(t *testing.T) {
+	got := ToStringSliceFromClaim([]any{"a", "b", 42, "c"})
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %v want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+	if ToStringSliceFromClaim("not-an-array") != nil {
+		t.Fatal("non-array should return nil")
+	}
+}


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#2 (JWT helper 共通化)**。`middleware/jwt.go` と `handler/auth_handler.go` の両方に同等の **JWT payload デコードロジックが複製**されていた DRY 違反を解消し、`middleware.DecodeClaims` に一本化します。あわせて Go Code Review Comments の慣習に従ってエラーを `errors.New` ベースに正規化し、単体テストを追加します。

## 変更内容

### `internal/handler/middleware/jwt.go`
- 旧 unexported `decodeClaims` を **`DecodeClaims` (exported)** に改名（auth_handler から再利用するため）
- 旧 `errInvalidJWT` (独自の `jwtError` 型) を **`ErrInvalidJWT` (`errors.New`)** に変更
  - Go Code Review Comments: "Don't define error types where standard `errors.New` suffices"
  - `errors.Is(err, ErrInvalidJWT)` で判定可能になる
- 既存の `JWTAuth` middleware は新名 `DecodeClaims` を呼ぶよう更新

### `internal/handler/auth_handler.go`
- 重複していた `decodeJWTClaims` / `base64URLDecode` を **削除**（〜30 行）
- `middleware.DecodeClaims(tok.IDToken)` を呼ぶように変更
- 不要になった import（`encoding/base64`, `fmt`）を削除

### `internal/handler/middleware/jwt_test.go` (新規)
6 件の単体テスト:
- `TestDecodeClaims_Success` — 正常系（sub / email / cognito:groups の取り出し確認）
- `TestDecodeClaims_InvalidFormat` — `""` / `"only.two"` / `"a.b.c.d"` で `ErrInvalidJWT` を返す
- `TestDecodeClaims_InvalidBase64` — payload が壊れた base64
- `TestDecodeClaims_InvalidJSON` — base64 デコードはできるが JSON が壊れている
- `TestIsAdminFromGroups` — admin / non-admin / nil
- `TestToStringSliceFromClaim` — `[]any` の混在型を string slice に変換、非配列は nil

## テスト

- [x] `go build ./...` 成功
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全 pass（既存テスト含む）
- [x] 新規 6 テスト全 pass
- [x] `gofmt -l backend/` → 0 件

## 後続 PR

| # | テーマ |
|---|---|
| 3 | Cookie 定数（`refresh_token` の文字列直書きを定数化）+ `SetAuthCookies` / `ClearAuthCookies` helper |
| 4 | Cognito token 交換（Callback / Refresh の重複 ~140 行）を `internal/infra/cognito/` に service 抽出 |
| 5 | `router.go` (315 行) をドメインごとに `register*Routes` 関数へ分割 |
| 6 | `cmd/server/main.go` の Cognito secret 末尾 4 文字診断ログを削除 |
| 7 | backend CI に `gofmt -l` / `go vet` チェックを追加 |