### PR TITLE
feat(backend): Cognito AdminCreateUser で招待メールを本実装 + CodeEditor Illegal argument 修正

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.15 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -18,6 +18,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24 h1:OQqn11BtaYv1WLUowvcA30MpzIu
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.24/go.mod h1:X5ZJyfwVrWA96GzPmUCWFQaEARPR7gCrpq2E92PJwAE=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6 h1:Wbo1WlWyGaAXlr6C7OGXq9avbdJhIV9cQ4M6E34b5x8=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.6/go.mod h1:uY1fJe6m3I3w/m8UAkQ89Cm/ZAt/um6LW+AOZU33LDI=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2 h1:pZxE29WAHgnk0jGj1P4UOOJnNPHXfltkfnK4F1Tg8jU=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2/go.mod h1:nbe4Nf/HOY+e54Dl+yjv04scYTGTC+4ZthbfOuPTXQs=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3 h1:XgjzLEE8CrNYnr4Xmi1W5PfKsKMjp4Pu1rWkJNO43JI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.3/go.mod h1:r7sfLXEN8RUA89tAHy1E7lCtVOOWIkqVy/FbnUdxW1E=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.16 h1:nWMRNW3SFeJCdK7OsZ9lmbl1AAEAs8s6w5Gsa3MQqNo=

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -1,7 +1,11 @@
 package handler
 
 import (
+	"context"
+	"log"
+
 	"github.com/gin-gonic/gin"
+	cognitoinfra "github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
@@ -15,11 +19,26 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	)
 	g.GET("/admin/companies", companyHandler.List)
 
-	// Phase 25: AdminInvitation
+	// Phase 25: AdminInvitation — Cognito AdminCreateUser で招待メールを送信
 	adminInvRepo := repository.NewAdminInvitationRepository(deps.db)
+
+	var cognitoClient repository.CognitoAdminClient
+	if deps.cfg.Cognito.UserPoolID != "" {
+		ac, err := cognitoinfra.NewAdminClient(context.Background(), "ap-northeast-1", deps.cfg.Cognito.UserPoolID)
+		if err != nil {
+			log.Printf("WARN: Cognito admin client init failed, falling back to stub: %v", err)
+			cognitoClient = repository.NewStubCognitoAdminClient()
+		} else {
+			cognitoClient = ac
+		}
+	} else {
+		log.Printf("WARN: COGNITO_USER_POOL_ID not set — invitation emails will NOT be sent (stub mode)")
+		cognitoClient = repository.NewStubCognitoAdminClient()
+	}
+
 	adminInvHandler := NewAdminInvitationHandler(
 		usecase.NewListAdminInvitationsUseCase(adminInvRepo),
-		usecase.NewCreateAdminInvitationUseCase(adminInvRepo, repository.NewStubCognitoAdminClient()),
+		usecase.NewCreateAdminInvitationUseCase(adminInvRepo, cognitoClient),
 		usecase.NewCancelAdminInvitationUseCase(adminInvRepo),
 	)
 	g.GET("/admin/invitations", adminInvHandler.List)

--- a/backend/internal/infra/cognito/admin_client.go
+++ b/backend/internal/infra/cognito/admin_client.go
@@ -1,0 +1,67 @@
+package cognito
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+)
+
+// AdminClient は Cognito User Pool の管理 API（AdminCreateUser など）を担う。
+type AdminClient struct {
+	client     *cognitoidentityprovider.Client
+	userPoolID string
+}
+
+// NewAdminClient は AWS デフォルト認証情報チェーン（IAM ロール）で AdminClient を初期化する。
+func NewAdminClient(ctx context.Context, region, userPoolID string) (*AdminClient, error) {
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("cognito admin client: load aws config: %w", err)
+	}
+	return &AdminClient{
+		client:     cognitoidentityprovider.NewFromConfig(cfg),
+		userPoolID: userPoolID,
+	}, nil
+}
+
+// InviteUser は Cognito AdminCreateUser で一時パスワード付き招待メールを送信し、CognitoSub を返す。
+// Cognito の招待メールテンプレートはユーザープール設定で管理する。
+func (c *AdminClient) InviteUser(ctx context.Context, email, displayName, _ string) (string, error) {
+	attrs := []types.AttributeType{
+		{Name: aws.String("email"), Value: aws.String(email)},
+		{Name: aws.String("email_verified"), Value: aws.String("true")},
+	}
+	if displayName != "" {
+		attrs = append(attrs, types.AttributeType{
+			Name:  aws.String("name"),
+			Value: aws.String(displayName),
+		})
+	}
+
+	out, err := c.client.AdminCreateUser(ctx, &cognitoidentityprovider.AdminCreateUserInput{
+		UserPoolId:        aws.String(c.userPoolID),
+		Username:          aws.String(email),
+		UserAttributes:    attrs,
+		DesiredDeliveryMediums: []types.DeliveryMediumType{
+			types.DeliveryMediumTypeEmail,
+		},
+		// MessageAction を省略することで Cognito が招待メールを自動送信する
+	})
+	if err != nil {
+		return "", fmt.Errorf("cognito admin create user: %w", err)
+	}
+	if out.User == nil {
+		return "", fmt.Errorf("cognito admin create user: nil user in response")
+	}
+
+	for _, attr := range out.User.Attributes {
+		if aws.ToString(attr.Name) == "sub" {
+			return aws.ToString(attr.Value), nil
+		}
+	}
+	return aws.ToString(out.User.Username), nil
+}

--- a/backend/internal/infra/cognito/admin_client.go
+++ b/backend/internal/infra/cognito/admin_client.go
@@ -43,9 +43,9 @@ func (c *AdminClient) InviteUser(ctx context.Context, email, displayName, _ stri
 	}
 
 	out, err := c.client.AdminCreateUser(ctx, &cognitoidentityprovider.AdminCreateUserInput{
-		UserPoolId:        aws.String(c.userPoolID),
-		Username:          aws.String(email),
-		UserAttributes:    attrs,
+		UserPoolId:     aws.String(c.userPoolID),
+		Username:       aws.String(email),
+		UserAttributes: attrs,
 		DesiredDeliveryMediums: []types.DeliveryMediumType{
 			types.DeliveryMediumTypeEmail,
 		},

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -47,6 +47,7 @@ type CognitoConfig struct {
 	RedirectURI  string
 	TokenURI     string
 	JwkSetURI    string
+	UserPoolID   string // AdminCreateUser API 用
 }
 
 func Load() (*Config, error) {
@@ -65,6 +66,7 @@ func Load() (*Config, error) {
 			RedirectURI:  os.Getenv("COGNITO_REDIRECT_URI"),
 			TokenURI:     os.Getenv("COGNITO_TOKEN_URI"),
 			JwkSetURI:    os.Getenv("COGNITO_JWK_SET_URI"),
+			UserPoolID:   os.Getenv("COGNITO_USER_POOL_ID"),
 		},
 		S3: S3Config{
 			Region:           getEnvOrDefault("AWS_REGION", "ap-northeast-1"),

--- a/docs/admin/admin-feature.md
+++ b/docs/admin/admin-feature.md
@@ -100,6 +100,47 @@ aws cognito-idp admin-add-user-to-group --region ap-northeast-1 \
 - 直接 URL `/admin/scenarios` に行くと **/ にリダイレクト**
 - 万一 API を直接叩いても **403 Forbidden**
 
+## メンバー招待機能（AdminInvitation）
+
+### 概要
+
+Super Admin が会社・ロール・メールアドレスを指定すると、Cognito `AdminCreateUser` API が一時パスワード付きの招待メールを送信する。  
+受信者は Cognito Hosted UI で初回ログイン時にパスワード変更を要求される。
+
+### バックエンド
+
+| 層 | ファイル |
+|---|---|
+| Handler | `internal/handler/admin_invitation_handler.go` |
+| UseCase | `internal/usecase/create_admin_invitation_usecase.go` |
+| Repository | `internal/repository/admin_invitation_repository.go` |
+| Cognito client | `internal/infra/cognito/admin_client.go` |
+
+`CognitoAdminClient` インターフェースを実装した `AdminClient` が `AdminCreateUser` を呼び出す。  
+環境変数 `COGNITO_USER_POOL_ID` が未設定の場合はスタブにフォールバックし、メールは送信されない（ローカル開発用）。
+
+### 必要な環境変数
+
+| 変数 | 値（本番） | 備考 |
+|---|---|---|
+| `COGNITO_USER_POOL_ID` | `ap-northeast-1_TkRen4lyD` | AdminCreateUser API に必要 |
+
+ECS タスク定義（`ecs.yml`）に追加済み。
+
+### フロントエンド
+
+- `src/pages/AdminInvitationsPage.tsx`: 会社セレクター・メール・ロール・表示名のフォーム
+- `src/repositories/AdminInvitationRepository.ts`: POST に `companyId` を含める
+- `src/repositories/CompanyRepository.ts`: `/admin/companies` から会社一覧を取得
+
+### API
+
+| メソッド | パス | 用途 |
+|---|---|---|
+| GET | `/api/v2/admin/invitations` | 未承諾招待一覧 |
+| POST | `/api/v2/admin/invitations` | 招待メール送信 |
+| DELETE | `/api/v2/admin/invitations/:id` | 招待取り消し |
+
 ## 拡張ポイント
 
 - ユーザー管理（一覧・凍結・admin 付与）

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -37,7 +37,7 @@ export default function CodeEditor({
   useEffect(() => {
     if (!containerRef.current) return;
     const editor = monaco.editor.create(containerRef.current, {
-      value,
+      value: value ?? '',
       language,
       theme: theme === 'dark' ? 'vs-dark' : 'vs',
       fontSize: 14,
@@ -75,8 +75,8 @@ export default function CodeEditor({
 
   useEffect(() => {
     const editor = editorRef.current;
-    if (editor && editor.getValue() !== value) {
-      editor.setValue(value);
+    if (editor && editor.getValue() !== (value ?? '')) {
+      editor.setValue(value ?? '');
     }
   }, [value]);
 


### PR DESCRIPTION
## 概要
- 招待フォーム送信時に実際の招待メールが届かない問題を解消（スタブ撤去）
- コードエディター画面で `Error: Illegal argument` エラーが出る問題を修正

## 変更内容

### バックエンド
- `infra/cognito/admin_client.go` を新設: AWS SDK v2 の `AdminCreateUser` API で招待メールを送信
- `infra/config/config.go`: `CognitoConfig` に `UserPoolID` フィールドを追加（`COGNITO_USER_POOL_ID` 環境変数から読み込み）
- `handler/routes_admin.go`: スタブを本実装に差し替え。`COGNITO_USER_POOL_ID` 未設定時はスタブにフォールバック（ローカル開発用）
- `go.mod`: `aws-sdk-go-v2/service/cognitoidentityprovider v1.60.2` を追加

### フロントエンド
- `components/CodeEditor.tsx`: `editor.setValue(value)` に `undefined` が渡ると `Illegal argument` で落ちるため `value ?? ''` でガード

### ドキュメント
- `docs/admin/admin-feature.md`: 招待機能の実装詳細・必要な環境変数・API を追記

## テスト
- バックエンドビルド成功（`go build ./...`）
- 環境変数 `COGNITO_USER_POOL_ID=ap-northeast-1_TkRen4lyD` を ECS に追加する infra PR (frestyle-infrastructure #43) と連動して動作確認

## 関連 Issue
- infra PR: https://github.com/norman6464/frestyle-infrastructure/pull/43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added member invitation capability for Super Admins to invite team members via email with temporary passwords.

* **Bug Fixes**
  * Fixed Code Editor component to properly handle null/undefined values.

* **Documentation**
  * Added comprehensive guide for the new admin member invitation feature, including setup requirements and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->