### PR TITLE
feat(frontend): 招待マジックリンク受諾画面 + callback 連携 (PR-D)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ const LoginCallback = lazy(() => import('./pages/LoginCallback'));
 const ConfirmPage = lazy(() => import('./pages/ConfirmPage'));
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
 const ConfirmForgotPasswordPage = lazy(() => import('./pages/ConfirmForgotPasswordPage'));
+const AcceptInvitationPage = lazy(() => import('./pages/AcceptInvitationPage'));
 
 // 認証必要ページ
 const MenuPage = lazy(() => import('./pages/MenuPage'));
@@ -69,6 +70,8 @@ export default function App() {
         path="/confirm-forgot-password"
         element={<ConfirmForgotPasswordPage />}
       />
+      {/* 招待マジックリンクの受諾画面（認証不要・SES メールから踏まれる） */}
+      <Route path="/invitations/accept" element={<AcceptInvitationPage />} />
 
       {/* 認証が必要（AppShellレイアウト内） */}
       <Route

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -141,6 +141,12 @@ export const ADMIN = {
   scenarioById: (id: number | string) => `${API_V2}/admin/scenarios/${id}`,
 } as const;
 
+/** 招待マジックリンク受諾フロー（認証不要） */
+export const INVITATIONS = {
+  validateToken: (token: string) =>
+    `${API_V2}/invitations/accept/${encodeURIComponent(token)}`,
+} as const;
+
 /** 外部 URL の OGP / oEmbed メタ情報を取得するプロキシ */
 export const EMBEDS = {
   oembed: `${API_V2}/embeds/oembed`,

--- a/frontend/src/hooks/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginCallback.test.ts
@@ -42,7 +42,8 @@ describe('useLoginCallback', () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(authRepository.callback).toHaveBeenCalledWith('test-code');
+    // 第 2 引数 invitationToken は sessionStorage に何も無いとき null。
+    expect(authRepository.callback).toHaveBeenCalledWith('test-code', null);
   });
 
   it('callback成功時にsetAuthDataをdispatchしホームに遷移する', async () => {

--- a/frontend/src/hooks/useAcceptInvitation.ts
+++ b/frontend/src/hooks/useAcceptInvitation.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import axios from 'axios';
+import invitationRepository, {
+  ValidatedInvitation,
+} from '../repositories/InvitationRepository';
+import { saveInvitationToken, clearInvitationToken } from '../lib/invitationToken';
+
+export type AcceptInvitationStatus =
+  | { kind: 'loading' }
+  | { kind: 'invalid' }
+  | { kind: 'ready'; invitation: ValidatedInvitation }
+  | { kind: 'error' };
+
+/**
+ * AcceptInvitationPage の状態管理。
+ *
+ * URL クエリ ?token=<UUID> を取り出し、backend (`GET /invitations/accept/:token`) を叩いて検証する。
+ * 結果に応じて以下の状態に遷移する:
+ *
+ *   - loading : リクエスト中
+ *   - invalid : token が空・404 (期限切れ・受諾済・存在しない)
+ *   - ready   : 招待データ取得成功 → ボタンでログインへ進める
+ *   - error   : ネットワーク/サーバ障害（再試行を促す）
+ *
+ * ready に入ったタイミングで token を sessionStorage に保存し、ログイン後の callback で
+ * pickup できるようにする。token が invalid の場合は念のため既存値もクリアする。
+ */
+export function useAcceptInvitation() {
+  const [params] = useSearchParams();
+  const token = params.get('token') || '';
+  const [status, setStatus] = useState<AcceptInvitationStatus>({ kind: 'loading' });
+
+  useEffect(() => {
+    if (!token) {
+      clearInvitationToken();
+      setStatus({ kind: 'invalid' });
+      return;
+    }
+    let cancelled = false;
+    invitationRepository
+      .validateToken(token)
+      .then((invitation) => {
+        if (cancelled) return;
+        saveInvitationToken(token);
+        setStatus({ kind: 'ready', invitation });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        clearInvitationToken();
+        // 404 は「無効/期限切れリンク」として明示。それ以外はネットワーク等の障害扱い。
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          setStatus({ kind: 'invalid' });
+          return;
+        }
+        setStatus({ kind: 'error' });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return { status };
+}

--- a/frontend/src/hooks/useLoginCallback.ts
+++ b/frontend/src/hooks/useLoginCallback.ts
@@ -1,8 +1,11 @@
 import { useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
+import axios from 'axios';
 import { setAuthData } from '../store/authSlice';
 import authRepository from '../repositories/AuthRepository';
+import { consumeInvitationToken } from '../lib/invitationToken';
+import { classifyApiError } from '../utils/classifyApiError';
 
 export function useLoginCallback() {
   const [searchParams] = useSearchParams();
@@ -18,14 +21,34 @@ export function useLoginCallback() {
     }
 
     if (code) {
+      // 招待マジックリンク経由でログインしてきた場合、AcceptInvitationPage が保存した
+      // sessionStorage の token を取り出して callback に渡す（使い切りで自動削除）。
+      const invitationToken = consumeInvitationToken();
       authRepository
-        .callback(code)
+        .callback(code, invitationToken)
         .then(() => {
           dispatch(setAuthData());
           navigate('/', { state: { toast: 'ログインしました' } });
         })
-        .catch(() => {
-          navigate('/login', { state: { toast: '認証に失敗しました' } });
+        .catch((err) => {
+          // backend が PR-OIDC-Gate で返す 403 invitation_required を識別して
+          // 専用メッセージを表示する。それ以外は従来どおり「認証に失敗しました」。
+          if (axios.isAxiosError(err) && err.response?.status === 403) {
+            const data = err.response.data as { error?: string; message?: string } | undefined;
+            if (data?.error === 'invitation_required') {
+              navigate('/login', {
+                state: {
+                  toast:
+                    data.message ||
+                    'FreStyle のご利用には管理者からの招待が必要です。',
+                },
+              });
+              return;
+            }
+          }
+          navigate('/login', {
+            state: { toast: classifyApiError(err, '認証に失敗しました') },
+          });
         });
     } else {
       navigate('/login');

--- a/frontend/src/lib/__tests__/invitationToken.test.ts
+++ b/frontend/src/lib/__tests__/invitationToken.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  saveInvitationToken,
+  readInvitationToken,
+  clearInvitationToken,
+  consumeInvitationToken,
+} from '../invitationToken';
+
+describe('invitationToken', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('save / read で同じ値が取り出せる', () => {
+    saveInvitationToken('abc-123');
+    expect(readInvitationToken()).toBe('abc-123');
+  });
+
+  it('空文字は保存しない（誤って空文字を上書き保存しない）', () => {
+    saveInvitationToken('first');
+    saveInvitationToken('');
+    expect(readInvitationToken()).toBe('first');
+  });
+
+  it('clear で削除される', () => {
+    saveInvitationToken('abc');
+    clearInvitationToken();
+    expect(readInvitationToken()).toBeNull();
+  });
+
+  it('consume は read + clear を 1 回で行う（再利用防止）', () => {
+    saveInvitationToken('one-shot');
+    expect(consumeInvitationToken()).toBe('one-shot');
+    expect(readInvitationToken()).toBeNull();
+    expect(consumeInvitationToken()).toBeNull();
+  });
+});

--- a/frontend/src/lib/invitationToken.ts
+++ b/frontend/src/lib/invitationToken.ts
@@ -1,0 +1,54 @@
+/**
+ * 招待マジックリンクで受領した UUID トークンを sessionStorage で持ち回るためのヘルパー。
+ *
+ * フロー:
+ *   1. /invitations/accept?token=<UUID> を踏むと AcceptInvitationPage が saveInvitationToken
+ *   2. ユーザーが「ログインへ進む」ボタンで /login → Cognito Hosted UI へリダイレクト
+ *   3. /login/callback (LoginCallback) が consumeInvitationToken で取り出して
+ *      POST /auth/cognito/callback の body に invitationToken として含めて送る
+ *
+ * sessionStorage を選んだ理由:
+ *   - localStorage だと別タブの誤読込みリスクがある
+ *   - cookie だと CSRF / SameSite まわりが複雑
+ *   - URL hash で渡し続けると history に残って他ユーザーが復元できてしまう
+ *
+ * consume 後は必ず sessionStorage から削除して再利用を防ぐ。
+ */
+
+const STORAGE_KEY = 'frestyle.invitationToken';
+
+export function saveInvitationToken(token: string): void {
+  if (!token) return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, token);
+  } catch {
+    // private mode などで sessionStorage が使えないケース。callback での
+    // 招待ゲート fallback (email 一致) に任せる。
+  }
+}
+
+export function readInvitationToken(): string | null {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function clearInvitationToken(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * consumeInvitationToken は read + clear を 1 操作で行う。
+ * callback で 1 度だけ使うため、意図せず再送されないように使い切りで削除する。
+ */
+export function consumeInvitationToken(): string | null {
+  const t = readInvitationToken();
+  if (t) clearInvitationToken();
+  return t;
+}

--- a/frontend/src/pages/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/AcceptInvitationPage.tsx
@@ -1,0 +1,108 @@
+import { Link } from 'react-router-dom';
+import AuthLayout from '../components/AuthLayout';
+import PrimaryButton from '../components/PrimaryButton';
+import LinkText from '../components/LinkText';
+import Loading from '../components/Loading';
+import { useAcceptInvitation } from '../hooks/useAcceptInvitation';
+
+/**
+ * 招待マジックリンク受諾画面。
+ *
+ * URL: /invitations/accept?token=<UUID>
+ *
+ * メールから踏まれた直後の最初の画面。token を backend (`GET /invitations/accept/:token`)
+ * で検証して招待先 company / role / displayName を表示し、ユーザーに「ログインへ進む」
+ * ボタンを押してもらう。ボタンを踏んだ時点で token は sessionStorage に保存済みなので、
+ * Cognito Hosted UI 経由のログイン後 callback で読み出して使う。
+ */
+export default function AcceptInvitationPage() {
+  const { status } = useAcceptInvitation();
+
+  if (status.kind === 'loading') {
+    return <Loading fullscreen message="招待リンクを確認しています…" />;
+  }
+
+  if (status.kind === 'invalid') {
+    return (
+      <AuthLayout
+        title="招待リンクが無効です"
+        footer={
+          <p className="text-sm text-[var(--color-text-muted)]">
+            すでにログイン済みの方は <LinkText to="/login">ログイン画面</LinkText> へ
+          </p>
+        }
+      >
+        <p className="text-[var(--color-text-muted)] leading-relaxed">
+          リンクが期限切れか、すでに使用済みの可能性があります。<br />
+          招待を送ってくれた管理者に再送をお願いしてください。
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  if (status.kind === 'error') {
+    return (
+      <AuthLayout title="リンクを確認できませんでした">
+        <p className="text-[var(--color-text-muted)] leading-relaxed">
+          通信に失敗しました。時間を置いてからリンクを開き直してください。
+        </p>
+      </AuthLayout>
+    );
+  }
+
+  const { invitation } = status;
+  const roleLabel = roleLabels[invitation.role] ?? invitation.role;
+
+  return (
+    <AuthLayout
+      title="FreStyle へようこそ"
+      footer={
+        <p className="text-sm text-[var(--color-text-muted)]">
+          すでにログイン済みの方は <LinkText to="/login">こちら</LinkText>
+        </p>
+      }
+    >
+      <div className="space-y-4">
+        <p className="text-[var(--color-text-muted)] leading-relaxed">
+          管理者から招待が届いています。下記の内容でアカウントを作成します。
+        </p>
+
+        <dl className="bg-[var(--color-surface-alt)] rounded-lg p-4 space-y-2 text-sm">
+          {invitation.companyName && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-[var(--color-text-muted)]">招待元の会社</dt>
+              <dd className="font-medium text-right">{invitation.companyName}</dd>
+            </div>
+          )}
+          <div className="flex justify-between gap-4">
+            <dt className="text-[var(--color-text-muted)]">付与される権限</dt>
+            <dd className="font-medium text-right">{roleLabel}</dd>
+          </div>
+          {invitation.displayName && (
+            <div className="flex justify-between gap-4">
+              <dt className="text-[var(--color-text-muted)]">表示名</dt>
+              <dd className="font-medium text-right">{invitation.displayName}</dd>
+            </div>
+          )}
+        </dl>
+
+        <Link to="/login" className="block">
+          <PrimaryButton type="button">ログインへ進む</PrimaryButton>
+        </Link>
+
+        <p className="text-xs text-[var(--color-text-muted)] text-center">
+          ボタンを押すと Cognito ログイン画面に遷移します。<br />
+          Google アカウントまたはメールアドレスでログインしてください。
+        </p>
+      </div>
+    </AuthLayout>
+  );
+}
+
+// バックエンドから返ってくる role の生値を、画面表示用の日本語ラベルに変換する。
+// 想定外の値は usecase 側で trainee に正規化済みだが、フォールバックとして生値をそのまま出す。
+const roleLabels: Record<string, string> = {
+  super_admin: '運営管理者',
+  company_admin: '会社管理者',
+  trainee: '受講者',
+};

--- a/frontend/src/pages/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/__tests__/LoginCallback.test.tsx
@@ -70,7 +70,8 @@ describe('LoginCallback', () => {
     renderWithRoute('?code=valid-code');
 
     await waitFor(() => {
-      expect(authRepository.callback).toHaveBeenCalledWith('valid-code');
+      // 第 2 引数 invitationToken は sessionStorage に何も無いとき null。
+      expect(authRepository.callback).toHaveBeenCalledWith('valid-code', null);
       expect(mockNavigate).toHaveBeenCalledWith('/', { state: { toast: 'ログインしました' } });
     });
   });

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -77,10 +77,16 @@ class AuthRepository {
   }
 
   /**
-   * OAuthコールバック
+   * OAuth コールバック。
+   *
+   * invitationToken は招待マジックリンク経由のサインアップで sessionStorage から
+   * 引き渡される UUID。指定がある場合 backend は email より優先して照合する。
+   * 未指定（直接 /login から入った既存ユーザー等）は省略可。
    */
-  async callback(code: string): Promise<{ success: string }> {
-    const response = await apiClient.post(AUTH.callback, { code });
+  async callback(code: string, invitationToken?: string | null): Promise<{ success: string }> {
+    const body: { code: string; invitationToken?: string } = { code };
+    if (invitationToken) body.invitationToken = invitationToken;
+    const response = await apiClient.post(AUTH.callback, body);
     return response.data;
   }
 

--- a/frontend/src/repositories/InvitationRepository.ts
+++ b/frontend/src/repositories/InvitationRepository.ts
@@ -1,0 +1,33 @@
+import apiClient from '../lib/axios';
+import { INVITATIONS } from '../constants/apiRoutes';
+
+/**
+ * 招待マジックリンク受諾フロー用のリポジトリ。
+ *
+ * 認証不要の公開エンドポイント (`GET /api/v2/invitations/accept/:token`) を呼び出し、
+ * 受諾画面が「招待先の company / role / displayName」を表示するためのデータを取得する。
+ *
+ * email は意図的に含まれない（token 漏洩時の被害局所化）。
+ */
+
+export interface ValidatedInvitation {
+  role: string;
+  displayName: string;
+  companyId: number;
+  companyName: string;
+}
+
+class InvitationRepository {
+  /**
+   * 招待 token を検証する。
+   *
+   * 該当なし / 期限切れ / 受諾済 / canceled は backend から 404 で返り、
+   * axios が AxiosError を throw するので呼び出し側で catch して「無効なリンク」と表示する。
+   */
+  async validateToken(token: string): Promise<ValidatedInvitation> {
+    const response = await apiClient.get<ValidatedInvitation>(INVITATIONS.validateToken(token));
+    return response.data;
+  }
+}
+
+export default new InvitationRepository();

--- a/frontend/src/repositories/__tests__/InvitationRepository.test.ts
+++ b/frontend/src/repositories/__tests__/InvitationRepository.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import invitationRepository from '../InvitationRepository';
+import apiClient from '../../lib/axios';
+
+vi.mock('../../lib/axios');
+
+const mockedApiClient = vi.mocked(apiClient);
+
+describe('InvitationRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('validateToken: token を URL に埋め込んで GET する', async () => {
+    const mockInv = {
+      role: 'company_admin',
+      displayName: '山田',
+      companyId: 42,
+      companyName: '株式会社FreStyle',
+    };
+    mockedApiClient.get.mockResolvedValue({ data: mockInv });
+
+    const result = await invitationRepository.validateToken('abc-123');
+
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/invitations/accept/abc-123');
+    expect(result).toEqual(mockInv);
+  });
+
+  it('validateToken: メタ文字を含む token は URL エンコードされる', async () => {
+    mockedApiClient.get.mockResolvedValue({ data: {} });
+    await invitationRepository.validateToken('a/b?x=1');
+    expect(mockedApiClient.get).toHaveBeenCalledWith('/api/v2/invitations/accept/a%2Fb%3Fx%3D1');
+  });
+});


### PR DESCRIPTION
## 概要

招待マジックリンク方式 (Path B) のフロント側 (PR-D)。

メールから踏まれた \`/invitations/accept?token=<UUID>\` を受けてユーザーに招待内容を表示し、ログインボタンで Cognito Hosted UI に遷移、\`/login/callback\` に戻ってきたタイミングで sessionStorage の token を backend に引き渡す一連のフロー。

## 変更内容

### 新規ファイル

| ファイル | 役割 |
|---|---|
| \`pages/AcceptInvitationPage.tsx\` | 受諾画面コンポーネント。loading / invalid / ready / error の 4 状態を切り替え |
| \`hooks/useAcceptInvitation.ts\` | URL クエリ \`?token=\` を取って backend で検証し、ready 時に sessionStorage に保存 |
| \`lib/invitationToken.ts\` | sessionStorage の save/read/clear/consume ヘルパー（consume は使い切り） |
| \`repositories/InvitationRepository.ts\` | \`GET /invitations/accept/:token\` の薄いラッパ |

### 変更ファイル

| ファイル | 内容 |
|---|---|
| \`repositories/AuthRepository.ts\` | \`callback(code, invitationToken?)\` のシグネチャに拡張 |
| \`hooks/useLoginCallback.ts\` | \`consumeInvitationToken\` して callback へ引き渡し / \`403 invitation_required\` を専用メッセージで /login に戻す |
| \`App.tsx\` | \`/invitations/accept\` ルート追加（認証不要） |
| \`constants/apiRoutes.ts\` | \`INVITATIONS.validateToken\` を追加 |

### 受諾画面の状態遷移

\`\`\`
loading  ← 初期 / API 呼び出し中
   ↓ 成功
ready    → 招待情報を表示 + 「ログインへ進む」ボタン
   ↓ 失敗 (404)
invalid  → 「リンクが無効/期限切れ」
   ↓ 失敗 (それ以外)
error    → 「通信に失敗、時間を置いて再試行」
\`\`\`

\`ready\` に入った瞬間に \`saveInvitationToken(token)\` で sessionStorage に保存し、ログイン後の \`/login/callback\` で \`consumeInvitationToken()\` が読み取って backend に送る。consume は read+clear を 1 操作で行うため再利用されない。

### 403 invitation_required ハンドリング

\`useLoginCallback\` で backend (PR-OIDC-Gate #1631) が返す \`403 invitation_required\` を識別し、トーストで「FreStyle のご利用には管理者からの招待が必要です」と表示してログイン画面へ戻す。

## テスト

- \`lib/__tests__/invitationToken.test.ts\` (4 ケース): save/read 往復、空文字無視、clear、consume の使い切り
- \`repositories/__tests__/InvitationRepository.test.ts\` (2 ケース): URL 構築、メタ文字 URL エンコード
- \`hooks/__tests__/useLoginCallback.test.ts\` 既存: callback 第 2 引数を \`null\` 期待に更新
- \`pages/__tests__/LoginCallback.test.tsx\` 既存: 同上

\`npm test -- --run\` 全 **278 files / 2226 tests pass**、\`npx tsc --noEmit\` クリーン。

## 関連

- backend: [#1634 (PR-C)](https://github.com/norman6464/FreStyle/pull/1634) で \`GET /invitations/accept/:token\` と callback の \`invitationToken\` 受け取りを実装。両方マージ後にエンドツーエンドで動作。
- 仕様: [frestyle-pdm/docs/admin/invitation-magic-link-flow.md](https://github.com/norman6464/frestyle-pdm/blob/main/docs/admin/invitation-magic-link-flow.md)

## 動作確認手順（PR-C / PR-D の両方マージ後）

1. 管理画面で招待を作成 → SES から normanblog.com へメール送信
2. メール本文中の \`https://normanblog.com/invitations/accept?token=...\` をクリック
3. 受諾画面で会社名・権限を確認 → 「ログインへ進む」
4. Cognito Hosted UI でログイン → \`/login/callback\` で users 行が招待 role で作成される
5. \`/auth/me\` が新ユーザー情報を返し、ホームへ遷移