### PR TITLE
style: body 色をクリームから淡いオフホワイトに変更 + ヘッダーロゴ拡大 (PR-R)

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -35,7 +35,7 @@ export default function AppShell() {
         >
           <Bars3Icon className="w-5 h-5" />
         </button>
-        <img src="/logo.svg" alt="FreStyle" className="h-9 w-auto" />
+        <img src="/logo.svg" alt="FreStyle" className="h-11 w-auto" />
       </header>
 
       {/* ヘッダー下: サイドバー + メインコンテンツ */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,16 +6,16 @@
  * ライトテーマ単一構成（ダークモードは廃止）。
  *
  * カラー設計:
- *   - body 全体: #F2EDE4（クリーム）
+ *   - body 全体: #F9F6F1（ごく淡い暖色オフホワイト）
  *   - サイドバー / ヘッダー: #DCE0F2（淡い青紫）→ --color-nav として独立変数化
- *   - カード / raised surface: 白に近い #FFFFFF / #EFEBDD で階層を視認できるように差を付ける
+ *   - カード / raised surface: 白に近い #FFFFFF / #F4F0E8 で階層を視認できるように差を付ける
  *   - サーフェス階層は「ページ背景 < カード < 強調」の順に並べる
  */
 :root {
-  --color-surface: #F2EDE4;
+  --color-surface: #F9F6F1;
   --color-surface-1: #FFFFFF;
-  --color-surface-2: #EFEBDD;
-  --color-surface-3: #E0DBC9;
+  --color-surface-2: #F4F0E8;
+  --color-surface-3: #E5DFCF;
   /* サイドバーとヘッダー専用。 surface-1 と区別して body との差別化を可能にする */
   --color-nav: #DCE0F2;
   --color-text-primary: #191919;
@@ -25,7 +25,7 @@
   --color-text-faint: #D3D3D0;
   --color-text-subtle: #E8E8E6;
   --color-border-hover: #D3D3D0;
-  --scrollbar-track: #F2EDE4;
+  --scrollbar-track: #F9F6F1;
   --scrollbar-thumb: #D3D3D0;
   --scrollbar-thumb-hover: #A4A4A0;
 


### PR DESCRIPTION
## 概要

PR-Q で導入したクリーム色 (\`#F2EDE4\`) が想定より黄みが強かったため、ユーザのリファレンス画像（DRESSING DESIGN 系の柔らかい暖色オフホワイト）に近い \`#F9F6F1\` に変更します。あわせてヘッダーのロゴが小さく感じたので少しだけ拡大します。

## 変更内容

### body 背景色
- \`--color-surface\`: \`#F2EDE4\` → \`#F9F6F1\`（暖色オフホワイト）
- \`--color-surface-2\`: \`#EFEBDD\` → \`#F4F0E8\`
- \`--color-surface-3\`: \`#E0DBC9\` → \`#E5DFCF\`
- \`--scrollbar-track\`: \`#F2EDE4\` → \`#F9F6F1\`
- サイドバー / ヘッダー (\`--color-nav: #DCE0F2\`) は据え置き

### ロゴサイズ
- ヘッダーの \`<img src="/logo.svg">\` を \`h-9\` (36px) → \`h-11\` (44px) に拡大。ヘッダー高さ \`h-14\` (56px) 内に収まる範囲で控えめに。

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅

## 関連 Issue

- なし（小規模な見た目調整）