### PR TITLE
style: チャット入力の文字数カウント表示を撤去

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -240,15 +240,6 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
           >
             <PlusIcon className="h-5 w-5" />
           </button>
-          {text.length > 0 && (
-            <span
-              data-testid="char-count"
-              className="text-[10px] text-[var(--color-text-muted)]"
-              aria-live="polite"
-            >
-              {text.length}
-            </span>
-          )}
         </div>
 
         <div className="flex items-center gap-2">

--- a/frontend/src/components/__tests__/MessageInput.test.tsx
+++ b/frontend/src/components/__tests__/MessageInput.test.tsx
@@ -146,44 +146,6 @@ describe('MessageInput', () => {
     expect(mockOnSend).toHaveBeenCalledWith('ボタン送信', []);
   });
 
-  it('テキスト入力時に文字数が表示される', () => {
-    render(<MessageInput onSend={mockOnSend} />);
-
-    fireEvent.change(screen.getByPlaceholderText('メッセージを入力...'), {
-      target: { value: 'テスト入力' },
-    });
-
-    expect(screen.getByText('5')).toBeInTheDocument();
-  });
-
-  it('空テキスト時は文字数が表示されない', () => {
-    render(<MessageInput onSend={mockOnSend} />);
-
-    expect(screen.queryByTestId('char-count')).not.toBeInTheDocument();
-  });
-
-  it('送信後に文字数表示が消える', () => {
-    render(<MessageInput onSend={mockOnSend} />);
-
-    const textarea = screen.getByPlaceholderText('メッセージを入力...');
-    fireEvent.change(textarea, { target: { value: 'テスト' } });
-    expect(screen.getByText('3')).toBeInTheDocument();
-
-    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
-    expect(screen.queryByTestId('char-count')).not.toBeInTheDocument();
-  });
-
-  it('文字数表示にaria-live="polite"が設定されている', () => {
-    render(<MessageInput onSend={mockOnSend} />);
-
-    fireEvent.change(screen.getByPlaceholderText('メッセージを入力...'), {
-      target: { value: 'テスト入力' },
-    });
-
-    const charCount = screen.getByTestId('char-count');
-    expect(charCount).toHaveAttribute('aria-live', 'polite');
-  });
-
   it('画像を選択すると presigned URL を取得して S3 へ PUT する', async () => {
     vi.mocked(aiChatRepository.issueAttachmentUploadUrl).mockResolvedValue({
       uploadUrl: 'https://s3.example.com/put',


### PR DESCRIPTION
## 概要

\`MessageInput\` の textarea 下に出していた文字数カウント表示を撤去します。 デザイン専用変更で CLAUDE.md 4.2 ルールに従い admin merge。

## 変更内容

- \`MessageInput.tsx\`: \`data-testid="char-count"\` の \`<span>\` ブロックを削除
- \`MessageInput.test.tsx\`: 文字数表示まわり 4 件のテストを撤去（「テキスト入力時に表示」「空テキスト時に非表示」「送信後に消える」「aria-live=polite」）

## ねらい

モダン AI チャット UI に倣い入力中ノイズを最小化。 送信可否は送信ボタンの色 / disabled で十分視覚化されているため。

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1716 / 1716 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅