### PR TITLE
fix(auth): 招待受諾フロー実装（初回ログインで invitation の role/company を反映）

### DIFF
--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -1,12 +1,14 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	cognitoinfra "github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -88,6 +90,12 @@ func (h *AdminInvitationHandler) Create(c *gin.Context) {
 		CompanyID: req.CompanyID, Email: req.Email, Role: req.Role, DisplayName: req.DisplayName,
 	})
 	if err != nil {
+		if errors.Is(err, cognitoinfra.ErrUserAlreadyConfirmed) {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "このメールアドレスはすでに登録済みです。再招待は不要です。",
+			})
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/backend/internal/handler/admin_invitation_handler_test.go
+++ b/backend/internal/handler/admin_invitation_handler_test.go
@@ -32,6 +32,9 @@ func (r *fakeAdminInvRepo) ListByCompanyID(_ context.Context, companyID uint64) 
 }
 func (r *fakeAdminInvRepo) Create(_ context.Context, _ *domain.AdminInvitation) error { return nil }
 func (r *fakeAdminInvRepo) UpdateStatus(_ context.Context, _ uint64, _ string) error  { return nil }
+func (r *fakeAdminInvRepo) FindPendingByEmail(_ context.Context, _ string) (*domain.AdminInvitation, error) {
+	return nil, nil
+}
 
 func init() {
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -22,15 +22,23 @@ import (
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
 	users          repository.UserRepository
+	invitations    repository.AdminInvitationRepository
 	cognitoCfg     *config.CognitoConfig
 	tokens         *cognito.TokenExchanger
 }
 
 // NewAuthHandler は本番用に http.Client + 10s timeout の TokenExchanger を組み立てて DI する。
-func NewAuthHandler(getCurrentUser *usecase.GetCurrentUserUseCase, users repository.UserRepository, cognitoCfg *config.CognitoConfig) *AuthHandler {
+// invitations は招待受諾フロー（初回ログイン時に invitations から role/companyId を反映）に使う。nil 可。
+func NewAuthHandler(
+	getCurrentUser *usecase.GetCurrentUserUseCase,
+	users repository.UserRepository,
+	invitations repository.AdminInvitationRepository,
+	cognitoCfg *config.CognitoConfig,
+) *AuthHandler {
 	return &AuthHandler{
 		getCurrentUser: getCurrentUser,
 		users:          users,
+		invitations:    invitations,
 		cognitoCfg:     cognitoCfg,
 		tokens: cognito.NewTokenExchanger(cognito.Config{
 			ClientID:     cognitoCfg.ClientID,
@@ -228,25 +236,52 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken string) {
 	}
 	email, _ := claims["email"].(string)
 	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
-	desiredRole := domain.RoleTrainee
-	if middleware.IsAdminFromGroups(groups) {
-		desiredRole = domain.RoleSuperAdmin
-	}
+	isCognitoAdmin := middleware.IsAdminFromGroups(groups)
 
 	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
 	if existing == nil {
-		_ = h.users.Create(c.Request.Context(), &domain.User{
+		// 招待受諾フロー: pending な invitation を email で引いて role / company_id / displayName を反映する
+		role := domain.RoleTrainee
+		var companyID *uint64
+		var acceptedInvID uint64
+		displayName := email
+
+		if isCognitoAdmin {
+			role = domain.RoleSuperAdmin
+		} else if h.invitations != nil && email != "" {
+			inv, _ := h.invitations.FindPendingByEmail(c.Request.Context(), email)
+			if inv != nil {
+				if inv.Role == domain.RoleCompanyAdmin || inv.Role == domain.RoleTrainee {
+					role = inv.Role
+				}
+				cid := inv.CompanyID
+				companyID = &cid
+				acceptedInvID = inv.ID
+				if inv.DisplayName != "" {
+					displayName = inv.DisplayName
+				}
+			}
+		}
+
+		if err := h.users.Create(c.Request.Context(), &domain.User{
 			CognitoSub:  sub,
 			Email:       email,
-			DisplayName: email,
-			Role:        desiredRole,
-		})
+			DisplayName: displayName,
+			Role:        role,
+			CompanyID:   companyID,
+		}); err != nil {
+			log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
+			return
+		}
+		// 招待を accepted にマーク（履歴・監査）
+		if h.invitations != nil && acceptedInvID != 0 {
+			_ = h.invitations.UpdateStatus(c.Request.Context(), acceptedInvID, domain.InvitationStatusAccepted)
+		}
 		return
 	}
-	// Cognito group で admin に昇格された場合のみ DB role を上書きする。
-	// 既に DB で super_admin / company_admin が設定されているケースは触らない
-	// （AdminInvitation 系の手動付与が他にある可能性があるため、降格は手動で）。
-	if existing.Role != desiredRole && desiredRole == domain.RoleSuperAdmin {
-		_ = h.users.UpdateRole(c.Request.Context(), existing.ID, desiredRole)
+
+	// 既存ユーザー: Cognito group で admin に昇格された場合のみ DB role を上書きする。
+	if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
+		_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
 	}
 }

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -11,7 +12,8 @@ import (
 // callback / refresh-token は HttpOnly Cookie の発行・更新を行うため middleware.JWTAuth の対象外。
 func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
-	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, &deps.cfg.Cognito)
+	invitations := repository.NewAdminInvitationRepository(deps.db)
+	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito)
 
 	g.POST("/auth/cognito/logout", authHandler.Logout)
 	// callback は code を受け取って token に交換するので認証不要

--- a/backend/internal/infra/cognito/admin_client.go
+++ b/backend/internal/infra/cognito/admin_client.go
@@ -2,6 +2,7 @@ package cognito
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -9,6 +10,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 )
+
+// ErrUserAlreadyConfirmed は既にパスワード変更済み（登録完了済み）のメールアドレスへの再招待を試みた場合に返る。
+var ErrUserAlreadyConfirmed = errors.New("user already confirmed")
 
 // AdminClient は Cognito User Pool の管理 API（AdminCreateUser など）を担う。
 type AdminClient struct {
@@ -28,8 +32,10 @@ func NewAdminClient(ctx context.Context, region, userPoolID string) (*AdminClien
 	}, nil
 }
 
-// InviteUser は Cognito AdminCreateUser で一時パスワード付き招待メールを送信し、CognitoSub を返す。
-// Cognito の招待メールテンプレートはユーザープール設定で管理する。
+// InviteUser は Cognito AdminCreateUser で招待メールを送信し、CognitoSub を返す。
+// 同一メールアドレスでの再招待にも対応:
+//   - 未確認ユーザー (FORCE_CHANGE_PASSWORD): MessageAction=RESEND で招待メールを再送
+//   - 確認済みユーザー (CONFIRMED): ErrUserAlreadyConfirmed を返す
 func (c *AdminClient) InviteUser(ctx context.Context, email, displayName, _ string) (string, error) {
 	attrs := []types.AttributeType{
 		{Name: aws.String("email"), Value: aws.String(email)},
@@ -49,19 +55,51 @@ func (c *AdminClient) InviteUser(ctx context.Context, email, displayName, _ stri
 		DesiredDeliveryMediums: []types.DeliveryMediumType{
 			types.DeliveryMediumTypeEmail,
 		},
-		// MessageAction を省略することで Cognito が招待メールを自動送信する
 	})
-	if err != nil {
-		return "", fmt.Errorf("cognito admin create user: %w", err)
-	}
-	if out.User == nil {
-		return "", fmt.Errorf("cognito admin create user: nil user in response")
+	if err == nil {
+		return extractSub(out.User), nil
 	}
 
-	for _, attr := range out.User.Attributes {
+	var existsErr *types.UsernameExistsException
+	if !errors.As(err, &existsErr) {
+		return "", fmt.Errorf("cognito admin create user: %w", err)
+	}
+
+	// 既存ユーザーの状態を確認して再送信できるか判定する
+	got, getErr := c.client.AdminGetUser(ctx, &cognitoidentityprovider.AdminGetUserInput{
+		UserPoolId: aws.String(c.userPoolID),
+		Username:   aws.String(email),
+	})
+	if getErr != nil {
+		return "", fmt.Errorf("cognito admin get user: %w", getErr)
+	}
+	if got.UserStatus == types.UserStatusTypeConfirmed {
+		return "", ErrUserAlreadyConfirmed
+	}
+
+	// 未確認状態（FORCE_CHANGE_PASSWORD など）なら招待を再送信
+	resendOut, resendErr := c.client.AdminCreateUser(ctx, &cognitoidentityprovider.AdminCreateUserInput{
+		UserPoolId:    aws.String(c.userPoolID),
+		Username:      aws.String(email),
+		MessageAction: types.MessageActionTypeResend,
+		DesiredDeliveryMediums: []types.DeliveryMediumType{
+			types.DeliveryMediumTypeEmail,
+		},
+	})
+	if resendErr != nil {
+		return "", fmt.Errorf("cognito resend invitation: %w", resendErr)
+	}
+	return extractSub(resendOut.User), nil
+}
+
+func extractSub(user *types.UserType) string {
+	if user == nil {
+		return ""
+	}
+	for _, attr := range user.Attributes {
 		if aws.ToString(attr.Name) == "sub" {
-			return aws.ToString(attr.Value), nil
+			return aws.ToString(attr.Value)
 		}
 	}
-	return aws.ToString(out.User.Username), nil
+	return aws.ToString(user.Username)
 }

--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"gorm.io/gorm"
@@ -12,6 +13,9 @@ type AdminInvitationRepository interface {
 	ListAll(ctx context.Context) ([]domain.AdminInvitation, error)
 	// ListByCompanyID は CompanyAdmin が自社の招待のみを見るための query。
 	ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error)
+	// FindPendingByEmail は招待受諾フローで「ログインしてきたユーザーが招待ユーザーか」
+	// を判定するために使う。同一 email で複数 pending があれば最新を返す。
+	FindPendingByEmail(ctx context.Context, email string) (*domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
 	UpdateStatus(ctx context.Context, id uint64, status string) error
 }
@@ -38,6 +42,22 @@ func (r *adminInvitationRepository) ListByCompanyID(ctx context.Context, company
 		Where("company_id = ? AND status = ?", companyID, domain.InvitationStatusPending).
 		Order("created_at DESC").Find(&rows).Error
 	return rows, err
+}
+
+func (r *adminInvitationRepository) FindPendingByEmail(ctx context.Context, email string) (*domain.AdminInvitation, error) {
+	var row domain.AdminInvitation
+	err := r.db.WithContext(ctx).
+		Where("email = ? AND status = ?", email, domain.InvitationStatusPending).
+		Order("created_at DESC").First(&row).Error
+	if err != nil {
+		// レコードが無いケースは「招待ユーザーではない通常サインアップ」なので nil, nil を返す
+		// （呼び出し側でデフォルトロールにフォールバックする想定）
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
 }
 
 func (r *adminInvitationRepository) Create(ctx context.Context, inv *domain.AdminInvitation) error {

--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -22,15 +22,21 @@ func NewAdminInvitationRepository(db *gorm.DB) AdminInvitationRepository {
 	return &adminInvitationRepository{db: db}
 }
 
+// 一覧 API は「未承諾の招待」を返すため pending 以外（accepted / canceled）は除外する。
+// 監査目的で行は物理削除せず status のみ更新している。
 func (r *adminInvitationRepository) ListAll(ctx context.Context) ([]domain.AdminInvitation, error) {
 	var rows []domain.AdminInvitation
-	err := r.db.WithContext(ctx).Order("created_at DESC").Find(&rows).Error
+	err := r.db.WithContext(ctx).
+		Where("status = ?", domain.InvitationStatusPending).
+		Order("created_at DESC").Find(&rows).Error
 	return rows, err
 }
 
 func (r *adminInvitationRepository) ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error) {
 	var rows []domain.AdminInvitation
-	err := r.db.WithContext(ctx).Where("company_id = ?", companyID).Order("created_at DESC").Find(&rows).Error
+	err := r.db.WithContext(ctx).
+		Where("company_id = ? AND status = ?", companyID, domain.InvitationStatusPending).
+		Order("created_at DESC").Find(&rows).Error
 	return rows, err
 }
 

--- a/backend/internal/usecase/admin_invitation_usecase_test.go
+++ b/backend/internal/usecase/admin_invitation_usecase_test.go
@@ -32,6 +32,9 @@ func (s *stubAdminInvRepo) Create(_ context.Context, inv *domain.AdminInvitation
 	return nil
 }
 func (s *stubAdminInvRepo) UpdateStatus(_ context.Context, _ uint64, _ string) error { return s.err }
+func (s *stubAdminInvRepo) FindPendingByEmail(_ context.Context, _ string) (*domain.AdminInvitation, error) {
+	return nil, s.err
+}
 
 type stubCognitoAdmin struct{ err error }
 

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -19,6 +19,24 @@ const EMPTY_FORM: CreateInvitationForm = {
   displayName: '',
 };
 
+// バックエンドが英語の Cognito エラーをそのまま返した場合のフォールバック日本語化。
+// バックエンドでカテゴリ化済みの日本語メッセージはそのまま通す。
+function translateInviteError(raw: string): string {
+  if (raw.includes('UsernameExistsException') || raw.includes('User account already exists')) {
+    return 'このメールアドレスはすでに登録済みです。再招待は不要です。';
+  }
+  if (raw.includes('InvalidParameterException')) {
+    return '入力値が不正です。メールアドレス形式を確認してください。';
+  }
+  if (raw.includes('LimitExceededException') || raw.includes('TooManyRequestsException')) {
+    return '招待リクエストが多すぎます。しばらく待ってから再試行してください。';
+  }
+  if (raw.includes('AccessDeniedException') || raw.includes('not authorized')) {
+    return '権限エラー: バックエンドの IAM ロール設定を確認してください。';
+  }
+  return raw;
+}
+
 export default function AdminInvitationsPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
@@ -79,13 +97,13 @@ export default function AdminInvitationsPage() {
       setForm((f) => ({ ...EMPTY_FORM, companyId: f.companyId }));
       await fetchAll();
     } catch (err: unknown) {
-      const msg =
+      const raw =
         (err as { response?: { data?: { message?: string; error?: string } } })?.response?.data
           ?.message ||
         (err as { response?: { data?: { message?: string; error?: string } } })?.response?.data
           ?.error ||
         '招待の作成に失敗しました';
-      setError(msg);
+      setError(translateInviteError(raw));
       logger.error(err);
     } finally {
       setSubmitting(false);

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -9,6 +9,7 @@ import CompanyRepository, { Company } from '../repositories/CompanyRepository';
 import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
+import ConfirmModal from '../components/ConfirmModal';
 import { logger } from '../lib/logger';
 
 const EMPTY_FORM: CreateInvitationForm = {
@@ -29,6 +30,8 @@ export default function AdminInvitationsPage() {
   const [form, setForm] = useState<CreateInvitationForm>(EMPTY_FORM);
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<AdminInvitation | null>(null);
+  const [canceling, setCanceling] = useState(false);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
@@ -89,14 +92,28 @@ export default function AdminInvitationsPage() {
     }
   };
 
-  const cancel = async (id: number) => {
-    if (!confirm('この招待をキャンセルしますか？')) return;
+  const requestCancel = (inv: AdminInvitation) => {
+    setError(null);
+    setCancelTarget(inv);
+  };
+
+  const closeCancelModal = () => {
+    if (canceling) return;
+    setCancelTarget(null);
+  };
+
+  const confirmCancel = async () => {
+    if (!cancelTarget) return;
+    setCanceling(true);
     try {
-      await AdminInvitationRepository.cancel(id);
+      await AdminInvitationRepository.cancel(cancelTarget.id);
+      setCancelTarget(null);
       await fetchAll();
     } catch (err) {
       setError('招待のキャンセルに失敗しました');
       logger.error(err);
+    } finally {
+      setCanceling(false);
     }
   };
 
@@ -217,8 +234,8 @@ export default function AdminInvitationsPage() {
                   </p>
                 </div>
                 <button
-                  onClick={() => cancel(inv.id)}
-                  className="text-xs px-2 py-1 border border-red-300 rounded text-red-700"
+                  onClick={() => requestCancel(inv)}
+                  className="text-xs px-2 py-1 border border-red-300 rounded text-red-700 hover:bg-red-50 transition-colors"
                 >
                   取り消し
                 </button>
@@ -227,6 +244,21 @@ export default function AdminInvitationsPage() {
           </ul>
         )}
       </section>
+
+      <ConfirmModal
+        isOpen={cancelTarget !== null}
+        title="招待を取り消し"
+        message={
+          cancelTarget
+            ? `${cancelTarget.email} 宛の招待を取り消します。受信者は招待リンクから登録できなくなります。`
+            : ''
+        }
+        confirmText={canceling ? '処理中...' : '取り消す'}
+        cancelText="戻る"
+        onConfirm={confirmCancel}
+        onCancel={closeCancelModal}
+        isDanger={true}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
招待メール経由のユーザーが初回ログインしても、招待時のロール (company_admin) や会社が紐付かないバグを修正する。

## 問題
- `AdminCreateUser` で Cognito にユーザーを作成 + 招待メール送信は成功
- しかし初回ログイン時の `upsertUserFromIDToken` が `invitations` テーブルを見ていなかった
- 結果:
  1. ロールがデフォルトの `trainee` に固定（`company_admin` で招待しても trainee 扱い）
  2. `company_id` が `NULL` で会社未所属
  3. `invitations.status` が永遠に `pending` のまま

## 修正

### バックエンド
- `repository.AdminInvitationRepository.FindPendingByEmail` を追加
- `AuthHandler` に `invitations` 依存を追加
- `upsertUserFromIDToken` で初回ログイン時のロール決定ロジック:
  1. Cognito group に admin → `super_admin`（既存）
  2. pending invitation あり → invitation の `role` / `company_id` / `displayName` を反映
  3. それ以外 → `trainee`（既存）
- 受諾後に invitation の status を `accepted` に更新

### テスト
- 既存スタブ（`stubAdminInvRepo` / `fakeAdminInvRepo`）に `FindPendingByEmail` メソッドを追加

## 動作確認
1. SuperAdmin が `company_admin` ロールでメンバーを招待
2. 招待されたユーザーが初回ログイン
3. **DB の users テーブルに `role=company_admin`, `company_id=...` でレコード作成**
4. **invitations.status が `accepted` に更新**
5. ユーザーがサイドバーで「管理: 招待管理」「シナリオ管理」にアクセス可能

## テスト
- `go build ./...` 成功
- `go test ./...` 全パス
- `gofmt -l ./internal/` クリーン

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザー登録時に保留中の招待を自動検出し、役割と企業情報を適用
  * 招待エラーメッセージを日本語で表示
  * 招待キャンセルの確認ダイアログを追加

* **バグ修正**
  * 確認済みユーザーへの重複招待時に適切なエラー応答を返却

<!-- end of auto-generated comment: release notes by coderabbit.ai -->