### PR TITLE
fix(ai-chat): 空 Bedrock 応答の負のループを修正 (PR-K)

### DIFF
--- a/backend/internal/infra/bedrock/client.go
+++ b/backend/internal/infra/bedrock/client.go
@@ -151,9 +151,12 @@ func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, histor
 // 展開して text の前に並べる（Bedrock の慣習: 画像 → テキストの順が推奨）。
 // BlobData が空の Attachment は無視する（usecase で S3 から取得済みであることが前提）。
 //
-// 空コンテンツ + 添付バイト取得失敗（blocks も text も無い）の場合は当該メッセージを
-// スキップする。Bedrock は空テキストブロックを 400 で弾くため、誤って空メッセージを
-// 送らないための防御。
+// 空コンテンツ対応: Bedrock は user/assistant 役割の交互パターンを必須とする。空の
+// assistant 応答が DB に保存されているケースでも会話を成立させるため、空メッセージは
+// **skip しない** で、placeholder テキストを差し込んで Bedrock に渡す。
+// （旧実装で skip した結果、連続する user メッセージが発生して Bedrock が無言の
+// 空応答を返し、それがまた DB に空 assistant として保存されて負のループに陥る不具合
+// が判明したため）。
 func buildBedrockMessages(history []domain.AiChatMessage) []brtypes.Message {
 	messages := make([]brtypes.Message, 0, len(history))
 	for _, m := range history {
@@ -169,17 +172,28 @@ func buildBedrockMessages(history []domain.AiChatMessage) []brtypes.Message {
 			}
 		}
 		text := m.Content
-		// Bedrock の document ブロックは「同一メッセージに text ブロックがあること」を
-		// 要求する。画像のみの場合は text 無しでも OK だが、document を含むなら
-		// 空でない placeholder を必ず付ける。
-		if text == "" && hasDocumentBlock(blocks) {
-			text = "(添付ファイルを参照してください)"
+		if text == "" {
+			switch {
+			case hasDocumentBlock(blocks):
+				// document ブロックは text 必須なので placeholder を付ける。
+				text = "(添付ファイルを参照してください)"
+			case len(blocks) > 0:
+				// image だけのメッセージは Bedrock が text 無しでも受け付ける。
+				// 何も追加しない（text "" のまま skip される）。
+			default:
+				// 何も無いメッセージ。役割交互制約のため placeholder を入れる。
+				if role == brtypes.ConversationRoleAssistant {
+					text = "(応答が空でした)"
+				} else {
+					text = "(空のメッセージ)"
+				}
+			}
 		}
 		if text != "" {
 			blocks = append(blocks, &brtypes.ContentBlockMemberText{Value: text})
 		}
 		if len(blocks) == 0 {
-			// 空コンテンツ + 全添付ダウンロード失敗 → skip。
+			// image only かつ BlobData も無い → 何もない実質空メッセージ。skip。
 			continue
 		}
 		messages = append(messages, brtypes.Message{Role: role, Content: blocks})

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -157,6 +157,14 @@ func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessa
 			}
 		}
 
+		// Bedrock が token を 1 つも emit しなかった場合は空のアシスタントメッセージに
+		// なる。これを DDB に保存すると将来の history 構築時に「連続 user → 空応答」の
+		// 負のループに陥るため、空応答は保存せずエラーとしてフロントに通知する。
+		if assistantBuf.Len() == 0 {
+			emit(ctx, out, StreamEvent{Err: fmt.Errorf("bedrock returned empty response")})
+			return
+		}
+
 		final := &domain.AiChatMessage{
 			SessionID: sessionID,
 			MessageID: uuid.New().String(),

--- a/backend/internal/usecase/send_ai_message_stream_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase_test.go
@@ -228,6 +228,45 @@ func (f *fakeDownloader) Download(_ context.Context, key string) ([]byte, error)
 	return b, nil
 }
 
+// Bedrock が token を 1 つも emit せず Done だけを返した場合、空アシスタントを
+// DDB に保存しないでエラーを伝える（負のループ防止）。
+func TestSendAiMessageStream_EmptyResponse_DoesNotSaveAndPropagatesErr(t *testing.T) {
+	sessionRepo := new(mockSessionRepo)
+	msgRepo := new(mockMsgRepo)
+	bc := new(mockStreamBedrock)
+
+	msgRepo.On("Save", mock.Anything, mock.AnythingOfType("*domain.AiChatMessage")).Return(nil)
+	msgRepo.On("ListBySessionID", mock.Anything, uint64(8)).Return([]domain.AiChatMessage{}, nil)
+
+	// Delta なし、Done のみ。
+	src := make(chan bedrock.StreamEvent, 1)
+	src <- bedrock.StreamEvent{Done: true}
+	close(src)
+	var ro <-chan bedrock.StreamEvent = src
+	bc.On("ConverseStream", mock.Anything, mock.Anything, mock.Anything).Return(ro, nil)
+
+	uc := usecase.NewSendAiMessageStreamUseCase(sessionRepo, msgRepo, bc, nil)
+	ch, err := uc.Execute(context.Background(), usecase.SendAiMessageInput{
+		UserID: 7, SessionID: 8, Content: "hi",
+	})
+	require.NoError(t, err)
+
+	var sawErr bool
+	var finalCount int
+	for ev := range ch {
+		if ev.Err != nil {
+			sawErr = true
+		}
+		if ev.FinalMessage != nil {
+			finalCount++
+		}
+	}
+	assert.True(t, sawErr, "expected ev.Err for empty response")
+	assert.Equal(t, 0, finalCount, "must not emit FinalMessage when response is empty")
+	// ユーザーメッセージ 1 件だけ保存（assistant の保存はスキップ）
+	msgRepo.AssertNumberOfCalls(t, "Save", 1)
+}
+
 // Bedrock 呼び出しで stream エラー: ev.Err が channel に流れて使い手に伝わる。
 func TestSendAiMessageStream_StreamError_PropagatesErr(t *testing.T) {
 	sessionRepo := new(mockSessionRepo)


### PR DESCRIPTION
## 概要

AI チャットで一度空応答が起きたセッションが恒久的に応答しなくなる不具合を修正。

## 症状

- ECS の SSE エンドポイントが \`200 を 1.26s で完了\`（エラーログ無し）
- ユーザーから AI に質問しても、応答が画面に表示されない
- 一度発生すると **そのセッションでは何度送っても同じ症状** が続く（新セッションでは正常）

## 原因

PR-G1 の CodeRabbit fix で \`buildBedrockMessages\` が「**空 content + 空 attachments のメッセージを skip**」するロジックに変わった結果、過去のセッションに空 assistant メッセージが残っていた場合に以下の負のループに陥る:

1. 空 assistant が history から skip される
2. → 連続 user メッセージとして Bedrock に渡る
3. → Bedrock が無言の空応答を返す（HTTP は 200、Delta なし、Done のみ）
4. → 空 assistant が DDB に保存される
5. → 1 に戻る

## 修正

### 1. \`infra/bedrock/client.go\`

\`buildBedrockMessages\` を **skip ではなく placeholder 注入** に変更:

| ケース | 旧（skip） | 新（placeholder） |
|---|---|---|
| 空コンテンツ + image のみ | text 不要 | text 不要（変更なし） |
| 空コンテンツ + document あり | "(添付ファイル...)" 注入 | 同左（変更なし） |
| 完全空 + **assistant** role | skip | **\"(応答が空でした)\"** 注入 |
| 完全空 + **user** role | skip | **\"(空のメッセージ)\"** 注入 |

これにより既存 DB に残っている空 assistant でも Bedrock の役割交互制約を満たし、新規対話で正常な応答が得られる。

### 2. \`usecase/send_ai_message_stream_usecase.go\`

Bedrock が Delta を 1 つも emit しなかった場合、**空 assistant を DDB に保存せず** \`ev.Err\` を channel に流す（負のループの根本を断つ defense in depth）:

\`\`\`go
if assistantBuf.Len() == 0 {
    emit(ctx, out, StreamEvent{Err: fmt.Errorf("bedrock returned empty response")})
    return
}
\`\`\`

## テスト

- \`TestSendAiMessageStream_EmptyResponse_DoesNotSaveAndPropagatesErr\` を追加
  - Done のみ・Delta 無しの stream で
  - \`Save\` は user メッセージ 1 件のみ（assistant は保存しない）
  - \`ev.Err\` が伝搬する
- 既存 4 ケース（既存セッション / 新規セッション / 添付付き / stream error）も pass

\`go test ./...\` 全件 pass / \`gofmt\` クリーン。

## デプロイ後の効果

merge + backend redeploy 後:

- 既存セッションでも応答が返るようになる（過去の空 assistant に placeholder が補完される）
- 今後は空応答が DB に蓄積されないため負のループが再発しない
- まれに Bedrock が本当に空応答を返した場合はフロントにエラー表示される（無言で詰まらない）

## 関連

- PR-G1 (#1649): 画像添付対応で導入された CodeRabbit fix の副作用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI からの空の応答がデータベースに保存されないように改善しました。また、空の応答を受け取った場合のエラーハンドリングを強化しました。

* **Tests**
  * 空の応答シナリオに関するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->