### PR TITLE
fix: AIページ遷移でadminメニュー消失・PhpExerciseのJSON・エディタ色を修正

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ja-JP"
+tone_instructions: "丁寧な日本語で、若手エンジニアに教えるようなトーンでレビューしてください。"
+reviews:
+  profile: "chill"
+  high_level_summary: true
+  poem: false
+  review_status: false
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "main"

--- a/backend/internal/domain/php_exercise.go
+++ b/backend/internal/domain/php_exercise.go
@@ -5,14 +5,14 @@ import "time"
 // PhpExercise は PHP 学習教材の演習問題エンティティ。
 // 難易度・カテゴリ別に整理し、スターターコードとヒントを持つ。
 type PhpExercise struct {
-	ID             uint   `gorm:"primaryKey;autoIncrement"`
-	OrderIndex     int    `gorm:"not null;default:0"`
-	Category       string `gorm:"size:64;not null"`
-	Title          string `gorm:"size:200;not null"`
-	Description    string `gorm:"type:text;not null"`
-	StarterCode    string `gorm:"type:text;not null"`
-	HintText       string `gorm:"type:text"`
-	ExpectedOutput string `gorm:"type:text"`
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID             uint      `gorm:"primaryKey;autoIncrement" json:"id"`
+	OrderIndex     int       `gorm:"not null;default:0" json:"orderIndex"`
+	Category       string    `gorm:"size:64;not null" json:"category"`
+	Title          string    `gorm:"size:200;not null" json:"title"`
+	Description    string    `gorm:"type:text;not null" json:"description"`
+	StarterCode    string    `gorm:"type:text;not null" json:"starterCode"`
+	HintText       string    `gorm:"type:text" json:"hintText"`
+	ExpectedOutput string    `gorm:"type:text" json:"expectedOutput"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
 }

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import * as monaco from 'monaco-editor';
 import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
-import { useTheme } from '../hooks/useTheme';
 
 // CDN 読み込みを完全回避: Vite バンドル済み monaco-editor を直接使う。
 // @monaco-editor/react は loader が jsDelivr を参照するため使わない。
@@ -36,7 +35,6 @@ export default function CodeEditor({
   height = '400px',
   readOnly = false,
 }: CodeEditorProps) {
-  const { theme } = useTheme();
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const onChangeRef = useRef(onChange);
@@ -47,7 +45,8 @@ export default function CodeEditor({
     const editor = monaco.editor.create(containerRef.current, {
       value: toSafeString(value),
       language,
-      theme: theme === 'dark' ? 'vs-dark' : 'vs',
+      // コードエディタは常にダークテーマで統一（ライト/ダークどちらの UI でも視認性確保）
+      theme: 'vs-dark',
       fontSize: 14,
       minimap: { enabled: false },
       scrollBeyondLastLine: false,
@@ -77,10 +76,6 @@ export default function CodeEditor({
   useEffect(() => {
     editorRef.current?.updateOptions({ readOnly });
   }, [readOnly]);
-
-  useEffect(() => {
-    monaco.editor.setTheme(theme === 'dark' ? 'vs-dark' : 'vs');
-  }, [theme]);
 
   useEffect(() => {
     const editor = editorRef.current;

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -21,6 +21,14 @@ interface CodeEditorProps {
   readOnly?: boolean;
 }
 
+// Monaco の setValue / create({value}) は引数が string でない場合 "Illegal argument" を throw する。
+// API レスポンスが null や undefined を返す可能性があるため必ず string に正規化する。
+function toSafeString(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v == null) return '';
+  return String(v);
+}
+
 export default function CodeEditor({
   value,
   onChange,
@@ -37,7 +45,7 @@ export default function CodeEditor({
   useEffect(() => {
     if (!containerRef.current) return;
     const editor = monaco.editor.create(containerRef.current, {
-      value: value ?? '',
+      value: toSafeString(value),
       language,
       theme: theme === 'dark' ? 'vs-dark' : 'vs',
       fontSize: 14,
@@ -56,6 +64,7 @@ export default function CodeEditor({
     return () => {
       sub.dispose();
       editor.dispose();
+      editorRef.current = null;
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -75,8 +84,13 @@ export default function CodeEditor({
 
   useEffect(() => {
     const editor = editorRef.current;
-    if (editor && editor.getValue() !== (value ?? '')) {
-      editor.setValue(value ?? '');
+    if (!editor) return;
+    // model が dispose 済みだと setValue が "Illegal argument" を投げるため事前チェック。
+    const model = editor.getModel();
+    if (!model || model.isDisposed()) return;
+    const safeValue = toSafeString(value);
+    if (editor.getValue() !== safeValue) {
+      editor.setValue(safeValue);
     }
   }, [value]);
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -48,7 +48,7 @@ export const useAuth = () => {
       try {
         const userInfo = await AuthRepository.login(request);
         setUser(userInfo);
-        dispatch(setAuthData());
+        dispatch(setAuthData({ isAdmin: !!userInfo.isAdmin }));
         return true;
       } catch (err) {
         setError(classifyApiError(err, 'ログインに失敗しました。'));
@@ -164,7 +164,7 @@ export const useAuth = () => {
     try {
       const userInfo = await AuthRepository.getCurrentUser();
       setUser(userInfo);
-      dispatch(setAuthData());
+      dispatch(setAuthData({ isAdmin: !!userInfo.isAdmin }));
       return userInfo;
     } catch (err) {
       setError(classifyApiError(err, 'ユーザー情報の取得に失敗しました。'));

--- a/frontend/src/hooks/usePhpEditor.ts
+++ b/frontend/src/hooks/usePhpEditor.ts
@@ -22,7 +22,7 @@ export function usePhpEditor() {
         setExercises(list);
         if (list.length > 0) {
           setSelectedExercise(list[0]);
-          setCode(list[0].starterCode);
+          setCode(list[0].starterCode ?? '');
         }
       })
       .catch(() => setError('演習問題の取得に失敗しました'))
@@ -31,7 +31,7 @@ export function usePhpEditor() {
 
   const selectExercise = useCallback((exercise: PhpExercise) => {
     setSelectedExercise(exercise);
-    setCode(exercise.starterCode);
+    setCode(exercise.starterCode ?? '');
     setResult(null);
     setShowHint(false);
   }, []);
@@ -52,7 +52,7 @@ export function usePhpEditor() {
 
   const resetCode = useCallback(() => {
     if (selectedExercise) {
-      setCode(selectedExercise.starterCode);
+      setCode(selectedExercise.starterCode ?? '');
       setResult(null);
     }
   }, [selectedExercise]);

--- a/frontend/src/pages/CodeEditorPage.tsx
+++ b/frontend/src/pages/CodeEditorPage.tsx
@@ -129,8 +129,8 @@ export default function CodeEditorPage() {
                 </button>
               </div>
             </div>
-            <div className="flex-1 overflow-hidden">
-              <Suspense fallback={<div className="h-full bg-[var(--color-surface-1)]" />}>
+            <div className="flex-1 overflow-hidden bg-[#1e1e1e]">
+              <Suspense fallback={<div className="h-full bg-[#1e1e1e]" />}>
                 <CodeEditor
                   value={code}
                   onChange={setCode}

--- a/frontend/src/store/__tests__/authSlice.test.ts
+++ b/frontend/src/store/__tests__/authSlice.test.ts
@@ -21,11 +21,23 @@ describe('authSlice', () => {
     expect(state.isAdmin).toBe(true);
   });
 
+  it('setAuthDataでpayload未指定の場合は既存のisAdminを保持する', () => {
+    const adminState = { isAuthenticated: true, loading: false, isAdmin: true };
+    const state = authReducer(adminState, setAuthData());
+    expect(state.isAdmin).toBe(true);
+  });
+
   it('setAuthenticatedでisAuthenticated=true, loading=falseになる', () => {
     const state = authReducer(initialState, setAuthenticated());
     expect(state.isAuthenticated).toBe(true);
     expect(state.loading).toBe(false);
     expect(state.isAdmin).toBe(false);
+  });
+
+  it('setAuthenticatedでpayload未指定の場合は既存のisAdminを保持する', () => {
+    const adminState = { isAuthenticated: true, loading: false, isAdmin: true };
+    const state = authReducer(adminState, setAuthenticated());
+    expect(state.isAdmin).toBe(true);
   });
 
   it('clearAuthでisAuthenticated=false, loading=false, isAdmin=falseになる', () => {

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -14,13 +14,19 @@ const authSlice = createSlice({
     setAuthData(state, action: PayloadAction<{ isAdmin?: boolean } | undefined>) {
       state.isAuthenticated = true;
       state.loading = false;
-      state.isAdmin = action.payload?.isAdmin ?? false;
+      // payload.isAdmin が undefined のときは現在の state を維持する
+      // (caller が isAdmin を明示しない再認証で誤って権限を失わせないため)
+      if (action.payload?.isAdmin !== undefined) {
+        state.isAdmin = action.payload.isAdmin;
+      }
     },
 
     setAuthenticated(state, action: PayloadAction<{ isAdmin?: boolean } | undefined>) {
       state.isAuthenticated = true;
       state.loading = false;
-      state.isAdmin = action.payload?.isAdmin ?? false;
+      if (action.payload?.isAdmin !== undefined) {
+        state.isAdmin = action.payload.isAdmin;
+      }
     },
 
     clearAuth(state) {


### PR DESCRIPTION
## 概要
3 つの不具合を一括修正する。

## 修正内容

### 1. AI ページに移動すると管理メニューが消える
**原因:** `useAuth.getCurrentUser` / `login` が `dispatch(setAuthData())` を payload 無しで呼んでおり、`authSlice` が `state.isAdmin = false` に上書きしていた。`useAskAi` の初期化時に `getCurrentUser` を呼んでいるためページ遷移で admin 権限が失われていた。

**修正:**
- `authSlice`: `payload.isAdmin` が undefined のときは既存の state を保持
- `useAuth`: `getCurrentUser` / `login` で取得した `userInfo.isAdmin` を明示的に dispatch
- テストに保持シナリオを追加

### 2. コードエディタ画面の演習リストが `#` だけ表示される
**原因:** バックエンドの `domain.PhpExercise` 構造体に JSON タグが無く、デフォルトの PascalCase（`"Title"`, `"OrderIndex"` 等）で出力されていた。フロントは camelCase を期待。

**修正:** 全フィールドに json タグを追加

### 3. コードエディタの色が薄すぎる/見づらい
**原因:** `useTheme` の値（ライト/ダーク）に応じて Monaco テーマを切り替えていたが、ライトモードでは VS Code 風の `vs` テーマが背景白で視認性が悪かった。

**修正:** コードエディタは `vs-dark` テーマ固定に変更（コードエディタは慣習的にダークが標準）、コンテナ背景も `#1e1e1e` に。

## テスト
- バックエンド: `go build ./...` パス
- フロントエンド: `npx tsc --noEmit` パス
- authSlice テストに保持シナリオを追加

## デプロイ
- バックエンドデプロイ必須（PhpExercise JSON タグ）
- フロントエンドデプロイ必須（authSlice / CodeEditor / useAuth）