### PR TITLE
ci(backend): gofmt -l チェックと staticcheck を CI に追加

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -29,8 +29,30 @@ jobs:
       - name: go mod download
         run: go mod download
 
+      # gofmt 未整形のコードがあれば失敗させる。
+      # Effective Go の "gofmt'd code is the standard" を CI で強制するための
+      # 入り口チェック。`gofmt -l .` が 1 ファイルでも出したら CI を fail にして
+      # ローカル `gofmt -w .` で直してもらう運用にする。
+      - name: gofmt check
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::The following files are not gofmt-formatted:"
+            echo "$unformatted"
+            echo "Run 'gofmt -w backend/' locally and commit the result."
+            exit 1
+          fi
+
       - name: go vet
         run: go vet ./...
+
+      # staticcheck は Go 公式 Tools チームが推奨する高品質 linter。
+      # honnef.co/go/tools/cmd/staticcheck でしか拾えない bug pattern (SA*** 系)
+      # を CI で検知する。go vet との重複は避けつつ深いバグを拾える。
+      - name: staticcheck
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
+          staticcheck ./...
 
       - name: go test
         run: go test ./...


### PR DESCRIPTION
## 概要

バックエンドリファクタリング 全 7 PR の **#7 (CI lint 強化、最終)**。これまでの 6 PR でクリーンにしたフォーマット・構造を将来 drift させないよう、`ci-backend-go.yml` に **gofmt 強制** と **staticcheck** の 2 ステップを追加します。

## 変更内容

### `.github/workflows/ci-backend-go.yml`

新規ステップ:

1. **`gofmt check`**
   - `gofmt -l .` が 1 ファイルでも出力したら CI を fail
   - Effective Go の "gofmt'd code is the standard" を CI で強制
   - エラーメッセージにローカル修正コマンド (`gofmt -w backend/`) を案内

2. **`staticcheck`** (`honnef.co/go/tools/cmd/staticcheck@2025.1.1`)
   - `go vet` では拾えない `SA****` 系 bug pattern を検知（unused / dead code / 危険な型変換 / context misuse 等）
   - Go 公式 Tools チームが推奨する高品質 linter
   - ローカル試走 → exit 0 (警告ゼロ) 確認済み

### ステップ順序
```
go mod download → gofmt check → go vet → staticcheck → go test → go build
```
静的解析を先に走らせ、test 失敗より早く fail させる構成です。

## テスト

- [x] ローカルで `staticcheck ./...` → exit 0 (警告なし)
- [x] `gofmt -l backend/` → 0 件
- [x] `go vet ./...` 警告なし
- [x] `go test ./...` 全 pass
- [x] `go build` 成功

## 7 連 PR まとめ

| # | テーマ | PR |
|---|---|---|
| 1 | gofmt 全体適用 + README 未使用 AWS 削除 | #1583 ✅ MERGED |
| 2 | JWT claim デコード共通化 (`middleware.DecodeClaims`) | #1584 ✅ MERGED |
| 3 | 認証 Cookie 操作の helper 集約 | #1585 ✅ MERGED |
| 4 | Cognito token 交換を `infra/cognito.TokenExchanger` に抽出 | #1586 ✅ MERGED |
| 5 | `router.go` (315 行→74 行) をドメインごとに分割 | #1587 ✅ MERGED |
| 6 | `main.go` の Cognito 診断ログ削除 | #1588 ✅ MERGED |
| 7 | backend CI に gofmt / staticcheck 追加（本 PR） | (this) |

これでバックエンドのリファクタリングフェーズは完了予定です。