### PR TITLE
feat(backend): 招待 token 検証 API + callback での token 受け取り (PR-C)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ frestyle-infrastructure/
 
 # PdM 用プライベートリポ（FreStyle 配下に clone する運用、本リポの管理対象外）
 frestyle-pdm/
+
+# IntelliJ IDEA / GoLand
+.idea/

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -104,6 +104,10 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 type cognitoCallbackReq struct {
 	Code string `json:"code" binding:"required"`
+	// InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で
+	// 受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より
+	// 優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。
+	InvitationToken string `json:"invitationToken"`
 }
 
 // Callback は Cognito Hosted UI から戻ってきた認可コードをアクセストークンに交換し、
@@ -134,7 +138,7 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	//   - 既存ユーザーは Cognito group が変わっていれば role を update する
 	// 上記いずれでもない（=招待なし & Cognito admin でもない）新規ユーザーはログイン拒否し、
 	// 直前にセットした Cookie をクリアしてセッションを残さない。
-	if allowed := h.upsertUserFromIDToken(c, tok.IDToken); !allowed {
+	if allowed := h.upsertUserFromIDToken(c, tok.IDToken, req.InvitationToken); !allowed {
 		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "invitation_required",
@@ -178,7 +182,8 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	// — DB から削除されたユーザーが refresh する稀ケースは別途 401 にすべきだが、本 PR の
 	// スコープ外として既存挙動を維持する。
 	if tok.IDToken != "" {
-		_ = h.upsertUserFromIDToken(c, tok.IDToken)
+		// refresh は既存ユーザー前提で、新規招待を引く必要はないため invitationToken は空文字を渡す。
+		_ = h.upsertUserFromIDToken(c, tok.IDToken, "")
 	} else {
 		h.syncRoleFromAccessToken(c, tok.AccessToken)
 	}
@@ -243,9 +248,12 @@ func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (in
 //   - true : 既存ユーザー、または「Cognito group admin / pending invitation あり」で新規作成成功
 //   - false: 「招待なし & Cognito admin でもない」新規ユーザー（ログイン拒否）または create 失敗
 //
+// invitationToken はマジックリンク経由の不透明 token（任意）。指定がある場合は email より
+// 優先して照合する（同 email に複数 pending invitation がある異常系での誤一致を防ぐ）。
+//
 // 招待ゲートを usecase ではなく handler 層に置いているのは、認可境界（Cookie 発行 / 401-403 を返す責務）が
 // HTTP 層であり、ユーザーが拒否された理由を上位ハンドラが直接知る必要があるため。
-func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken string) (allowed bool) {
+func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationToken string) (allowed bool) {
 	claims, err := middleware.DecodeClaims(idToken)
 	if err != nil || h.users == nil {
 		// claims を読めない / users repo 無し は内部エラー扱い。Cookie はクリアして拒否する。
@@ -269,12 +277,20 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken string) (all
 	}
 
 	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否。
+	// 招待検索の優先順位:
+	//   1. invitationToken が指定されていれば FindPendingByToken で照合（マジックリンク経由）
+	//   2. 1 で見つからない場合は email でフォールバック検索（旧フロー互換）
 	var inv *domain.AdminInvitation
-	if h.invitations != nil && email != "" {
-		inv, _ = h.invitations.FindPendingByEmail(c.Request.Context(), email)
+	if h.invitations != nil {
+		if invitationToken != "" {
+			inv, _ = h.invitations.FindPendingByToken(c.Request.Context(), invitationToken)
+		}
+		if inv == nil && email != "" {
+			inv, _ = h.invitations.FindPendingByEmail(c.Request.Context(), email)
+		}
 	}
 	if !isCognitoAdmin && inv == nil {
-		log.Printf("upsertUserFromIDToken: signup blocked — no invitation and not Cognito admin sub=%s email=%s", sub, email)
+		log.Printf("upsertUserFromIDToken: signup blocked — no invitation and not Cognito admin sub=%s email=%s token_provided=%t", sub, email, invitationToken != "")
 		return false
 	}
 

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -44,9 +44,10 @@ func (r *fakeUserRepo) UpdateRole(_ context.Context, id uint64, role string) err
 }
 
 // fakeInvitationRepo は AdminInvitationRepository の最小スタブ。
-// FindPendingByEmail だけ振る舞いをカスタムにしてテストする。
+// FindPendingByEmail / FindPendingByToken の振る舞いをカスタムにしてテストする。
 type fakeInvitationRepo struct {
 	pendingByEmail map[string]*domain.AdminInvitation
+	pendingByToken map[string]*domain.AdminInvitation
 	updatedID      uint64
 	updatedStatus  string
 }
@@ -63,7 +64,10 @@ func (r *fakeInvitationRepo) FindPendingByEmail(_ context.Context, email string)
 	}
 	return nil, nil
 }
-func (r *fakeInvitationRepo) FindPendingByToken(_ context.Context, _ string) (*domain.AdminInvitation, error) {
+func (r *fakeInvitationRepo) FindPendingByToken(_ context.Context, token string) (*domain.AdminInvitation, error) {
+	if v, ok := r.pendingByToken[token]; ok {
+		return v, nil
+	}
 	return nil, nil
 }
 func (r *fakeInvitationRepo) Create(_ context.Context, _ *domain.AdminInvitation) error { return nil }
@@ -112,7 +116,7 @@ func TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin(t *testing.
 		// cognito:groups なし、招待もなし → 拒否されるべき
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
 	if allowed {
 		t.Fatalf("expected allowed=false for non-invited non-admin signup")
 	}
@@ -132,7 +136,7 @@ func TestUpsertUserFromIDToken_AllowsCognitoAdminWithoutInvitation(t *testing.T)
 		"cognito:groups": []string{"admin"},
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
 	if !allowed {
 		t.Fatalf("Cognito group admin must be allowed even without invitation")
 	}
@@ -159,7 +163,7 @@ func TestUpsertUserFromIDToken_AllowsInvitedUser_AppliesRoleAndCompany(t *testin
 		"email": "trainee@example.com",
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
 	if !allowed {
 		t.Fatalf("invited user must be allowed")
 	}
@@ -192,7 +196,7 @@ func TestUpsertUserFromIDToken_ExistingUser_AlwaysAllowed(t *testing.T) {
 		"email": "u@example.com",
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken)
+	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
 	if !allowed {
 		t.Fatalf("existing user must always be allowed (no invitation re-check)")
 	}
@@ -211,7 +215,7 @@ func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T)
 		"email":          "u@example.com",
 		"cognito:groups": []string{"admin"},
 	})
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken) {
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.updateRoleID != 5 || users.updateRoleVal != domain.RoleSuperAdmin {
@@ -221,8 +225,67 @@ func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T)
 
 func TestUpsertUserFromIDToken_RejectsMalformedToken(t *testing.T) {
 	h := newTestAuthHandler(&fakeUserRepo{}, &fakeInvitationRepo{})
-	if h.upsertUserFromIDToken(newGinCtx(), "not-a-jwt") {
+	if h.upsertUserFromIDToken(newGinCtx(), "not-a-jwt", "") {
 		t.Fatal("malformed token must be rejected")
+	}
+}
+
+// invitationToken が指定されているとき、email ベースより token ベースが優先されることを確認する。
+// email ベースで見つかる古い invitation よりも、token ベースの新しい invitation を採用する。
+func TestUpsertUserFromIDToken_InvitationToken_TakesPrecedenceOverEmail(t *testing.T) {
+	cidByToken := uint64(99)
+	cidByEmail := uint64(1)
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{
+		pendingByEmail: map[string]*domain.AdminInvitation{
+			"u@example.com": {ID: 1, CompanyID: cidByEmail, Email: "u@example.com", Role: domain.RoleTrainee},
+		},
+		pendingByToken: map[string]*domain.AdminInvitation{
+			"magic-token-xyz": {ID: 7, CompanyID: cidByToken, Email: "u@example.com", Role: domain.RoleCompanyAdmin, DisplayName: "佐藤"},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "google-user-1",
+		"email": "u@example.com",
+	})
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "magic-token-xyz") {
+		t.Fatal("must be allowed when token matches a pending invitation")
+	}
+	if users.created == nil {
+		t.Fatalf("user must be created")
+	}
+	if users.created.Role != domain.RoleCompanyAdmin {
+		t.Errorf("token-based invitation role should win, got %q", users.created.Role)
+	}
+	if users.created.CompanyID == nil || *users.created.CompanyID != cidByToken {
+		t.Errorf("token-based companyID should win, got %+v", users.created.CompanyID)
+	}
+	if invs.updatedID != 7 || invs.updatedStatus != domain.InvitationStatusAccepted {
+		t.Errorf("token-based invitation must be marked accepted, got id=%d status=%q", invs.updatedID, invs.updatedStatus)
+	}
+}
+
+// invitationToken が無効でも、email ベースで見つかれば許可する（旧フロー互換）。
+func TestUpsertUserFromIDToken_InvalidToken_FallsBackToEmail(t *testing.T) {
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{
+		pendingByEmail: map[string]*domain.AdminInvitation{
+			"u@example.com": {ID: 1, CompanyID: 1, Email: "u@example.com", Role: domain.RoleTrainee},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "google-user-2",
+		"email": "u@example.com",
+	})
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "garbage-token") {
+		t.Fatal("must fall back to email-based invitation when token is invalid")
+	}
+	if users.created == nil || users.created.Role != domain.RoleTrainee {
+		t.Errorf("expected trainee from email-based invitation, got %+v", users.created)
 	}
 }
 

--- a/backend/internal/handler/public_invitation_handler.go
+++ b/backend/internal/handler/public_invitation_handler.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// PublicInvitationHandler は招待マジックリンク受諾画面用の **認証不要** エンドポイントを提供する。
+// 通常 admin 系 (POST/GET/DELETE /admin/invitations) は AdminInvitationHandler が担当するが、
+// 受諾画面はログイン前のユーザーが踏むため、認証必須グループの外に切り出す。
+type PublicInvitationHandler struct {
+	validate *usecase.ValidateInvitationTokenUseCase
+}
+
+func NewPublicInvitationHandler(v *usecase.ValidateInvitationTokenUseCase) *PublicInvitationHandler {
+	return &PublicInvitationHandler{validate: v}
+}
+
+// Validate は GET /api/v2/invitations/accept/:token。
+//
+// 仕様:
+//   - 認証不要（招待リンクをまだログインしていないユーザーが踏むため）
+//   - token が空・該当なし・期限切れ・既受諾・canceled は **すべて 404** （メタ情報を漏らさない）
+//   - 成功時は role / displayName / companyId / companyName のみ返す（email は返さない）
+//
+// レート制限はミドルウェア層で別途実装する想定（現状は未実装）。
+func (h *PublicInvitationHandler) Validate(c *gin.Context) {
+	token := c.Param("token")
+	got, err := h.validate.Execute(c.Request.Context(), token)
+	if err != nil {
+		// 内部エラーは 500 だが、フロントには「招待が無効」とだけ伝えてメタ情報を出さない。
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	if got == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "invitation_not_found_or_expired"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"role":        got.Role,
+		"displayName": got.DisplayName,
+		"companyId":   got.CompanyID,
+		"companyName": got.CompanyName,
+	})
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -56,6 +56,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	v2 := r.Group("/api/v2")
 
 	registerHealthRoutes(v2, deps)
+	registerInvitationPublicRoutes(v2, deps)
 	authHandler := registerAuthPublicRoutes(v2, deps)
 
 	authed := v2.Group("")

--- a/backend/internal/handler/routes_invitation_public.go
+++ b/backend/internal/handler/routes_invitation_public.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerInvitationPublicRoutes は招待マジックリンク受諾画面用の認証不要エンドポイントを登録する。
+//
+//	GET /api/v2/invitations/accept/:token  招待 token の検証 + 受諾画面用の最低限の情報返却
+//
+// 認可は無し（受諾前にユーザーが踏むため）。token が無効・期限切れの場合は 404 を返し、
+// 「招待が存在するかどうか」のメタ情報を漏らさない。
+func registerInvitationPublicRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	invRepo := repository.NewAdminInvitationRepository(deps.db)
+	companies := repository.NewCompanyRepository(deps.db)
+	h := NewPublicInvitationHandler(usecase.NewValidateInvitationTokenUseCase(invRepo, companies))
+	g.GET("/invitations/accept/:token", h.Validate)
+}

--- a/backend/internal/usecase/validate_invitation_token_usecase.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase.go
@@ -1,0 +1,80 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// ValidateInvitationTokenUseCase はマジックリンク受諾画面で token を検証する。
+//
+// 公開エンドポイント (GET /api/v2/invitations/accept/:token) から呼ばれる。
+// 該当なし / 期限切れ / 既受諾 / canceled はすべて (nil, nil) を返し、
+// 呼び出し側で 404 を返す（メタ情報を漏らさない設計）。
+//
+// 成功時は ValidatedInvitation (DTO) を返す。email は含めない:
+//   - 本人がメールから踏んでくる前提なので email は本人が知っている
+//   - 万一 token が漏れた場合の被害局所化（招待先 email を覗かれない）
+type ValidateInvitationTokenUseCase struct {
+	invitations repository.AdminInvitationRepository
+	companies   repository.CompanyRepository
+}
+
+func NewValidateInvitationTokenUseCase(
+	invitations repository.AdminInvitationRepository,
+	companies repository.CompanyRepository,
+) *ValidateInvitationTokenUseCase {
+	return &ValidateInvitationTokenUseCase{invitations: invitations, companies: companies}
+}
+
+// ValidatedInvitation は受諾画面に表示する最低限の情報。
+type ValidatedInvitation struct {
+	Role        string
+	DisplayName string
+	CompanyID   uint64
+	CompanyName string
+}
+
+func (u *ValidateInvitationTokenUseCase) Execute(ctx context.Context, token string) (*ValidatedInvitation, error) {
+	if token == "" {
+		// 空 token は repository でも nil 返却するが、handler が空文字を渡してきた場合の
+		// ガードを usecase 側にも置いて防御層を二重にする。
+		return nil, nil
+	}
+	inv, err := u.invitations.FindPendingByToken(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+	if inv == nil {
+		return nil, nil
+	}
+
+	// 招待の company を引いて name を返す。FindByID が err を返した場合は
+	// 招待そのものは有効なので company unknown でも 404 にせず、CompanyName を空で返す
+	// （フロントは「招待先を取得できませんでした」とフォールバック表示する想定）。
+	companyName := ""
+	if u.companies != nil {
+		if c, err := u.companies.FindByID(ctx, inv.CompanyID); err == nil && c != nil {
+			companyName = c.Name
+		}
+	}
+
+	return &ValidatedInvitation{
+		Role:        normalizeInvitationRole(inv.Role),
+		DisplayName: inv.DisplayName,
+		CompanyID:   inv.CompanyID,
+		CompanyName: companyName,
+	}, nil
+}
+
+// normalizeInvitationRole は invitation の role を表示用に正規化する。
+// 想定外の値が入っていた場合は trainee にフォールバックして UI を壊さないようにする。
+func normalizeInvitationRole(role string) string {
+	switch role {
+	case domain.RoleCompanyAdmin, domain.RoleTrainee:
+		return role
+	default:
+		return domain.RoleTrainee
+	}
+}

--- a/backend/internal/usecase/validate_invitation_token_usecase_test.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase_test.go
@@ -1,0 +1,132 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubCompanies struct {
+	byID map[uint64]*domain.Company
+	err  error
+}
+
+func (s *stubCompanies) ListAll(_ context.Context) ([]domain.Company, error) { return nil, s.err }
+func (s *stubCompanies) FindByID(_ context.Context, id uint64) (*domain.Company, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if c, ok := s.byID[id]; ok {
+		return c, nil
+	}
+	return nil, errors.New("not found")
+}
+
+// stubAdminInvRepoWithToken は ValidateInvitationTokenUseCase 専用の stub。
+// stubAdminInvRepo (admin_invitation_usecase_test.go) は他テストで FindPendingByToken を
+// nil 固定で返してしまうため、このテストでは別の stub を持つ。
+type stubAdminInvRepoWithToken struct {
+	stubAdminInvRepo
+	pendingByToken map[string]*domain.AdminInvitation
+}
+
+func (s *stubAdminInvRepoWithToken) FindPendingByToken(_ context.Context, token string) (*domain.AdminInvitation, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if v, ok := s.pendingByToken[token]; ok {
+		return v, nil
+	}
+	return nil, nil
+}
+
+func TestValidateInvitationToken_EmptyToken_ReturnsNil(t *testing.T) {
+	uc := NewValidateInvitationTokenUseCase(&stubAdminInvRepoWithToken{}, &stubCompanies{})
+	got, err := uc.Execute(context.Background(), "")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("empty token must return nil, got %+v", got)
+	}
+}
+
+func TestValidateInvitationToken_NotFound_ReturnsNil(t *testing.T) {
+	uc := NewValidateInvitationTokenUseCase(&stubAdminInvRepoWithToken{}, &stubCompanies{})
+	got, err := uc.Execute(context.Background(), "missing-token")
+	if err != nil || got != nil {
+		t.Fatalf("missing token must return (nil, nil), got=%+v err=%v", got, err)
+	}
+}
+
+func TestValidateInvitationToken_OK_AttachesCompanyName(t *testing.T) {
+	repo := &stubAdminInvRepoWithToken{
+		pendingByToken: map[string]*domain.AdminInvitation{
+			"abc-123": {
+				ID: 9, CompanyID: 42, Email: "u@example.com",
+				Role: domain.RoleCompanyAdmin, DisplayName: "山田",
+			},
+		},
+	}
+	companies := &stubCompanies{
+		byID: map[uint64]*domain.Company{
+			42: {ID: 42, Name: "株式会社FreStyle"},
+		},
+	}
+	uc := NewValidateInvitationTokenUseCase(repo, companies)
+
+	got, err := uc.Execute(context.Background(), "abc-123")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected non-nil result")
+	}
+	if got.Role != domain.RoleCompanyAdmin {
+		t.Errorf("Role = %q, want company_admin", got.Role)
+	}
+	if got.DisplayName != "山田" {
+		t.Errorf("DisplayName = %q, want 山田", got.DisplayName)
+	}
+	if got.CompanyID != 42 || got.CompanyName != "株式会社FreStyle" {
+		t.Errorf("Company = %d/%q, want 42/株式会社FreStyle", got.CompanyID, got.CompanyName)
+	}
+}
+
+func TestValidateInvitationToken_CompanyLookupFails_StillReturnsInvitation(t *testing.T) {
+	// company 取得失敗は invitation 自体の有効性を否定しない。
+	// CompanyName 空でも受諾画面を表示できる方が UX として良い。
+	repo := &stubAdminInvRepoWithToken{
+		pendingByToken: map[string]*domain.AdminInvitation{
+			"t": {ID: 9, CompanyID: 999, Email: "u@example.com", Role: domain.RoleTrainee},
+		},
+	}
+	companies := &stubCompanies{} // 空 → FindByID で「not found」
+	uc := NewValidateInvitationTokenUseCase(repo, companies)
+
+	got, err := uc.Execute(context.Background(), "t")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got == nil || got.CompanyID != 999 {
+		t.Fatalf("invitation must be returned with CompanyID even when company lookup fails, got %+v", got)
+	}
+	if got.CompanyName != "" {
+		t.Errorf("CompanyName should be empty on lookup failure, got %q", got.CompanyName)
+	}
+}
+
+func TestValidateInvitationToken_NormalizesUnknownRole(t *testing.T) {
+	repo := &stubAdminInvRepoWithToken{
+		pendingByToken: map[string]*domain.AdminInvitation{
+			"t": {ID: 9, CompanyID: 1, Role: "garbage_role"},
+		},
+	}
+	uc := NewValidateInvitationTokenUseCase(repo, &stubCompanies{byID: map[uint64]*domain.Company{1: {ID: 1, Name: "x"}}})
+	got, _ := uc.Execute(context.Background(), "t")
+	if got == nil || got.Role != domain.RoleTrainee {
+		t.Errorf("unknown role must fallback to trainee, got %+v", got)
+	}
+}


### PR DESCRIPTION
## 概要

招待マジックリンク方式 (Path B) の **PR-C**: バックエンド側で
- 公開エンドポイント \`GET /api/v2/invitations/accept/:token\` を新設
- \`POST /auth/cognito/callback\` で \`invitationToken\` を受け取り、email より優先して照合

を実装。

## 変更内容

### 新規エンドポイント

\`\`\`
GET /api/v2/invitations/accept/:token   (認証不要)
\`\`\`

- 使う場面: フロントの \`/invitations/accept?token=...\` ページが踏まれたときに、token の妥当性確認 + 受諾画面に表示する情報（招待先 company / role / displayName）を取得する
- 該当なし / 期限切れ / 受諾済 / canceled は **すべて 404** （メタ情報を漏らさない）
- email は返さない（token 漏洩時の被害局所化）

レスポンス例:
\`\`\`json
{
  "role": "company_admin",
  "displayName": "山田",
  "companyId": 42,
  "companyName": "株式会社FreStyle"
}
\`\`\`

### callback の拡張

\`cognitoCallbackReq\` に \`invitationToken\` を追加（任意）。

\`upsertUserFromIDToken\` のシグネチャを \`(idToken, invitationToken)\` に拡張し、招待検索の優先順位を:

1. \`invitationToken\` が指定されていれば \`FindPendingByToken\` で照合
2. 見つからなければ \`email\` でフォールバック（旧フロー互換）

これにより同一 email に複数 pending invitation がある異常系でも、token 一致を優先して誤一致を防ぐ。

\`Refresh\` は既存ユーザー前提のため \`invitationToken\` は空文字を渡す（招待検索に到達しない）。

### usecase

- \`ValidateInvitationTokenUseCase\` を新設
- \`AdminInvitationRepository.FindPendingByToken\` (PR-A) + \`CompanyRepository.FindByID\` を組み合わせて DTO 化
- 不明な role が DB に入っていた場合は \`trainee\` にフォールバック（UI を壊さない）

## テスト

- \`usecase/validate_invitation_token_usecase_test.go\`: 5 ケース
  - 空 token は nil 返却
  - 該当なしは nil 返却（404 にする責務は handler）
  - OK 時は company name を join して返す
  - company 取得失敗でも invitation は返す（CompanyName は空）
  - 想定外 role は trainee にフォールバック
- \`handler/auth_handler_test.go\`: 既存 6 ケースに加えて 2 ケース追加
  - \`invitationToken\` 優先（同 email でも token のロール/会社が勝つ）
  - 不正 \`invitationToken\` は email でフォールバック

\`go test ./...\` 全 pass、\`go vet\` クリーン。

## 関連

- PR-A #1629 / PR-B #1630 / PR-OIDC-Gate #1631 (すべて merged)
- 後続 PR-D: フロント \`/invitations/accept\` ページ + sessionStorage token + callback 連携
- 仕様 docs: [frestyle-pdm/docs/admin/invitation-magic-link-flow.md](https://github.com/norman6464/frestyle-pdm/blob/main/docs/admin/invitation-magic-link-flow.md)