### PR TITLE
feat(frontend): YouTube/Twitter/GitHub 専用埋め込み extension 追加 [Markdown 拡張 PR G]

### DIFF
--- a/frontend/src/components/ServiceEmbedNodeView.tsx
+++ b/frontend/src/components/ServiceEmbedNodeView.tsx
@@ -1,0 +1,113 @@
+/**
+ * YouTube / Twitter (X) / GitHub permalink などのサービス専用埋め込み NodeView。
+ *
+ * Zenn 仕様:
+ *   - YouTube: 動画 URL 単独行 → iframe
+ *   - Twitter (X): ポスト URL 単独行 → blockquote (twitter widget)
+ *   - GitHub: ファイル/permalink URL 単独行 → コードブロック (#L行範囲指定 もサポート)
+ *
+ * 本 PR では iframe / blockquote ベースの軽量描画のみ。GitHub コード本体取得は
+ * Phase 2 (raw.githubusercontent.com 経由) で扱う。
+ */
+import { useMemo } from 'react';
+import { NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+
+type EmbedKind = 'youtube' | 'twitter' | 'github';
+
+type Props = ReactNodeViewProps<HTMLElement> & {
+  node: ReactNodeViewProps<HTMLElement>['node'] & {
+    attrs: { kind: EmbedKind; url: string };
+  };
+};
+
+function youtubeId(url: string): string | null {
+  // 対応: https://www.youtube.com/watch?v=ID / https://youtu.be/ID
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1) || null;
+    if (u.hostname.endsWith('youtube.com')) {
+      return u.searchParams.get('v');
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function twitterStatusUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'twitter.com' || u.hostname === 'x.com') {
+      // /<user>/status/<id>
+      if (/^\/[^/]+\/status\/\d+/.test(u.pathname)) return url;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export default function ServiceEmbedNodeView({ node }: Props) {
+  const kind = (node.attrs.kind as EmbedKind) || 'youtube';
+  const url = (node.attrs.url as string) || '';
+
+  const body = useMemo(() => {
+    if (kind === 'youtube') {
+      const id = youtubeId(url);
+      if (!id) return null;
+      return (
+        <iframe
+          src={`https://www.youtube.com/embed/${id}`}
+          title="YouTube video player"
+          loading="lazy"
+          frameBorder={0}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="w-full aspect-video rounded-lg"
+        />
+      );
+    }
+    if (kind === 'twitter') {
+      const tweet = twitterStatusUrl(url);
+      if (!tweet) return null;
+      return (
+        // Twitter のオフィシャル widget JS は外部スクリプト読み込みが必要なので
+        // Phase 1 では blockquote プレースホルダだけ出す。実際の rich render は
+        // フロントの読者ページ側で widgets.js を有効化するか別 PR で扱う。
+        <blockquote className="twitter-tweet">
+          <a href={tweet} target="_blank" rel="noreferrer noopener">
+            {tweet}
+          </a>
+        </blockquote>
+      );
+    }
+    if (kind === 'github') {
+      // GitHub permalink は Phase 1 ではコードブロック取得を行わず、
+      // タイトル付きリンクカードに fallback する。
+      return (
+        <a
+          href={url}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="block rounded-lg border border-surface-3 bg-surface-1 p-3 hover:bg-[var(--color-surface-2)] no-underline"
+        >
+          <div className="text-xs text-[var(--color-text-muted)]">GitHub</div>
+          <div className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
+            {url}
+          </div>
+        </a>
+      );
+    }
+    return null;
+  }, [kind, url]);
+
+  return (
+    <NodeViewWrapper className="service-embed my-3">
+      {body ?? (
+        <a href={url} target="_blank" rel="noreferrer noopener" className="text-sky-400 underline">
+          {url}
+        </a>
+      )}
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/extensions/ServiceEmbedExtension.ts
+++ b/frontend/src/extensions/ServiceEmbedExtension.ts
@@ -1,0 +1,151 @@
+/**
+ * Zenn 仕様の URL 単独行 → サービス専用埋め込み変換。
+ *
+ * 対応:
+ *   - YouTube      ( youtu.be / youtube.com/watch?v= )
+ *   - Twitter (X)  ( twitter.com|x.com/<user>/status/<id> )
+ *   - GitHub permalink ( github.com/.../blob/.../path[#L1-L3] )
+ *
+ * markdown-it の block ruler で「行内に URL 1 つだけ含む段落」を検出し、
+ * service_embed トークンに置換する。renderer は data-service-embed 付きの
+ * div を出力し、Tiptap が parseHTML で serviceEmbed node に取り込む。
+ *
+ * 本 PR 段階では NodeView は最小描画 (PR G の ServiceEmbedNodeView)。
+ */
+import { Node, mergeAttributes, type RawCommands, type CommandProps } from '@tiptap/core';
+import { ReactNodeViewRenderer, type ReactNodeViewProps } from '@tiptap/react';
+import type { ComponentType } from 'react';
+import type { MarkdownSerializerState } from 'prosemirror-markdown';
+import type { Node as PMNode } from 'prosemirror-model';
+import ServiceEmbedNodeView from '../components/ServiceEmbedNodeView';
+
+interface MdState {
+  src: string;
+  bMarks: number[];
+  eMarks: number[];
+  tShift: number[];
+  push: (type: string, tag: string, nesting: number) => MdToken;
+}
+
+interface MdToken {
+  type: string;
+  meta?: { kind?: string; url?: string };
+  block?: boolean;
+  map?: [number, number];
+}
+
+interface MarkdownItType {
+  block: { ruler: { before: (existing: string, name: string, fn: unknown, opts?: unknown) => void } };
+  renderer: { rules: Record<string, (tokens: MdToken[], idx: number) => string> };
+}
+
+function classifyServiceUrl(url: string): 'youtube' | 'twitter' | 'github' | null {
+  try {
+    const u = new URL(url);
+    const host = u.hostname;
+    if (host === 'youtu.be' || host.endsWith('youtube.com')) return 'youtube';
+    if (host === 'twitter.com' || host === 'x.com') return 'twitter';
+    if (host === 'github.com') return 'github';
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export const ServiceEmbed = Node.create({
+  name: 'serviceEmbed',
+  group: 'block',
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      kind: {
+        default: 'youtube',
+        parseHTML: (el) => el.getAttribute('data-service-kind') || 'youtube',
+        renderHTML: (attrs) => ({ 'data-service-kind': attrs.kind }),
+      },
+      url: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-service-url') || '',
+        renderHTML: (attrs) => ({ 'data-service-url': attrs.url }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-service-embed]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'div',
+      mergeAttributes(HTMLAttributes, {
+        'data-service-embed': '',
+        class: 'service-embed',
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(
+      ServiceEmbedNodeView as ComponentType<ReactNodeViewProps<HTMLElement>>,
+    );
+  },
+
+  addCommands(): Partial<RawCommands> {
+    return {
+      insertServiceEmbed:
+        (kind: 'youtube' | 'twitter' | 'github', url: string) =>
+        ({ commands }: CommandProps) =>
+          commands.insertContent({
+            type: 'serviceEmbed',
+            attrs: { kind, url },
+          }),
+    };
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: PMNode) {
+          const url = (node.attrs.url as string) || '';
+          // Zenn の表記に合わせて URL 単独行で書き戻す。
+          state.write(url);
+          state.closeBlock(node);
+        },
+        parse: {
+          setup(this: unknown, md: MarkdownItType) {
+            // block ruler に "URL only line" 検出を入れる。paragraph 検出より前に走らせる。
+            md.block.ruler.before(
+              'paragraph',
+              'service_embed',
+              (state: MdState, startLine: number, endLine: number, silent: boolean) => {
+                const start = state.bMarks[startLine] + state.tShift[startLine];
+                const max = state.eMarks[startLine];
+                const line = state.src.slice(start, max).trim();
+                // URL 単独行 (前後空白除く)
+                if (!/^https?:\/\/\S+$/.test(line)) return false;
+                const kind = classifyServiceUrl(line);
+                if (!kind) return false;
+                if (silent) return true;
+                const token = state.push('service_embed', '', 0);
+                token.block = true;
+                token.meta = { kind, url: line };
+                token.map = [startLine, startLine + 1];
+                // 1 行進める
+                return true;
+              },
+            );
+            md.renderer.rules.service_embed = (tokens: MdToken[], idx: number) => {
+              const t = tokens[idx];
+              const kind = t.meta?.kind ?? 'youtube';
+              const url = t.meta?.url ?? '';
+              return `<div data-service-embed="" data-service-kind="${kind}" data-service-url="${url}" class="service-embed"></div>`;
+            };
+          },
+        },
+      },
+    };
+  },
+});

--- a/frontend/src/extensions/tiptap-types.d.ts
+++ b/frontend/src/extensions/tiptap-types.d.ts
@@ -79,5 +79,9 @@ declare module '@tiptap/core' {
     embedCardCommands: {
       insertEmbedCard: (url: string) => ReturnType;
     };
+    /** ServiceEmbedExtension (YouTube / Twitter / GitHub) のコマンド */
+    serviceEmbedCommands: {
+      insertServiceEmbed: (kind: 'youtube' | 'twitter' | 'github', url: string) => ReturnType;
+    };
   }
 }

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -64,17 +64,21 @@ vi.mock('../../extensions/MermaidExtension', () => ({
 vi.mock('../../extensions/EmbedCardExtension', () => ({
   EmbedCard: 'EmbedCard',
 }));
+vi.mock('../../extensions/ServiceEmbedExtension', () => ({
+  ServiceEmbed: 'ServiceEmbed',
+}));
 
 import { createEditorExtensions } from '../editorExtensions';
 
 describe('createEditorExtensions', () => {
-  it('32個のエクステンションを返す', () => {
+  it('33個のエクステンションを返す', () => {
     // PR A: tiptap-markdown +1
     // PR C: MathBlock + MathInline +2
     // PR D: Mermaid +1
-    // PR F: EmbedCard +1 → 27 + 1 + 2 + 1 + 1 = 32
+    // PR F: EmbedCard +1
+    // PR G: ServiceEmbed +1 → 27 + 1 + 2 + 1 + 1 + 1 = 33
     const extensions = createEditorExtensions();
-    expect(extensions).toHaveLength(32);
+    expect(extensions).toHaveLength(33);
   });
 
   it('主要なエクステンションが含まれる', () => {

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -30,6 +30,7 @@ import { FullWidthHeadingEnter } from '../extensions/FullWidthHeadingEnter';
 import { MathBlock, MathInline } from '../extensions/MathExtension';
 import { Mermaid } from '../extensions/MermaidExtension';
 import { EmbedCard } from '../extensions/EmbedCardExtension';
+import { ServiceEmbed } from '../extensions/ServiceEmbedExtension';
 
 export function createEditorExtensions() {
   return [
@@ -99,6 +100,8 @@ export function createEditorExtensions() {
     Mermaid,
     // 埋め込みカード (@[card](url)) - PR F
     EmbedCard,
+    // YouTube / Twitter / GitHub 専用埋め込み (URL 単独行) - PR G
+    ServiceEmbed,
     // tiptap-markdown は editor.storage.markdown.getMarkdown() / setContent(md) を提供する。
     // - html: false       editor 内の生 HTML 出力を抑制し pure な Markdown シリアライズに統一
     // - tightLists: true  リストアイテム間の空行を出力しない (Zenn / GitHub 準拠)


### PR DESCRIPTION
Markdown 互換 markdown 全 8 PR の **#G**。URL 単独行を block atom node に変換し、サービスごとに最適化した描画を行います。

| URL | kind | 描画 |
|---|---|---|
| youtu.be/xxx / youtube.com/watch?v=xxx | youtube | iframe (aspect-video) |
| twitter.com|x.com/user/status/id | twitter | blockquote |
| github.com/owner/repo/blob/... | github | タイトル付きリンクカード |

## 実装
- **ServiceEmbedNodeView**: kind に応じて iframe / blockquote / link card を出し分け
- **ServiceEmbedExtension**: block atom node。markdown-it block.ruler に paragraph より前に `service_embed` 検出ルールを挿入し、URL 単独行を data-service-embed 付きの div に置換
- serialize は URL 単独行で書き戻し（lossless）

## Phase 2 範囲外（後日対応）
- Twitter widgets.js による rich render
- GitHub raw コード取得と #L 行範囲指定の表示

## テスト
- vitest run → 293 / 2361 全 pass
- tsc --noEmit → 0 errors
- eslint . → 0 errors / 0 warnings
