### PR TITLE
fix(bedrock): default model を sonnet-4-5 inference profile に変更（Claude 4 系の on-demand 非対応対応）

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -89,14 +89,22 @@ func Load() (*Config, error) {
 		},
 		Bedrock: BedrockConfig{
 			Region: getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
-			// ap-northeast-1 で ACTIVE な Anthropic モデルを default にする。
-			// 旧 default の "anthropic.claude-3-5-haiku-20241022-v1:0" は当 region に存在せず
-			// Bedrock Converse API が ValidationException: invalid model identifier を返していた
-			// （2026-05-06 本番でユーザーから AI チャット返信なしの報告で発覚）。
-			// 利用可能 model 確認:
-			//   aws bedrock list-foundation-models --region ap-northeast-1 \
-			//     --query 'modelSummaries[?providerName==`Anthropic`].modelId'
-			ModelID: getEnvOrDefault("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-20251001-v1:0"),
+			// Claude 4 系（haiku-4-5 / sonnet-4-x / opus-4-x）は on-demand throughput では呼べず、
+			// Inference Profile 経由必須。foundation-model ARN を直接指定すると ConverseStream が
+			// ValidationException で 400 を返す（2026-05-08 本番でユーザーから AI チャット返信なし
+			// の報告で発覚）。
+			//
+			// `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` が ap-northeast-1 用の Japan inference
+			// profile（sonnet-4.5）。IAM 側 (frestyle-infrastructure: BedrockInvokeAccess) でも
+			// `arn:aws:bedrock:${region}:${account}:inference-profile/jp.anthropic.claude-sonnet-4-*`
+			// を許可しておく必要がある。
+			//
+			// モデル選定: 旧 default の haiku-4-5 から sonnet-4-5 にアップグレード。応答品質を優先し、
+			// チャット用途なら latency / コストとも実用範囲（ユーザー指示・2026-05-08）。
+			//
+			// 利用可能 inference profile 一覧:
+			//   aws bedrock list-inference-profiles --region ap-northeast-1
+			ModelID: getEnvOrDefault("BEDROCK_MODEL_ID", "jp.anthropic.claude-sonnet-4-5-20250929-v1:0"),
 		},
 		DynamoDB: DynamoDBConfig{
 			Region:      getEnvOrDefault("AWS_REGION", "ap-northeast-1"),


### PR DESCRIPTION
## 概要

本番 AI チャットが返事しなくなる障害（2026-05-08 朝）の修正。
Claude 4 系（haiku-4-5 / sonnet-4-x / opus-4-x）は **on-demand throughput では呼べず Inference Profile 経由必須** となっており、foundation-model ID `anthropic.claude-haiku-4-5-20251001-v1:0` を直接 `BEDROCK_MODEL_ID` に渡していた構成では `ConverseStream` が ValidationException で 400 を返していた。

ECS ログ:
```
ValidationException: Invocation of model ID anthropic.claude-haiku-4-5-20251001-v1:0
with on-demand throughput isn't supported.
Retry your request with the ID or ARN of an inference profile that contains this model.
```

## 変更内容

- `backend/internal/infra/config/config.go` の `BEDROCK_MODEL_ID` default を
  `anthropic.claude-haiku-4-5-20251001-v1:0` → `jp.anthropic.claude-sonnet-4-5-20250929-v1:0`
  （ap-northeast-1 用 Japan inference profile / sonnet-4.5）に変更
- 旧 default の haiku-4-5 から sonnet-4-5 にアップグレード（応答品質優先・ユーザー指示）
- 設計判断と `list-inference-profiles` で profile を確認する運用手順を comment に追記

## デプロイ順序（重要）

逆順だと AccessDenied 期間が発生するため、必ず以下の順で:

1. `norman6464/frestyle-infrastructure#51` を先にマージ
2. `ENV=prod make deploy-iam-runtime` で TaskRole の inference-profile 許可を反映
3. 本 PR をマージ
4. `make ecr-build-push && make ecs-update-service-force` で backend 再デプロイ

## テスト

- `go build ./...`: pass
- `go test ./internal/usecase/...`: pass
- 本番デプロイ後、`aws logs tail /ecs/frestyle-prod --since 5m` で ValidationException が消えていることを確認

## 関連 docs

- 設計判断・障害メモ: `frestyle-pdm/docs/aichat/bedrock-inference-profile.md`（別 PR）
- インフラ側 IAM 修正: https://github.com/norman6464/frestyle-infrastructure/pull/51

## 関連 Issue

なし