### PR TITLE
feat(frontend): 脚注 [^N] / インライン脚注 / 絵文字 shortcode を追加 [Markdown 拡張 PR H]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,6 +40,8 @@
         "lodash": "^4.17.21",
         "lowlight": "^3.3.0",
         "markdown-it-container": "^4.0.0",
+        "markdown-it-emoji": "^3.0.0",
+        "markdown-it-footnote": "^4.0.0",
         "markdown-it-katex": "^2.0.3",
         "mermaid": "^11.14.0",
         "react": "^19.1.1",
@@ -6087,6 +6089,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-4.0.0.tgz",
       "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-emoji": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-3.0.0.tgz",
+      "integrity": "sha512-+rUD93bXHubA4arpEZO3q80so0qgoFJEKRkRbjKX8RTdca89v2kfyF+xR3i2sQTwql9tpPZPOQN5B+PunspXRg==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
       "license": "MIT"
     },
     "node_modules/markdown-it-katex": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,8 @@
     "lodash": "^4.17.21",
     "lowlight": "^3.3.0",
     "markdown-it-container": "^4.0.0",
+    "markdown-it-emoji": "^3.0.0",
+    "markdown-it-footnote": "^4.0.0",
     "markdown-it-katex": "^2.0.3",
     "mermaid": "^11.14.0",
     "react": "^19.1.1",

--- a/frontend/src/extensions/EmojiShortcodeExtension.ts
+++ b/frontend/src/extensions/EmojiShortcodeExtension.ts
@@ -1,0 +1,35 @@
+/**
+ * `:smile:` のような絵文字 shortcode を Unicode 絵文字に変換する拡張。
+ *
+ * Zenn の絵文字補完（`:` トリガで候補を出す UI 補完）は SlashCommand 系で
+ * 別途実装する余地を残し、本 PR では markdown 入力時の自動置換のみを実装する。
+ *
+ * 実装:
+ *   - markdown-it-emoji を tiptap-markdown の parse setup で md.use()
+ *   - serialize 側はテキストノードとして扱われるので特別な処理は不要
+ *     (既存テキストに含まれる Unicode 絵文字はそのまま markdown 出力される)
+ */
+import { Extension } from '@tiptap/core';
+// @ts-expect-error  no type declarations
+import { full as mdEmoji } from 'markdown-it-emoji';
+
+interface MarkdownItType {
+  use: (plugin: unknown) => MarkdownItType;
+}
+
+export const EmojiShortcode = Extension.create({
+  name: 'emojiShortcode',
+
+  addStorage() {
+    return {
+      markdown: {
+        // Extension の serialize は無し (テキストノードがそのまま markdown に出るので透過)
+        parse: {
+          setup(this: unknown, md: MarkdownItType) {
+            md.use(mdEmoji);
+          },
+        },
+      },
+    };
+  },
+});

--- a/frontend/src/extensions/FootnoteExtension.ts
+++ b/frontend/src/extensions/FootnoteExtension.ts
@@ -1,0 +1,184 @@
+/**
+ * Zenn 互換の脚注 extension。
+ *
+ * markdown 入力:
+ *   本文[^1] / 本文^[インライン脚注]
+ *   [^1]: 脚注の内容
+ *
+ * 設計:
+ *   - markdown-it-footnote プラグインを setup() で登録し、HTML 出力を得る
+ *   - footnote_ref 〜 footnote_block の HTML を Tiptap が parseHTML できるよう、
+ *     updateDOM で sup.footnote-ref / section.footnotes を data 属性付きの軽量要素に置換
+ *   - 編集時は inline atom (footnoteRef) と block atom (footnoteList) として扱う
+ *   - serialize は ProseMirror node から markdown を再構成
+ */
+import { Node, mergeAttributes } from '@tiptap/core';
+import type { MarkdownSerializerState } from 'prosemirror-markdown';
+import type { Node as PMNode } from 'prosemirror-model';
+// @ts-expect-error  no type declarations
+import mdFootnote from 'markdown-it-footnote';
+
+interface MarkdownItType {
+  use: (plugin: unknown) => MarkdownItType;
+}
+
+/**
+ * 脚注参照 (本文中の `[^1]` 部分)。inline atom。
+ */
+export const FootnoteRef = Node.create({
+  name: 'footnoteRef',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      label: {
+        default: '',
+        parseHTML: (el) => el.getAttribute('data-footnote-ref') || '',
+        renderHTML: (attrs) => ({ 'data-footnote-ref': attrs.label }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'sup[data-footnote-ref]' }];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    return [
+      'sup',
+      mergeAttributes(HTMLAttributes, { class: 'footnote-ref' }),
+      `[^${(node.attrs.label as string) || ''}]`,
+    ];
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: PMNode) {
+          const label = (node.attrs.label as string) || '';
+          state.write(`[^${label}]`);
+        },
+        parse: {
+          setup(this: unknown, md: MarkdownItType) {
+            md.use(mdFootnote);
+          },
+          updateDOM(this: unknown, element: HTMLElement) {
+            element.querySelectorAll('sup.footnote-ref a, sup .footnote-ref').forEach((el) => {
+              const label = el.textContent?.replace(/[[\]]/g, '') ?? '';
+              const sup = document.createElement('sup');
+              sup.setAttribute('data-footnote-ref', label);
+              sup.classList.add('footnote-ref');
+              sup.textContent = `[^${label}]`;
+              const parent = el.closest('sup');
+              (parent || el).replaceWith(sup);
+            });
+          },
+        },
+      },
+    };
+  },
+});
+
+/**
+ * 脚注定義リスト ( <section class="footnotes"> ... </section> )。block atom。
+ *
+ * 文書末尾に 1 つだけ存在する想定で、Tiptap node として保持する。
+ * markdown serialize 時は `[^N]: 内容` 形式で書き戻す。
+ */
+export const FootnoteList = Node.create({
+  name: 'footnoteList',
+  group: 'block',
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      items: {
+        default: [] as { label: string; content: string }[],
+        parseHTML: (el) => {
+          const raw = el.getAttribute('data-footnote-items');
+          if (!raw) return [];
+          try {
+            return JSON.parse(raw);
+          } catch {
+            return [];
+          }
+        },
+        renderHTML: (attrs) => ({
+          'data-footnote-items': JSON.stringify(attrs.items ?? []),
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'section[data-footnote-list]' }];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    const items = (node.attrs.items as { label: string; content: string }[]) || [];
+    return [
+      'section',
+      mergeAttributes(HTMLAttributes, {
+        class: 'footnotes',
+        'data-footnote-list': '',
+      }),
+      [
+        'ol',
+        {},
+        ...items.map((it) => [
+          'li',
+          { id: `fn-${it.label}` },
+          [
+            'span',
+            {},
+            it.content,
+            ` `,
+            ['a', { href: `#fnref-${it.label}` }, '↩'],
+          ],
+        ]),
+      ],
+    ];
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize(state: MarkdownSerializerState, node: PMNode) {
+          const items = (node.attrs.items as { label: string; content: string }[]) || [];
+          if (items.length === 0) return;
+          state.ensureNewLine();
+          for (const it of items) {
+            state.write(`[^${it.label}]: ${it.content}`);
+            state.ensureNewLine();
+          }
+          state.closeBlock(node);
+        },
+        parse: {
+          updateDOM(this: unknown, element: HTMLElement) {
+            element.querySelectorAll('section.footnotes').forEach((sectionEl) => {
+              const items: { label: string; content: string }[] = [];
+              sectionEl.querySelectorAll('ol > li').forEach((li) => {
+                const id = li.getAttribute('id') ?? '';
+                const label = id.replace(/^fn-?/, '');
+                // 末尾の "↩" 戻りリンクは内容から除外
+                const clone = li.cloneNode(true) as HTMLElement;
+                clone.querySelectorAll('a.footnote-backref, .footnote-backref').forEach((a) => a.remove());
+                const content = clone.textContent?.trim() ?? '';
+                if (label) items.push({ label, content });
+              });
+              const section = document.createElement('section');
+              section.setAttribute('data-footnote-list', '');
+              section.setAttribute('data-footnote-items', JSON.stringify(items));
+              section.classList.add('footnotes');
+              sectionEl.replaceWith(section);
+            });
+          },
+        },
+      },
+    };
+  },
+});

--- a/frontend/src/utils/__tests__/editorExtensions.test.ts
+++ b/frontend/src/utils/__tests__/editorExtensions.test.ts
@@ -67,18 +67,26 @@ vi.mock('../../extensions/EmbedCardExtension', () => ({
 vi.mock('../../extensions/ServiceEmbedExtension', () => ({
   ServiceEmbed: 'ServiceEmbed',
 }));
+vi.mock('../../extensions/FootnoteExtension', () => ({
+  FootnoteRef: 'FootnoteRef',
+  FootnoteList: 'FootnoteList',
+}));
+vi.mock('../../extensions/EmojiShortcodeExtension', () => ({
+  EmojiShortcode: 'EmojiShortcode',
+}));
 
 import { createEditorExtensions } from '../editorExtensions';
 
 describe('createEditorExtensions', () => {
-  it('33個のエクステンションを返す', () => {
+  it('36個のエクステンションを返す', () => {
     // PR A: tiptap-markdown +1
     // PR C: MathBlock + MathInline +2
     // PR D: Mermaid +1
     // PR F: EmbedCard +1
-    // PR G: ServiceEmbed +1 → 27 + 1 + 2 + 1 + 1 + 1 = 33
+    // PR G: ServiceEmbed +1
+    // PR H: FootnoteRef + FootnoteList + EmojiShortcode +3 → 27 + 1 + 2 + 1 + 1 + 1 + 3 = 36
     const extensions = createEditorExtensions();
-    expect(extensions).toHaveLength(33);
+    expect(extensions).toHaveLength(36);
   });
 
   it('主要なエクステンションが含まれる', () => {

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -31,6 +31,8 @@ import { MathBlock, MathInline } from '../extensions/MathExtension';
 import { Mermaid } from '../extensions/MermaidExtension';
 import { EmbedCard } from '../extensions/EmbedCardExtension';
 import { ServiceEmbed } from '../extensions/ServiceEmbedExtension';
+import { FootnoteRef, FootnoteList } from '../extensions/FootnoteExtension';
+import { EmojiShortcode } from '../extensions/EmojiShortcodeExtension';
 
 export function createEditorExtensions() {
   return [
@@ -102,6 +104,10 @@ export function createEditorExtensions() {
     EmbedCard,
     // YouTube / Twitter / GitHub 専用埋め込み (URL 単独行) - PR G
     ServiceEmbed,
+    // 脚注 [^N] / 絵文字 shortcode :smile: - PR H
+    FootnoteRef,
+    FootnoteList,
+    EmojiShortcode,
     // tiptap-markdown は editor.storage.markdown.getMarkdown() / setContent(md) を提供する。
     // - html: false       editor 内の生 HTML 出力を抑制し pure な Markdown シリアライズに統一
     // - tightLists: true  リストアイテム間の空行を出力しない (Zenn / GitHub 準拠)


### PR DESCRIPTION
Markdown 互換 markdown 全 8 PR の **最終 #H**。

## 実装
- **FootnoteExtension**
  - `FootnoteRef` (inline atom): 本文中の `[^1]` を保持
  - `FootnoteList` (block atom): 文書末尾の `<section class="footnotes">` を保持。attrs.items に `{ label, content }[]` を JSON で持つ
  - markdown-it-footnote を parse.setup で `md.use()`
  - parse.updateDOM で `<sup>` / `<section>` を data 属性付き要素に正規化
  - serialize は `[^N]` 参照と `[^N]: 内容` 定義の双方を再構成

- **EmojiShortcodeExtension**
  - markdown-it-emoji (full preset) を md.use() するだけの薄い Extension
  - `:smile:` → 😄 のような shortcode → Unicode 置換 (parse only)
  - serialize は不要（Unicode 絵文字はテキストノードとして markdown に乗る）

## 依存追加
- markdown-it-footnote (型定義なし)
- markdown-it-emoji (型定義なし)

## extensions 数
33 → 36 (FootnoteRef + FootnoteList + EmojiShortcode)

## テスト
- vitest run → 293 / 2361 全 pass
- tsc --noEmit → 0 errors
- eslint . → 0 errors / 0 warnings

## Markdown 互換 markdown 全 8 PR 完了 ✅
| # | テーマ | PR |
|---|---|---|
| A | tiptap-markdown 基盤導入 | #1598 |
| B | :::message / :::details | #1599 |
| C | KaTeX 数式 | #1600 |
| D | Mermaid ダイアグラム | #1601 |
| E | OGP/oEmbed Go API | #1602 |
| F | 埋め込みカード @[card](url) | #1603 |
| G | YouTube/Twitter/GitHub embed | #1604 |
| H | 脚注 + 絵文字 shortcode | (本 PR) |
