### PR TITLE
fix(ai-chat): 新規セッション作成時の race condition 修正 (PR-L)

### DIFF
--- a/frontend/src/hooks/__tests__/useAskAi.test.tsx
+++ b/frontend/src/hooks/__tests__/useAskAi.test.tsx
@@ -34,11 +34,15 @@ vi.mock('../useAuth', () => ({
   }),
 }));
 
+// onEvent コールバックを後から呼べるように capture する。テスト側で
+// `lastOnEvent({ type: 'session', id: ... })` 等を投げて SSE をシミュレート可能。
+let lastOnEvent: ((ev: unknown) => void) | null = null;
+const mockSseSend = vi.fn();
 vi.mock('../useAiChatSse', () => ({
-  useAiChatSse: () => ({
-    send: vi.fn(),
-    abort: vi.fn(),
-  }),
+  useAiChatSse: (opts: { onEvent: (ev: unknown) => void }) => {
+    lastOnEvent = opts.onEvent;
+    return { send: mockSseSend, abort: vi.fn() };
+  },
 }));
 
 function makeWrapper(initialPath: string) {
@@ -63,6 +67,8 @@ function makeWrapper(initialPath: string) {
 describe('useAskAi', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    lastOnEvent = null;
+    mockSseSend.mockReset();
   });
 
   it('sessionId 付き URL では fetchMessages の結果が messages にロードされる', async () => {
@@ -95,5 +101,50 @@ describe('useAskAi', () => {
     await waitFor(() => {
       expect(result.current.messages).toEqual([]);
     });
+  });
+
+  // PR-J で導入した「session 切替で messages クリア」のロジックが、PR-G1 から動いていた
+  // 「新規セッションを SSE 'session' イベントで受け取って currentSessionId を切替える」flow と
+  // race して、streaming 中の placeholder を fetchMessages が上書きしてしまう不具合があった。
+  // PR-L で streamingIdRef による guard を追加し、streaming 中は fetchMessages を skip する。
+  it('streaming 中に SSE session イベントで currentSessionId が切り替わっても messages を上書きしない', async () => {
+    const aiChatRepo = (await import('../../repositories/AiChatRepository')).default;
+    vi.mocked(aiChatRepo.getMessages).mockClear();
+
+    const { result } = renderHook(() => useAskAi(), {
+      wrapper: makeWrapper('/chat/ask-ai'), // session 無し（新規チャット画面）からスタート
+    });
+
+    // 初期: currentSessionId は null、messages は空
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([]);
+    });
+    expect(aiChatRepo.getMessages).not.toHaveBeenCalled();
+
+    // 新規送信を発火（streamingIdRef がセットされる）
+    act(() => {
+      result.current.handleSend('PHPとGo言語の違いは何？');
+    });
+
+    // ローカルに userMsg + placeholder の 2 件が入った状態
+    expect(result.current.messages).toHaveLength(2);
+
+    // SSE が新規セッション作成イベントを emit したシミュレート
+    act(() => {
+      lastOnEvent?.({
+        type: 'session',
+        id: 99,
+        title: 'PHPとGo言語の違いは何？',
+        sessionType: 'free',
+        createdAt: '2026-05-08T11:21:34Z',
+      });
+    });
+
+    // currentSessionId は 99 に切り替わるが、streaming 中なので fetchMessages は skip される
+    // → messages は handleSend で入れた 2 件のまま保持される
+    await waitFor(() => {
+      expect(aiChatRepo.getMessages).not.toHaveBeenCalled();
+    });
+    expect(result.current.messages).toHaveLength(2);
   });
 });

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -172,12 +172,20 @@ export function useAskAi() {
   }, [urlSessionId, setCurrentSessionId]);
 
   // セッション内のメッセージ履歴取得。
+  //
   // 「新しいチャット」ボタンや、未確定セッション（URL に sessionId 無し）に切替えた場合は
   // currentSessionId が null になるので、前セッションのメッセージを画面から明示的に消去する。
   // クリアしないと前セッションのチャット履歴が残ったまま空打ち状態になり、新規開始
   // の見た目にならない。
+  //
+  // ただし、ストリーミング中は fetchMessages を skip する。新規セッション作成 flow で
+  // SSE が 'session' イベントを emit すると currentSessionId が null → N に切り替わり、
+  // この useEffect が fetchMessages(N) を呼んで在 streaming 中の placeholder を
+  // バックエンドから取得した（まだ user message も保存されていない可能性のある）配列で
+  // 上書きしてしまう race を防ぐ。streaming が終わった次回以降の切替では通常通り fetch する。
   useEffect(() => {
     if (currentSessionId) {
+      if (streamingIdRef.current) return;
       fetchMessages(currentSessionId);
     } else {
       setMessages([]);


### PR DESCRIPTION
## 概要

PR-J で導入した「currentSessionId 切替で前セッションのメッセージをクリア」useEffect が、SSE 'session' イベントによる新規セッション作成 flow と race して、**streaming 中の placeholder を fetchMessages が空配列で上書きしてしまう不具合**を修正。

## 症状

- 「新しいチャット」ボタンから新規メッセージ送信時、Bedrock 応答が正常に返っているのに画面に何も表示されない
- ECS ログでは \`POST /ai-chat/stream\` が **15.82s で 200**（エラー無し）
- 既存セッションでの送信では発生しない（再現困難）

## 原因 sequence

1. user が \`/chat/ask-ai\` で送信 → \`setMessages([userMsg, placeholder])\`
2. SSE 'session' event 到着 → \`setCurrentSessionId(N)\`
3. PR-J の useEffect が \`currentSessionId\` null→N の切替を検知
4. \`fetchMessages(N)\` が走り、**まだ DDB に user メッセージが保存される前**のタイミングで getMessages → 空配列
5. \`setMessages([])\` で placeholder を上書き
6. 後続の token / done イベントは \`streamingIdRef\` が指す placeholder を探すが既に消えているため何も描画されない

## 修正

useAskAi の messages フェッチ useEffect で、\`streamingIdRef.current\` が non-null（= streaming 中）のときは fetchMessages を skip:

```ts
useEffect(() => {
  if (currentSessionId) {
    if (streamingIdRef.current) return; // ← 新規 guard
    fetchMessages(currentSessionId);
  } else {
    setMessages([]);
  }
}, [currentSessionId, fetchMessages, setMessages]);
```

## テスト

- \`useAskAi.test.tsx\` に追加: streaming 中に SSE session イベントで currentSessionId が null→99 に切り替わっても、\`getMessages\` は呼ばれず messages が 2 件（userMsg + placeholder）保持される
- vitest **1727 件** pass / tsc / eslint clean

## 関連

- PR-J (#1651): 「新しいチャット」ボタンで前メッセージをクリアする fix（race の起点）
- PR-G1 (#1649): 新規セッション SSE 'session' イベント発火 flow