### PR TITLE
fix: Monaco CSP エラー・AI チャット 404・admin 未認識の3件を解消

### DIFF
--- a/backend/internal/handler/ai_chat_handler.go
+++ b/backend/internal/handler/ai_chat_handler.go
@@ -1,24 +1,42 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
 )
 
 // AiChatHandler は AI チャット関連のエンドポイントを提供する。
 type AiChatHandler struct {
 	getSessions   *usecase.GetAiChatSessionsByUserIDUseCase
 	createSession *usecase.CreateAiChatSessionUseCase
+	getSession    *usecase.GetAiChatSessionUseCase
+	updateTitle   *usecase.UpdateAiChatSessionTitleUseCase
+	deleteSession *usecase.DeleteAiChatSessionUseCase
+	getMessages   *usecase.GetAiChatMessagesUseCase
 }
 
 func NewAiChatHandler(
 	getSessions *usecase.GetAiChatSessionsByUserIDUseCase,
 	createSession *usecase.CreateAiChatSessionUseCase,
+	getSession *usecase.GetAiChatSessionUseCase,
+	updateTitle *usecase.UpdateAiChatSessionTitleUseCase,
+	deleteSession *usecase.DeleteAiChatSessionUseCase,
+	getMessages *usecase.GetAiChatMessagesUseCase,
 ) *AiChatHandler {
-	return &AiChatHandler{getSessions: getSessions, createSession: createSession}
+	return &AiChatHandler{
+		getSessions:   getSessions,
+		createSession: createSession,
+		getSession:    getSession,
+		updateTitle:   updateTitle,
+		deleteSession: deleteSession,
+		getMessages:   getMessages,
+	}
 }
 
 // GetSessions は GET /ai-chat/sessions
@@ -67,4 +85,95 @@ func (h *AiChatHandler) CreateSession(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, created)
+}
+
+// parseSessionID は :id パスパラメータを uint64 に変換する共通ヘルパー。
+func parseSessionID(c *gin.Context) (uint64, bool) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session id"})
+		return 0, false
+	}
+	return id, true
+}
+
+// GetSession は GET /ai-chat/sessions/:id
+func (h *AiChatHandler) GetSession(c *gin.Context) {
+	id, ok := parseSessionID(c)
+	if !ok {
+		return
+	}
+	s, err := h.getSession.Execute(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, s)
+}
+
+type updateSessionTitleReq struct {
+	Title string `json:"title" binding:"required"`
+}
+
+// UpdateSessionTitle は PUT /ai-chat/sessions/:id
+func (h *AiChatHandler) UpdateSessionTitle(c *gin.Context) {
+	id, ok := parseSessionID(c)
+	if !ok {
+		return
+	}
+	var req updateSessionTitleReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.updateTitle.Execute(c.Request.Context(), id, req.Title); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	s, _ := h.getSession.Execute(c.Request.Context(), id)
+	c.JSON(http.StatusOK, s)
+}
+
+// DeleteSession は DELETE /ai-chat/sessions/:id
+func (h *AiChatHandler) DeleteSession(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	id, ok := parseSessionID(c)
+	if !ok {
+		return
+	}
+	if err := h.deleteSession.Execute(c.Request.Context(), id, uid); err != nil {
+		if err.Error() == "forbidden" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// GetMessages は GET /ai-chat/sessions/:id/messages
+func (h *AiChatHandler) GetMessages(c *gin.Context) {
+	id, ok := parseSessionID(c)
+	if !ok {
+		return
+	}
+	msgs, err := h.getMessages.Execute(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, msgs)
 }

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -67,6 +67,13 @@ func (h *AuthHandler) Me(c *gin.Context) {
 	isAdmin := middleware.IsAdminFromGroups(groups) ||
 		user.Role == domain.RoleSuperAdmin ||
 		user.Role == domain.RoleCompanyAdmin
+	// access_token に admin グループがあるが DB role が未昇格の場合はここで同期する。
+	// Google federated ユーザーはログイン時の upsert で groups が取れないケースがある。
+	if middleware.IsAdminFromGroups(groups) && user.Role != domain.RoleSuperAdmin && user.Role != domain.RoleCompanyAdmin {
+		if h.users != nil {
+			_ = h.users.UpdateRole(c.Request.Context(), user.ID, domain.RoleSuperAdmin)
+		}
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"id":          user.ID,
 		"cognitoSub":  user.CognitoSub,
@@ -144,7 +151,39 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	}
 
 	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
+	// refresh_token grant でも id_token が返る場合は DB role を同期する。
+	// Google federated ユーザーは ID token に cognito:groups が含まれないことがあるため
+	// access_token の claims からも昇格を試みる。
+	if tok.IDToken != "" {
+		h.upsertUserFromIDToken(c, tok.IDToken)
+	} else {
+		h.syncRoleFromAccessToken(c, tok.AccessToken)
+	}
 	c.JSON(http.StatusOK, gin.H{"message": "refreshed"})
+}
+
+// syncRoleFromAccessToken は access_token の cognito:groups を見て DB role を super_admin に昇格する。
+// ID token に groups が含まれない Google federated ユーザー向けのフォールバック。
+func (h *AuthHandler) syncRoleFromAccessToken(c *gin.Context, accessToken string) {
+	if h.users == nil {
+		return
+	}
+	claims, err := middleware.DecodeClaims(accessToken)
+	if err != nil {
+		return
+	}
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return
+	}
+	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
+	if !middleware.IsAdminFromGroups(groups) {
+		return
+	}
+	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
+	if existing != nil && existing.Role != domain.RoleSuperAdmin && existing.Role != domain.RoleCompanyAdmin {
+		_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
+	}
 }
 
 // handleTokenError は cognito.TokenExchanger が返したエラーを HTTP レスポンスに変換する。

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -13,7 +13,15 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	aiHandler := NewAiChatHandler(
 		usecase.NewGetAiChatSessionsByUserIDUseCase(aiSessionRepo),
 		usecase.NewCreateAiChatSessionUseCase(aiSessionRepo),
+		usecase.NewGetAiChatSessionUseCase(aiSessionRepo),
+		usecase.NewUpdateAiChatSessionTitleUseCase(aiSessionRepo),
+		usecase.NewDeleteAiChatSessionUseCase(aiSessionRepo),
+		usecase.NewGetAiChatMessagesUseCase(deps.msgRepo),
 	)
 	g.GET("/ai-chat/sessions", aiHandler.GetSessions)
 	g.POST("/ai-chat/sessions", aiHandler.CreateSession)
+	g.GET("/ai-chat/sessions/:id", aiHandler.GetSession)
+	g.PUT("/ai-chat/sessions/:id", aiHandler.UpdateSessionTitle)
+	g.DELETE("/ai-chat/sessions/:id", aiHandler.DeleteSession)
+	g.GET("/ai-chat/sessions/:id/messages", aiHandler.GetMessages)
 }

--- a/backend/internal/repository/ai_chat_session_repository.go
+++ b/backend/internal/repository/ai_chat_session_repository.go
@@ -13,6 +13,7 @@ type AiChatSessionRepository interface {
 	FindByID(ctx context.Context, id uint64) (*domain.AiChatSession, error)
 	Create(ctx context.Context, s *domain.AiChatSession) error
 	UpdateTitle(ctx context.Context, id uint64, title string) error
+	Delete(ctx context.Context, id uint64) error
 }
 
 type aiChatSessionRepository struct{ db *gorm.DB }
@@ -47,4 +48,8 @@ func (r *aiChatSessionRepository) UpdateTitle(ctx context.Context, id uint64, ti
 		Model(&domain.AiChatSession{}).
 		Where("id = ?", id).
 		Update("title", title).Error
+}
+
+func (r *aiChatSessionRepository) Delete(ctx context.Context, id uint64) error {
+	return r.db.WithContext(ctx).Delete(&domain.AiChatSession{}, id).Error
 }

--- a/backend/internal/usecase/ai_chat_usecase.go
+++ b/backend/internal/usecase/ai_chat_usecase.go
@@ -55,3 +55,68 @@ func (u *CreateAiChatSessionUseCase) Execute(ctx context.Context, in CreateAiCha
 	}
 	return s, nil
 }
+
+// GetAiChatSessionUseCase は単一セッションを返す。
+type GetAiChatSessionUseCase struct {
+	sessions repository.AiChatSessionRepository
+}
+
+func NewGetAiChatSessionUseCase(s repository.AiChatSessionRepository) *GetAiChatSessionUseCase {
+	return &GetAiChatSessionUseCase{sessions: s}
+}
+
+func (u *GetAiChatSessionUseCase) Execute(ctx context.Context, id uint64) (*domain.AiChatSession, error) {
+	return u.sessions.FindByID(ctx, id)
+}
+
+// UpdateAiChatSessionTitleUseCase はセッションタイトルを更新する。
+type UpdateAiChatSessionTitleUseCase struct {
+	sessions repository.AiChatSessionRepository
+}
+
+func NewUpdateAiChatSessionTitleUseCase(s repository.AiChatSessionRepository) *UpdateAiChatSessionTitleUseCase {
+	return &UpdateAiChatSessionTitleUseCase{sessions: s}
+}
+
+func (u *UpdateAiChatSessionTitleUseCase) Execute(ctx context.Context, id uint64, title string) error {
+	if title == "" {
+		return errors.New("title is required")
+	}
+	return u.sessions.UpdateTitle(ctx, id, title)
+}
+
+// DeleteAiChatSessionUseCase はセッションを削除する。
+type DeleteAiChatSessionUseCase struct {
+	sessions repository.AiChatSessionRepository
+}
+
+func NewDeleteAiChatSessionUseCase(s repository.AiChatSessionRepository) *DeleteAiChatSessionUseCase {
+	return &DeleteAiChatSessionUseCase{sessions: s}
+}
+
+func (u *DeleteAiChatSessionUseCase) Execute(ctx context.Context, id uint64, userID uint64) error {
+	s, err := u.sessions.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if s.UserID != userID {
+		return errors.New("forbidden")
+	}
+	return u.sessions.Delete(ctx, id)
+}
+
+// GetAiChatMessagesUseCase は DynamoDB からセッションのメッセージ一覧を返す。
+type GetAiChatMessagesUseCase struct {
+	messages repository.AiChatMessageRepository
+}
+
+func NewGetAiChatMessagesUseCase(m repository.AiChatMessageRepository) *GetAiChatMessagesUseCase {
+	return &GetAiChatMessagesUseCase{messages: m}
+}
+
+func (u *GetAiChatMessagesUseCase) Execute(ctx context.Context, sessionID uint64) ([]domain.AiChatMessage, error) {
+	if u.messages == nil {
+		return nil, errors.New("message repository unavailable")
+	}
+	return u.messages.ListBySessionID(ctx, sessionID)
+}

--- a/backend/internal/usecase/ai_chat_usecase_test.go
+++ b/backend/internal/usecase/ai_chat_usecase_test.go
@@ -28,6 +28,9 @@ func (s *stubAiChatSessionRepo) Create(_ context.Context, sess *domain.AiChatSes
 func (s *stubAiChatSessionRepo) UpdateTitle(_ context.Context, _ uint64, _ string) error {
 	return s.err
 }
+func (s *stubAiChatSessionRepo) Delete(_ context.Context, _ uint64) error {
+	return s.err
+}
 
 func TestGetAiChatSessionsByUserID(t *testing.T) {
 	repo := &stubAiChatSessionRepo{rows: []domain.AiChatSession{{ID: 1, UserID: 7, Title: "a"}}}

--- a/backend/internal/usecase/send_ai_message_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_usecase_test.go
@@ -34,6 +34,9 @@ func (m *mockSessionRepo) Create(ctx context.Context, s *domain.AiChatSession) e
 func (m *mockSessionRepo) UpdateTitle(ctx context.Context, id uint64, title string) error {
 	return m.Called(ctx, id, title).Error(0)
 }
+func (m *mockSessionRepo) Delete(ctx context.Context, id uint64) error {
+	return m.Called(ctx, id).Error(0)
+}
 
 // --- mock: AiChatMessageRepository ---
 

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,5 +1,18 @@
-import { Editor } from '@monaco-editor/react';
+import { Editor, loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import { useTheme } from '../hooks/useTheme';
+
+// CSP script-src 'self' 準拠: CDN (jsDelivr) からの動的ロードを禁止し、
+// Vite でバンドルしたローカルの monaco-editor を使う。
+if (typeof self !== 'undefined') {
+  self.MonacoEnvironment = {
+    getWorker(_: unknown, _label: string) {
+      return new editorWorker();
+    },
+  };
+}
+loader.config({ monaco });
 
 interface CodeEditorProps {
   value: string;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -27,6 +27,8 @@ export default defineConfig(({ mode }) => ({
             '@tiptap/starter-kit',
             '@tiptap/core',
           ],
+          // Monaco Editor（CDN ロード禁止のためローカルバンドル、重いので分離）
+          'vendor-monaco': ['monaco-editor'],
         },
       },
     },


### PR DESCRIPTION
## 概要

本番環境で確認された3件の不具合を一括修正します。

## 変更内容

### 1. Monaco Editor CSP エラー修正 (frontend)

- `@monaco-editor/react` がデフォルトで jsDelivr CDN からスクリプトを動的ロードするため、`script-src 'self'` の CSP に違反してコードエディタページが動作しない問題を修正
- `loader.config({ monaco })` でローカルバンドル済みの `monaco-editor` パッケージを使用するよう設定
- `MonacoEnvironment.getWorker` を Vite の `?worker` 構文で設定
- `vite.config.js` に `vendor-monaco` manualChunk を追加してバンドル分割

### 2. AI チャット 404 修正 (backend)

- `GET /api/v2/ai-chat/sessions/:id/messages` 等のエンドポイントが未登録だったため、AIチャット画面でメッセージ取得・セッション操作が全て 404 になっていた問題を修正
- `AiChatSessionRepository` に `Delete` メソッドを追加
- 4つの UseCase を新規追加: `GetAiChatSessionUseCase`, `UpdateAiChatSessionTitleUseCase`, `DeleteAiChatSessionUseCase`, `GetAiChatMessagesUseCase`
- `routes_chat.go` に4エンドポイントを登録: `GET /sessions/:id`, `PUT /sessions/:id`, `DELETE /sessions/:id`, `GET /sessions/:id/messages`

### 3. admin 未認識修正 (backend)

- Google federated ユーザーはコールバック時の ID token に `cognito:groups` が含まれないケースがあり、DB の role が `trainee` のまま昇格されない問題を修正
- `syncRoleFromAccessToken` を新規追加: access token の `cognito:groups` を参照して DB role を `super_admin` に昇格
- `Refresh` ハンドラで ID token がある場合は `upsertUserFromIDToken`、ない場合は `syncRoleFromAccessToken` を呼ぶよう修正
- `Me` ハンドラで access token groups に admin が含まれる場合に DB role を自動昇格する処理を追加

## テスト

- `go test ./...` 全テスト通過確認済み
- `stubAiChatSessionRepo`・`mockSessionRepo` に `Delete` メソッドを追加してインターフェース準拠を維持

## 関連 Issue

本番で確認された3件の不具合修正