### PR TITLE
refactor(backend): Cognito token 交換を infra/cognito.TokenExchanger に抽出

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,17 +1,14 @@
 package handler
 
 import (
-	"encoding/json"
-	"io"
+	"errors"
 	"log"
 	"net/http"
-	"net/url"
-	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
@@ -19,27 +16,35 @@ import (
 
 // AuthHandler は Cognito 関連の認証エンドポイントを提供する。
 // Spring Boot の CognitoAuthController に相当。
+//
+// HTTP / OAuth2 通信の詳細は infra/cognito.TokenExchanger に切り出してあり、
+// このハンドラは HTTP プロトコル境界とユーザー upsert ロジックだけを持つ。
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
 	users          repository.UserRepository
-	cognito        *config.CognitoConfig
-	httpClient     *http.Client
+	cognitoCfg     *config.CognitoConfig
+	tokens         *cognito.TokenExchanger
 }
 
-func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, users repository.UserRepository, cognito *config.CognitoConfig) *AuthHandler {
+// NewAuthHandler は本番用に http.Client + 10s timeout の TokenExchanger を組み立てて DI する。
+func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, users repository.UserRepository, cognitoCfg *config.CognitoConfig) *AuthHandler {
 	return &AuthHandler{
 		getCurrentUser: getCurrentUser,
 		users:          users,
-		cognito:        cognito,
-		// Cognito token endpoint への通信が無限待ちにならないよう必ず timeout を設定する
-		httpClient: &http.Client{Timeout: 10 * time.Second},
+		cognitoCfg:     cognitoCfg,
+		tokens: cognito.NewTokenExchanger(cognito.Config{
+			ClientID:     cognitoCfg.ClientID,
+			ClientSecret: cognitoCfg.ClientSecret,
+			RedirectURI:  cognitoCfg.RedirectURI,
+			TokenURI:     cognitoCfg.TokenURI,
+		}),
 	}
 }
 
 // Me は現在ログイン中のユーザー情報を返す。
 // レスポンスは domain.User の各フィールド + 派生 `isAdmin` / `groups` を含める。
 // isAdmin の判定:
-//  1. Cognito の `cognito:groups` claim に "ADMIN" が含まれている (Spring Boot 時代と同等)
+//  1. Cognito の `cognito:groups` claim に "admin" が含まれている (Spring Boot 時代と同等)
 //  2. または DB users.role が super_admin / company_admin
 //
 // 上記いずれかで true。フロントは `isAdmin` を見て管理画面の表示可否を決める。
@@ -86,14 +91,6 @@ type cognitoCallbackReq struct {
 	Code string `json:"code" binding:"required"`
 }
 
-type cognitoTokenResponse struct {
-	AccessToken  string `json:"access_token"`
-	IDToken      string `json:"id_token"`
-	RefreshToken string `json:"refresh_token"`
-	ExpiresIn    int    `json:"expires_in"`
-	TokenType    string `json:"token_type"`
-}
-
 // Callback は Cognito Hosted UI から戻ってきた認可コードをアクセストークンに交換し、
 // HttpOnly Cookie に格納する。Spring Boot の CognitoAuthController#callback 相当。
 func (h *AuthHandler) Callback(c *gin.Context) {
@@ -102,89 +99,22 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if h.cognito == nil || h.cognito.TokenURI == "" || h.cognito.ClientID == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"})
+
+	tok, err := h.tokens.ExchangeAuthorizationCode(c.Request.Context(), req.Code)
+	if status, body, ok := h.handleTokenError(c, "callback", err); ok {
+		c.JSON(status, body)
 		return
 	}
 
-	// Cognito の OAuth2 token endpoint には「Authorization Basic header 方式」と
-	// 「body 方式 (client_id + client_secret を form に入れる)」があるが、両方送ると
-	// invalid_client を返すケースがある。本実装では body 方式に統一する（AWS docs 推奨）。
-	form := url.Values{}
-	form.Set("grant_type", "authorization_code")
-	form.Set("client_id", h.cognito.ClientID)
-	if h.cognito.ClientSecret != "" {
-		form.Set("client_secret", h.cognito.ClientSecret)
-	}
-	form.Set("code", req.Code)
-	form.Set("redirect_uri", h.cognito.RedirectURI)
-
-	httpReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost,
-		h.cognito.TokenURI, strings.NewReader(form.Encode()))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "request_build_failed"})
-		return
-	}
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := h.httpClient.Do(httpReq)
-	if err != nil {
-		log.Printf("cognito callback: token exchange request failed: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "cognito_unreachable"})
-		return
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		// Cognito 側が拒否した本当の理由 (invalid_grant / invalid_client / redirect_uri_mismatch 等) を
-		// CloudWatch Logs に必ず残す。クライアントには簡素なエラーだけ返す。
-		log.Printf("cognito callback: token exchange status=%d body=%s redirect_uri=%s client_id_set=%t client_secret_set=%t",
-			resp.StatusCode, string(body), h.cognito.RedirectURI, h.cognito.ClientID != "", h.cognito.ClientSecret != "")
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "token_exchange_failed"})
-		return
-	}
-
-	var tok cognitoTokenResponse
-	if err := json.Unmarshal(body, &tok); err != nil {
-		log.Printf("cognito callback: invalid token response: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "invalid_token_response"})
-		return
-	}
-
-	// HttpOnly + Secure + SameSite=None でアプリ全体に Cookie を渡す
 	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
 	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
 	// 初回ログインで users 行が無いと /auth/me が 404 になるため自動で upsert する。
 	// id_token の payload から sub / email / cognito:groups を取り出して同期する:
-	//   - 未登録なら role = (group に ADMIN なら super_admin / 無ければ trainee) で create
+	//   - 未登録なら role = (group に admin なら super_admin / 無ければ trainee) で create
 	//   - 既存ユーザーは Cognito group が変わっていれば role を update する
 	// これで Spring Boot 時代と同じ「Cognito group が真のソース」で運用できる。
-	if claims, err := middleware.DecodeClaims(tok.IDToken); err == nil {
-		sub, _ := claims["sub"].(string)
-		email, _ := claims["email"].(string)
-		groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
-		desiredRole := domain.RoleTrainee
-		if middleware.IsAdminFromGroups(groups) {
-			desiredRole = domain.RoleSuperAdmin
-		}
-		if sub != "" && h.users != nil {
-			existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
-			if existing == nil {
-				_ = h.users.Create(c.Request.Context(), &domain.User{
-					CognitoSub:  sub,
-					Email:       email,
-					DisplayName: email,
-					Role:        desiredRole,
-				})
-			} else if existing.Role != desiredRole && desiredRole == domain.RoleSuperAdmin {
-				// Cognito group で admin に昇格された場合のみ DB role を上書きする。
-				// 既に DB で super_admin / company_admin が設定されているケースは触らない
-				// （AdminInvitation 系の手動付与が他にある可能性があるため、降格は手動で）。
-				_ = h.users.UpdateRole(c.Request.Context(), existing.ID, desiredRole)
-			}
-		}
-	}
+	h.upsertUserFromIDToken(c, tok.IDToken)
 
 	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
 }
@@ -196,49 +126,88 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "refresh_token_missing"})
 		return
 	}
-	if h.cognito == nil || h.cognito.TokenURI == "" || h.cognito.ClientID == "" {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"})
-		return
-	}
 
-	// Callback と同じく body 方式に統一する。
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("client_id", h.cognito.ClientID)
-	if h.cognito.ClientSecret != "" {
-		form.Set("client_secret", h.cognito.ClientSecret)
-	}
-	form.Set("refresh_token", rt)
-
-	httpReq, err := http.NewRequestWithContext(c.Request.Context(), http.MethodPost,
-		h.cognito.TokenURI, strings.NewReader(form.Encode()))
+	tok, err := h.tokens.RefreshAccessToken(c.Request.Context(), rt)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "request_build_failed"})
-		return
-	}
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := h.httpClient.Do(httpReq)
-	if err != nil {
-		log.Printf("cognito refresh: token endpoint unreachable: %v", err)
-		c.JSON(http.StatusBadGateway, gin.H{"error": "cognito_unreachable"})
-		return
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		log.Printf("cognito refresh: status=%d body=%s", resp.StatusCode, string(body))
-		// refresh が無効ならログイン状態をクリアして 401 を返し、フロントは login へ誘導する
-		middleware.ClearAuthCookies(c)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "refresh_failed"})
+		// refresh_token が無効と判明した時はログイン状態をクリアして 401。
+		// それ以外（502: Cognito 不到達など）は Cookie を残してリトライ余地を残す。
+		var exErr *cognito.TokenExchangeError
+		if errors.As(err, &exErr) {
+			log.Printf("cognito refresh: status=%d body=%s", exErr.HTTPStatus, exErr.Body)
+			middleware.ClearAuthCookies(c)
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "refresh_failed"})
+			return
+		}
+		status, body, _ := h.handleTokenError(c, "refresh", err)
+		c.JSON(status, body)
 		return
 	}
 
-	var tok cognitoTokenResponse
-	if err := json.Unmarshal(body, &tok); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "invalid_token_response"})
-		return
-	}
 	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
 	c.JSON(http.StatusOK, gin.H{"message": "refreshed"})
+}
+
+// handleTokenError は cognito.TokenExchanger が返したエラーを HTTP レスポンスに変換する。
+// returned ok=true なら呼び元は早期 return する想定。
+func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (int, gin.H, bool) {
+	if err == nil {
+		return 0, nil, false
+	}
+
+	var exErr *cognito.TokenExchangeError
+	switch {
+	case errors.Is(err, cognito.ErrNotConfigured):
+		return http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"}, true
+	case errors.As(err, &exErr):
+		// 本物の理由 (invalid_grant / invalid_client / redirect_uri_mismatch 等) を残す。
+		// クライアントには簡素なエラーだけ返す。
+		log.Printf("cognito %s: token exchange status=%d body=%s redirect_uri=%s client_id_set=%t client_secret_set=%t",
+			op, exErr.HTTPStatus, exErr.Body, h.cognitoCfg.RedirectURI, h.cognitoCfg.ClientID != "", h.cognitoCfg.ClientSecret != "")
+		return http.StatusUnauthorized, gin.H{"error": "token_exchange_failed"}, true
+	case errors.Is(err, cognito.ErrUnreachable):
+		log.Printf("cognito %s: token endpoint unreachable: %v", op, err)
+		return http.StatusBadGateway, gin.H{"error": "cognito_unreachable"}, true
+	case errors.Is(err, cognito.ErrInvalidResponse):
+		log.Printf("cognito %s: invalid token response: %v", op, err)
+		return http.StatusBadGateway, gin.H{"error": "invalid_token_response"}, true
+	default:
+		log.Printf("cognito %s: unexpected error: %v", op, err)
+		return http.StatusInternalServerError, gin.H{"error": "internal_error"}, true
+	}
+}
+
+// upsertUserFromIDToken は id_token の claim を見て users 行を新規作成 / role 更新する。
+// Cognito group "admin" 所属時のみ super_admin に昇格する。降格は AdminInvitation 経由のみ。
+func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken string) {
+	claims, err := middleware.DecodeClaims(idToken)
+	if err != nil || h.users == nil {
+		return
+	}
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return
+	}
+	email, _ := claims["email"].(string)
+	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
+	desiredRole := domain.RoleTrainee
+	if middleware.IsAdminFromGroups(groups) {
+		desiredRole = domain.RoleSuperAdmin
+	}
+
+	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
+	if existing == nil {
+		_ = h.users.Create(c.Request.Context(), &domain.User{
+			CognitoSub:  sub,
+			Email:       email,
+			DisplayName: email,
+			Role:        desiredRole,
+		})
+		return
+	}
+	// Cognito group で admin に昇格された場合のみ DB role を上書きする。
+	// 既に DB で super_admin / company_admin が設定されているケースは触らない
+	// （AdminInvitation 系の手動付与が他にある可能性があるため、降格は手動で）。
+	if existing.Role != desiredRole && desiredRole == domain.RoleSuperAdmin {
+		_ = h.users.UpdateRole(c.Request.Context(), existing.ID, desiredRole)
+	}
 }

--- a/backend/internal/infra/cognito/token_exchanger.go
+++ b/backend/internal/infra/cognito/token_exchanger.go
@@ -1,0 +1,160 @@
+// Package cognito は AWS Cognito User Pool との通信を Go の純粋なコードに閉じ込める。
+// handler 層はこのパッケージのみに依存し、url.Values / http.Client / OAuth2 token endpoint
+// の URL 組み立てといった低レベルな詳細は知らないようにする（Clean Architecture の Infra 層）。
+package cognito
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// 既定の HTTP 通信タイムアウト。Cognito token endpoint への通信が
+// 無限待ちにならないよう必ず timeout を設定する。
+const defaultHTTPTimeout = 10 * time.Second
+
+// Token は Cognito の OAuth2 token endpoint レスポンスを表現する。
+// 各フィールド名は AWS Cognito Hosted UI / OIDC Discovery 仕様の token response に対応。
+//
+// 参考: https://docs.aws.amazon.com/cognito/latest/developerguide/token-endpoint.html
+type Token struct {
+	AccessToken  string `json:"access_token"`
+	IDToken      string `json:"id_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}
+
+// Config は TokenExchanger が必要とする Cognito 設定。
+// infra/config.CognitoConfig から必要部分のみコピーして渡す。
+type Config struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURI  string
+	TokenURI     string
+}
+
+// TokenExchanger は Cognito User Pool の OAuth2 token endpoint を叩いて
+// authorization_code / refresh_token を access/id/refresh token に交換する。
+//
+// 旧実装は handler/auth_handler.go の Callback / Refresh に同じ HTTP 構築・
+// レスポンス処理が ~140 行重複していたが、grant_type だけ違う構造だったため
+// このパッケージに集約した。
+type TokenExchanger struct {
+	cfg        Config
+	httpClient *http.Client
+}
+
+// NewTokenExchanger は HTTP timeout を含めた標準クライアントで TokenExchanger を組み立てる。
+func NewTokenExchanger(cfg Config) *TokenExchanger {
+	return &TokenExchanger{
+		cfg:        cfg,
+		httpClient: &http.Client{Timeout: defaultHTTPTimeout},
+	}
+}
+
+// NewTokenExchangerWithClient はテスト時に http.Client を差し替えるための DI コンストラクタ。
+func NewTokenExchangerWithClient(cfg Config, client *http.Client) *TokenExchanger {
+	if client == nil {
+		client = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	return &TokenExchanger{cfg: cfg, httpClient: client}
+}
+
+// 既定で発生し得るエラー値。エラーラップ越しに呼び元が分岐できるよう sentinel として公開する。
+var (
+	// ErrNotConfigured は ClientID / TokenURI が空の状態で呼ばれたときに返る。
+	// handler 側で 500 (cognito_not_configured) に変換することを想定。
+	ErrNotConfigured = errors.New("cognito: not configured")
+
+	// ErrUnreachable は token endpoint への HTTP リクエスト自体が失敗したとき。
+	// (DNS / TLS / connect / read deadline 等) handler 側で 502 を返す目安。
+	ErrUnreachable = errors.New("cognito: token endpoint unreachable")
+
+	// ErrInvalidResponse はステータス 200 だが JSON が壊れているとき。
+	ErrInvalidResponse = errors.New("cognito: invalid token response")
+
+	// ErrTokenExchangeFailed は Cognito が 4xx/5xx を返したとき。
+	// HTTPStatus / Body を見たい場合は TokenExchangeError 型で wrap される。
+	ErrTokenExchangeFailed = errors.New("cognito: token exchange failed")
+)
+
+// TokenExchangeError は Cognito が non-2xx を返したときの詳細を保持する。
+// errors.Is(err, ErrTokenExchangeFailed) で判定可能。
+// CloudWatch Logs への記録用に HTTPStatus / Body を残す（handler 側でログ済）。
+type TokenExchangeError struct {
+	HTTPStatus int
+	Body       string
+}
+
+func (e *TokenExchangeError) Error() string {
+	return fmt.Sprintf("cognito: token exchange failed: status=%d body=%s", e.HTTPStatus, e.Body)
+}
+
+func (e *TokenExchangeError) Unwrap() error { return ErrTokenExchangeFailed }
+
+// ExchangeAuthorizationCode は Cognito Hosted UI から戻った認可コードを token に交換する。
+// Spring Boot CognitoAuthController#callback と等価。
+func (t *TokenExchanger) ExchangeAuthorizationCode(ctx context.Context, code string) (*Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", t.cfg.RedirectURI)
+	return t.exchange(ctx, form)
+}
+
+// RefreshAccessToken は HttpOnly Cookie の refresh_token を使って access_token を再発行する。
+func (t *TokenExchanger) RefreshAccessToken(ctx context.Context, refreshToken string) (*Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	return t.exchange(ctx, form)
+}
+
+// exchange は authorization_code / refresh_token grant の差を吸収した内部実装。
+//
+// Cognito の OAuth2 token endpoint には「Authorization Basic header 方式」と
+// 「body 方式 (client_id + client_secret を form に入れる)」があるが、両方送ると
+// invalid_client を返すケースがある。本実装では body 方式に統一する（AWS docs 推奨）。
+func (t *TokenExchanger) exchange(ctx context.Context, form url.Values) (*Token, error) {
+	if t.cfg.TokenURI == "" || t.cfg.ClientID == "" {
+		return nil, ErrNotConfigured
+	}
+
+	form.Set("client_id", t.cfg.ClientID)
+	if t.cfg.ClientSecret != "" {
+		form.Set("client_secret", t.cfg.ClientSecret)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.cfg.TokenURI, strings.NewReader(form.Encode()))
+	if err != nil {
+		// NewRequestWithContext は URL parse 不能などで失敗する。
+		// 設定不備に近いので handler 側で 500 にする想定。
+		return nil, fmt.Errorf("cognito: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := t.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnreachable, err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		// 4xx/5xx は本物の理由 (invalid_grant / redirect_uri_mismatch 等) を保持して返す。
+		return nil, &TokenExchangeError{HTTPStatus: resp.StatusCode, Body: string(body)}
+	}
+
+	var tok Token
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidResponse, err)
+	}
+	return &tok, nil
+}

--- a/backend/internal/infra/cognito/token_exchanger_test.go
+++ b/backend/internal/infra/cognito/token_exchanger_test.go
@@ -1,0 +1,142 @@
+package cognito
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestServer は与えた handler でリクエストを受ける httptest.Server を立てる。
+func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, Config) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	cfg := Config{
+		ClientID:     "client-xyz",
+		ClientSecret: "secret-abc",
+		RedirectURI:  "https://normanblog.com/auth/callback",
+		TokenURI:     srv.URL,
+	}
+	return srv, cfg
+}
+
+func TestExchangeAuthorizationCode_Success(t *testing.T) {
+	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		form := string(body)
+		for _, want := range []string{"grant_type=authorization_code", "code=auth-code-123", "client_id=client-xyz", "client_secret=secret-abc"} {
+			if !strings.Contains(form, want) {
+				t.Errorf("body missing %q: %s", want, form)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"AT","id_token":"IT","refresh_token":"RT","expires_in":3600,"token_type":"Bearer"}`))
+	})
+
+	tx := NewTokenExchanger(cfg)
+	tok, err := tx.ExchangeAuthorizationCode(context.Background(), "auth-code-123")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if tok.AccessToken != "AT" || tok.RefreshToken != "RT" || tok.ExpiresIn != 3600 {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+}
+
+func TestRefreshAccessToken_Success(t *testing.T) {
+	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		form := string(body)
+		if !strings.Contains(form, "grant_type=refresh_token") {
+			t.Errorf("expected refresh_token grant: %s", form)
+		}
+		if !strings.Contains(form, "refresh_token=RT") {
+			t.Errorf("missing refresh_token in body: %s", form)
+		}
+		_, _ = w.Write([]byte(`{"access_token":"AT2","expires_in":1800}`))
+	})
+
+	tx := NewTokenExchanger(cfg)
+	tok, err := tx.RefreshAccessToken(context.Background(), "RT")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if tok.AccessToken != "AT2" || tok.ExpiresIn != 1800 {
+		t.Fatalf("unexpected: %+v", tok)
+	}
+}
+
+func TestExchange_NotConfigured(t *testing.T) {
+	tx := NewTokenExchanger(Config{}) // ClientID / TokenURI 共に空
+	_, err := tx.ExchangeAuthorizationCode(context.Background(), "code")
+	if !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("want ErrNotConfigured, got %v", err)
+	}
+}
+
+func TestExchange_TokenExchangeFailedWraps(t *testing.T) {
+	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	})
+
+	tx := NewTokenExchanger(cfg)
+	_, err := tx.ExchangeAuthorizationCode(context.Background(), "bad-code")
+	if !errors.Is(err, ErrTokenExchangeFailed) {
+		t.Fatalf("want ErrTokenExchangeFailed, got %v", err)
+	}
+	var exErr *TokenExchangeError
+	if !errors.As(err, &exErr) {
+		t.Fatalf("expected *TokenExchangeError, got %T", err)
+	}
+	if exErr.HTTPStatus != http.StatusBadRequest {
+		t.Fatalf("HTTPStatus = %d", exErr.HTTPStatus)
+	}
+	if !strings.Contains(exErr.Body, "invalid_grant") {
+		t.Fatalf("Body = %q", exErr.Body)
+	}
+}
+
+func TestExchange_InvalidResponse(t *testing.T) {
+	_, cfg := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not-json`))
+	})
+
+	tx := NewTokenExchanger(cfg)
+	_, err := tx.ExchangeAuthorizationCode(context.Background(), "code")
+	if !errors.Is(err, ErrInvalidResponse) {
+		t.Fatalf("want ErrInvalidResponse, got %v", err)
+	}
+}
+
+func TestExchange_Unreachable(t *testing.T) {
+	cfg := Config{ClientID: "x", TokenURI: "http://127.0.0.1:1"} // 接続失敗
+	tx := NewTokenExchangerWithClient(cfg, &http.Client{Timeout: 100 * time.Millisecond})
+	_, err := tx.ExchangeAuthorizationCode(context.Background(), "code")
+	if !errors.Is(err, ErrUnreachable) {
+		t.Fatalf("want ErrUnreachable, got %v", err)
+	}
+}
+
+func TestExchange_OmitsSecretWhenEmpty(t *testing.T) {
+	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if strings.Contains(string(body), "client_secret=") {
+			t.Errorf("client_secret should be omitted when empty: %s", string(body))
+		}
+		_, _ = w.Write([]byte(`{"access_token":"AT"}`))
+	})
+	cfg.ClientSecret = ""
+	tx := NewTokenExchanger(cfg)
+	if _, err := tx.ExchangeAuthorizationCode(context.Background(), "code"); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#4 (Cognito service 抽出)**。`handler/auth_handler.go` の `Callback` / `Refresh` に **同一構造で複製されていた ~140 行** の Cognito OAuth2 token endpoint 通信を `internal/infra/cognito` パッケージに切り出し、Clean Architecture の Infra 層へ移します。

## 問題

- `url.Values` 構築 → `http.NewRequestWithContext` → `httpClient.Do` → ステータス判定 → JSON unmarshal の流れが Callback / Refresh で 2 重化
- 違いは `grant_type` だけ (`authorization_code` / `refresh_token`)
- handler 層が `url.Values` / `http.Client` / OAuth2 token endpoint URL 組み立てなどの低レベル詳細を直接抱えていた

## 変更内容

### `internal/infra/cognito/token_exchanger.go` (新規)
| 公開シンボル | 用途 |
|---|---|
| `TokenExchanger` | Cognito OAuth2 token endpoint クライアント |
| `Token` | OIDC token response (`access_token` / `id_token` / `refresh_token` / `expires_in`) |
| `Config` | `ClientID` / `ClientSecret` / `RedirectURI` / `TokenURI` |
| `ExchangeAuthorizationCode(ctx, code)` | Hosted UI から戻った認可コードを token に交換 |
| `RefreshAccessToken(ctx, refreshToken)` | refresh_token で access_token 再発行 |
| `NewTokenExchanger(cfg)` | 標準 (10s timeout) http.Client で組み立て |
| `NewTokenExchangerWithClient(cfg, client)` | テスト用に http.Client を差し替え |

**Sentinel error 設計** (Go Code Review Comments の "Wrap errors" / "Sentinel errors" に従う):
- `ErrNotConfigured` — `ClientID` / `TokenURI` が空 → handler 側で 500
- `ErrUnreachable` — DNS / TLS / connect / read deadline → 502
- `ErrInvalidResponse` — 200 だが JSON が壊れている → 502
- `ErrTokenExchangeFailed` — Cognito が 4xx/5xx を返した → 401
- `TokenExchangeError` 構造体で `HTTPStatus` / `Body` を保持し `Unwrap()` で `ErrTokenExchangeFailed` を返す（`errors.Is` / `errors.As` 両対応）

### `internal/handler/auth_handler.go`
- 重複していた token 交換ロジック ~140 行を **完全削除**
- `Callback` / `Refresh` は `h.tokens.Exchange*` を呼ぶだけに
- `handleTokenError(c, op, err)` — sentinel error → HTTP レスポンス (500/401/502) のマップ関数
- `upsertUserFromIDToken(c, idToken)` — id_token から sub/email/groups を取り出して users 同期する責務を関数として分離
- 不要 import (`encoding/json`, `io`, `net/url`, `strings`, `time`, `http` の重複) を削除

### `internal/infra/cognito/token_exchanger_test.go` (新規)
7 件の単体テスト（`httptest.Server` でモック Cognito を立てて検証）:
- 正常系（`authorization_code` / `refresh_token` 双方）
- body 方式の form 内容検証（`grant_type` / `code` / `refresh_token` / `client_id` / `client_secret` 全部 body に入る）
- `ErrNotConfigured`（空設定）
- `ErrTokenExchangeFailed` + `TokenExchangeError` の `HTTPStatus` / `Body` 保持
- `ErrInvalidResponse`（200 だが JSON 不正）
- `ErrUnreachable`（接続失敗、`http://127.0.0.1:1`）
- `ClientSecret` が空のとき form から省略される

## テスト

- [x] `go build ./...` 成功
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全 pass
- [x] 新規 7 テスト pass
- [x] `gofmt -l backend/` → 0 件

## 後続 PR

| # | テーマ |
|---|---|
| 5 | `router.go` (315 行) をドメインごとに `register*Routes` 関数へ分割 |
| 6 | `cmd/server/main.go` の Cognito secret 末尾 4 文字診断ログを削除 |
| 7 | backend CI に `gofmt -l` / `go vet` チェックを追加 |