### PR TITLE
fix(frontend): MenuPage の二重スクロールバー / プロフィール画像 S3 PUT の CSP ブロックを解消

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,10 @@
         - img-src 'self' data: https:                   : avatar / CDN 経由画像 / data URL
         - font-src 'self' data:                         : ローカルフォント + base64 埋め込み
         - connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com
-                                                         : API / WebSocket / Cognito callback
+                       https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com
+                                                         : API / WebSocket / Cognito callback /
+                                                           プロフィール / Note 画像の S3 presigned PUT
+                                                           (frestyle-prod-note-images.s3.amazonaws.com)
         - form-action 'self' https://*.amazoncognito.com: ログイン flow が Cognito Hosted UI へ POST
         - base-uri 'self'                               : <base> 注入対策
         - object-src 'none'                             : <object>/<embed>/<applet> 禁止
@@ -25,7 +28,7 @@
       `report-uri` / `report-to` / `sandbox` も同様 meta では無視されるので、配信が必要な場合は
       CloudFront 側に追加する。
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com; form-action 'self' https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com; form-action 'self' https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <title>FreStyle</title>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -71,12 +71,23 @@ export default function AppShell() {
       </div>
 
       {/* メインコンテンツ */}
-      <div className="flex-1 flex flex-col min-w-0">
+      {/*
+        flex-1 flex-col / min-h-0 / min-w-0 / overflow-hidden を組み合わせるのが
+        Tailwind + Flexbox 内で「内側だけ overflow-auto してくれ」を成立させる
+        必須レシピ。これらが無いと flex item の default min-height: auto により
+        子コンテンツが column 全体を伸ばしてしまい、AppShell の h-screen を超え、
+        body 側にも 2 本目のスクロールバーが発生する (実際 MenuPage でだけ顕在化していた)。
+      */}
+      <div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
         <TopBar
           title={title}
           onMenuToggle={() => setMobileMenuOpen(!mobileMenuOpen)}
         />
-        <main id="main-content" tabIndex={-1} className="flex-1 overflow-auto outline-none">
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="flex-1 min-h-0 overflow-auto outline-none"
+        >
           <Outlet />
         </main>
         <ScrollToTop targetId="main-content" />


### PR DESCRIPTION
## 問題 1: MenuPage で右端にスクロールバーが 2 本

**原因**: AppShell の `<main className="flex-1 overflow-auto">` は flex item の default `min-height: auto` により、子コンテンツが縦に長いと main 自体が伸びて親の `h-screen` を超え、body 側にも scroll が発生する典型的な Tailwind/Flexbox の落とし穴。MenuPage が一番縦に長いため顕在化。

**修正**: `<main>` と外側 flex column に `min-h-0` と `overflow-hidden` を付与する公式レシピを適用。

```diff
-<div className="flex-1 flex flex-col min-w-0">
+<div className="flex-1 flex flex-col min-w-0 min-h-0 overflow-hidden">
   <TopBar ... />
-  <main className="flex-1 overflow-auto outline-none">
+  <main className="flex-1 min-h-0 overflow-auto outline-none">
```

## 問題 2: プロフィール画像アップロードが CSP でブロックされる

**ブラウザコンソール**:
```
Connecting to 'https://frestyle-prod-note-images.s3.amazonaws.com/profiles/...'
violates the following Content Security Policy directive: "connect-src 'self'
https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com"
```

**原因**: `index.html` の CSP meta で `connect-src` に S3 ドメインを許可していなかった。presigned URL に PUT する際 axios (XHR) が connect-src でブロックされる。

**修正**: `connect-src` に以下 2 ホストを追加（path-style と virtual-hosted-style 両対応）:
- `https://*.s3.amazonaws.com`
- `https://*.s3.ap-northeast-1.amazonaws.com`

これでプロフィール画像 / Note 画像の S3 presigned PUT がいずれも通る。

## テスト

- [x] vitest run → 293 files / 2361 tests 全 pass
- [x] tsc --noEmit → 0 errors
- [x] eslint . → 0 errors / 0 warnings
- [x] E2E smoke の CSP meta assertion は `script-src 'self'` のみを検査しているので影響なし

## 後続

merge 後 `gh workflow run cd-frontend.yml -f confirm=deploy` で本番反映 (S3 sync + CloudFront invalidation)。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page layout scrolling behavior to eliminate unwanted secondary scrollbars.

* **Chores**
  * Updated security policies to enable integration with cloud storage services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->