### PR TITLE
fix(ci): scheduled-start の RDS 復元に RdsSecurityGroupId / ManageMasterUserPassword=false を渡す

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -118,15 +118,31 @@ jobs:
             exit 1
           fi
           echo "Restoring from snapshot: $LATEST"
-          # rds-postgres.yml は frestyle-infrastructure 側で `DBSnapshotIdentifier`
-          # パラメータを受け付ける必要がある。受け付ければ snapshot 復元として動作。
-          # rds-postgres.yml の正規パラメータ名は `SnapshotIdentifier`。
-          # 指定すると Conditions.RestoreFromSnapshot が true になり、
-          # DBSnapshotIdentifier として CFn が DB を復元する。
+          # rds-postgres.yml の必須 / 重要パラメータを sg スタックの Output から解決する。
+          # 旧コードは Environment と SnapshotIdentifier しか渡していなかったため
+          #   ValidationError: Parameters: [RdsSecurityGroupId] must have values
+          # で復元自体が起動しないバグがあった (2026-04-30 のロスト)。
+          #
+          # - RdsSecurityGroupId: rds-postgres.yml の必須 param (frestyle-prod-sg の Output)
+          # - ManageMasterUserPassword=false: snapshot 復元では AWS が snapshot 内の master
+          #   password を引き継ぐ。true のままだと CFn が新規 secret を作ろうとして整合性エラー。
+          # - SnapshotIdentifier を指定すると Conditions.RestoreFromSnapshot=true になり、
+          #   DBSnapshotIdentifier 経由で CFn が DB を復元する。
+          RDS_SG=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sg \
+            --query 'Stacks[0].Outputs[?OutputKey==`RdsSecurityGroupId`].OutputValue' --output text)
+          if [ -z "$RDS_SG" ] || [ "$RDS_SG" = "None" ]; then
+            echo "::error::Could not resolve RdsSecurityGroupId from $STACK_PFX-sg outputs"
+            exit 1
+          fi
           aws cloudformation deploy --region $AWS_REGION \
             --stack-name $RDS_STACK \
             --template-file iac/infrastructure/cloudformation/templates/runtime/rds-postgres.yml \
-            --parameter-overrides Environment=prod SnapshotIdentifier="$LATEST" \
+            --parameter-overrides \
+              Environment=prod \
+              RdsSecurityGroupId="$RDS_SG" \
+              SnapshotIdentifier="$LATEST" \
+              ManageMasterUserPassword=false \
             --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
             --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
           echo "✅ RDS restored from $LATEST"


### PR DESCRIPTION
## 問題

2026-04-30 22:18 UTC (07:00 JST 翌朝) の scheduled-start が

```
ValidationError: Parameters: [RdsSecurityGroupId] must have values
```

で失敗し、RDS / ALB / ECS が再作成されず **prod が DNS 解決不能 (NX) のまま停止**。直前の "No nightly snapshot found" は副次的ログで、本当の原因は CFn deploy の必須パラメータ欠落でした。

## 原因

scheduled-start.yml の RDS 復元 step は `Environment=prod SnapshotIdentifier=$LATEST` しか渡していなかった。`rds-postgres.yml` は `RdsSecurityGroupId` を必須パラメータとして要求するため CFn change-set 作成時点で fail。

## 修正

- `frestyle-prod-sg` の Output `RdsSecurityGroupId` を describe-stacks で解決
- `--parameter-overrides` に `RdsSecurityGroupId` を追加
- `ManageMasterUserPassword=false` を明示 (snapshot 復元時は snapshot 内の master password を引き継ぐ。true のままだと CFn が新規 secret を作ろうとして整合性エラー)
- 解決失敗時は step を fail させる guard を追加

## 検証

- [x] YAML 構文チェック OK
- [ ] **本 PR merge 後**: `gh workflow run scheduled-start.yml -f confirm=start` で手動復旧

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced RDS deployment process with improved parameter validation and configuration handling to ensure more reliable infrastructure restoration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->