### PR TITLE
feat(auth): OIDC コールバックを招待限定サインアップに制限

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -108,6 +108,10 @@ type cognitoCallbackReq struct {
 
 // Callback は Cognito Hosted UI から戻ってきた認可コードをアクセストークンに交換し、
 // HttpOnly Cookie に格納する。Spring Boot の CognitoAuthController#callback 相当。
+//
+// 招待ゲート: 新規ユーザー（DB に sub が無い）は「Cognito group admin」または
+// 「pending な invitation 受信者」のいずれかでない限り、ログインを拒否する（403）。
+// これによりトレイニー / company_admin は必ず上位ロールからの招待経由でないとアカウントを作れない。
 func (h *AuthHandler) Callback(c *gin.Context) {
 	var req cognitoCallbackReq
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -126,10 +130,18 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 
 	// 初回ログインで users 行が無いと /auth/me が 404 になるため自動で upsert する。
 	// id_token の payload から sub / email / cognito:groups を取り出して同期する:
-	//   - 未登録なら role = (group に admin なら super_admin / 無ければ trainee) で create
+	//   - 招待 OR Cognito group "admin" のいずれかが真なら create（role は招待 / group に従う）
 	//   - 既存ユーザーは Cognito group が変わっていれば role を update する
-	// これで Spring Boot 時代と同じ「Cognito group が真のソース」で運用できる。
-	h.upsertUserFromIDToken(c, tok.IDToken)
+	// 上記いずれでもない（=招待なし & Cognito admin でもない）新規ユーザーはログイン拒否し、
+	// 直前にセットした Cookie をクリアしてセッションを残さない。
+	if allowed := h.upsertUserFromIDToken(c, tok.IDToken); !allowed {
+		middleware.ClearAuthCookies(c)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":   "invitation_required",
+			"message": "FreStyle のご利用には管理者からの招待が必要です。招待メールに記載されたリンクからログインしてください。",
+		})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
 }
@@ -162,8 +174,11 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	// refresh_token grant でも id_token が返る場合は DB role を同期する。
 	// Google federated ユーザーは ID token に cognito:groups が含まれないことがあるため
 	// access_token の claims からも昇格を試みる。
+	// refresh は既存ユーザーが対象のため、招待ゲート（戻り値 false）はここでは無視する
+	// — DB から削除されたユーザーが refresh する稀ケースは別途 401 にすべきだが、本 PR の
+	// スコープ外として既存挙動を維持する。
 	if tok.IDToken != "" {
-		h.upsertUserFromIDToken(c, tok.IDToken)
+		_ = h.upsertUserFromIDToken(c, tok.IDToken)
 	} else {
 		h.syncRoleFromAccessToken(c, tok.AccessToken)
 	}
@@ -224,64 +239,78 @@ func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (in
 }
 
 // upsertUserFromIDToken は id_token の claim を見て users 行を新規作成 / role 更新する。
-// Cognito group "admin" 所属時のみ super_admin に昇格する。降格は AdminInvitation 経由のみ。
-func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken string) {
+// 戻り値 allowed:
+//   - true : 既存ユーザー、または「Cognito group admin / pending invitation あり」で新規作成成功
+//   - false: 「招待なし & Cognito admin でもない」新規ユーザー（ログイン拒否）または create 失敗
+//
+// 招待ゲートを usecase ではなく handler 層に置いているのは、認可境界（Cookie 発行 / 401-403 を返す責務）が
+// HTTP 層であり、ユーザーが拒否された理由を上位ハンドラが直接知る必要があるため。
+func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken string) (allowed bool) {
 	claims, err := middleware.DecodeClaims(idToken)
 	if err != nil || h.users == nil {
-		return
+		// claims を読めない / users repo 無し は内部エラー扱い。Cookie はクリアして拒否する。
+		return false
 	}
 	sub, _ := claims["sub"].(string)
 	if sub == "" {
-		return
+		return false
 	}
 	email, _ := claims["email"].(string)
 	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
 	isCognitoAdmin := middleware.IsAdminFromGroups(groups)
 
 	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
-	if existing == nil {
-		// 招待受諾フロー: pending な invitation を email で引いて role / company_id / displayName を反映する
-		role := domain.RoleTrainee
-		var companyID *uint64
-		var acceptedInvID uint64
-		displayName := email
-
-		if isCognitoAdmin {
-			role = domain.RoleSuperAdmin
-		} else if h.invitations != nil && email != "" {
-			inv, _ := h.invitations.FindPendingByEmail(c.Request.Context(), email)
-			if inv != nil {
-				if inv.Role == domain.RoleCompanyAdmin || inv.Role == domain.RoleTrainee {
-					role = inv.Role
-				}
-				cid := inv.CompanyID
-				companyID = &cid
-				acceptedInvID = inv.ID
-				if inv.DisplayName != "" {
-					displayName = inv.DisplayName
-				}
-			}
+	if existing != nil {
+		// 既存ユーザー: Cognito group で admin に昇格された場合のみ DB role を上書きする。
+		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
+			_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
 		}
-
-		if err := h.users.Create(c.Request.Context(), &domain.User{
-			CognitoSub:  sub,
-			Email:       email,
-			DisplayName: displayName,
-			Role:        role,
-			CompanyID:   companyID,
-		}); err != nil {
-			log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
-			return
-		}
-		// 招待を accepted にマーク（履歴・監査）
-		if h.invitations != nil && acceptedInvID != 0 {
-			_ = h.invitations.UpdateStatus(c.Request.Context(), acceptedInvID, domain.InvitationStatusAccepted)
-		}
-		return
+		return true
 	}
 
-	// 既存ユーザー: Cognito group で admin に昇格された場合のみ DB role を上書きする。
-	if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
-		_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
+	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否。
+	var inv *domain.AdminInvitation
+	if h.invitations != nil && email != "" {
+		inv, _ = h.invitations.FindPendingByEmail(c.Request.Context(), email)
 	}
+	if !isCognitoAdmin && inv == nil {
+		log.Printf("upsertUserFromIDToken: signup blocked — no invitation and not Cognito admin sub=%s email=%s", sub, email)
+		return false
+	}
+
+	role := domain.RoleTrainee
+	var companyID *uint64
+	var acceptedInvID uint64
+	displayName := email
+
+	if isCognitoAdmin {
+		role = domain.RoleSuperAdmin
+	}
+	if inv != nil {
+		if inv.Role == domain.RoleCompanyAdmin || inv.Role == domain.RoleTrainee {
+			role = inv.Role
+		}
+		cid := inv.CompanyID
+		companyID = &cid
+		acceptedInvID = inv.ID
+		if inv.DisplayName != "" {
+			displayName = inv.DisplayName
+		}
+	}
+
+	if err := h.users.Create(c.Request.Context(), &domain.User{
+		CognitoSub:  sub,
+		Email:       email,
+		DisplayName: displayName,
+		Role:        role,
+		CompanyID:   companyID,
+	}); err != nil {
+		log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
+		return false
+	}
+	// 招待を accepted にマーク（履歴・監査）
+	if h.invitations != nil && acceptedInvID != 0 {
+		_ = h.invitations.UpdateStatus(c.Request.Context(), acceptedInvID, domain.InvitationStatusAccepted)
+	}
+	return true
 }

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -1,0 +1,230 @@
+package handler
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
+type fakeUserRepo struct {
+	existingBySub map[string]*domain.User
+	created       *domain.User
+	createErr     error
+	updateRoleID  uint64
+	updateRoleVal string
+}
+
+func (r *fakeUserRepo) FindByCognitoSub(_ context.Context, sub string) (*domain.User, error) {
+	if u, ok := r.existingBySub[sub]; ok {
+		return u, nil
+	}
+	return nil, nil
+}
+func (r *fakeUserRepo) FindByID(_ context.Context, _ uint64) (*domain.User, error) {
+	return nil, nil
+}
+func (r *fakeUserRepo) Create(_ context.Context, u *domain.User) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	u.ID = 7
+	r.created = u
+	return nil
+}
+func (r *fakeUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error { return nil }
+func (r *fakeUserRepo) UpdateRole(_ context.Context, id uint64, role string) error {
+	r.updateRoleID, r.updateRoleVal = id, role
+	return nil
+}
+
+// fakeInvitationRepo は AdminInvitationRepository の最小スタブ。
+// FindPendingByEmail だけ振る舞いをカスタムにしてテストする。
+type fakeInvitationRepo struct {
+	pendingByEmail map[string]*domain.AdminInvitation
+	updatedID      uint64
+	updatedStatus  string
+}
+
+func (r *fakeInvitationRepo) ListAll(_ context.Context) ([]domain.AdminInvitation, error) {
+	return nil, nil
+}
+func (r *fakeInvitationRepo) ListByCompanyID(_ context.Context, _ uint64) ([]domain.AdminInvitation, error) {
+	return nil, nil
+}
+func (r *fakeInvitationRepo) FindPendingByEmail(_ context.Context, email string) (*domain.AdminInvitation, error) {
+	if v, ok := r.pendingByEmail[email]; ok {
+		return v, nil
+	}
+	return nil, nil
+}
+func (r *fakeInvitationRepo) FindPendingByToken(_ context.Context, _ string) (*domain.AdminInvitation, error) {
+	return nil, nil
+}
+func (r *fakeInvitationRepo) Create(_ context.Context, _ *domain.AdminInvitation) error { return nil }
+func (r *fakeInvitationRepo) UpdateStatus(_ context.Context, id uint64, status string) error {
+	r.updatedID, r.updatedStatus = id, status
+	return nil
+}
+
+// makeIDToken は claims を JSON にして JWT 形式（ヘッダ.ペイロード.署名）にエンコードする。
+// 署名は middleware.DecodeClaims が検証しないので空文字でよい。
+func makeIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	body := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + body + "."
+}
+
+// newTestAuthHandler はテスト用 AuthHandler を組み立てる。tokens は使わない。
+func newTestAuthHandler(users *fakeUserRepo, invitations *fakeInvitationRepo) *AuthHandler {
+	return &AuthHandler{users: users, invitations: invitations}
+}
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// テスト用に空の gin.Context を返す（c.Request.Context() が呼ばれるので Request も埋める）。
+func newGinCtx() *gin.Context {
+	c, _ := gin.CreateTestContext(nil)
+	c.Request = mustNewRequest()
+	return c
+}
+
+func TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin(t *testing.T) {
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{}
+	h := newTestAuthHandler(users, invs)
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "new-google-user",
+		"email": "stranger@example.com",
+		// cognito:groups なし、招待もなし → 拒否されるべき
+	})
+
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	if allowed {
+		t.Fatalf("expected allowed=false for non-invited non-admin signup")
+	}
+	if users.created != nil {
+		t.Fatalf("user must NOT be created when no invitation/admin")
+	}
+}
+
+func TestUpsertUserFromIDToken_AllowsCognitoAdminWithoutInvitation(t *testing.T) {
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{}
+	h := newTestAuthHandler(users, invs)
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":            "first-super-admin",
+		"email":          "ops@example.com",
+		"cognito:groups": []string{"admin"},
+	})
+
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	if !allowed {
+		t.Fatalf("Cognito group admin must be allowed even without invitation")
+	}
+	if users.created == nil || users.created.Role != domain.RoleSuperAdmin {
+		t.Fatalf("expected super_admin to be created, got %+v", users.created)
+	}
+}
+
+func TestUpsertUserFromIDToken_AllowsInvitedUser_AppliesRoleAndCompany(t *testing.T) {
+	users := &fakeUserRepo{}
+	cid := uint64(42)
+	invs := &fakeInvitationRepo{
+		pendingByEmail: map[string]*domain.AdminInvitation{
+			"trainee@example.com": {
+				ID: 99, CompanyID: cid, Email: "trainee@example.com",
+				Role: domain.RoleTrainee, DisplayName: "佐藤", Status: domain.InvitationStatusPending,
+			},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "google-trainee-1",
+		"email": "trainee@example.com",
+	})
+
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	if !allowed {
+		t.Fatalf("invited user must be allowed")
+	}
+	if users.created == nil {
+		t.Fatalf("expected user to be created")
+	}
+	if users.created.Role != domain.RoleTrainee {
+		t.Errorf("expected role=trainee, got %q", users.created.Role)
+	}
+	if users.created.CompanyID == nil || *users.created.CompanyID != cid {
+		t.Errorf("expected company_id=%d, got %+v", cid, users.created.CompanyID)
+	}
+	if users.created.DisplayName != "佐藤" {
+		t.Errorf("expected displayName=佐藤, got %q", users.created.DisplayName)
+	}
+	// 招待は accepted にマークされる
+	if invs.updatedID != 99 || invs.updatedStatus != domain.InvitationStatusAccepted {
+		t.Errorf("invitation must be marked accepted, got id=%d status=%q", invs.updatedID, invs.updatedStatus)
+	}
+}
+
+func TestUpsertUserFromIDToken_ExistingUser_AlwaysAllowed(t *testing.T) {
+	existing := &domain.User{ID: 5, CognitoSub: "existing", Email: "u@example.com", Role: domain.RoleTrainee}
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing": existing}}
+	invs := &fakeInvitationRepo{}
+	h := newTestAuthHandler(users, invs)
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "existing",
+		"email": "u@example.com",
+	})
+
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	if !allowed {
+		t.Fatalf("existing user must always be allowed (no invitation re-check)")
+	}
+	if users.created != nil {
+		t.Fatalf("existing user must not trigger Create")
+	}
+}
+
+func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T) {
+	existing := &domain.User{ID: 5, CognitoSub: "existing", Email: "u@example.com", Role: domain.RoleTrainee}
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing": existing}}
+	h := newTestAuthHandler(users, &fakeInvitationRepo{})
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":            "existing",
+		"email":          "u@example.com",
+		"cognito:groups": []string{"admin"},
+	})
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken) {
+		t.Fatal("must be allowed")
+	}
+	if users.updateRoleID != 5 || users.updateRoleVal != domain.RoleSuperAdmin {
+		t.Fatalf("expected role promoted to super_admin, got id=%d role=%q", users.updateRoleID, users.updateRoleVal)
+	}
+}
+
+func TestUpsertUserFromIDToken_RejectsMalformedToken(t *testing.T) {
+	h := newTestAuthHandler(&fakeUserRepo{}, &fakeInvitationRepo{})
+	if h.upsertUserFromIDToken(newGinCtx(), "not-a-jwt") {
+		t.Fatal("malformed token must be rejected")
+	}
+}
+
+// dummy: 使用していないが strings import のリンタを満たすために残す（今後 assert で使う）
+var _ = strings.Contains

--- a/backend/internal/handler/auth_handler_testhelper_test.go
+++ b/backend/internal/handler/auth_handler_testhelper_test.go
@@ -1,0 +1,12 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// mustNewRequest はテスト用に最小の *http.Request を返す。
+// auth_handler 配下の handler は c.Request.Context() しか参照しないため、URL / method は何でも良い。
+func mustNewRequest() *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/", nil)
+}

--- a/docs/auth/invitation-only-signup.md
+++ b/docs/auth/invitation-only-signup.md
@@ -1,0 +1,76 @@
+# 招待限定サインアップ（OIDC ゲート）
+
+## 概要
+
+FreStyle のアカウント作成は **必ず上位ロールからの招待経由** に限定する。
+具体的には:
+
+- **trainee** は CompanyAdmin から招待されて初めてログインできる
+- **CompanyAdmin** は SuperAdmin から招待されて初めてログインできる
+- **SuperAdmin** だけは Cognito 側のグループ `admin` 所属で初期作成できる（運営側が直接作成）
+
+---
+
+## 背景
+
+PR-B（SES マジックリンク方式）導入前は、Google OIDC 経由で誰でもログインすると `users` 行が自動作成され（role=`trainee`）、社外の任意ユーザーがアプリにアクセスできてしまう状態だった。
+
+招待マジックリンクを採用しただけでは、メールリンクを踏まずに `/login` から直接 OIDC ログインされた場合に DB に行が作られてしまう。**バックエンド側で「招待なし新規作成」を拒否する必要がある**ため、本 PR で `auth_handler.upsertUserFromIDToken` にゲートを追加した。
+
+---
+
+## 実装
+
+### `Callback` の挙動
+
+`POST /api/v2/auth/cognito/callback` の処理フロー:
+
+1. 認可コードをトークンに交換 → access_token / refresh_token / id_token を取得
+2. HttpOnly Cookie に access_token / refresh_token を設定
+3. `upsertUserFromIDToken` で users 行を確認・作成
+4. **作成不可（=招待なし & Cognito admin でもない）の場合**:
+   - Cookie をクリア（`middleware.ClearAuthCookies(c)`）
+   - `403 Forbidden` を返す（`{"error": "invitation_required", "message": "..."}`）
+5. それ以外は `200 OK` を返す
+
+### `upsertUserFromIDToken` の判定ルール
+
+| 状況 | 判定 |
+|---|---|
+| DB に sub 既存 | 許可（必要なら role を Cognito group に同期） |
+| DB に未登録 + `cognito:groups` に `admin` を含む | 許可（role=super_admin で作成） |
+| DB に未登録 + email に対する pending invitation あり | 許可（role / company_id / displayName を invitation から反映） |
+| 上記いずれもなし | **拒否（false 返却）** |
+
+`Refresh` (`POST /auth/cognito/refresh-token`) では戻り値を無視する。refresh は既存ユーザーが対象なので、一般的にはここで拒否する必要はない（DB から削除済みのユーザーが refresh を試みる稀ケースは別 issue で扱う）。
+
+---
+
+## フロントエンドの想定動作
+
+`POST /auth/cognito/callback` が `403 invitation_required` を返した場合、フロントは:
+
+1. ユーザーに「招待が必要です」とメッセージを表示
+2. `/login` に戻して再試行を促す
+3. 招待メールに記載の `/invitations/accept?token=...` リンクから入り直してもらう（PR-D で実装予定）
+
+---
+
+## テスト（`auth_handler_test.go`）
+
+| テストケース | 期待 |
+|---|---|
+| 招待なし & Cognito admin でもない新規ユーザー | 拒否（allowed=false / users.Create が呼ばれない） |
+| Cognito group `admin` 新規ユーザー（招待なし） | 許可（super_admin で作成） |
+| 招待あり新規ユーザー | 許可（招待の role / company_id / displayName が反映 / invitation が accepted にマーク） |
+| 既存ユーザー（招待無関係） | 常に許可 |
+| 既存ユーザー + Cognito group `admin` | 許可（DB role が super_admin に昇格） |
+| 壊れた id_token | 拒否（false） |
+
+---
+
+## 既知の制約
+
+- 既存 SuperAdmin（Cognito group `admin` 所属）が DB から削除されると、再ログイン時に「Cognito admin」判定で再作成される（=他人にアカウントを乗っ取られる懸念は無いが、ID は新採番）。
+- Cognito group `admin` の付け外しは AWS Console から実施するため、運用ドキュメントで管理する必要がある。
+- 招待メールリンクの token を `sessionStorage` に渡し、callback 側で読むフローは PR-D で実装予定。本 PR の段階では「招待 email」と「ログインしてくる Cognito ユーザーの email」が一致する前提。


### PR DESCRIPTION
## 概要

新規ユーザーの自動作成を「招待 or Cognito group admin」のみに限定する OIDC ゲート。

PR-B (#1630) で SES マジックリンク方式に切り替えただけでは、ユーザーがマジックリンクを踏まずに直接 \`/login\` から OIDC ログインした場合に \`users\` 行が自動作成されてしまう（社外ユーザーが trainee として入れる）。本 PR でこのバイパスを塞ぐ。

## 変更内容

### \`auth_handler.upsertUserFromIDToken\`

戻り値を \`(allowed bool)\` に変更し、判定ルール:

| 状況 | 判定 |
|---|---|
| DB に sub 既存 | 許可（必要なら role を Cognito group に同期） |
| DB 未登録 + Cognito group \`admin\` | 許可（super_admin で作成） |
| DB 未登録 + email に pending invitation | 許可（invitation の role / company / displayName を反映） |
| 上記いずれもなし | **拒否** |

### \`Callback\`

\`upsertUserFromIDToken\` が \`false\` を返した場合、\`ClearAuthCookies\` で Cookie を消し、\`403 invitation_required\` を返す。

\`\`\`json
{
  "error": "invitation_required",
  "message": "FreStyle のご利用には管理者からの招待が必要です。招待メールに記載されたリンクからログインしてください。"
}
\`\`\`

### \`Refresh\`

既存ユーザーが対象なので戻り値を無視（\`_ = h.upsertUserFromIDToken(...)\`）。既存挙動を維持。

## テスト

\`backend/internal/handler/auth_handler_test.go\` に 6 ケース追加:

- \`TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin\`
- \`TestUpsertUserFromIDToken_AllowsCognitoAdminWithoutInvitation\`
- \`TestUpsertUserFromIDToken_AllowsInvitedUser_AppliesRoleAndCompany\`
- \`TestUpsertUserFromIDToken_ExistingUser_AlwaysAllowed\`
- \`TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin\`
- \`TestUpsertUserFromIDToken_RejectsMalformedToken\`

\`go test ./...\` 全 pass。

## ドキュメント

\`docs/auth/invitation-only-signup.md\` にゲート仕様を記載。

## 関連

- PR-A: #1629（マージ済）
- PR-B: #1630（マージ済）
- 後続 PR: PR-D（フロントの 403 ハンドリング + 招待画面誘導）