### PR TITLE
style: nav 色を #E4EAF2 に変更 + サイドバー hover/active を同色系に統一 (PR-T)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -113,7 +113,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
           <button
             onClick={() => { setExpanded((v) => !v); if (expanded) setAdminOpen(false); }}
             title={expanded ? 'サイドバーを閉じる' : 'サイドバーを開く'}
-            className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-primary)] transition-colors"
+            className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)] transition-colors"
           >
             {expanded
               ? <ChevronDoubleLeftIcon className="w-4 h-4" />
@@ -134,8 +134,8 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
                 title={!expanded ? item.label : undefined}
                 className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors duration-150 ${
                   active
-                    ? 'bg-surface-3 text-primary-300'
-                    : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                    ? 'bg-[var(--color-nav-active)] text-[var(--color-text-primary)]'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]'
                 }`}
               >
                 <item.icon className="w-5 h-5 flex-shrink-0" />
@@ -157,8 +157,8 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
                 title={!expanded ? item.label : undefined}
                 className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors duration-150 ${
                   active
-                    ? 'bg-surface-3 text-primary-300'
-                    : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                    ? 'bg-[var(--color-nav-active)] text-[var(--color-text-primary)]'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]'
                 }`}
               >
                 <item.icon className="w-5 h-5 flex-shrink-0" />
@@ -176,8 +176,8 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
                 title={!expanded ? adminNavItem.label : undefined}
                 className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium w-full transition-colors duration-150 ${
                   adminActive
-                    ? 'bg-surface-3 text-primary-300'
-                    : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                    ? 'bg-[var(--color-nav-active)] text-[var(--color-text-primary)]'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]'
                 }`}
               >
                 <adminNavItem.icon className="w-5 h-5 flex-shrink-0" />
@@ -205,8 +205,8 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
                         onClick={onNavigate}
                         className={`flex items-center px-2 py-1.5 rounded-md text-xs transition-colors ${
                           subActive
-                            ? 'bg-surface-3 text-primary-300'
-                            : 'text-[var(--color-text-tertiary)] hover:bg-surface-2 hover:text-[var(--color-text-primary)]'
+                            ? 'bg-[var(--color-nav-active)] text-[var(--color-text-primary)]'
+                            : 'text-[var(--color-text-tertiary)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]'
                         }`}
                       >
                         {sub.label}

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -65,7 +65,7 @@ describe('Sidebar', () => {
   it('ホームルートでホームがアクティブになる', () => {
     renderSidebar('/');
     const homeLink = screen.getByText('ホーム').closest('a');
-    expect(homeLink?.className).toContain('bg-surface-3');
+    expect(homeLink?.className).toContain('bg-[var(--color-nav-active)]');
   });
 
   it('折りたたみボタンでサイドバーが折りたたまれる', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,7 @@
  *
  * カラー設計:
  *   - body 全体: #FAFAFA（ニュートラルな白寄り）
- *   - サイドバー / ヘッダー: #DCE0F2（淡い青紫）→ --color-nav として独立変数化
+ *   - サイドバー / ヘッダー: #E4EAF2（淡いブルーグレー）→ --color-nav として独立変数化
  *   - カード / raised surface: 純白 #FFFFFF / 微差 #F0F0F0 で階層を視認できるように差を付ける
  *   - サーフェス階層は「ページ背景 < カード < 強調」の順に並べる
  */
@@ -17,7 +17,11 @@
   --color-surface-2: #F0F0F0;
   --color-surface-3: #E0E0E0;
   /* サイドバーとヘッダー専用。 surface-1 と区別して body との差別化を可能にする */
-  --color-nav: #DCE0F2;
+  --color-nav: #E4EAF2;
+  /* nav 上のホバー / アクティブ状態。 nav と同じ色相 (ブルーグレー) を維持しつつ段階的に濃くすることで
+     surface-2 / surface-3 のニュートラルグレーが nav 上で「白い塊」に見える違和感を解消する。 */
+  --color-nav-hover: #D2DAE6;
+  --color-nav-active: #B8C3D4;
   --color-text-primary: #191919;
   --color-text-secondary: #37352F;
   --color-text-tertiary: #787774;


### PR DESCRIPTION
## 概要

サイドバー / ヘッダーの背景色をユーザ希望の \`#E4EAF2\` (淡いブルーグレー) に変更します。あわせて、サイドバーのナビゲーション項目の hover / active 状態が body のニュートラルグレー (\`bg-surface-2/3\`) を使っていたため nav 上で「白い塊」に見えていた問題を解決し、 nav と同色系で段階的に濃くなる正攻法のステート設計に統一します。

## 変更内容

### nav 系カラー (index.css)
- \`--color-nav\`: \`#DCE0F2\` → \`#E4EAF2\`
- 新規 \`--color-nav-hover\`: \`#D2DAE6\`（nav より少し濃い）
- 新規 \`--color-nav-active\`: \`#B8C3D4\`（さらに濃く、active 状態を明確化）

### Sidebar.tsx
- ナビ項目（メイン / プロフィール / 管理 / 管理サブメニュー）の active / hover を統一:
  - active: \`bg-[var(--color-nav-active)] text-[var(--color-text-primary)]\`
  - hover: \`bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]\`
- 折りたたみトグルボタンの hover も \`bg-[var(--color-nav-hover)]\` に統一

### Sidebar.test.tsx
- アクティブ表現の class 名検証を \`bg-surface-3\` → \`bg-[var(--color-nav-active)]\` に更新

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1720 / 1720 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅