### PR TITLE
docs(readme): 「苦労した点・学び」セクションを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,16 +317,6 @@ sequenceDiagram
 
 ---
 
-## 苦労した点・学び
-- **WebSocket の構成方針転換**: 当初は Lambda + API Gateway のサーバレス WebSocket でコスト最適化していたが、トラフィック増加時のスケール特性とコネクション管理（DynamoDB の `connectionId` テーブル）の運用負荷が嵩み、最終的に **ECS + `gorilla/websocket` の単一経路** に統一
-- Spring Security の JWT / JWK / Cookie 設計を Go 移行後は **Gin middleware（`golang-jwt/jwt` + Cognito JWKS キャッシュ）** で再実装
-- ALB の TLS Termination（ACM 証明書）と ECS Backend 間は HTTP（VPC 内）で割り切り、外向き HTTPS 強制は CloudFront の ResponseHeadersPolicy + HSTS で多層化
-- Spring Boot の JVM オーバーヘッドにより Fargate 2 vCPU / 4 GB を要し、ランニングコストが嵩んでいた → Go (Gin + GORM) に置き換えて **0.25 vCPU / 0.5 GB へ縮退（約 80% コスト削減）**
-- 既存資産を捨てない移行戦略の設計（path-based routing による Spring Boot / Go 並行運用 → 全機能 cutover 後に Spring Boot を完全削除）
-- RDS マスターパスワードを **Secrets Manager の自動ローテーション**（`ManageMasterUserPassword=true`）に切替えて、`.env` での平文保管を撤廃
-
----
-
 ## 技術選定理由（HTTP API / ECS Fargate / Go）
 
 1. **Go (Gin + GORM)** で書き直すことでコンテナ要求リソースを最小化


### PR DESCRIPTION
## 概要

README から「苦労した点・学び」セクション（6 項目 + 区切り線、計 10 行）を削除。

## 削除した内容

- WebSocket の構成方針転換（Lambda + API Gateway → ECS + gorilla/websocket）
- Spring Security の JWT / JWK / Cookie 設計 → Gin middleware で再実装
- ALB の TLS Termination + CloudFront 多層化
- Spring Boot → Go (Gin + GORM) で約 80% のランニングコスト削減
- path-based routing による Spring Boot / Go 並行運用
- RDS マスターパスワードを Secrets Manager 自動ローテーションに切替

これらの過去経緯は frestyle-pdm / frestyle-infrastructure の docs に集約済みのため、
README からは取り除き、現在の構成説明にフォーカスさせる。

## diff 規模

10 行削除のみ（追加なし）。

## テスト

- 該当なし（README のみ）

## 関連 Issue

なし