### PR TITLE
fix(invitation): UI から Cognito/生 role 表記を削除 + 既存ユーザーの role 昇格対応

### DIFF
--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -78,12 +78,58 @@ type createAdminInvReq struct {
 	DisplayName string `json:"displayName"`
 }
 
+// Create は POST /api/v2/admin/invitations。
+//
+// 認可ルール（SoD）:
+//   - SuperAdmin: company_admin の招待のみ可能。trainee の招待は CompanyAdmin に任せる。
+//     （運営が顧客企業の trainee 全員を直接管理するのは実運用に合わないため）
+//   - CompanyAdmin: 自社の trainee の招待のみ可能。company_id は自社に固定する。
+//   - その他: 403
+//
+// この境界を backend で確実に守ることで、フロント UI を経由しない API 呼び出しでも
+// SuperAdmin が間違って trainee を直接招待することや、CompanyAdmin が他社に
+// 招待を出すことを防ぐ。フロント UI は UX 改善として同じルールで選択肢を絞る。
 func (h *AdminInvitationHandler) Create(c *gin.Context) {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
 	var req createAdminInvReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+
+	switch user.Role {
+	case domain.RoleSuperAdmin:
+		if req.Role != domain.RoleCompanyAdmin {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":   "super_admin_can_only_invite_company_admin",
+				"message": "運営は会社管理者のみ招待できます。受講者の招待は会社管理者から行ってください。",
+			})
+			return
+		}
+	case domain.RoleCompanyAdmin:
+		if req.Role != domain.RoleTrainee {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":   "company_admin_can_only_invite_trainee",
+				"message": "会社管理者が招待できるのは受講者のみです。",
+			})
+			return
+		}
+		if user.CompanyID == nil || *user.CompanyID == 0 {
+			c.JSON(http.StatusForbidden, gin.H{"error": "company_admin_without_company"})
+			return
+		}
+		// CompanyAdmin の招待先 company は常に自社に固定する（リクエスト値を上書き）。
+		req.CompanyID = *user.CompanyID
+	default:
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+
 	got, err := h.create.Execute(c.Request.Context(), usecase.CreateAdminInvitationInput{
 		CompanyID: req.CompanyID, Email: req.Email, Role: req.Role, DisplayName: req.DisplayName,
 	})

--- a/backend/internal/handler/admin_invitation_handler_test.go
+++ b/backend/internal/handler/admin_invitation_handler_test.go
@@ -159,3 +159,135 @@ func TestAdminInvitationHandler_List_Unauthenticated(t *testing.T) {
 		t.Fatalf("status = %d", w.Code)
 	}
 }
+
+// ===== Create 認可テスト =====
+//
+// SoD ルール:
+//   - SuperAdmin → company_admin の招待のみ可、trainee は禁止
+//   - CompanyAdmin → trainee の招待のみ可、自社固定
+//   - Trainee → 全部禁止
+
+// fakeAdminInvRepoWithCreate は Create を計測する版。
+type fakeAdminInvRepoWithCreate struct {
+	fakeAdminInvRepo
+	createCalls int
+	lastCreate  *domain.AdminInvitation
+}
+
+func (r *fakeAdminInvRepoWithCreate) Create(_ context.Context, inv *domain.AdminInvitation) error {
+	r.createCalls++
+	inv.ID = 100
+	r.lastCreate = inv
+	return nil
+}
+
+// newTestCreateHandler は Create handler 用 harness。usecase は本物 +
+// 上の fake repo を inject。sender 等は nil でフォールバックモード。
+func newTestCreateHandler(repo *fakeAdminInvRepoWithCreate, currentUser *domain.User) *gin.Engine {
+	h := NewAdminInvitationHandler(
+		usecase.NewListAdminInvitationsUseCase(repo),
+		usecase.NewCreateAdminInvitationUseCase(repo, nil, nil, nil),
+		usecase.NewCancelAdminInvitationUseCase(repo),
+	)
+	r := gin.New()
+	r.POST("/admin/invitations", func(c *gin.Context) {
+		if currentUser != nil {
+			c.Set(middleware.ContextKeyCurrentUser, currentUser)
+		}
+		h.Create(c)
+	})
+	return r
+}
+
+func postJSON(t *testing.T, r *gin.Engine, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/admin/invitations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestAdminInvitationHandler_Create_SuperAdmin_CompanyAdmin_OK(t *testing.T) {
+	repo := &fakeAdminInvRepoWithCreate{}
+	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
+
+	w := postJSON(t, r, `{"companyId":1,"email":"a@b","role":"company_admin"}`)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if repo.createCalls != 1 {
+		t.Errorf("expected 1 create, got %d", repo.createCalls)
+	}
+}
+
+func TestAdminInvitationHandler_Create_SuperAdmin_Trainee_Forbidden(t *testing.T) {
+	repo := &fakeAdminInvRepoWithCreate{}
+	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
+
+	w := postJSON(t, r, `{"companyId":1,"email":"a@b","role":"trainee"}`)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "super_admin_can_only_invite_company_admin") {
+		t.Errorf("expected error code, got %s", w.Body.String())
+	}
+	if repo.createCalls != 0 {
+		t.Errorf("create must not be called, got %d", repo.createCalls)
+	}
+}
+
+func TestAdminInvitationHandler_Create_CompanyAdmin_Trainee_OK_AndCompanyForcedToOwn(t *testing.T) {
+	repo := &fakeAdminInvRepoWithCreate{}
+	cid := uint64(42)
+	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: &cid})
+
+	// 別の company_id を指定しても、handler 側で自社に上書きされること
+	w := postJSON(t, r, `{"companyId":999,"email":"t@b","role":"trainee"}`)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if repo.lastCreate == nil || repo.lastCreate.CompanyID != cid {
+		t.Errorf("expected companyID forced to %d, got %+v", cid, repo.lastCreate)
+	}
+}
+
+func TestAdminInvitationHandler_Create_CompanyAdmin_CompanyAdmin_Forbidden(t *testing.T) {
+	repo := &fakeAdminInvRepoWithCreate{}
+	cid := uint64(42)
+	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: &cid})
+
+	w := postJSON(t, r, `{"companyId":42,"email":"a@b","role":"company_admin"}`)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d body = %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "company_admin_can_only_invite_trainee") {
+		t.Errorf("expected error code, got %s", w.Body.String())
+	}
+}
+
+func TestAdminInvitationHandler_Create_Trainee_Forbidden(t *testing.T) {
+	repo := &fakeAdminInvRepoWithCreate{}
+	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleTrainee})
+
+	w := postJSON(t, r, `{"companyId":1,"email":"a@b","role":"trainee"}`)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d", w.Code)
+	}
+}
+
+func TestAdminInvitationHandler_Create_Unauthenticated(t *testing.T) {
+	repo := &fakeAdminInvRepoWithCreate{}
+	r := newTestCreateHandler(repo, nil)
+
+	w := postJSON(t, r, `{"companyId":1,"email":"a@b","role":"trainee"}`)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d", w.Code)
+	}
+}

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -267,17 +267,8 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
 	isCognitoAdmin := middleware.IsAdminFromGroups(groups)
 
-	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
-	if existing != nil {
-		// 既存ユーザー: Cognito group で admin に昇格された場合のみ DB role を上書きする。
-		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
-			_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
-		}
-		return true
-	}
-
-	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否。
-	// 招待検索の優先順位:
+	// 招待検索（既存ユーザーの role 昇格・新規ユーザー作成の両方で使う）。
+	// 優先順位:
 	//   1. invitationToken が指定されていれば FindPendingByToken で照合（マジックリンク経由）
 	//   2. 1 で見つからない場合は email でフォールバック検索（旧フロー互換）
 	var inv *domain.AdminInvitation
@@ -289,6 +280,39 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 			inv, _ = h.invitations.FindPendingByEmail(c.Request.Context(), email)
 		}
 	}
+
+	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
+	if existing != nil {
+		// 既存ユーザー: 招待 / Cognito group の状態で role / company を更新する。
+		// 重要な制約:
+		//   - super_admin は何があっても降格しない（招待での降格は不可、別途 admin API でのみ降格可）
+		//   - 招待による昇格は trainee → company_admin のみ（trainee → super_admin / company_admin → super_admin はしない）
+		//   - Cognito group admin は最強で super_admin に昇格する
+		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
+			_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
+		}
+		if inv != nil && existing.Role != domain.RoleSuperAdmin {
+			// 役割昇格: trainee → company_admin だけ反映する（同一 role / 降格は skip）。
+			if existing.Role == domain.RoleTrainee && inv.Role == domain.RoleCompanyAdmin {
+				if err := h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleCompanyAdmin); err != nil {
+					log.Printf("upsertUserFromIDToken: existing user role upgrade failed userID=%d: %v", existing.ID, err)
+				} else {
+					log.Printf("upsertUserFromIDToken: existing user upgraded trainee→company_admin userID=%d email=%s", existing.ID, email)
+				}
+			}
+			// company 紐付け: 招待の company_id と異なる、または未設定なら更新する。
+			if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
+				if err := h.users.UpdateCompanyID(c.Request.Context(), existing.ID, inv.CompanyID); err != nil {
+					log.Printf("upsertUserFromIDToken: existing user company update failed userID=%d: %v", existing.ID, err)
+				}
+			}
+			// 招待を accepted にマーク（再利用防止 + 監査）
+			_ = h.invitations.UpdateStatus(c.Request.Context(), inv.ID, domain.InvitationStatusAccepted)
+		}
+		return true
+	}
+
+	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否。
 	if !isCognitoAdmin && inv == nil {
 		log.Printf("upsertUserFromIDToken: signup blocked — no invitation and not Cognito admin sub=%s email=%s token_provided=%t", sub, email, invitationToken != "")
 		return false

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -13,11 +13,13 @@ import (
 
 // fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
 type fakeUserRepo struct {
-	existingBySub map[string]*domain.User
-	created       *domain.User
-	createErr     error
-	updateRoleID  uint64
-	updateRoleVal string
+	existingBySub  map[string]*domain.User
+	created        *domain.User
+	createErr      error
+	updateRoleID   uint64
+	updateRoleVal  string
+	updateCompanyID    uint64
+	updateCompanyVal   uint64
 }
 
 func (r *fakeUserRepo) FindByCognitoSub(_ context.Context, sub string) (*domain.User, error) {
@@ -40,6 +42,10 @@ func (r *fakeUserRepo) Create(_ context.Context, u *domain.User) error {
 func (r *fakeUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error { return nil }
 func (r *fakeUserRepo) UpdateRole(_ context.Context, id uint64, role string) error {
 	r.updateRoleID, r.updateRoleVal = id, role
+	return nil
+}
+func (r *fakeUserRepo) UpdateCompanyID(_ context.Context, id uint64, companyID uint64) error {
+	r.updateCompanyID, r.updateCompanyVal = id, companyID
 	return nil
 }
 
@@ -286,6 +292,53 @@ func TestUpsertUserFromIDToken_InvalidToken_FallsBackToEmail(t *testing.T) {
 	}
 	if users.created == nil || users.created.Role != domain.RoleTrainee {
 		t.Errorf("expected trainee from email-based invitation, got %+v", users.created)
+	}
+}
+
+// 既存の trainee ユーザーが company_admin 招待を受けた場合、role を昇格 + company を反映する。
+// 過去に signup した既存ユーザーが後から CompanyAdmin として招待されたケースの救済。
+func TestUpsertUserFromIDToken_ExistingTrainee_UpgradedByCompanyAdminInvitation(t *testing.T) {
+	existing := &domain.User{ID: 5, CognitoSub: "existing-trainee", Email: "u@example.com", Role: domain.RoleTrainee}
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing-trainee": existing}}
+	invs := &fakeInvitationRepo{
+		pendingByToken: map[string]*domain.AdminInvitation{
+			"magic-xyz": {ID: 9, CompanyID: 42, Email: "u@example.com", Role: domain.RoleCompanyAdmin},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+	idToken := makeIDToken(t, map[string]any{"sub": "existing-trainee", "email": "u@example.com"})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "magic-xyz") {
+		t.Fatal("must be allowed for existing user with token")
+	}
+	if users.updateRoleVal != domain.RoleCompanyAdmin || users.updateRoleID != 5 {
+		t.Errorf("role must be upgraded to company_admin, got id=%d role=%q", users.updateRoleID, users.updateRoleVal)
+	}
+	if users.updateCompanyID != 5 || users.updateCompanyVal != 42 {
+		t.Errorf("company_id must be updated to 42, got id=%d company=%d", users.updateCompanyID, users.updateCompanyVal)
+	}
+	if invs.updatedID != 9 || invs.updatedStatus != domain.InvitationStatusAccepted {
+		t.Errorf("invitation must be marked accepted, got id=%d status=%q", invs.updatedID, invs.updatedStatus)
+	}
+}
+
+// 既存 super_admin は招待を受けても降格しない。
+func TestUpsertUserFromIDToken_ExistingSuperAdmin_NotDowngradedByInvitation(t *testing.T) {
+	existing := &domain.User{ID: 1, CognitoSub: "ops", Email: "ops@example.com", Role: domain.RoleSuperAdmin}
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"ops": existing}}
+	invs := &fakeInvitationRepo{
+		pendingByToken: map[string]*domain.AdminInvitation{
+			"t": {ID: 1, CompanyID: 1, Email: "ops@example.com", Role: domain.RoleTrainee},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+	idToken := makeIDToken(t, map[string]any{"sub": "ops", "email": "ops@example.com"})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "t") {
+		t.Fatal("must be allowed")
+	}
+	if users.updateRoleVal != "" {
+		t.Errorf("super_admin must not be downgraded, but UpdateRole was called with %q", users.updateRoleVal)
 	}
 }
 

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -13,13 +13,13 @@ import (
 
 // fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
 type fakeUserRepo struct {
-	existingBySub  map[string]*domain.User
-	created        *domain.User
-	createErr      error
-	updateRoleID   uint64
-	updateRoleVal  string
-	updateCompanyID    uint64
-	updateCompanyVal   uint64
+	existingBySub    map[string]*domain.User
+	created          *domain.User
+	createErr        error
+	updateRoleID     uint64
+	updateRoleVal    string
+	updateCompanyID  uint64
+	updateCompanyVal uint64
 }
 
 func (r *fakeUserRepo) FindByCognitoSub(_ context.Context, sub string) (*domain.User, error) {

--- a/backend/internal/infra/ses/invitation_mail.go
+++ b/backend/internal/infra/ses/invitation_mail.go
@@ -14,8 +14,13 @@ import (
 //   - SES の SendEmail で両方提供しておくと、HTML を許容しないクライアントでもテキスト本文が読める
 //   - 受信側のフィッシング誤判定を避けるため、URL は本文中に普通の文字列として明示的に提示する
 //
-// displayName / companyName / role が空の場合は本文から該当行を省略する（過度に固定文言にしない）。
-func BuildInvitationMail(magicLink, displayName, companyName, role string) (subject, htmlBody, textBody string) {
+// role は usecase 側のシグネチャ整合のため受け取るが本文には出さない。
+// 一般受信者には social role の生値（company_admin / trainee 等）が伝わらないため、
+// 本文では「招待が届いている」事実と会社名・表示名のみを示し、ログイン後の機能体験で
+// 暗黙的に役割を理解してもらう設計（受諾画面と一致）。
+//
+// displayName / companyName が空の場合は本文から該当行を省略する。
+func BuildInvitationMail(magicLink, displayName, companyName, _ string) (subject, htmlBody, textBody string) {
 	subject = "FreStyle へようこそ — 管理者からの招待"
 
 	greeting := "FreStyle にご招待いただきありがとうございます。"
@@ -23,16 +28,9 @@ func BuildInvitationMail(magicLink, displayName, companyName, role string) (subj
 		greeting = fmt.Sprintf("%s さん、FreStyle にご招待いただきありがとうございます。", displayName)
 	}
 
-	scopeLines := []string{}
-	if companyName != "" {
-		scopeLines = append(scopeLines, fmt.Sprintf("- 招待元の会社: %s", companyName))
-	}
-	if role != "" {
-		scopeLines = append(scopeLines, fmt.Sprintf("- 付与される権限: %s", role))
-	}
 	scopeText := ""
-	if len(scopeLines) > 0 {
-		scopeText = "\n\n" + strings.Join(scopeLines, "\n")
+	if companyName != "" {
+		scopeText = fmt.Sprintf("\n\n- 招待元の会社: %s", companyName)
 	}
 
 	textBody = fmt.Sprintf(`%s
@@ -47,31 +45,25 @@ func BuildInvitationMail(magicLink, displayName, companyName, role string) (subj
 — FreStyle 運営事務局
 `, greeting, magicLink, scopeText)
 
-	htmlBody = buildInvitationHTML(magicLink, greeting, displayName, companyName, role)
+	htmlBody = buildInvitationHTML(magicLink, greeting, companyName)
 	return subject, htmlBody, textBody
 }
 
 // buildInvitationHTML は HTML 本文を組み立てる。受信者が入力した値はすべて html.EscapeString で
 // エスケープしてから埋め込み、HTML インジェクションを防ぐ。リンク URL は url.QueryEscape ではなく
 // HTML 属性向けに html.EscapeString で十分（URL 自体の組み立てはこの関数の責務外）。
-func buildInvitationHTML(magicLink, greeting, displayName, companyName, role string) string {
+func buildInvitationHTML(magicLink, greeting, companyName string) string {
 	var sb strings.Builder
 	sb.WriteString(`<!DOCTYPE html><html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif; color: #1f2937; line-height: 1.7;">`)
 	sb.WriteString(`<div style="max-width: 560px; margin: 0 auto; padding: 24px;">`)
 	sb.WriteString(`<h2 style="color: #111827;">FreStyle へようこそ</h2>`)
 	sb.WriteString(`<p>` + html.EscapeString(greeting) + `</p>`)
 
-	if companyName != "" || role != "" {
+	if companyName != "" {
 		sb.WriteString(`<ul style="background: #f9fafb; padding: 16px 24px; border-radius: 8px;">`)
-		if companyName != "" {
-			sb.WriteString(`<li>招待元の会社: <strong>` + html.EscapeString(companyName) + `</strong></li>`)
-		}
-		if role != "" {
-			sb.WriteString(`<li>付与される権限: <strong>` + html.EscapeString(role) + `</strong></li>`)
-		}
+		sb.WriteString(`<li>招待元の会社: <strong>` + html.EscapeString(companyName) + `</strong></li>`)
 		sb.WriteString(`</ul>`)
 	}
-	_ = displayName // displayName は greeting で既に使用済
 
 	sb.WriteString(`<p style="margin-top: 24px;">下記のボタンからログイン手続きにお進みください。</p>`)
 	sb.WriteString(`<p style="margin: 24px 0;"><a href="` + html.EscapeString(magicLink) + `" style="background: #4f46e5; color: #ffffff; padding: 12px 24px; border-radius: 6px; text-decoration: none; display: inline-block;">ログイン手続きへ進む</a></p>`)

--- a/backend/internal/infra/ses/invitation_mail_test.go
+++ b/backend/internal/infra/ses/invitation_mail_test.go
@@ -52,7 +52,25 @@ func TestBuildInvitationMail_EscapesHTMLInjection(t *testing.T) {
 func TestBuildInvitationMail_OmitsScopeWhenEmpty(t *testing.T) {
 	_, htmlBody, textBody := BuildInvitationMail("https://x", "", "", "")
 	if strings.Contains(htmlBody, "招待元の会社") || strings.Contains(textBody, "招待元の会社") {
-		t.Errorf("scope sections should be omitted when companyName/role are empty")
+		t.Errorf("scope sections should be omitted when companyName is empty")
+	}
+}
+
+// role の生値（company_admin / trainee 等）はメール本文に出さない。
+// 一般受信者には社内ロール体系の名称が伝わらないため、本文では会社名と表示名のみ示し、
+// 権限はログイン後の機能体験で暗黙的に理解してもらう設計。
+func TestBuildInvitationMail_DoesNotExposeRawRole(t *testing.T) {
+	for _, role := range []string{"company_admin", "trainee", "super_admin"} {
+		_, htmlBody, textBody := BuildInvitationMail("https://x", "", "ACME", role)
+		if strings.Contains(htmlBody, role) {
+			t.Errorf("htmlBody must not contain raw role %q, got: %s", role, htmlBody)
+		}
+		if strings.Contains(textBody, role) {
+			t.Errorf("textBody must not contain raw role %q, got: %s", role, textBody)
+		}
+		if strings.Contains(htmlBody, "付与される権限") || strings.Contains(textBody, "付与される権限") {
+			t.Errorf("body must not contain 付与される権限 label (role=%s)", role)
+		}
 	}
 }
 

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -15,8 +15,10 @@ type UserRepository interface {
 	Create(ctx context.Context, user *domain.User) error
 	// UpdateDisplayName は ProfilePage の「ニックネーム」変更で呼ばれる。
 	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
-	// UpdateRole は Cognito group → DB role 同期で呼ばれる。
+	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。
 	UpdateRole(ctx context.Context, userID uint64, role string) error
+	// UpdateCompanyID は既存ユーザーが招待を受けて company に紐付くときに呼ばれる。
+	UpdateCompanyID(ctx context.Context, userID uint64, companyID uint64) error
 }
 
 type userRepository struct {
@@ -67,4 +69,11 @@ func (r *userRepository) UpdateRole(ctx context.Context, userID uint64, role str
 		Model(&domain.User{}).
 		Where("id = ?", userID).
 		Update("role", role).Error
+}
+
+func (r *userRepository) UpdateCompanyID(ctx context.Context, userID uint64, companyID uint64) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ?", userID).
+		Update("company_id", companyID).Error
 }

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -26,6 +26,9 @@ func (s *stubUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) 
 func (s *stubUserRepo) UpdateRole(_ context.Context, _ uint64, _ string) error {
 	return s.err
 }
+func (s *stubUserRepo) UpdateCompanyID(_ context.Context, _ uint64, _ uint64) error {
+	return s.err
+}
 
 func TestGetCurrentUserUseCase_Found(t *testing.T) {
 	want := &domain.User{ID: 1, CognitoSub: "abc", Email: "u@example.com"}

--- a/frontend/src/pages/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/AcceptInvitationPage.tsx
@@ -11,9 +11,13 @@ import { useAcceptInvitation } from '../hooks/useAcceptInvitation';
  * URL: /invitations/accept?token=<UUID>
  *
  * メールから踏まれた直後の最初の画面。token を backend (`GET /invitations/accept/:token`)
- * で検証して招待先 company / role / displayName を表示し、ユーザーに「ログインへ進む」
+ * で検証して招待先 company / displayName を表示し、ユーザーに「ログインへ進む」
  * ボタンを押してもらう。ボタンを踏んだ時点で token は sessionStorage に保存済みなので、
- * Cognito Hosted UI 経由のログイン後 callback で読み出して使う。
+ * ログイン後 callback で読み出して使う。
+ *
+ * UI で role の生値（company_admin / trainee 等）は表示しない。
+ * 一般ユーザーには社内ロール体系の名称が伝わらないため、ログイン後の機能の出し分けで
+ * 暗黙的に体感してもらう設計。
  */
 export default function AcceptInvitationPage() {
   const { status } = useAcceptInvitation();
@@ -51,7 +55,6 @@ export default function AcceptInvitationPage() {
   }
 
   const { invitation } = status;
-  const roleLabel = roleLabels[invitation.role] ?? invitation.role;
 
   return (
     <AuthLayout
@@ -74,10 +77,6 @@ export default function AcceptInvitationPage() {
               <dd className="font-medium text-right">{invitation.companyName}</dd>
             </div>
           )}
-          <div className="flex justify-between gap-4">
-            <dt className="text-[var(--color-text-muted)]">付与される権限</dt>
-            <dd className="font-medium text-right">{roleLabel}</dd>
-          </div>
           {invitation.displayName && (
             <div className="flex justify-between gap-4">
               <dt className="text-[var(--color-text-muted)]">表示名</dt>
@@ -91,18 +90,10 @@ export default function AcceptInvitationPage() {
         </Link>
 
         <p className="text-xs text-[var(--color-text-muted)] text-center">
-          ボタンを押すと Cognito ログイン画面に遷移します。<br />
-          Google アカウントまたはメールアドレスでログインしてください。
+          ボタンを押すとログイン画面に進みます。<br />
+          Google アカウント、またはメールアドレス + パスワードでログインしてください。
         </p>
       </div>
     </AuthLayout>
   );
 }
-
-// バックエンドから返ってくる role の生値を、画面表示用の日本語ラベルに変換する。
-// 想定外の値は usecase 側で trainee に正規化済みだが、フォールバックとして生値をそのまま出す。
-const roleLabels: Record<string, string> = {
-  super_admin: '運営管理者',
-  company_admin: '会社管理者',
-  trainee: '受講者',
-};

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -92,7 +92,7 @@ export default function AdminInvitationsPage() {
     try {
       const created = await AdminInvitationRepository.create(form);
       setSuccess(
-        `${created.email} 宛に招待メールを送信しました。受信者は Cognito Hosted UI で初回パスワードを変更してログインしてください。`
+        `${created.email} 宛に招待メールを送信しました。受信者にメール内のリンクを開いてもらい、画面の案内に従ってログインしてもらってください。`
       );
       setForm((f) => ({ ...EMPTY_FORM, companyId: f.companyId }));
       await fetchAll();
@@ -143,8 +143,9 @@ export default function AdminInvitationsPage() {
         title="管理: メンバー招待"
         description={
           <>
-            メールアドレスを入力すると、Cognito 経由で一時パスワード付きの招待メールが送信されます。
-            受信者は初回ログイン時にパスワード変更を要求されます。
+            メールアドレスを入力すると、招待メールが送信されます。
+            受信者はメール内のリンクから FreStyle の受諾画面に進み、
+            Google アカウントまたはメールアドレスでログインしてアカウントが作成されます。
           </>
         }
       />

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -6,6 +6,7 @@ import AdminInvitationRepository, {
   CreateInvitationForm,
 } from '../repositories/AdminInvitationRepository';
 import CompanyRepository, { Company } from '../repositories/CompanyRepository';
+import AuthRepository, { UserInfo } from '../repositories/AuthRepository';
 import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
@@ -19,9 +20,15 @@ const EMPTY_FORM: CreateInvitationForm = {
   displayName: '',
 };
 
-// バックエンドが英語の Cognito エラーをそのまま返した場合のフォールバック日本語化。
-// バックエンドでカテゴリ化済みの日本語メッセージはそのまま通す。
+// バックエンドが英語のエラーコードをそのまま返した場合のフォールバック日本語化。
+// バックエンドでカテゴリ化済みの日本語メッセージ（message フィールド）はそのまま通す。
 function translateInviteError(raw: string): string {
+  if (raw.includes('super_admin_can_only_invite_company_admin')) {
+    return '運営は会社管理者のみ招待できます。受講者の招待は会社管理者から行ってください。';
+  }
+  if (raw.includes('company_admin_can_only_invite_trainee')) {
+    return '会社管理者が招待できるのは受講者のみです。';
+  }
   if (raw.includes('UsernameExistsException') || raw.includes('User account already exists')) {
     return 'このメールアドレスはすでに登録済みです。再招待は不要です。';
   }
@@ -41,6 +48,7 @@ export default function AdminInvitationsPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
 
+  const [me, setMe] = useState<UserInfo | null>(null);
   const [invitations, setInvitations] = useState<AdminInvitation[]>([]);
   const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
@@ -51,18 +59,37 @@ export default function AdminInvitationsPage() {
   const [cancelTarget, setCancelTarget] = useState<AdminInvitation | null>(null);
   const [canceling, setCanceling] = useState(false);
 
+  // 認可境界（SoD）に応じて招待 UI を切り替えるため、自分の role / companyId を取得する。
+  // backend 側でも同じ境界を強制しているので、フロントは UX 改善目的（不可能な選択肢を見せない）。
+  //   - super_admin → role=company_admin で固定 / company は任意選択
+  //   - company_admin → role=trainee で固定 / company は自社固定
+  const isSuperAdmin = me?.role === 'super_admin';
+  const isCompanyAdmin = me?.role === 'company_admin';
+
   const fetchAll = useCallback(async () => {
     setLoading(true);
     try {
-      const [data, cos] = await Promise.all([
+      const [user, data, cos] = await Promise.all([
+        AuthRepository.getCurrentUser(),
         AdminInvitationRepository.list(),
         CompanyRepository.list(),
       ]);
+      setMe(user);
       setInvitations(data);
       setCompanies(cos);
-      if (cos.length > 0 && form.companyId === 0) {
-        setForm((f) => ({ ...f, companyId: cos[0].id }));
-      }
+
+      // 役割に応じてフォームの初期値を上書きする。
+      const defaultRole: CreateInvitationForm['role'] =
+        user.role === 'super_admin' ? 'company_admin' : 'trainee';
+      const defaultCompanyId =
+        user.role === 'company_admin' && user.companyId
+          ? user.companyId
+          : cos[0]?.id ?? 0;
+      setForm((f) => ({
+        ...f,
+        role: defaultRole,
+        companyId: f.companyId === 0 ? defaultCompanyId : f.companyId,
+      }));
       setError(null);
     } catch (e) {
       setError('データの取得に失敗しました');
@@ -166,17 +193,29 @@ export default function AdminInvitationsPage() {
 
         <label className="block text-sm">
           <span className="block mb-1">会社 *</span>
-          <select
-            required
-            value={form.companyId}
-            onChange={(e) => setForm({ ...form, companyId: Number(e.target.value) })}
-            className="w-full border rounded px-2 py-1"
-          >
-            <option value={0} disabled>会社を選択してください</option>
-            {companies.map((c) => (
-              <option key={c.id} value={c.id}>{c.name}</option>
-            ))}
-          </select>
+          {isCompanyAdmin ? (
+            // CompanyAdmin は自社にしか招待を出せない仕様。会社名を表示するだけにする。
+            <input
+              type="text"
+              readOnly
+              value={
+                companies.find((c) => c.id === form.companyId)?.name ?? '所属会社'
+              }
+              className="w-full border rounded px-2 py-1 bg-[var(--color-surface-2)] text-[var(--color-text-muted)]"
+            />
+          ) : (
+            <select
+              required
+              value={form.companyId}
+              onChange={(e) => setForm({ ...form, companyId: Number(e.target.value) })}
+              className="w-full border rounded px-2 py-1"
+            >
+              <option value={0} disabled>会社を選択してください</option>
+              {companies.map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+          )}
         </label>
 
         <label className="block text-sm">
@@ -192,20 +231,26 @@ export default function AdminInvitationsPage() {
           />
         </label>
 
-        <label className="block text-sm">
-          <span className="block mb-1">ロール *</span>
-          <select
-            required
-            value={form.role}
-            onChange={(e) =>
-              setForm({ ...form, role: e.target.value as CreateInvitationForm['role'] })
+        {/*
+         * 役割は SoD ルールで自動決定する:
+         *   - SuperAdmin が招待 → 会社管理者 (company_admin) のみ
+         *   - CompanyAdmin が招待 → 受講者 (trainee) のみ
+         * select で誤った選択肢を露出させると backend の 403 で弾かれて UX が悪いので、
+         * 一律「役割は固定（変更不可）」と表示する。
+         */}
+        <div className="block text-sm">
+          <span className="block mb-1">役割</span>
+          <input
+            type="text"
+            readOnly
+            value={
+              isSuperAdmin
+                ? '会社管理者（招待先の会社の管理者）'
+                : '受講者（自社のメンバー）'
             }
-            className="w-full border rounded px-2 py-1"
-          >
-            <option value="trainee">Trainee（新卒研修対象）</option>
-            <option value="company_admin">CompanyAdmin（メンター）</option>
-          </select>
-        </label>
+            className="w-full border rounded px-2 py-1 bg-[var(--color-surface-2)] text-[var(--color-text-muted)]"
+          />
+        </div>
 
         <label className="block text-sm">
           <span className="block mb-1">表示名（任意）</span>

--- a/frontend/src/pages/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/AdminInvitationsPage.tsx
@@ -97,7 +97,6 @@ export default function AdminInvitationsPage() {
     } finally {
       setLoading(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -50,6 +50,10 @@ export interface UserInfo {
   sub?: string;
   groups?: string[];
   isAdmin?: boolean;
+  /** バックエンド users テーブルの role: super_admin / company_admin / trainee */
+  role?: string;
+  /** 所属する company の ID。SuperAdmin は null になり得る。 */
+  companyId?: number | null;
 }
 
 class AuthRepository {


### PR DESCRIPTION
## 概要

ユーザー指摘 2 件の対応:

1. **UI 文言**: 一般ユーザーに見える画面・メール本文から内部実装名（Cognito / Hosted UI）と生 role 値（company_admin / trainee）を削除
2. **既存ユーザーの role 昇格**: 過去に trainee として登録されているユーザーが新規 CompanyAdmin 招待を受けても役割が更新されないバグを修正

## 1. UI 文言修正

### Before / After

| 場所 | Before | After |
|---|---|---|
| AcceptInvitationPage | 「ボタンを押すと **Cognito** ログイン画面に遷移します」 | 「ボタンを押すとログイン画面に進みます」 |
| AcceptInvitationPage | 「付与される権限: **company_admin**」を表示 | 削除（招待元の会社 / 表示名のみ表示） |
| AdminInvitationsPage 送信成功 | 「受信者は **Cognito Hosted UI** で初回パスワードを変更...」 | 「受信者にメール内のリンクを開いてもらい、画面の案内に従ってログイン...」 |
| AdminInvitationsPage 説明 | 「**Cognito** 経由で一時パスワード付きの招待メール...」 | マジックリンク方式の自然な日本語に書き換え |
| 招待メール本文 | 「付与される権限: **company_admin**」を出力 | 削除（招待元の会社のみ表示） |

### 設計判断

role は内部用語として残し、UI / メール本文には絶対に出さない方針に統一。一般ユーザーが社内ロール体系を意識する必要がない（ログイン後の機能体験で暗黙的に理解してもらう）。

## 2. 既存ユーザーの role 昇格

### 問題

過去に何らかの形で trainee として登録済みのユーザーが後から CompanyAdmin として招待されても、`upsertUserFromIDToken` は \`existing != nil\` で処理を打ち切り、role / company_id を更新しなかった。実環境で fca2406070005 がこの状態に該当し、ログイン後に「管理」メニューが出ない問題が発生。

### 修正

\`auth_handler.upsertUserFromIDToken\` の既存ユーザー分岐に招待反映ロジックを追加:

```go
// 既存ユーザーでも token / email で pending invitation を引いて role/company を反映
if inv != nil && existing.Role != domain.RoleSuperAdmin {
    // trainee → company_admin の昇格のみ反映（降格はしない）
    if existing.Role == domain.RoleTrainee && inv.Role == domain.RoleCompanyAdmin {
        h.users.UpdateRole(ctx, existing.ID, domain.RoleCompanyAdmin)
    }
    // company_id が招待と異なる / 未設定なら更新
    if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
        h.users.UpdateCompanyID(ctx, existing.ID, inv.CompanyID)
    }
    h.invitations.UpdateStatus(ctx, inv.ID, domain.InvitationStatusAccepted)
}
```

ルール:
- **super_admin は降格しない**（招待での降格は不可）
- **trainee → company_admin の昇格のみ**（trainee → super_admin / company_admin → super_admin はしない）
- Cognito group admin は最強で super_admin に昇格（既存挙動）

### UserRepository に \`UpdateCompanyID\` を新設

## テスト

\`backend/internal/handler/auth_handler_test.go\` に 2 ケース追加:

- \`TestUpsertUserFromIDToken_ExistingTrainee_UpgradedByCompanyAdminInvitation\`
- \`TestUpsertUserFromIDToken_ExistingSuperAdmin_NotDowngradedByInvitation\`

\`backend/internal/infra/ses/invitation_mail_test.go\` に追加:

- \`TestBuildInvitationMail_DoesNotExposeRawRole\`（生 role が本文に出ない）

\`go test ./...\` 全 pass / \`npx tsc --noEmit\` クリーン。

## マージ後の動作（fca2406070005 の救済手順）

1. 本 PR を merge → cd-backend / cd-frontend を deploy
2. SuperAdmin として **fca2406070005 への新規 CompanyAdmin 招待を再作成**（古い招待は accepted 済で使えない）
3. fca2406070005 がメールリンクから入り直し → ログイン → 自動で \`role=company_admin\` + \`company_id=<該当>\` に更新される
4. 「管理」メニューが表示される