### PR TITLE
feat(ai-chat): AI 応答のコードブロックにコピーボタンを追加

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, ReactNode } from 'react';
+import { memo, useState, useMemo, ReactNode, isValidElement } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
@@ -299,11 +299,7 @@ function MarkdownView({ content }: { content: string }) {
             </code>
           );
         },
-        pre: ({ children }) => (
-          <pre className="p-3 rounded-md bg-[var(--color-surface-3)] overflow-x-auto text-xs">
-            {children as ReactNode}
-          </pre>
-        ),
+        pre: ({ children }) => <CodeBlock>{children as ReactNode}</CodeBlock>,
         table: ({ children }) => (
           <div className="overflow-x-auto">
             <table className="text-sm border-collapse">{children as ReactNode}</table>
@@ -324,4 +320,100 @@ function MarkdownView({ content }: { content: string }) {
       {content}
     </ReactMarkdown>
   );
+}
+
+/**
+ * AI 応答の Markdown 内コードブロックに、言語名表示 + コピーボタン付きのヘッダを足す。
+ *
+ * ChatGPT / Claude.ai と同じ UX で、ユーザーは AI 応答のコードを 1 クリックでクリップボードに
+ * 取り込める。「メッセージ全体コピー」ボタンとは別に、コードブロック単位のコピー UI を提供する。
+ *
+ * react-markdown が rehype-highlight 後に渡してくる構造:
+ *
+ *   <pre>            ← この `pre` コンポーネント置換が CodeBlock のエントリ
+ *     <code class="language-py">
+ *       <span class="hljs-keyword">def</span>
+ *       ...
+ *     </code>
+ *   </pre>
+ *
+ * `children` の最も内側の文字列を再帰的に集めて生コードを復元する（rehype-highlight が
+ * 挿入した <span> はクラスだけ付けて textContent は変えないため、テキスト連結で正確に
+ * 元のコードが復元できる）。
+ */
+function CodeBlock({ children }: { children: ReactNode }) {
+  const [copied, setCopied] = useState(false);
+
+  const language = useMemo(() => extractLanguage(children), [children]);
+  const rawCode = useMemo(
+    () => extractTextContent(children).replace(/\n$/, ''),
+    [children]
+  );
+
+  const handleCopy = async () => {
+    if (!rawCode) return;
+    try {
+      await navigator.clipboard.writeText(rawCode);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard API はブラウザ設定 / HTTP 環境で拒否されることがある。
+      // エラーは握りつぶし、ユーザーには反応なしのままにする（壊れた挙動より無反応の方が安全）。
+    }
+  };
+
+  return (
+    <div className="my-2 rounded-md overflow-hidden bg-[var(--color-surface-3)]">
+      <div className="flex items-center justify-between px-3 py-1 bg-[var(--color-surface-2)] border-b border-[var(--color-surface-3)] text-[11px]">
+        <span className="text-[var(--color-text-muted)] font-mono">
+          {language || 'code'}
+        </span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={copied ? 'コードをコピーしました' : 'コードをコピー'}
+          className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-3)] transition-colors"
+        >
+          {copied ? (
+            <>
+              <ClipboardDocumentCheckIcon className="w-3.5 h-3.5 text-green-400" />
+              <span>コピー済み</span>
+            </>
+          ) : (
+            <>
+              <ClipboardDocumentIcon className="w-3.5 h-3.5" />
+              <span>コピー</span>
+            </>
+          )}
+        </button>
+      </div>
+      <pre className="p-3 overflow-x-auto text-xs">{children as ReactNode}</pre>
+    </div>
+  );
+}
+
+/**
+ * 子要素の className から `language-xxx` を抽出する。複数行コードのときだけ言語が付く。
+ * 言語不明（インラインコード相当 / 未知の言語）は空文字を返す。
+ */
+function extractLanguage(node: ReactNode): string {
+  if (!isValidElement(node)) return '';
+  const el = node as React.ReactElement<{ className?: string }>;
+  const match = el.props.className?.match(/language-(\w+)/);
+  return match?.[1] ?? '';
+}
+
+/**
+ * React 要素ツリーから text node だけを連結して返す。
+ * rehype-highlight 後の `<span class="hljs-...">code</span>` 構造から元のコードを復元する用途。
+ */
+function extractTextContent(node: ReactNode): string {
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractTextContent).join('');
+  if (isValidElement(node)) {
+    const props = node.props as { children?: ReactNode };
+    return extractTextContent(props.children);
+  }
+  return '';
 }

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import MessageBubble from '../MessageBubble';
 
 describe('MessageBubble', () => {
@@ -110,5 +110,57 @@ describe('MessageBubble', () => {
   it('受信メッセージで Markdown の見出しが描画される', () => {
     render(<MessageBubble isSender={false} content="# タイトル" id="m16" />);
     expect(screen.getByRole('heading', { name: 'タイトル' })).toBeInTheDocument();
+  });
+
+  describe('コードブロックのコピー UI', () => {
+    const writeText = vi.fn();
+    beforeEach(() => {
+      writeText.mockReset();
+      writeText.mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      });
+    });
+
+    it('コードブロックには言語ラベルとコピー用ボタンが表示される', () => {
+      const md = '```python\nprint("hi")\n```';
+      render(<MessageBubble isSender={false} content={md} id="cb1" />);
+      expect(screen.getByText('python')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'コードをコピー' })).toBeInTheDocument();
+    });
+
+    it('コピーをクリックするとコードブロックの中身が clipboard に書き込まれる', async () => {
+      const md = '```python\nprint("hi")\n```';
+      render(<MessageBubble isSender={false} content={md} id="cb2" />);
+      fireEvent.click(screen.getByRole('button', { name: 'コードをコピー' }));
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith('print("hi")');
+      });
+    });
+
+    it('クリック後はラベルが「コピー済み」になり、aria-label も更新される', async () => {
+      const md = '```ts\nconst x = 1;\n```';
+      render(<MessageBubble isSender={false} content={md} id="cb3" />);
+      fireEvent.click(screen.getByRole('button', { name: 'コードをコピー' }));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'コードをコピーしました' })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('言語指定なしのコードブロックでは "code" ラベルでフォールバックする', () => {
+      const md = '```\necho hi\n```';
+      render(<MessageBubble isSender={false} content={md} id="cb4" />);
+      expect(screen.getByText('code')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'コードをコピー' })).toBeInTheDocument();
+    });
+
+    it('インラインコードにはコピーボタンが付かない', () => {
+      const md = 'これは `const a = 1` というコードです';
+      render(<MessageBubble isSender={false} content={md} id="cb5" />);
+      expect(screen.queryByRole('button', { name: 'コードをコピー' })).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## 概要

ChatGPT / Claude.ai と同じ UX で、AI 応答内のコードブロック単位に「コピー」ボタンを
表示する。既存の「メッセージ全体コピー」ボタンと併存し、ユーザーは Markdown の
\`\`\`...\`\`\` で囲まれたコードだけを 1 クリックでクリップボードに取り込める。

## 変更内容

- `MessageBubble.tsx` の Markdown レンダラの `pre` ラッパを `CodeBlock` コンポーネントに
  差し替え。ヘッダに **言語ラベル**（\`language-xxx\` から抽出 / 未指定は \`code\` にフォールバック）と
  **「コピー / コピー済み」ボタン**を表示
- ボタン押下で \`navigator.clipboard.writeText\` → 1.5 秒後に元の状態に戻る
- \`rehype-highlight\` 後の \`<span class="hljs-...">\` ツリーから生コードを再帰的に
  抽出するヘルパ \`extractTextContent\` / \`extractLanguage\` を追加
- インラインコード（pre 直下でない code）には影響なし

## テスト

- \`MessageBubble.test.tsx\` に 5 ケース追加
  - 言語ラベル + コピーボタンの表示
  - クリックで \`navigator.clipboard.writeText\` に生コードが渡る
  - クリック後の aria-label が「コードをコピーしました」に更新される
  - 言語指定なしは \`code\` ラベルでフォールバック
  - インラインコードにはボタンが付かない
- \`vitest run\`: 1722 件 pass
- \`tsc --noEmit\`: pass
- \`eslint src --max-warnings 0\`: pass

## 関連

- 既存の Markdown レンダリングは PR-B で導入済み（react-markdown + remark-gfm + rehype-highlight）。
  本 PR はそのレンダラのコードブロック装飾を ChatGPT 風に拡張するもの

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * コードブロックに言語ラベルを表示するようになりました
  * 各コードブロックにコピーボタンを追加しました
  * コピーボタンをクリックするとコードをクリップボードにコピーでき、確認メッセージが表示されます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->