### PR TITLE
fix(frontend): 縦長ページ最下部の見切れを pb-24 で解消

### DIFF
--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -92,7 +92,8 @@ export default function AdminInvitationsPage() {
   const formatDate = (iso: string) => new Date(iso).toLocaleString('ja-JP');
 
   return (
-    <div className="p-6 max-w-3xl mx-auto space-y-6">
+    // 招待一覧 (テーブル) が長くなるケースで viewport 下端の見切れを防ぐため pb-24
+    <div className="px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
       <PageIntro
         title="管理: メンバー招待"
         description={

--- a/frontend/src/pages/AdminScenariosPage.tsx
+++ b/frontend/src/pages/AdminScenariosPage.tsx
@@ -109,7 +109,8 @@ export default function AdminScenariosPage() {
   };
 
   return (
-    <div className="p-6 max-w-4xl mx-auto space-y-6">
+    // シナリオ一覧 + フォームで縦長になるため pb-24 で下部見切れ回避
+    <div className="px-6 pt-6 pb-24 max-w-4xl mx-auto space-y-6">
       <PageIntro
         title="管理: 練習シナリオ"
         description={<>新規作成・編集・削除ができます。一般ユーザーには表示されません。</>}

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -68,7 +68,10 @@ export default function MenuPage() {
   const isFirstTimeUser = totalSessions === 0;
 
   return (
-    <div className="p-6 max-w-2xl mx-auto space-y-6">
+    // 下にスクロールしたとき最後のカードが viewport 下端で見切れる問題を回避するため、
+    // 縦方向は px-6 pt-6 pb-24 に分割して bottom padding を 6rem 確保する
+    // (p-6 のままだと 1.5rem しか取れず、最終カードと viewport 端が密着して見切れる)。
+    <div className="px-6 pt-6 pb-24 max-w-2xl mx-auto space-y-6">
       <PageIntro
         icon={<HomeIcon className="h-6 w-6" />}
         title="ホーム"

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -45,7 +45,8 @@ export default function ProfilePage() {
   }
 
   return (
-    <div className="p-6 max-w-2xl mx-auto space-y-6">
+    // 縦長コンテンツの最終要素が viewport 下端で見切れないよう pb-24 で余白確保
+    <div className="px-6 pt-6 pb-24 max-w-2xl mx-auto space-y-6">
       <FormMessage message={message} />
 
       {/* セクション1: 基本情報 */}


### PR DESCRIPTION
## 概要

ユーザー報告: **MenuPage を下にスクロールするとコンポーネントが viewport 下端で途中で途切れる**問題を修正します。

## 原因

- 旧コードは外側 div に `p-6` (上下左右 1.5rem) しか確保しておらず、最終カードと viewport 下端が密着して見切れる
- `AppShell` の `<main>` は `overflow-auto` なので scroll 自体は機能しているが、scroll content の bottom margin が不足

## 修正内容

該当 4 ページの outer div を **`p-6` → `px-6 pt-6 pb-24`** に分割（横 1.5rem / 上 1.5rem / 下 6rem）:

- `MenuPage.tsx` ← ユーザー報告対象
- `ProfilePage.tsx`
- `AdminInvitationsPage.tsx`
- `AdminScenariosPage.tsx`

`pb-24` (96px) は既存の `HelpPage.pb-16` を参考に少し増やして、長いリストでも最終要素が完全に visible になる余白を確保。

## テスト

- [x] `vitest run` → **293 files / 2361 tests** 全 pass（UI ロジック影響なし）
- [x] `tsc --noEmit` → 0 errors