### PR TITLE
fix(ai-chat): 自動スクロールをユーザー操作と共存させる (PR-O)

### DIFF
--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -24,7 +24,6 @@ export function useAskAi() {
   const STREAM_ENDPOINT = `${API_BASE_URL}${AI_CHAT.stream}`;
 
   const [sessionSearchQuery, setSessionSearchQuery] = useState('');
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
   // ストリーミング中のアシスタントメッセージ ID（placeholder）
   const streamingIdRef = useRef<string | null>(null);
 
@@ -192,10 +191,9 @@ export function useAskAi() {
     }
   }, [currentSessionId, fetchMessages, setMessages]);
 
-  // メッセージ最下部へスクロール
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  // 自動スクロールは AskAiPage 側で「ユーザーが下端付近にいる時のみ」の条件付きで実装する。
+  // 旧実装は messages 変化のたびに無条件で scrollIntoView していたため、ストリーミング中
+  // にユーザーが上にスクロールしても強制的に底へ戻されてしまう不具合があった。
 
   // unmount で進行中の stream を abort
   useEffect(() => {
@@ -213,7 +211,6 @@ export function useAskAi() {
     filteredSessions,
     messages,
     loading,
-    messagesEndRef,
     sessionSearchQuery,
     setSessionSearchQuery,
 

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
 import MessageBubbleAi from '../components/MessageBubbleAi';
 import MessageInput from '../components/MessageInput';
 import ConfirmModal from '../components/ConfirmModal';
@@ -10,10 +11,15 @@ import {
   Bars3Icon,
   SparklesIcon,
   MagnifyingGlassIcon,
+  ArrowDownIcon,
 } from '@heroicons/react/24/outline';
 import { useAskAi } from '../hooks/useAskAi';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
 import { useCopyToClipboard } from '../hooks/useCopyToClipboard';
+
+// 自動スクロールの「下端付近」と判定する閾値（px）。これ以上スクロールアップしたら
+// auto-scroll を停止し、ユーザーが過去メッセージを読みやすくする。
+const STICK_TO_BOTTOM_THRESHOLD = 80;
 
 /**
  * 汎用 AI チャット画面。
@@ -32,7 +38,6 @@ export default function AskAiPage() {
     filteredSessions,
     messages,
     loading,
-    messagesEndRef,
     currentSessionId,
     deleteModal,
     editingSessionId,
@@ -50,6 +55,39 @@ export default function AskAiPage() {
     handleCancelEditTitle,
     handleSend,
   } = useAskAi();
+
+  // 自動スクロール制御:
+  //   stickToBottom=true → messages 変化のたびに最下部へスクロール（streaming 中の追従）
+  //   stickToBottom=false → ユーザーが上にスクロールしたので auto-scroll を停止
+  // ユーザーが手動で底まで戻したら stickToBottom を再 true に戻す（onScroll で検知）。
+  // ChatGPT / Claude.ai と同じ UX。
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+  const [stickToBottom, setStickToBottom] = useState(true);
+
+  const handleContainerScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setStickToBottom(distanceFromBottom < STICK_TO_BOTTOM_THRESHOLD);
+  }, []);
+
+  // messages 変化時に stick している場合のみ最下部へ。stick していない時はそのまま
+  // ユーザーが見ている位置を保つ。
+  useEffect(() => {
+    if (!stickToBottom) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, stickToBottom]);
+
+  // セッション切替で先頭に戻ったときは強制的に底へ（履歴の最後を見せる）。
+  useEffect(() => {
+    setStickToBottom(true);
+  }, [currentSessionId]);
+
+  const jumpToBottom = useCallback(() => {
+    setStickToBottom(true);
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, []);
 
   if (loading && sessions.length === 0) {
     return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
@@ -116,7 +154,7 @@ export default function AskAiPage() {
       </SecondaryPanel>
 
       {/* メイン: チャット */}
-      <div className="flex-1 flex flex-col min-w-0">
+      <div className="flex-1 flex flex-col min-w-0 relative">
         {/* モバイル用パネル開閉ボタン */}
         <div className="md:hidden p-2 border-b border-surface-3">
           <button
@@ -128,7 +166,11 @@ export default function AskAiPage() {
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-4 py-6">
+        <div
+          ref={containerRef}
+          onScroll={handleContainerScroll}
+          className="flex-1 overflow-y-auto px-4 py-6 relative"
+        >
           {messages.length === 0 ? (
             <EmptyState
               icon={SparklesIcon}
@@ -153,6 +195,21 @@ export default function AskAiPage() {
             </div>
           )}
         </div>
+
+        {/* stick が解除されているとき（= 上にスクロールしている）だけ表示する
+             「最下部へ戻る」ボタン。ChatGPT / Claude.ai と同じ UX */}
+        {!stickToBottom && messages.length > 0 && (
+          <div className="absolute right-6 bottom-24 z-10">
+            <button
+              type="button"
+              onClick={jumpToBottom}
+              aria-label="最下部にスクロール"
+              className="flex items-center justify-center w-10 h-10 rounded-full bg-[var(--color-surface-3)] text-[var(--color-text-primary)] shadow-md hover:bg-[var(--color-surface-2)] border border-[var(--color-surface-3)]"
+            >
+              <ArrowDownIcon className="w-5 h-5" />
+            </button>
+          </div>
+        )}
 
         <div className="border-t border-surface-3 p-3 bg-[var(--color-surface-1)]">
           <div className="max-w-3xl mx-auto">


### PR DESCRIPTION
## 概要

AI 応答ストリーミング中に messages 配列が更新されるたび無条件で \`scrollIntoView\` していたため、**ユーザーが過去メッセージを読もうと上にスクロールしても強制的に底へ戻されてしまう**不具合を修正。ChatGPT / Claude.ai と同じ「stick to bottom」パターンを実装する。

## 修正方針

- 旧: messages 変化のたびに \`scrollIntoView\`（useAskAi 内）
- 新: AskAiPage 側で
  - \`containerRef\` (overflow-y-auto コンテナ) と \`messagesEndRef\` (sentinel) を直接保持
  - \`onScroll\` で「下端まで 80px 以内か」を判定して \`stickToBottom\` state を更新
  - messages 変化時の useEffect は \`stickToBottom === true\` の時のみ自動スクロール
  - セッション切替時は \`stickToBottom\` を強制 true に戻す（履歴最後尾表示）
  - \`stickToBottom === false\` の時だけ右下に「↓」ジャンプボタンを表示し、クリックで底へ戻す

## 変更ファイル

- \`hooks/useAskAi.ts\`: \`messagesEndRef\` と auto-scroll useEffect を撤去
- \`pages/AskAiPage.tsx\`:
  - \`containerRef\` / \`messagesEndRef\` / \`stickToBottom\` state を追加
  - \`onScroll\` handler 追加
  - 条件付き auto-scroll の useEffect 追加
  - ジャンプボタン UI 追加
  - 親 div に \`relative\` 付与（absolute ボタンの位置基準）

## 検証

- \`npx tsc --noEmit\`: pass
- \`npx vitest run\`: **1727 件** pass（既存 useAskAi テストは \`messagesEndRef\` を参照していないため影響なし）
- \`npx eslint src --max-warnings 0\`: pass

## 手動確認手順

1. AI チャットで長めの応答を要求（例: 「Python の Transformer モデルを 30 行で書いて」）
2. 応答ストリーミング中に上にスクロール → **底に戻されない**
3. 右下に「↓」ボタンが現れる → クリックで底に戻る + auto-scroll 再開
4. 底まで戻すと auto-scroll が再開し新しい token を追従する