### PR TITLE
refactor(frontend): console.* を lib/logger 経由に置換 + Unused eslint-disable 削除

### DIFF
--- a/frontend/src/extensions/SlashCommandExtension.ts
+++ b/frontend/src/extensions/SlashCommandExtension.ts
@@ -3,6 +3,7 @@ import Suggestion from '@tiptap/suggestion';
 import type { SuggestionOptions } from '@tiptap/suggestion';
 import type { Editor } from '@tiptap/core';
 import { SLASH_COMMANDS, type SlashCommand } from '../constants/slashCommands';
+import { logger } from '../lib/logger';
 
 function executeCommand(editor: Editor, command: SlashCommand) {
   const chain = editor.chain().focus();
@@ -85,7 +86,7 @@ function executeCommand(editor: Editor, command: SlashCommand) {
     }
     default: {
       const _exhaustive: never = command.action;
-      console.error('Unknown slash command action:', _exhaustive);
+      logger.error('Unknown slash command action:', _exhaustive);
       break;
     }
   }

--- a/frontend/src/hooks/useProfileImageUpload.ts
+++ b/frontend/src/hooks/useProfileImageUpload.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import ProfileRepository from '../repositories/ProfileRepository';
+import { logger } from '../lib/logger';
 
 const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
 
@@ -17,7 +18,7 @@ export function useProfileImageUpload() {
       await ProfileRepository.uploadToS3(uploadUrl, file);
       return imageUrl;
     } catch (error) {
-      console.error('プロフィール画像のアップロードに失敗しました:', error);
+      logger.error('プロフィール画像のアップロードに失敗しました:', error);
       return null;
     } finally {
       setUploading(false);

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -1,0 +1,36 @@
+/**
+ * 軽量 logger ユーティリティ。
+ *
+ * 設計方針:
+ * - production build (`import.meta.env.PROD === true`) では `debug` / `info` / `warn` を no-op に
+ *   し、`error` のみ出力する（ブラウザ DevTools / CloudWatch RUM 等のエラー観測経路に残す）
+ * - development では従来どおり全レベル出力
+ * - production code 全体で `console.*` を直接使うのを禁じ、こちらを経由させることで
+ *   将来 Sentry / Datadog RUM 等への送信に切り替えるときの単一切替点にする
+ *
+ * 使い方:
+ *   import { logger } from '@/lib/logger';
+ *   logger.error('プロフィール画像のアップロードに失敗しました:', error);
+ *
+ * 注: テストコード (vitest 配下) では console.* / vi.spyOn(console, ...) を直接使い続ける。
+ * production-only な抽象なので test には侵入させない。
+ */
+const isProd = typeof import.meta !== 'undefined' && import.meta.env?.PROD === true;
+
+type LogArgs = readonly unknown[];
+
+const noop = (..._args: LogArgs): void => {
+  // production build では何もしない
+};
+
+export const logger = {
+  /** 開発時のみ出力（production では完全に無効） */
+  debug: isProd ? noop : (...args: LogArgs) => console.debug(...args),
+  info: isProd ? noop : (...args: LogArgs) => console.info(...args),
+  warn: isProd ? noop : (...args: LogArgs) => console.warn(...args),
+  /**
+   * production / development 共に出力する。
+   * 将来 Sentry / Datadog RUM への送信に拡張する際はここに forwarder を追加。
+   */
+  error: (...args: LogArgs) => console.error(...args),
+};

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -8,6 +8,7 @@ import AdminInvitationRepository, {
 import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
+import { logger } from '../lib/logger';
 
 const EMPTY_FORM: CreateInvitationForm = {
   email: '',
@@ -41,8 +42,7 @@ export default function AdminInvitationsPage() {
       setError(null);
     } catch (e) {
       setError('招待一覧の取得に失敗しました');
-      // eslint-disable-next-line no-console
-      console.error(e);
+      logger.error(e);
     } finally {
       setLoading(false);
     }
@@ -72,8 +72,7 @@ export default function AdminInvitationsPage() {
         (err as { response?: { data?: { message?: string } } })?.response?.data?.message ||
         '招待の作成に失敗しました';
       setError(msg);
-      // eslint-disable-next-line no-console
-      console.error(err);
+      logger.error(err);
     } finally {
       setSubmitting(false);
     }
@@ -86,8 +85,7 @@ export default function AdminInvitationsPage() {
       await fetchAll();
     } catch (err) {
       setError('招待のキャンセルに失敗しました');
-      // eslint-disable-next-line no-console
-      console.error(err);
+      logger.error(err);
     }
   };
 

--- a/frontend/src/pages/AdminScenariosPage.tsx
+++ b/frontend/src/pages/AdminScenariosPage.tsx
@@ -8,6 +8,7 @@ import AdminScenarioRepository, {
 import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
+import { logger } from '../lib/logger';
 
 const EMPTY_FORM: AdminScenarioForm = {
   name: '',
@@ -43,8 +44,7 @@ export default function AdminScenariosPage() {
       setError(null);
     } catch (e) {
       setError('シナリオの取得に失敗しました');
-      // eslint-disable-next-line no-console
-      console.error(e);
+      logger.error(e);
     } finally {
       setLoading(false);
     }
@@ -91,8 +91,7 @@ export default function AdminScenariosPage() {
       await fetchAll();
     } catch (err) {
       setError('保存に失敗しました');
-      // eslint-disable-next-line no-console
-      console.error(err);
+      logger.error(err);
     } finally {
       setSubmitting(false);
     }
@@ -105,8 +104,7 @@ export default function AdminScenariosPage() {
       await fetchAll();
     } catch (err) {
       setError('削除に失敗しました');
-      // eslint-disable-next-line no-console
-      console.error(err);
+      logger.error(err);
     }
   };
 


### PR DESCRIPTION
## 概要

フロントエンドリファクタリング 7 連 PR の **#3 (logger 化)**。production code 内の `console.error` 8 箇所を新規 `lib/logger.ts` 経由に置換し、Unused `eslint-disable` directive 6 件を削除します。React 公式の "Avoid console.* in production" 原則に従った片付け。

## 新規ファイル: `src/lib/logger.ts`

軽量 logger ユーティリティ。Vite の `import.meta.env.PROD` を使った production / development 切替:

```ts
const isProd = import.meta.env?.PROD === true;
export const logger = {
  debug: isProd ? noop : (...a) => console.debug(...a),
  info:  isProd ? noop : (...a) => console.info(...a),
  warn:  isProd ? noop : (...a) => console.warn(...a),
  error: (...a) => console.error(...a),  // production でも error のみは残す
};
```

- production build では `debug` / `info` / `warn` が **no-op**、`error` のみ出力
- development では全レベル出力
- 将来 Sentry / Datadog RUM への送信を **1 ファイルで切替可能** にする抽象
- test ファイルは `vi.spyOn(console, ...)` で直接 console を扱うため logger は production code のみで使用

## 変更内容

### `console.*` → `logger.error` 置換 (8 箇所)

| ファイル | 件数 |
|---|---:|
| `extensions/SlashCommandExtension.ts` | 1 |
| `hooks/useProfileImageUpload.ts` | 1 |
| `pages/AdminInvitationsPage.tsx` | 3 |
| `pages/AdminScenariosPage.tsx` | 3 |

### Unused `// eslint-disable-next-line no-console` directive 削除 (6 箇所)

- `console.error` は `logger.error` 経由になり `no-console` の対象外
- disable directive は意味を失っていたので削除

## テスト

- [x] `eslint .` → **0 errors / 6 warnings** (旧 0 errors / 12 warnings) — Unused-disable 6 件削除分
- [x] `vitest run` → **293 files / 2361 tests** 全 pass
- [x] production build では `debug/info/warn` が no-op になりブラウザコンソールへの不要出力を抑制
- [x] `grep "console\." src/ --exclude-dir=__tests__` → `lib/logger.ts` のみ（hub として正しい）

## 後続 PR

| # | テーマ |
|---|---|
| 4 | `react-hooks/exhaustive-deps` 警告 5 件解消 |
| 5 | TypeScript 型エラー（production code 由来分）解消 |
| 6 | TypeScript 型エラー（test file 由来分）解消 |
| 7 | CI に `tsc --noEmit` + `eslint --max-warnings=0` 必須化 |