### PR TITLE
fix(ai-chat): 「新しいチャット」ボタンで前セッションのメッセージが残る不具合を修正

### DIFF
--- a/frontend/src/hooks/__tests__/useAskAi.test.tsx
+++ b/frontend/src/hooks/__tests__/useAskAi.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import authReducer from '../../store/authSlice';
+import { useAskAi } from '../useAskAi';
+
+// useAskAi は useAiChatSse / AiChatRepository / fetchSessions / fetchMessages を内部で叩く。
+// バックエンド呼び出しはすべてモックして、純粋な state 遷移ロジック（特に
+// 「new chat ボタン → currentSessionId=null → messages がクリアされる」） を検証する。
+
+vi.mock('../../repositories/AiChatRepository', () => ({
+  default: {
+    getSessions: vi.fn().mockResolvedValue([]),
+    getMessages: vi.fn().mockResolvedValue([
+      {
+        id: 'srv-1',
+        sessionId: 5,
+        role: 'user',
+        content: 'session 5 の発話',
+      },
+    ]),
+    deleteSession: vi.fn().mockResolvedValue(undefined),
+    updateSessionTitle: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock('../useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 1, email: 'a@example.com' },
+    getCurrentUser: vi.fn(),
+  }),
+}));
+
+vi.mock('../useAiChatSse', () => ({
+  useAiChatSse: () => ({
+    send: vi.fn(),
+    abort: vi.fn(),
+  }),
+}));
+
+function makeWrapper(initialPath: string) {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: { isAuthenticated: true, loading: false, isAdmin: false, onboarded: true, role: 'trainee' },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/chat/ask-ai" element={<>{children}</>} />
+          <Route path="/chat/ask-ai/:sessionId" element={<>{children}</>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+describe('useAskAi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sessionId 付き URL では fetchMessages の結果が messages にロードされる', async () => {
+    const { result } = renderHook(() => useAskAi(), {
+      wrapper: makeWrapper('/chat/ask-ai/5'),
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages.length).toBeGreaterThan(0);
+    });
+    expect(result.current.messages[0].content).toBe('session 5 の発話');
+  });
+
+  it('「新しいチャット」を押して session 無し URL に切替えると messages がクリアされる', async () => {
+    const { result } = renderHook(() => useAskAi(), {
+      wrapper: makeWrapper('/chat/ask-ai/5'),
+    });
+
+    // 一度メッセージが入った状態を作る
+    await waitFor(() => {
+      expect(result.current.messages.length).toBeGreaterThan(0);
+    });
+
+    // handleNewSession 経由で sessionId を null に切り替える
+    act(() => {
+      result.current.handleNewSession();
+    });
+
+    // currentSessionId 変更後、useEffect 内の setMessages([]) が走り messages が空配列になる
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -171,12 +171,18 @@ export function useAskAi() {
     }
   }, [urlSessionId, setCurrentSessionId]);
 
-  // セッション内のメッセージ履歴取得
+  // セッション内のメッセージ履歴取得。
+  // 「新しいチャット」ボタンや、未確定セッション（URL に sessionId 無し）に切替えた場合は
+  // currentSessionId が null になるので、前セッションのメッセージを画面から明示的に消去する。
+  // クリアしないと前セッションのチャット履歴が残ったまま空打ち状態になり、新規開始
+  // の見た目にならない。
   useEffect(() => {
     if (currentSessionId) {
       fetchMessages(currentSessionId);
+    } else {
+      setMessages([]);
     }
-  }, [currentSessionId, fetchMessages]);
+  }, [currentSessionId, fetchMessages, setMessages]);
 
   // メッセージ最下部へスクロール
   useEffect(() => {


### PR DESCRIPTION
## 概要

サイドバーの「新しいチャット」ボタンを押したときに、前セッションのチャット履歴が
画面に残ったままで新規開始の見た目にならないバグを修正。

## 原因

\`useAskAi\` の messages フェッチ useEffect が、currentSessionId が **truthy のときだけ** fetchMessages を呼んでおり、null になったときに messages 配列をクリアしていなかった。

\`\`\`ts
// 旧
useEffect(() => {
  if (currentSessionId) {
    fetchMessages(currentSessionId);
  }
}, [currentSessionId, fetchMessages]);
\`\`\`

「新しいチャット」 → \`setCurrentSessionId(null)\` + \`navigate('/chat/ask-ai')\` まで走るが、
messages は前セッションのまま残り続ける。

## 修正

\`\`\`ts
useEffect(() => {
  if (currentSessionId) {
    fetchMessages(currentSessionId);
  } else {
    setMessages([]);
  }
}, [currentSessionId, fetchMessages, setMessages]);
\`\`\`

## テスト

\`src/hooks/__tests__/useAskAi.test.tsx\` を新設:
- sessionId 付き URL で fetchMessages の結果が messages にロードされる
- handleNewSession 後 messages が空配列にクリアされる

vitest 1724 件 / tsc / eslint clean。