### PR TITLE
feat(frontend): super_admin はメニューと trainee 向け画面を非表示化 (PR-F)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -46,6 +46,10 @@ const mainNavItems: NavItem[] = [
   { id: 'reports', icon: DocumentChartBarIcon, label: 'レポート', to: '/reports', matchExact: true },
 ];
 
+// super_admin に表示する main nav の id 集合。
+// super_admin は企業管理に専念するロールで、trainee 向け学習機能は表示しない。
+const SUPER_ADMIN_MAIN_NAV_IDS = new Set(['home', 'notifications']);
+
 const bottomNavItems: NavItem[] = [
   { id: 'profile', icon: UserCircleIcon, label: 'プロフィール', to: '/profile/me', matchExact: true },
 ];
@@ -77,13 +81,18 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   const { handleLogout, loggingOut } = useSidebar();
   const { theme, toggleTheme } = useTheme();
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
+  const role = useSelector((state: RootState) => state.auth.role);
+  const isSuperAdmin = role === 'super_admin';
 
   // expanded: パネル（ラベル）表示状態。false = アイコンのみの折りたたみ状態
   const [expanded, setExpanded] = useState(true);
   // 管理サブメニューの開閉
   const [adminOpen, setAdminOpen] = useState(false);
 
-  const allNavItems = [...mainNavItems, ...bottomNavItems, ...(isAdmin ? [adminNavItem] : [])];
+  // super_admin は trainee 向けメニュー（AI / コード / ノート / レポート）を非表示。
+  const visibleMainNavItems = isSuperAdmin
+    ? mainNavItems.filter((item) => SUPER_ADMIN_MAIN_NAV_IDS.has(item.id))
+    : mainNavItems;
   const adminActive = isActive(adminNavItem, location.pathname);
 
   const handleAdminClick = () => {
@@ -119,7 +128,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
 
         {/* メインナビ */}
         <nav className="flex-1 px-2 space-y-0.5 overflow-y-auto">
-          {mainNavItems.map((item) => {
+          {visibleMainNavItems.map((item) => {
             const active = isActive(item, location.pathname);
             return (
               <Link

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -17,18 +17,18 @@ vi.mock('../../../hooks/useTheme', () => ({
   useTheme: () => mockUseTheme(),
 }));
 
-function createTestStore(isAdmin = false) {
+function createTestStore(isAdmin = false, role: string | null = null) {
   return configureStore({
     reducer: { auth: authReducer },
     preloadedState: {
-      auth: { isAuthenticated: true, loading: false, isAdmin, onboarded: true },
+      auth: { isAuthenticated: true, loading: false, isAdmin, onboarded: true, role },
     },
   });
 }
 
-function renderSidebar(currentPath = '/', isAdmin = false) {
+function renderSidebar(currentPath = '/', isAdmin = false, role: string | null = null) {
   return render(
-    <Provider store={createTestStore(isAdmin)}>
+    <Provider store={createTestStore(isAdmin, role)}>
       <MemoryRouter initialEntries={[currentPath]}>
         <Sidebar />
       </MemoryRouter>
@@ -132,5 +132,27 @@ describe('Sidebar', () => {
   it('非 admin ユーザーには管理メニューが表示されない', () => {
     renderSidebar('/');
     expect(screen.queryByText('管理')).toBeNull();
+  });
+
+  it('super_admin には trainee 向けメニュー (AI / コード学習 / ノート / レポート) が表示されない', () => {
+    renderSidebar('/', true, 'super_admin');
+    expect(screen.queryByText('AI')).toBeNull();
+    expect(screen.queryByText('コード学習')).toBeNull();
+    expect(screen.queryByText('ノート')).toBeNull();
+    expect(screen.queryByText('レポート')).toBeNull();
+    // ホーム / 通知 / プロフィール / 管理は表示される
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('通知')).toBeInTheDocument();
+    expect(screen.getByText('プロフィール')).toBeInTheDocument();
+    expect(screen.getByText('管理')).toBeInTheDocument();
+  });
+
+  it('company_admin には trainee 向けメニューも表示される', () => {
+    renderSidebar('/', true, 'company_admin');
+    expect(screen.getByText('AI')).toBeInTheDocument();
+    expect(screen.getByText('コード学習')).toBeInTheDocument();
+    expect(screen.getByText('ノート')).toBeInTheDocument();
+    expect(screen.getByText('レポート')).toBeInTheDocument();
+    expect(screen.getByText('管理')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,11 +1,15 @@
 import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import {
   HomeIcon,
   SparklesIcon,
   CodeBracketIcon,
   DocumentTextIcon,
   DocumentChartBarIcon,
+  BuildingOffice2Icon,
+  EnvelopeIcon,
 } from '@heroicons/react/24/outline';
+import type { RootState } from '../store';
 
 /**
  * シンプルなホーム画面。
@@ -16,8 +20,12 @@ import {
  *   - ヘッダーのアイコン + タイトルで現在地を明示
  *   - 4 枚のリンクカードで主要機能に直接遷移
  *   - 表示する数値・進捗系は一切持たない（store / API 依存なし）
+ *   - super_admin は trainee 向け学習機能を使わないため、企業管理 / 招待管理のみ表示
  */
 export default function MenuPage() {
+  const role = useSelector((state: RootState) => state.auth.role);
+  const isSuperAdmin = role === 'super_admin';
+
   return (
     <div className="px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
       <header className="flex items-center gap-2">
@@ -26,34 +34,55 @@ export default function MenuPage() {
       </header>
 
       <p className="text-sm text-[var(--color-text-muted)] leading-relaxed">
-        左のメニューから機能を選んでください。下のカードからもアクセスできます。
+        {isSuperAdmin
+          ? '管理者向けの操作メニューです。'
+          : '左のメニューから機能を選んでください。下のカードからもアクセスできます。'}
       </p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <NavCard
-          to="/chat/ask-ai"
-          icon={SparklesIcon}
-          title="AI チャット"
-          description="質問・要約・コード補助など、自由に対話できます。"
-        />
-        <NavCard
-          to="/code-editor"
-          icon={CodeBracketIcon}
-          title="コード学習"
-          description="演習問題を解いて手を動かしながら学べます。"
-        />
-        <NavCard
-          to="/notes"
-          icon={DocumentTextIcon}
-          title="ノート"
-          description="学習メモを残す・振り返ることができます。"
-        />
-        <NavCard
-          to="/reports"
-          icon={DocumentChartBarIcon}
-          title="レポート"
-          description="月次の学習サマリーを確認できます。"
-        />
+        {isSuperAdmin ? (
+          <>
+            <NavCard
+              to="/admin/companies"
+              icon={BuildingOffice2Icon}
+              title="会社一覧"
+              description="登録済み企業の管理を行います。"
+            />
+            <NavCard
+              to="/admin/invitations"
+              icon={EnvelopeIcon}
+              title="招待管理"
+              description="企業管理者への招待を作成・管理できます。"
+            />
+          </>
+        ) : (
+          <>
+            <NavCard
+              to="/chat/ask-ai"
+              icon={SparklesIcon}
+              title="AI チャット"
+              description="質問・要約・コード補助など、自由に対話できます。"
+            />
+            <NavCard
+              to="/code-editor"
+              icon={CodeBracketIcon}
+              title="コード学習"
+              description="演習問題を解いて手を動かしながら学べます。"
+            />
+            <NavCard
+              to="/notes"
+              icon={DocumentTextIcon}
+              title="ノート"
+              description="学習メモを残す・振り返ることができます。"
+            />
+            <NavCard
+              to="/reports"
+              icon={DocumentChartBarIcon}
+              title="レポート"
+              description="月次の学習サマリーを確認できます。"
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/store/__tests__/authSlice.test.ts
+++ b/frontend/src/store/__tests__/authSlice.test.ts
@@ -13,9 +13,10 @@ describe('authSlice', () => {
     loading: true,
     isAdmin: false,
     onboarded: false,
+    role: null,
   };
 
-  it('初期状態はisAuthenticated=false, loading=true, isAdmin=false, onboarded=false', () => {
+  it('初期状態はisAuthenticated=false, loading=true, isAdmin=false, onboarded=false, role=null', () => {
     const state = authReducer(undefined, { type: 'unknown' });
     expect(state).toEqual(initialState);
   });
@@ -33,15 +34,27 @@ describe('authSlice', () => {
   });
 
   it('setAuthDataでpayload未指定の場合は既存のisAdminを保持する', () => {
-    const adminState = { isAuthenticated: true, loading: false, isAdmin: true, onboarded: true };
+    const adminState = {
+      isAuthenticated: true,
+      loading: false,
+      isAdmin: true,
+      onboarded: true,
+      role: 'super_admin',
+    };
     const state = authReducer(adminState, setAuthData());
     expect(state.isAdmin).toBe(true);
     expect(state.onboarded).toBe(true);
+    expect(state.role).toBe('super_admin');
   });
 
   it('setAuthDataでpayload.onboarded=trueを渡すとonboardedがtrueになる', () => {
     const state = authReducer(initialState, setAuthData({ onboarded: true }));
     expect(state.onboarded).toBe(true);
+  });
+
+  it('setAuthDataでpayload.roleを渡すとroleが反映される', () => {
+    const state = authReducer(initialState, setAuthData({ role: 'super_admin' }));
+    expect(state.role).toBe('super_admin');
   });
 
   it('setAuthenticatedでisAuthenticated=true, loading=falseになる', () => {
@@ -52,9 +65,16 @@ describe('authSlice', () => {
   });
 
   it('setAuthenticatedでpayload未指定の場合は既存のisAdminを保持する', () => {
-    const adminState = { isAuthenticated: true, loading: false, isAdmin: true, onboarded: true };
+    const adminState = {
+      isAuthenticated: true,
+      loading: false,
+      isAdmin: true,
+      onboarded: true,
+      role: 'company_admin',
+    };
     const state = authReducer(adminState, setAuthenticated());
     expect(state.isAdmin).toBe(true);
+    expect(state.role).toBe('company_admin');
   });
 
   it('markOnboardedでonboardedがtrueになる', () => {
@@ -62,18 +82,20 @@ describe('authSlice', () => {
     expect(state.onboarded).toBe(true);
   });
 
-  it('clearAuthでisAuthenticated=false, loading=false, isAdmin=false, onboarded=falseになる', () => {
+  it('clearAuthで全フィールドが初期値にリセットされる', () => {
     const authenticatedState = {
       isAuthenticated: true,
       loading: false,
       isAdmin: true,
       onboarded: true,
+      role: 'super_admin',
     };
     const state = authReducer(authenticatedState, clearAuth());
     expect(state.isAuthenticated).toBe(false);
     expect(state.loading).toBe(false);
     expect(state.isAdmin).toBe(false);
     expect(state.onboarded).toBe(false);
+    expect(state.role).toBeNull();
   });
 
   it('finishLoadingでloading=falseになりisAuthenticatedは変わらない', () => {

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -6,19 +6,23 @@ const initialState: AuthState = {
   loading: true,
   isAdmin: false,
   onboarded: false,
+  role: null,
+};
+
+type AuthPayload = {
+  isAdmin?: boolean;
+  onboarded?: boolean;
+  role?: string | null;
 };
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setAuthData(
-      state,
-      action: PayloadAction<{ isAdmin?: boolean; onboarded?: boolean } | undefined>
-    ) {
+    setAuthData(state, action: PayloadAction<AuthPayload | undefined>) {
       state.isAuthenticated = true;
       state.loading = false;
-      // payload.isAdmin / onboarded が undefined のときは現在の state を維持する
+      // payload の各フィールドが undefined のときは現在の state を維持する
       // (caller が値を明示しない再認証で誤って権限を失わせないため)
       if (action.payload?.isAdmin !== undefined) {
         state.isAdmin = action.payload.isAdmin;
@@ -26,12 +30,12 @@ const authSlice = createSlice({
       if (action.payload?.onboarded !== undefined) {
         state.onboarded = action.payload.onboarded;
       }
+      if (action.payload?.role !== undefined) {
+        state.role = action.payload.role;
+      }
     },
 
-    setAuthenticated(
-      state,
-      action: PayloadAction<{ isAdmin?: boolean; onboarded?: boolean } | undefined>
-    ) {
+    setAuthenticated(state, action: PayloadAction<AuthPayload | undefined>) {
       state.isAuthenticated = true;
       state.loading = false;
       if (action.payload?.isAdmin !== undefined) {
@@ -39,6 +43,9 @@ const authSlice = createSlice({
       }
       if (action.payload?.onboarded !== undefined) {
         state.onboarded = action.payload.onboarded;
+      }
+      if (action.payload?.role !== undefined) {
+        state.role = action.payload.role;
       }
     },
 
@@ -53,6 +60,7 @@ const authSlice = createSlice({
       state.loading = false;
       state.isAdmin = false;
       state.onboarded = false;
+      state.role = null;
     },
 
     finishLoading(state) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -105,6 +105,12 @@ export interface AuthState {
    * 有無に応じてセットされる。Protected で /welcome リダイレクト判定に使う。
    */
   onboarded: boolean;
+  /**
+   * 現在ユーザーの role（'super_admin' / 'company_admin' / 'trainee'）。
+   * メニュー出し分け（super_admin は管理機能のみ）と Protected の trainee 用ルート保護に使う。
+   * 未認証 / 未確定は null。
+   */
+  role: string | null;
 }
 
 /** 言い換え提案結果 */

--- a/frontend/src/utils/AuthInitializer.tsx
+++ b/frontend/src/utils/AuthInitializer.tsx
@@ -23,6 +23,7 @@ export default function AuthInitializer({ children }: AuthInitializerProps) {
             // Welcome 画面に飛ばすかの判定を Protected で使う。
             // backend から undefined が返ってきた場合は完了扱い（既存ユーザー保護）。
             onboarded: me.onboarded ?? true,
+            role: me.role ?? null,
           })
         );
       } catch {

--- a/frontend/src/utils/Protected.tsx
+++ b/frontend/src/utils/Protected.tsx
@@ -7,18 +7,23 @@ interface ProtectedProps {
   children: ReactNode;
 }
 
+// super_admin は trainee 向け学習機能を利用しないため、これらのパスにアクセスしたら
+// /admin/companies へリダイレクトする。Sidebar の filter とセットで運用する。
+const TRAINEE_ONLY_PATH_PREFIXES = ['/chat/ask-ai', '/code-editor', '/notes', '/reports'];
+
 /**
  * 認証必須ルートのガード。
  *
  * 1. 未認証 → /login
  * 2. 認証済 + onboarded === false → /welcome（初回オンボーディング）
- * 3. 認証済 + onboarded === true → 子コンポーネントを描画
+ * 3. role === 'super_admin' + trainee 向けパス → /admin/companies
+ * 4. それ以外は子コンポーネントを描画
  *
  * /welcome 自体への navigate ループを避けるため、現在 path が /welcome の場合は
  * onboarded 判定を skip する（WelcomePage 側でガード）。
  */
 export default function Protected({ children }: ProtectedProps) {
-  const { isAuthenticated, onboarded } = useSelector((state: RootState) => state.auth);
+  const { isAuthenticated, onboarded, role } = useSelector((state: RootState) => state.auth);
   const location = useLocation();
 
   if (!isAuthenticated) {
@@ -27,6 +32,13 @@ export default function Protected({ children }: ProtectedProps) {
 
   if (!onboarded && location.pathname !== '/welcome') {
     return <Navigate to="/welcome" replace />;
+  }
+
+  if (
+    role === 'super_admin' &&
+    TRAINEE_ONLY_PATH_PREFIXES.some((p) => location.pathname.startsWith(p))
+  ) {
+    return <Navigate to="/admin/companies" replace />;
   }
 
   return children;

--- a/frontend/src/utils/__tests__/AuthInitializer.test.tsx
+++ b/frontend/src/utils/__tests__/AuthInitializer.test.tsx
@@ -96,4 +96,36 @@ describe('AuthInitializer', () => {
       expect(store.getState().auth.loading).toBe(false);
     });
   });
+
+  it('/auth/me が role=super_admin を返した場合 store に反映される', async () => {
+    vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
+      id: 1,
+      email: 'admin@example.com',
+      sub: 'sub-456',
+      role: 'super_admin',
+      onboarded: true,
+      isAdmin: true,
+    });
+
+    const { store } = renderWithStore(true);
+
+    await waitFor(() => {
+      expect(store.getState().auth.role).toBe('super_admin');
+      expect(store.getState().auth.isAdmin).toBe(true);
+    });
+  });
+
+  it('/auth/me に role が無い場合 role=null になる', async () => {
+    vi.mocked(authRepository.getCurrentUser).mockResolvedValue({
+      id: 2,
+      email: 'user@example.com',
+      sub: 'sub-789',
+    });
+
+    const { store } = renderWithStore(true);
+
+    await waitFor(() => {
+      expect(store.getState().auth.role).toBeNull();
+    });
+  });
 });

--- a/frontend/src/utils/__tests__/Protected.test.tsx
+++ b/frontend/src/utils/__tests__/Protected.test.tsx
@@ -12,7 +12,7 @@ function renderWithAuth(isAuthenticated: boolean, onboarded: boolean = true) {
     preloadedState: {
       // onboarded=true デフォルトで /welcome リダイレクトを回避（既存テストの意図を維持）。
       // /welcome リダイレクト経路は別テストでカバー。
-      auth: { isAuthenticated, loading: false, isAdmin: false, onboarded },
+      auth: { isAuthenticated, loading: false, isAdmin: false, onboarded, role: null },
     },
   });
 
@@ -61,7 +61,13 @@ describe('Protected', () => {
     const store = configureStore({
       reducer: { auth: authReducer },
       preloadedState: {
-        auth: { isAuthenticated: true, loading: false, isAdmin: false, onboarded: false },
+        auth: {
+          isAuthenticated: true,
+          loading: false,
+          isAdmin: false,
+          onboarded: false,
+          role: null,
+        },
       },
     });
     render(
@@ -84,5 +90,106 @@ describe('Protected', () => {
     );
     expect(screen.getByText('Welcome 画面')).toBeInTheDocument();
     expect(screen.queryByText('保護されたコンテンツ')).not.toBeInTheDocument();
+  });
+
+  // super_admin が trainee 向けルート (/chat/ask-ai 等) にアクセスしたら /admin/companies に飛ばす。
+  it('role=super_admin が /chat/ask-ai にアクセスすると /admin/companies にリダイレクト', () => {
+    const store = configureStore({
+      reducer: { auth: authReducer },
+      preloadedState: {
+        auth: {
+          isAuthenticated: true,
+          loading: false,
+          isAdmin: true,
+          onboarded: true,
+          role: 'super_admin',
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/chat/ask-ai']}>
+          <Routes>
+            <Route
+              path="/chat/ask-ai"
+              element={
+                <Protected>
+                  <div>AI チャット画面</div>
+                </Protected>
+              }
+            />
+            <Route path="/admin/companies" element={<div>会社一覧</div>} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.getByText('会社一覧')).toBeInTheDocument();
+    expect(screen.queryByText('AI チャット画面')).not.toBeInTheDocument();
+  });
+
+  // super_admin でも /admin 配下は通る。
+  it('role=super_admin が /admin/companies にアクセスすると children を表示', () => {
+    const store = configureStore({
+      reducer: { auth: authReducer },
+      preloadedState: {
+        auth: {
+          isAuthenticated: true,
+          loading: false,
+          isAdmin: true,
+          onboarded: true,
+          role: 'super_admin',
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/admin/companies']}>
+          <Routes>
+            <Route
+              path="/admin/companies"
+              element={
+                <Protected>
+                  <div>会社一覧</div>
+                </Protected>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.getByText('会社一覧')).toBeInTheDocument();
+  });
+
+  // trainee は trainee ルートにアクセス可能。
+  it('role=trainee は /chat/ask-ai にアクセスできる', () => {
+    const store = configureStore({
+      reducer: { auth: authReducer },
+      preloadedState: {
+        auth: {
+          isAuthenticated: true,
+          loading: false,
+          isAdmin: false,
+          onboarded: true,
+          role: 'trainee',
+        },
+      },
+    });
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={['/chat/ask-ai']}>
+          <Routes>
+            <Route
+              path="/chat/ask-ai"
+              element={
+                <Protected>
+                  <div>AI チャット画面</div>
+                </Protected>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.getByText('AI チャット画面')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要

PR-F: 認可ルール調整の最後の仕上げ。
`super_admin` は「企業管理に専念するロール」と定義し、trainee 向け学習機能（AI チャット / コード学習 / ノート / レポート）をフロント側で**メニュー非表示 + 直接 URL もリダイレクト**で二重にガードする。

PR-A 〜 PR-E でバックエンド・フロントのコア機能整理（4 領域に絞り込み・DB DROP マイグレーション）を完了したのを受けた、UX 仕上げの PR。

## 変更内容

### types / store

- `AuthState` に `role: string | null` を追加
- `authSlice` の payload 型に `role` を含めて `clearAuth` でも `null` リセット

### Auth 初期化

- `AuthInitializer` が `/api/v2/auth/me` の `role` フィールドを `setAuthData` 経由で反映

### サイドバー / ガード

- `Sidebar`: `role === 'super_admin'` のときは `home` / `notifications` のみ表示（AI / コード学習 / ノート / レポートを非表示）
- `Protected`: `super_admin` が `/chat/ask-ai` / `/code-editor` / `/notes` / `/reports` にアクセスしたら `/admin/companies` へ Navigate

### ホーム画面

- `MenuPage` のカードを `super_admin` 向け（会社一覧 / 招待管理）に出し分け

## ロールごとの可視性

| メニュー / 画面 | trainee | company_admin | super_admin |
|---|---|---|---|
| ホーム / 通知 / プロフィール | ✅ | ✅ | ✅ |
| AI / コード / ノート / レポート | ✅ | ✅ | ❌ |
| 管理 (`/admin/*`) | ❌ | ✅ | ✅ |

## テスト

- `npx vitest run`: 1715 件 green
- `npx tsc --noEmit`: pass
- `npx eslint src --max-warnings 0`: pass
- 追加テスト:
  - `authSlice`: role の payload 反映 / clearAuth でリセット
  - `AuthInitializer`: `/auth/me` の role を store に反映 / role 無しは null
  - `Protected`: super_admin が trainee ルートで `/admin/companies` リダイレクト / `/admin/*` は通る / trainee は trainee ルート可
  - `Sidebar`: super_admin は trainee メニュー非表示 / company_admin は両方表示

## docs

設計ドキュメントは `frestyle-pdm` 側で別 PR にて追加: https://github.com/norman6464/frestyle-pdm/pull/7

## 関連 Issue

PR-A 〜 PR-E（コア機能整理）の最後の仕上げ。