### PR TITLE
refactor(backend): main.go の Cognito secret 診断ログを削除

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -29,15 +29,7 @@ func main() {
 
 	r := handler.NewRouter(db, cfg)
 	addr := ":" + cfg.ServerPort
-	// Cognito secret 不一致の診断用一時ログ。値そのものは出さず長さと末尾 4 文字のみ。
-	// 解消後に削除する。
-	csLen := len(cfg.Cognito.ClientSecret)
-	csTail := ""
-	if csLen >= 4 {
-		csTail = cfg.Cognito.ClientSecret[csLen-4:]
-	}
-	log.Printf("FreStyle Go backend listening on %s (env=%s) cognito_client_id=%s cognito_secret_len=%d cognito_secret_tail=...%s cognito_token_uri=%s",
-		addr, cfg.AppEnv, cfg.Cognito.ClientID, csLen, csTail, cfg.Cognito.TokenURI)
+	log.Printf("FreStyle Go backend listening on %s (env=%s)", addr, cfg.AppEnv)
 	if err := r.Run(addr); err != nil {
 		log.Fatalf("server stopped: %v", err)
 	}


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#6 (main.go クリーン)**。`cmd/server/main.go` の起動時ログに残っていた **Cognito `client_secret` の長さと末尾 4 文字を出力する一時的な診断コード**を削除します。

## 背景

PR #1581 までの Cognito secret 不一致トラブルシュート用の一時ログでした。コメントにも「解消後に削除する」と書かれており、原因は既に解決済み（Cognito client secret 同期完了 / cd-backend グリーン）。

セキュリティ観点でも、本番 CloudWatch Logs に secret の末尾 4 文字を出すのは原則避けるべき。Go の "log only what's actionable" 原則に沿った片付けです。

## 変更内容

### `cmd/server/main.go`

**Before** (12 行):
```go
csLen := len(cfg.Cognito.ClientSecret)
csTail := ""
if csLen >= 4 {
    csTail = cfg.Cognito.ClientSecret[csLen-4:]
}
log.Printf("FreStyle Go backend listening on %s (env=%s) cognito_client_id=%s cognito_secret_len=%d cognito_secret_tail=...%s cognito_token_uri=%s",
    addr, cfg.AppEnv, cfg.Cognito.ClientID, csLen, csTail, cfg.Cognito.TokenURI)
```

**After** (2 行):
```go
log.Printf("FreStyle Go backend listening on %s (env=%s)", addr, cfg.AppEnv)
```

## テスト

- [x] `go build ./...` 成功
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全 pass
- [x] `gofmt -l backend/` → 0 件

## 後続 PR

| # | テーマ |
|---|---|
| 7 | backend CI に `gofmt -l` / `go vet` チェックを追加（将来のドリフト防止） |