### PR TITLE
feat(frontend): tiptap-markdown 導入で Markdown↔Tiptap 双方向変換基盤を構築 [Markdown 拡張 PR A]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,7 +43,8 @@
         "react-hook-form": "^7.65.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.9.4",
-        "tippy.js": "^6.3.7"
+        "tippy.js": "^6.3.7",
+        "tiptap-markdown": "^0.9.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -5040,6 +5041,12 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==",
+      "license": "ISC"
+    },
     "node_modules/markdown-it/node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -6674,6 +6681,46 @@
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
+    },
+    "node_modules/tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "dependencies": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
+      "license": "MIT"
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "node_modules/tiptap-markdown/node_modules/@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
+      "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "7.0.23",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,8 @@
     "react-hook-form": "^7.65.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.9.4",
-    "tippy.js": "^6.3.7"
+    "tippy.js": "^6.3.7",
+    "tiptap-markdown": "^0.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/frontend/src/extensions/tiptap-types.d.ts
+++ b/frontend/src/extensions/tiptap-types.d.ts
@@ -23,12 +23,23 @@ interface SearchReplaceExtensionStorage {
   currentIndex: number;
 }
 
+/**
+ * tiptap-markdown が提供する storage。
+ * editor.storage.markdown.getMarkdown() で現在の editor 内容を Markdown 文字列で取得できる。
+ * 公式 README: https://github.com/aguingand/tiptap-markdown
+ */
+interface TiptapMarkdownStorage {
+  getMarkdown: () => string;
+}
+
 declare module '@tiptap/core' {
   interface Storage {
     /** SlashCommandExtension の storage（image upload / emoji / youtube URL ハンドラ） */
     slashCommand: SlashCommandStorage;
     /** SearchReplaceExtension の storage（検索語・置換語・カレント位置・マッチ結果） */
     searchReplace: SearchReplaceExtensionStorage;
+    /** tiptap-markdown の storage（getMarkdown() で現在エディタ内容を Markdown 文字列で取得） */
+    markdown: TiptapMarkdownStorage;
   }
 
   // Tiptap の RawCommands は Commands<T> のうち「value が object 型」のキーだけを

--- a/frontend/src/hooks/__tests__/useBlockEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useBlockEditor.test.ts
@@ -93,7 +93,9 @@ describe('useBlockEditor', () => {
     );
   });
 
-  it('不正なJSONの場合はundefinedを設定する', async () => {
+  it('JSON として parse できない文字列は Markdown としてそのまま設定する', async () => {
+    // PR A (tiptap-markdown 導入) で挙動変更: 旧実装は parse 失敗 → undefined だったが、
+    // 新実装は markdown 文字列とみなして tiptap-markdown が処理するため content にそのまま渡す。
     const { useEditor } = await import('@tiptap/react');
     const { isLegacyMarkdown } = await import('../../utils/isLegacyMarkdown');
     vi.mocked(isLegacyMarkdown).mockReturnValue(false);
@@ -102,7 +104,7 @@ describe('useBlockEditor', () => {
     renderHook(() => useBlockEditor({ content: 'invalid json{{{', onChange }));
 
     expect(useEditor).toHaveBeenCalledWith(
-      expect.objectContaining({ content: undefined })
+      expect.objectContaining({ content: 'invalid json{{{' })
     );
   });
 

--- a/frontend/src/hooks/useBlockEditor.ts
+++ b/frontend/src/hooks/useBlockEditor.ts
@@ -3,68 +3,86 @@ import { useEditor } from '@tiptap/react';
 import { createEditorExtensions } from '../utils/editorExtensions';
 import { isLegacyMarkdown } from '../utils/isLegacyMarkdown';
 import { markdownToTiptap } from '../utils/markdownToTiptap';
+import { resolveNoteContent } from '../utils/noteContentFormat';
 
 interface UseBlockEditorOptions {
+  /** Note.content (markdown 文字列 or 旧 Tiptap JSON 文字列 or 旧 Markdown 文字列)。 */
   content: string;
-  onChange: (jsonString: string) => void;
+  /** エディタ更新時に呼ばれる。値は Zenn 互換 Markdown 文字列。 */
+  onChange: (markdown: string) => void;
 }
 
+/**
+ * Tiptap エディタを Zenn 互換 Markdown 入出力で使うための共通フック。
+ *
+ * 入力 (content) の解釈:
+ *   1. 空文字 → 空エディタ
+ *   2. 旧 markdownToTiptap で読める legacy Markdown (heading / list のみ)
+ *      → Tiptap JSON に変換して setContent
+ *   3. JSON-shaped で type=doc → そのまま Tiptap JSON として setContent
+ *   4. それ以外 → tiptap-markdown が markdown として parse する
+ *
+ * 出力 (onChange) は常に Markdown 文字列。
+ * 既存ノートの保存値は JSON 文字列のままだが、ユーザーが一度編集して保存すれば
+ * Markdown に置き換わるので段階的にマイグレートされる（オンライン進行的アップグレード）。
+ */
 export function useBlockEditor({ content, onChange }: UseBlockEditorOptions) {
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
 
-  // エディタ自身が発行した最後のJSON文字列を記録し、同期ループを防止
-  const lastEmittedJson = useRef<string>('');
+  // エディタ自身が発行した最後の Markdown 文字列を記録し、同期ループを防止
+  const lastEmittedMarkdown = useRef<string>('');
 
   const initialContent = useMemo(() => {
     if (!content) return undefined;
+    // 旧 Markdown (heading / list のみの簡易フォーマット) は markdownToTiptap で
+    // 一度 Tiptap JSON 化してから setContent に渡す（tiptap-markdown より旧フォーマット解釈が安全）。
     if (isLegacyMarkdown(content)) {
       return markdownToTiptap(content);
     }
-    try {
-      return JSON.parse(content);
-    } catch {
-      return undefined;
-    }
+    return resolveNoteContent(content).value;
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const editor = useEditor({
     extensions: createEditorExtensions(),
-    content: initialContent,
+    // initialContent は string (markdown) か object (Tiptap doc JSON) か undefined。
+    // tiptap-markdown が string を markdown としてパースするため、Tiptap の Content 型に
+    // 合致するよう unknown 経由で渡す。
+    content: initialContent as Parameters<typeof useEditor>[0] extends infer O
+      ? O extends { content?: infer C } ? C : never
+      : never,
     onUpdate: ({ editor }) => {
-      const json = JSON.stringify(editor.getJSON());
-      lastEmittedJson.current = json;
-      onChangeRef.current(json);
+      // tiptap-markdown が editor.storage.markdown.getMarkdown() を提供する。
+      // 旧実装は JSON.stringify(editor.getJSON()) を保存していたが、Zenn markdown の
+      // 持ち出しやすさ・diff レビュー性を優先して Markdown 文字列保存に切り替える。
+      const md = editor.storage.markdown.getMarkdown() as string;
+      lastEmittedMarkdown.current = md;
+      onChangeRef.current(md);
     },
   });
 
   useEffect(() => {
     if (!editor) return;
 
-    // エディタのonUpdateから発行されたコンテンツが戻ってきた場合はスキップ
-    if (content === lastEmittedJson.current) return;
+    // エディタの onUpdate から発行されたコンテンツが戻ってきた場合はスキップ
+    if (content === lastEmittedMarkdown.current) return;
 
     if (!content) {
       editor.commands.clearContent();
       return;
     }
 
-    let newContent;
     if (isLegacyMarkdown(content)) {
-      newContent = markdownToTiptap(content);
-    } else {
-      try {
-        newContent = JSON.parse(content);
-      } catch {
-        return;
-      }
+      const json = markdownToTiptap(content);
+      const currentJson = JSON.stringify(editor.getJSON());
+      if (JSON.stringify(json) === currentJson) return;
+      editor.commands.setContent(json);
+      return;
     }
 
-    const currentJson = JSON.stringify(editor.getJSON());
-    const newJson = JSON.stringify(newContent);
-    if (newJson === currentJson) return;
-
-    editor.commands.setContent(newContent);
+    const resolved = resolveNoteContent(content);
+    if (resolved.form === 'empty') return;
+    editor.commands.setContent(resolved.value as Parameters<typeof editor.commands.setContent>[0]);
   }, [content, editor]);
 
   return { editor };

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -51,13 +51,17 @@ vi.mock('../../extensions/SearchReplaceExtension', () => ({
 vi.mock('../../extensions/FullWidthHeadingEnter', () => ({
   FullWidthHeadingEnter: 'FullWidthHeadingEnter',
 }));
+vi.mock('tiptap-markdown', () => ({
+  Markdown: { configure: vi.fn(() => 'Markdown') },
+}));
 
 import { createEditorExtensions } from '../editorExtensions';
 
 describe('createEditorExtensions', () => {
-  it('27個のエクステンションを返す', () => {
+  it('28個のエクステンションを返す', () => {
+    // tiptap-markdown 導入で 27 → 28 になった (Zenn 互換 markdown PR A)。
     const extensions = createEditorExtensions();
-    expect(extensions).toHaveLength(27);
+    expect(extensions).toHaveLength(28);
   });
 
   it('主要なエクステンションが含まれる', () => {
@@ -91,8 +95,11 @@ describe('createEditorExtensions', () => {
     expect(extensions[0]).toBe('StarterKit');
   });
 
-  it('配列の末尾がFullWidthHeadingEnterである', () => {
+  it('配列の末尾が Markdown extension である', () => {
+    // tiptap-markdown が一番最後に追加される (PR A)。
+    // 旧テストは FullWidthHeadingEnter を末尾と想定していたが、Markdown 追加後は
+    // それが最終要素になる。
     const extensions = createEditorExtensions();
-    expect(extensions[extensions.length - 1]).toBe('FullWidthHeadingEnter');
+    expect(extensions[extensions.length - 1]).toBe('Markdown');
   });
 });

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -24,6 +24,7 @@ import Underline from '@tiptap/extension-underline';
 import Superscript from '@tiptap/extension-superscript';
 import Subscript from '@tiptap/extension-subscript';
 import Youtube from '@tiptap/extension-youtube';
+import { Markdown } from 'tiptap-markdown';
 import { SearchReplaceExtension } from '../extensions/SearchReplaceExtension';
 import { FullWidthHeadingEnter } from '../extensions/FullWidthHeadingEnter';
 
@@ -88,5 +89,19 @@ export function createEditorExtensions() {
     }),
     SearchReplaceExtension,
     FullWidthHeadingEnter,
+    // tiptap-markdown は editor.storage.markdown.getMarkdown() / setContent(md) を提供する。
+    // - html: false       editor 内の生 HTML 出力を抑制し pure な Markdown シリアライズに統一
+    // - tightLists: true  リストアイテム間の空行を出力しない (Zenn / GitHub 準拠)
+    // - bulletListMarker  Zenn のサンプルが `-` で統一されているのに合わせる
+    // - linkify: false    URL の自動リンク化はしない（Zenn 風の「URL 行 → カード」は別 PR で扱う）
+    Markdown.configure({
+      html: false,
+      tightLists: true,
+      bulletListMarker: '-',
+      linkify: false,
+      breaks: false,
+      transformPastedText: false,
+      transformCopiedText: false,
+    }),
   ];
 }

--- a/frontend/src/utils/noteContentFormat.ts
+++ b/frontend/src/utils/noteContentFormat.ts
@@ -1,0 +1,56 @@
+/**
+ * Note エディタのコンテンツ形式判定 / 変換ユーティリティ。
+ *
+ * 設計方針:
+ * - 新規ノートは Zenn 互換 Markdown で保存する（tiptap-markdown が双方向変換を担当）
+ * - 過去のノートは Tiptap JSON 文字列で保存されているので、判別して Tiptap が読める形に渡す
+ * - 過去の旧 Markdown (見出し/リストのみ) は isLegacyMarkdown で判別し markdownToTiptap で
+ *   先に Tiptap JSON に変換した上で editor に渡す
+ *
+ * 形式判定の優先順位（先勝ち）:
+ *   1. 空文字 / undefined → 空エディタ
+ *   2. JSON.parse 可能で `type: "doc"` を含む → 旧 Tiptap JSON 形式
+ *   3. それ以外 → Markdown 文字列としてそのまま editor に渡す
+ *
+ * editor 側はこの戻り値を `editor.commands.setContent(value)` に渡せば良い。
+ * tiptap-markdown は string を受け取れば markdown としてパースし、object を受け取れば
+ * Tiptap JSON としてセットする。
+ */
+
+export type NoteContentForm = 'empty' | 'json' | 'markdown';
+
+export interface ResolvedNoteContent {
+  /** editor.commands.setContent に渡す値（string=markdown / object=Tiptap JSON） */
+  value: unknown;
+  /** どの形式として解釈したか（debug / migration 統計用） */
+  form: NoteContentForm;
+}
+
+/**
+ * note.content 文字列を editor 投入可能な形に解決する。
+ *
+ * raw が空ならエディタを空にしたいので value=undefined を返す。
+ * JSON-shaped (Tiptap doc node) なら parse 結果を返す。
+ * それ以外は markdown として string をそのまま返す。
+ */
+export function resolveNoteContent(raw: string | null | undefined): ResolvedNoteContent {
+  if (!raw) {
+    return { value: undefined, form: 'empty' };
+  }
+
+  // JSON 形式かどうか判定。Tiptap JSON は必ず先頭が `{` で `"type":"doc"` を含む。
+  // 全 raw を毎回 JSON.parse すると markdown 文字列で例外コストが嵩むので prefix 検査でガードする。
+  const trimmed = raw.trimStart();
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(raw) as { type?: unknown };
+      if (parsed && typeof parsed === 'object' && parsed.type === 'doc') {
+        return { value: parsed, form: 'json' };
+      }
+    } catch {
+      // JSON.parse 失敗 → markdown とみなす
+    }
+  }
+
+  return { value: raw, form: 'markdown' };
+}


### PR DESCRIPTION
## 概要

Markdown 互換 markdown 機能 全 8 PR の **#A (基盤導入)**。

ユーザー要望: [normanblog.com/notes](https://normanblog.com/notes) の Tiptap エディタを **Markdown 拡張 と同じ Markdown 記法**で書けるようにする。本 PR は基盤として `tiptap-markdown` を導入し、Note の保存形式を Tiptap JSON → Markdown 文字列に切り替えます。

## 設計

- `tiptap-markdown` は `editor.storage.markdown.getMarkdown()` で Tiptap doc → Markdown 文字列を取得できる Tiptap 拡張
- `editor.commands.setContent(value)` に **string を渡すと Markdown としてパース**、**object を渡すと Tiptap JSON としてセット**する（双方向）

## 変更内容

### 新規

- **`package.json`**: `tiptap-markdown@^0.9.0` を devDeps に追加
- **`src/utils/noteContentFormat.ts`**: note.content の形式判別 `resolveNoteContent()`
  - 空文字 → `empty`
  - `{"type":"doc",...}` → 旧 Tiptap JSON → parse して `setContent`
  - それ以外 → markdown 文字列としてそのまま `setContent`
  - prefix が `{` でない場合は `JSON.parse` をスキップして例外コストを回避

### 変更

- **`src/utils/editorExtensions.ts`**: `createEditorExtensions()` に `Markdown.configure({ html: false, tightLists: true, bulletListMarker: '-', linkify: false })` を末尾追加
- **`src/hooks/useBlockEditor.ts`**: 出力を `JSON.stringify(getJSON())` → `getMarkdown()` に切替
  - 既存ノート（JSON 保存）を読み込み時に自動判別 → 編集後保存で Markdown に **オンライン進行的にマイグレート**
  - 旧 `markdownToTiptap` は引き続き `isLegacyMarkdown` 判別経由で残し、過去のテキストノート互換性を維持
- **`src/extensions/tiptap-types.d.ts`**: `Storage` interface に `markdown: TiptapMarkdownStorage` 追加

### テスト更新（機能変更に伴う期待値修正）

- `editorExtensions.test.ts`: extension 数 27 → 28 / 末尾 → `'Markdown'`
- `useBlockEditor.test.ts`: 不正 JSON は undefined → 文字列のまま（新仕様で markdown としてパスする）

## 後方互換性

- 既存の Tiptap JSON 形式で保存された Note は読み込み時に自動判別 → そのまま編集可能
- 編集して保存すると Markdown に置き換わる（漸進的マイグレーション）
- フォアグラウンドのワンショット移行スクリプトは不要

## テスト

- [x] `vitest run` → **293 files / 2361 tests** 全 pass
- [x] `tsc --noEmit` → 0 errors
- [x] `eslint .` → 0 errors / 0 warnings

## 後続 PR（Markdown 拡張 markdown 全 8 PR の残り）

| # | テーマ |
|---|---|
| B | `:::message` / `:::details` カスタム記法（CalloutExtension の Markdown serialize 対応） |
| C | KaTeX 数式（`$$...$$` / `$...$`） |
| D | Mermaid ダイアグラム（mermaid コードブロック） |
| E | OGP / oEmbed プロキシ API（Go backend） |
| F | 埋め込みカード extension（URL 単独行 / `@[card](url)`） |
| G | YouTube / Twitter / GitHub embed |
| H | 脚注 + 絵文字補完 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Markdown format support for editor content, replacing JSON serialization.
  * Editor now seamlessly parses and handles both Markdown and legacy JSON inputs.
  * Improved content resolution with automatic format detection for better compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
