### PR TITLE
fix(bedrock): default model を ap-northeast-1 で ACTIVE な claude-haiku-4-5 に変更

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -88,8 +88,15 @@ func Load() (*Config, error) {
 			NoteImagesCDNBase: getEnvOrDefault("NOTE_IMAGES_CDN_URL", ""),
 		},
 		Bedrock: BedrockConfig{
-			Region:  getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
-			ModelID: getEnvOrDefault("BEDROCK_MODEL_ID", "anthropic.claude-3-5-haiku-20241022-v1:0"),
+			Region: getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
+			// ap-northeast-1 で ACTIVE な Anthropic モデルを default にする。
+			// 旧 default の "anthropic.claude-3-5-haiku-20241022-v1:0" は当 region に存在せず
+			// Bedrock Converse API が ValidationException: invalid model identifier を返していた
+			// （2026-05-06 本番でユーザーから AI チャット返信なしの報告で発覚）。
+			// 利用可能 model 確認:
+			//   aws bedrock list-foundation-models --region ap-northeast-1 \
+			//     --query 'modelSummaries[?providerName==`Anthropic`].modelId'
+			ModelID: getEnvOrDefault("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-20251001-v1:0"),
 		},
 		DynamoDB: DynamoDBConfig{
 			Region:      getEnvOrDefault("AWS_REGION", "ap-northeast-1"),


### PR DESCRIPTION
## 緊急: 本番 AI チャットが 0 件返信になる問題の修正

ECS ログ:
\`\`\`
AiChat send message failed: bedrock converse: bedrock: converse:
ValidationException: The provided model identifier is invalid.
\`\`\`

## 原因

\`config.go\` の default \`anthropic.claude-3-5-haiku-20241022-v1:0\` は ap-northeast-1 から消失（モデル世代更新）。

\`\`\`bash
$ aws bedrock list-foundation-models --region ap-northeast-1 \\
    --query 'modelSummaries[?providerName==\`Anthropic\`].modelId'
# claude-3-5-haiku-* は含まれない
# 現在 ACTIVE: claude-haiku-4-5 / claude-sonnet-4-* / claude-opus-4-*
\`\`\`

## 修正

default を \`anthropic.claude-haiku-4-5-20251001-v1:0\` に変更。これは ap-northeast-1 で ACTIVE。

## 関連

- IaC: [frestyle-infrastructure PR #49](https://github.com/norman6464/frestyle-infrastructure/pull/49)（merged + deploy-iam 完了）で IAM の Resource に claude-haiku-4-\* / claude-sonnet-4-\* / claude-opus-4-\* を追加済
- Action に bedrock:Converse / ConverseStream も許可（後続 SSE 実装で使用）

## マージ後

cd-backend.yml を trigger して新 image を deploy。