### PR TITLE
fix(invitation): UTC_TIMESTAMP() を PostgreSQL 互換の Go 側時刻バインドに置換

### DIFF
--- a/backend/internal/repository/admin_invitation_repository.go
+++ b/backend/internal/repository/admin_invitation_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"gorm.io/gorm"
@@ -70,10 +71,13 @@ func (r *adminInvitationRepository) FindPendingByToken(ctx context.Context, toke
 	var row domain.AdminInvitation
 	// expires_at は招待作成時に必ず未来の値を入れる前提（usecase 側で 7 日後をセット）。
 	// 期限切れを DB 側で弾くことで「フロントで時刻がズレていても安全」な検証になる。
-	// UTC_TIMESTAMP() を使うことで DB サーバーのローカルタイムゾーン設定に依存せず比較する
-	// （RDS が JST に設定されていてもアプリは UTC で時刻を扱う前提なので統一）。
+	//
+	// 時刻比較は DB 関数（NOW() / UTC_TIMESTAMP()）ではなく Go 側で生成した UTC 現在時刻を
+	// パラメータバインドで渡す。理由:
+	//   - DB エンジン横断のポータビリティ（PostgreSQL には UTC_TIMESTAMP() が無い）
+	//   - GORM が time.Time を timestamptz として扱うため、DB のローカル TZ 設定に依存しない
 	err := r.db.WithContext(ctx).
-		Where("token = ? AND status = ? AND expires_at > UTC_TIMESTAMP()", token, domain.InvitationStatusPending).
+		Where("token = ? AND status = ? AND expires_at > ?", token, domain.InvitationStatusPending, time.Now().UTC()).
 		First(&row).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
## 緊急度: 本番 500 修正

\`GET /api/v2/invitations/accept/:token\` が本番で **500 internal_error** を返している。

## 原因

PR-A #1629 で CodeRabbit 指摘により \`NOW()\` を \`UTC_TIMESTAMP()\` に変更したが、本番 DB は MariaDB → **PostgreSQL** に切替済（\`frestyle-prod-rds-postgres\`）で、PostgreSQL には \`UTC_TIMESTAMP()\` が存在しない。

ECS Logs:
\`\`\`
ERROR: function utc_timestamp() does not exist (SQLSTATE 42883)
SELECT * FROM "invitations" WHERE token = 'dummy' AND status = 'pending' AND expires_at > UTC_TIMESTAMP() ...
[GIN] | 500 | GET "/api/v2/invitations/accept/dummy"
\`\`\`

## 修正

DB 関数ではなく Go の \`time.Now().UTC()\` をパラメータバインドで渡す。

\`\`\`go
.Where("token = ? AND status = ? AND expires_at > ?", token, domain.InvitationStatusPending, time.Now().UTC())
\`\`\`

理由:
- **DB エンジン横断のポータビリティ**（PostgreSQL / MariaDB の差を吸収）
- GORM が \`time.Time\` を \`timestamptz\` として扱うため、DB ローカル TZ 設定に依存しない
- CodeRabbit が PR-A で意図していた「DB の TZ 設定を考慮しない安全な比較」も同等に実現できる
- ローカル開発の MariaDB 互換性も維持

## テスト

stub repository を使う既存テストは変更不要。
\`go test ./...\` 全 pass / \`go vet\` クリーン。

## マージ後

cd-backend.yml を即時 trigger して本番反映 → \`api.normanblog.com/api/v2/invitations/accept/dummy\` が 404 を返すことを確認。