### PR TITLE
feat(ai-chat): SSE ストリーミングで AI 応答を文字単位に表示

### DIFF
--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -1,0 +1,196 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AiChatSseHandler は AI チャット用の Server-Sent Events エンドポイント。
+//
+// 送信フォーマット (text/event-stream):
+//
+//	event: session
+//	data: {"id": 42, "title": "...", ...}
+//
+//	event: token
+//	data: {"sessionId": 42, "delta": "ご"}
+//
+//	event: done
+//	data: {"sessionId": 42, "id": "uuid", "createdAt": "...", "content": "ご質問..."}
+//
+//	event: error
+//	data: {"message": "..."}
+//
+// クライアントは fetch + ReadableStream で line-based に読む（標準の EventSource は POST に
+// 対応しないため、本実装では fetch ベースで送る）。
+type AiChatSseHandler struct {
+	sendStream *usecase.SendAiMessageStreamUseCase
+}
+
+func NewAiChatSseHandler(sendStream *usecase.SendAiMessageStreamUseCase) *AiChatSseHandler {
+	return &AiChatSseHandler{sendStream: sendStream}
+}
+
+type sseRequestBody struct {
+	SessionID   int64   `json:"sessionId"`
+	Content     string  `json:"content"`
+	Scene       string  `json:"scene"`
+	SessionType string  `json:"sessionType"`
+	ScenarioID  *uint64 `json:"scenarioId"`
+}
+
+// Handle は POST /api/v2/ai-chat/stream。
+//
+// gin.Context.SSEvent は `Content-Type: text/event-stream` を自動でセットしないため、
+// 明示的にヘッダを付けて、`c.Writer.Flush()` を伴う書き込みでバッチを流す。
+// HTTP/1.1 chunked transfer で送るのが SSE の前提。CloudFront / ALB のバッファリングは
+// 標準で SSE をサポートしている（`X-Accel-Buffering: no` も併せて立てる）。
+func (h *AiChatSseHandler) Handle(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	if h.sendStream == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "ai_chat_unavailable"})
+		return
+	}
+
+	var body sseRequestBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if body.Content == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "content_required"})
+		return
+	}
+
+	// SSE ヘッダ
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+	flushOrPanic(c.Writer)
+
+	// usecase の context は client 切断で cancel される c.Request.Context() を渡す。
+	// goroutine が長時間生きないように切断検知を伝播させる。
+	ctx, cancel := context.WithCancel(c.Request.Context())
+	defer cancel()
+
+	stream, err := h.sendStream.Execute(ctx, usecase.SendAiMessageInput{
+		UserID:      uid,
+		SessionID:   uint64(body.SessionID),
+		Content:     body.Content,
+		Scene:       body.Scene,
+		SessionType: body.SessionType,
+		ScenarioID:  body.ScenarioID,
+	})
+	if err != nil {
+		writeSSEEvent(c.Writer, "error", map[string]string{"message": "メッセージの送信に失敗しました"})
+		return
+	}
+
+	// keepalive: 15 秒ごとにコメント行 ":\n\n" を送って ALB / CloudFront のアイドルタイムアウト
+	// （既定 60 秒）で切断されるのを防ぐ。
+	keep := time.NewTicker(15 * time.Second)
+	defer keep.Stop()
+
+	clientGone := c.Writer.CloseNotify()
+
+	for {
+		select {
+		case <-clientGone:
+			return
+		case <-keep.C:
+			if _, err := c.Writer.Write([]byte(": keepalive\n\n")); err != nil {
+				return
+			}
+			c.Writer.Flush()
+		case ev, ok := <-stream:
+			if !ok {
+				// usecase 側の channel が close した = 完了（FinalMessage で done 通知済）
+				return
+			}
+			if ev.Err != nil {
+				log.Printf("AiChat SSE: usecase error: %v", ev.Err)
+				writeSSEEvent(c.Writer, "error", map[string]string{"message": "メッセージの送信に失敗しました"})
+				return
+			}
+			if ev.NewSession != nil {
+				writeSSEEvent(c.Writer, "session", map[string]any{
+					"id":          ev.NewSession.ID,
+					"title":       ev.NewSession.Title,
+					"sessionType": ev.NewSession.SessionType,
+					"scenarioId":  ev.NewSession.ScenarioID,
+					"createdAt":   ev.NewSession.CreatedAt.Format(time.RFC3339),
+				})
+				continue
+			}
+			if ev.Delta != "" {
+				writeSSEEvent(c.Writer, "token", map[string]any{
+					"delta": ev.Delta,
+				})
+				continue
+			}
+			if ev.FinalMessage != nil {
+				writeSSEEvent(c.Writer, "done", map[string]any{
+					"sessionId": ev.FinalMessage.SessionID,
+					"id":        ev.FinalMessage.MessageID,
+					"role":      ev.FinalMessage.Role,
+					"content":   ev.FinalMessage.Content,
+					"createdAt": ev.FinalMessage.CreatedAt.Format(time.RFC3339),
+				})
+				return
+			}
+		}
+	}
+}
+
+// writeSSEEvent は 1 イベントを SSE フォーマットで書き出す。
+//
+// 仕様: `event:` 行の後に空行 / `data:` 行 / 空行で 1 イベント完結。
+// 改行を含む payload は `data:` 行を分割する必要があるが、ここでは JSON を 1 行で
+// 出すので分割不要。
+func writeSSEEvent(w gin.ResponseWriter, event string, payload any) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("AiChat SSE: marshal failed: %v", err)
+		return
+	}
+	if _, err := w.Write([]byte("event: " + event + "\n")); err != nil {
+		return
+	}
+	if _, err := w.Write([]byte("data: ")); err != nil {
+		return
+	}
+	if _, err := w.Write(body); err != nil {
+		return
+	}
+	if _, err := w.Write([]byte("\n\n")); err != nil {
+		return
+	}
+	w.Flush()
+}
+
+// flushOrPanic は最初のヘッダ送信で flush できないと SSE 自体機能しないので
+// 開発時の bug を早期発見するため panic させる。本番では gin の ResponseWriter は
+// 必ず Flusher を実装するので発生しない。
+func flushOrPanic(w gin.ResponseWriter) {
+	if f, ok := any(w).(interface{ Flush() }); ok {
+		f.Flush()
+		return
+	}
+	if _, ok := any(w).(io.Writer); !ok {
+		panic("ai_chat_sse_handler: ResponseWriter is not flushable")
+	}
+}

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -6,8 +6,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerChatRoutes は AI チャットセッションの REST エンドポイントを登録する。
-// WebSocket は registerWebSocketRoutes 側で別途登録する。
+// registerChatRoutes は AI チャットセッションの REST + SSE エンドポイントを登録する。
+// WebSocket は registerWebSocketRoutes 側で別途登録する（SSE 移行完了まで並行運用）。
 func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	aiSessionRepo := repository.NewAiChatSessionRepository(deps.db)
 	aiHandler := NewAiChatHandler(
@@ -24,4 +24,14 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.PUT("/ai-chat/sessions/:id", aiHandler.UpdateSessionTitle)
 	g.DELETE("/ai-chat/sessions/:id", aiHandler.DeleteSession)
 	g.GET("/ai-chat/sessions/:id/messages", aiHandler.GetMessages)
+
+	// SSE ストリーミング（汎用 AI チャットの token 単位送信）。
+	// Bedrock / DynamoDB の初期化に失敗していると bedrockClient / msgRepo は nil。
+	// nil sentinel は handler 側で 503 にする。
+	if deps.bedrockClient != nil && deps.msgRepo != nil {
+		sseHandler := NewAiChatSseHandler(
+			usecase.NewSendAiMessageStreamUseCase(aiSessionRepo, deps.msgRepo, deps.bedrockClient),
+		)
+		g.POST("/ai-chat/stream", sseHandler.Handle)
+	}
 }

--- a/backend/internal/infra/bedrock/client.go
+++ b/backend/internal/infra/bedrock/client.go
@@ -72,3 +72,98 @@ func (c *Client) Converse(ctx context.Context, systemPrompt string, history []do
 	}
 	return "", fmt.Errorf("bedrock: no text content in response")
 }
+
+// StreamEvent は ConverseStream が emit する 1 イベント。
+// Delta は途中チャンクのテキスト追加分、Done が true なら末尾（StopReason 受信時）。
+// Err が non-nil なら ストリーム途中での失敗。
+type StreamEvent struct {
+	Delta string
+	Done  bool
+	Err   error
+}
+
+// ConverseStream は ConverseStream API を呼び出して、token を逐次 channel に流す。
+//
+// 呼び出し側は返ってきた channel を range でループするだけで token を消費できる:
+//
+//	ch, err := bc.ConverseStream(ctx, prompt, history)
+//	if err != nil { ... }
+//	for ev := range ch {
+//	    if ev.Err != nil { ... break }
+//	    if ev.Done { break }
+//	    write(ev.Delta)
+//	}
+//
+// ctx が cancel されると channel は閉じられる。AWS SDK の EventStream は内部で
+// channel を持っているが、本ラッパでは「アプリケーションが扱いやすい形」に変換して提供する
+// ことで infra 詳細（brtypes の各 Member 型）を usecase 層に漏らさない。
+func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan StreamEvent, error) {
+	messages := make([]brtypes.Message, 0, len(history))
+	for _, m := range history {
+		role := brtypes.ConversationRoleUser
+		if m.Role == domain.AiChatRoleAssistant {
+			role = brtypes.ConversationRoleAssistant
+		}
+		messages = append(messages, brtypes.Message{
+			Role: role,
+			Content: []brtypes.ContentBlock{
+				&brtypes.ContentBlockMemberText{Value: m.Content},
+			},
+		})
+	}
+
+	input := &bedrockruntime.ConverseStreamInput{
+		ModelId:  &c.modelID,
+		Messages: messages,
+	}
+	if systemPrompt != "" {
+		input.System = []brtypes.SystemContentBlock{
+			&brtypes.SystemContentBlockMemberText{Value: systemPrompt},
+		}
+	}
+
+	output, err := c.svc.ConverseStream(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("bedrock: converse stream: %w", err)
+	}
+
+	out := make(chan StreamEvent, 16)
+	go func() {
+		defer close(out)
+		defer output.GetStream().Close()
+
+		stream := output.GetStream()
+		for ev := range stream.Events() {
+			switch v := ev.(type) {
+			case *brtypes.ConverseStreamOutputMemberContentBlockDelta:
+				if delta, ok := v.Value.Delta.(*brtypes.ContentBlockDeltaMemberText); ok {
+					select {
+					case out <- StreamEvent{Delta: delta.Value}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			case *brtypes.ConverseStreamOutputMemberMessageStop:
+				// stop reason は本ラッパでは利用しないが、Done を立てて呼び出し側にループ終端を伝える。
+				select {
+				case out <- StreamEvent{Done: true}:
+				case <-ctx.Done():
+				}
+				return
+			case *brtypes.ConverseStreamOutputMemberMessageStart,
+				*brtypes.ConverseStreamOutputMemberContentBlockStart,
+				*brtypes.ConverseStreamOutputMemberContentBlockStop,
+				*brtypes.ConverseStreamOutputMemberMetadata:
+				// メタイベントは UI に流さない（メタデータは保存しない）
+			}
+		}
+		if err := stream.Err(); err != nil {
+			select {
+			case out <- StreamEvent{Err: fmt.Errorf("bedrock: stream err: %w", err)}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+
+	return out, nil
+}

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -1,0 +1,148 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/bedrock"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// StreamingBedrockClient は Bedrock の streaming 呼び出し抽象。
+// テストでは fake を差し替える。infra/bedrock.Client が満たす想定。
+type StreamingBedrockClient interface {
+	ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan bedrock.StreamEvent, error)
+}
+
+// StreamEvent は handler に流すイベント。bedrock.StreamEvent と同形だが、
+// ここでは「session 作成済」「message 完成済」など usecase レベルの状態も合わせて返す。
+type StreamEvent struct {
+	// Delta が non-empty なら token 追加（途中チャンク）
+	Delta string
+	// NewSession が non-nil なら新規セッションが作成されたことを示す（最初の 1 回のみ）
+	NewSession *domain.AiChatSession
+	// FinalMessage が non-nil ならアシスタント返答が完成して DB 保存済（末尾で 1 回のみ）
+	FinalMessage *domain.AiChatMessage
+	// Err が non-nil ならエラー終了
+	Err error
+}
+
+// SendAiMessageStreamUseCase は WebSocket 版 (SendAiMessageUseCase) の streaming 版。
+// 互換のため両方を残し、フロントが対応した順から SSE に切り替える。
+type SendAiMessageStreamUseCase struct {
+	sessions      repository.AiChatSessionRepository
+	messages      repository.AiChatMessageRepository
+	bedrockClient StreamingBedrockClient
+}
+
+func NewSendAiMessageStreamUseCase(
+	sessions repository.AiChatSessionRepository,
+	messages repository.AiChatMessageRepository,
+	bc StreamingBedrockClient,
+) *SendAiMessageStreamUseCase {
+	return &SendAiMessageStreamUseCase{sessions: sessions, messages: messages, bedrockClient: bc}
+}
+
+// Execute は handler 側でレスポンス書き込みに使う channel を返す。
+//
+// 流れ:
+//  1. sessionID == 0 なら新規セッション作成 → NewSession イベントを emit
+//  2. ユーザーメッセージを DB に保存 → 履歴を取得
+//  3. Bedrock ConverseStream を呼び、 token を Delta イベントで emit
+//  4. token を全て連結したアシスタント返答を DB に保存 → FinalMessage イベントを emit
+//  5. channel を close
+//
+// ctx の cancel で全工程が中断される（クライアント切断時の goroutine リーク防止）。
+func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessageInput) (<-chan StreamEvent, error) {
+	out := make(chan StreamEvent, 16)
+
+	go func() {
+		defer close(out)
+
+		sessionID := in.SessionID
+		var newSession *domain.AiChatSession
+		if sessionID == 0 {
+			title := truncateTitle(in.Content, 30)
+			s, err := NewCreateAiChatSessionUseCase(u.sessions).Execute(ctx, CreateAiChatSessionInput{
+				UserID:      in.UserID,
+				Title:       title,
+				SessionType: in.SessionType,
+				ScenarioID:  in.ScenarioID,
+			})
+			if err != nil {
+				emit(ctx, out, StreamEvent{Err: fmt.Errorf("create session: %w", err)})
+				return
+			}
+			newSession = s
+			sessionID = s.ID
+			emit(ctx, out, StreamEvent{NewSession: newSession})
+		}
+
+		userMsg := &domain.AiChatMessage{
+			SessionID: sessionID,
+			MessageID: uuid.New().String(),
+			Role:      domain.AiChatRoleUser,
+			Content:   in.Content,
+			CreatedAt: time.Now().UTC(),
+		}
+		if err := u.messages.Save(ctx, userMsg); err != nil {
+			emit(ctx, out, StreamEvent{Err: fmt.Errorf("save user message: %w", err)})
+			return
+		}
+
+		history, err := u.messages.ListBySessionID(ctx, sessionID)
+		if err != nil {
+			emit(ctx, out, StreamEvent{Err: fmt.Errorf("list messages: %w", err)})
+			return
+		}
+
+		systemPrompt := buildSystemPrompt(in.SessionType, in.Scene)
+		stream, err := u.bedrockClient.ConverseStream(ctx, systemPrompt, history)
+		if err != nil {
+			emit(ctx, out, StreamEvent{Err: fmt.Errorf("bedrock converse stream: %w", err)})
+			return
+		}
+
+		var assistantBuf strings.Builder
+		for ev := range stream {
+			if ev.Err != nil {
+				emit(ctx, out, StreamEvent{Err: ev.Err})
+				return
+			}
+			if ev.Delta != "" {
+				assistantBuf.WriteString(ev.Delta)
+				emit(ctx, out, StreamEvent{Delta: ev.Delta})
+			}
+			if ev.Done {
+				break
+			}
+		}
+
+		final := &domain.AiChatMessage{
+			SessionID: sessionID,
+			MessageID: uuid.New().String(),
+			Role:      domain.AiChatRoleAssistant,
+			Content:   assistantBuf.String(),
+			CreatedAt: time.Now().UTC(),
+		}
+		if err := u.messages.Save(ctx, final); err != nil {
+			emit(ctx, out, StreamEvent{Err: fmt.Errorf("save ai message: %w", err)})
+			return
+		}
+		emit(ctx, out, StreamEvent{FinalMessage: final})
+	}()
+
+	return out, nil
+}
+
+// emit は ctx 終了時に block しないように選択的送信する。
+func emit(ctx context.Context, out chan<- StreamEvent, ev StreamEvent) {
+	select {
+	case out <- ev:
+	case <-ctx.Done():
+	}
+}

--- a/backend/internal/usecase/send_ai_message_stream_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase_test.go
@@ -1,0 +1,149 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/bedrock"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// --- mock: StreamingBedrockClient ---
+
+type mockStreamBedrock struct{ mock.Mock }
+
+func (m *mockStreamBedrock) ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan bedrock.StreamEvent, error) {
+	args := m.Called(ctx, systemPrompt, history)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(<-chan bedrock.StreamEvent), args.Error(1)
+}
+
+// 既存セッションの場合: Delta が逐次流れて、最後に FinalMessage で完了する。
+func TestSendAiMessageStream_ExistingSession_StreamsTokensAndSavesFinal(t *testing.T) {
+	sessionRepo := new(mockSessionRepo)
+	msgRepo := new(mockMsgRepo)
+	bc := new(mockStreamBedrock)
+
+	// 履歴: ユーザー発話 1 件
+	history := []domain.AiChatMessage{
+		{SessionID: 5, MessageID: "u1", Role: domain.AiChatRoleUser, Content: "Hello", CreatedAt: time.Now()},
+	}
+	msgRepo.On("Save", mock.Anything, mock.AnythingOfType("*domain.AiChatMessage")).Return(nil)
+	msgRepo.On("ListBySessionID", mock.Anything, uint64(5)).Return(history, nil)
+
+	// Bedrock の擬似 stream を作る
+	src := make(chan bedrock.StreamEvent, 4)
+	src <- bedrock.StreamEvent{Delta: "Hi"}
+	src <- bedrock.StreamEvent{Delta: " there"}
+	src <- bedrock.StreamEvent{Done: true}
+	close(src)
+	var ro <-chan bedrock.StreamEvent = src
+	bc.On("ConverseStream", mock.Anything, mock.AnythingOfType("string"), history).Return(ro, nil)
+
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc)
+	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
+		UserID:    7,
+		SessionID: 5,
+		Content:   "Hello",
+	})
+	require.NoError(t, err)
+
+	var deltas []string
+	var final *domain.AiChatMessage
+	for ev := range ch {
+		require.NoError(t, ev.Err)
+		if ev.Delta != "" {
+			deltas = append(deltas, ev.Delta)
+		}
+		if ev.FinalMessage != nil {
+			final = ev.FinalMessage
+		}
+	}
+
+	assert.Equal(t, []string{"Hi", " there"}, deltas)
+	require.NotNil(t, final)
+	assert.Equal(t, "Hi there", final.Content)
+	assert.Equal(t, domain.AiChatRoleAssistant, final.Role)
+	// ユーザー msg + アシスタント msg の 2 回保存
+	msgRepo.AssertNumberOfCalls(t, "Save", 2)
+}
+
+// 新規セッションの場合: NewSession イベントが先に流れて、token + Final が続く。
+func TestSendAiMessageStream_NewSession_EmitsSessionFirst(t *testing.T) {
+	sessionRepo := new(mockSessionRepo)
+	msgRepo := new(mockMsgRepo)
+	bc := new(mockStreamBedrock)
+
+	// セッション作成: ID を埋める
+	sessionRepo.On("Create", mock.Anything, mock.AnythingOfType("*domain.AiChatSession")).
+		Run(func(args mock.Arguments) {
+			s := args.Get(1).(*domain.AiChatSession)
+			s.ID = 99
+			s.CreatedAt = time.Now()
+		}).Return(nil)
+	msgRepo.On("Save", mock.Anything, mock.AnythingOfType("*domain.AiChatMessage")).Return(nil)
+	msgRepo.On("ListBySessionID", mock.Anything, uint64(99)).Return([]domain.AiChatMessage{}, nil)
+
+	src := make(chan bedrock.StreamEvent, 2)
+	src <- bedrock.StreamEvent{Delta: "ok"}
+	src <- bedrock.StreamEvent{Done: true}
+	close(src)
+	var ro <-chan bedrock.StreamEvent = src
+	bc.On("ConverseStream", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(ro, nil)
+
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc)
+	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
+		UserID:  7,
+		Content: "新しい会話を始めたい",
+	})
+	require.NoError(t, err)
+
+	first := <-ch
+	require.NotNil(t, first.NewSession)
+	assert.Equal(t, uint64(99), first.NewSession.ID)
+
+	// 残りはイベントが流れて FinalMessage で終わる
+	for ev := range ch {
+		require.NoError(t, ev.Err)
+	}
+}
+
+// Bedrock 呼び出しで stream エラー: ev.Err が channel に流れて使い手に伝わる。
+func TestSendAiMessageStream_StreamError_PropagatesErr(t *testing.T) {
+	sessionRepo := new(mockSessionRepo)
+	msgRepo := new(mockMsgRepo)
+	bc := new(mockStreamBedrock)
+
+	msgRepo.On("Save", mock.Anything, mock.AnythingOfType("*domain.AiChatMessage")).Return(nil)
+	msgRepo.On("ListBySessionID", mock.Anything, uint64(3)).Return([]domain.AiChatMessage{}, nil)
+
+	src := make(chan bedrock.StreamEvent, 1)
+	src <- bedrock.StreamEvent{Err: errors.New("bedrock down")}
+	close(src)
+	var ro <-chan bedrock.StreamEvent = src
+	bc.On("ConverseStream", mock.Anything, mock.Anything, mock.Anything).Return(ro, nil)
+
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc)
+	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
+		UserID: 7, SessionID: 3, Content: "x",
+	})
+	require.NoError(t, err)
+
+	var sawErr bool
+	for ev := range ch {
+		if ev.Err != nil {
+			sawErr = true
+		}
+	}
+	assert.True(t, sawErr, "expected ev.Err to surface to caller")
+	// FinalMessage の Save は呼ばれない（エラー前 return）
+	msgRepo.AssertNumberOfCalls(t, "Save", 1)
+}

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -43,13 +43,14 @@ export const PROFILE = {
   meOnboardingComplete: `${API_V2}/profile/me/onboarding/complete`,
 } as const;
 
-/** AI チャット（セッション・メッセージ・言い換え） */
+/** AI チャット（セッション CRUD + SSE ストリーミング） */
 export const AI_CHAT = {
   sessions: `${API_V2}/ai-chat/sessions`,
   session: (sessionId: number | string) => `${API_V2}/ai-chat/sessions/${sessionId}`,
   sessionMessages: (sessionId: number | string) =>
     `${API_V2}/ai-chat/sessions/${sessionId}/messages`,
-  aiRephrase: `${API_V2}/chat/ai/rephrase`,
+  /** POST /ai-chat/stream — SSE ストリーミング送信 */
+  stream: `${API_V2}/ai-chat/stream`,
 } as const;
 
 /** Note CRUD と画像 presigned upload */

--- a/frontend/src/hooks/useAiChat.ts
+++ b/frontend/src/hooks/useAiChat.ts
@@ -137,6 +137,8 @@ export const useAiChat = () => {
     sessions,
     currentSession,
     messages,
+    /** ストリーミング受信中の token append に使う。useAskAi 経由の SSE 取り込みで利用。 */
+    setMessages,
     loading,
     error,
     fetchSessions,

--- a/frontend/src/hooks/useAiChatSse.ts
+++ b/frontend/src/hooks/useAiChatSse.ts
@@ -1,0 +1,185 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Server-Sent Events ベースの AI チャット送受信フック。
+ *
+ * 標準の EventSource は GET しかサポートしないため、本実装は fetch + ReadableStream で
+ * line-based に SSE フレームを読む（多くの汎用 AI チャット製品が採用するパターン）。
+ *
+ * バックエンドの送信フォーマット（backend/internal/handler/ai_chat_sse_handler.go）:
+ *
+ *   event: session   data: {...}
+ *   event: token     data: {"delta": "..."}
+ *   event: done      data: {"sessionId":..., "id":..., "content":...}
+ *   event: error     data: {"message": "..."}
+ *
+ * 各イベントは `event:` 行 + `data:` 行 + 空行 で 1 単位。本フックは line buffer を
+ * 持って 1 イベントが揃った時点でハンドラを呼ぶ。
+ */
+
+export interface SseSessionEvent {
+  type: 'session';
+  id: number;
+  title?: string;
+  sessionType?: string;
+  scenarioId?: number | null;
+  createdAt?: string;
+}
+
+export interface SseTokenEvent {
+  type: 'token';
+  delta: string;
+}
+
+export interface SseDoneEvent {
+  type: 'done';
+  sessionId: number;
+  id: string;
+  role: 'assistant';
+  content: string;
+  createdAt: string;
+}
+
+export interface SseErrorEvent {
+  type: 'error';
+  message: string;
+}
+
+export type SseEvent = SseSessionEvent | SseTokenEvent | SseDoneEvent | SseErrorEvent;
+
+export interface SendStreamRequest {
+  sessionId: number | null;
+  content: string;
+}
+
+export interface UseAiChatSseOptions {
+  endpoint: string;
+  onEvent: (ev: SseEvent) => void;
+  /** stream 終了（done / error / abort）で呼ぶ。クライアント側のリセットに使う */
+  onClose?: () => void;
+}
+
+export function useAiChatSse({ endpoint, onEvent, onClose }: UseAiChatSseOptions) {
+  // 進行中のリクエストを中断するための AbortController を保持。
+  // 同じセッションで連投したときに前の stream を捨てるため。
+  const abortRef = useRef<AbortController | null>(null);
+
+  const send = useCallback(
+    async (req: SendStreamRequest): Promise<void> => {
+      // 既存の stream があればキャンセル
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'text/event-stream',
+          },
+          body: JSON.stringify({
+            sessionId: req.sessionId ?? 0,
+            content: req.content,
+          }),
+          signal: controller.signal,
+        });
+
+        if (!res.ok || !res.body) {
+          onEvent({
+            type: 'error',
+            message:
+              res.status === 401
+                ? 'ログインが必要です'
+                : res.status === 503
+                ? 'AI チャットが一時的に利用できません'
+                : 'メッセージの送信に失敗しました',
+          });
+          onClose?.();
+          return;
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        while (true) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+
+          // SSE は \n\n で 1 イベントを区切る。一度に複数イベントが届く可能性もある。
+          let sep: number;
+          while ((sep = buffer.indexOf('\n\n')) !== -1) {
+            const raw = buffer.slice(0, sep);
+            buffer = buffer.slice(sep + 2);
+            const ev = parseSseFrame(raw);
+            if (ev) onEvent(ev);
+          }
+        }
+      } catch (err) {
+        // AbortController.abort() は AbortError を投げる。意図的なキャンセルなので無視。
+        if ((err as Error).name === 'AbortError') return;
+        onEvent({ type: 'error', message: 'ネットワークエラーが発生しました' });
+      } finally {
+        if (abortRef.current === controller) abortRef.current = null;
+        onClose?.();
+      }
+    },
+    [endpoint, onEvent, onClose]
+  );
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  return { send, abort };
+}
+
+/**
+ * 1 つの SSE フレームをパースする。
+ * 形式:
+ *   event: <name>
+ *   data: <json>
+ * data 行が複数になる可能性もある（仕様上は \n で連結される）。
+ */
+function parseSseFrame(raw: string): SseEvent | null {
+  const lines = raw.split('\n');
+  let event = '';
+  let data = '';
+  for (const line of lines) {
+    if (line.startsWith(':')) continue; // コメント行（keepalive など）
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trim();
+    } else if (line.startsWith('data:')) {
+      data += (data ? '\n' : '') + line.slice('data:'.length).trim();
+    }
+  }
+  if (!event || !data) return null;
+
+  try {
+    const payload = JSON.parse(data);
+    switch (event) {
+      case 'session':
+        return { type: 'session', ...payload };
+      case 'token':
+        return { type: 'token', delta: String(payload.delta ?? '') };
+      case 'done':
+        return {
+          type: 'done',
+          sessionId: payload.sessionId,
+          id: payload.id,
+          role: 'assistant',
+          content: payload.content,
+          createdAt: payload.createdAt,
+        };
+      case 'error':
+        return { type: 'error', message: String(payload.message ?? '') };
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -2,27 +2,31 @@ import { useEffect, useRef, useMemo, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from './useAuth';
 import { useAiChat } from './useAiChat';
-import { useWebSocketNative } from './useWebSocketNative';
 import { useAiSession } from './useAiSession';
-import { WS } from '../constants/apiRoutes';
+import { useAiChatSse, SseEvent } from './useAiChatSse';
+import { AI_CHAT } from '../constants/apiRoutes';
+import { AiMessage } from '../types';
 
 /**
- * AskAiPage フック（汎用 AI チャット版）。
+ * AskAiPage フック（SSE ストリーミング版）。
  *
- * 旧版は「練習モード / scoreCard / シナリオ受け渡し / chat-feedback」など複合機能を
- * 引き受けていたが、PR-A の機能整理でアプリは「自由対話の AI チャット」に集約した。
- * このフックも以下のみを扱う:
- *   - セッション一覧 / 検索 / 切替
- *   - メッセージ送受信（WebSocket; SSE への置換は PR-C）
- *   - 編集中タイトルやモーダル状態
+ * メッセージ送信は WebSocket から SSE に切り替え:
+ *   1. ユーザー発話を即座に画面に表示
+ *   2. 「ストリーミング中のアシスタントメッセージ placeholder」を 1 つ追加
+ *   3. token イベントごとに placeholder.content の末尾に append（文字パラパラ）
+ *   4. done イベントで placeholder を確定（id / createdAt が backend から戻る）
+ *   5. session イベントが来た場合は新規セッションをリストに追加 + currentSessionId 切替
  *
- * 削除した機能: 練習モード / scoreCard / scenario / chat-feedback / scene
+ * 進行中の stream は AbortController で中断可能（次の send 時に自動 abort）。
  */
 export function useAskAi() {
-  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+  const STREAM_ENDPOINT = `${API_BASE_URL}${AI_CHAT.stream}`;
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  // ストリーミング中のアシスタントメッセージ ID（placeholder）
+  const streamingIdRef = useRef<string | null>(null);
 
   const { sessionId: urlSessionId } = useParams<{ sessionId: string }>();
 
@@ -30,56 +34,110 @@ export function useAskAi() {
   const {
     sessions,
     messages,
+    setMessages,
     loading,
     fetchSessions,
     fetchMessages,
     deleteSession,
     updateSessionTitle,
-    handleIncomingMessage,
     handleIncomingSession,
   } = useAiChat();
 
   const aiSession = useAiSession({ deleteSession, updateSessionTitle });
   const { currentSessionId, setCurrentSessionId } = aiSession;
 
-  const wsUrl = user?.id && API_BASE_URL
-    ? toWsUrl(`${API_BASE_URL}${WS.aiChat}`)
-    : null;
-
-  type AiWsInbound =
-    | { type: 'message'; sessionId?: number; [k: string]: unknown }
-    | { type: 'session'; id: number; [k: string]: unknown }
-    | { type: 'session-deleted'; sessionId: number };
-
-  const { send } = useWebSocketNative({
-    url: wsUrl,
-    onMessage: (raw) => {
-      const data = raw as AiWsInbound;
-      if (data.type === 'message') {
-        handleIncomingMessage(data as unknown as Parameters<typeof handleIncomingMessage>[0]);
-        return;
-      }
-      if (data.type === 'session') {
-        handleIncomingSession(data);
-        setCurrentSessionId(data.id);
-        return;
-      }
-      if (data.type === 'session-deleted') {
-        if (currentSessionId === data.sessionId) {
-          setCurrentSessionId(null);
+  const handleEvent = useCallback(
+    (ev: SseEvent) => {
+      switch (ev.type) {
+        case 'session':
+          handleIncomingSession({
+            id: ev.id,
+            title: ev.title,
+            sessionType: ev.sessionType,
+            scenarioId: ev.scenarioId ?? undefined,
+            createdAt: ev.createdAt,
+          });
+          setCurrentSessionId(ev.id);
+          return;
+        case 'token': {
+          const id = streamingIdRef.current;
+          if (!id) return;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === id ? { ...m, content: m.content + ev.delta } : m
+            )
+          );
+          return;
         }
+        case 'done': {
+          const tempId = streamingIdRef.current;
+          if (!tempId) return;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === tempId
+                ? {
+                    ...m,
+                    id: ev.id,
+                    content: ev.content,
+                    createdAt: ev.createdAt,
+                  }
+                : m
+            )
+          );
+          streamingIdRef.current = null;
+          return;
+        }
+        case 'error':
+          // placeholder にエラー本文を残す（ユーザーに状況を伝える）
+          if (streamingIdRef.current) {
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === streamingIdRef.current
+                  ? { ...m, content: `（エラー）${ev.message}` }
+                  : m
+              )
+            );
+            streamingIdRef.current = null;
+          }
+          return;
       }
     },
+    [handleIncomingSession, setCurrentSessionId, setMessages]
+  );
+
+  const { send: sendSse, abort: abortSse } = useAiChatSse({
+    endpoint: STREAM_ENDPOINT,
+    onEvent: handleEvent,
   });
 
-  const handleSend = useCallback((text: string): void => {
-    send({
-      type: 'send',
-      sessionId: currentSessionId,
-      content: text,
-      role: 'user',
-    });
-  }, [send, currentSessionId]);
+  const handleSend = useCallback(
+    (text: string): void => {
+      if (!text.trim()) return;
+
+      // ユーザー発話 + アシスタント placeholder を即座に追加
+      const now = new Date().toISOString();
+      const userMsg: AiMessage = {
+        id: `local-user-${Date.now()}`,
+        sessionId: currentSessionId ?? 0,
+        role: 'user',
+        content: text,
+        createdAt: now,
+      };
+      const placeholderId = `streaming-${Date.now()}`;
+      streamingIdRef.current = placeholderId;
+      const placeholder: AiMessage = {
+        id: placeholderId,
+        sessionId: currentSessionId ?? 0,
+        role: 'assistant',
+        content: '',
+        createdAt: now,
+      };
+      setMessages((prev) => [...prev, userMsg, placeholder]);
+
+      void sendSse({ sessionId: currentSessionId, content: text });
+    },
+    [sendSse, currentSessionId, setMessages]
+  );
 
   // ユーザー情報取得
   useEffect(() => {
@@ -93,7 +151,7 @@ export function useAskAi() {
     }
   }, [user?.id, fetchSessions]);
 
-  // URL パラメータのセッション ID 変更で current を切替（無いときは null にリセット）
+  // URL パラメータのセッション ID 変更で current を切替
   useEffect(() => {
     if (urlSessionId) {
       setCurrentSessionId(parseInt(urlSessionId, 10));
@@ -114,6 +172,11 @@ export function useAskAi() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  // unmount で進行中の stream を abort
+  useEffect(() => {
+    return () => abortSse();
+  }, [abortSse]);
+
   const filteredSessions = useMemo(() => {
     if (!sessionSearchQuery) return sessions;
     const query = sessionSearchQuery.toLowerCase();
@@ -133,8 +196,4 @@ export function useAskAi() {
 
     handleSend,
   };
-}
-
-function toWsUrl(httpUrl: string): string {
-  return httpUrl.replace(/^http:/, 'ws:').replace(/^https:/, 'wss:');
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -70,13 +70,14 @@ export interface AiChatMessageDto {
 /**
  * AiMessage は AskAi 画面表示用の view 型。
  * `id` (string) を画面側で扱いやすい一意キーとして使う。
+ * `createdAt` は ISO 8601 文字列（backend の SSE / REST 双方が ISO で返す）。
  */
 export interface AiMessage {
   id: string;
   sessionId: number;
   content: string;
   role: 'user' | 'assistant';
-  createdAt?: number;
+  createdAt?: string;
   isSender?: boolean;
   isDeleted?: boolean;
 }


### PR DESCRIPTION
## 概要

AI 応答を ChatGPT 相当の **文字パラパラ表示** にするため、Bedrock ConverseStream + Server-Sent Events で token を逐次配信する経路を追加します。WebSocket は段階的撤去のため当面残し、PR-D で削除予定。

## Backend

| ファイル | 役割 |
|---|---|
| \`infra/bedrock/client.go\` | \`ConverseStream\` ラッパを新設。EventStream を \`chan StreamEvent\` に変換して infra 詳細（\`brtypes\` の各 Member 型）を usecase に漏らさない |
| \`usecase/send_ai_message_stream_usecase.go\` | \`SendAiMessageStreamUseCase\`。channel で \`Delta\` / \`NewSession\` / \`FinalMessage\` / \`Err\` を順次 emit し、最後に DB へアシスタント返答を保存 |
| \`handler/ai_chat_sse_handler.go\` | \`text/event-stream\` を返す SSE handler。15 秒の keepalive コメントで ALB / CloudFront のアイドル切断を回避。client 切断検知で usecase ctx を cancel |
| \`routes_chat.go\` | \`POST /api/v2/ai-chat/stream\` を登録（Bedrock / DynamoDB が初期化失敗しているときは登録しない fail-safe） |

### 送信フォーマット

\`\`\`
event: session
data: {"id":42,"title":"...","createdAt":"..."}

event: token
data: {"delta":"こ"}

event: token
data: {"delta":"ん"}

event: done
data: {"sessionId":42,"id":"uuid","content":"こんにちは...","createdAt":"..."}

event: error
data: {"message":"..."}
\`\`\`

### usecase テスト

3 ケース追加:
- 既存 session で token が逐次 emit + Final で DB 保存
- 新規 session 作成時は \`NewSession\` イベントが先頭に流れる
- stream エラー時に \`ev.Err\` がそのまま呼び出し側へ伝播

## Frontend

| ファイル | 役割 |
|---|---|
| \`hooks/useAiChatSse.ts\` | fetch + ReadableStream で SSE を受信。標準 \`EventSource\` は GET 限定 / Cookie 送信制約があるので、汎用 AI チャット製品同様 fetch ベースに |
| \`hooks/useAskAi.ts\` | 送信経路を WebSocket → SSE に切替。送信時に user msg + 空の assistant placeholder を即追加し、token イベントごとに placeholder.content を append。done で placeholder を確定 |
| \`constants/apiRoutes.ts\` | \`AI_CHAT.stream\` を追加、撤去済の \`aiRephrase\` を削除 |
| \`types/index.ts\` | \`AiMessage.createdAt\` を string (ISO 8601) に統一 |

## 動作確認

ローカル: \`docker compose up -d --build\` → AI チャット画面でメッセージ送信 → 文字が逐次表示される。
本番: cd-backend / cd-frontend deploy 後、 \`https://normanblog.com/chat/ask-ai\` で確認。

## テスト

- backend 全 pass / frontend 全 **1716 tests pass**
- \`npx tsc --noEmit\` / \`npx eslint . --max-warnings=0\` クリーン

## 今後

- PR-D: WebSocket 経路（\`/ws/ai-chat\` + \`SendAiMessageUseCase\`）と不要 endpoint（rephrase / scoreCard / scoreHistory）を撤去
- PR-E: DB スキーマの DROP migration
- PR-F: 認可ルール調整（super_admin は管理メニューのみ）