### PR TITLE
fix(frontend): 二重スクロールバー / TopBar 重複タイトル / TopBar 余白を解消

### DIFF
--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -6,8 +6,11 @@ interface TopBarProps {
 }
 
 export default function TopBar({ title, onMenuToggle }: TopBarProps) {
+  // タイトル文字列は各 page の PageIntro が h1 として表示するため、
+  // ここではビジュアルとして繰り返さず screen reader 用にだけ残す。
+  // h-12 → h-10 に縮め、上部に空きすぎる帯ができていた問題も合わせて解消。
   return (
-    <header className="h-12 bg-surface-1 border-b border-surface-3 flex items-center px-4 flex-shrink-0">
+    <header className="h-10 bg-surface-1 border-b border-surface-3 flex items-center px-4 flex-shrink-0">
       <button
         onClick={onMenuToggle}
         className="md:hidden p-1.5 -ml-1.5 mr-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-surface-2 rounded-md transition-colors"
@@ -15,7 +18,7 @@ export default function TopBar({ title, onMenuToggle }: TopBarProps) {
       >
         <Bars3Icon className="w-5 h-5" />
       </button>
-      <h1 className="text-sm font-semibold text-[var(--color-text-primary)]">{title}</h1>
+      <h1 className="sr-only">{title}</h1>
     </header>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -45,8 +45,20 @@
 }
 
 @layer base {
+  /*
+   * 外側スクロールバー (Chrome ブラウザ標準) と内側スクロールバー (AppShell の <main>)
+   * の二重表示を防ぐため、ルート要素を viewport 高さに固定し overflow を切る。
+   * h-screen の AppShell がこの 100% 領域を占有し、子の <main overflow-auto>
+   * のみがスクロール対象になる。
+   */
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
   body {
     @apply bg-surface text-[var(--color-text-primary)];
+    overflow: hidden;
   }
 
   select,


### PR DESCRIPTION
ユーザー報告の 3 点まとめて修正。

## 問題 1: 二重スクロールバー (Chrome 標準 + 内側 main)

**原因**: `html / body / #root` に高さ指定が無く、AppShell の `h-screen` (100vh) 子要素のレイアウト次第で body も縦に伸びて Chrome の外側 scroll が発生。PR #1610 の `min-h-0 + overflow-hidden` レシピだけでは「body が縦に伸びるケース」までは抑え込めていなかった。

**修正**: `index.css` の base layer に
```css
html, body, #root { height: 100%; }
body { overflow: hidden; }
```
を追加。viewport 高さに固定し、scroll は AppShell 内 `<main>` に閉じ込める。

## 問題 2: ヘッダー部「ホーム」が二重表示

**原因**: TopBar が h1 でタイトルを描画 + PageIntro も同名 h1 を描画 → 同じ文字が 2 行並んで見える。

**修正**: TopBar の h1 を `sr-only` 化。screen reader 向けには残し、視覚的には PageIntro 一本に統一。

## 問題 3: TopBar 上部余白が広すぎる

**修正**: TopBar 高さ `h-12` (48px) → `h-10` (40px) に縮小。

## テスト

- [x] vitest run → 293 files / 2361 tests 全 pass (TopBar test 含む)
- [x] tsc --noEmit → 0 errors
- [x] eslint . → 0 errors / 0 warnings

## 後続

merge 後 `gh workflow run cd-frontend.yml -f confirm=deploy` で S3 sync + CloudFront invalidation。