### PR TITLE
refactor(backend): router.go (315行) をドメインごとの register*Routes に分割

### DIFF
--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -9,8 +9,21 @@ import (
 	"gorm.io/gorm"
 )
 
+// routeDeps はドメインごとの register*Routes 関数に渡す共通依存。
+// db / cfg / userRepo の 3 点が大半の register で必要になるため struct でまとめる。
+// 個別の register が追加で repository を必要とする場合は db から都度組み立てる
+// (lifecycle はリクエスト境界より長く、Gin ハンドラからは pure な関数 closure として参照される)。
+type routeDeps struct {
+	db       *gorm.DB
+	cfg      *config.Config
+	userRepo repository.UserRepository
+}
+
 // NewRouter は API ルーティングを組み立てる。
 // /api/v2/* は Go バックエンドの単独エンドポイント（旧 Spring Boot /api/* は廃止済み）。
+//
+// 旧実装は本関数 1 つに 28 phase 分のルーティング登録が直書きされていたが (315 行)、
+// 1 ファイル 1 ドメインの routes_*.go に分割し、本関数は組み立てだけを担う。
 func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
@@ -22,294 +35,40 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		c.JSON(200, gin.H{"message": "FreStyle Go backend"})
 	})
 
+	deps := &routeDeps{
+		db:       db,
+		cfg:      cfg,
+		userRepo: repository.NewUserRepository(db),
+	}
+
 	v2 := r.Group("/api/v2")
 
-	// Phase 1: 認証不要のヘルスチェック
-	healthHandler := NewHealthHandler(
-		usecase.NewCheckHealthUseCase(repository.NewHealthRepository(db)),
-	)
-	v2.GET("/health", healthHandler.Get)
+	// 認証不要のルート（health / cognito callback / refresh）。
+	registerHealthRoutes(v2, deps)
+	authHandler := registerAuthPublicRoutes(v2, deps)
 
-	// Phase 2: 認証 (Cognito)
-	userRepo := repository.NewUserRepository(db)
-	authHandler := NewAuthHandler(usecase.NewGetCurrentUserUseCase(userRepo), userRepo, &cfg.Cognito)
-	v2.POST("/auth/cognito/logout", authHandler.Logout)
-	// callback は code を受け取って token に交換するので認証不要
-	v2.POST("/auth/cognito/callback", authHandler.Callback)
-	// refresh-token は HttpOnly Cookie の refresh_token を読むため認証 middleware の対象外
-	v2.POST("/auth/cognito/refresh-token", authHandler.Refresh)
-
-	// 認証必須グループ。JWTAuth で sub を context に詰めた後、CurrentUser で users.id を解決する。
+	// 認証必須ルート。JWTAuth で sub を context に詰めた後、CurrentUser で users.id を解決する。
 	authed := v2.Group("")
 	authed.Use(middleware.JWTAuth())
-	authed.Use(middleware.CurrentUser(userRepo))
-	authed.GET("/auth/me", authHandler.Me)
+	authed.Use(middleware.CurrentUser(deps.userRepo))
 
-	// Phase 3: AI チャット
-	aiSessionRepo := repository.NewAiChatSessionRepository(db)
-	aiHandler := NewAiChatHandler(
-		usecase.NewGetAiChatSessionsByUserIDUseCase(aiSessionRepo),
-		usecase.NewCreateAiChatSessionUseCase(aiSessionRepo),
-	)
-	authed.GET("/ai-chat/sessions", aiHandler.GetSessions)
-	authed.POST("/ai-chat/sessions", aiHandler.CreateSession)
-
-	// Phase 4: ユーザー間チャット (ルーム CRUD)
-	chatRoomRepo := repository.NewChatRoomRepository(db)
-	chatHandler := NewChatHandler(
-		usecase.NewGetChatRoomsByUserIDUseCase(chatRoomRepo),
-		usecase.NewCreateChatRoomUseCase(chatRoomRepo),
-	)
-	authed.GET("/chat/rooms", chatHandler.GetRooms)
-	authed.POST("/chat/rooms", chatHandler.CreateRoom)
-
-	// Phase 5: プロフィール
-	profileRepo := repository.NewProfileRepository(db)
-	profileHandler := NewProfileHandler(
-		usecase.NewGetProfileUseCase(profileRepo),
-		usecase.NewUpdateProfileUseCase(profileRepo),
-		userRepo,
-	)
-	// /profile/:userId は数字 / "me" の両方を受ける（handler.resolveUserID で current user 解決）。
-	// フロント互換のため /profile/:userId/update PUT / /profile/:userId/image/presigned-url POST も提供する。
-	authed.GET("/profile/:userId", profileHandler.Get)
-	authed.PUT("/profile/:userId", profileHandler.Update)
-	authed.PUT("/profile/:userId/update", profileHandler.Update)
-
-	// Profile アイコン画像の S3 presigned-url。bucket / CDN は note image と同じインフラを共有する
-	// （別 prefix `profiles/` で分離）。AWS SDK 統合は別 issue。
-	profileImageHandler := NewProfileImageHandler(
-		usecase.NewIssueProfileImageUploadURLUseCase(
-			repository.NewStubProfileImagePresigner("frestyle-prod-note-images", "https://normanblog.com"),
-		),
-	)
-	authed.POST("/profile/:userId/image/presigned-url", profileImageHandler.IssueUploadURL)
-
-	// Phase 6: ユーザー統計
-	statsHandler := NewUserStatsHandler(
-		usecase.NewGetUserStatsUseCase(repository.NewUserStatsRepository(db)),
-	)
-	// 旧 path /user-stats/:userId と Spring 風 /users/:userId/stats の両方を提供する。
-	authed.GET("/user-stats/:userId", statsHandler.Get)
-	authed.GET("/users/:userId/stats", statsHandler.Get)
-
-	// Phase 7: 練習モード (シナリオ)
-	practiceRepo := repository.NewPracticeScenarioRepository(db)
-	practiceHandler := NewPracticeHandler(
-		usecase.NewListPracticeScenariosUseCase(practiceRepo),
-		usecase.NewGetPracticeScenarioUseCase(practiceRepo),
-	)
-	authed.GET("/practice/scenarios", practiceHandler.List)
-	authed.GET("/practice/scenarios/:id", practiceHandler.Get)
-
-	// Phase 8: シナリオブックマーク
-	bookmarkRepo := repository.NewScenarioBookmarkRepository(db)
-	bookmarkHandler := NewScenarioBookmarkHandler(
-		usecase.NewListScenarioBookmarksUseCase(bookmarkRepo),
-		usecase.NewAddScenarioBookmarkUseCase(bookmarkRepo),
-		usecase.NewRemoveScenarioBookmarkUseCase(bookmarkRepo),
-	)
-	// scenario-bookmarks は current user の所有物のみ操作可能（IDOR 対策で userId は受けない）。
-	// フロントは /scenario-bookmarks/:scenarioId に POST/DELETE を投げる。
-	authed.GET("/scenario-bookmarks", bookmarkHandler.List)
-	authed.POST("/scenario-bookmarks/:scenarioId", bookmarkHandler.Add)
-	authed.DELETE("/scenario-bookmarks/:scenarioId", bookmarkHandler.Remove)
-
-	// Phase 9: 共有 AI 会話セッション
-	sharedRepo := repository.NewSharedSessionRepository(db)
-	sharedHandler := NewSharedSessionHandler(
-		usecase.NewListSharedSessionsUseCase(sharedRepo),
-		usecase.NewCreateSharedSessionUseCase(sharedRepo),
-	)
-	authed.GET("/shared-sessions", sharedHandler.List)
-	authed.POST("/shared-sessions", sharedHandler.Create)
-
-	// Phase 10: Note CRUD
-	noteRepo := repository.NewNoteRepository(db)
-	noteHandler := NewNoteHandler(
-		usecase.NewListNotesByUserIDUseCase(noteRepo),
-		usecase.NewCreateNoteUseCase(noteRepo),
-		usecase.NewUpdateNoteUseCase(noteRepo),
-		usecase.NewDeleteNoteUseCase(noteRepo),
-	)
-	authed.GET("/notes", noteHandler.List)
-	authed.POST("/notes", noteHandler.Create)
-	authed.PUT("/notes/:id", noteHandler.Update)
-	authed.DELETE("/notes/:id", noteHandler.Delete)
-
-	// Phase 11: Note image (S3 presigned upload)
-	noteImageHandler := NewNoteImageHandler(
-		usecase.NewIssueNoteImageUploadURLUseCase(
-			repository.NewStubNoteImagePresigner("frestyle-prod-note-images"),
-		),
-	)
-	authed.POST("/notes/images/upload-url", noteImageHandler.IssueUploadURL)
-
-	// Phase 12: SessionNote (セッション固有ノート)
-	sessionNoteRepo := repository.NewSessionNoteRepository(db)
-	sessionNoteHandler := NewSessionNoteHandler(
-		usecase.NewGetSessionNoteUseCase(sessionNoteRepo),
-		usecase.NewUpsertSessionNoteUseCase(sessionNoteRepo),
-	)
-	authed.GET("/sessions/:sessionId/note", sessionNoteHandler.Get)
-	authed.PUT("/sessions/:sessionId/note", sessionNoteHandler.Upsert)
-
-	// Phase 13: ScoreCard
-	scoreCardRepo := repository.NewScoreCardRepository(db)
-	scoreCardHandler := NewScoreCardHandler(
-		usecase.NewListScoreCardsByUserIDUseCase(scoreCardRepo),
-		usecase.NewCreateScoreCardUseCase(scoreCardRepo),
-	)
-	authed.GET("/score-cards", scoreCardHandler.List)
-	authed.POST("/score-cards", scoreCardHandler.Create)
-
-	// Phase 14: ScoreGoal
-	scoreGoalRepo := repository.NewScoreGoalRepository(db)
-	scoreGoalHandler := NewScoreGoalHandler(
-		usecase.NewGetScoreGoalUseCase(scoreGoalRepo),
-		usecase.NewUpsertScoreGoalUseCase(scoreGoalRepo),
-	)
-	// 認証済 current user の score goal のみを返す。
-	// 旧 `/score-goals/:userId` 系は admin 認可機構が無く IDOR になるため廃止。
-	// admin 用の他ユーザー閲覧/変更が必要になったら別途 /admin/users/:id/score-goal として追加する。
-	authed.GET("/score-goals", scoreGoalHandler.Get)
-	authed.PUT("/score-goals", scoreGoalHandler.Upsert)
-
-	// Phase 15: ScoreTrend
-	scoreTrendHandler := NewScoreTrendHandler(
-		usecase.NewGetScoreTrendUseCase(repository.NewScoreTrendRepository(db)),
-	)
-	authed.GET("/score-trends/:userId", scoreTrendHandler.Get)
-
-	// Phase 16: Ranking
-	rankingHandler := NewRankingHandler(
-		usecase.NewGetRankingUseCase(repository.NewRankingRepository(db)),
-	)
-	authed.GET("/rankings", rankingHandler.Get)
-
-	// Phase 17: LearningReport (非同期生成)
-	learningReportRepo := repository.NewLearningReportRepository(db)
-	learningReportHandler := NewLearningReportHandler(
-		usecase.NewListLearningReportsUseCase(learningReportRepo),
-		usecase.NewRequestLearningReportUseCase(learningReportRepo, repository.NewStubSqsEnqueuer()),
-	)
-	authed.GET("/learning-reports", learningReportHandler.List)
-	authed.POST("/learning-reports", learningReportHandler.Request)
-
-	// Phase 18: ConversationTemplate
-	templateHandler := NewConversationTemplateHandler(
-		usecase.NewListConversationTemplatesUseCase(repository.NewConversationTemplateRepository(db)),
-	)
-	authed.GET("/conversation-templates", templateHandler.List)
-
-	// Phase 19: FavoritePhrase
-	favRepo := repository.NewFavoritePhraseRepository(db)
-	favHandler := NewFavoritePhraseHandler(
-		usecase.NewListFavoritePhrasesUseCase(favRepo),
-		usecase.NewAddFavoritePhraseUseCase(favRepo),
-		usecase.NewDeleteFavoritePhraseUseCase(favRepo),
-	)
-	authed.GET("/favorite-phrases", favHandler.List)
-	authed.POST("/favorite-phrases", favHandler.Add)
-	authed.DELETE("/favorite-phrases/:id", favHandler.Remove)
-
-	// Phase 20: Friendship + 単方向フォロー（フロントの follow / unfollow / status / following / followers に対応）
-	friendshipRepo := repository.NewFriendshipRepository(db)
-	friendshipHandler := NewFriendshipHandler(
-		usecase.NewListFriendshipsUseCase(friendshipRepo),
-		usecase.NewRequestFriendshipUseCase(friendshipRepo),
-		usecase.NewRespondFriendshipUseCase(friendshipRepo),
-		usecase.NewFollowUserUseCase(friendshipRepo),
-		usecase.NewUnfollowUserUseCase(friendshipRepo),
-		usecase.NewListFollowingUseCase(friendshipRepo),
-		usecase.NewListFollowersUseCase(friendshipRepo),
-		usecase.NewGetFollowStatusUseCase(friendshipRepo),
-	)
-	authed.GET("/friendships", friendshipHandler.List)
-	authed.POST("/friendships", friendshipHandler.Request)
-	authed.PATCH("/friendships/:id", friendshipHandler.Respond)
-	authed.GET("/friendships/following", friendshipHandler.Following)
-	authed.GET("/friendships/followers", friendshipHandler.Followers)
-	authed.POST("/friendships/:userId/follow", friendshipHandler.Follow)
-	authed.DELETE("/friendships/:userId/follow", friendshipHandler.Unfollow)
-	authed.GET("/friendships/:userId/status", friendshipHandler.Status)
-
-	// Phase 21: Notification
-	notificationRepo := repository.NewNotificationRepository(db)
-	notificationHandler := NewNotificationHandler(
-		usecase.NewListNotificationsUseCase(notificationRepo),
-		usecase.NewMarkNotificationReadUseCase(notificationRepo),
-		usecase.NewMarkAllNotificationsReadUseCase(notificationRepo),
-		usecase.NewCountUnreadNotificationsUseCase(notificationRepo),
-	)
-	authed.GET("/notifications", notificationHandler.List)
-	authed.GET("/notifications/unread-count", notificationHandler.UnreadCount)
-	authed.PATCH("/notifications/:id/read", notificationHandler.MarkRead)
-	authed.PUT("/notifications/:id/read", notificationHandler.MarkRead)
-	authed.PATCH("/notifications/read-all", notificationHandler.MarkAllRead)
-	authed.PUT("/notifications/read-all", notificationHandler.MarkAllRead)
-
-	// Phase 22: ReminderSetting
-	reminderRepo := repository.NewReminderSettingRepository(db)
-	reminderHandler := NewReminderSettingHandler(
-		usecase.NewGetReminderSettingUseCase(reminderRepo),
-		usecase.NewUpsertReminderSettingUseCase(reminderRepo),
-	)
-	authed.GET("/reminder-settings/:userId", reminderHandler.Get)
-	authed.PUT("/reminder-settings/:userId", reminderHandler.Upsert)
-
-	// Phase 23: DailyGoal
-	dailyGoalRepo := repository.NewDailyGoalRepository(db)
-	dailyGoalHandler := NewDailyGoalHandler(
-		usecase.NewGetDailyGoalUseCase(dailyGoalRepo),
-		usecase.NewUpsertDailyGoalUseCase(dailyGoalRepo),
-	)
-	// /daily-goals/today はフロント MenuPage が呼ぶ。handler 側で path の :userId が "today" や数値以外なら
-	// current user に解決する仕組みを入れている (see daily_goal_handler.go resolveUserID)。
-	authed.GET("/daily-goals/:userId", dailyGoalHandler.Get)
-	authed.PUT("/daily-goals/:userId", dailyGoalHandler.Upsert)
-
-	// Phase 24: WeeklyChallenge
-	weeklyRepo := repository.NewWeeklyChallengeRepository(db)
-	weeklyHandler := NewWeeklyChallengeHandler(
-		usecase.NewGetCurrentWeeklyChallengeUseCase(weeklyRepo),
-		usecase.NewCompleteWeeklyChallengeUseCase(weeklyRepo),
-	)
-	authed.GET("/weekly-challenges/current", weeklyHandler.GetCurrent)
-	authed.POST("/weekly-challenges/complete", weeklyHandler.Complete)
-
-	// Phase 25: AdminInvitation
-	adminInvRepo := repository.NewAdminInvitationRepository(db)
-	adminInvHandler := NewAdminInvitationHandler(
-		usecase.NewListAdminInvitationsUseCase(adminInvRepo),
-		usecase.NewCreateAdminInvitationUseCase(adminInvRepo, repository.NewStubCognitoAdminClient()),
-		usecase.NewCancelAdminInvitationUseCase(adminInvRepo),
-	)
-	authed.GET("/admin/invitations", adminInvHandler.List)
-	authed.POST("/admin/invitations", adminInvHandler.Create)
-	authed.DELETE("/admin/invitations/:id", adminInvHandler.Cancel)
-
-	// Phase 26: AdminScenario
-	adminScenarioRepo := repository.NewAdminScenarioRepository(db)
-	adminScenarioHandler := NewAdminScenarioHandler(
-		usecase.NewListAdminScenariosUseCase(adminScenarioRepo),
-		usecase.NewCreateAdminScenarioUseCase(adminScenarioRepo),
-		usecase.NewUpdateAdminScenarioUseCase(adminScenarioRepo),
-		usecase.NewDeleteAdminScenarioUseCase(adminScenarioRepo),
-	)
-	authed.GET("/admin/scenarios", adminScenarioHandler.List)
-	authed.POST("/admin/scenarios", adminScenarioHandler.Create)
-	authed.PUT("/admin/scenarios/:id", adminScenarioHandler.Update)
-	authed.DELETE("/admin/scenarios/:id", adminScenarioHandler.Delete)
-
-	// AiChat WebSocket (raw / native, Bedrock 連携は別 PR)
-	// SockJS / STOMP は廃止し、フロントは ブラウザ標準 `WebSocket` で接続する。
-	aiChatWsHandler := NewAiChatWsHandler()
-	authed.GET("/ws/ai-chat", aiChatWsHandler.Handle)
-
-	// Chat WebSocket (ルームごとブロードキャスト)。raw WebSocket + JSON プロトコル。
-	chatWsHandler := NewChatWsHandler()
-	authed.GET("/ws/chat/:roomId", chatWsHandler.Handle)
+	registerAuthAuthedRoutes(authed, authHandler)
+	registerChatRoutes(authed, deps)
+	registerProfileRoutes(authed, deps)
+	registerPracticeRoutes(authed, deps)
+	registerNoteRoutes(authed, deps)
+	registerScoreRoutes(authed, deps)
+	registerPhraseRoutes(authed, deps)
+	registerSocialRoutes(authed, deps)
+	registerSettingsRoutes(authed, deps)
+	registerAdminRoutes(authed, deps)
+	registerWebSocketRoutes(authed)
 
 	return r
+}
+
+// registerHealthRoutes は認証不要のヘルスチェック (/api/v2/health) を登録する。
+func registerHealthRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	h := NewHealthHandler(usecase.NewCheckHealthUseCase(repository.NewHealthRepository(deps.db)))
+	g.GET("/health", h.Get)
 }

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerAdminRoutes は管理者向けの招待管理・シナリオ管理エンドポイントを登録する。
+// 認可（super_admin / company_admin のみ操作可能）は handler 層で実施する。
+func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 25: AdminInvitation
+	adminInvRepo := repository.NewAdminInvitationRepository(deps.db)
+	adminInvHandler := NewAdminInvitationHandler(
+		usecase.NewListAdminInvitationsUseCase(adminInvRepo),
+		usecase.NewCreateAdminInvitationUseCase(adminInvRepo, repository.NewStubCognitoAdminClient()),
+		usecase.NewCancelAdminInvitationUseCase(adminInvRepo),
+	)
+	g.GET("/admin/invitations", adminInvHandler.List)
+	g.POST("/admin/invitations", adminInvHandler.Create)
+	g.DELETE("/admin/invitations/:id", adminInvHandler.Cancel)
+
+	// Phase 26: AdminScenario
+	adminScenarioRepo := repository.NewAdminScenarioRepository(deps.db)
+	adminScenarioHandler := NewAdminScenarioHandler(
+		usecase.NewListAdminScenariosUseCase(adminScenarioRepo),
+		usecase.NewCreateAdminScenarioUseCase(adminScenarioRepo),
+		usecase.NewUpdateAdminScenarioUseCase(adminScenarioRepo),
+		usecase.NewDeleteAdminScenarioUseCase(adminScenarioRepo),
+	)
+	g.GET("/admin/scenarios", adminScenarioHandler.List)
+	g.POST("/admin/scenarios", adminScenarioHandler.Create)
+	g.PUT("/admin/scenarios/:id", adminScenarioHandler.Update)
+	g.DELETE("/admin/scenarios/:id", adminScenarioHandler.Delete)
+}

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerAuthPublicRoutes は認証不要の Cognito 認証エンドポイント (logout / callback / refresh-token)
+// を登録し、後段の authed group で再利用するため AuthHandler を返す。
+//
+// callback / refresh-token は HttpOnly Cookie の発行・更新を行うため middleware.JWTAuth の対象外。
+func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
+	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
+	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, &deps.cfg.Cognito)
+
+	g.POST("/auth/cognito/logout", authHandler.Logout)
+	// callback は code を受け取って token に交換するので認証不要
+	g.POST("/auth/cognito/callback", authHandler.Callback)
+	// refresh-token は HttpOnly Cookie の refresh_token を読むため認証 middleware の対象外
+	g.POST("/auth/cognito/refresh-token", authHandler.Refresh)
+
+	return authHandler
+}
+
+// registerAuthAuthedRoutes は認証必須の自己情報取得 (/auth/me) を登録する。
+func registerAuthAuthedRoutes(g *gin.RouterGroup, authHandler *AuthHandler) {
+	g.GET("/auth/me", authHandler.Me)
+}

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerChatRoutes は AI チャットセッションとユーザー間チャットルームの REST エンドポイントを登録する。
+// WebSocket は registerWebSocketRoutes 側で別途登録する。
+func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 3: AI チャット
+	aiSessionRepo := repository.NewAiChatSessionRepository(deps.db)
+	aiHandler := NewAiChatHandler(
+		usecase.NewGetAiChatSessionsByUserIDUseCase(aiSessionRepo),
+		usecase.NewCreateAiChatSessionUseCase(aiSessionRepo),
+	)
+	g.GET("/ai-chat/sessions", aiHandler.GetSessions)
+	g.POST("/ai-chat/sessions", aiHandler.CreateSession)
+
+	// Phase 4: ユーザー間チャット (ルーム CRUD)
+	chatRoomRepo := repository.NewChatRoomRepository(deps.db)
+	chatHandler := NewChatHandler(
+		usecase.NewGetChatRoomsByUserIDUseCase(chatRoomRepo),
+		usecase.NewCreateChatRoomUseCase(chatRoomRepo),
+	)
+	g.GET("/chat/rooms", chatHandler.GetRooms)
+	g.POST("/chat/rooms", chatHandler.CreateRoom)
+}

--- a/backend/internal/handler/routes_note.go
+++ b/backend/internal/handler/routes_note.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerNoteRoutes は Note CRUD・Note 画像 presigned URL・SessionNote のエンドポイントを登録する。
+func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 10: Note CRUD
+	noteRepo := repository.NewNoteRepository(deps.db)
+	noteHandler := NewNoteHandler(
+		usecase.NewListNotesByUserIDUseCase(noteRepo),
+		usecase.NewCreateNoteUseCase(noteRepo),
+		usecase.NewUpdateNoteUseCase(noteRepo),
+		usecase.NewDeleteNoteUseCase(noteRepo),
+	)
+	g.GET("/notes", noteHandler.List)
+	g.POST("/notes", noteHandler.Create)
+	g.PUT("/notes/:id", noteHandler.Update)
+	g.DELETE("/notes/:id", noteHandler.Delete)
+
+	// Phase 11: Note image (S3 presigned upload)
+	noteImageHandler := NewNoteImageHandler(
+		usecase.NewIssueNoteImageUploadURLUseCase(
+			repository.NewStubNoteImagePresigner("frestyle-prod-note-images"),
+		),
+	)
+	g.POST("/notes/images/upload-url", noteImageHandler.IssueUploadURL)
+
+	// Phase 12: SessionNote (セッション固有ノート)
+	sessionNoteRepo := repository.NewSessionNoteRepository(deps.db)
+	sessionNoteHandler := NewSessionNoteHandler(
+		usecase.NewGetSessionNoteUseCase(sessionNoteRepo),
+		usecase.NewUpsertSessionNoteUseCase(sessionNoteRepo),
+	)
+	g.GET("/sessions/:sessionId/note", sessionNoteHandler.Get)
+	g.PUT("/sessions/:sessionId/note", sessionNoteHandler.Upsert)
+}

--- a/backend/internal/handler/routes_phrase.go
+++ b/backend/internal/handler/routes_phrase.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerPhraseRoutes は会話テンプレートとお気に入りフレーズの REST エンドポイントを登録する。
+func registerPhraseRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 18: ConversationTemplate
+	templateHandler := NewConversationTemplateHandler(
+		usecase.NewListConversationTemplatesUseCase(repository.NewConversationTemplateRepository(deps.db)),
+	)
+	g.GET("/conversation-templates", templateHandler.List)
+
+	// Phase 19: FavoritePhrase
+	favRepo := repository.NewFavoritePhraseRepository(deps.db)
+	favHandler := NewFavoritePhraseHandler(
+		usecase.NewListFavoritePhrasesUseCase(favRepo),
+		usecase.NewAddFavoritePhraseUseCase(favRepo),
+		usecase.NewDeleteFavoritePhraseUseCase(favRepo),
+	)
+	g.GET("/favorite-phrases", favHandler.List)
+	g.POST("/favorite-phrases", favHandler.Add)
+	g.DELETE("/favorite-phrases/:id", favHandler.Remove)
+}

--- a/backend/internal/handler/routes_practice.go
+++ b/backend/internal/handler/routes_practice.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerPracticeRoutes は練習モード（シナリオ・ブックマーク・共有セッション）の
+// エンドポイントを登録する。
+func registerPracticeRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 7: 練習モード (シナリオ)
+	practiceRepo := repository.NewPracticeScenarioRepository(deps.db)
+	practiceHandler := NewPracticeHandler(
+		usecase.NewListPracticeScenariosUseCase(practiceRepo),
+		usecase.NewGetPracticeScenarioUseCase(practiceRepo),
+	)
+	g.GET("/practice/scenarios", practiceHandler.List)
+	g.GET("/practice/scenarios/:id", practiceHandler.Get)
+
+	// Phase 8: シナリオブックマーク
+	bookmarkRepo := repository.NewScenarioBookmarkRepository(deps.db)
+	bookmarkHandler := NewScenarioBookmarkHandler(
+		usecase.NewListScenarioBookmarksUseCase(bookmarkRepo),
+		usecase.NewAddScenarioBookmarkUseCase(bookmarkRepo),
+		usecase.NewRemoveScenarioBookmarkUseCase(bookmarkRepo),
+	)
+	// scenario-bookmarks は current user の所有物のみ操作可能（IDOR 対策で userId は受けない）。
+	// フロントは /scenario-bookmarks/:scenarioId に POST/DELETE を投げる。
+	g.GET("/scenario-bookmarks", bookmarkHandler.List)
+	g.POST("/scenario-bookmarks/:scenarioId", bookmarkHandler.Add)
+	g.DELETE("/scenario-bookmarks/:scenarioId", bookmarkHandler.Remove)
+
+	// Phase 9: 共有 AI 会話セッション
+	sharedRepo := repository.NewSharedSessionRepository(deps.db)
+	sharedHandler := NewSharedSessionHandler(
+		usecase.NewListSharedSessionsUseCase(sharedRepo),
+		usecase.NewCreateSharedSessionUseCase(sharedRepo),
+	)
+	g.GET("/shared-sessions", sharedHandler.List)
+	g.POST("/shared-sessions", sharedHandler.Create)
+}

--- a/backend/internal/handler/routes_profile.go
+++ b/backend/internal/handler/routes_profile.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerProfileRoutes は profile / user-stats 関連の REST エンドポイントを登録する。
+func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 5: プロフィール
+	profileRepo := repository.NewProfileRepository(deps.db)
+	profileHandler := NewProfileHandler(
+		usecase.NewGetProfileUseCase(profileRepo),
+		usecase.NewUpdateProfileUseCase(profileRepo),
+		deps.userRepo,
+	)
+	// /profile/:userId は数字 / "me" の両方を受ける（handler.resolveUserID で current user 解決）。
+	// フロント互換のため /profile/:userId/update PUT / /profile/:userId/image/presigned-url POST も提供する。
+	g.GET("/profile/:userId", profileHandler.Get)
+	g.PUT("/profile/:userId", profileHandler.Update)
+	g.PUT("/profile/:userId/update", profileHandler.Update)
+
+	// Profile アイコン画像の S3 presigned-url。bucket / CDN は note image と同じインフラを共有する
+	// （別 prefix `profiles/` で分離）。AWS SDK 統合は別 issue。
+	profileImageHandler := NewProfileImageHandler(
+		usecase.NewIssueProfileImageUploadURLUseCase(
+			repository.NewStubProfileImagePresigner("frestyle-prod-note-images", "https://normanblog.com"),
+		),
+	)
+	g.POST("/profile/:userId/image/presigned-url", profileImageHandler.IssueUploadURL)
+
+	// Phase 6: ユーザー統計
+	statsHandler := NewUserStatsHandler(
+		usecase.NewGetUserStatsUseCase(repository.NewUserStatsRepository(deps.db)),
+	)
+	// 旧 path /user-stats/:userId と Spring 風 /users/:userId/stats の両方を提供する。
+	g.GET("/user-stats/:userId", statsHandler.Get)
+	g.GET("/users/:userId/stats", statsHandler.Get)
+}

--- a/backend/internal/handler/routes_score.go
+++ b/backend/internal/handler/routes_score.go
@@ -1,0 +1,62 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerScoreRoutes はスコアカード・スコアゴール・トレンド・ランキング・
+// 学習レポート・週次チャレンジを含む「スコア / 進捗」ドメインのエンドポイントをまとめて登録する。
+func registerScoreRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 13: ScoreCard
+	scoreCardRepo := repository.NewScoreCardRepository(deps.db)
+	scoreCardHandler := NewScoreCardHandler(
+		usecase.NewListScoreCardsByUserIDUseCase(scoreCardRepo),
+		usecase.NewCreateScoreCardUseCase(scoreCardRepo),
+	)
+	g.GET("/score-cards", scoreCardHandler.List)
+	g.POST("/score-cards", scoreCardHandler.Create)
+
+	// Phase 14: ScoreGoal
+	scoreGoalRepo := repository.NewScoreGoalRepository(deps.db)
+	scoreGoalHandler := NewScoreGoalHandler(
+		usecase.NewGetScoreGoalUseCase(scoreGoalRepo),
+		usecase.NewUpsertScoreGoalUseCase(scoreGoalRepo),
+	)
+	// 認証済 current user の score goal のみを返す。
+	// 旧 `/score-goals/:userId` 系は admin 認可機構が無く IDOR になるため廃止。
+	// admin 用の他ユーザー閲覧/変更が必要になったら別途 /admin/users/:id/score-goal として追加する。
+	g.GET("/score-goals", scoreGoalHandler.Get)
+	g.PUT("/score-goals", scoreGoalHandler.Upsert)
+
+	// Phase 15: ScoreTrend
+	scoreTrendHandler := NewScoreTrendHandler(
+		usecase.NewGetScoreTrendUseCase(repository.NewScoreTrendRepository(deps.db)),
+	)
+	g.GET("/score-trends/:userId", scoreTrendHandler.Get)
+
+	// Phase 16: Ranking
+	rankingHandler := NewRankingHandler(
+		usecase.NewGetRankingUseCase(repository.NewRankingRepository(deps.db)),
+	)
+	g.GET("/rankings", rankingHandler.Get)
+
+	// Phase 17: LearningReport (非同期生成)
+	learningReportRepo := repository.NewLearningReportRepository(deps.db)
+	learningReportHandler := NewLearningReportHandler(
+		usecase.NewListLearningReportsUseCase(learningReportRepo),
+		usecase.NewRequestLearningReportUseCase(learningReportRepo, repository.NewStubSqsEnqueuer()),
+	)
+	g.GET("/learning-reports", learningReportHandler.List)
+	g.POST("/learning-reports", learningReportHandler.Request)
+
+	// Phase 24: WeeklyChallenge
+	weeklyRepo := repository.NewWeeklyChallengeRepository(deps.db)
+	weeklyHandler := NewWeeklyChallengeHandler(
+		usecase.NewGetCurrentWeeklyChallengeUseCase(weeklyRepo),
+		usecase.NewCompleteWeeklyChallengeUseCase(weeklyRepo),
+	)
+	g.GET("/weekly-challenges/current", weeklyHandler.GetCurrent)
+	g.POST("/weekly-challenges/complete", weeklyHandler.Complete)
+}

--- a/backend/internal/handler/routes_settings.go
+++ b/backend/internal/handler/routes_settings.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerSettingsRoutes はリマインダー設定と日次目標の REST エンドポイントを登録する。
+func registerSettingsRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 22: ReminderSetting
+	reminderRepo := repository.NewReminderSettingRepository(deps.db)
+	reminderHandler := NewReminderSettingHandler(
+		usecase.NewGetReminderSettingUseCase(reminderRepo),
+		usecase.NewUpsertReminderSettingUseCase(reminderRepo),
+	)
+	g.GET("/reminder-settings/:userId", reminderHandler.Get)
+	g.PUT("/reminder-settings/:userId", reminderHandler.Upsert)
+
+	// Phase 23: DailyGoal
+	dailyGoalRepo := repository.NewDailyGoalRepository(deps.db)
+	dailyGoalHandler := NewDailyGoalHandler(
+		usecase.NewGetDailyGoalUseCase(dailyGoalRepo),
+		usecase.NewUpsertDailyGoalUseCase(dailyGoalRepo),
+	)
+	// /daily-goals/today はフロント MenuPage が呼ぶ。handler 側で path の :userId が "today" や数値以外なら
+	// current user に解決する仕組みを入れている (see daily_goal_handler.go resolveUserID)。
+	g.GET("/daily-goals/:userId", dailyGoalHandler.Get)
+	g.PUT("/daily-goals/:userId", dailyGoalHandler.Upsert)
+}

--- a/backend/internal/handler/routes_social.go
+++ b/backend/internal/handler/routes_social.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerSocialRoutes は Friendship + 単方向フォローと通知の REST エンドポイントを登録する。
+func registerSocialRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// Phase 20: Friendship + 単方向フォロー（フロントの follow / unfollow / status / following / followers に対応）
+	friendshipRepo := repository.NewFriendshipRepository(deps.db)
+	friendshipHandler := NewFriendshipHandler(
+		usecase.NewListFriendshipsUseCase(friendshipRepo),
+		usecase.NewRequestFriendshipUseCase(friendshipRepo),
+		usecase.NewRespondFriendshipUseCase(friendshipRepo),
+		usecase.NewFollowUserUseCase(friendshipRepo),
+		usecase.NewUnfollowUserUseCase(friendshipRepo),
+		usecase.NewListFollowingUseCase(friendshipRepo),
+		usecase.NewListFollowersUseCase(friendshipRepo),
+		usecase.NewGetFollowStatusUseCase(friendshipRepo),
+	)
+	g.GET("/friendships", friendshipHandler.List)
+	g.POST("/friendships", friendshipHandler.Request)
+	g.PATCH("/friendships/:id", friendshipHandler.Respond)
+	g.GET("/friendships/following", friendshipHandler.Following)
+	g.GET("/friendships/followers", friendshipHandler.Followers)
+	g.POST("/friendships/:userId/follow", friendshipHandler.Follow)
+	g.DELETE("/friendships/:userId/follow", friendshipHandler.Unfollow)
+	g.GET("/friendships/:userId/status", friendshipHandler.Status)
+
+	// Phase 21: Notification
+	notificationRepo := repository.NewNotificationRepository(deps.db)
+	notificationHandler := NewNotificationHandler(
+		usecase.NewListNotificationsUseCase(notificationRepo),
+		usecase.NewMarkNotificationReadUseCase(notificationRepo),
+		usecase.NewMarkAllNotificationsReadUseCase(notificationRepo),
+		usecase.NewCountUnreadNotificationsUseCase(notificationRepo),
+	)
+	g.GET("/notifications", notificationHandler.List)
+	g.GET("/notifications/unread-count", notificationHandler.UnreadCount)
+	g.PATCH("/notifications/:id/read", notificationHandler.MarkRead)
+	g.PUT("/notifications/:id/read", notificationHandler.MarkRead)
+	g.PATCH("/notifications/read-all", notificationHandler.MarkAllRead)
+	g.PUT("/notifications/read-all", notificationHandler.MarkAllRead)
+}

--- a/backend/internal/handler/routes_websocket.go
+++ b/backend/internal/handler/routes_websocket.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// registerWebSocketRoutes は AI チャット / ユーザー間チャットの WebSocket エンドポイントを登録する。
+// SockJS / STOMP は廃止し、フロントは ブラウザ標準 `WebSocket` で接続する。
+//
+// 認証は親 group の middleware.JWTAuth + middleware.CurrentUser を継承する
+// （Cookie の access_token をそのまま WebSocket upgrade リクエストでも検証）。
+func registerWebSocketRoutes(g *gin.RouterGroup) {
+	// AiChat WebSocket (raw / native, Bedrock 連携は別 PR)
+	aiChatWsHandler := NewAiChatWsHandler()
+	g.GET("/ws/ai-chat", aiChatWsHandler.Handle)
+
+	// Chat WebSocket (ルームごとブロードキャスト)。raw WebSocket + JSON プロトコル。
+	chatWsHandler := NewChatWsHandler()
+	g.GET("/ws/chat/:roomId", chatWsHandler.Handle)
+}


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#5 (router 分割)**。`internal/handler/router.go` (315 行) に直書きされていた 28 phase 分のルート登録を、ドメインごとの `routes_*.go` (10 ファイル) に分割します。`router.go` は組み立てだけを担う 74 行の薄い entrypoint に変更。Go 標準プロジェクト構造の慣習（"small files focused on a single concern"）に沿った構造です。

## 変更内容

### 設計
- **`routeDeps` 構造体** に共通依存 (`db` / `cfg` / `userRepo`) を集約
- 各 `register*Routes(g, deps)` 関数はドメイン内の repo / usecase / handler を自前で組み立てて `RouterGroup` に登録。副作用は `g.HTTPメソッド()` のみ
- `registerAuthPublicRoutes` は `AuthHandler` を返し、authed group で再利用（`/auth/me`）

### ファイル分割

| ファイル | 行数 | 責務 (Phase) |
|---|---:|---|
| `routes_auth.go` | 28 | Phase 2: Cognito callback / refresh / logout / me |
| `routes_chat.go` | 29 | Phase 3-4: AI chat / user chat REST |
| `routes_profile.go` | 40 | Phase 5-6: profile / profile-image / user-stats |
| `routes_practice.go` | 42 | Phase 7-9: scenarios / bookmarks / shared sessions |
| `routes_note.go` | 40 | Phase 10-12: notes / note-image / session-note |
| `routes_score.go` | 62 | Phase 13-17, 24: ScoreCard / ScoreGoal / ScoreTrend / Ranking / LearningReport / WeeklyChallenge |
| `routes_phrase.go` | 27 | Phase 18-19: ConversationTemplate / FavoritePhrase |
| `routes_social.go` | 46 | Phase 20-21: Friendship / Notification |
| `routes_settings.go` | 30 | Phase 22-23: ReminderSetting / DailyGoal |
| `routes_admin.go` | 35 | Phase 25-26: AdminInvitation / AdminScenario |
| `routes_websocket.go` | 20 | AiChatWs / ChatWs |
| `router.go` | 74 | 組み立て + `registerHealthRoutes` のみ |

### サイズ変化
- `router.go`: **315 行 → 74 行** （組み立てに専念）
- 合計: 1 ファイル 315 行 → 12 ファイル 473 行（責務分離コメント増分含む）

## テスト

- [x] `go build ./...` 成功
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全 pass — route 登録の挙動変更ゼロ
- [x] `gofmt -l backend/` → 0 件
- [x] 既存 handler テスト全 pass

## 後続 PR

| # | テーマ |
|---|---|
| 6 | `cmd/server/main.go` の Cognito secret 末尾 4 文字診断ログを削除 |
| 7 | backend CI に `gofmt -l` / `go vet` チェックを追加 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured backend routing infrastructure for improved code maintainability and modularity. Routes are now organized by domain (authentication, chat, notes, profiles, etc.) with centralized dependency management. This change maintains existing functionality while enabling easier future feature additions and modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->