### PR TITLE
fix(admin): 招待取り消しをモーダル化 + 取り消し済みを一覧から除外

### DIFF
--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -22,15 +22,21 @@ func NewAdminInvitationRepository(db *gorm.DB) AdminInvitationRepository {
 	return &adminInvitationRepository{db: db}
 }
 
+// 一覧 API は「未承諾の招待」を返すため pending 以外（accepted / canceled）は除外する。
+// 監査目的で行は物理削除せず status のみ更新している。
 func (r *adminInvitationRepository) ListAll(ctx context.Context) ([]domain.AdminInvitation, error) {
 	var rows []domain.AdminInvitation
-	err := r.db.WithContext(ctx).Order("created_at DESC").Find(&rows).Error
+	err := r.db.WithContext(ctx).
+		Where("status = ?", domain.InvitationStatusPending).
+		Order("created_at DESC").Find(&rows).Error
 	return rows, err
 }
 
 func (r *adminInvitationRepository) ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error) {
 	var rows []domain.AdminInvitation
-	err := r.db.WithContext(ctx).Where("company_id = ?", companyID).Order("created_at DESC").Find(&rows).Error
+	err := r.db.WithContext(ctx).
+		Where("company_id = ? AND status = ?", companyID, domain.InvitationStatusPending).
+		Order("created_at DESC").Find(&rows).Error
 	return rows, err
 }
 

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -9,6 +9,7 @@ import CompanyRepository, { Company } from '../repositories/CompanyRepository';
 import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
+import ConfirmModal from '../components/ConfirmModal';
 import { logger } from '../lib/logger';
 
 const EMPTY_FORM: CreateInvitationForm = {
@@ -29,6 +30,8 @@ export default function AdminInvitationsPage() {
   const [form, setForm] = useState<CreateInvitationForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<AdminInvitation | null>(null);
+  const [canceling, setCanceling] = useState(false);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
@@ -89,14 +92,28 @@ export default function AdminInvitationsPage() {
     }
   };
 
-  const cancel = async (id: number) => {
-    if (!confirm('この招待をキャンセルしますか？')) return;
+  const requestCancel = (inv: AdminInvitation) => {
+    setError(null);
+    setCancelTarget(inv);
+  };
+
+  const closeCancelModal = () => {
+    if (canceling) return;
+    setCancelTarget(null);
+  };
+
+  const confirmCancel = async () => {
+    if (!cancelTarget) return;
+    setCanceling(true);
     try {
-      await AdminInvitationRepository.cancel(id);
+      await AdminInvitationRepository.cancel(cancelTarget.id);
+      setCancelTarget(null);
       await fetchAll();
     } catch (err) {
       setError('招待のキャンセルに失敗しました');
       logger.error(err);
+    } finally {
+      setCanceling(false);
     }
   };
 
@@ -217,8 +234,8 @@ export default function AdminInvitationsPage() {
                   </p>
                 </div>
                 <button
-                  onClick={() => cancel(inv.id)}
-                  className="text-xs px-2 py-1 border border-red-300 rounded text-red-700"
+                  onClick={() => requestCancel(inv)}
+                  className="text-xs px-2 py-1 border border-red-300 rounded text-red-700 hover:bg-red-50 transition-colors"
                 >
                   取り消し
                 </button>
@@ -227,6 +244,21 @@ export default function AdminInvitationsPage() {
           </ul>
         )}
       </section>
+
+      <ConfirmModal
+        isOpen={cancelTarget !== null}
+        title="招待を取り消し"
+        message={
+          cancelTarget
+            ? `${cancelTarget.email} 宛の招待を取り消します。受信者は招待リンクから登録できなくなります。`
+            : ''
+        }
+        confirmText={canceling ? '処理中...' : '取り消す'}
+        cancelText="戻る"
+        onConfirm={confirmCancel}
+        onCancel={closeCancelModal}
+        isDanger={true}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- 招待取り消しの UX を browser `confirm()` から `ConfirmModal` に変更
- 取り消しても一覧から消えなかった問題（status フィルタ漏れ）を修正

## 変更内容

### バックエンド
- `AdminInvitationRepository.ListAll` / `ListByCompanyID` に `status='pending'` フィルタを追加
- 監査目的で行は物理削除せず `status` のみ更新する設計を維持（accepted / canceled は一覧から除外）

### フロントエンド
- `AdminInvitationsPage`: 既存の `ConfirmModal` を使った取り消し UI に変更
- 処理中の二重実行防止（`canceling` state）
- 取り消し成功時に自動で一覧再取得 → 該当行が消える

## テスト
- バックエンド: `go build ./...` パス、UseCase テストパス
- フロントエンド: `npx tsc --noEmit` パス

## デプロイ
- バックエンド・フロントエンド両方のデプロイが必要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 招待管理画面に保留中の招待のみが表示されるように改善されました。

* **新機能**
  * 招待のキャンセル確認がモーダルダイアログに変更されました。処理中の状態表示が追加されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->