### PR TITLE
ci(frontend): tsc --noEmit と eslint --max-warnings=0 を CI 必須化

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -40,6 +40,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # TypeScript 型チェック (production code 限定 / test ファイルは tsconfig.exclude で除外済み)。
+      # tsc が 1 エラーでも報告したら fail する。React / TypeScript Handbook の
+      # "static type-checking before runtime" を CI で強制する。
+      - name: TypeScript type-check
+        run: npx tsc --noEmit
+
+      # ESLint で 1 件でも warning があれば fail させる（将来のドリフト防止）。
+      # rules は eslint.config.js で管理。
+      - name: ESLint (max-warnings=0)
+        run: npx eslint . --max-warnings=0
+
       - name: Run Vitest
         run: npm test -- --run
 


### PR DESCRIPTION
## 概要

フロントエンドリファクタリング 7 連 PR の **#7 (CI strict、最終)**。これまでの 6 PR でクリーンにした型と lint を将来 drift させないよう、`ci-frontend.yml` に **TypeScript 型チェック** と **ESLint zero-warning** の 2 ステップを追加します。

## 変更内容

### `.github/workflows/ci-frontend.yml`

新規ステップ:

1. **TypeScript type-check** (`npx tsc --noEmit`)
   - production code（test は `tsconfig.exclude` で除外済み）に対して厳密チェック
   - 1 error でも fail
   - React / TypeScript Handbook の "static type-checking before runtime" を CI 強制

2. **ESLint (max-warnings=0)** (`npx eslint . --max-warnings=0`)
   - 1 warning でも fail（将来のドリフト防止）
   - 現状 0 errors / 0 warnings なので即座に通る

### ステップ順序
```
npm ci → tsc --noEmit → eslint → vitest run → vite build
```
静的解析を先に走らせ、test や build より早く fail させる構成。

## テスト

- [x] ローカルで `tsc --noEmit` → 0 errors
- [x] `eslint .` → 0 errors / 0 warnings
- [x] `vitest run` → 293 files / 2361 tests 全 pass

## 7 連 PR まとめ

| # | テーマ | PR |
|---|---|---|
| 1 | API path constants 集約（166 ハードコード → 1 ファイル） | #1590 ✅ |
| 2 | ESLint errors 2 件解消（this aliasing / fast-refresh exports） | #1591 ✅ |
| 3 | console.* → logger + Unused-disable 削除 | #1592 ✅ |
| 4 | react-hooks/exhaustive-deps 警告 6 件解消 | #1593 ✅ |
| 5 | production code TS 型エラー 54 件解消（Tiptap module augmentation 他） | #1594 ✅ |
| 6 | test file TS 型エラー解消（Vitest globals + tsconfig.exclude） | #1595 ✅ |
| 7 | CI に tsc + eslint --max-warnings=0 必須化（本 PR） | (this) |

これでフロントエンドのリファクタリングフェーズは完了予定です。次は user 指示で:
- **MenuPage 下部スクロール途切れ**の修正（パディング不足）
- **Markdown 互換 markdown** の段階的実装（PR A〜H）
