### PR TITLE
feat(invitation): マジックリンク基盤として invitations.token カラム追加

### DIFF
--- a/backend/internal/domain/admin_invitation.go
+++ b/backend/internal/domain/admin_invitation.go
@@ -12,7 +12,11 @@ type AdminInvitation struct {
 	// Token はマジックリンク用の不透明 UUID。SES で送信するメールに ?token=<UUID> として埋め込み、
 	// 受諾画面で照合する。漏洩時の被害局所化のため一招待につき 1 値・受諾後は無効化（status=accepted で参照不可に）。
 	// json では返さない（管理 UI でも露出させない方針。受諾フローでのみ使う秘匿値）。
-	Token     string    `gorm:"column:token;uniqueIndex;size:64" json:"-"`
+	//
+	// *string にしている理由: GORM AutoMigrate で UNIQUE INDEX を張るとき、既存 pending 行は
+	// token がまだ無い（後続 PR-B で backfill 予定）。MariaDB の UNIQUE 制約は空文字 '' 同士は
+	// 重複扱いになるが NULL 同士は重複扱いにならないため、未設定値は NULL にする必要がある。
+	Token     *string   `gorm:"column:token;uniqueIndex;size:64" json:"-"`
 	ExpiresAt time.Time `gorm:"column:expires_at" json:"expiresAt"`
 	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
 }

--- a/backend/internal/domain/admin_invitation.go
+++ b/backend/internal/domain/admin_invitation.go
@@ -3,14 +3,18 @@ package domain
 import "time"
 
 type AdminInvitation struct {
-	ID          uint64    `gorm:"primaryKey" json:"id"`
-	CompanyID   uint64    `gorm:"column:company_id;index" json:"companyId"`
-	Email       string    `gorm:"column:email" json:"email"`
-	Role        string    `gorm:"column:role" json:"role"`
-	DisplayName string    `gorm:"column:display_name" json:"displayName"`
-	Status      string    `gorm:"column:status" json:"status"`
-	ExpiresAt   time.Time `gorm:"column:expires_at" json:"expiresAt"`
-	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID          uint64 `gorm:"primaryKey" json:"id"`
+	CompanyID   uint64 `gorm:"column:company_id;index" json:"companyId"`
+	Email       string `gorm:"column:email" json:"email"`
+	Role        string `gorm:"column:role" json:"role"`
+	DisplayName string `gorm:"column:display_name" json:"displayName"`
+	Status      string `gorm:"column:status" json:"status"`
+	// Token はマジックリンク用の不透明 UUID。SES で送信するメールに ?token=<UUID> として埋め込み、
+	// 受諾画面で照合する。漏洩時の被害局所化のため一招待につき 1 値・受諾後は無効化（status=accepted で参照不可に）。
+	// json では返さない（管理 UI でも露出させない方針。受諾フローでのみ使う秘匿値）。
+	Token     string    `gorm:"column:token;uniqueIndex;size:64" json:"-"`
+	ExpiresAt time.Time `gorm:"column:expires_at" json:"expiresAt"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (AdminInvitation) TableName() string { return "invitations" }

--- a/backend/internal/handler/admin_invitation_handler_test.go
+++ b/backend/internal/handler/admin_invitation_handler_test.go
@@ -35,6 +35,9 @@ func (r *fakeAdminInvRepo) UpdateStatus(_ context.Context, _ uint64, _ string) e
 func (r *fakeAdminInvRepo) FindPendingByEmail(_ context.Context, _ string) (*domain.AdminInvitation, error) {
 	return nil, nil
 }
+func (r *fakeAdminInvRepo) FindPendingByToken(_ context.Context, _ string) (*domain.AdminInvitation, error) {
+	return nil, nil
+}
 
 func init() {
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -16,6 +16,9 @@ type AdminInvitationRepository interface {
 	// FindPendingByEmail は招待受諾フローで「ログインしてきたユーザーが招待ユーザーか」
 	// を判定するために使う。同一 email で複数 pending があれば最新を返す。
 	FindPendingByEmail(ctx context.Context, email string) (*domain.AdminInvitation, error)
+	// FindPendingByToken はマジックリンク受諾フロー用。token 一致 & status=pending & expires_at 未経過のみ返す。
+	// 該当なしは (nil, nil) を返し、呼び出し側で「無効/期限切れ token」として扱う。
+	FindPendingByToken(ctx context.Context, token string) (*domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
 	UpdateStatus(ctx context.Context, id uint64, status string) error
 }
@@ -52,6 +55,25 @@ func (r *adminInvitationRepository) FindPendingByEmail(ctx context.Context, emai
 	if err != nil {
 		// レコードが無いケースは「招待ユーザーではない通常サインアップ」なので nil, nil を返す
 		// （呼び出し側でデフォルトロールにフォールバックする想定）
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (r *adminInvitationRepository) FindPendingByToken(ctx context.Context, token string) (*domain.AdminInvitation, error) {
+	if token == "" {
+		return nil, nil
+	}
+	var row domain.AdminInvitation
+	// expires_at は招待作成時に必ず未来の値を入れる前提（usecase 側で 7 日後をセット）。
+	// NOW() 比較で期限切れを DB 側で弾くことで「フロントで時刻がズレていても安全」な検証になる。
+	err := r.db.WithContext(ctx).
+		Where("token = ? AND status = ? AND expires_at > NOW()", token, domain.InvitationStatusPending).
+		First(&row).Error
+	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}

--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -69,9 +69,11 @@ func (r *adminInvitationRepository) FindPendingByToken(ctx context.Context, toke
 	}
 	var row domain.AdminInvitation
 	// expires_at は招待作成時に必ず未来の値を入れる前提（usecase 側で 7 日後をセット）。
-	// NOW() 比較で期限切れを DB 側で弾くことで「フロントで時刻がズレていても安全」な検証になる。
+	// 期限切れを DB 側で弾くことで「フロントで時刻がズレていても安全」な検証になる。
+	// UTC_TIMESTAMP() を使うことで DB サーバーのローカルタイムゾーン設定に依存せず比較する
+	// （RDS が JST に設定されていてもアプリは UTC で時刻を扱う前提なので統一）。
 	err := r.db.WithContext(ctx).
-		Where("token = ? AND status = ? AND expires_at > NOW()", token, domain.InvitationStatusPending).
+		Where("token = ? AND status = ? AND expires_at > UTC_TIMESTAMP()", token, domain.InvitationStatusPending).
 		First(&row).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/backend/internal/usecase/admin_invitation_usecase_test.go
+++ b/backend/internal/usecase/admin_invitation_usecase_test.go
@@ -35,6 +35,9 @@ func (s *stubAdminInvRepo) UpdateStatus(_ context.Context, _ uint64, _ string) e
 func (s *stubAdminInvRepo) FindPendingByEmail(_ context.Context, _ string) (*domain.AdminInvitation, error) {
 	return nil, s.err
 }
+func (s *stubAdminInvRepo) FindPendingByToken(_ context.Context, _ string) (*domain.AdminInvitation, error) {
+	return nil, s.err
+}
 
 type stubCognitoAdmin struct{ err error }
 

--- a/docs/admin/invitation-magic-link-flow.md
+++ b/docs/admin/invitation-magic-link-flow.md
@@ -1,0 +1,86 @@
+# 招待マジックリンクフロー（Path B）
+
+## 概要
+
+CompanyAdmin 招待を **Cognito 事前作成 + Cognito 自動メール** から **token 付きマジックリンク + SES 独自メール** に切り替える。
+
+理由:
+- Google OIDC 利用時に「Cognito 事前作成済みアカウント」と「OIDC で作られるアカウント」が email で重複して識別できなくなる問題があった
+- Cognito の招待メールは件名・本文・差出人名のカスタマイズに制約があり、ブランディング・日本語表現の自由度が低かった
+- 招待リンクをユーザー側で「このメールが本物か」確認しづらかった
+
+## 全体フロー
+
+```
+[SuperAdmin] 招待作成
+  POST /api/v2/admin/invitations
+    ↓
+[Backend] invitations に UUID token を保存（Cognito 操作なし）
+[Backend] SES で独自 HTML メール送信
+  本文に https://normanblog.com/invitations/accept?token=<UUID>
+    ↓
+[ユーザー] メールのリンクをクリック
+    ↓
+[/invitations/accept?token=...] フロントエンド
+  GET /api/v2/invitations/accept/:token で検証
+    → 「ログインへ進む」ボタンを表示（招待先の company / role を表示）
+    → token を sessionStorage に保持
+    ↓
+[/login] ログイン画面
+  - Google OIDC（推奨）
+  - or Cognito SignUp（メール+パスワードを自分で設定）
+    ↓
+[Backend] /auth/cognito/callback の upsertUserFromIDToken が
+  sessionStorage の token（state パラメータ経由）を invitations と照合し、
+  invitation の role / company / display_name を新規ユーザーに反映 + status=accepted
+```
+
+## データモデル
+
+### `invitations` テーブル
+
+| カラム | 型 | 用途 |
+|---|---|---|
+| `id` | uint64 PK | |
+| `company_id` | uint64 INDEX | 招待先 company |
+| `email` | string | 招待先メールアドレス |
+| `role` | string | 付与する role（company_admin / trainee） |
+| `display_name` | string | 表示名（任意） |
+| `status` | string | `pending` / `accepted` / `canceled` |
+| `token` | string UNIQUE size:64 | **PR-A で追加。** マジックリンクの不透明 UUID |
+| `expires_at` | datetime | 招待有効期限（usecase で 7 日後をセット） |
+| `created_at` | datetime | |
+
+### Token 設計
+
+- 形式: UUID v4（128 bit）。推測不能な値。
+- 漏洩時の被害局所化のため:
+  - 一招待につき 1 値（再発行は status=canceled で旧 token 失効 + 新規 invitation 作成）
+  - DB 検証時に `status = 'pending' AND expires_at > NOW()` を必ず付与
+  - JSON 応答には含めない（`json:"-"`）
+
+## API
+
+| メソッド | パス | 公開 | 用途 |
+|---|---|---|---|
+| POST | `/api/v2/admin/invitations` | 認証必須（admin） | 招待作成 + SES でメール送信 |
+| GET | `/api/v2/admin/invitations` | 認証必須（admin） | 一覧 |
+| DELETE | `/api/v2/admin/invitations/:id` | 認証必須（admin） | 取り消し |
+| GET | `/api/v2/invitations/accept/:token` | **公開** | token 検証（招待先の company/role を返す） |
+
+token 検証 API は認証不要だが、レート制限と「該当なし → 404」のみ返してメタ情報を漏らさない設計。
+
+## PR 分割
+
+| PR | スコープ | 状態 |
+|---|---|---|
+| **PR-A** | `invitations.token` カラム追加 + domain/repository 拡張 | ✅ 本 PR |
+| PR-B | SES クライアント新設 + Cognito 事前作成撤去 + 招待メール送信 | 未着手 |
+| PR-C | token 検証 API + ログイン後 invitation 受諾フロー | 未着手 |
+| PR-D | フロント `/invitations/accept` ページ + login 統合 | 未着手 |
+| Infra | SES ドメイン検証（normanblog.com） + IAM `ses:SendEmail` 追加 | 未着手 |
+
+## SES サンドボックスについて
+
+サンドボックス解除（送信量上限 200 通/日 → 50,000 通/日）は本リリースでは申請しない。
+当面は社内招待用途のみで使うため 200 通/日で十分。必要になったら AWS Console から申請する。

--- a/docs/admin/invitation-magic-link-flow.md
+++ b/docs/admin/invitation-magic-link-flow.md
@@ -47,7 +47,7 @@ CompanyAdmin 招待を **Cognito 事前作成 + Cognito 自動メール** から
 | `role` | string | 付与する role（company_admin / trainee） |
 | `display_name` | string | 表示名（任意） |
 | `status` | string | `pending` / `accepted` / `canceled` |
-| `token` | string UNIQUE size:64 | **PR-A で追加。** マジックリンクの不透明 UUID |
+| `token` | *string UNIQUE size:64 NULL | **PR-A で追加。** マジックリンクの不透明 UUID。NULL 許容（既存 pending を NULL のまま残し UNIQUE 競合を避ける） |
 | `expires_at` | datetime | 招待有効期限（usecase で 7 日後をセット） |
 | `created_at` | datetime | |
 


### PR DESCRIPTION
## 概要

Path B（SES + マジックリンク招待フロー）の最初の段階として、`invitations` テーブルに `token` カラムを追加する schema/domain だけの最小 PR。SES 連携・Cognito 事前作成撤去・受諾画面/API は本 PR には**含まない**（後続 PR で順次入れる）。

背景・全体設計は [docs/admin/invitation-magic-link-flow.md](../blob/feat/invitation-token-column/docs/admin/invitation-magic-link-flow.md) を参照。

## 変更内容

### Backend
- `domain.AdminInvitation` に `Token string` フィールドを追加
  - `gorm:"column:token;uniqueIndex;size:64"` で UNIQUE 制約付き
  - `json:"-"` で API レスポンスに含めない（漏洩リスク低減）
- `AdminInvitationRepository` インターフェイスに `FindPendingByToken(ctx, token)` を追加
  - `status='pending' AND expires_at > NOW()` を DB 側で必ず付ける（フロント時刻ズレ耐性）
  - 該当なし or 空 token → `(nil, nil)`
- 既存テストの `fakeAdminInvRepo` / `stubAdminInvRepo` に空実装を追加（interface 満たす目的）

### Schema migration
- GORM AutoMigrate により次回起動時に `token` カラム + UNIQUE INDEX が自動追加される
- 既存行は `token=''` だが UNIQUE 制約は MariaDB では `''` 同士も重複扱いになる点に注意 → 後続 PR-B で「既存 pending 招待の一斉キャンセル」または「token を一括 backfill」で対応

### Docs
- `docs/admin/invitation-magic-link-flow.md` を新規作成。Path B の全体設計と PR 分割（A〜D + Infra）を記録

## テスト

- [x] `go build ./...` 通過
- [x] `go test ./internal/handler/... ./internal/usecase/...` 通過（既存テストに影響なし）
- [ ] DB マイグレーションは PR-B と一緒にステージングで通す予定

## 関連 Issue

なし（連続 PR の起点）。後続 PR-B〜D で SES 連携・受諾フローを実装する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * トークンベースの管理者招待システムを実装しました
  * メールに含まれるマジックリンク経由での招待受け入れに対応しました
  * トークンの有効期限自動検証機能を追加しました

* **ドキュメント**
  * 管理者招待フローの詳細仕様を文書化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->