### PR TITLE
feat(ai-chat): 画像添付対応 (PR-G1) — + ボタンで Claude vision に画像を渡す

### DIFF
--- a/backend/internal/domain/ai_chat.go
+++ b/backend/internal/domain/ai_chat.go
@@ -2,7 +2,7 @@ package domain
 
 import "time"
 
-// AiChatSession は AI チャットの 1 セッション。Spring Boot の entity.AiChatSession に相当。
+// AiChatSession は AI チャットの 1 セッション
 type AiChatSession struct {
 	ID          uint64    `gorm:"primaryKey" json:"id"`
 	UserID      uint64    `gorm:"column:user_id;index" json:"userId"`
@@ -22,15 +22,47 @@ const (
 
 // AiChatMessage は AI チャットの 1 メッセージ。実体は DynamoDB に保存されるが、
 // API ではこの形で返却する。
+//
+// Attachments はユーザー発話に紐付く画像 / ドキュメント等の添付ファイル群。
+// S3 のオブジェクトキーとメタデータだけを保存し、実体バイト列 (BlobData) は
+// DynamoDB / JSON への永続化対象外（Bedrock 呼び出し直前に S3 から取得して詰める）。
 type AiChatMessage struct {
-	SessionID uint64    `json:"sessionId"`
-	MessageID string    `json:"messageId"`
-	Role      string    `json:"role"`
-	Content   string    `json:"content"`
-	CreatedAt time.Time `json:"createdAt"`
+	SessionID   uint64       `json:"sessionId"`
+	MessageID   string       `json:"messageId"`
+	Role        string       `json:"role"`
+	Content     string       `json:"content"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	CreatedAt   time.Time    `json:"createdAt"`
+}
+
+// Attachment は AI チャット送信時の添付ファイル。
+//
+// Kind:
+//   - "image": Bedrock の content[].image ブロックに詰めて vision 入力にする
+//   - "document": 将来の PR-G2 で PDF / CSV を扱う際の値（PR-G1 では未使用）
+//
+// Format は AWS Bedrock Converse API が要求する短い文字列。
+//   - 画像: "png" / "jpeg" / "gif" / "webp"
+//   - ドキュメント (PR-G2 以降): "pdf" / "csv" / "txt" など
+//
+// SizeBytes は S3 アップロード後の確認用メタ。Bedrock 上限超過時は handler で 400 を返す。
+//
+// BlobData は usecase が Bedrock に渡す直前に S3 GetObject で詰める一時フィールド。
+// JSON / DynamoDB には永続化しないため `json:"-"` と repository 側 dynamoItem 除外で扱う。
+type Attachment struct {
+	Key         string `json:"key"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	Format      string `json:"format"`
+	Kind        string `json:"kind"`
+	SizeBytes   int64  `json:"sizeBytes"`
+	BlobData    []byte `json:"-"`
 }
 
 const (
 	AiChatRoleUser      = "user"
 	AiChatRoleAssistant = "assistant"
+
+	AttachmentKindImage    = "image"
+	AttachmentKindDocument = "document"
 )

--- a/backend/internal/handler/ai_chat_attachment_handler.go
+++ b/backend/internal/handler/ai_chat_attachment_handler.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AiChatAttachmentHandler は AI チャット添付の S3 PUT presigned URL を発行する HTTP handler。
+//
+// フロントの送信フロー:
+//  1. ユーザーが画像 / ドキュメントを + ボタンで選ぶ
+//  2. POST /api/v2/ai-chat/attachments/upload-url で presigned PUT URL を取得
+//  3. 同 URL に PUT で実体を直アップロード
+//  4. SSE 送信 (POST /api/v2/ai-chat/stream) の attachments[] に key とメタを詰める
+type AiChatAttachmentHandler struct {
+	issueUseCase *usecase.IssueAiChatAttachmentUploadURLUseCase
+}
+
+func NewAiChatAttachmentHandler(uc *usecase.IssueAiChatAttachmentUploadURLUseCase) *AiChatAttachmentHandler {
+	return &AiChatAttachmentHandler{issueUseCase: uc}
+}
+
+type aiChatAttachmentUploadURLRequest struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	SizeBytes   int64  `json:"sizeBytes"`
+}
+
+// IssueUploadURL は POST /api/v2/ai-chat/attachments/upload-url。
+//
+// 戻り値: { uploadUrl, key, expiresIn }。
+//
+// 4xx 応答:
+//   - 400: contentType / filename / sizeBytes バリデーション失敗
+//   - 401: 未認証
+//   - 413: サイズ上限超過
+//   - 415: 未サポートの MIME
+func (h *AiChatAttachmentHandler) IssueUploadURL(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	if h.issueUseCase == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "attachment_upload_unavailable"})
+		return
+	}
+	var body aiChatAttachmentUploadURLRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if body.ContentType == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "contentType is required"})
+		return
+	}
+	out, err := h.issueUseCase.Execute(c.Request.Context(), usecase.IssueAiChatAttachmentUploadURLInput{
+		UserID:      uid,
+		Filename:    body.Filename,
+		ContentType: body.ContentType,
+		SizeBytes:   body.SizeBytes,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrAttachmentUnsupportedType):
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": err.Error()})
+		case errors.Is(err, usecase.ErrAttachmentTooLarge):
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": err.Error()})
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/backend/internal/handler/ai_chat_attachment_handler.go
+++ b/backend/internal/handler/ai_chat_attachment_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -58,6 +59,14 @@ func (h *AiChatAttachmentHandler) IssueUploadURL(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "contentType is required"})
 		return
 	}
+	if body.Filename == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "filename is required"})
+		return
+	}
+	if body.SizeBytes <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "sizeBytes must be positive"})
+		return
+	}
 	out, err := h.issueUseCase.Execute(c.Request.Context(), usecase.IssueAiChatAttachmentUploadURLInput{
 		UserID:      uid,
 		Filename:    body.Filename,
@@ -71,7 +80,9 @@ func (h *AiChatAttachmentHandler) IssueUploadURL(c *gin.Context) {
 		case errors.Is(err, usecase.ErrAttachmentTooLarge):
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": err.Error()})
 		default:
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			// 内部エラー（presigner 障害等）は詳細を漏らさず 500。原因は server log にだけ残す。
+			log.Printf("ai-chat-attachment: presigned URL issue failed: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		}
 		return
 	}

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
@@ -40,12 +42,26 @@ func NewAiChatSseHandler(sendStream *usecase.SendAiMessageStreamUseCase) *AiChat
 }
 
 type sseRequestBody struct {
-	SessionID   int64   `json:"sessionId"`
-	Content     string  `json:"content"`
-	Scene       string  `json:"scene"`
-	SessionType string  `json:"sessionType"`
-	ScenarioID  *uint64 `json:"scenarioId"`
+	SessionID   int64                    `json:"sessionId"`
+	Content     string                   `json:"content"`
+	Scene       string                   `json:"scene"`
+	SessionType string                   `json:"sessionType"`
+	ScenarioID  *uint64                  `json:"scenarioId"`
+	Attachments []sseAttachmentRequest   `json:"attachments"`
 }
+
+// sseAttachmentRequest はフロントが事前に S3 へアップロード済みの添付ファイルを参照する。
+// 実体バイトは含まず、key とメタだけ送って backend が S3 GetObject で取り出す。
+type sseAttachmentRequest struct {
+	Key         string `json:"key"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"contentType"`
+	SizeBytes   int64  `json:"sizeBytes"`
+}
+
+// 1 リクエストあたりの添付上限。Bedrock 仕様（image 20 / document 5）に対し、
+// UI / 課金観点で 4 枚に絞っている（仕様検討で確定）。
+const maxAttachmentsPerMessage = 4
 
 // Handle は POST /api/v2/ai-chat/stream。
 //
@@ -69,8 +85,17 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if body.Content == "" {
+	if body.Content == "" && len(body.Attachments) == 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "content_required"})
+		return
+	}
+	if len(body.Attachments) > maxAttachmentsPerMessage {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "too_many_attachments"})
+		return
+	}
+	attachments, err := buildAttachmentsFromRequest(body.Attachments)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -94,6 +119,7 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 		Scene:       body.Scene,
 		SessionType: body.SessionType,
 		ScenarioID:  body.ScenarioID,
+		Attachments: attachments,
 	})
 	if err != nil {
 		writeSSEEvent(c.Writer, "error", map[string]string{"message": "メッセージの送信に失敗しました"})
@@ -194,3 +220,49 @@ func flushOrPanic(w gin.ResponseWriter) {
 		panic("ai_chat_sse_handler: ResponseWriter is not flushable")
 	}
 }
+
+// buildAttachmentsFromRequest はリクエスト body の attachments[] を domain.Attachment に変換する。
+//
+// 各添付について:
+//   - key / contentType 必須
+//   - contentType は usecase.AllowedAttachmentContentTypes に含まれる必要あり
+//   - sizeBytes は MIME ごとの上限以下
+//   - key は S3 prefix `ai-chat/` に必ず属する（ディレクトリトラバーサル / 他 prefix 参照防止）
+//
+// バリデーションを SSE handler 側で 1 回通すのは「presigned URL 取得を経由したか」を
+// 軽く再確認する目的（プロンプトインジェクションで任意 S3 オブジェクトを読み出させない）。
+func buildAttachmentsFromRequest(reqs []sseAttachmentRequest) ([]domain.Attachment, error) {
+	if len(reqs) == 0 {
+		return nil, nil
+	}
+	out := make([]domain.Attachment, 0, len(reqs))
+	for _, r := range reqs {
+		if r.Key == "" || r.ContentType == "" {
+			return nil, sseAttachmentError("attachment_invalid")
+		}
+		if !strings.HasPrefix(r.Key, "ai-chat/") {
+			return nil, sseAttachmentError("attachment_key_not_allowed")
+		}
+		rule, ok := usecase.AllowedAttachmentContentTypes[r.ContentType]
+		if !ok {
+			return nil, sseAttachmentError("attachment_unsupported_type")
+		}
+		if r.SizeBytes <= 0 || r.SizeBytes > rule.Max {
+			return nil, sseAttachmentError("attachment_too_large")
+		}
+		out = append(out, domain.Attachment{
+			Key:         r.Key,
+			Filename:    r.Filename,
+			ContentType: r.ContentType,
+			Format:      rule.Format,
+			Kind:        rule.Kind,
+			SizeBytes:   r.SizeBytes,
+		})
+	}
+	return out, nil
+}
+
+// sseAttachmentError は handler 内で 400 を返すための軽量エラー型。
+type sseAttachmentError string
+
+func (e sseAttachmentError) Error() string { return string(e) }

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -93,7 +94,7 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "too_many_attachments"})
 		return
 	}
-	attachments, err := buildAttachmentsFromRequest(body.Attachments)
+	attachments, err := buildAttachmentsFromRequest(uid, body.Attachments)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -227,20 +228,22 @@ func flushOrPanic(w gin.ResponseWriter) {
 //   - key / contentType 必須
 //   - contentType は usecase.AllowedAttachmentContentTypes に含まれる必要あり
 //   - sizeBytes は MIME ごとの上限以下
-//   - key は S3 prefix `ai-chat/` に必ず属する（ディレクトリトラバーサル / 他 prefix 参照防止）
+//   - key は **userID 配下の S3 prefix** `ai-chat/{userID}/` に必ず属する
+//     （他ユーザーの添付や他 prefix の S3 オブジェクトをサーバ側で読まされるのを防止）
 //
 // バリデーションを SSE handler 側で 1 回通すのは「presigned URL 取得を経由したか」を
 // 軽く再確認する目的（プロンプトインジェクションで任意 S3 オブジェクトを読み出させない）。
-func buildAttachmentsFromRequest(reqs []sseAttachmentRequest) ([]domain.Attachment, error) {
+func buildAttachmentsFromRequest(userID uint64, reqs []sseAttachmentRequest) ([]domain.Attachment, error) {
 	if len(reqs) == 0 {
 		return nil, nil
 	}
+	expectedPrefix := fmt.Sprintf("ai-chat/%d/", userID)
 	out := make([]domain.Attachment, 0, len(reqs))
 	for _, r := range reqs {
 		if r.Key == "" || r.ContentType == "" {
 			return nil, sseAttachmentError("attachment_invalid")
 		}
-		if !strings.HasPrefix(r.Key, "ai-chat/") {
+		if !strings.HasPrefix(r.Key, expectedPrefix) {
 			return nil, sseAttachmentError("attachment_key_not_allowed")
 		}
 		rule, ok := usecase.AllowedAttachmentContentTypes[r.ContentType]

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -42,12 +42,12 @@ func NewAiChatSseHandler(sendStream *usecase.SendAiMessageStreamUseCase) *AiChat
 }
 
 type sseRequestBody struct {
-	SessionID   int64                    `json:"sessionId"`
-	Content     string                   `json:"content"`
-	Scene       string                   `json:"scene"`
-	SessionType string                   `json:"sessionType"`
-	ScenarioID  *uint64                  `json:"scenarioId"`
-	Attachments []sseAttachmentRequest   `json:"attachments"`
+	SessionID   int64                  `json:"sessionId"`
+	Content     string                 `json:"content"`
+	Scene       string                 `json:"scene"`
+	SessionType string                 `json:"sessionType"`
+	ScenarioID  *uint64                `json:"scenarioId"`
+	Attachments []sseAttachmentRequest `json:"attachments"`
 }
 
 // sseAttachmentRequest はフロントが事前に S3 へアップロード済みの添付ファイルを参照する。

--- a/backend/internal/handler/ai_chat_sse_handler_test.go
+++ b/backend/internal/handler/ai_chat_sse_handler_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// buildAttachmentsFromRequest はクロスユーザの S3 key を弾く必要がある。
+// userID=7 のユーザーが userID=42 配下の key を渡してきたら attachment_key_not_allowed を返す。
+func TestBuildAttachmentsFromRequest_RejectsCrossUserKey(t *testing.T) {
+	_, err := buildAttachmentsFromRequest(7, []sseAttachmentRequest{
+		{
+			Key:         "ai-chat/42/abc.png",
+			Filename:    "abc.png",
+			ContentType: "image/png",
+			SizeBytes:   100,
+		},
+	})
+	assert.ErrorContains(t, err, "attachment_key_not_allowed")
+}
+
+// 自分の userID 配下の key は正しく domain.Attachment に変換されること。
+func TestBuildAttachmentsFromRequest_AcceptsOwnKey(t *testing.T) {
+	out, err := buildAttachmentsFromRequest(7, []sseAttachmentRequest{
+		{
+			Key:         "ai-chat/7/abc.png",
+			Filename:    "abc.png",
+			ContentType: "image/png",
+			SizeBytes:   100,
+		},
+	})
+	assert.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.Equal(t, "ai-chat/7/abc.png", out[0].Key)
+	assert.Equal(t, "image", out[0].Kind)
+	assert.Equal(t, "png", out[0].Format)
+}
+
+// MIME 未対応 / 容量超過 / ai-chat 以外の prefix はそれぞれ専用エラーで弾く。
+func TestBuildAttachmentsFromRequest_RejectsUnsupportedAndOversize(t *testing.T) {
+	cases := []struct {
+		name string
+		req  sseAttachmentRequest
+		want string
+	}{
+		{
+			name: "未対応 MIME",
+			req:  sseAttachmentRequest{Key: "ai-chat/7/a.txt", ContentType: "text/plain", SizeBytes: 100},
+			want: "attachment_unsupported_type",
+		},
+		{
+			name: "サイズ 0",
+			req:  sseAttachmentRequest{Key: "ai-chat/7/a.png", ContentType: "image/png", SizeBytes: 0},
+			want: "attachment_too_large",
+		},
+		{
+			name: "サイズ超過",
+			req:  sseAttachmentRequest{Key: "ai-chat/7/a.png", ContentType: "image/png", SizeBytes: 10 * 1024 * 1024},
+			want: "attachment_too_large",
+		},
+		{
+			name: "ai-chat 外 prefix",
+			req:  sseAttachmentRequest{Key: "notes/7/a.png", ContentType: "image/png", SizeBytes: 100},
+			want: "attachment_key_not_allowed",
+		},
+		{
+			name: "key 空",
+			req:  sseAttachmentRequest{Key: "", ContentType: "image/png", SizeBytes: 100},
+			want: "attachment_invalid",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildAttachmentsFromRequest(7, []sseAttachmentRequest{tc.req})
+			assert.ErrorContains(t, err, tc.want)
+		})
+	}
+}

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -1,7 +1,11 @@
 package handler
 
 import (
+	"context"
+	"log"
+
 	"github.com/gin-gonic/gin"
+	infraS3 "github.com/norman6464/FreStyle/backend/internal/infra/s3"
 	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
@@ -25,13 +29,55 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.DELETE("/ai-chat/sessions/:id", aiHandler.DeleteSession)
 	g.GET("/ai-chat/sessions/:id/messages", aiHandler.GetMessages)
 
+	// 添付ファイル用 presigned PUT URL（PR-G1: 画像）。
+	// note image 系と同じく NOTE_IMAGES_BUCKET（= note-images バケット）を再利用し、
+	// `ai-chat/{userId}/{uuid}.{ext}` の prefix で運用する。bucket policy / IAM は
+	// 既存ノート画像と共有（runtime/iam.yml の `${NoteImagesBucketArn}/*` でカバー）。
+	attachmentPresigner := newAiChatAttachmentPresignerOrFallback(deps)
+	attachmentHandler := NewAiChatAttachmentHandler(
+		usecase.NewIssueAiChatAttachmentUploadURLUseCase(attachmentPresigner),
+	)
+	g.POST("/ai-chat/attachments/upload-url", attachmentHandler.IssueUploadURL)
+
 	// SSE ストリーミング（汎用 AI チャットの token 単位送信）。
 	// Bedrock / DynamoDB の初期化に失敗していると bedrockClient / msgRepo は nil。
 	// nil sentinel は handler 側で 503 にする。
 	if deps.bedrockClient != nil && deps.msgRepo != nil {
+		downloader := newAiChatAttachmentDownloaderOrNil(deps)
 		sseHandler := NewAiChatSseHandler(
-			usecase.NewSendAiMessageStreamUseCase(aiSessionRepo, deps.msgRepo, deps.bedrockClient),
+			usecase.NewSendAiMessageStreamUseCase(aiSessionRepo, deps.msgRepo, deps.bedrockClient, downloader),
 		)
 		g.POST("/ai-chat/stream", sseHandler.Handle)
 	}
+}
+
+// newAiChatAttachmentPresignerOrFallback は本番経路では infra/s3.Presigner を、
+// dev / NOTE_IMAGES_BUCKET 未設定時は stub presigner を返す。Note 系と同じ fail open。
+func newAiChatAttachmentPresignerOrFallback(deps *routeDeps) repository.AiChatAttachmentPresigner {
+	bucket := deps.cfg.S3.NoteImagesBucket
+	if bucket == "" {
+		log.Printf("[ai-chat-attachment] NOTE_IMAGES_BUCKET unset — using stub presigner (DEV)")
+		return repository.NewStubAiChatAttachmentPresigner("stub-bucket")
+	}
+	pre, err := infraS3.NewPresigner(context.Background(), deps.cfg.S3.Region, bucket)
+	if err != nil {
+		log.Printf("[ai-chat-attachment] failed to init S3 presigner (%v) — falling back to stub", err)
+		return repository.NewStubAiChatAttachmentPresigner(bucket)
+	}
+	return repository.NewAiChatAttachmentPresigner(pre)
+}
+
+// newAiChatAttachmentDownloaderOrNil は本番では S3 GetObject downloader を返す。
+// bucket 未設定 / 初期化失敗時は nil を返し、SSE usecase 側で「添付なしと同じ振る舞い」にフォールバック。
+func newAiChatAttachmentDownloaderOrNil(deps *routeDeps) usecase.AttachmentDownloader {
+	bucket := deps.cfg.S3.NoteImagesBucket
+	if bucket == "" {
+		return nil
+	}
+	dl, err := infraS3.NewDownloader(context.Background(), deps.cfg.S3.Region, bucket)
+	if err != nil {
+		log.Printf("[ai-chat-attachment] failed to init S3 downloader (%v) — attachments will be ignored", err)
+		return nil
+	}
+	return dl
 }

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -74,7 +74,8 @@ func newAiChatAttachmentDownloaderOrNil(deps *routeDeps) usecase.AttachmentDownl
 	if bucket == "" {
 		return nil
 	}
-	dl, err := infraS3.NewDownloader(context.Background(), deps.cfg.S3.Region, bucket)
+	// `ai-chat/` prefix のみ読み出し許可（他用途の S3 オブジェクト読み出しを防止）。
+	dl, err := infraS3.NewDownloader(context.Background(), deps.cfg.S3.Region, bucket, "ai-chat/")
 	if err != nil {
 		log.Printf("[ai-chat-attachment] failed to init S3 downloader (%v) — attachments will be ignored", err)
 		return nil

--- a/backend/internal/infra/bedrock/client.go
+++ b/backend/internal/infra/bedrock/client.go
@@ -4,6 +4,7 @@ package bedrock
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -149,6 +150,10 @@ func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, histor
 // ユーザー発話に Attachments が付いていれば、各添付を image / document ContentBlock に
 // 展開して text の前に並べる（Bedrock の慣習: 画像 → テキストの順が推奨）。
 // BlobData が空の Attachment は無視する（usecase で S3 から取得済みであることが前提）。
+//
+// 空コンテンツ + 添付バイト取得失敗（blocks も text も無い）の場合は当該メッセージを
+// スキップする。Bedrock は空テキストブロックを 400 で弾くため、誤って空メッセージを
+// 送らないための防御。
 func buildBedrockMessages(history []domain.AiChatMessage) []brtypes.Message {
 	messages := make([]brtypes.Message, 0, len(history))
 	for _, m := range history {
@@ -163,12 +168,32 @@ func buildBedrockMessages(history []domain.AiChatMessage) []brtypes.Message {
 				blocks = append(blocks, block)
 			}
 		}
-		if m.Content != "" || len(blocks) == 0 {
-			blocks = append(blocks, &brtypes.ContentBlockMemberText{Value: m.Content})
+		text := m.Content
+		// Bedrock の document ブロックは「同一メッセージに text ブロックがあること」を
+		// 要求する。画像のみの場合は text 無しでも OK だが、document を含むなら
+		// 空でない placeholder を必ず付ける。
+		if text == "" && hasDocumentBlock(blocks) {
+			text = "(添付ファイルを参照してください)"
+		}
+		if text != "" {
+			blocks = append(blocks, &brtypes.ContentBlockMemberText{Value: text})
+		}
+		if len(blocks) == 0 {
+			// 空コンテンツ + 全添付ダウンロード失敗 → skip。
+			continue
 		}
 		messages = append(messages, brtypes.Message{Role: role, Content: blocks})
 	}
 	return messages
+}
+
+func hasDocumentBlock(blocks []brtypes.ContentBlock) bool {
+	for _, b := range blocks {
+		if _, ok := b.(*brtypes.ContentBlockMemberDocument); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // attachmentToBlock は 1 つの添付を Bedrock の ContentBlock に変換する。
@@ -204,7 +229,7 @@ func strPtr(s string) *string { return &s }
 // 拡張子は除外し、許可外文字は '-' に置換する。空になったら "document" にフォールバック。
 func documentName(filename string) string {
 	base := filename
-	if i := lastIndexByte(base, '.'); i >= 0 {
+	if i := strings.LastIndexByte(base, '.'); i >= 0 {
 		base = base[:i]
 	}
 	out := make([]byte, 0, len(base))
@@ -227,13 +252,4 @@ func documentName(filename string) string {
 		out = out[:200]
 	}
 	return string(out)
-}
-
-func lastIndexByte(s string, c byte) int {
-	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == c {
-			return i
-		}
-	}
-	return -1
 }

--- a/backend/internal/infra/bedrock/client.go
+++ b/backend/internal/infra/bedrock/client.go
@@ -32,19 +32,7 @@ func NewClient(ctx context.Context, region, modelID string) (*Client, error) {
 // Converse は会話履歴と新規ユーザーメッセージを Bedrock に送り、アシスタント返答テキストを返す。
 // history には直近の会話（user/assistant 交互）を渡す。最後の要素はユーザーの最新発話。
 func (c *Client) Converse(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (string, error) {
-	messages := make([]brtypes.Message, 0, len(history))
-	for _, m := range history {
-		role := brtypes.ConversationRoleUser
-		if m.Role == domain.AiChatRoleAssistant {
-			role = brtypes.ConversationRoleAssistant
-		}
-		messages = append(messages, brtypes.Message{
-			Role: role,
-			Content: []brtypes.ContentBlock{
-				&brtypes.ContentBlockMemberText{Value: m.Content},
-			},
-		})
-	}
+	messages := buildBedrockMessages(history)
 
 	input := &bedrockruntime.ConverseInput{
 		ModelId:  &c.modelID,
@@ -98,19 +86,7 @@ type StreamEvent struct {
 // channel を持っているが、本ラッパでは「アプリケーションが扱いやすい形」に変換して提供する
 // ことで infra 詳細（brtypes の各 Member 型）を usecase 層に漏らさない。
 func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan StreamEvent, error) {
-	messages := make([]brtypes.Message, 0, len(history))
-	for _, m := range history {
-		role := brtypes.ConversationRoleUser
-		if m.Role == domain.AiChatRoleAssistant {
-			role = brtypes.ConversationRoleAssistant
-		}
-		messages = append(messages, brtypes.Message{
-			Role: role,
-			Content: []brtypes.ContentBlock{
-				&brtypes.ContentBlockMemberText{Value: m.Content},
-			},
-		})
-	}
+	messages := buildBedrockMessages(history)
 
 	input := &bedrockruntime.ConverseStreamInput{
 		ModelId:  &c.modelID,
@@ -166,4 +142,98 @@ func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, histor
 	}()
 
 	return out, nil
+}
+
+// buildBedrockMessages は domain.AiChatMessage を Bedrock Converse の Message 列に変換する。
+//
+// ユーザー発話に Attachments が付いていれば、各添付を image / document ContentBlock に
+// 展開して text の前に並べる（Bedrock の慣習: 画像 → テキストの順が推奨）。
+// BlobData が空の Attachment は無視する（usecase で S3 から取得済みであることが前提）。
+func buildBedrockMessages(history []domain.AiChatMessage) []brtypes.Message {
+	messages := make([]brtypes.Message, 0, len(history))
+	for _, m := range history {
+		role := brtypes.ConversationRoleUser
+		if m.Role == domain.AiChatRoleAssistant {
+			role = brtypes.ConversationRoleAssistant
+		}
+		blocks := make([]brtypes.ContentBlock, 0, len(m.Attachments)+1)
+		for _, a := range m.Attachments {
+			block := attachmentToBlock(a)
+			if block != nil {
+				blocks = append(blocks, block)
+			}
+		}
+		if m.Content != "" || len(blocks) == 0 {
+			blocks = append(blocks, &brtypes.ContentBlockMemberText{Value: m.Content})
+		}
+		messages = append(messages, brtypes.Message{Role: role, Content: blocks})
+	}
+	return messages
+}
+
+// attachmentToBlock は 1 つの添付を Bedrock の ContentBlock に変換する。
+// BlobData が空（S3 取得失敗 / 未取得）なら nil を返してスキップする。
+func attachmentToBlock(a domain.Attachment) brtypes.ContentBlock {
+	if len(a.BlobData) == 0 {
+		return nil
+	}
+	switch a.Kind {
+	case domain.AttachmentKindImage:
+		return &brtypes.ContentBlockMemberImage{
+			Value: brtypes.ImageBlock{
+				Format: brtypes.ImageFormat(a.Format),
+				Source: &brtypes.ImageSourceMemberBytes{Value: a.BlobData},
+			},
+		}
+	case domain.AttachmentKindDocument:
+		return &brtypes.ContentBlockMemberDocument{
+			Value: brtypes.DocumentBlock{
+				Format: brtypes.DocumentFormat(a.Format),
+				Name:   strPtr(documentName(a.Filename)),
+				Source: &brtypes.DocumentSourceMemberBytes{Value: a.BlobData},
+			},
+		}
+	}
+	return nil
+}
+
+func strPtr(s string) *string { return &s }
+
+// documentName は Bedrock document.name 用の identifier を返す。
+// Bedrock 仕様: 1〜200 文字、英数字 / 空白 / ハイフン / 括弧 / 角括弧 のみ許可。
+// 拡張子は除外し、許可外文字は '-' に置換する。空になったら "document" にフォールバック。
+func documentName(filename string) string {
+	base := filename
+	if i := lastIndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	out := make([]byte, 0, len(base))
+	for i := 0; i < len(base); i++ {
+		c := base[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == ' ', c == '-', c == '(', c == ')', c == '[', c == ']':
+			out = append(out, c)
+		default:
+			out = append(out, '-')
+		}
+	}
+	if len(out) == 0 {
+		return "document"
+	}
+	if len(out) > 200 {
+		out = out[:200]
+	}
+	return string(out)
+}
+
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
 }

--- a/backend/internal/infra/s3/downloader.go
+++ b/backend/internal/infra/s3/downloader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -19,10 +20,22 @@ import (
 type Downloader struct {
 	client *awss3.Client
 	bucket string
+	// allowedKeyPrefix は読み出し許容 prefix。空のときは prefix チェックをスキップする。
+	// AI チャット添付では `ai-chat/` を渡して、誤って他用途の prefix を読まれないようにする。
+	allowedKeyPrefix string
+	// maxBytes は 1 オブジェクトあたりの最大読み込みサイズ（バイト）。
+	// 任意 S3 オブジェクトを読まれた場合の OOM 防止用。
+	maxBytes int64
 }
 
+// 既定の最大読み込みサイズ。Bedrock の image 上限 (5MB) と document 上限 (4.5MB) より
+// 余裕をもたせて 10MB を 1 オブジェクトの上限とする。実際のサイズ検証は usecase / handler 側で
+// 行うが、Downloader でも belt-and-suspenders として強制する。
+const defaultMaxDownloadBytes int64 = 10 * 1024 * 1024
+
 // NewDownloader は本番用 (ECS Task Role 経由) で Downloader を組み立てる。
-func NewDownloader(ctx context.Context, region, bucket string) (*Downloader, error) {
+// allowedKeyPrefix は読み出し許容 prefix（空文字は無制限。AI チャット用途では "ai-chat/" 推奨）。
+func NewDownloader(ctx context.Context, region, bucket, allowedKeyPrefix string) (*Downloader, error) {
 	if bucket == "" {
 		return nil, fmt.Errorf("s3: bucket name is required")
 	}
@@ -31,17 +44,27 @@ func NewDownloader(ctx context.Context, region, bucket string) (*Downloader, err
 		return nil, fmt.Errorf("s3: load aws config: %w", err)
 	}
 	return &Downloader{
-		client: awss3.NewFromConfig(cfg),
-		bucket: bucket,
+		client:           awss3.NewFromConfig(cfg),
+		bucket:           bucket,
+		allowedKeyPrefix: allowedKeyPrefix,
+		maxBytes:         defaultMaxDownloadBytes,
 	}, nil
 }
 
 // Download は指定 key のオブジェクトをメモリに読み込んで返す。
 // Bedrock の image / document ブロックがバイト列を要求するため、ストリーミングではなく
-// 一括ロードで返す。サイズ上限は呼び出し側で事前に確認する前提。
+// 一括ロードで返す。
+//
+// 防御:
+//   - allowedKeyPrefix を持つ場合は prefix 不一致を error で弾く
+//   - maxBytes を超える object は error にしてメモリを使い切らない
+//     （io.LimitReader で +1 byte 余分に読んで超過判定する）
 func (d *Downloader) Download(ctx context.Context, key string) ([]byte, error) {
 	if key == "" {
 		return nil, fmt.Errorf("s3: key is required")
+	}
+	if d.allowedKeyPrefix != "" && !strings.HasPrefix(key, d.allowedKeyPrefix) {
+		return nil, fmt.Errorf("s3: key %q outside allowed prefix %q", key, d.allowedKeyPrefix)
 	}
 	out, err := d.client.GetObject(ctx, &awss3.GetObjectInput{
 		Bucket: aws.String(d.bucket),
@@ -51,5 +74,17 @@ func (d *Downloader) Download(ctx context.Context, key string) ([]byte, error) {
 		return nil, fmt.Errorf("s3: get object %q: %w", key, err)
 	}
 	defer out.Body.Close()
-	return io.ReadAll(out.Body)
+
+	limit := d.maxBytes
+	if limit <= 0 {
+		limit = defaultMaxDownloadBytes
+	}
+	data, err := io.ReadAll(io.LimitReader(out.Body, limit+1))
+	if err != nil {
+		return nil, fmt.Errorf("s3: read object %q: %w", key, err)
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("s3: object %q exceeds %d bytes", key, limit)
+	}
+	return data, nil
 }

--- a/backend/internal/infra/s3/downloader.go
+++ b/backend/internal/infra/s3/downloader.go
@@ -1,0 +1,55 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// Downloader はサーバ側で S3 オブジェクトの実体を取得する。
+//
+// 用途: ユーザーが presigned PUT で S3 にアップロードした画像 / ドキュメントを
+// バックエンドが Bedrock Converse に渡す前に GetObject でバイト列として取り出す。
+// presigner.go と分けているのは「presigned URL は短期 / 一方通行（PUT）専用」と
+// 「server-side GetObject は IAM 権限経由 / 任意のサイズ」で責務が違うため。
+type Downloader struct {
+	client *awss3.Client
+	bucket string
+}
+
+// NewDownloader は本番用 (ECS Task Role 経由) で Downloader を組み立てる。
+func NewDownloader(ctx context.Context, region, bucket string) (*Downloader, error) {
+	if bucket == "" {
+		return nil, fmt.Errorf("s3: bucket name is required")
+	}
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("s3: load aws config: %w", err)
+	}
+	return &Downloader{
+		client: awss3.NewFromConfig(cfg),
+		bucket: bucket,
+	}, nil
+}
+
+// Download は指定 key のオブジェクトをメモリに読み込んで返す。
+// Bedrock の image / document ブロックがバイト列を要求するため、ストリーミングではなく
+// 一括ロードで返す。サイズ上限は呼び出し側で事前に確認する前提。
+func (d *Downloader) Download(ctx context.Context, key string) ([]byte, error) {
+	if key == "" {
+		return nil, fmt.Errorf("s3: key is required")
+	}
+	out, err := d.client.GetObject(ctx, &awss3.GetObjectInput{
+		Bucket: aws.String(d.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s3: get object %q: %w", key, err)
+	}
+	defer out.Body.Close()
+	return io.ReadAll(out.Body)
+}

--- a/backend/internal/repository/ai_chat_attachment_repository.go
+++ b/backend/internal/repository/ai_chat_attachment_repository.go
@@ -1,0 +1,89 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// AiChatAttachmentPresigner は AI チャットの添付ファイル用 PUT presigned URL を発行する。
+//
+// note_image / profile_image と同様の責務だが、key prefix と content-type の許容範囲が違う。
+// 共通化せず別プレゼンタを切るのは、将来 PR-G2 で document (PDF/CSV) 対応をする際に
+// 「画像と document で別バケット / 別 lifecycle にしたい」可能性を残すため。
+type AiChatAttachmentPresigner interface {
+	Generate(ctx context.Context, userID uint64, filename, contentType string) (*AiChatAttachmentUploadURL, error)
+}
+
+// AiChatAttachmentUploadURL は presigned URL 発行結果。
+//
+// Key は S3 オブジェクトキー。クライアントは UploadURL に PUT した後、
+// この Key を SSE 送信ペイロードの attachments[].key に詰めて返す。
+type AiChatAttachmentUploadURL struct {
+	UploadURL string `json:"uploadUrl"`
+	Key       string `json:"key"`
+	ExpiresIn int    `json:"expiresIn"`
+}
+
+type aiChatAttachmentPresigner struct {
+	pre s3Presigner
+}
+
+// NewAiChatAttachmentPresigner は本番経路。infra/s3.Presigner を渡して使う。
+func NewAiChatAttachmentPresigner(p s3Presigner) AiChatAttachmentPresigner {
+	return &aiChatAttachmentPresigner{pre: p}
+}
+
+// NewStubAiChatAttachmentPresigner は test / dev 用 stub。
+func NewStubAiChatAttachmentPresigner(bucket string) AiChatAttachmentPresigner {
+	return &aiChatAttachmentPresigner{pre: &stubPresigner{bucket: bucket}}
+}
+
+// Generate は ai-chat/{userId}/{uuid}.{ext} のキーで PUT presigned URL を返す。
+//
+// filename は拡張子推定 / オブジェクト名表示用にだけ使い、key には埋めない（衝突回避と
+// インジェクション対策）。
+func (p *aiChatAttachmentPresigner) Generate(ctx context.Context, userID uint64, filename, contentType string) (*AiChatAttachmentUploadURL, error) {
+	if userID == 0 {
+		return nil, fmt.Errorf("userID is required")
+	}
+	if contentType == "" {
+		return nil, fmt.Errorf("contentType is required")
+	}
+	ext := extensionForContentType(contentType, filename)
+	key := fmt.Sprintf("ai-chat/%d/%s%s", userID, uuid.New().String(), ext)
+	url, ttl, err := p.pre.PresignPut(ctx, key, contentType)
+	if err != nil {
+		return nil, err
+	}
+	return &AiChatAttachmentUploadURL{
+		UploadURL: url,
+		Key:       key,
+		ExpiresIn: int(ttl.Seconds()),
+	}, nil
+}
+
+// extensionForContentType は MIME から拡張子を逆引きする。
+// 不明な MIME は filename 末尾の拡張子をそのまま使う。両方無ければ "" を返す。
+func extensionForContentType(contentType, filename string) string {
+	switch contentType {
+	case "image/png":
+		return ".png"
+	case "image/jpeg", "image/jpg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "application/pdf":
+		return ".pdf"
+	case "text/csv":
+		return ".csv"
+	}
+	if i := strings.LastIndexByte(filename, '.'); i >= 0 && i < len(filename)-1 {
+		return strings.ToLower(filename[i:])
+	}
+	return ""
+}

--- a/backend/internal/repository/ai_chat_message_repository.go
+++ b/backend/internal/repository/ai_chat_message_repository.go
@@ -39,21 +39,72 @@ func NewAiChatMessageRepository(ctx context.Context, region, table string) (AiCh
 }
 
 // dynamoItem は DynamoDB に保存するアイテムの形式。
+//
+// Attachments は domain.Attachment と 1:1 だが、BlobData（一時バイト列）は永続化しない。
+// 既存メッセージは attachments 列が無いまま保存されており、Unmarshal で空スライスに
+// なるよう omitempty で扱う。
 type dynamoItem struct {
-	SessionID string `dynamodbav:"sessionId"`
-	MessageID string `dynamodbav:"messageId"`
-	Role      string `dynamodbav:"role"`
-	Content   string `dynamodbav:"content"`
-	CreatedAt string `dynamodbav:"createdAt"`
+	SessionID   string         `dynamodbav:"sessionId"`
+	MessageID   string         `dynamodbav:"messageId"`
+	Role        string         `dynamodbav:"role"`
+	Content     string         `dynamodbav:"content"`
+	Attachments []dynamoAttach `dynamodbav:"attachments,omitempty"`
+	CreatedAt   string         `dynamodbav:"createdAt"`
+}
+
+type dynamoAttach struct {
+	Key         string `dynamodbav:"key"`
+	Filename    string `dynamodbav:"filename"`
+	ContentType string `dynamodbav:"contentType"`
+	Format      string `dynamodbav:"format"`
+	Kind        string `dynamodbav:"kind"`
+	SizeBytes   int64  `dynamodbav:"sizeBytes"`
+}
+
+func toDynamoAttachments(in []domain.Attachment) []dynamoAttach {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]dynamoAttach, len(in))
+	for i, a := range in {
+		out[i] = dynamoAttach{
+			Key:         a.Key,
+			Filename:    a.Filename,
+			ContentType: a.ContentType,
+			Format:      a.Format,
+			Kind:        a.Kind,
+			SizeBytes:   a.SizeBytes,
+		}
+	}
+	return out
+}
+
+func fromDynamoAttachments(in []dynamoAttach) []domain.Attachment {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]domain.Attachment, len(in))
+	for i, a := range in {
+		out[i] = domain.Attachment{
+			Key:         a.Key,
+			Filename:    a.Filename,
+			ContentType: a.ContentType,
+			Format:      a.Format,
+			Kind:        a.Kind,
+			SizeBytes:   a.SizeBytes,
+		}
+	}
+	return out
 }
 
 func (r *aiChatMessageRepository) Save(ctx context.Context, msg *domain.AiChatMessage) error {
 	item := dynamoItem{
-		SessionID: strconv.FormatUint(msg.SessionID, 10),
-		MessageID: msg.MessageID,
-		Role:      msg.Role,
-		Content:   msg.Content,
-		CreatedAt: msg.CreatedAt.UTC().Format(time.RFC3339),
+		SessionID:   strconv.FormatUint(msg.SessionID, 10),
+		MessageID:   msg.MessageID,
+		Role:        msg.Role,
+		Content:     msg.Content,
+		Attachments: toDynamoAttachments(msg.Attachments),
+		CreatedAt:   msg.CreatedAt.UTC().Format(time.RFC3339),
 	}
 	av, err := attributevalue.MarshalMap(item)
 	if err != nil {
@@ -87,11 +138,12 @@ func (r *aiChatMessageRepository) ListBySessionID(ctx context.Context, sessionID
 		}
 		t, _ := time.Parse(time.RFC3339, item.CreatedAt)
 		msgs = append(msgs, domain.AiChatMessage{
-			SessionID: sessionID,
-			MessageID: item.MessageID,
-			Role:      item.Role,
-			Content:   item.Content,
-			CreatedAt: t,
+			SessionID:   sessionID,
+			MessageID:   item.MessageID,
+			Role:        item.Role,
+			Content:     item.Content,
+			Attachments: fromDynamoAttachments(item.Attachments),
+			CreatedAt:   t,
 		})
 	}
 	return msgs, nil

--- a/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
+++ b/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
@@ -1,0 +1,75 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// IssueAiChatAttachmentUploadURLUseCase は AI チャット添付の S3 PUT presigned URL を発行する。
+//
+// 入力検証:
+//   - userID 必須
+//   - contentType は事前に許容セット (image/png 等) であること
+//   - sizeBytes は Bedrock 上限 (5MB / image, 4.5MB / document) 以内であること
+//
+// 上限チェックを usecase 層で行うのは「presigned URL を発行する前に 413 を返す」ためで、
+// クライアント側の不正利用や typo を S3 アップロード前の早い段階で弾く目的。
+type IssueAiChatAttachmentUploadURLUseCase struct {
+	presigner repository.AiChatAttachmentPresigner
+}
+
+func NewIssueAiChatAttachmentUploadURLUseCase(p repository.AiChatAttachmentPresigner) *IssueAiChatAttachmentUploadURLUseCase {
+	return &IssueAiChatAttachmentUploadURLUseCase{presigner: p}
+}
+
+// IssueAiChatAttachmentUploadURLInput は handler から受け取るリクエスト形。
+type IssueAiChatAttachmentUploadURLInput struct {
+	UserID      uint64
+	Filename    string
+	ContentType string
+	SizeBytes   int64
+}
+
+const (
+	maxImageBytes    int64 = 5 * 1024 * 1024
+	maxDocumentBytes int64 = 4_500_000 // Bedrock document upper bound
+)
+
+// AllowedAttachmentContentTypes は presigned URL 発行 OK / SSE 送信 OK な MIME 一覧。
+// PR-G1 では画像のみ。PR-G2 で application/pdf / text/csv を追加する想定。
+var AllowedAttachmentContentTypes = map[string]struct {
+	Kind   string // "image" | "document"
+	Format string // Bedrock format (png/jpeg/gif/webp/pdf/csv)
+	Max    int64
+}{
+	"image/png":  {Kind: "image", Format: "png", Max: maxImageBytes},
+	"image/jpeg": {Kind: "image", Format: "jpeg", Max: maxImageBytes},
+	"image/jpg":  {Kind: "image", Format: "jpeg", Max: maxImageBytes},
+	"image/gif":  {Kind: "image", Format: "gif", Max: maxImageBytes},
+	"image/webp": {Kind: "image", Format: "webp", Max: maxImageBytes},
+}
+
+// ErrAttachmentUnsupportedType は未対応 MIME。
+var ErrAttachmentUnsupportedType = errors.New("attachment: unsupported content type")
+
+// ErrAttachmentTooLarge はサイズ上限超過。
+var ErrAttachmentTooLarge = errors.New("attachment: file too large")
+
+func (u *IssueAiChatAttachmentUploadURLUseCase) Execute(ctx context.Context, in IssueAiChatAttachmentUploadURLInput) (*repository.AiChatAttachmentUploadURL, error) {
+	if in.UserID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	rule, ok := AllowedAttachmentContentTypes[in.ContentType]
+	if !ok {
+		return nil, ErrAttachmentUnsupportedType
+	}
+	if in.SizeBytes <= 0 || in.SizeBytes > rule.Max {
+		return nil, ErrAttachmentTooLarge
+	}
+	return u.presigner.Generate(ctx, in.UserID, in.Filename, in.ContentType)
+}
+
+// _ = maxDocumentBytes は未使用警告抑止 + PR-G2 で利用予定の予約定数の宣言を残す目的。
+var _ = maxDocumentBytes

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -16,6 +17,15 @@ import (
 // テストでは fake を差し替える。infra/bedrock.Client が満たす想定。
 type StreamingBedrockClient interface {
 	ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan bedrock.StreamEvent, error)
+}
+
+// AttachmentDownloader は S3 から attachment のバイト列を取得する抽象。
+// 本番では infra/s3.Downloader が満たす。usecase テストでは in-memory 実装を差し替える。
+//
+// nil でも動作する（その場合は添付なしと同等の振る舞い）。Bedrock / DynamoDB の初期化失敗
+// などで一時的に S3 利用不可になったときも、テキストだけは送れるよう優雅に degrade する。
+type AttachmentDownloader interface {
+	Download(ctx context.Context, key string) ([]byte, error)
 }
 
 // StreamEvent は handler に流すイベント。bedrock.StreamEvent と同形だが、
@@ -37,14 +47,21 @@ type SendAiMessageStreamUseCase struct {
 	sessions      repository.AiChatSessionRepository
 	messages      repository.AiChatMessageRepository
 	bedrockClient StreamingBedrockClient
+	attachments   AttachmentDownloader
 }
 
 func NewSendAiMessageStreamUseCase(
 	sessions repository.AiChatSessionRepository,
 	messages repository.AiChatMessageRepository,
 	bc StreamingBedrockClient,
+	dl AttachmentDownloader,
 ) *SendAiMessageStreamUseCase {
-	return &SendAiMessageStreamUseCase{sessions: sessions, messages: messages, bedrockClient: bc}
+	return &SendAiMessageStreamUseCase{
+		sessions:      sessions,
+		messages:      messages,
+		bedrockClient: bc,
+		attachments:   dl,
+	}
 }
 
 // Execute は handler 側でレスポンス書き込みに使う channel を返す。
@@ -83,11 +100,12 @@ func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessa
 		}
 
 		userMsg := &domain.AiChatMessage{
-			SessionID: sessionID,
-			MessageID: uuid.New().String(),
-			Role:      domain.AiChatRoleUser,
-			Content:   in.Content,
-			CreatedAt: time.Now().UTC(),
+			SessionID:   sessionID,
+			MessageID:   uuid.New().String(),
+			Role:        domain.AiChatRoleUser,
+			Content:     in.Content,
+			Attachments: in.Attachments,
+			CreatedAt:   time.Now().UTC(),
 		}
 		if err := u.messages.Save(ctx, userMsg); err != nil {
 			emit(ctx, out, StreamEvent{Err: fmt.Errorf("save user message: %w", err)})
@@ -98,6 +116,15 @@ func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessa
 		if err != nil {
 			emit(ctx, out, StreamEvent{Err: fmt.Errorf("list messages: %w", err)})
 			return
+		}
+
+		// Bedrock 呼び出し直前に最新ユーザー発話の attachment 実体を S3 から取得して詰める。
+		// 過去履歴の画像は再送しない（料金 / latency / Bedrock 上限への配慮）。
+		// 取得失敗した attachment は除外して text だけで送る（部分劣化）。
+		if u.attachments != nil && len(in.Attachments) > 0 {
+			if last := lastUserMessageIndex(history); last >= 0 {
+				history[last].Attachments = u.fetchAttachmentBlobs(ctx, in.Attachments)
+			}
 		}
 
 		systemPrompt := buildSystemPrompt(in.SessionType, in.Scene)
@@ -145,4 +172,38 @@ func emit(ctx context.Context, out chan<- StreamEvent, ev StreamEvent) {
 	case out <- ev:
 	case <-ctx.Done():
 	}
+}
+
+// lastUserMessageIndex は history 末尾から最も近い user メッセージの index を返す。
+// 見つからなければ -1。最新ユーザー発話だけに今回のリクエスト由来 attachments を貼る用途。
+func lastUserMessageIndex(history []domain.AiChatMessage) int {
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == domain.AiChatRoleUser {
+			return i
+		}
+	}
+	return -1
+}
+
+// fetchAttachmentBlobs は in.Attachments それぞれを S3 から GetObject して BlobData を埋める。
+//
+// 取得失敗した attachment はスライスから落とす（その 1 枚だけ Bedrock に渡らない）。
+// すべて失敗したら空スライスを返し、Bedrock はテキストのみで応答する。
+// SizeBytes が 0 の attachment は metadata 不整合（フロント側のバグ）なのでスキップする。
+func (u *SendAiMessageStreamUseCase) fetchAttachmentBlobs(ctx context.Context, in []domain.Attachment) []domain.Attachment {
+	out := make([]domain.Attachment, 0, len(in))
+	for _, a := range in {
+		if a.Key == "" {
+			continue
+		}
+		data, err := u.attachments.Download(ctx, a.Key)
+		if err != nil {
+			// 1 件の失敗は致命でない。ログだけ残して続行（Bedrock には残りの添付＋テキストで送る）。
+			log.Printf("ai-chat attachment download failed: key=%s err=%v", a.Key, err)
+			continue
+		}
+		a.BlobData = data
+		out = append(out, a)
+	}
+	return out
 }

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -83,7 +83,15 @@ func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessa
 		sessionID := in.SessionID
 		var newSession *domain.AiChatSession
 		if sessionID == 0 {
+			// 添付のみで本文が空の場合に session タイトルが空文字にならないようフォールバック。
 			title := truncateTitle(in.Content, 30)
+			if title == "" {
+				if len(in.Attachments) > 0 {
+					title = "添付ファイルを送信"
+				} else {
+					title = "新しいチャット"
+				}
+			}
 			s, err := NewCreateAiChatSessionUseCase(u.sessions).Execute(ctx, CreateAiChatSessionInput{
 				UserID:      in.UserID,
 				Title:       title,

--- a/backend/internal/usecase/send_ai_message_stream_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase_test.go
@@ -211,6 +211,8 @@ func TestSendAiMessageStream_WithAttachment_FetchesBlobAndSavesMetadata(t *testi
 		require.NoError(t, ev.Err)
 	}
 	bc.AssertExpectations(t)
+	// ユーザー（添付メタ付き）+ アシスタント の 2 回保存
+	msgRepo.AssertNumberOfCalls(t, "Save", 2)
 }
 
 // fakeDownloader は in-memory key→bytes map を返す簡易実装。

--- a/backend/internal/usecase/send_ai_message_stream_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase_test.go
@@ -86,7 +86,7 @@ func TestSendAiMessageStream_ExistingSession_StreamsTokensAndSavesFinal(t *testi
 	var ro <-chan bedrock.StreamEvent = src
 	bc.On("ConverseStream", mock.Anything, mock.AnythingOfType("string"), history).Return(ro, nil)
 
-	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc)
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc, nil)
 	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
 		UserID:    7,
 		SessionID: 5,
@@ -137,7 +137,7 @@ func TestSendAiMessageStream_NewSession_EmitsSessionFirst(t *testing.T) {
 	var ro <-chan bedrock.StreamEvent = src
 	bc.On("ConverseStream", mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(ro, nil)
 
-	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc)
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc, nil)
 	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
 		UserID:  7,
 		Content: "新しい会話を始めたい",
@@ -152,6 +152,78 @@ func TestSendAiMessageStream_NewSession_EmitsSessionFirst(t *testing.T) {
 	for ev := range ch {
 		require.NoError(t, ev.Err)
 	}
+}
+
+// 添付付き発話: Downloader が S3 から bytes を取得し、Bedrock 呼び出し前に
+// 履歴の最新 user メッセージへ BlobData が詰められる。
+func TestSendAiMessageStream_WithAttachment_FetchesBlobAndSavesMetadata(t *testing.T) {
+	sessionRepo := new(mockSessionRepo)
+	msgRepo := new(mockMsgRepo)
+	bc := new(mockStreamBedrock)
+	dl := &fakeDownloader{
+		bytes: map[string][]byte{
+			"ai-chat/7/abc.png": []byte("fake-png-bytes"),
+		},
+	}
+
+	// 履歴: 今回送ったユーザー発話だけ（attachments 付き）
+	saved := &domain.AiChatMessage{
+		SessionID:   5,
+		MessageID:   "u1",
+		Role:        domain.AiChatRoleUser,
+		Content:     "この画像なに？",
+		Attachments: []domain.Attachment{{Key: "ai-chat/7/abc.png", Format: "png", Kind: "image", ContentType: "image/png", SizeBytes: 14}},
+		CreatedAt:   time.Now(),
+	}
+	msgRepo.On("Save", mock.Anything, mock.AnythingOfType("*domain.AiChatMessage")).Return(nil)
+	msgRepo.On("ListBySessionID", mock.Anything, uint64(5)).Return([]domain.AiChatMessage{*saved}, nil)
+
+	src := make(chan bedrock.StreamEvent, 2)
+	src <- bedrock.StreamEvent{Delta: "猫です"}
+	src <- bedrock.StreamEvent{Done: true}
+	close(src)
+	var ro <-chan bedrock.StreamEvent = src
+
+	// Bedrock に渡る history の末尾要素に BlobData が詰まっていることを assert する。
+	bc.On("ConverseStream", mock.Anything, mock.AnythingOfType("string"),
+		mock.MatchedBy(func(history []domain.AiChatMessage) bool {
+			if len(history) == 0 {
+				return false
+			}
+			last := history[len(history)-1]
+			if len(last.Attachments) != 1 {
+				return false
+			}
+			return string(last.Attachments[0].BlobData) == "fake-png-bytes"
+		})).Return(ro, nil)
+
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc, dl)
+	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
+		UserID:    7,
+		SessionID: 5,
+		Content:   "この画像なに？",
+		Attachments: []domain.Attachment{
+			{Key: "ai-chat/7/abc.png", Format: "png", Kind: "image", ContentType: "image/png", SizeBytes: 14, Filename: "abc.png"},
+		},
+	})
+	require.NoError(t, err)
+	for ev := range ch {
+		require.NoError(t, ev.Err)
+	}
+	bc.AssertExpectations(t)
+}
+
+// fakeDownloader は in-memory key→bytes map を返す簡易実装。
+type fakeDownloader struct {
+	bytes map[string][]byte
+}
+
+func (f *fakeDownloader) Download(_ context.Context, key string) ([]byte, error) {
+	b, ok := f.bytes[key]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return b, nil
 }
 
 // Bedrock 呼び出しで stream エラー: ev.Err が channel に流れて使い手に伝わる。
@@ -169,7 +241,7 @@ func TestSendAiMessageStream_StreamError_PropagatesErr(t *testing.T) {
 	var ro <-chan bedrock.StreamEvent = src
 	bc.On("ConverseStream", mock.Anything, mock.Anything, mock.Anything).Return(ro, nil)
 
-	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc)
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc, nil)
 	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
 		UserID: 7, SessionID: 3, Content: "x",
 	})

--- a/backend/internal/usecase/send_ai_message_usecase.go
+++ b/backend/internal/usecase/send_ai_message_usecase.go
@@ -1,5 +1,7 @@
 package usecase
 
+import "github.com/norman6464/FreStyle/backend/internal/domain"
+
 // 旧 SendAiMessageUseCase（WebSocket 経由の同期呼び出し）は PR-D で撤去した。
 // SSE ストリーミング版（SendAiMessageStreamUseCase）が後継。
 //
@@ -12,6 +14,10 @@ package usecase
 //
 // Scene / SessionType / ScenarioID は旧フロント仕様の互換のため残しているが、
 // 練習モード撤去（PR-A）以降はどれもプロンプトに反映しない。次のクリーンアップで削除予定。
+//
+// Attachments はユーザー発話に紐付く添付ファイル群（画像 / 将来の PDF / CSV）。
+// フロントは事前に S3 へ presigned PUT でアップロード済みで、ここには key と
+// メタデータだけが渡る。usecase が S3 から実体バイトを取得して Bedrock に渡す。
 type SendAiMessageInput struct {
 	UserID      uint64
 	SessionID   uint64
@@ -19,6 +25,7 @@ type SendAiMessageInput struct {
 	Scene       string
 	SessionType string
 	ScenarioID  *uint64
+	Attachments []domain.Attachment
 }
 
 func truncateTitle(s string, max int) string {

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -49,11 +49,13 @@ test.describe('FreStyle smoke', () => {
   });
 
   test('認証必須エンドポイントは Cookie 無で 401 を返す', async ({ request }) => {
+    // PR-A で `/api/v2/score-goals` 系は撤去済 → 認可ガードの代表として
+    //   /auth/me / /notes / /profile/me / /notifications / /ai-chat/sessions を確認する。
     for (const path of [
       '/api/v2/auth/me',
       '/api/v2/notes',
       '/api/v2/profile/me',
-      '/api/v2/score-goals',
+      '/api/v2/ai-chat/sessions',
       '/api/v2/notifications',
     ]) {
       const res = await request.get(`${API_BASE}${path}`);

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -14,12 +14,14 @@ import { formatHourMinute } from '../utils/formatters';
 /**
  * 自分のメッセージに添付された画像 / ドキュメントの参照（送信中の Object URL も許容）。
  * MessageBubble 内では画像のみインラインプレビュー、それ以外はファイル名カードに落とす。
+ *
+ * `kind` は backend `domain.AttachmentKind*` と整合する `'image' | 'document'`。
  */
 export interface MessageAttachmentView {
   key: string;
   filename: string;
   contentType: string;
-  kind: string;
+  kind: 'image' | 'document';
   sizeBytes: number;
   /** 送信中チップから引き継ぐローカル Object URL */
   previewUrl?: string;

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -11,6 +11,22 @@ import {
 import 'highlight.js/styles/github-dark.css';
 import { formatHourMinute } from '../utils/formatters';
 
+/**
+ * 自分のメッセージに添付された画像 / ドキュメントの参照（送信中の Object URL も許容）。
+ * MessageBubble 内では画像のみインラインプレビュー、それ以外はファイル名カードに落とす。
+ */
+export interface MessageAttachmentView {
+  key: string;
+  filename: string;
+  contentType: string;
+  kind: string;
+  sizeBytes: number;
+  /** 送信中チップから引き継ぐローカル Object URL */
+  previewUrl?: string;
+  /** 送信完了後 backend が返す CDN / S3 URL（あれば優先） */
+  url?: string;
+}
+
 interface MessageBubbleProps {
   isSender: boolean;
   type?: 'text' | 'image' | 'bot';
@@ -18,6 +34,7 @@ interface MessageBubbleProps {
   id: string;
   senderName?: string;
   createdAt?: string;
+  attachments?: MessageAttachmentView[];
   onDelete?: ((id: string) => void) | null;
   onCopy?: ((id: string, content: string) => void) | null;
   isCopied?: boolean;
@@ -46,6 +63,7 @@ export default memo(function MessageBubble({
   id,
   senderName,
   createdAt,
+  attachments,
   onDelete,
   onCopy,
   isCopied = false,
@@ -86,10 +104,15 @@ export default memo(function MessageBubble({
         role="article"
         aria-label="自分のメッセージ"
       >
-        <div className="max-w-[85%] flex flex-col items-end">
-          <div className="px-4 py-2 rounded-2xl bg-[var(--color-surface-3)] text-[var(--color-text-primary)] text-sm whitespace-pre-wrap break-words">
-            {content}
-          </div>
+        <div className="max-w-[85%] flex flex-col items-end gap-1">
+          {attachments && attachments.length > 0 && (
+            <AttachmentList attachments={attachments} />
+          )}
+          {content && (
+            <div className="px-4 py-2 rounded-2xl bg-[var(--color-surface-3)] text-[var(--color-text-primary)] text-sm whitespace-pre-wrap break-words">
+              {content}
+            </div>
+          )}
           <MessageActionRow
             isSender
             id={id}
@@ -200,6 +223,40 @@ function MessageActionRow({
           <TrashIcon className="w-3.5 h-3.5" />
         </button>
       )}
+    </div>
+  );
+}
+
+/**
+ * 自分のメッセージに紐付く添付の表示。
+ *
+ * 画像は max-w 240px のサムネで横並び（Object URL でローカル送信中も表示できる）。
+ * 画像以外（PR-G2 で増える PDF / CSV）は filename カードのフォールバック。
+ */
+function AttachmentList({ attachments }: { attachments: MessageAttachmentView[] }) {
+  return (
+    <div className="flex flex-wrap gap-2 justify-end" aria-label="添付ファイル">
+      {attachments.map((a) => {
+        const src = a.url ?? a.previewUrl;
+        if (a.kind === 'image' && src) {
+          return (
+            <img
+              key={a.key}
+              src={src}
+              alt={a.filename}
+              className="max-w-[240px] max-h-[240px] rounded-lg object-cover border border-[var(--color-surface-3)]"
+            />
+          );
+        }
+        return (
+          <div
+            key={a.key}
+            className="px-3 py-2 rounded-lg border border-[var(--color-surface-3)] bg-[var(--color-surface-2)] text-xs text-[var(--color-text-primary)]"
+          >
+            {a.filename}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/MessageBubbleAi.tsx
+++ b/frontend/src/components/MessageBubbleAi.tsx
@@ -1,10 +1,11 @@
-import MessageBubble from './MessageBubble';
+import MessageBubble, { type MessageAttachmentView } from './MessageBubble';
 
 interface MessageBubbleAiProps {
   isSender: boolean;
   type?: 'text' | 'image' | 'bot';
   content: string;
   id: string;
+  attachments?: MessageAttachmentView[];
   onDelete?: (id: string) => void;
   onCopy?: ((id: string, content: string) => void) | null;
   isCopied?: boolean;

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,16 +1,49 @@
-import { useState, useRef, useEffect, KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, KeyboardEvent, ChangeEvent } from 'react';
 import { PaperAirplaneIcon, PlusIcon } from '@heroicons/react/24/solid';
+import { XMarkIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
+import aiChatRepository from '../repositories/AiChatRepository';
+import type { AiAttachment } from '../types';
 
 interface MessageInputProps {
-  onSend: (text: string) => void;
+  onSend: (text: string, attachments?: AiAttachment[]) => void;
   isSending?: boolean;
+}
+
+// 画像のみ受け付ける（PR-G1）。PR-G2 で application/pdf, text/csv を追加予定。
+const ACCEPTED_FILE_TYPES = 'image/png,image/jpeg,image/gif,image/webp';
+
+const ACCEPTED_CONTENT_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+const MAX_ATTACHMENTS = 4;
+const MAX_BYTES_PER_FILE = 5 * 1024 * 1024; // Bedrock image upper bound
+
+const FORMAT_FROM_CONTENT_TYPE: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpeg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+interface PendingAttachment extends AiAttachment {
+  /** アップロード進行中フラグ（送信ボタンの活性制御用） */
+  uploading?: boolean;
+  /** アップロード失敗時のメッセージ */
+  error?: string;
 }
 
 export default function MessageInput({ onSend, isSending = false }: MessageInputProps) {
   const [text, setText] = useState('');
+  const [pending, setPending] = useState<PendingAttachment[]>([]);
+  const [validationError, setValidationError] = useState<string | null>(null);
   const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useAutoResizeTextarea({ text });
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const prevIsSendingRef = useRef(isSending);
   useEffect(() => {
@@ -20,10 +53,30 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
     prevIsSendingRef.current = isSending;
   }, [isSending, textareaRef]);
 
+  // unmount で残った Object URL を確実に revoke する（メモリリーク防止）。
+  useEffect(() => {
+    return () => {
+      pending.forEach((a) => {
+        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+      });
+    };
+    // 最終 unmount のみで実行したい。送信ボタン等の通常 setPending では別途 revoke している。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const anyUploading = pending.some((a) => a.uploading);
+  const canSend = !isSending && !anyUploading && (text.trim().length > 0 || pending.length > 0);
+
   const handleSend = () => {
-    if (!text.trim() || isSending) return;
-    onSend(text);
+    if (!canSend) return;
+    const ready = pending.filter((a) => !a.uploading && !a.error);
+    onSend(text, ready);
     setText('');
+    pending.forEach((a) => {
+      if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+    });
+    setPending([]);
+    setValidationError(null);
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -33,47 +86,229 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
     }
   };
 
-  return (
-    <div className="w-full bg-surface-1 flex items-end p-3 border-t border-surface-3">
-      <button
-        className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] p-2.5 rounded-full transition-colors duration-150 flex-shrink-0 mb-1"
-        aria-label="添付ファイル"
-      >
-        <PlusIcon className="h-6 w-6" />
-      </button>
+  const handlePickClick = () => {
+    fileInputRef.current?.click();
+  };
 
-      <div className="flex-1 min-w-0">
-        <textarea
-          ref={textareaRef}
-          rows={1}
-          className="w-full bg-transparent text-[var(--color-text-primary)] outline-none resize-none px-3 py-2 placeholder-slate-400 leading-6"
-          placeholder="メッセージを入力..."
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onCompositionStart={() => setIsComposing(true)}
-          onCompositionEnd={() => setIsComposing(false)}
-          disabled={isSending}
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const list = e.target.files;
+    if (!list || list.length === 0) return;
+    const remaining = MAX_ATTACHMENTS - pending.length;
+    const files = Array.from(list).slice(0, remaining);
+
+    if (Array.from(list).length > remaining) {
+      setValidationError(`添付できるのは ${MAX_ATTACHMENTS} 件までです`);
+    } else {
+      setValidationError(null);
+    }
+
+    // input を即時リセットして同じファイルを再選択できるようにする。
+    e.target.value = '';
+
+    for (const file of files) {
+      const validation = validateFile(file);
+      if (validation) {
+        setValidationError(validation);
+        continue;
+      }
+      const previewUrl = URL.createObjectURL(file);
+      const tempKey = `local-${Date.now()}-${file.name}`;
+      const placeholder: PendingAttachment = {
+        key: tempKey,
+        filename: file.name,
+        contentType: file.type,
+        kind: 'image',
+        format: FORMAT_FROM_CONTENT_TYPE[file.type] ?? 'png',
+        sizeBytes: file.size,
+        previewUrl,
+        uploading: true,
+      };
+      setPending((prev) => [...prev, placeholder]);
+
+      try {
+        const { uploadUrl, key } = await aiChatRepository.issueAttachmentUploadUrl({
+          filename: file.name,
+          contentType: file.type,
+          sizeBytes: file.size,
+        });
+        const putRes = await fetch(uploadUrl, {
+          method: 'PUT',
+          headers: { 'Content-Type': file.type },
+          body: file,
+        });
+        if (!putRes.ok) {
+          throw new Error(`upload failed: ${putRes.status}`);
+        }
+        setPending((prev) =>
+          prev.map((a) =>
+            a.key === tempKey ? { ...a, key, uploading: false } : a
+          )
+        );
+      } catch (err) {
+        setPending((prev) =>
+          prev.map((a) =>
+            a.key === tempKey
+              ? { ...a, uploading: false, error: 'アップロードに失敗しました' }
+              : a
+          )
+        );
+        console.error('attachment upload failed', err);
+      }
+    }
+  };
+
+  const handleRemove = (key: string) => {
+    setPending((prev) => {
+      const target = prev.find((a) => a.key === key);
+      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((a) => a.key !== key);
+    });
+  };
+
+  return (
+    <div className="w-full bg-surface-1 border-t border-surface-3">
+      {pending.length > 0 && (
+        <div
+          className="flex flex-wrap gap-2 p-3 pb-0"
+          aria-label="添付ファイル"
+        >
+          {pending.map((a) => (
+            <AttachmentChip key={a.key} attachment={a} onRemove={handleRemove} />
+          ))}
+        </div>
+      )}
+      {validationError && (
+        <p className="px-4 pt-2 text-xs text-red-400" role="alert">
+          {validationError}
+        </p>
+      )}
+      <div className="flex items-end p-3">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPTED_FILE_TYPES}
+          multiple
+          className="hidden"
+          onChange={handleFileChange}
+          aria-label="添付ファイルを選択"
         />
-        {text.length > 0 && (
-          <span data-testid="char-count" className="block px-3 pb-1 text-[10px] text-[var(--color-text-muted)] text-right" aria-live="polite">
-            {text.length}
-          </span>
+        <button
+          type="button"
+          onClick={handlePickClick}
+          disabled={pending.length >= MAX_ATTACHMENTS || isSending}
+          className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] p-2.5 rounded-full transition-colors duration-150 flex-shrink-0 mb-1 disabled:opacity-40 disabled:cursor-not-allowed"
+          aria-label="添付ファイル"
+        >
+          <PlusIcon className="h-6 w-6" />
+        </button>
+
+        <div className="flex-1 min-w-0">
+          <textarea
+            ref={textareaRef}
+            rows={1}
+            className="w-full bg-transparent text-[var(--color-text-primary)] outline-none resize-none px-3 py-2 placeholder-slate-400 leading-6"
+            placeholder="メッセージを入力..."
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
+            disabled={isSending}
+          />
+          {text.length > 0 && (
+            <span data-testid="char-count" className="block px-3 pb-1 text-[10px] text-[var(--color-text-muted)] text-right" aria-live="polite">
+              {text.length}
+            </span>
+          )}
+        </div>
+
+        <button
+          onClick={handleSend}
+          className="text-white bg-primary-500 p-2.5 rounded-full hover:bg-primary-600 transition-colors duration-150 flex-shrink-0 disabled:bg-surface-3 mb-1 ml-2"
+          disabled={!canSend}
+          aria-label="送信"
+        >
+          <PaperAirplaneIcon className="h-6 w-6 rotate-90" />
+        </button>
+
+        {isSending && (
+          <span className="text-xs text-[var(--color-text-faint)] ml-2 mb-2 flex-shrink-0">送信中...</span>
         )}
       </div>
-
-      <button
-        onClick={handleSend}
-        className="text-white bg-primary-500 p-2.5 rounded-full hover:bg-primary-600 transition-colors duration-150 flex-shrink-0 disabled:bg-surface-3 mb-1 ml-2"
-        disabled={!text.trim() || isSending}
-        aria-label="送信"
-      >
-        <PaperAirplaneIcon className="h-6 w-6 rotate-90" />
-      </button>
-
-      {isSending && (
-        <span className="text-xs text-[var(--color-text-faint)] ml-2 mb-2 flex-shrink-0">送信中...</span>
-      )}
     </div>
   );
+}
+
+function validateFile(file: File): string | null {
+  if (!ACCEPTED_CONTENT_TYPES.has(file.type)) {
+    return `${file.name}: 対応していない形式です`;
+  }
+  if (file.size > MAX_BYTES_PER_FILE) {
+    return `${file.name}: 5MB を超える画像は送信できません`;
+  }
+  if (file.size <= 0) {
+    return `${file.name}: ファイルが空です`;
+  }
+  return null;
+}
+
+interface AttachmentChipProps {
+  attachment: PendingAttachment;
+  onRemove: (key: string) => void;
+}
+
+/**
+ * 送信前の添付チップ。ChatGPT / Claude.ai の compose UI に倣い、
+ * 画像 thumbnail + filename + サイズ（or 状態）を 1 行で並べる。
+ *
+ * 画像は previewUrl（Object URL）でローカル描画する。アップロード失敗時は赤い枠で通知。
+ */
+function AttachmentChip({ attachment, onRemove }: AttachmentChipProps) {
+  return (
+    <div
+      className={`relative flex items-center gap-2 pr-7 pl-2 py-1.5 rounded-lg border ${
+        attachment.error
+          ? 'border-red-500/60 bg-red-500/10'
+          : 'border-surface-3 bg-surface-2'
+      }`}
+    >
+      <div className="w-9 h-9 rounded overflow-hidden bg-surface-3 flex items-center justify-center flex-shrink-0">
+        {attachment.previewUrl ? (
+          <img
+            src={attachment.previewUrl}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <PhotoIcon className="w-5 h-5 text-[var(--color-text-muted)]" />
+        )}
+      </div>
+      <div className="min-w-0 flex flex-col">
+        <span className="text-xs font-medium text-[var(--color-text-primary)] truncate max-w-[180px]">
+          {attachment.filename}
+        </span>
+        <span className="text-[10px] text-[var(--color-text-muted)]">
+          {attachment.uploading
+            ? 'アップロード中...'
+            : attachment.error
+            ? attachment.error
+            : formatBytes(attachment.sizeBytes)}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => onRemove(attachment.key)}
+        aria-label={`${attachment.filename} を削除`}
+        className="absolute top-1 right-1 p-0.5 rounded-full bg-surface-3 hover:bg-surface-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+      >
+        <XMarkIcon className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -3,7 +3,7 @@ import { PaperAirplaneIcon, PlusIcon } from '@heroicons/react/24/solid';
 import { XMarkIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 import aiChatRepository from '../repositories/AiChatRepository';
-import type { AiAttachment } from '../types';
+import type { AiAttachment, AiAttachmentFormat } from '../types';
 
 interface MessageInputProps {
   onSend: (text: string, attachments?: AiAttachment[]) => void;
@@ -23,7 +23,7 @@ const ACCEPTED_CONTENT_TYPES = new Set([
 const MAX_ATTACHMENTS = 4;
 const MAX_BYTES_PER_FILE = 5 * 1024 * 1024; // Bedrock image upper bound
 
-const FORMAT_FROM_CONTENT_TYPE: Record<string, string> = {
+const FORMAT_FROM_CONTENT_TYPE: Record<string, AiAttachmentFormat> = {
   'image/png': 'png',
   'image/jpeg': 'jpeg',
   'image/gif': 'gif',
@@ -45,6 +45,14 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
   const textareaRef = useAutoResizeTextarea({ text });
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  // pending の最新状態を unmount cleanup から参照するための ref。
+  // setPending と並行して更新し、cleanup が stale な closure に閉じ込められても
+  // 最新の Object URL を revoke できるようにする。
+  const pendingRef = useRef<PendingAttachment[]>([]);
+  useEffect(() => {
+    pendingRef.current = pending;
+  }, [pending]);
+
   const prevIsSendingRef = useRef(isSending);
   useEffect(() => {
     if (prevIsSendingRef.current && !isSending) {
@@ -56,25 +64,34 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
   // unmount で残った Object URL を確実に revoke する（メモリリーク防止）。
   useEffect(() => {
     return () => {
-      pending.forEach((a) => {
+      pendingRef.current.forEach((a) => {
         if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
       });
     };
-    // 最終 unmount のみで実行したい。送信ボタン等の通常 setPending では別途 revoke している。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const anyUploading = pending.some((a) => a.uploading);
-  const canSend = !isSending && !anyUploading && (text.trim().length > 0 || pending.length > 0);
+  // 送信可能条件: テキストがあるか、エラーでないアップロード済 attachment が 1 件以上ある。
+  // errored attachment しか無い状態では送信不可（送ってもユーザーの意図とずれるため）。
+  const hasReadyAttachment = pending.some((a) => !a.uploading && !a.error);
+  const canSend = !isSending && !anyUploading && (text.trim().length > 0 || hasReadyAttachment);
 
   const handleSend = () => {
     if (!canSend) return;
     const ready = pending.filter((a) => !a.uploading && !a.error);
+    // 失敗・送信中の item の previewUrl は不要なので破棄する。
+    // 送信に乗せた item の URL は MessageBubble が描画に使うため revoke せず、
+    // 親（useAskAi の messages 配列）が所有権を引き継ぐ。
+    // セッション内で送信された画像 URL は long-lived（ページ離脱時にブラウザが
+    // 自動回収）。長時間チャットでの累積は PR-G3 (UX 仕上げ) で revoke を
+    // 親側に移して対応する想定。
+    pending.forEach((a) => {
+      if (a.previewUrl && (a.error || a.uploading)) {
+        URL.revokeObjectURL(a.previewUrl);
+      }
+    });
     onSend(text, ready);
     setText('');
-    pending.forEach((a) => {
-      if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
-    });
     setPending([]);
     setValidationError(null);
   };

--- a/frontend/src/components/__tests__/MessageInput.test.tsx
+++ b/frontend/src/components/__tests__/MessageInput.test.tsx
@@ -1,12 +1,28 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import MessageInput from '../MessageInput';
+
+vi.mock('../../repositories/AiChatRepository', () => ({
+  default: {
+    issueAttachmentUploadUrl: vi.fn(),
+  },
+}));
+
+import aiChatRepository from '../../repositories/AiChatRepository';
 
 describe('MessageInput', () => {
   const mockOnSend = vi.fn();
 
   beforeEach(() => {
     mockOnSend.mockClear();
+    vi.mocked(aiChatRepository.issueAttachmentUploadUrl).mockReset();
+    if (!('createObjectURL' in URL)) {
+      // happy-dom fallback: 一部バージョンで未定義
+      (URL as unknown as { createObjectURL?: (b: Blob) => string }).createObjectURL = vi.fn(
+        () => 'blob:mock'
+      );
+      (URL as unknown as { revokeObjectURL?: (u: string) => void }).revokeObjectURL = vi.fn();
+    }
   });
 
   it('テキスト入力と送信ボタンが表示される', () => {
@@ -64,7 +80,7 @@ describe('MessageInput', () => {
     fireEvent.change(textarea, { target: { value: 'テスト送信' } });
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
-    expect(mockOnSend).toHaveBeenCalledWith('テスト送信');
+    expect(mockOnSend).toHaveBeenCalledWith('テスト送信', []);
   });
 
   it('Shift+Enterでは送信されない', () => {
@@ -97,7 +113,7 @@ describe('MessageInput', () => {
     fireEvent.compositionEnd(textarea);
     fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
 
-    expect(mockOnSend).toHaveBeenCalledWith('テスト');
+    expect(mockOnSend).toHaveBeenCalledWith('テスト', []);
   });
 
   it('空テキストではEnterで送信されない', () => {
@@ -127,7 +143,7 @@ describe('MessageInput', () => {
     });
     fireEvent.click(screen.getByLabelText('送信'));
 
-    expect(mockOnSend).toHaveBeenCalledWith('ボタン送信');
+    expect(mockOnSend).toHaveBeenCalledWith('ボタン送信', []);
   });
 
   it('テキスト入力時に文字数が表示される', () => {
@@ -166,5 +182,62 @@ describe('MessageInput', () => {
 
     const charCount = screen.getByTestId('char-count');
     expect(charCount).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('画像を選択すると presigned URL を取得して S3 へ PUT する', async () => {
+    vi.mocked(aiChatRepository.issueAttachmentUploadUrl).mockResolvedValue({
+      uploadUrl: 'https://s3.example.com/put',
+      key: 'ai-chat/7/abc.png',
+      expiresIn: 600,
+    });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 })
+    );
+
+    render(<MessageInput onSend={mockOnSend} />);
+
+    const file = new File(['fake-bytes'], 'cat.png', { type: 'image/png' });
+    const fileInput = screen.getByLabelText('添付ファイルを選択') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(aiChatRepository.issueAttachmentUploadUrl).toHaveBeenCalledWith({
+        filename: 'cat.png',
+        contentType: 'image/png',
+        sizeBytes: file.size,
+      });
+    });
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://s3.example.com/put',
+        expect.objectContaining({ method: 'PUT' })
+      );
+    });
+
+    // 送信ボタンをクリックすると、presigned URL の key で onSend が呼ばれる
+    fireEvent.click(screen.getByLabelText('送信'));
+    await waitFor(() => {
+      expect(mockOnSend).toHaveBeenCalledWith(
+        '',
+        expect.arrayContaining([
+          expect.objectContaining({ key: 'ai-chat/7/abc.png', filename: 'cat.png' }),
+        ])
+      );
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it('未対応の MIME はバリデーションエラーで弾かれ presigned URL を呼ばない', async () => {
+    render(<MessageInput onSend={mockOnSend} />);
+
+    const file = new File(['x'], 'a.exe', { type: 'application/x-msdownload' });
+    const fileInput = screen.getByLabelText('添付ファイルを選択') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(aiChatRepository.issueAttachmentUploadUrl).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -43,7 +43,7 @@ export const PROFILE = {
   meOnboardingComplete: `${API_V2}/profile/me/onboarding/complete`,
 } as const;
 
-/** AI チャット（セッション CRUD + SSE ストリーミング） */
+/** AI チャット（セッション CRUD + SSE ストリーミング + 添付ファイル） */
 export const AI_CHAT = {
   sessions: `${API_V2}/ai-chat/sessions`,
   session: (sessionId: number | string) => `${API_V2}/ai-chat/sessions/${sessionId}`,
@@ -51,6 +51,8 @@ export const AI_CHAT = {
     `${API_V2}/ai-chat/sessions/${sessionId}/messages`,
   /** POST /ai-chat/stream — SSE ストリーミング送信 */
   stream: `${API_V2}/ai-chat/stream`,
+  /** POST /ai-chat/attachments/upload-url — 添付ファイル PUT 用 presigned URL */
+  attachmentUploadUrl: `${API_V2}/ai-chat/attachments/upload-url`,
 } as const;
 
 /** Note CRUD と画像 presigned upload */

--- a/frontend/src/hooks/useAiChatSse.ts
+++ b/frontend/src/hooks/useAiChatSse.ts
@@ -47,9 +47,17 @@ export interface SseErrorEvent {
 
 export type SseEvent = SseSessionEvent | SseTokenEvent | SseDoneEvent | SseErrorEvent;
 
+export interface SendStreamAttachment {
+  key: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}
+
 export interface SendStreamRequest {
   sessionId: number | null;
   content: string;
+  attachments?: SendStreamAttachment[];
 }
 
 export interface UseAiChatSseOptions {
@@ -82,6 +90,7 @@ export function useAiChatSse({ endpoint, onEvent, onClose }: UseAiChatSseOptions
           body: JSON.stringify({
             sessionId: req.sessionId ?? 0,
             content: req.content,
+            attachments: req.attachments ?? [],
           }),
           signal: controller.signal,
         });

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -5,7 +5,7 @@ import { useAiChat } from './useAiChat';
 import { useAiSession } from './useAiSession';
 import { useAiChatSse, SseEvent } from './useAiChatSse';
 import { AI_CHAT } from '../constants/apiRoutes';
-import { AiMessage } from '../types';
+import { AiAttachment, AiMessage } from '../types';
 
 /**
  * AskAiPage フック（SSE ストリーミング版）。
@@ -111,8 +111,8 @@ export function useAskAi() {
   });
 
   const handleSend = useCallback(
-    (text: string): void => {
-      if (!text.trim()) return;
+    (text: string, attachments: AiAttachment[] = []): void => {
+      if (!text.trim() && attachments.length === 0) return;
 
       // ユーザー発話 + アシスタント placeholder を即座に追加
       const now = new Date().toISOString();
@@ -121,6 +121,7 @@ export function useAskAi() {
         sessionId: currentSessionId ?? 0,
         role: 'user',
         content: text,
+        attachments: attachments.length > 0 ? attachments : undefined,
         createdAt: now,
       };
       const placeholderId = `streaming-${Date.now()}`;
@@ -134,7 +135,17 @@ export function useAskAi() {
       };
       setMessages((prev) => [...prev, userMsg, placeholder]);
 
-      void sendSse({ sessionId: currentSessionId, content: text });
+      void sendSse({
+        sessionId: currentSessionId,
+        content: text,
+        // SSE 送信時は preview URL を含めない（不要 / バックエンドにリーク防止）。
+        attachments: attachments.map(({ key, filename, contentType, sizeBytes }) => ({
+          key,
+          filename,
+          contentType,
+          sizeBytes,
+        })),
+      });
     },
     [sendSse, currentSessionId, setMessages]
   );

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -143,6 +143,7 @@ export default function AskAiPage() {
                   id={message.id}
                   type="text"
                   content={message.content}
+                  attachments={message.attachments}
                   isSender={message.role === 'user'}
                   isCopied={copiedId === message.id}
                   onCopy={copyToClipboard}

--- a/frontend/src/repositories/AiChatRepository.ts
+++ b/frontend/src/repositories/AiChatRepository.ts
@@ -17,6 +17,18 @@ export interface UpdateSessionTitleRequest {
   title: string;
 }
 
+export interface IssueAttachmentUploadUrlRequest {
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+}
+
+export interface AttachmentUploadUrlResponse {
+  uploadUrl: string;
+  key: string;
+  expiresIn: number;
+}
+
 class AiChatRepository {
   async getSessions(): Promise<AiSession[]> {
     const response = await apiClient.get(AI_CHAT.sessions);
@@ -44,6 +56,14 @@ class AiChatRepository {
 
   async getMessages(sessionId: number): Promise<AiMessage[]> {
     const response = await apiClient.get(AI_CHAT.sessionMessages(sessionId));
+    return response.data;
+  }
+
+  /** AI チャット添付ファイル用の S3 PUT presigned URL を取得する。 */
+  async issueAttachmentUploadUrl(
+    request: IssueAttachmentUploadUrlRequest
+  ): Promise<AttachmentUploadUrlResponse> {
+    const response = await apiClient.post(AI_CHAT.attachmentUploadUrl, request);
     return response.data;
   }
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,6 +68,24 @@ export interface AiChatMessageDto {
 }
 
 /**
+ * AiAttachment は AI チャットメッセージに添付された画像 / ドキュメントの参照。
+ * 実体は S3 にあり `key` で一意特定する。`previewUrl` は送信前のローカルプレビュー
+ * （Object URL）を保持する用途で、バックエンドへは送らない。
+ */
+export interface AiAttachment {
+  key: string;
+  filename: string;
+  contentType: string;
+  /** "image" | "document"（PR-G2 で document 追加） */
+  kind: string;
+  /** Bedrock 用の format（png / jpeg / gif / webp / pdf / csv） */
+  format: string;
+  sizeBytes: number;
+  /** ローカル状態用: ブラウザ内 preview URL（送信完了後は破棄） */
+  previewUrl?: string;
+}
+
+/**
  * AiMessage は AskAi 画面表示用の view 型。
  * `id` (string) を画面側で扱いやすい一意キーとして使う。
  * `createdAt` は ISO 8601 文字列（backend の SSE / REST 双方が ISO で返す）。
@@ -77,6 +95,7 @@ export interface AiMessage {
   sessionId: number;
   content: string;
   role: 'user' | 'assistant';
+  attachments?: AiAttachment[];
   createdAt?: string;
   isSender?: boolean;
   isDeleted?: boolean;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -58,14 +58,35 @@ export interface ScenarioBookmark {
 /**
  * AiChatMessageDto は Go backend `domain.AiChatMessage` と 1:1。
  * `messageId` (DynamoDB key) と `createdAt` (RFC3339 string) を持つ。
+ * `attachments` はユーザー発話に紐付く画像 / ドキュメント（PR-G1: 画像のみ）。
  */
 export interface AiChatMessageDto {
   sessionId: number;
   messageId: string;
   role: 'user' | 'assistant';
   content: string;
+  attachments?: AiAttachment[];
   createdAt: string;
 }
+
+/**
+ * AiAttachmentKind は backend `domain.AttachmentKind*` 定数 と 1:1。
+ * PR-G1 では "image" のみ実用。"document" は PR-G2 で PDF / CSV 対応のため予約。
+ */
+export type AiAttachmentKind = 'image' | 'document';
+
+/**
+ * AiAttachmentFormat は AWS Bedrock Converse の image/document format に渡す短い文字列。
+ * バリデーションは backend 側 (`usecase.AllowedAttachmentContentTypes`) が一次情報。
+ */
+export type AiAttachmentFormat =
+  | 'png'
+  | 'jpeg'
+  | 'gif'
+  | 'webp'
+  | 'pdf'
+  | 'csv'
+  | 'txt';
 
 /**
  * AiAttachment は AI チャットメッセージに添付された画像 / ドキュメントの参照。
@@ -76,10 +97,8 @@ export interface AiAttachment {
   key: string;
   filename: string;
   contentType: string;
-  /** "image" | "document"（PR-G2 で document 追加） */
-  kind: string;
-  /** Bedrock 用の format（png / jpeg / gif / webp / pdf / csv） */
-  format: string;
+  kind: AiAttachmentKind;
+  format: AiAttachmentFormat;
   sizeBytes: number;
   /** ローカル状態用: ブラウザ内 preview URL（送信完了後は破棄） */
   previewUrl?: string;


### PR DESCRIPTION
## 概要

AI チャット入力欄の **+ ボタン**から画像を添付し、プロンプトと一緒に Claude Sonnet 4.5
（vision 対応）に送って解釈させられるようにした。スクリーンショットで指示された
ChatGPT 風のチップ UI を採用（白カードに thumbnail + filename + サイズ）。

PR-G2（PDF / CSV）と PR-G3（UX 仕上げ）に拡張可能な設計で、`Attachment.Kind` に
`image` / `document` を許容する形でドメイン側は将来分も先に揃えてある。

## 実装範囲

### backend

- `domain.Attachment` 構造体追加（Key / Filename / ContentType / Format / Kind /
  SizeBytes と、Bedrock 呼び出し直前にだけ詰める一時 `BlobData []byte`）
- `AiChatMessage.Attachments` を DynamoDB に save / load
  （既存メッセージは `attachments` 無しで完全互換）
- `infra/s3.Downloader` を新設（GetObject でサーバ側からバイト列を取り出す）
- bedrock client が `Attachment.BlobData` を `image` / `document` ContentBlock に展開
- `POST /api/v2/ai-chat/attachments/upload-url` で presigned PUT URL を発行
  - MIME / サイズ検証あり: 415（未対応 MIME）/ 413（容量超過）
- `POST /api/v2/ai-chat/stream` の body に `attachments[]` を受けて、
  最新ユーザー発話に S3 から取得した bytes を貼って `ConverseStream` に渡す
- 1 メッセージ最大 4 添付 / 画像 5MB 上限を handler / usecase 二重で検証
- key prefix `ai-chat/` 強制で任意 S3 オブジェクトの読み出しを防止

### frontend

- types に `AiAttachment` / `AiMessage.attachments` を追加
- `AiChatRepository.issueAttachmentUploadUrl` を実装
- `useAiChatSse` / `useAskAi` が attachments を SSE body に乗せる
- `MessageInput` に + ボタンのファイル選択 UI、チップ表示（thumbnail + filename +
  size）、削除ボタン、アップロード中 / 失敗状態の可視化を追加
- `MessageBubble` に自分メッセージの画像インライン表示（max 240px）

## 仕様（合意済）

| 項目 | 値 |
|---|---|
| 1 メッセージあたりの添付数 | **4 枚** |
| 1 ファイルの最大サイズ | **5 MB**（Bedrock image 上限） |
| 対応 MIME（PR-G1） | png / jpeg / gif / webp |
| 既存メッセージの後方互換 | OK（attachments 無し → 空配列扱い） |
| チップ UI | 提案通り（白カード thumbnail + filename + size） |

## 制限・運用

- 利用バケット: 既存 `frestyle-note-images-prod-...` の `ai-chat/` プレフィックス
  （TaskRole の S3 policy は `${NoteImagesBucketArn}/*` ワイルドカードでカバー済、
  **IAM 変更不要**）
- presigned URL TTL: 10 分（既存 `infra/s3.Presigner` の defaultPresignTTL）

## テスト

- `cd backend && go test ./...`: pass
  - 新テスト: `TestSendAiMessageStream_WithAttachment_FetchesBlobAndSavesMetadata` で
    S3 download → Bedrock の最新 user message に BlobData が詰まることを assert
- `cd frontend && npx vitest run`: 1717 件 pass
  - 新テスト: presigned URL 取得 → S3 PUT → onSend に key を渡すハッピーパス
  - 新テスト: 未対応 MIME はバリデーションで弾かれて API 未到達
- `npx tsc --noEmit`: pass
- `npx eslint src --max-warnings 0`: pass

## 関連 docs

- 設計詳細: `frestyle-pdm/docs/aichat/attachments.md`（別 PR）

## 次の PR

- PR-G2: PDF / CSV 対応（`AllowedAttachmentContentTypes` に追加 + `MessageBubble`
  のドキュメントカード表示）
- PR-G3: アップロード進捗バー、ドラッグ＆ドロップ、複数選択 UX 仕上げ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * AIチャットメッセージに画像やファイルの添付機能を追加しました。
  * メッセージ作成時にファイルをアップロードできるようになりました。ファイル形式とサイズの検証が自動的に行われます。
  * チャット履歴に添付ファイルが表示されるようになりました。
  * AIモデルが画像などの添付コンテンツを処理できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->