### PR TITLE
feat(auth): Welcome / オンボーディング画面を業界標準フローで実装

### DIFF
--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -5,12 +5,15 @@ import "time"
 // User はアプリケーション利用者のドメインモデル。
 // Spring Boot 側の entity.User と同じカラム構造を踏襲する。
 type User struct {
-	ID          uint64     `gorm:"primaryKey" json:"id"`
-	CognitoSub  string     `gorm:"column:cognito_sub;uniqueIndex" json:"cognitoSub"`
-	Email       string     `gorm:"column:email" json:"email"`
-	DisplayName string     `gorm:"column:display_name" json:"displayName"`
-	CompanyID   *uint64    `gorm:"column:company_id" json:"companyId,omitempty"`
-	Role        string     `gorm:"column:role" json:"role"`
+	ID          uint64  `gorm:"primaryKey" json:"id"`
+	CognitoSub  string  `gorm:"column:cognito_sub;uniqueIndex" json:"cognitoSub"`
+	Email       string  `gorm:"column:email" json:"email"`
+	DisplayName string  `gorm:"column:display_name" json:"displayName"`
+	CompanyID   *uint64 `gorm:"column:company_id" json:"companyId,omitempty"`
+	Role        string  `gorm:"column:role" json:"role"`
+	// OnboardedAt は Welcome 画面の完了日時。NULL なら初回ログイン直後の Welcome を表示する。
+	// 一度値が入ったら二度と変えない（再オンボーディングは別 issue）。
+	OnboardedAt *time.Time `gorm:"column:onboarded_at" json:"onboardedAt,omitempty"`
 	CreatedAt   time.Time  `gorm:"column:created_at" json:"createdAt"`
 	UpdatedAt   time.Time  `gorm:"column:updated_at" json:"updatedAt"`
 	DeletedAt   *time.Time `gorm:"column:deleted_at" json:"deletedAt,omitempty"`

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -93,6 +93,8 @@ func (h *AuthHandler) Me(c *gin.Context) {
 		"updatedAt":   user.UpdatedAt,
 		"groups":      groups,
 		"isAdmin":     isAdmin,
+		// onboarded: フロントが /welcome リダイレクト判定に使う（true なら Welcome 表示済）。
+		"onboarded": user.OnboardedAt != nil,
 	})
 }
 

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -48,6 +48,9 @@ func (r *fakeUserRepo) UpdateCompanyID(_ context.Context, id uint64, companyID u
 	r.updateCompanyID, r.updateCompanyVal = id, companyID
 	return nil
 }
+func (r *fakeUserRepo) MarkOnboarded(_ context.Context, _ uint64) error {
+	return nil
+}
 
 // fakeInvitationRepo は AdminInvitationRepository の最小スタブ。
 // FindPendingByEmail / FindPendingByToken の振る舞いをカスタムにしてテストする。

--- a/backend/internal/handler/onboarding_handler.go
+++ b/backend/internal/handler/onboarding_handler.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// OnboardingHandler は Welcome 画面の完了通知を受ける認証必須エンドポイント。
+// 別途 ProfileHandler に同居させる選択肢もあったが、責務（onboarding 状態管理）が
+// 明確に独立しているので別 handler に切り出す（将来「再オンボーディング」「skipped」
+// などのバリエーションが増えても影響範囲を局所化できる）。
+type OnboardingHandler struct {
+	complete *usecase.CompleteOnboardingUseCase
+}
+
+func NewOnboardingHandler(complete *usecase.CompleteOnboardingUseCase) *OnboardingHandler {
+	return &OnboardingHandler{complete: complete}
+}
+
+// Complete は POST /api/v2/profile/me/onboarding/complete。
+// 自分自身の users.onboarded_at を NOW() に更新する。
+// repo 側で IS NULL ガード付きなので冪等（複数回呼んでも初回日時が保持される）。
+func (h *OnboardingHandler) Complete(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	if err := h.complete.Execute(c.Request.Context(), uid); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/backend/internal/handler/routes_profile.go
+++ b/backend/internal/handler/routes_profile.go
@@ -41,6 +41,11 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	// 旧 path /user-stats/:userId と Spring 風 /users/:userId/stats の両方を提供する。
 	g.GET("/user-stats/:userId", statsHandler.Get)
 	g.GET("/users/:userId/stats", statsHandler.Get)
+
+	// Welcome / オンボーディング完了通知。自分自身の users.onboarded_at を NOW() で更新。
+	// 詳細設計: frestyle-pdm docs/auth/auth-flow-screen-transitions.md
+	onboardingHandler := NewOnboardingHandler(usecase.NewCompleteOnboardingUseCase(deps.userRepo))
+	g.POST("/profile/me/onboarding/complete", onboardingHandler.Complete)
 }
 
 // newProfileImagePresignerOrFallback は本番では infra/s3.Presigner で real な PUT presign を返し、

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"gorm.io/gorm"
@@ -19,6 +20,9 @@ type UserRepository interface {
 	UpdateRole(ctx context.Context, userID uint64, role string) error
 	// UpdateCompanyID は既存ユーザーが招待を受けて company に紐付くときに呼ばれる。
 	UpdateCompanyID(ctx context.Context, userID uint64, companyID uint64) error
+	// MarkOnboarded は Welcome 画面の「はじめる」ボタン押下時に呼ばれ、
+	// onboarded_at = NOW() に更新する。冪等（既に値が入っていても上書きしない）。
+	MarkOnboarded(ctx context.Context, userID uint64) error
 }
 
 type userRepository struct {
@@ -76,4 +80,14 @@ func (r *userRepository) UpdateCompanyID(ctx context.Context, userID uint64, com
 		Model(&domain.User{}).
 		Where("id = ?", userID).
 		Update("company_id", companyID).Error
+}
+
+func (r *userRepository) MarkOnboarded(ctx context.Context, userID uint64) error {
+	// 冪等性: 既に onboarded_at が入っているレコードには上書きしない（IS NULL でガード）。
+	// これで「Welcome 画面に戻ってもう一度押された」場合でも初回日時を保持できる。
+	now := time.Now().UTC()
+	return r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ? AND onboarded_at IS NULL", userID).
+		Update("onboarded_at", now).Error
 }

--- a/backend/internal/usecase/complete_onboarding_usecase.go
+++ b/backend/internal/usecase/complete_onboarding_usecase.go
@@ -1,0 +1,30 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// CompleteOnboardingUseCase はユーザーが Welcome 画面の「はじめる」を押した時に
+// users.onboarded_at を NOW() で更新する。
+//
+// 仕様:
+//   - 既に値が入っているユーザーに対しても 200 を返す（冪等）。repo の MarkOnboarded が
+//     IS NULL ガード付きなので二度押しでも初回日時は保持される。
+//   - userID は handler で current user から渡す前提（API は自分自身しか変更不可）。
+type CompleteOnboardingUseCase struct {
+	users repository.UserRepository
+}
+
+func NewCompleteOnboardingUseCase(users repository.UserRepository) *CompleteOnboardingUseCase {
+	return &CompleteOnboardingUseCase{users: users}
+}
+
+func (u *CompleteOnboardingUseCase) Execute(ctx context.Context, userID uint64) error {
+	if userID == 0 {
+		return errors.New("userID is required")
+	}
+	return u.users.MarkOnboarded(ctx, userID)
+}

--- a/backend/internal/usecase/complete_onboarding_usecase_test.go
+++ b/backend/internal/usecase/complete_onboarding_usecase_test.go
@@ -1,0 +1,43 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type stubMarkOnboardedRepo struct {
+	stubUserRepo
+	calledID uint64
+	err      error
+}
+
+func (s *stubMarkOnboardedRepo) MarkOnboarded(_ context.Context, userID uint64) error {
+	s.calledID = userID
+	return s.err
+}
+
+func TestCompleteOnboarding_RequiresUserID(t *testing.T) {
+	uc := NewCompleteOnboardingUseCase(&stubMarkOnboardedRepo{})
+	if err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error for userID=0")
+	}
+}
+
+func TestCompleteOnboarding_DelegatesToRepo(t *testing.T) {
+	repo := &stubMarkOnboardedRepo{}
+	uc := NewCompleteOnboardingUseCase(repo)
+	if err := uc.Execute(context.Background(), 42); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if repo.calledID != 42 {
+		t.Errorf("expected MarkOnboarded(42), got %d", repo.calledID)
+	}
+}
+
+func TestCompleteOnboarding_RepoErrorBubbles(t *testing.T) {
+	uc := NewCompleteOnboardingUseCase(&stubMarkOnboardedRepo{err: errors.New("db down")})
+	if err := uc.Execute(context.Background(), 1); err == nil {
+		t.Fatal("expected error to bubble")
+	}
+}

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -29,6 +29,9 @@ func (s *stubUserRepo) UpdateRole(_ context.Context, _ uint64, _ string) error {
 func (s *stubUserRepo) UpdateCompanyID(_ context.Context, _ uint64, _ uint64) error {
 	return s.err
 }
+func (s *stubUserRepo) MarkOnboarded(_ context.Context, _ uint64) error {
+	return s.err
+}
 
 func TestGetCurrentUserUseCase_Found(t *testing.T) {
 	want := &domain.User{ID: 1, CognitoSub: "abc", Email: "u@example.com"}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ const ConfirmPage = lazy(() => import('./pages/ConfirmPage'));
 const ForgotPasswordPage = lazy(() => import('./pages/ForgotPasswordPage'));
 const ConfirmForgotPasswordPage = lazy(() => import('./pages/ConfirmForgotPasswordPage'));
 const AcceptInvitationPage = lazy(() => import('./pages/AcceptInvitationPage'));
+const WelcomePage = lazy(() => import('./pages/WelcomePage'));
 
 // 認証必要ページ
 const MenuPage = lazy(() => import('./pages/MenuPage'));
@@ -72,6 +73,18 @@ export default function App() {
       />
       {/* 招待マジックリンクの受諾画面（認証不要・SES メールから踏まれる） */}
       <Route path="/invitations/accept" element={<AcceptInvitationPage />} />
+
+      {/* Welcome / オンボーディング（認証必須・AppShell 外で全画面表示） */}
+      <Route
+        path="/welcome"
+        element={
+          <AuthInitializer>
+            <Protected>
+              <WelcomePage />
+            </Protected>
+          </AuthInitializer>
+        }
+      />
 
       {/* 認証が必要（AppShellレイアウト内） */}
       <Route

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -32,13 +32,15 @@ export const AUTH = {
   me: `${API_V2}/auth/me`,
 } as const;
 
-/** プロフィール / アイコン画像 / 統計 */
+/** プロフィール / アイコン画像 / 統計 / オンボーディング */
 export const PROFILE = {
   me: `${API_V2}/profile/me`,
   meUpdate: `${API_V2}/profile/me/update`,
   meImagePresignedUrl: `${API_V2}/profile/me/image/presigned-url`,
   /** GET /users/me/stats — 自分の使い方統計 */
   meStats: `${API_V2}/users/me/stats`,
+  /** POST /profile/me/onboarding/complete — Welcome 画面の「はじめる」押下で onboarded_at を更新 */
+  meOnboardingComplete: `${API_V2}/profile/me/onboarding/complete`,
 } as const;
 
 /** AI チャット（セッション・メッセージ・言い換え） */

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import AuthLayout from '../components/AuthLayout';
+import PrimaryButton from '../components/PrimaryButton';
+import authRepository, { UserInfo } from '../repositories/AuthRepository';
+import { markOnboarded } from '../store/authSlice';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import { logger } from '../lib/logger';
+
+/**
+ * Welcome / オンボーディング画面（初回ログイン直後にのみ表示）。
+ *
+ * 業界標準 (Slack / Notion / Linear) に倣った 1 画面 / 1 ボタン構成。
+ * プロフィール詳細などはあえて聞かず、「ようこそ」と「できること」を簡単に示してから
+ * 「はじめる」で onboarded_at を更新してホームに遷移させる。
+ *
+ * ガード:
+ *   - 既に onboarded === true なら即 / にリダイレクト（二度通させない）
+ *
+ * 詳細設計: frestyle-pdm/docs/auth/auth-flow-screen-transitions.md §4
+ */
+export default function WelcomePage() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const onboarded = useSelector((state: RootState) => state.auth.onboarded);
+
+  const [me, setMe] = useState<UserInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  // 既に Welcome 完了済みの人がブラウザバック等でこの画面に来たら即座にホームへ。
+  useEffect(() => {
+    if (onboarded) {
+      navigate('/', { replace: true });
+    }
+  }, [onboarded, navigate]);
+
+  useEffect(() => {
+    let cancelled = false;
+    authRepository
+      .getCurrentUser()
+      .then((user) => {
+        if (cancelled) return;
+        setMe(user);
+      })
+      .catch((err) => {
+        logger.error(err);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleStart = async () => {
+    setSubmitting(true);
+    try {
+      await authRepository.completeOnboarding();
+      // store を即時更新して Protected の /welcome リダイレクトループを回避
+      dispatch(markOnboarded());
+      navigate('/', { replace: true, state: { toast: 'FreStyle へようこそ！' } });
+    } catch (err) {
+      logger.error(err);
+      // 失敗してもブロックしない: store だけ更新してホームに進ませる（次回 /auth/me で
+      // 同期される。重要操作ではないので UX を優先）。
+      dispatch(markOnboarded());
+      navigate('/', { replace: true });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <Loading fullscreen message="準備中..." />;
+  }
+
+  const roleLabel = me?.role ? roleLabels[me.role] ?? '' : '';
+  const greetName = me?.displayName || me?.name || '';
+
+  return (
+    <AuthLayout title="FreStyle へようこそ">
+      <div className="space-y-5">
+        <p className="text-[var(--color-text-muted)] leading-relaxed">
+          {greetName ? `${greetName} さん、` : ''}
+          ご登録ありがとうございます。
+          {roleLabel && (
+            <>
+              <br />
+              あなたは <strong className="text-[var(--color-text)]">{roleLabel}</strong>
+              {' '}としてアカウントが作成されました。
+            </>
+          )}
+        </p>
+
+        <div className="bg-[var(--color-surface-alt)] rounded-lg p-4 text-sm">
+          <h3 className="font-bold mb-2">FreStyle でできること</h3>
+          <ul className="list-disc list-inside space-y-1 text-[var(--color-text-muted)]">
+            <li>AI チャットでビジネスメールの添削や言い換え提案</li>
+            <li>練習モードでビジネスシナリオのロールプレイ</li>
+            <li>学習ノート / お気に入りフレーズ / 進捗の可視化</li>
+            {(me?.role === 'company_admin' || me?.role === 'super_admin') && (
+              <li>管理画面で自社メンバーの招待 / 管理</li>
+            )}
+          </ul>
+        </div>
+
+        <p className="text-xs text-[var(--color-text-muted)]">
+          表示名やプロフィール画像は、ログイン後の「プロフィール」画面でいつでも変更できます。
+        </p>
+
+        <PrimaryButton type="button" onClick={handleStart} loading={submitting}>
+          はじめる
+        </PrimaryButton>
+      </div>
+    </AuthLayout>
+  );
+}
+
+const roleLabels: Record<string, string> = {
+  super_admin: '運営管理者',
+  company_admin: '会社管理者',
+  trainee: '受講者',
+};

--- a/frontend/src/pages/__tests__/WelcomePage.test.tsx
+++ b/frontend/src/pages/__tests__/WelcomePage.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import authReducer from '../../store/authSlice';
+import authRepository from '../../repositories/AuthRepository';
+import WelcomePage from '../WelcomePage';
+
+vi.mock('../../repositories/AuthRepository');
+
+function renderPage(opts?: { onboarded?: boolean }) {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: {
+        isAuthenticated: true,
+        loading: false,
+        isAdmin: false,
+        onboarded: opts?.onboarded ?? false,
+      },
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/welcome']}>
+        <Routes>
+          <Route path="/welcome" element={<WelcomePage />} />
+          <Route path="/" element={<div>ホーム</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+describe('WelcomePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('役割と表示名で挨拶し、できることを表示する', async () => {
+    vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
+      id: 1,
+      email: 't@example.com',
+      role: 'company_admin',
+      displayName: '佐藤',
+      onboarded: false,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/佐藤 さん/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/会社管理者/)).toBeInTheDocument();
+    expect(
+      screen.getByText('管理画面で自社メンバーの招待 / 管理')
+    ).toBeInTheDocument();
+  });
+
+  it('trainee には管理機能の項目を出さない', async () => {
+    vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
+      id: 2,
+      role: 'trainee',
+      displayName: '山田',
+      onboarded: false,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/山田 さん/)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText('管理画面で自社メンバーの招待 / 管理')
+    ).not.toBeInTheDocument();
+  });
+
+  it('「はじめる」を押すと completeOnboarding を呼んでホームに遷移', async () => {
+    vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
+      id: 1,
+      role: 'trainee',
+      displayName: '佐藤',
+      onboarded: false,
+    });
+    vi.mocked(authRepository.completeOnboarding).mockResolvedValue();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'はじめる' })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'はじめる' }));
+
+    await waitFor(() => {
+      expect(authRepository.completeOnboarding).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('ホーム')).toBeInTheDocument();
+    });
+  });
+
+  // onboarded=true の状態で /welcome に来たら即ホームへリダイレクトする。
+  it('onboarded=true で /welcome に来た場合は即ホームへリダイレクト', async () => {
+    vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
+      id: 1,
+      role: 'trainee',
+      onboarded: true,
+    });
+
+    renderPage({ onboarded: true });
+
+    await waitFor(() => {
+      expect(screen.getByText('ホーム')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/repositories/AuthRepository.ts
+++ b/frontend/src/repositories/AuthRepository.ts
@@ -1,5 +1,5 @@
 import apiClient from '../lib/axios';
-import { AUTH } from '../constants/apiRoutes';
+import { AUTH, PROFILE } from '../constants/apiRoutes';
 
 /**
  * 認証リポジトリ
@@ -54,6 +54,10 @@ export interface UserInfo {
   role?: string;
   /** 所属する company の ID。SuperAdmin は null になり得る。 */
   companyId?: number | null;
+  /** Welcome 画面を完了しているか。false なら初回ログイン直後の Welcome へ誘導する。 */
+  onboarded?: boolean;
+  /** /auth/me が返す表示名（招待時に displayName として登録された値） */
+  displayName?: string;
 }
 
 class AuthRepository {
@@ -130,6 +134,14 @@ class AuthRepository {
    */
   async refreshToken(): Promise<void> {
     await apiClient.post(AUTH.refreshToken);
+  }
+
+  /**
+   * Welcome / オンボーディング完了通知。
+   * users.onboarded_at を NOW() で更新（IS NULL ガード付きで冪等）。
+   */
+  async completeOnboarding(): Promise<void> {
+    await apiClient.post(PROFILE.meOnboardingComplete);
   }
 }
 

--- a/frontend/src/store/__tests__/authSlice.test.ts
+++ b/frontend/src/store/__tests__/authSlice.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import authReducer, { setAuthData, setAuthenticated, clearAuth, finishLoading } from '../authSlice';
+import authReducer, {
+  setAuthData,
+  setAuthenticated,
+  markOnboarded,
+  clearAuth,
+  finishLoading,
+} from '../authSlice';
 
 describe('authSlice', () => {
-  const initialState = { isAuthenticated: false, loading: true, isAdmin: false };
+  const initialState = {
+    isAuthenticated: false,
+    loading: true,
+    isAdmin: false,
+    onboarded: false,
+  };
 
-  it('初期状態はisAuthenticated=false, loading=true, isAdmin=false', () => {
+  it('初期状態はisAuthenticated=false, loading=true, isAdmin=false, onboarded=false', () => {
     const state = authReducer(undefined, { type: 'unknown' });
     expect(state).toEqual(initialState);
   });
@@ -22,9 +33,15 @@ describe('authSlice', () => {
   });
 
   it('setAuthDataでpayload未指定の場合は既存のisAdminを保持する', () => {
-    const adminState = { isAuthenticated: true, loading: false, isAdmin: true };
+    const adminState = { isAuthenticated: true, loading: false, isAdmin: true, onboarded: true };
     const state = authReducer(adminState, setAuthData());
     expect(state.isAdmin).toBe(true);
+    expect(state.onboarded).toBe(true);
+  });
+
+  it('setAuthDataでpayload.onboarded=trueを渡すとonboardedがtrueになる', () => {
+    const state = authReducer(initialState, setAuthData({ onboarded: true }));
+    expect(state.onboarded).toBe(true);
   });
 
   it('setAuthenticatedでisAuthenticated=true, loading=falseになる', () => {
@@ -35,17 +52,28 @@ describe('authSlice', () => {
   });
 
   it('setAuthenticatedでpayload未指定の場合は既存のisAdminを保持する', () => {
-    const adminState = { isAuthenticated: true, loading: false, isAdmin: true };
+    const adminState = { isAuthenticated: true, loading: false, isAdmin: true, onboarded: true };
     const state = authReducer(adminState, setAuthenticated());
     expect(state.isAdmin).toBe(true);
   });
 
-  it('clearAuthでisAuthenticated=false, loading=false, isAdmin=falseになる', () => {
-    const authenticatedState = { isAuthenticated: true, loading: false, isAdmin: true };
+  it('markOnboardedでonboardedがtrueになる', () => {
+    const state = authReducer(initialState, markOnboarded());
+    expect(state.onboarded).toBe(true);
+  });
+
+  it('clearAuthでisAuthenticated=false, loading=false, isAdmin=false, onboarded=falseになる', () => {
+    const authenticatedState = {
+      isAuthenticated: true,
+      loading: false,
+      isAdmin: true,
+      onboarded: true,
+    };
     const state = authReducer(authenticatedState, clearAuth());
     expect(state.isAuthenticated).toBe(false);
     expect(state.loading).toBe(false);
     expect(state.isAdmin).toBe(false);
+    expect(state.onboarded).toBe(false);
   });
 
   it('finishLoadingでloading=falseになりisAuthenticatedは変わらない', () => {

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -5,34 +5,54 @@ const initialState: AuthState = {
   isAuthenticated: false,
   loading: true,
   isAdmin: false,
+  onboarded: false,
 };
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setAuthData(state, action: PayloadAction<{ isAdmin?: boolean } | undefined>) {
+    setAuthData(
+      state,
+      action: PayloadAction<{ isAdmin?: boolean; onboarded?: boolean } | undefined>
+    ) {
       state.isAuthenticated = true;
       state.loading = false;
-      // payload.isAdmin が undefined のときは現在の state を維持する
-      // (caller が isAdmin を明示しない再認証で誤って権限を失わせないため)
+      // payload.isAdmin / onboarded が undefined のときは現在の state を維持する
+      // (caller が値を明示しない再認証で誤って権限を失わせないため)
       if (action.payload?.isAdmin !== undefined) {
         state.isAdmin = action.payload.isAdmin;
+      }
+      if (action.payload?.onboarded !== undefined) {
+        state.onboarded = action.payload.onboarded;
       }
     },
 
-    setAuthenticated(state, action: PayloadAction<{ isAdmin?: boolean } | undefined>) {
+    setAuthenticated(
+      state,
+      action: PayloadAction<{ isAdmin?: boolean; onboarded?: boolean } | undefined>
+    ) {
       state.isAuthenticated = true;
       state.loading = false;
       if (action.payload?.isAdmin !== undefined) {
         state.isAdmin = action.payload.isAdmin;
       }
+      if (action.payload?.onboarded !== undefined) {
+        state.onboarded = action.payload.onboarded;
+      }
+    },
+
+    /** Welcome 画面で「はじめる」を押した直後に dispatch する。store を即時更新して
+     *  Protected の /welcome リダイレクトループを回避する（API 側は IS NULL ガードで冪等）。 */
+    markOnboarded(state) {
+      state.onboarded = true;
     },
 
     clearAuth(state) {
       state.isAuthenticated = false;
       state.loading = false;
       state.isAdmin = false;
+      state.onboarded = false;
     },
 
     finishLoading(state) {
@@ -41,5 +61,6 @@ const authSlice = createSlice({
   },
 });
 
-export const { setAuthData, setAuthenticated, clearAuth, finishLoading } = authSlice.actions;
+export const { setAuthData, setAuthenticated, markOnboarded, clearAuth, finishLoading } =
+  authSlice.actions;
 export default authSlice.reducer;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -98,6 +98,12 @@ export interface AuthState {
   isAuthenticated: boolean;
   loading: boolean;
   isAdmin: boolean;
+  /**
+   * Welcome / オンボーディングを完了済みかどうか。
+   * 未認証 / 未確定の状態（loading 中）は false。確定後は backend の users.onboarded_at の
+   * 有無に応じてセットされる。Protected で /welcome リダイレクト判定に使う。
+   */
+  onboarded: boolean;
 }
 
 /** 言い換え提案結果 */

--- a/frontend/src/utils/AuthInitializer.tsx
+++ b/frontend/src/utils/AuthInitializer.tsx
@@ -17,7 +17,14 @@ export default function AuthInitializer({ children }: AuthInitializerProps) {
     const checkAuth = async () => {
       try {
         const me = await authRepository.getCurrentUser();
-        dispatch(setAuthData({ isAdmin: !!me.isAdmin }));
+        dispatch(
+          setAuthData({
+            isAdmin: !!me.isAdmin,
+            // Welcome 画面に飛ばすかの判定を Protected で使う。
+            // backend から undefined が返ってきた場合は完了扱い（既存ユーザー保護）。
+            onboarded: me.onboarded ?? true,
+          })
+        );
       } catch {
         dispatch(clearAuth());
       } finally {

--- a/frontend/src/utils/Protected.tsx
+++ b/frontend/src/utils/Protected.tsx
@@ -1,19 +1,32 @@
 import { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 import type { RootState } from '../store';
 
 interface ProtectedProps {
   children: ReactNode;
 }
 
+/**
+ * 認証必須ルートのガード。
+ *
+ * 1. 未認証 → /login
+ * 2. 認証済 + onboarded === false → /welcome（初回オンボーディング）
+ * 3. 認証済 + onboarded === true → 子コンポーネントを描画
+ *
+ * /welcome 自体への navigate ループを避けるため、現在 path が /welcome の場合は
+ * onboarded 判定を skip する（WelcomePage 側でガード）。
+ */
 export default function Protected({ children }: ProtectedProps) {
-  const isAuthenticated = useSelector(
-    (state: RootState) => state.auth.isAuthenticated
-  );
+  const { isAuthenticated, onboarded } = useSelector((state: RootState) => state.auth);
+  const location = useLocation();
 
   if (!isAuthenticated) {
     return <Navigate to="/login" replace />;
+  }
+
+  if (!onboarded && location.pathname !== '/welcome') {
+    return <Navigate to="/welcome" replace />;
   }
 
   return children;

--- a/frontend/src/utils/__tests__/Protected.test.tsx
+++ b/frontend/src/utils/__tests__/Protected.test.tsx
@@ -6,11 +6,13 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import Protected from '../Protected';
 import authReducer from '../../store/authSlice';
 
-function renderWithAuth(isAuthenticated: boolean) {
+function renderWithAuth(isAuthenticated: boolean, onboarded: boolean = true) {
   const store = configureStore({
     reducer: { auth: authReducer },
     preloadedState: {
-      auth: { isAuthenticated, loading: false },
+      // onboarded=true デフォルトで /welcome リダイレクトを回避（既存テストの意図を維持）。
+      // /welcome リダイレクト経路は別テストでカバー。
+      auth: { isAuthenticated, loading: false, isAdmin: false, onboarded },
     },
   });
 
@@ -51,6 +53,36 @@ describe('Protected', () => {
 
   it('未認証の場合、childrenを表示しない', () => {
     renderWithAuth(false);
+    expect(screen.queryByText('保護されたコンテンツ')).not.toBeInTheDocument();
+  });
+
+  // Welcome 未完了（onboarded=false）の認証済ユーザーは /welcome にリダイレクトされる。
+  it('認証済 + onboarded=false の場合、/welcome にリダイレクトする', () => {
+    const store = configureStore({
+      reducer: { auth: authReducer },
+      preloadedState: {
+        auth: { isAuthenticated: true, loading: false, isAdmin: false, onboarded: false },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/protected']}>
+          <Routes>
+            <Route
+              path="/protected"
+              element={
+                <Protected>
+                  <div>保護されたコンテンツ</div>
+                </Protected>
+              }
+            />
+            <Route path="/welcome" element={<div>Welcome 画面</div>} />
+            <Route path="/login" element={<div>ログインページ</div>} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.getByText('Welcome 画面')).toBeInTheDocument();
     expect(screen.queryByText('保護されたコンテンツ')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要

BtoB SaaS の招待〜認証フローの業界標準（業界標準 SaaS / 業界標準 SaaS / 業界標準 SaaS）に倣い、初回ログイン直後の Welcome 画面を **1 画面 / 1 ボタン構成** で追加します。

設計詳細は [frestyle-pdm/docs/auth/auth-flow-screen-transitions.md §4](https://github.com/norman6464/frestyle-pdm/blob/main/docs/auth/auth-flow-screen-transitions.md) 参照。

## 画面遷移（追加分）

\`\`\`
[受諾画面] → [Cognito ログイン] → [/login/callback]
                                      ↓
                                 onboarded?
                                  ├─ false → /welcome（NEW）
                                  │           ├─「はじめる」ボタン
                                  │           ↓
                                  │       onboarded_at = NOW()
                                  │           ↓
                                  └─ true → /  ←─────────┘
\`\`\`

## Backend

| 変更 | 内容 |
|---|---|
| \`domain.User.OnboardedAt *time.Time\` | AutoMigrate で users.onboarded_at を追加 |
| \`UserRepository.MarkOnboarded\` | IS NULL ガード付きで冪等更新 |
| \`usecase.CompleteOnboardingUseCase\` | 単純な委譲 + userID validation |
| \`handler.OnboardingHandler.Complete\` | POST /api/v2/profile/me/onboarding/complete |
| \`/auth/me\` レスポンス | \`onboarded: bool\` を追加 |

## Frontend

| 変更 | 内容 |
|---|---|
| \`pages/WelcomePage.tsx\` | 役割ラベル + 機能紹介 + 「はじめる」ボタン |
| \`App.tsx\` /welcome ルート | AppShell 外で全画面表示 |
| \`Protected.tsx\` | onboarded === false なら /welcome へ |
| \`store/authSlice.ts\` | \`onboarded\` フィールド + \`markOnboarded\` action |
| \`AuthRepository.completeOnboarding\` | API 薄ラッパ |
| \`UserInfo\` / \`AuthState\` | onboarded / displayName を追加 |

## UX 設計のポイント

- **1 画面 / 1 ボタン**: ステップウィザードにせず、第一印象で機能を触ってもらうことを優先
- 役割ラベル（運営管理者 / 会社管理者 / 受講者）を表示
- CompanyAdmin / SuperAdmin には「管理画面で自社メンバーの招待 / 管理」を追加表示
- 「表示名やプロフィール画像は、ログイン後の『プロフィール』画面でいつでも変更できます」と明記
- backend は IS NULL ガードで冪等。フロントは store 即時更新でリダイレクトループ回避

## テスト

- **Backend**: \`CompleteOnboarding\` 3 ケース + 既存 stub に \`MarkOnboarded\` 追加で全 pass
- **Frontend**: \`WelcomePage\` 4 ケース + \`Protected\` /welcome リダイレクト 1 ケース + \`authSlice\` の \`markOnboarded\` / \`onboarded\` payload 関連 3 ケース。全 **2233 tests pass**

## 既存ユーザーへの影響

- 既存ユーザー（onboarded_at が NULL）はマイグレーション直後の初回ログインで /welcome を 1 度だけ通る
- バックエンド側の \`/auth/me\` から \`onboarded\` が undefined で返った場合（古い image を踏んだ場合）はフロント側で \`true\` 扱い（既存ユーザー誤誘導を防ぐ）

## 関連

- 設計: [frestyle-pdm/docs/auth/auth-flow-screen-transitions.md](https://github.com/norman6464/frestyle-pdm/blob/main/docs/auth/auth-flow-screen-transitions.md)
- 直近マージ: PR #1638（UI 文言修正・既存ユーザー role 昇格・招待 SoD ルール）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* ユーザー初回ログイン時のオンボーディングフローが追加されました
* ウェルカムページでユーザーロール情報を表示
* オンボーディング完了まで本体機能へのアクセスが制限されます
* オンボーディング状態の追跡と管理機能を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
