### PR TITLE
fix(aichat): WebSocket keepalive + 自動再接続で Bedrock 返信が来ない問題を解消

### DIFF
--- a/backend/internal/handler/ai_chat_ws_handler.go
+++ b/backend/internal/handler/ai_chat_ws_handler.go
@@ -1,14 +1,30 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// WebSocket keepalive 周りの定数。値の根拠:
+//   - ALB / CloudFront のアイドルタイムアウト既定値は 60 秒。pingPeriod=54s でその手前に server → client ping を打つ
+//   - pongWait は ALB の 60 秒に合わせ、それを超えても pong が来なければ切断する
+//   - writeWait は遅い回線で 10 秒。これを超えても書き込めなければ切断
+//
+// WebSocket は単一接続を複数 goroutine から書き込めない（gorilla/websocket の制約）ため、
+// すべての書き込みを 1 つの writer goroutine に集約する。
+const (
+	aiChatWriteWait      = 10 * time.Second
+	aiChatPongWait       = 60 * time.Second
+	aiChatPingPeriod     = (aiChatPongWait * 9) / 10
+	aiChatMaxMessageSize = 64 * 1024
 )
 
 // AiChatWsHandler は AI チャット用 WebSocket エンドポイント。
@@ -66,6 +82,12 @@ func (h *AiChatWsHandler) Handle(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
+	// Bedrock / DynamoDB の初期化に失敗していると sendMsg は nil。upgrade 前に弾いて
+	// クライアントに 503 を返す（接続だけ確立して即無言切断するより明示的）。
+	if h.sendMsg == nil {
+		c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "ai_chat_unavailable"})
+		return
+	}
 
 	conn, err := h.upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
@@ -73,6 +95,21 @@ func (h *AiChatWsHandler) Handle(c *gin.Context) {
 		return
 	}
 	defer conn.Close()
+
+	conn.SetReadLimit(aiChatMaxMessageSize)
+	_ = conn.SetReadDeadline(time.Now().Add(aiChatPongWait))
+	conn.SetPongHandler(func(string) error {
+		_ = conn.SetReadDeadline(time.Now().Add(aiChatPongWait))
+		return nil
+	})
+
+	// gin の c.Request.Context() は handler return で cancel される。WebSocket は
+	// 長時間生き続けるため、独立した context を ws のライフサイクルに紐付ける。
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	writes := make(chan any, 16)
+	go h.writePump(conn, writes, cancel)
 
 	for {
 		_, raw, err := conn.ReadMessage()
@@ -90,7 +127,9 @@ func (h *AiChatWsHandler) Handle(c *gin.Context) {
 			sessionID = uint64(*msg.SessionID)
 		}
 
-		out, err := h.sendMsg.Execute(c.Request.Context(), usecase.SendAiMessageInput{
+		// usecase 呼び出しに ws の context を渡す。Bedrock 呼び出しが詰まっても
+		// 接続切断時に cancel されて goroutine が漏れない。
+		out, err := h.sendMsg.Execute(ctx, usecase.SendAiMessageInput{
 			UserID:      uid,
 			SessionID:   sessionID,
 			Content:     msg.Content,
@@ -100,12 +139,12 @@ func (h *AiChatWsHandler) Handle(c *gin.Context) {
 		})
 		if err != nil {
 			log.Printf("AiChat send message failed: %v", err)
-			wsWriteJSON(conn, map[string]string{"type": "error", "message": "メッセージの送信に失敗しました"})
+			enqueueWS(writes, map[string]string{"type": "error", "message": "メッセージの送信に失敗しました"})
 			continue
 		}
 
 		if out.NewSession != nil {
-			wsWriteJSON(conn, wsOutSession{
+			enqueueWS(writes, wsOutSession{
 				Type:        "session",
 				ID:          out.NewSession.ID,
 				Title:       out.NewSession.Title,
@@ -115,7 +154,7 @@ func (h *AiChatWsHandler) Handle(c *gin.Context) {
 			})
 		}
 
-		wsWriteJSON(conn, wsOutMessage{
+		enqueueWS(writes, wsOutMessage{
 			Type:      "message",
 			SessionID: out.AiMsg.SessionID,
 			ID:        out.AiMsg.MessageID,
@@ -126,13 +165,47 @@ func (h *AiChatWsHandler) Handle(c *gin.Context) {
 	}
 }
 
-func wsWriteJSON(conn *websocket.Conn, v any) {
-	b, err := json.Marshal(v)
-	if err != nil {
-		log.Printf("AiChat ws marshal failed: %v", err)
-		return
+// writePump は ws への書き込みを単一 goroutine に集約する。
+//   - pingPeriod ごとに server → client へ ping を送り、ALB のアイドルタイムアウトを回避
+//   - writes チャネルから受け取った payload を JSON で送信
+//   - 書き込み失敗 / writes クローズで cancel を呼んで read ループも終了させる
+func (h *AiChatWsHandler) writePump(conn *websocket.Conn, writes <-chan any, cancel context.CancelFunc) {
+	ticker := time.NewTicker(aiChatPingPeriod)
+	defer func() {
+		ticker.Stop()
+		cancel()
+	}()
+
+	for {
+		select {
+		case <-ticker.C:
+			_ = conn.SetWriteDeadline(time.Now().Add(aiChatWriteWait))
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		case payload, ok := <-writes:
+			if !ok {
+				return
+			}
+			b, err := json.Marshal(payload)
+			if err != nil {
+				log.Printf("AiChat ws marshal failed: %v", err)
+				continue
+			}
+			_ = conn.SetWriteDeadline(time.Now().Add(aiChatWriteWait))
+			if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
+				return
+			}
+		}
 	}
-	if err := conn.WriteMessage(websocket.TextMessage, b); err != nil {
-		log.Printf("AiChat ws write failed: %v", err)
+}
+
+// enqueueWS は writes チャネルへ非ブロッキング送信する。
+// 送信先がバッファ満杯ならドロップしてログに残す（外部要因で詰まったときに read ループを止めない）。
+func enqueueWS(writes chan<- any, payload any) {
+	select {
+	case writes <- payload:
+	default:
+		log.Printf("AiChat ws writes channel full — dropping payload: %T", payload)
 	}
 }

--- a/docs/aichat/websocket-keepalive.md
+++ b/docs/aichat/websocket-keepalive.md
@@ -1,0 +1,64 @@
+# AI チャット WebSocket — keepalive と自動再接続
+
+## 背景
+
+ユーザーが AI チャット画面を開いたまましばらく放置 → 次のメッセージを送っても返信が来ない、という不具合があった。
+
+原因:
+
+1. **ALB のアイドルタイムアウト**（既定 60 秒）で WebSocket が切断される
+2. バックエンドに ping/pong がなく、放置中の接続を ALB が「死んだ」と判断する
+3. フロントは onclose で何もしないため、切断後にユーザーが新しいメッセージを送っても、すでに closed の socket にキューが積まれるだけで送信されない
+4. バックエンドの usecase 呼び出しが `c.Request.Context()` を使っており、接続切断時に正しく cancel できない可能性
+5. Bedrock client の初期化失敗時 `sendMsg` が nil で渡され、メッセージ送信のたびに 500 / panic
+
+## 修正概要
+
+### Backend (`backend/internal/handler/ai_chat_ws_handler.go`)
+
+- **ping/pong keepalive**: 54 秒ごとに server → client へ ping を送り、ALB のアイドルタイムアウトを回避
+- **pong wait**: 60 秒以内に pong（または通常メッセージ）が来なければ切断
+- **書き込み単一化**: gorilla/websocket は単一接続を複数 goroutine から書けないため、書き込み専用 goroutine（`writePump`）に集約
+- **独立 context**: `context.WithCancel(context.Background())` を作って ws lifecycle に紐付け、`c.Request.Context()` の cancel に巻き込まれない
+- **Bedrock 不在時の 503**: `sendMsg == nil` のとき upgrade 前に 503 を返してサイレント切断を回避
+
+```
+const (
+    aiChatWriteWait      = 10 * time.Second
+    aiChatPongWait       = 60 * time.Second
+    aiChatPingPeriod     = (aiChatPongWait * 9) / 10  // 54s
+    aiChatMaxMessageSize = 64 * 1024
+)
+```
+
+### Frontend (`frontend/src/hooks/useWebSocketNative.ts`)
+
+- **自動再接続**: onclose で指数バックオフ（1s → 2s → 4s → 8s → 16s → 30s 上限）で再接続
+- **キュー保持**: 切断中の `send()` は `queueRef` に積まれ、再接続成功後の onopen で `flushQueue` により送信
+- **disconnect 経由は再接続しない**: ユーザーが明示的にログアウト等で切った場合は `cancelledRef = true` でループを止める
+
+```
+sock.onclose = () => {
+  onCloseRef.current?.();
+  if (cancelledRef.current) return;
+  const delay = Math.min(30000, 1000 * 2 ** attempt);
+  reconnectTimerRef.current = setTimeout(connect, delay);
+};
+```
+
+## テスト
+
+| ケース | 場所 |
+|---|---|
+| ALB が切ったケースで onclose 後に再接続が走る | `useWebSocketNative.test.ts` |
+| `disconnect()` 後は再接続しない | 同上 |
+| OPEN 前 send → キュー → open 後 flush | 同上（既存） |
+
+バックエンドの ping ループは時間依存テストが書きづらいため、本 PR では単体テストではなく実機検証で確認する想定。
+
+## 動作確認手順
+
+1. `docker compose up -d --build` でローカル起動
+2. ブラウザで AI チャット画面を開いて 1 通送信 → 返信を確認
+3. **画面を 2〜3 分放置** → 4 通目を送信 → ALB タイムアウトを再現できる本番環境でも返信が来ること
+4. ブラウザの DevTools → Network → WS を開き、Frames タブで ping (opcode 0x9) / pong (0xA) が周期的に流れているか確認

--- a/frontend/src/hooks/__tests__/useWebSocketNative.test.ts
+++ b/frontend/src/hooks/__tests__/useWebSocketNative.test.ts
@@ -98,4 +98,38 @@ describe('useWebSocketNative', () => {
     act(() => result.current.disconnect());
     expect(MockWebSocket.instances[0].readyState).toBe(MockWebSocket.CLOSED);
   });
+
+  // ALB のアイドルタイムアウトでサーバ側から切断されたケース（onclose のみ発火）
+  // でも、ユーザー操作なしで再接続が走ることを確認する。
+  it('予期せぬ onclose で自動再接続される（指数バックオフ）', () => {
+    vi.useFakeTimers();
+    try {
+      renderHook(() => useWebSocketNative({ url: 'wss://example.com' }));
+      expect(MockWebSocket.instances).toHaveLength(1);
+      // 1 つ目を open → close（ALB が切ったケース）
+      act(() => MockWebSocket.instances[0].open());
+      act(() => MockWebSocket.instances[0].close());
+      // 1 秒後に 2 つ目の接続が作られる
+      expect(MockWebSocket.instances).toHaveLength(1);
+      act(() => vi.advanceTimersByTime(1000));
+      expect(MockWebSocket.instances).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // disconnect されたときは再接続しない（ユーザーが明示的に切ったケース）。
+  it('disconnect 後は再接続しない', () => {
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useWebSocketNative({ url: 'wss://example.com' }));
+      act(() => MockWebSocket.instances[0].open());
+      act(() => result.current.disconnect());
+      // disconnect は close も呼ぶ（onclose が発火するが cancelled なので再接続しない）
+      act(() => vi.advanceTimersByTime(60000));
+      expect(MockWebSocket.instances).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/frontend/src/hooks/useWebSocketNative.ts
+++ b/frontend/src/hooks/useWebSocketNative.ts
@@ -7,6 +7,8 @@ import { useEffect, useRef, useCallback, useLayoutEffect } from 'react';
  * - url が null のときは接続を作らない（認証前など、まだ接続条件が揃わないケース用）
  * - send() は OPEN 前でも呼べる（キューに積み、open 直後に flush）
  * - onMessage は受信した JSON を parse 済の object として呼び出す
+ * - onclose 時は自動再接続する（指数バックオフ: 1s → 2s → 4s → 8s → 16s → 30s 上限）
+ *   フロント・サーバ・ALB のいずれが切断しても、ユーザー操作なしで復旧する
  */
 
 interface UseWebSocketNativeOptions {
@@ -17,6 +19,9 @@ interface UseWebSocketNativeOptions {
   onError?: (err: Event) => void;
 }
 
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_MAX_MS = 30000;
+
 export function useWebSocketNative({
   url,
   onOpen,
@@ -26,6 +31,10 @@ export function useWebSocketNative({
 }: UseWebSocketNativeOptions) {
   const socketRef = useRef<WebSocket | null>(null);
   const queueRef = useRef<string[]>([]);
+  // 再接続まわりの状態。effect cleanup から touch するため ref に保持。
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelledRef = useRef(false);
 
   // コールバックは ref に保持して、ハンドラ参照変更による再接続を防ぐ。
   const onOpenRef = useRef(onOpen);
@@ -53,10 +62,16 @@ export function useWebSocketNative({
       sock.send(raw);
       return;
     }
+    // OPEN 前 / 切断中 → キューに積む。再接続後に flushQueue で送信される。
     queueRef.current.push(raw);
   }, []);
 
   const disconnect = useCallback(() => {
+    cancelledRef.current = true;
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
     const sock = socketRef.current;
     if (sock) {
       sock.close();
@@ -67,30 +82,53 @@ export function useWebSocketNative({
 
   useEffect(() => {
     if (!url) return;
-    const sock = new WebSocket(url);
-    socketRef.current = sock;
+    cancelledRef.current = false;
+    reconnectAttemptsRef.current = 0;
 
-    sock.onopen = () => {
-      flushQueue();
-      onOpenRef.current?.();
+    const connect = () => {
+      if (cancelledRef.current) return;
+      const sock = new WebSocket(url);
+      socketRef.current = sock;
+
+      sock.onopen = () => {
+        // 再接続成功でカウンタをリセットする。次回の切断は再び 1s から開始。
+        reconnectAttemptsRef.current = 0;
+        flushQueue();
+        onOpenRef.current?.();
+      };
+      sock.onmessage = (ev) => {
+        try {
+          const parsed = typeof ev.data === 'string' ? JSON.parse(ev.data) : ev.data;
+          onMessageRef.current?.(parsed);
+        } catch {
+          // バックエンドが JSON 以外を返したらドロップする（プロトコル外）。
+        }
+      };
+      sock.onclose = () => {
+        onCloseRef.current?.();
+        if (cancelledRef.current) return;
+        // ALB のアイドルタイムアウト / サーバ再起動 / ネットワーク断のいずれでも、
+        // ユーザー操作なしで復旧したい。指数バックオフで再接続を試みる。
+        const attempt = reconnectAttemptsRef.current;
+        const delay = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * 2 ** attempt);
+        reconnectAttemptsRef.current = attempt + 1;
+        reconnectTimerRef.current = setTimeout(connect, delay);
+      };
+      sock.onerror = (ev) => {
+        onErrorRef.current?.(ev);
+      };
     };
-    sock.onmessage = (ev) => {
-      try {
-        const parsed = typeof ev.data === 'string' ? JSON.parse(ev.data) : ev.data;
-        onMessageRef.current?.(parsed);
-      } catch {
-        // バックエンドが JSON 以外を返したらドロップする（プロトコル外）。
-      }
-    };
-    sock.onclose = () => {
-      onCloseRef.current?.();
-    };
-    sock.onerror = (ev) => {
-      onErrorRef.current?.(ev);
-    };
+
+    connect();
 
     return () => {
-      sock.close();
+      cancelledRef.current = true;
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      const sock = socketRef.current;
+      if (sock) sock.close();
       socketRef.current = null;
       queueRef.current = [];
     };


### PR DESCRIPTION
## 問題

AI チャット画面を数分放置した後にメッセージを送ると Bedrock 返信が返ってこない。
原因:

1. **ALB のアイドルタイムアウト**（既定 60 秒）で WebSocket が切断される
2. バックエンドに ping/pong がないため、放置中の接続を ALB が「死んだ」と判断する
3. フロントは onclose で何もしないため、切断後にユーザーが新メッセージを送っても closed socket にキューが積まれるだけで詰まる
4. usecase 呼び出しに \`c.Request.Context()\` を渡していて、本来 ws lifecycle と独立すべき箇所が gin の context cancel に巻き込まれる
5. Bedrock client の初期化失敗時 \`sendMsg\` が nil で、メッセージ送信のたびに 500 / nil pointer

## 修正

### Backend (\`backend/internal/handler/ai_chat_ws_handler.go\`)

- **ping/pong keepalive**: 54s 周期で server → client へ ping、60s 以内に pong が来なければ切断
- **書き込み単一化**: \`writePump\` goroutine に集約（gorilla/websocket の単一接続書き込み制約）
- **独立 context**: \`context.WithCancel(context.Background())\` を作って ws lifecycle に紐付け
- **Bedrock 不在時の 503**: \`sendMsg == nil\` のとき upgrade 前に 503 を返す

### Frontend (\`frontend/src/hooks/useWebSocketNative.ts\`)

- **自動再接続**: onclose で指数バックオフ（1s → 2s → 4s → 8s → 16s → 30s 上限）
- **キュー保持**: 切断中の \`send()\` は queue に積み、再接続成功後の onopen で flush
- **disconnect 時は止める**: \`cancelledRef\` フラグで再接続ループを終了

## テスト

\`frontend/src/hooks/__tests__/useWebSocketNative.test.ts\` に 2 ケース追加:
- 予期せぬ onclose で自動再接続される（指数バックオフ）
- disconnect 後は再接続しない

\`go test ./...\` 全 pass / \`npm test -- useWebSocketNative\` 9 tests passed。

## ドキュメント

\`docs/aichat/websocket-keepalive.md\` に対処内容と動作確認手順を記載。

## 動作確認

ローカル: \`docker compose up -d --build\` → AI チャット画面で 1 通送信 → 数分放置 → さらに 1 通送ると返信が返る（再接続済）。
DevTools → Network → WS → Frames で ping (0x9) / pong (0xA) が周期的に流れる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AIチャットがネットワークが不安定な環境でも安定するようになりました
  * WebSocket接続が切れた場合に自動的に再接続するようになりました
  * 送信予定のメッセージが自動的にキューに保存され、再接続後に送信されるようになりました

* **ドキュメント**
  * WebSocketキープアライブの仕様と実装を記載しました

* **テスト**
  * 自動再接続機能の動作確認テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->