### PR TITLE
feat(ai-chat): 「考え中...」インジケータ + favicon 回転アニメーション

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -129,7 +129,10 @@ export default memo(function MessageBubble({
     );
   }
 
-  // アシスタント / 他者のメッセージ: フラット、本文に Markdown
+  // アシスタント / 他者のメッセージ: フラット、本文に Markdown。
+  // 本文が空のときは SSE で最初の token が来るまでの「考え中」状態とみなし、
+  // favicon を回しながら "考え中..." ラベルを出す（Claude / ChatGPT 同様の UX）。
+  const isThinking = type === 'text' && content.trim() === '';
   return (
     <div
       className="my-6 group flex gap-3"
@@ -139,28 +142,44 @@ export default memo(function MessageBubble({
       aria-label={senderName ? `${senderName}のメッセージ` : 'AIのメッセージ'}
     >
       <div className="flex-shrink-0 w-7 h-7 rounded-full bg-[var(--color-surface-2)] flex items-center justify-center">
-        <img src="/favicon.svg" alt="" aria-hidden="true" className="w-4 h-4" />
+        <img
+          src="/favicon.svg"
+          alt=""
+          aria-hidden="true"
+          className={`w-4 h-4 ${isThinking ? 'animate-thinking' : ''}`}
+        />
       </div>
       <div className="flex-1 min-w-0">
         {senderName && (
           <p className="text-xs text-[var(--color-text-muted)] mb-1">{senderName}</p>
         )}
-        <div className="prose prose-sm max-w-none text-[var(--color-text-primary)] leading-relaxed">
-          {type === 'bot' ? (
-            <p className="italic opacity-80">{content}</p>
-          ) : (
-            <MarkdownView content={content} />
-          )}
-        </div>
-        <MessageActionRow
-          isSender={false}
-          id={id}
-          content={content}
-          createdAt={createdAt}
-          isCopied={isCopied}
-          onCopy={onCopy}
-          visible={showActions}
-        />
+        {isThinking ? (
+          <p
+            className="text-sm text-[var(--color-text-muted)] italic"
+            aria-live="polite"
+          >
+            考え中...
+          </p>
+        ) : (
+          <>
+            <div className="prose prose-sm max-w-none text-[var(--color-text-primary)] leading-relaxed">
+              {type === 'bot' ? (
+                <p className="italic opacity-80">{content}</p>
+              ) : (
+                <MarkdownView content={content} />
+              )}
+            </div>
+            <MessageActionRow
+              isSender={false}
+              id={id}
+              content={content}
+              createdAt={createdAt}
+              isCopied={isCopied}
+              onCopy={onCopy}
+              visible={showActions}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -8,6 +8,19 @@ describe('MessageBubble', () => {
     expect(screen.getByText('こんにちは')).toBeInTheDocument();
   });
 
+  it('AI 応答が空文字のときは「考え中...」インジケータが出る', () => {
+    render(<MessageBubble isSender={false} content="" id="thinking-1" />);
+    expect(screen.getByText('考え中...')).toBeInTheDocument();
+  });
+
+  it('AI 応答に最初のトークンが入ると「考え中...」が消える', () => {
+    const { rerender } = render(<MessageBubble isSender={false} content="" id="thinking-2" />);
+    expect(screen.getByText('考え中...')).toBeInTheDocument();
+    rerender(<MessageBubble isSender={false} content="返答" id="thinking-2" />);
+    expect(screen.queryByText('考え中...')).not.toBeInTheDocument();
+    expect(screen.getByText('返答')).toBeInTheDocument();
+  });
+
   it('送信者メッセージが表示される', () => {
     render(<MessageBubble isSender={true} content="テスト送信" id="m2" />);
     expect(screen.getByText('テスト送信')).toBeInTheDocument();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,21 @@
   color-scheme: light;
 }
 
+/*
+ * AI チャットの「考え中...」インジケータ用アニメーション。
+ * favicon (3 つの青い三角) をゆったり 1 周させてブランド感を出しつつ「処理中」を可視化する。
+ * `animate-spin` (1s linear) は速すぎて派手なので 2.4s ease-in-out で自然な呼吸感を出す。
+ */
+@keyframes thinking-spin {
+  0%   { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.animate-thinking {
+  animation: thinking-spin 2.4s ease-in-out infinite;
+  transform-origin: center;
+}
+
 @layer base {
   /*
    * 外側スクロールバー (Chrome ブラウザ標準) と内側スクロールバー (AppShell の <main>)


### PR DESCRIPTION
## 概要

AI チャットで送信直後〜最初のトークンが返ってくるまでの間、 ユーザに「処理中」だと明確に伝えるインジケータを追加します。 主要 AI チャット (Claude / ChatGPT 等) と同じ UX。 デザイン専用の見た目変更で CLAUDE.md 4.2 ルールに従い admin merge。

## 変更内容

### \`index.css\`
- \`@keyframes thinking-spin\` と \`.animate-thinking\` クラスを追加
- 2.4s ease-in-out infinite で 360 度回転（\`animate-spin\` の 1s linear は派手すぎるため）

### \`MessageBubble.tsx\`
- AI メッセージで \`content.trim() === ''\` のとき:
  - favicon アバターに \`animate-thinking\` クラスを付与（回転アニメ）
  - 本文の代わりに **「考え中...」** ラベル（aria-live=polite）を表示
- 最初のトークンが届いて content に文字が入ったら、 通常の Markdown 表示に切替

### テスト
- 「AI 応答が空文字のとき『考え中...』が出る」
- 「最初のトークンが入ると『考え中...』が消えて本文が出る」

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1718 / 1718 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅