### PR TITLE
refactor(backend): 認証 Cookie 操作を middleware ヘルパーに集約

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -78,8 +78,7 @@ func (h *AuthHandler) Me(c *gin.Context) {
 
 // Logout はリフレッシュ・アクセストークンの Cookie を消去する。
 func (h *AuthHandler) Logout(c *gin.Context) {
-	c.SetCookie(middleware.CookieAccessToken, "", -1, "/", "", true, true)
-	c.SetCookie("refresh_token", "", -1, "/", "", true, true)
+	middleware.ClearAuthCookies(c)
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました。"})
 }
 
@@ -153,15 +152,8 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	}
 
 	// HttpOnly + Secure + SameSite=None でアプリ全体に Cookie を渡す
-	maxAge := tok.ExpiresIn
-	if maxAge <= 0 {
-		maxAge = 3600
-	}
-	c.SetSameSite(http.SameSiteNoneMode)
-	c.SetCookie(middleware.CookieAccessToken, tok.AccessToken, maxAge, "/", "", true, true)
-	if tok.RefreshToken != "" {
-		c.SetCookie("refresh_token", tok.RefreshToken, 30*24*3600, "/", "", true, true)
-	}
+	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
+	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
 	// 初回ログインで users 行が無いと /auth/me が 404 になるため自動で upsert する。
 	// id_token の payload から sub / email / cognito:groups を取り出して同期する:
@@ -199,7 +191,7 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 
 // Refresh は HttpOnly Cookie の refresh_token を使ってアクセストークンを再発行する。
 func (h *AuthHandler) Refresh(c *gin.Context) {
-	rt, err := c.Cookie("refresh_token")
+	rt, err := c.Cookie(middleware.CookieRefreshToken)
 	if err != nil || rt == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "refresh_token_missing"})
 		return
@@ -237,8 +229,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	if resp.StatusCode != http.StatusOK {
 		log.Printf("cognito refresh: status=%d body=%s", resp.StatusCode, string(body))
 		// refresh が無効ならログイン状態をクリアして 401 を返し、フロントは login へ誘導する
-		c.SetCookie(middleware.CookieAccessToken, "", -1, "/", "", true, true)
-		c.SetCookie("refresh_token", "", -1, "/", "", true, true)
+		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "refresh_failed"})
 		return
 	}
@@ -248,11 +239,6 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "invalid_token_response"})
 		return
 	}
-	maxAge := tok.ExpiresIn
-	if maxAge <= 0 {
-		maxAge = 3600
-	}
-	c.SetSameSite(http.SameSiteNoneMode)
-	c.SetCookie(middleware.CookieAccessToken, tok.AccessToken, maxAge, "/", "", true, true)
+	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
 	c.JSON(http.StatusOK, gin.H{"message": "refreshed"})
 }

--- a/backend/internal/handler/middleware/auth_cookie.go
+++ b/backend/internal/handler/middleware/auth_cookie.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// 認証 Cookie 関連の定数。値はフロントエンド側 (Cognito callback / axios withCredentials)
+// と整合させる必要があるため、変えるときは双方を同期更新すること。
+const (
+	// CookieRefreshToken は Cognito から取得した refresh_token を格納する Cookie 名。
+	// CookieAccessToken は jwt.go に定義済み（middleware 全体で再利用）。
+	CookieRefreshToken = "refresh_token"
+
+	// AccessTokenDefaultMaxAgeSeconds は Cognito レスポンスに expires_in が
+	// 含まれていなかったときの fallback (1 時間)。Cognito User Pool の標準寿命と一致。
+	AccessTokenDefaultMaxAgeSeconds = 3600
+
+	// RefreshTokenMaxAgeSeconds は refresh_token Cookie の寿命 (30 日)。
+	// Cognito User Pool の refresh-token-validity 設定と整合させる。
+	RefreshTokenMaxAgeSeconds = 30 * 24 * 3600
+)
+
+// SetAccessTokenCookie は HttpOnly + Secure + SameSite=None で access_token を設定する。
+// maxAgeSeconds が 0 以下の場合は AccessTokenDefaultMaxAgeSeconds に丸める。
+//
+// Cognito refresh / callback 双方で同じヘッダー設定が必要だったため共通化した。
+// 旧実装では SetSameSite と SetCookie の組み合わせが各 handler に散在し
+// 設定漏れリスクがあったため、責務を 1 箇所に集約する。
+func SetAccessTokenCookie(c *gin.Context, accessToken string, maxAgeSeconds int) {
+	if maxAgeSeconds <= 0 {
+		maxAgeSeconds = AccessTokenDefaultMaxAgeSeconds
+	}
+	c.SetSameSite(http.SameSiteNoneMode)
+	c.SetCookie(CookieAccessToken, accessToken, maxAgeSeconds, "/", "", true, true)
+}
+
+// SetRefreshTokenCookie は refresh_token を 30 日寿命で書き込む。
+// 空文字列のときは何もしない（Cognito が refresh_token を返さないケースに対応）。
+func SetRefreshTokenCookie(c *gin.Context, refreshToken string) {
+	if refreshToken == "" {
+		return
+	}
+	c.SetSameSite(http.SameSiteNoneMode)
+	c.SetCookie(CookieRefreshToken, refreshToken, RefreshTokenMaxAgeSeconds, "/", "", true, true)
+}
+
+// ClearAuthCookies は access / refresh の両 Cookie を即時失効させる。
+// Logout / refresh 失敗時のフロント誘導でログイン状態をクリアするのに使う。
+func ClearAuthCookies(c *gin.Context) {
+	c.SetSameSite(http.SameSiteNoneMode)
+	c.SetCookie(CookieAccessToken, "", -1, "/", "", true, true)
+	c.SetCookie(CookieRefreshToken, "", -1, "/", "", true, true)
+}

--- a/backend/internal/handler/middleware/auth_cookie_test.go
+++ b/backend/internal/handler/middleware/auth_cookie_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// runHandler は与えた handler を 1 回呼び出してレスポンスを返す簡易ヘルパー。
+func runHandler(handler gin.HandlerFunc) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	handler(c)
+	return w
+}
+
+func TestSetAccessTokenCookie_DefaultsMaxAge(t *testing.T) {
+	w := runHandler(func(c *gin.Context) {
+		SetAccessTokenCookie(c, "AT", 0)
+	})
+	cookie := findCookie(t, w, CookieAccessToken)
+	if cookie.Value != "AT" {
+		t.Fatalf("value = %q", cookie.Value)
+	}
+	if cookie.MaxAge != AccessTokenDefaultMaxAgeSeconds {
+		t.Fatalf("max-age = %d, want %d", cookie.MaxAge, AccessTokenDefaultMaxAgeSeconds)
+	}
+	if !cookie.HttpOnly {
+		t.Fatal("HttpOnly should be true")
+	}
+	if !cookie.Secure {
+		t.Fatal("Secure should be true")
+	}
+	if cookie.SameSite != http.SameSiteNoneMode {
+		t.Fatalf("SameSite = %v", cookie.SameSite)
+	}
+}
+
+func TestSetAccessTokenCookie_RespectsExplicitMaxAge(t *testing.T) {
+	w := runHandler(func(c *gin.Context) {
+		SetAccessTokenCookie(c, "AT", 7200)
+	})
+	cookie := findCookie(t, w, CookieAccessToken)
+	if cookie.MaxAge != 7200 {
+		t.Fatalf("max-age = %d, want 7200", cookie.MaxAge)
+	}
+}
+
+func TestSetRefreshTokenCookie_SkipsEmpty(t *testing.T) {
+	w := runHandler(func(c *gin.Context) {
+		SetRefreshTokenCookie(c, "")
+	})
+	for _, h := range w.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(h, CookieRefreshToken+"=") {
+			t.Fatalf("empty refresh_token should not produce a cookie, got %q", h)
+		}
+	}
+}
+
+func TestSetRefreshTokenCookie_LongMaxAge(t *testing.T) {
+	w := runHandler(func(c *gin.Context) {
+		SetRefreshTokenCookie(c, "RT")
+	})
+	cookie := findCookie(t, w, CookieRefreshToken)
+	if cookie.Value != "RT" {
+		t.Fatalf("value = %q", cookie.Value)
+	}
+	if cookie.MaxAge != RefreshTokenMaxAgeSeconds {
+		t.Fatalf("max-age = %d, want %d", cookie.MaxAge, RefreshTokenMaxAgeSeconds)
+	}
+}
+
+func TestClearAuthCookies_BothExpired(t *testing.T) {
+	w := runHandler(ClearAuthCookies)
+	for _, name := range []string{CookieAccessToken, CookieRefreshToken} {
+		cookie := findCookie(t, w, name)
+		if cookie.MaxAge != -1 {
+			t.Fatalf("%s max-age = %d, want -1", name, cookie.MaxAge)
+		}
+		if cookie.Value != "" {
+			t.Fatalf("%s value = %q, want empty", name, cookie.Value)
+		}
+	}
+}
+
+// findCookie は ResponseRecorder の Set-Cookie ヘッダーから指定名の Cookie を取り出す。
+func findCookie(t *testing.T, w *httptest.ResponseRecorder, name string) *http.Cookie {
+	t.Helper()
+	resp := http.Response{Header: w.Header()}
+	for _, c := range resp.Cookies() {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("cookie %q not found in %v", name, w.Header())
+	return nil
+}


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#3 (Cookie 定数 + helper 導入)**。`handler/auth_handler.go` の Logout / Callback / Refresh 各所に散在していた **`refresh_token` 文字列直書き / マジック値 (3600, 30*24*3600) / SameSite/HttpOnly/Secure フラグの組み合わせ** を `middleware` パッケージに集約します。

## 問題

| 種別 | 旧コード |
|---|---|
| Cookie 名直書き | `c.SetCookie("refresh_token", ...)` を 4 箇所で hardcode |
| マジック値 | access_token の fallback `3600` / refresh_token の `30*24*3600` |
| Cookie 設定の重複 | `c.SetSameSite(http.SameSiteNoneMode)` + `c.SetCookie(name, val, age, "/", "", true, true)` を 3 関数で繰り返し（HttpOnly / Secure フラグの設定漏れリスクあり） |

## 変更内容

### `internal/handler/middleware/auth_cookie.go` (新規)
- 定数:
  - `CookieRefreshToken = "refresh_token"`
  - `AccessTokenDefaultMaxAgeSeconds = 3600`
  - `RefreshTokenMaxAgeSeconds = 30 * 24 * 3600`
- ヘルパー:
  - `SetAccessTokenCookie(c, accessToken, maxAgeSeconds)` — `maxAgeSeconds <= 0` の時は fallback
  - `SetRefreshTokenCookie(c, refreshToken)` — 空文字なら no-op（Cognito が refresh_token を返さないケース対応）
  - `ClearAuthCookies(c)` — access / refresh 両方を即時失効
- `SameSite=None` / `HttpOnly` / `Secure` フラグを **1 箇所で固定** し、設定漏れを構造的に防止

### `internal/handler/auth_handler.go`
- `Logout`: 個別 `SetCookie` 2 行 → `middleware.ClearAuthCookies(c)`
- `Callback`: `SetSameSite` + 2 個の `SetCookie` + maxAge 計算 → helper 呼び出し 2 行
- `Refresh`: `c.Cookie("refresh_token")` → `CookieRefreshToken` 定数。refresh 失敗時クリアも `ClearAuthCookies` に統一

### `internal/handler/middleware/auth_cookie_test.go` (新規)
5 件の単体テスト:
- `TestSetAccessTokenCookie_DefaultsMaxAge` — `expiresIn=0` で `3600`、Secure / HttpOnly / SameSite=None
- `TestSetAccessTokenCookie_RespectsExplicitMaxAge` — `7200` を渡せば反映
- `TestSetRefreshTokenCookie_SkipsEmpty` — 空文字なら Set-Cookie ヘッダー自体を出さない
- `TestSetRefreshTokenCookie_LongMaxAge` — 30 日 maxAge
- `TestClearAuthCookies_BothExpired` — 両 Cookie が `MaxAge=-1` / 値空

## テスト

- [x] `go build ./...` 成功
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全 pass
- [x] 新規 5 テスト pass
- [x] `gofmt -l backend/` → 0 件

## 後続 PR

| # | テーマ |
|---|---|
| 4 | Cognito token 交換（Callback / Refresh の重複 ~140 行）を `internal/infra/cognito/` に service 抽出 |
| 5 | `router.go` (315 行) をドメインごとに `register*Routes` 関数へ分割 |
| 6 | `cmd/server/main.go` の Cognito secret 末尾 4 文字診断ログを削除 |
| 7 | backend CI に `gofmt -l` / `go vet` チェックを追加 |