### PR TITLE
refactor(frontend): ESLint errors 2 件解消 (this aliasing / fast-refresh exports)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,7 +5,8 @@ import Protected from './utils/Protected';
 import AppShell from './components/layout/AppShell';
 import ErrorBoundary from './components/ErrorBoundary';
 import Loading from './components/Loading';
-import { ToastProvider, useToast } from './hooks/useToast';
+import { ToastProvider } from './components/ToastProvider';
+import { useToast } from './hooks/useToast';
 import ToastContainer from './components/ToastContainer';
 
 // 認証不要ページ

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -1,0 +1,31 @@
+import { useCallback, useState, ReactNode } from 'react';
+import { ToastContext, type ToastItem } from '../hooks/useToastContext';
+import type { ToastType } from './Toast';
+
+let toastId = 0;
+
+/**
+ * ToastProvider は ToastContext の React Context Provider。
+ *
+ * showToast / removeToast を Context として配り、`useToast()` hook 経由で
+ * 任意の component から呼べるようにする。HMR を壊さないため hook と
+ * 同居させず単体ファイルに切り出している。
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const showToast = useCallback((type: ToastType, message: string) => {
+    const id = String(++toastId);
+    setToasts((prev) => [...prev, { id, type, message }]);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ toasts, showToast, removeToast }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}

--- a/frontend/src/components/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppShell.test.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from '../../../store/authSlice';
 import AppShell from '../AppShell';
-import { ToastProvider } from '../../../hooks/useToast';
+import { ToastProvider } from '../../ToastProvider';
 
 function createTestStore() {
   return configureStore({

--- a/frontend/src/extensions/SearchReplaceExtension.ts
+++ b/frontend/src/extensions/SearchReplaceExtension.ts
@@ -204,7 +204,11 @@ export const SearchReplaceExtension = Extension.create({
   },
 
   addProseMirrorPlugins() {
-    const extensionThis = this;
+    // ProseMirror plugin の state.apply() は state config object のメソッドとして呼ばれるため、
+    // 関数内 this は extension を指さない。storage はオブジェクト参照（mutate しても同じ参照）
+    // なのでここで closure に取り込んで apply 内から参照する。
+    // `const that = this` 形式の this aliasing は @typescript-eslint/no-this-alias で禁止されている。
+    const storage = this.storage as SearchReplaceState;
 
     return [
       new Plugin({
@@ -216,7 +220,6 @@ export const SearchReplaceExtension = Extension.create({
           apply(tr, oldDecorations) {
             const meta = tr.getMeta(searchReplacePluginKey);
             if (meta || tr.docChanged) {
-              const storage = extensionThis.storage as SearchReplaceState;
               const results = findMatches(tr.doc, storage.searchTerm, storage.caseSensitive);
               storage.results = results;
 

--- a/frontend/src/hooks/__tests__/useToast.test.tsx
+++ b/frontend/src/hooks/__tests__/useToast.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ToastProvider, useToast } from '../useToast';
+import { ToastProvider } from '../../components/ToastProvider';
+import { useToast } from '../useToast';
 import { ReactNode } from 'react';
 
 const wrapper = ({ children }: { children: ReactNode }) => (

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -1,41 +1,16 @@
-import { createContext, useCallback, useContext, useState, ReactNode } from 'react';
-import type { ToastType } from '../components/Toast';
+import { useContext } from 'react';
+import { ToastContext } from './useToastContext';
 
-interface ToastItem {
-  id: string;
-  type: ToastType;
-  message: string;
-}
-
-interface ToastContextValue {
-  toasts: ToastItem[];
-  showToast: (type: ToastType, message: string) => void;
-  removeToast: (id: string) => void;
-}
-
-const ToastContext = createContext<ToastContextValue | null>(null);
-
-let toastId = 0;
-
-export function ToastProvider({ children }: { children: ReactNode }) {
-  const [toasts, setToasts] = useState<ToastItem[]>([]);
-
-  const showToast = useCallback((type: ToastType, message: string) => {
-    const id = String(++toastId);
-    setToasts((prev) => [...prev, { id, type, message }]);
-  }, []);
-
-  const removeToast = useCallback((id: string) => {
-    setToasts((prev) => prev.filter((t) => t.id !== id));
-  }, []);
-
-  return (
-    <ToastContext.Provider value={{ toasts, showToast, removeToast }}>
-      {children}
-    </ToastContext.Provider>
-  );
-}
-
+/**
+ * useToast は ToastContext から showToast / removeToast / toasts を取り出す hook。
+ *
+ * ToastProvider component は src/components/ToastProvider.tsx に分離した。
+ * 同一ファイルで component + hook を export していると Vite React HMR の
+ * react-refresh/only-export-components ルールに引っかかるため。
+ *
+ * 旧コードとの互換性を保つため `import { ToastProvider } from '../hooks/useToast'`
+ * の参照は ../components/ToastProvider に書き換える必要がある。
+ */
 export function useToast() {
   const context = useContext(ToastContext);
   if (!context) {

--- a/frontend/src/hooks/useToastContext.ts
+++ b/frontend/src/hooks/useToastContext.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react';
+import type { ToastType } from '../components/Toast';
+
+export interface ToastItem {
+  id: string;
+  type: ToastType;
+  message: string;
+}
+
+export interface ToastContextValue {
+  toasts: ToastItem[];
+  showToast: (type: ToastType, message: string) => void;
+  removeToast: (id: string) => void;
+}
+
+/**
+ * ToastProvider と useToast hook で共有する React Context。
+ *
+ * ToastProvider (component) と useToast (hook) を同一ファイルから export すると
+ * react-refresh/only-export-components のルールに抵触し HMR が壊れるため、
+ * Context オブジェクトをこの専用ファイルに切り出した。
+ */
+export const ToastContext = createContext<ToastContextValue | null>(null);

--- a/frontend/src/pages/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/__tests__/LoginCallback.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import LoginCallback from '../LoginCallback';
 import authReducer from '../../store/authSlice';
 import authRepository from '../../repositories/AuthRepository';
-import { ToastProvider } from '../../hooks/useToast';
+import { ToastProvider } from '../../components/ToastProvider';
 
 const mockNavigate = vi.fn();
 


### PR DESCRIPTION
## 概要

フロントエンドリファクタリング 7 連 PR の **#2 (ESLint errors 解消)**。`eslint .` が報告する 2 件の **error** を構造的に解消します。warning (12 件) は次の PR で対応。

## 修正内容

### 1. `src/extensions/SearchReplaceExtension.ts` の `@typescript-eslint/no-this-alias`

**問題**: `addProseMirrorPlugins()` 内で
```ts
const extensionThis = this;
```
と `this` を local 変数に alias していた。typescript-eslint 公式推奨に違反。

**解決**: ProseMirror plugin の `state.apply()` コールバックは extension 文脈外で呼ばれるが、必要なのは `storage` オブジェクト参照のみ。`addProseMirrorPlugins` の頭で `const storage = this.storage as SearchReplaceState` を closure に閉じ込めることで `apply()` 内の参照が `storage.xxx` に統一され、this aliasing が不要に。

### 2. `src/hooks/useToast.tsx` の `react-refresh/only-export-components`

**問題**: 同一ファイルから `ToastProvider` (component) と `useToast` (hook) を export しており、Vite React Fast Refresh の HMR 制約に抵触。

**解決**: 3 ファイルに分離（Vite 公式推奨パターン）:
- `src/hooks/useToastContext.ts` (新規): React Context + `ToastItem` / `ToastContextValue` 型
- `src/components/ToastProvider.tsx` (新規): provider component のみ
- `src/hooks/useToast.tsx`: `useContext` で context を読む hook のみ

**関連 import 変更**:
- `App.tsx`: `ToastProvider` を `../components/ToastProvider` から import
- `components/layout/__tests__/AppShell.test.tsx`
- `hooks/__tests__/useToast.test.tsx`
- `pages/__tests__/LoginCallback.test.tsx`

## テスト

- [x] `eslint .` → **0 errors** (旧 2 errors)、warning 12 件は維持（次 PR で対応）
- [x] `vitest run` → **293 files / 2361 tests** 全 pass

## 後続 PR

| # | テーマ |
|---|---|
| 3 | `console.error` 8 箇所 → 軽量 logger ユーティリティに置換 + Unused eslint-disable 削除 |
| 4 | `react-hooks/exhaustive-deps` 警告 5 件解消 |
| 5 | TypeScript 型エラー（production code 由来分）解消 |
| 6 | TypeScript 型エラー（test file 由来分）解消 |
| 7 | CI に `tsc --noEmit` + `eslint --max-warnings=0` 必須化 |