### PR TITLE
style: AI チャット UI を刷新（入力カード化 + 左上タイトル + ブランドアバター）(PR-Y)

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -6,7 +6,6 @@ import {
   ClipboardDocumentIcon,
   ClipboardDocumentCheckIcon,
   TrashIcon,
-  SparklesIcon,
 } from '@heroicons/react/24/outline';
 import 'highlight.js/styles/github-dark.css';
 import { formatHourMinute } from '../utils/formatters';
@@ -139,8 +138,8 @@ export default memo(function MessageBubble({
       role="article"
       aria-label={senderName ? `${senderName}のメッセージ` : 'AIのメッセージ'}
     >
-      <div className="flex-shrink-0 w-7 h-7 rounded-full bg-[var(--color-surface-3)] flex items-center justify-center text-[var(--color-text-muted)]">
-        <SparklesIcon className="w-4 h-4" aria-hidden="true" />
+      <div className="flex-shrink-0 w-7 h-7 rounded-full bg-[var(--color-surface-2)] flex items-center justify-center">
+        <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
       </div>
       <div className="flex-1 min-w-0">
         {senderName && (

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -183,10 +183,14 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
   };
 
   return (
-    <div className="w-full bg-surface-1 border-t border-surface-3">
+    // 角丸カード型の compose UI。 ChatGPT / Claude.ai に倣い、
+    //   1 段目: textarea のみ
+    //   2 段目: 左に + (添付)、右に送信ボタンと送信中ラベル
+    // を縦に並べて、入力にスペースを取りつつ操作系をボトムバーに集約する。
+    <div className="w-full bg-[var(--color-surface-1)] border border-[var(--color-surface-3)] rounded-2xl shadow-sm focus-within:border-[var(--color-text-muted)] transition-colors">
       {pending.length > 0 && (
         <div
-          className="flex flex-wrap gap-2 p-3 pb-0"
+          className="flex flex-wrap gap-2 px-4 pt-3"
           aria-label="添付ファイル"
         >
           {pending.map((a) => (
@@ -195,62 +199,71 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
         </div>
       )}
       {validationError && (
-        <p className="px-4 pt-2 text-xs text-red-400" role="alert">
+        <p className="px-4 pt-2 text-xs text-red-500" role="alert">
           {validationError}
         </p>
       )}
-      <div className="flex items-end p-3">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept={ACCEPTED_FILE_TYPES}
-          multiple
-          className="hidden"
-          onChange={handleFileChange}
-          aria-label="添付ファイルを選択"
-        />
-        <button
-          type="button"
-          onClick={handlePickClick}
-          disabled={pending.length >= MAX_ATTACHMENTS || isSending}
-          className="text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] p-2.5 rounded-full transition-colors duration-150 flex-shrink-0 mb-1 disabled:opacity-40 disabled:cursor-not-allowed"
-          aria-label="添付ファイル"
-        >
-          <PlusIcon className="h-6 w-6" />
-        </button>
 
-        <div className="flex-1 min-w-0">
-          <textarea
-            ref={textareaRef}
-            rows={1}
-            className="w-full bg-transparent text-[var(--color-text-primary)] outline-none resize-none px-3 py-2 placeholder-slate-400 leading-6"
-            placeholder="メッセージを入力..."
-            value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={handleKeyDown}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
-            disabled={isSending}
-          />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_FILE_TYPES}
+        multiple
+        className="hidden"
+        onChange={handleFileChange}
+        aria-label="添付ファイルを選択"
+      />
+
+      <div className="px-4 pt-3">
+        <textarea
+          ref={textareaRef}
+          rows={1}
+          className="w-full bg-transparent text-[var(--color-text-primary)] outline-none resize-none placeholder:text-[var(--color-text-muted)] text-sm leading-6"
+          placeholder="メッセージを入力..."
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
+          disabled={isSending}
+        />
+      </div>
+
+      <div className="flex items-center justify-between px-3 py-2">
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={handlePickClick}
+            disabled={pending.length >= MAX_ATTACHMENTS || isSending}
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] p-1.5 rounded-full transition-colors duration-150 flex-shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label="添付ファイル"
+          >
+            <PlusIcon className="h-5 w-5" />
+          </button>
           {text.length > 0 && (
-            <span data-testid="char-count" className="block px-3 pb-1 text-[10px] text-[var(--color-text-muted)] text-right" aria-live="polite">
+            <span
+              data-testid="char-count"
+              className="text-[10px] text-[var(--color-text-muted)]"
+              aria-live="polite"
+            >
               {text.length}
             </span>
           )}
         </div>
 
-        <button
-          onClick={handleSend}
-          className="text-white bg-primary-500 p-2.5 rounded-full hover:bg-primary-600 transition-colors duration-150 flex-shrink-0 disabled:bg-surface-3 mb-1 ml-2"
-          disabled={!canSend}
-          aria-label="送信"
-        >
-          <PaperAirplaneIcon className="h-6 w-6 rotate-90" />
-        </button>
-
-        {isSending && (
-          <span className="text-xs text-[var(--color-text-faint)] ml-2 mb-2 flex-shrink-0">送信中...</span>
-        )}
+        <div className="flex items-center gap-2">
+          {isSending && (
+            <span className="text-xs text-[var(--color-text-muted)]">送信中...</span>
+          )}
+          <button
+            onClick={handleSend}
+            className="text-white bg-[var(--color-text-primary)] p-1.5 rounded-full hover:opacity-80 transition-opacity duration-150 flex-shrink-0 disabled:bg-[var(--color-surface-3)] disabled:text-[var(--color-text-muted)] disabled:cursor-not-allowed"
+            disabled={!canSend}
+            aria-label="送信"
+          >
+            <PaperAirplaneIcon className="h-4 w-4 rotate-90" />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -1,15 +1,13 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import MessageBubbleAi from '../components/MessageBubbleAi';
 import MessageInput from '../components/MessageInput';
 import ConfirmModal from '../components/ConfirmModal';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import AiSessionListItem from '../components/AiSessionListItem';
-import EmptyState from '../components/EmptyState';
 import Loading from '../components/Loading';
 import {
   PlusIcon,
   Bars3Icon,
-  SparklesIcon,
   MagnifyingGlassIcon,
   ArrowDownIcon,
 } from '@heroicons/react/24/outline';
@@ -89,6 +87,14 @@ export default function AskAiPage() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, []);
 
+  // 左上に出すタイトル。 currentSessionId に該当する session の title が無ければ
+  // 「新しいチャット」をフォールバックにする（ first message が確定するまでの間）。
+  const currentSessionTitle = useMemo(() => {
+    if (!currentSessionId) return '新しいチャット';
+    const found = sessions.find((s) => s.id === currentSessionId);
+    return found?.title?.trim() || '新しいチャット';
+  }, [sessions, currentSessionId]);
+
   if (loading && sessions.length === 0) {
     return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
   }
@@ -155,15 +161,18 @@ export default function AskAiPage() {
 
       {/* メイン: チャット */}
       <div className="flex-1 flex flex-col min-w-0 relative">
-        {/* モバイル用パネル開閉ボタン */}
-        <div className="md:hidden p-2 border-b border-surface-3">
+        {/* 上部ヘッダー: 左上にセッションタイトル、モバイルではハンバーガーも兼ねる */}
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-surface-3">
           <button
             onClick={openMobilePanel}
-            className="p-2 rounded hover:bg-surface-2"
+            className="md:hidden p-1.5 rounded hover:bg-[var(--color-surface-2)]"
             aria-label="セッションを開く"
           >
             <Bars3Icon className="w-5 h-5" />
           </button>
+          <h1 className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+            {currentSessionTitle}
+          </h1>
         </div>
 
         <div
@@ -172,11 +181,7 @@ export default function AskAiPage() {
           className="flex-1 overflow-y-auto px-4 py-6 relative"
         >
           {messages.length === 0 ? (
-            <EmptyState
-              icon={SparklesIcon}
-              title="質問してみましょう"
-              description="自由に質問・要約・コードのレビュー依頼などができます。"
-            />
+            <WelcomeGreeting />
           ) : (
             <div className="max-w-3xl mx-auto space-y-4">
               {messages.map((message) => (
@@ -197,21 +202,22 @@ export default function AskAiPage() {
         </div>
 
         {/* stick が解除されているとき（= 上にスクロールしている）だけ表示する
-             「最下部へ戻る」ボタン。ChatGPT / Claude.ai と同じ UX */}
+             「最下部へ戻る」ボタン */}
         {!stickToBottom && messages.length > 0 && (
-          <div className="absolute right-6 bottom-24 z-10">
+          <div className="absolute right-6 bottom-32 z-10">
             <button
               type="button"
               onClick={jumpToBottom}
               aria-label="最下部にスクロール"
-              className="flex items-center justify-center w-10 h-10 rounded-full bg-[var(--color-surface-3)] text-[var(--color-text-primary)] shadow-md hover:bg-[var(--color-surface-2)] border border-[var(--color-surface-3)]"
+              className="flex items-center justify-center w-10 h-10 rounded-full bg-[var(--color-surface-1)] text-[var(--color-text-primary)] shadow-md hover:bg-[var(--color-surface-2)] border border-[var(--color-surface-3)]"
             >
               <ArrowDownIcon className="w-5 h-5" />
             </button>
           </div>
         )}
 
-        <div className="border-t border-surface-3 p-3 bg-[var(--color-surface-1)]">
+        {/* 入力エリア: 角丸カード風 (paiza / 主要 AI チャットの compose UI に倣う) */}
+        <div className="px-4 pb-4 pt-2">
           <div className="max-w-3xl mx-auto">
             <MessageInput onSend={handleSend} />
           </div>
@@ -228,6 +234,37 @@ export default function AskAiPage() {
         onConfirm={confirmDeleteSession}
         onCancel={cancelDeleteSession}
       />
+    </div>
+  );
+}
+
+/**
+ * 新規セッション時にメッセージ欄が空のときに出すウェルカムグリーティング。
+ *
+ * デザイン:
+ *   - 大きめのブランドアイコン (favicon.svg = 三角の翼ロゴ) を見出しの左に置き、
+ *     「FreStyle 式の AI チャット」であることを最初の一画面で伝える。
+ *   - 中央寄せ、本文は控えめに 1〜2 行。
+ */
+function WelcomeGreeting() {
+  return (
+    <div className="h-full flex items-center justify-center px-4">
+      <div className="max-w-xl w-full text-center">
+        <div className="flex items-center justify-center gap-3 mb-4">
+          <img
+            src="/favicon.svg"
+            alt=""
+            aria-hidden="true"
+            className="w-10 h-10 flex-shrink-0"
+          />
+          <h2 className="text-2xl font-medium text-[var(--color-text-primary)]">
+            なにをお手伝いしましょうか？
+          </h2>
+        </div>
+        <p className="text-sm text-[var(--color-text-muted)]">
+          質問・要約・コードレビューなど、自由にメッセージを送ってください。
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

ユーザのリファレンス（モダン AI チャット UI）に合わせて、 \`/chat/ask-ai\` の主要 UI を 3 点リデザインします。 デザイン専用変更で CLAUDE.md 4.2 ルール通り CodeRabbit レビューは待たず admin merge します。

## 変更内容

### 1. 左上にセッションタイトル表示

チャット領域の最上部に \`h1\` のタイトル行を追加。 `currentSessionId` の session の `title` をそのまま表示し、未確定（新規 / タイトルなし）は **「新しいチャット」** をフォールバック。 モバイルでは同じ行にハンバーガーボタンを置いてセッション一覧を開ける。

### 2. 入力エリアを角丸カードに

\`MessageInput\` を `border-t` のみのフラット配置から **角丸カード（`rounded-2xl border shadow-sm`）** に変更。

- 1 段目: textarea のみ（プレースホルダ「メッセージを入力...」）
- 2 段目: 左 \`+\` ボタン（添付）+ 文字数、右に送信ボタン + 「送信中...」ラベル

送信ボタンは text-primary 背景にし、ライトテーマで視認性を確保。

### 3. AI 応答のアバターをブランドロゴに

\`MessageBubble\` の AI 応答アイコンを Heroicons の `SparklesIcon` から **\`/favicon.svg\`（青の三角羽ロゴ）** に置換。空状態（welcome 画面）にも同じ favicon を 40px で配置し、 「これは FreStyle 式の AI チャットだよ」と一画面で伝わるようにする。 EmptyState から自前の `WelcomeGreeting` 内部関数に置き換え（EmptyState は ComponentType しか受け取れず img を渡せないため）。

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1720 / 1720 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅

## 備考

PR-V (#1666) とは独立したデザイン専用 PR。 PR-V の backend スキーマ変更には依存しないので、どちらが先にマージされても問題ない。