### PR TITLE
fix(frontend): ライトモードでカードが背景と同色になる問題を解消

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,10 +22,16 @@
 }
 
 .light {
-  --color-surface: #FFFFFF;
+  /*
+   * ライトモードのサーフェスは「ページ背景 < カード < 強調」の階層を視認できるように差をつける。
+   * 旧設定は --color-surface と --color-surface-1 が同じ #FFFFFF だったため、
+   * bg-surface-1 のカードがページ背景と完全に同色になり「カードが消えて見える」レイアウト崩れの
+   * 原因になっていた。ページを薄いオフホワイト、カードを純白にして境界線も濃いめに。
+   */
+  --color-surface: #F7F7F5;
   --color-surface-1: #FFFFFF;
-  --color-surface-2: #F7F7F5;
-  --color-surface-3: #E8E8E6;
+  --color-surface-2: #EFEFEC;
+  --color-surface-3: #DCDCD8;
   --color-text-primary: #191919;
   --color-text-secondary: #37352F;
   --color-text-tertiary: #787774;


### PR DESCRIPTION
## 問題

ユーザー報告: ライトモードで MenuPage を下にスクロールしたとき、コンポーネントが「崩れて見える」。実際は **カードが背景と完全同色で境界が消えていた**。

## 原因

`index.css` の `.light` スコープで:
```css
--color-surface:   #FFFFFF  /* ページ背景 (bg-surface) */
--color-surface-1: #FFFFFF  /* カード背景 (bg-surface-1) */
```

両方が純白のため、カードとページがピクセル単位で同色 → `border-surface-3` (#E8E8E6) のごく薄い縁取りだけがカード形状を示す状態 → スクロールすると白い空白しか見えずコンポーネントが消えたように見える。

## 修正

「ページ背景 < カード < 強調」の階層を視認できるよう差をつける:

| 変数 | 旧 | 新 |
|---|---|---|
| `--color-surface` | #FFFFFF | **#F7F7F5** (オフホワイト) |
| `--color-surface-1` | #FFFFFF | #FFFFFF |
| `--color-surface-2` | #F7F7F5 | #EFEFEC |
| `--color-surface-3` | #E8E8E6 | **#DCDCD8** (境界少し濃く) |

ダークモードは変更なし。

## テスト

- [x] vitest run → 293 files / 2361 tests 全 pass
- [x] tsc --noEmit → 0 errors
- [x] eslint . → 0 errors / 0 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated light theme surface colors to create better visual distinction between page backgrounds and card surfaces, enhancing interface clarity and visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->