### PR TITLE
fix: サイドバー折りたたみ機能を実装（⟨⟨/⟩⟩ トグル）

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, ComponentType, SVGProps } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
   HomeIcon,
@@ -17,6 +17,7 @@ import {
   CodeBracketIcon,
   BuildingOffice2Icon,
   ChevronDoubleLeftIcon,
+  ChevronDoubleRightIcon,
 } from '@heroicons/react/24/outline';
 import Loading from '../Loading';
 import { useSidebar } from '../../hooks/useSidebar';
@@ -29,7 +30,7 @@ interface SubItem {
   matchPrefix?: string;
 }
 
-interface RailSection {
+interface NavItem {
   id: string;
   icon: ComponentType<SVGProps<SVGSVGElement>>;
   label: string;
@@ -39,23 +40,23 @@ interface RailSection {
   subItems?: SubItem[];
 }
 
-const mainSections: RailSection[] = [
+const mainNavItems: NavItem[] = [
   { id: 'home', icon: HomeIcon, label: 'ホーム', to: '/', matchExact: true },
   { id: 'ai', icon: SparklesIcon, label: 'AI', to: '/chat/ask-ai', matchPrefix: '/chat/ask-ai' },
   { id: 'practice', icon: AcademicCapIcon, label: '練習', to: '/practice', matchPrefix: '/practice' },
-  { id: 'code', icon: CodeBracketIcon, label: 'コード', to: '/code-editor', matchPrefix: '/code-editor' },
-  { id: 'scores', icon: ChartBarIcon, label: 'スコア', to: '/scores', matchExact: true },
+  { id: 'code', icon: CodeBracketIcon, label: 'コード学習', to: '/code-editor', matchPrefix: '/code-editor' },
+  { id: 'scores', icon: ChartBarIcon, label: 'スコア履歴', to: '/scores', matchExact: true },
   { id: 'favorites', icon: StarIcon, label: 'お気に入り', to: '/favorites', matchExact: true },
   { id: 'notes', icon: DocumentTextIcon, label: 'ノート', to: '/notes', matchPrefix: '/notes' },
   { id: 'notifications', icon: BellIcon, label: '通知', to: '/notifications', matchExact: true },
   { id: 'reports', icon: DocumentChartBarIcon, label: 'レポート', to: '/reports', matchExact: true },
 ];
 
-const profileSection: RailSection = {
-  id: 'profile', icon: UserCircleIcon, label: 'プロフィール', to: '/profile/me', matchExact: true,
-};
+const bottomNavItems: NavItem[] = [
+  { id: 'profile', icon: UserCircleIcon, label: 'プロフィール', to: '/profile/me', matchExact: true },
+];
 
-const adminSection: RailSection = {
+const adminNavItem: NavItem = {
   id: 'admin',
   icon: BuildingOffice2Icon,
   label: '管理',
@@ -71,164 +72,177 @@ interface SidebarProps {
   onNavigate?: () => void;
 }
 
-function isActiveSection(section: RailSection, pathname: string): boolean {
-  if (section.matchExact) return pathname === section.to;
-  if (section.matchPrefix) return pathname.startsWith(section.matchPrefix);
-  if (section.to) return pathname === section.to;
+function isActive(item: NavItem, pathname: string): boolean {
+  if (item.matchExact) return pathname === item.to;
+  if (item.matchPrefix) return pathname.startsWith(item.matchPrefix);
+  if (item.to) return pathname === item.to;
   return false;
-}
-
-interface RailItemProps {
-  section: RailSection;
-  active: boolean;
-  panelOpen: boolean;
-  onClick: () => void;
-}
-
-function RailItem({ section, active, panelOpen, onClick }: RailItemProps) {
-  const highlighted = active || panelOpen;
-  return (
-    <button
-      onClick={onClick}
-      title={section.label}
-      className={`relative flex flex-col items-center gap-0.5 w-12 py-2 rounded-md transition-colors ${
-        highlighted
-          ? 'text-primary-300 bg-surface-3'
-          : 'text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
-      }`}
-    >
-      {highlighted && (
-        <span className="absolute left-0 top-1.5 bottom-1.5 w-0.5 bg-primary-400 rounded-r" />
-      )}
-      <section.icon className="w-5 h-5 flex-shrink-0" />
-      <span className="text-[9px] leading-none text-center line-clamp-1 w-full px-0.5">
-        {section.label}
-      </span>
-    </button>
-  );
 }
 
 export default function Sidebar({ onNavigate }: SidebarProps) {
   const location = useLocation();
-  const navigate = useNavigate();
   const { handleLogout, loggingOut } = useSidebar();
   const { theme, toggleTheme } = useTheme();
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
 
-  const [openSectionId, setOpenSectionId] = useState<string | null>(null);
+  // expanded: パネル（ラベル）表示状態。false = アイコンのみの折りたたみ状態
+  const [expanded, setExpanded] = useState(true);
+  // 管理サブメニューの開閉
+  const [adminOpen, setAdminOpen] = useState(false);
 
-  const allSections = [...mainSections, profileSection, ...(isAdmin ? [adminSection] : [])];
-  const activePanelSection = allSections.find(
-    (s) => s.id === openSectionId && s.subItems && s.subItems.length > 0,
-  );
+  const allNavItems = [...mainNavItems, ...bottomNavItems, ...(isAdmin ? [adminNavItem] : [])];
+  const adminActive = isActive(adminNavItem, location.pathname);
 
-  const handleRailClick = (section: RailSection) => {
-    if (section.subItems && section.subItems.length > 0) {
-      setOpenSectionId((prev) => (prev === section.id ? null : section.id));
-    } else if (section.to) {
-      navigate(section.to);
-      setOpenSectionId(null);
-      onNavigate?.();
+  const handleAdminClick = () => {
+    if (!expanded) {
+      setExpanded(true);
+      setAdminOpen(true);
+    } else {
+      setAdminOpen((prev) => !prev);
     }
   };
 
   return (
     <>
       {loggingOut && <Loading fullscreen message="ログアウト中..." />}
-      <aside className="flex h-full bg-surface-1 border-r border-surface-3 flex-shrink-0">
-        {/* ─── アイコンレール (常時表示・56px) ─── */}
-        <div className="flex flex-col w-14 h-full py-2 items-center">
-          {/* メインナビ */}
-          <div className="flex-1 flex flex-col gap-0.5 overflow-y-auto items-center w-full px-1">
-            {mainSections.map((section) => (
-              <RailItem
-                key={section.id}
-                section={section}
-                active={isActiveSection(section, location.pathname)}
-                panelOpen={openSectionId === section.id}
-                onClick={() => handleRailClick(section)}
-              />
-            ))}
-          </div>
-
-          <div className="w-10 border-t border-surface-3 my-1" />
-
-          {/* プロフィール・管理・テーマ・ログアウト */}
-          <div className="flex flex-col gap-0.5 items-center w-full px-1">
-            <RailItem
-              section={profileSection}
-              active={isActiveSection(profileSection, location.pathname)}
-              panelOpen={false}
-              onClick={() => handleRailClick(profileSection)}
-            />
-            {isAdmin && (
-              <RailItem
-                section={adminSection}
-                active={isActiveSection(adminSection, location.pathname)}
-                panelOpen={openSectionId === adminSection.id}
-                onClick={() => handleRailClick(adminSection)}
-              />
-            )}
-            <button
-              onClick={toggleTheme}
-              title={theme === 'dark' ? 'ライトモード' : 'ダークモード'}
-              className="flex flex-col items-center gap-0.5 w-12 py-2 rounded-md text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-secondary)] transition-colors"
-            >
-              {theme === 'dark'
-                ? <SunIcon className="w-5 h-5" />
-                : <MoonIcon className="w-5 h-5" />
-              }
-              <span className="text-[9px] leading-none">
-                {theme === 'dark' ? 'ライト' : 'ダーク'}
-              </span>
-            </button>
-            <button
-              onClick={() => { onNavigate?.(); handleLogout(); }}
-              title="ログアウト"
-              className="flex flex-col items-center gap-0.5 w-12 py-2 rounded-md text-[var(--color-text-muted)] hover:bg-red-900/30 hover:text-red-400 transition-colors"
-            >
-              <ArrowLeftOnRectangleIcon className="w-5 h-5" />
-              <span className="text-[9px] leading-none">ログアウト</span>
-            </button>
-          </div>
+      <aside
+        className={`flex flex-col h-full bg-surface-1 border-r border-surface-3 flex-shrink-0 transition-all duration-200 ${
+          expanded ? 'w-56' : 'w-14'
+        }`}
+      >
+        {/* トグルボタン */}
+        <div className={`flex ${expanded ? 'justify-end' : 'justify-center'} px-2 pt-3 pb-1`}>
+          <button
+            onClick={() => { setExpanded((v) => !v); if (expanded) setAdminOpen(false); }}
+            title={expanded ? 'サイドバーを閉じる' : 'サイドバーを開く'}
+            className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            {expanded
+              ? <ChevronDoubleLeftIcon className="w-4 h-4" />
+              : <ChevronDoubleRightIcon className="w-4 h-4" />
+            }
+          </button>
         </div>
 
-        {/* ─── セカンダリパネル (折りたたみ可能・192px) ─── */}
-        {activePanelSection && (
-          <div className="w-48 flex flex-col border-l border-surface-3 h-full">
-            <div className="flex items-center justify-between px-3 py-3 border-b border-surface-3">
-              <span className="text-sm font-semibold">{activePanelSection.label}</span>
-              <button
-                onClick={() => setOpenSectionId(null)}
-                title="パネルを閉じる"
-                className="p-1 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-surface-2 transition-colors"
+        {/* メインナビ */}
+        <nav className="flex-1 px-2 space-y-0.5 overflow-y-auto">
+          {mainNavItems.map((item) => {
+            const active = isActive(item, location.pathname);
+            return (
+              <Link
+                key={item.id}
+                to={item.to!}
+                onClick={onNavigate}
+                title={!expanded ? item.label : undefined}
+                className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors duration-150 ${
+                  active
+                    ? 'bg-surface-3 text-primary-300'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                }`}
               >
-                <ChevronDoubleLeftIcon className="w-4 h-4" />
+                <item.icon className="w-5 h-5 flex-shrink-0" />
+                {expanded && <span className="truncate">{item.label}</span>}
+              </Link>
+            );
+          })}
+
+          <div className="my-2 border-t border-surface-3" />
+
+          {/* プロフィール */}
+          {bottomNavItems.map((item) => {
+            const active = isActive(item, location.pathname);
+            return (
+              <Link
+                key={item.id}
+                to={item.to!}
+                onClick={onNavigate}
+                title={!expanded ? item.label : undefined}
+                className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors duration-150 ${
+                  active
+                    ? 'bg-surface-3 text-primary-300'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                <item.icon className="w-5 h-5 flex-shrink-0" />
+                {expanded && <span className="truncate">{item.label}</span>}
+              </Link>
+            );
+          })}
+
+          {/* 管理メニュー (admin only) */}
+          {isAdmin && (
+            <>
+              <div className="my-2 border-t border-surface-3" />
+              <button
+                onClick={handleAdminClick}
+                title={!expanded ? adminNavItem.label : undefined}
+                className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium w-full transition-colors duration-150 ${
+                  adminActive
+                    ? 'bg-surface-3 text-primary-300'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                <adminNavItem.icon className="w-5 h-5 flex-shrink-0" />
+                {expanded && (
+                  <>
+                    <span className="flex-1 text-left truncate">{adminNavItem.label}</span>
+                    <ChevronDoubleRightIcon
+                      className={`w-3.5 h-3.5 flex-shrink-0 transition-transform ${adminOpen ? 'rotate-90' : ''}`}
+                    />
+                  </>
+                )}
               </button>
-            </div>
-            <nav className="flex-1 px-2 py-2 space-y-0.5 overflow-y-auto">
-              {activePanelSection.subItems?.map((sub) => {
-                const subActive = sub.matchPrefix
-                  ? location.pathname.startsWith(sub.matchPrefix)
-                  : location.pathname === sub.to;
-                return (
-                  <Link
-                    key={sub.to}
-                    to={sub.to}
-                    onClick={onNavigate}
-                    className={`block px-3 py-2 rounded-md text-sm transition-colors ${
-                      subActive
-                        ? 'bg-surface-3 text-primary-300'
-                        : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
-                    }`}
-                  >
-                    {sub.label}
-                  </Link>
-                );
-              })}
-            </nav>
-          </div>
-        )}
+
+              {/* 管理サブメニュー */}
+              {expanded && adminOpen && (
+                <div className="ml-4 space-y-0.5">
+                  {adminNavItem.subItems?.map((sub) => {
+                    const subActive = sub.matchPrefix
+                      ? location.pathname.startsWith(sub.matchPrefix)
+                      : location.pathname === sub.to;
+                    return (
+                      <Link
+                        key={sub.to}
+                        to={sub.to}
+                        onClick={onNavigate}
+                        className={`flex items-center px-2 py-1.5 rounded-md text-xs transition-colors ${
+                          subActive
+                            ? 'bg-surface-3 text-primary-300'
+                            : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                        }`}
+                      >
+                        {sub.label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </>
+          )}
+        </nav>
+
+        {/* テーマ切り替え・ログアウト */}
+        <div className="px-2 py-3 border-t border-surface-3 space-y-0.5">
+          <button
+            onClick={toggleTheme}
+            title={theme === 'dark' ? 'ライトモード' : 'ダークモード'}
+            className="flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-secondary)] transition-colors duration-150 w-full"
+          >
+            {theme === 'dark'
+              ? <SunIcon className="w-5 h-5 flex-shrink-0" />
+              : <MoonIcon className="w-5 h-5 flex-shrink-0" />
+            }
+            {expanded && <span>{theme === 'dark' ? 'ライトモード' : 'ダークモード'}</span>}
+          </button>
+          <button
+            onClick={() => { onNavigate?.(); handleLogout(); }}
+            title="ログアウト"
+            className="flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium text-[var(--color-text-muted)] hover:bg-red-900/30 hover:text-red-400 transition-colors duration-150 w-full"
+          >
+            <ArrowLeftOnRectangleIcon className="w-5 h-5 flex-shrink-0" />
+            {expanded && <span>ログアウト</span>}
+          </button>
+        </div>
       </aside>
     </>
   );

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -17,16 +17,16 @@ vi.mock('../../../hooks/useTheme', () => ({
   useTheme: () => mockUseTheme(),
 }));
 
-function createTestStore() {
+function createTestStore(isAdmin = false) {
   return configureStore({
     reducer: { auth: authReducer },
-    preloadedState: { auth: { isAuthenticated: true, loading: false } },
+    preloadedState: { auth: { isAuthenticated: true, loading: false, isAdmin } },
   });
 }
 
-function renderSidebar(currentPath = '/') {
+function renderSidebar(currentPath = '/', isAdmin = false) {
   return render(
-    <Provider store={createTestStore()}>
+    <Provider store={createTestStore(isAdmin)}>
       <MemoryRouter initialEntries={[currentPath]}>
         <Sidebar />
       </MemoryRouter>
@@ -62,29 +62,62 @@ describe('Sidebar', () => {
 
   it('ホームルートでホームがアクティブになる', () => {
     renderSidebar('/');
-    // Teams スタイルサイドバーはボタンで実装。アクティブ時に bg-surface-3 クラスを持つ
-    const homeBtn = screen.getByText('ホーム').closest('button');
-    expect(homeBtn?.className).toContain('bg-surface-3');
+    const homeLink = screen.getByText('ホーム').closest('a');
+    expect(homeLink?.className).toContain('bg-surface-3');
   });
 
-  it('ダークモード時にライトボタンを表示する', () => {
+  it('ダークモード時にライトモードボタンを表示する', () => {
     renderSidebar();
-    // 省略ラベル「ライト」が表示される
-    expect(screen.getByText('ライト')).toBeInTheDocument();
+    expect(screen.getByText('ライトモード')).toBeInTheDocument();
   });
 
-  it('ライトモード時にダークボタンを表示する', () => {
+  it('ライトモード時にダークモードボタンを表示する', () => {
     mockUseTheme.mockReturnValue({
       theme: 'light',
       toggleTheme: mockToggleTheme,
     });
     renderSidebar();
-    expect(screen.getByText('ダーク')).toBeInTheDocument();
+    expect(screen.getByText('ダークモード')).toBeInTheDocument();
   });
 
   it('テーマ切り替えボタンクリックでtoggleThemeが呼ばれる', () => {
     renderSidebar();
-    fireEvent.click(screen.getByTitle('ライトモード'));
+    fireEvent.click(screen.getByText('ライトモード'));
     expect(mockToggleTheme).toHaveBeenCalledTimes(1);
+  });
+
+  it('折りたたみボタンでサイドバーが折りたたまれる', () => {
+    renderSidebar();
+    // 展開状態ではラベルが見える
+    expect(screen.getByText('ホーム')).toBeVisible();
+    // 折りたたみボタンをクリック
+    fireEvent.click(screen.getByTitle('サイドバーを閉じる'));
+    // 折りたたみ後はラベルが消える（expanded=false）
+    expect(screen.queryByText('ホーム')).toBeNull();
+  });
+
+  it('折りたたみ後に展開ボタンでラベルが戻る', () => {
+    renderSidebar();
+    fireEvent.click(screen.getByTitle('サイドバーを閉じる'));
+    fireEvent.click(screen.getByTitle('サイドバーを開く'));
+    expect(screen.getByText('ホーム')).toBeVisible();
+  });
+
+  it('admin ユーザーには管理メニューが表示される', () => {
+    renderSidebar('/', true);
+    expect(screen.getByText('管理')).toBeInTheDocument();
+  });
+
+  it('admin メニュークリックでサブメニューが展開される', () => {
+    renderSidebar('/', true);
+    fireEvent.click(screen.getByText('管理'));
+    expect(screen.getByText('会社一覧')).toBeInTheDocument();
+    expect(screen.getByText('シナリオ管理')).toBeInTheDocument();
+    expect(screen.getByText('招待管理')).toBeInTheDocument();
+  });
+
+  it('非 admin ユーザーには管理メニューが表示されない', () => {
+    renderSidebar('/');
+    expect(screen.queryByText('管理')).toBeNull();
   });
 });


### PR DESCRIPTION
## 概要

サイドバーの開閉機能を実装します。

## 変更内容

- `⟨⟨` ボタンクリック → アイコンのみの折りたたみ状態（幅 56px）に切替
- `⟩⟩` ボタンクリック → ラベル付き展開状態（幅 224px）に戻す
- 管理メニュー（`BuildingOffice2Icon`）クリックで「会社一覧 / シナリオ管理 / 招待管理」のサブメニューをインライン展開
- 折りたたみ状態ではアイコンの `title` でラベルをツールチップ表示
- CSS `transition-all duration-200` でスムーズなアニメーション

## テスト

- Sidebar テストにトグル・admin サブメニュー動作テストを追加
- 2216件全テストパス

## 関連 Issue

サイドバーの開閉ができないという不具合報告対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sidebar is now collapsible—expand or collapse it to fit your workspace preferences.
  * Admin section is now hidden by default and accessible via a toggle menu for admin users only.

* **Refactor**
  * Redesigned navigation layout for improved usability and cleaner organization of navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->