### PR TITLE
fix(backend): 管理招待 List API を current user role 判定に切替

### DIFF
--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -18,14 +20,55 @@ func NewAdminInvitationHandler(l *usecase.ListAdminInvitationsUseCase, c *usecas
 	return &AdminInvitationHandler{list: l, create: c, cancel: x}
 }
 
+// List は GET /api/v2/admin/invitations。
+// 認可と scope 判定:
+//   - SuperAdmin (運営): 全社横断 → ListAll() / ?companyId= 指定で絞り込みも可
+//   - CompanyAdmin     : 自社の company_id で自動フィルタ → ListByCompanyID()
+//   - その他           : 403 Forbidden
+//
+// 旧実装は ?companyId= クエリ必須だったが、フロントが渡していなかったため
+// 常に 400 を返していた。current user の role / company_id から自動解決する設計に修正。
 func (h *AdminInvitationHandler) List(c *gin.Context) {
-	cid, _ := strconv.ParseUint(c.Query("companyId"), 10, 64)
-	rows, err := h.list.Execute(c.Request.Context(), cid)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	c.JSON(http.StatusOK, rows)
+
+	switch user.Role {
+	case domain.RoleSuperAdmin:
+		// SuperAdmin は全社横断アクセス可。?companyId= が指定されていればそれで絞り込み。
+		if q := c.Query("companyId"); q != "" {
+			cid, _ := strconv.ParseUint(q, 10, 64)
+			rows, err := h.list.ListByCompanyID(c.Request.Context(), cid)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			c.JSON(http.StatusOK, rows)
+			return
+		}
+		rows, err := h.list.ListAll(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+			return
+		}
+		c.JSON(http.StatusOK, rows)
+	case domain.RoleCompanyAdmin:
+		// CompanyAdmin は自社のみ。company_id 未設定なら 403 (誤用防止)。
+		if user.CompanyID == nil || *user.CompanyID == 0 {
+			c.JSON(http.StatusForbidden, gin.H{"error": "company_admin_without_company"})
+			return
+		}
+		rows, err := h.list.ListByCompanyID(c.Request.Context(), *user.CompanyID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, rows)
+	default:
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	}
 }
 
 type createAdminInvReq struct {

--- a/backend/internal/handler/admin_invitation_handler_test.go
+++ b/backend/internal/handler/admin_invitation_handler_test.go
@@ -1,0 +1,155 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// fakeAdminInvRepo は AdminInvitationRepository の最小スタブ。
+// list 系のテストで「どのメソッドが呼ばれたか」を確認するため calledWith を記録する。
+type fakeAdminInvRepo struct {
+	all     []domain.AdminInvitation
+	company []domain.AdminInvitation
+	called  string
+}
+
+func (r *fakeAdminInvRepo) ListAll(_ context.Context) ([]domain.AdminInvitation, error) {
+	r.called = "all"
+	return r.all, nil
+}
+func (r *fakeAdminInvRepo) ListByCompanyID(_ context.Context, companyID uint64) ([]domain.AdminInvitation, error) {
+	r.called = "company"
+	return r.company, nil
+}
+func (r *fakeAdminInvRepo) Create(_ context.Context, _ *domain.AdminInvitation) error { return nil }
+func (r *fakeAdminInvRepo) UpdateStatus(_ context.Context, _ uint64, _ string) error  { return nil }
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// newTestHandler は List handler をテストするための薄い harness。
+// CurrentUser middleware の代わりに context に *domain.User を直接 set する。
+func newTestHandler(repo *fakeAdminInvRepo, currentUser *domain.User) (*AdminInvitationHandler, *gin.Engine) {
+	h := NewAdminInvitationHandler(
+		usecase.NewListAdminInvitationsUseCase(repo),
+		nil,
+		nil,
+	)
+	r := gin.New()
+	r.GET("/admin/invitations", func(c *gin.Context) {
+		if currentUser != nil {
+			c.Set(middleware.ContextKeyCurrentUser, currentUser)
+		}
+		h.List(c)
+	})
+	return h, r
+}
+
+func TestAdminInvitationHandler_List_SuperAdmin_AllScope(t *testing.T) {
+	repo := &fakeAdminInvRepo{
+		all:     []domain.AdminInvitation{{ID: 1}, {ID: 2}},
+		company: []domain.AdminInvitation{{ID: 99}},
+	}
+	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/invitations", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if repo.called != "all" {
+		t.Fatalf("expected ListAll, got %q", repo.called)
+	}
+	var got []domain.AdminInvitation
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(got))
+	}
+}
+
+func TestAdminInvitationHandler_List_SuperAdmin_WithCompanyIDQuery(t *testing.T) {
+	repo := &fakeAdminInvRepo{company: []domain.AdminInvitation{{ID: 99}}}
+	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/invitations?companyId=42", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if repo.called != "company" {
+		t.Fatalf("expected ListByCompanyID, got %q", repo.called)
+	}
+}
+
+func TestAdminInvitationHandler_List_CompanyAdmin_AutoFiltersOwnCompany(t *testing.T) {
+	repo := &fakeAdminInvRepo{company: []domain.AdminInvitation{{ID: 7}}}
+	cid := uint64(123)
+	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: &cid})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/invitations", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if repo.called != "company" {
+		t.Fatalf("expected ListByCompanyID, got %q", repo.called)
+	}
+}
+
+func TestAdminInvitationHandler_List_CompanyAdmin_WithoutCompanyIDIsForbidden(t *testing.T) {
+	repo := &fakeAdminInvRepo{}
+	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: nil})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/invitations", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminInvitationHandler_List_Trainee_Forbidden(t *testing.T) {
+	repo := &fakeAdminInvRepo{}
+	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleTrainee})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/invitations", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "forbidden") {
+		t.Fatalf("body = %s", w.Body.String())
+	}
+}
+
+func TestAdminInvitationHandler_List_Unauthenticated(t *testing.T) {
+	repo := &fakeAdminInvRepo{}
+	_, r := newTestHandler(repo, nil) // current user 未設定
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/invitations", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d", w.Code)
+	}
+}

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -4,10 +4,16 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 )
 
-const ContextKeyCurrentUserID = "currentUserID"
+const (
+	ContextKeyCurrentUserID = "currentUserID"
+	// ContextKeyCurrentUser は JWTAuth の後段でセットされる *domain.User。
+	// handler 側で role / company_id を見たいケース (admin scope の判定など) で利用する。
+	ContextKeyCurrentUser = "currentUser"
+)
 
 // CurrentUser は JWTAuth の後段で動く middleware。
 // JWTAuth が context に詰めた cognito sub から users 行を引き、
@@ -39,6 +45,7 @@ func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
 			return
 		}
 		c.Set(ContextKeyCurrentUserID, user.ID)
+		c.Set(ContextKeyCurrentUser, user)
 		c.Next()
 	}
 }
@@ -54,4 +61,15 @@ func CurrentUserIDOrZero(c *gin.Context) uint64 {
 	}
 	id, _ := v.(uint64)
 	return id
+}
+
+// CurrentUserFromContext は CurrentUser middleware が保存した *domain.User を返す。
+// 未セット / 型不一致のときは nil。handler 側で role / company_id を扱うために使う。
+func CurrentUserFromContext(c *gin.Context) *domain.User {
+	v, ok := c.Get(ContextKeyCurrentUser)
+	if !ok {
+		return nil
+	}
+	u, _ := v.(*domain.User)
+	return u
 }

--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -8,6 +8,9 @@ import (
 )
 
 type AdminInvitationRepository interface {
+	// ListAll は全社横断で招待を返す。SuperAdmin (運営) のダッシュボード用。
+	ListAll(ctx context.Context) ([]domain.AdminInvitation, error)
+	// ListByCompanyID は CompanyAdmin が自社の招待のみを見るための query。
 	ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
 	UpdateStatus(ctx context.Context, id uint64, status string) error
@@ -17,6 +20,12 @@ type adminInvitationRepository struct{ db *gorm.DB }
 
 func NewAdminInvitationRepository(db *gorm.DB) AdminInvitationRepository {
 	return &adminInvitationRepository{db: db}
+}
+
+func (r *adminInvitationRepository) ListAll(ctx context.Context) ([]domain.AdminInvitation, error) {
+	var rows []domain.AdminInvitation
+	err := r.db.WithContext(ctx).Order("created_at DESC").Find(&rows).Error
+	return rows, err
 }
 
 func (r *adminInvitationRepository) ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error) {

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -17,7 +17,14 @@ func NewListAdminInvitationsUseCase(r repository.AdminInvitationRepository) *Lis
 	return &ListAdminInvitationsUseCase{repo: r}
 }
 
-func (u *ListAdminInvitationsUseCase) Execute(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error) {
+// ListAll は全社横断で招待一覧を返す。SuperAdmin (運営側) からのみ呼ばれる想定。
+// 認可は handler 層で current user.role を見て行う。
+func (u *ListAdminInvitationsUseCase) ListAll(ctx context.Context) ([]domain.AdminInvitation, error) {
+	return u.repo.ListAll(ctx)
+}
+
+// ListByCompanyID は指定 company の招待一覧を返す。CompanyAdmin が自社のみを見る用。
+func (u *ListAdminInvitationsUseCase) ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error) {
 	if companyID == 0 {
 		return nil, errors.New("companyID is required")
 	}

--- a/backend/internal/usecase/admin_invitation_usecase_test.go
+++ b/backend/internal/usecase/admin_invitation_usecase_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -11,9 +12,16 @@ import (
 type stubAdminInvRepo struct {
 	rows []domain.AdminInvitation
 	err  error
+	// 直近に呼ばれた絞り込み条件を記録する。"all" / "company:42" のような形式。
+	calledWith string
 }
 
-func (s *stubAdminInvRepo) ListByCompanyID(_ context.Context, _ uint64) ([]domain.AdminInvitation, error) {
+func (s *stubAdminInvRepo) ListAll(_ context.Context) ([]domain.AdminInvitation, error) {
+	s.calledWith = "all"
+	return s.rows, s.err
+}
+func (s *stubAdminInvRepo) ListByCompanyID(_ context.Context, companyID uint64) ([]domain.AdminInvitation, error) {
+	s.calledWith = "company:" + strconv.FormatUint(companyID, 10)
 	return s.rows, s.err
 }
 func (s *stubAdminInvRepo) Create(_ context.Context, inv *domain.AdminInvitation) error {
@@ -34,10 +42,40 @@ func (c *stubCognitoAdmin) InviteUser(_ context.Context, email, _, _ string) (st
 	return "sub-" + email, nil
 }
 
-func TestListAdminInvitations_RequiresCompanyID(t *testing.T) {
+func TestListAdminInvitations_ListByCompanyID_RequiresCompanyID(t *testing.T) {
 	uc := NewListAdminInvitationsUseCase(&stubAdminInvRepo{})
-	if _, err := uc.Execute(context.Background(), 0); err == nil {
+	if _, err := uc.ListByCompanyID(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestListAdminInvitations_ListByCompanyID_DelegatesToRepo(t *testing.T) {
+	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 1}}}
+	uc := NewListAdminInvitationsUseCase(repo)
+	got, err := uc.ListByCompanyID(context.Background(), 42)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != 1 {
+		t.Fatalf("unexpected rows: %+v", got)
+	}
+	if repo.calledWith != "company:42" {
+		t.Fatalf("expected company:42 query, got %q", repo.calledWith)
+	}
+}
+
+func TestListAdminInvitations_ListAll_DelegatesToRepo(t *testing.T) {
+	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 7}, {ID: 8}}}
+	uc := NewListAdminInvitationsUseCase(repo)
+	got, err := uc.ListAll(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("unexpected rows: %+v", got)
+	}
+	if repo.calledWith != "all" {
+		t.Fatalf("expected ListAll path, got %q", repo.calledWith)
 	}
 }
 


### PR DESCRIPTION
## 問題

`GET /api/v2/admin/invitations` が `?companyId=` クエリ必須で、フロント (`AdminInvitationRepository.list()`) がクエリ無しで呼ぶため常に **400 "companyID is required"** を返すバグ。

ユーザー報告の症状:
```
AxiosError: Request failed with status code 400
GET https://api.normanblog.com/api/v2/admin/invitations 400
画面: 「招待一覧の取得に失敗しました」
```

## 設計

| Role | scope |
|---|---|
| SuperAdmin (運営) | 全社横断 → `ListAll()` / `?companyId=` 指定で絞り込みも可 |
| CompanyAdmin | 自社の `company_id` で自動フィルタ → `ListByCompanyID()` |
| その他 (Trainee 等) | 403 Forbidden |
| 未認証 | 401 Unauthorized |

## 変更

1. **middleware/current_user.go** — `ContextKeyCurrentUser` を追加し `*domain.User` 全体を context に保存。`CurrentUserFromContext(c)` helper を export
2. **repository/admin_invitation_repository.go** — `ListAll(ctx)` メソッド追加
3. **usecase/admin_invitation_usecase.go** — 旧 `Execute(ctx, companyID)` を `ListByCompanyID` に rename、`ListAll(ctx)` を追加
4. **handler/admin_invitation_handler.go** — `middleware.CurrentUserFromContext` で current user を取得 → role で切り分け
5. **handler/admin_invitation_handler_test.go** (新規 6 件) — 全 role / 全 path をカバー
6. **usecase/admin_invitation_usecase_test.go** — stub に `ListAll` 追加、新 API でテストを書き直し

## テスト

- [x] go build / vet / test ./... 全 pass
- [x] 新規 8 テスト全 pass
- [x] gofmt -l → 0 件
- [x] staticcheck → 警告なし

## フロント変更

**なし**。`AdminInvitationRepository.list()` はクエリ無しのままで動作する (admin user の role が SuperAdmin なら ListAll、CompanyAdmin なら自動で自社フィルタ)。

## 後続

PR merge → cd-backend で本番反映。