### PR TITLE
feat(frontend): 埋め込みカード @[card](url) extension を追加 [Markdown 拡張 PR F]

### DIFF
--- a/frontend/src/components/EmbedCardNodeView.tsx
+++ b/frontend/src/components/EmbedCardNodeView.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'react';
+import { NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+import { EmbedRepository, type EmbedCardDto } from '../repositories/EmbedRepository';
+import { logger } from '../lib/logger';
+
+/**
+ * URL 単独行 / `@[card](url)` を render するカード。
+ *
+ * 表示パターン:
+ *   1. fetching:    URL のみ表示するスケルトン
+ *   2. resolved:    OGP の画像 + タイトル + サイト名 + URL のリンク
+ *   3. error:       fallback として通常リンクを表示
+ *
+ * Note: URL は Tiptap node の attrs.url から取り、Go backend の /api/v2/embeds/oembed
+ * を経由してメタを取得する (SSRF 対策はバックエンド側)。
+ */
+type Props = ReactNodeViewProps<HTMLElement> & {
+  node: ReactNodeViewProps<HTMLElement>['node'] & { attrs: { url: string } };
+};
+
+export default function EmbedCardNodeView({ node }: Props) {
+  const url = (node.attrs.url as string) || '';
+  const [card, setCard] = useState<EmbedCardDto | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!url) {
+      setError(true);
+      return;
+    }
+    EmbedRepository.resolve(url)
+      .then((c) => {
+        if (!cancelled) setCard(c);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          logger.error('embed resolve failed:', e);
+          setError(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  if (error || !url) {
+    return (
+      <NodeViewWrapper>
+        <a href={url} target="_blank" rel="noreferrer noopener" className="text-sky-400 underline">
+          {url || '(URL なし)'}
+        </a>
+      </NodeViewWrapper>
+    );
+  }
+
+  if (!card) {
+    return (
+      <NodeViewWrapper>
+        <div className="my-3 rounded-lg border border-surface-3 bg-surface-1 p-3 text-xs text-[var(--color-text-muted)]">
+          読み込み中: <span className="break-all">{url}</span>
+        </div>
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper>
+      <a
+        href={card.url}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="my-3 flex gap-3 rounded-lg border border-surface-3 bg-surface-1 p-3 hover:bg-[var(--color-surface-2)] transition-colors no-underline"
+      >
+        {card.imageUrl && (
+          <img
+            src={card.imageUrl}
+            alt=""
+            loading="lazy"
+            className="w-24 h-24 object-cover rounded-md flex-shrink-0"
+          />
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-semibold text-[var(--color-text-primary)] line-clamp-2">
+            {card.title || card.url}
+          </div>
+          {card.description && (
+            <div className="text-xs text-[var(--color-text-muted)] line-clamp-2 mt-1">
+              {card.description}
+            </div>
+          )}
+          <div className="text-[10px] text-[var(--color-text-faint)] mt-1 truncate">
+            {card.siteName ? `${card.siteName} · ` : ''}
+            {card.url}
+          </div>
+        </div>
+      </a>
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -157,6 +157,11 @@ export const ADMIN = {
   scenarioById: (id: number | string) => `${API_V2}/admin/scenarios/${id}`,
 } as const;
 
+/** 外部 URL の OGP / oEmbed メタ情報を取得するプロキシ */
+export const EMBEDS = {
+  oembed: `${API_V2}/embeds/oembed`,
+} as const;
+
 /** WebSocket（Cookie 認証 / 通常 ws:// or wss:// にフロント側で書き換え）*/
 export const WS = {
   /** ルームごとブロードキャスト（ユーザー間チャット） */

--- a/frontend/src/extensions/EmbedCardExtension.ts
+++ b/frontend/src/extensions/EmbedCardExtension.ts
@@ -1,0 +1,112 @@
+/**
+ * Zenn 互換の埋め込みカード extension。
+ *
+ * 仕様:
+ *   - markdown 入力で `@[card](https://example.com)` を Tiptap embedCard node に変換
+ *   - URL 単独行 (前後が空行) も embedCard 候補だが、Tiptap コア仕様との衝突を避けて
+ *     Phase 1 では `@[card](...)` のみサポート (URL 単独行は Phase 2 で対応)
+ *   - serialize: embedCard → `@[card](url)` に書き戻し
+ *   - NodeView: EmbedCardNodeView (Go backend の /api/v2/embeds/oembed を呼ぶ)
+ */
+import { Node, mergeAttributes, type RawCommands, type CommandProps } from '@tiptap/core';
+import { ReactNodeViewRenderer, type ReactNodeViewProps } from '@tiptap/react';
+import type { ComponentType } from 'react';
+import type { MarkdownSerializerState } from 'prosemirror-markdown';
+import type { Node as PMNode } from 'prosemirror-model';
+import EmbedCardNodeView from '../components/EmbedCardNodeView';
+
+interface MarkdownItType {
+  inline: { ruler: { before: (existing: string, name: string, fn: unknown) => void } };
+}
+
+interface MdToken {
+  type: string;
+  meta?: { url?: string };
+  block?: boolean;
+}
+
+export const EmbedCard = Node.create({
+  name: 'embedCard',
+  group: 'block',
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      url: {
+        default: '',
+        parseHTML: (element) => element.getAttribute('data-embed-url') || '',
+        renderHTML: (attributes) => ({ 'data-embed-url': attributes.url }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-embed-card]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes(HTMLAttributes, { 'data-embed-card': '', class: 'embed-card' })];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(
+      EmbedCardNodeView as ComponentType<ReactNodeViewProps<HTMLElement>>,
+    );
+  },
+
+  addCommands(): Partial<RawCommands> {
+    return {
+      insertEmbedCard:
+        (url: string) =>
+        ({ commands }: CommandProps) =>
+          commands.insertContent({
+            type: 'embedCard',
+            attrs: { url },
+          }),
+    };
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: PMNode) {
+          const url = (node.attrs.url as string) || '';
+          state.write(`@[card](${url})`);
+          state.closeBlock(node);
+        },
+        parse: {
+          // markdown-it の inline rule で `@[card](url)` をパースし、専用 token を発行する。
+          // tiptap-markdown は token → DOM 変換を介して node spec の parseHTML に流すため、
+          // ここでは render を data-embed-card 属性付きの div で出す。
+          setup(this: unknown, md: MarkdownItType) {
+            md.inline.ruler.before('link', 'embed_card', (state: unknown, silent: boolean) => {
+              const s = state as {
+                src: string;
+                pos: number;
+                posMax: number;
+                push: (type: string, tag: string, nesting: number) => MdToken;
+              };
+              if (silent) return false;
+              const start = s.pos;
+              if (s.src.charCodeAt(start) !== 0x40 /* @ */) return false;
+              const rest = s.src.slice(start);
+              const m = rest.match(/^@\[card\]\(([^)\s]+)\)/);
+              if (!m) return false;
+              const token = s.push('embed_card', '', 0);
+              token.meta = { url: m[1] };
+              s.pos = start + m[0].length;
+              return true;
+            });
+            // markdown-it の renderer に embed_card token をマップ。
+            (md as unknown as { renderer: { rules: Record<string, (tokens: MdToken[], idx: number) => string> } }).renderer.rules.embed_card =
+              (tokens: MdToken[], idx: number) => {
+                const url = tokens[idx].meta?.url ?? '';
+                return `<div data-embed-card="" data-embed-url="${url}" class="embed-card"></div>`;
+              };
+          },
+        },
+      },
+    };
+  },
+});

--- a/frontend/src/extensions/tiptap-types.d.ts
+++ b/frontend/src/extensions/tiptap-types.d.ts
@@ -75,5 +75,9 @@ declare module '@tiptap/core' {
     mermaidCommands: {
       insertMermaid: (code?: string) => ReturnType;
     };
+    /** EmbedCardExtension のコマンド */
+    embedCardCommands: {
+      insertEmbedCard: (url: string) => ReturnType;
+    };
   }
 }

--- a/frontend/src/repositories/EmbedRepository.ts
+++ b/frontend/src/repositories/EmbedRepository.ts
@@ -1,0 +1,23 @@
+import apiClient from '../lib/axios';
+import { EMBEDS } from '../constants/apiRoutes';
+
+/**
+ * 外部 URL の OGP / oEmbed メタを Go backend のプロキシ経由で取得する。
+ * バックエンドが SSRF 対策・キャッシュを担うため、フロントは薄い wrapper でよい。
+ */
+export interface EmbedCardDto {
+  url: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+  siteName?: string;
+  /** "ogp" / "youtube" / "github" / ... バックエンドが解決した戦略 */
+  provider?: string;
+}
+
+export const EmbedRepository = {
+  async resolve(url: string): Promise<EmbedCardDto> {
+    const res = await apiClient.get<EmbedCardDto>(EMBEDS.oembed, { params: { url } });
+    return res.data;
+  },
+};

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -61,16 +61,20 @@ vi.mock('../../extensions/MathExtension', () => ({
 vi.mock('../../extensions/MermaidExtension', () => ({
   Mermaid: 'Mermaid',
 }));
+vi.mock('../../extensions/EmbedCardExtension', () => ({
+  EmbedCard: 'EmbedCard',
+}));
 
 import { createEditorExtensions } from '../editorExtensions';
 
 describe('createEditorExtensions', () => {
-  it('31個のエクステンションを返す', () => {
+  it('32個のエクステンションを返す', () => {
     // PR A: tiptap-markdown +1
     // PR C: MathBlock + MathInline +2
-    // PR D: Mermaid +1 → 28 + 2 + 1 = 31
+    // PR D: Mermaid +1
+    // PR F: EmbedCard +1 → 27 + 1 + 2 + 1 + 1 = 32
     const extensions = createEditorExtensions();
-    expect(extensions).toHaveLength(31);
+    expect(extensions).toHaveLength(32);
   });
 
   it('主要なエクステンションが含まれる', () => {

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -29,6 +29,7 @@ import { SearchReplaceExtension } from '../extensions/SearchReplaceExtension';
 import { FullWidthHeadingEnter } from '../extensions/FullWidthHeadingEnter';
 import { MathBlock, MathInline } from '../extensions/MathExtension';
 import { Mermaid } from '../extensions/MermaidExtension';
+import { EmbedCard } from '../extensions/EmbedCardExtension';
 
 export function createEditorExtensions() {
   return [
@@ -96,6 +97,8 @@ export function createEditorExtensions() {
     MathInline,
     // Mermaid ダイアグラム (```mermaid ... ```)
     Mermaid,
+    // 埋め込みカード (@[card](url)) - PR F
+    EmbedCard,
     // tiptap-markdown は editor.storage.markdown.getMarkdown() / setContent(md) を提供する。
     // - html: false       editor 内の生 HTML 出力を抑制し pure な Markdown シリアライズに統一
     // - tightLists: true  リストアイテム間の空行を出力しない (Zenn / GitHub 準拠)


### PR DESCRIPTION
Markdown 互換 markdown 全 8 PR の **#F**。PR E で実装した Go backend の `/api/v2/embeds/oembed` を呼んで URL のメタ (OGP) を Card UI に描画します。

## 実装
- **EmbedRepository**: `/api/v2/embeds/oembed?url=` の薄い wrapper
- **EmbedCardNodeView**: fetching / resolved / error の 3 状態。target=_blank rel=noopener noreferrer でセキュア外部リンク
- **EmbedCardExtension**: block atom node。serialize で `@[card](url)`、parse は markdown-it inline ruler に `embed_card` トークンを登録 + renderer で `<div data-embed-card>` を出力 → tiptap-markdown が parseHTML に流す
- `apiRoutes.ts` に EMBEDS.oembed 追加

## Phase 1 スコープ
- `@[card](url)` のみ対応（URL 単独行記法は Phase 2）
- SSRF / キャッシュは backend (PR E) が担当

## テスト
- vitest run → 293 / 2361 全 pass
- tsc --noEmit → 0 errors
- eslint . → 0 errors / 0 warnings
