### PR TITLE
style: body 背景を #FAFAFA (ニュートラル白寄り) に変更 (PR-S)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,16 +6,16 @@
  * ライトテーマ単一構成（ダークモードは廃止）。
  *
  * カラー設計:
- *   - body 全体: #F9F6F1（ごく淡い暖色オフホワイト）
+ *   - body 全体: #FAFAFA（ニュートラルな白寄り）
  *   - サイドバー / ヘッダー: #DCE0F2（淡い青紫）→ --color-nav として独立変数化
- *   - カード / raised surface: 白に近い #FFFFFF / #F4F0E8 で階層を視認できるように差を付ける
+ *   - カード / raised surface: 純白 #FFFFFF / 微差 #F0F0F0 で階層を視認できるように差を付ける
  *   - サーフェス階層は「ページ背景 < カード < 強調」の順に並べる
  */
 :root {
-  --color-surface: #F9F6F1;
+  --color-surface: #FAFAFA;
   --color-surface-1: #FFFFFF;
-  --color-surface-2: #F4F0E8;
-  --color-surface-3: #E5DFCF;
+  --color-surface-2: #F0F0F0;
+  --color-surface-3: #E0E0E0;
   /* サイドバーとヘッダー専用。 surface-1 と区別して body との差別化を可能にする */
   --color-nav: #DCE0F2;
   --color-text-primary: #191919;
@@ -25,7 +25,7 @@
   --color-text-faint: #D3D3D0;
   --color-text-subtle: #E8E8E6;
   --color-border-hover: #D3D3D0;
-  --scrollbar-track: #F9F6F1;
+  --scrollbar-track: #FAFAFA;
   --scrollbar-thumb: #D3D3D0;
   --scrollbar-thumb-hover: #A4A4A0;
 


### PR DESCRIPTION
## 概要

PR-R (#1662) で導入した \`#F9F6F1\` がまだ暖色寄りに見えるため、ユーザの希望によりニュートラルな白寄り \`#FAFAFA\` に変更します。

## 変更内容

- \`--color-surface\`: \`#F9F6F1\` → \`#FAFAFA\`
- \`--color-surface-2\`: \`#F4F0E8\` → \`#F0F0F0\`（暖色寄り → ニュートラルグレー寄り）
- \`--color-surface-3\`: \`#E5DFCF\` → \`#E0E0E0\`
- \`--scrollbar-track\`: \`#F9F6F1\` → \`#FAFAFA\`
- サイドバー / ヘッダー (\`--color-nav: #DCE0F2\`) は据え置き

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅

## 関連

- PR-R (#1662) のフォローアップ