### PR TITLE
style: ログイン画面刷新 + AI 応答完了マーカー + 考え中アニメをパルスに

### DIFF
--- a/frontend/src/components/AuthLayout.tsx
+++ b/frontend/src/components/AuthLayout.tsx
@@ -10,19 +10,12 @@ export default function AuthLayout({ children, title, footer }: AuthLayoutProps)
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-surface px-4 py-12">
       <div className="mb-6 flex flex-col items-center">
-        <svg
-          className="w-10 h-10 text-[var(--color-text-primary)] mb-3"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+        <img
+          src="/favicon.svg"
+          alt=""
           aria-hidden="true"
-        >
-          <polyline points="16 18 22 12 16 6" />
-          <polyline points="8 6 2 12 8 18" />
-        </svg>
+          className="w-12 h-12 mb-3"
+        />
         {title && (
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)] tracking-tight">
             {title}

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -178,6 +178,19 @@ export default memo(function MessageBubble({
               onCopy={onCopy}
               visible={showActions}
             />
+            {/* 完了マーカー: ストリーミング placeholder ではない（= done 確定済 / 履歴ロード済）
+                AI 応答の末尾に favicon を 1 つ置いて「ここで応答が締まった」ことを視覚化する。
+                Claude 等のメジャー AI チャットで採用されている bookend 表現に倣う。
+                id は型定義上 string だが、 旧テスト互換のため number が来ても動くよう String 化して判定。 */}
+            {!String(id).startsWith('streaming-') && (
+              <div className="mt-8 flex" aria-hidden="true">
+                <img
+                  src="/favicon.svg"
+                  alt=""
+                  className="w-4 h-4 opacity-60"
+                />
+              </div>
+            )}
           </>
         )}
       </div>

--- a/frontend/src/components/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/components/__tests__/AuthLayout.test.tsx
@@ -52,9 +52,9 @@ describe('AuthLayout', () => {
     expect(screen.getByText('フッター内容')).toBeInTheDocument();
   });
 
-  it('アイコンが表示される', () => {
+  it('ブランドアイコン (favicon) が表示される', () => {
     const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
-    const svg = container.querySelector('svg');
-    expect(svg).toBeTruthy();
+    const img = container.querySelector('img[src="/favicon.svg"]');
+    expect(img).toBeTruthy();
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,16 +37,22 @@
 
 /*
  * AI チャットの「考え中...」インジケータ用アニメーション。
- * favicon (3 つの青い三角) をゆったり 1 周させてブランド感を出しつつ「処理中」を可視化する。
- * `animate-spin` (1s linear) は速すぎて派手なので 2.4s ease-in-out で自然な呼吸感を出す。
+ * favicon (3 つの青い三角) を「呼吸」のように緩やかに拡大 / 縮小させて「処理中」を可視化する。
+ * 回転よりも視線を奪わず、長い思考中も気にならない緩やかな鼓動感に寄せる。
  */
-@keyframes thinking-spin {
-  0%   { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+@keyframes thinking-pulse {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.18);
+    opacity: 1;
+  }
 }
 
 .animate-thinking {
-  animation: thinking-spin 2.4s ease-in-out infinite;
+  animation: thinking-pulse 1.6s ease-in-out infinite;
   transform-origin: center;
 }
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,7 +6,6 @@ import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
 import { useLoginPage } from '../hooks/useLoginPage';
 import { XCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
-import { GuidedHint } from '../components/ui';
 
 export default function LoginPage() {
   const { form, loginMessage, flashMessage, loading, handleLogin, handleChange } = useLoginPage();
@@ -21,14 +20,6 @@ export default function LoginPage() {
         </p>
       }
     >
-      {/* 初心者向け導入ヒント（一度閉じると再表示しない） */}
-      <div className="mb-4">
-        <GuidedHint title="FreStyle へようこそ" storageKey="hint:login:intro-v1" tone="info">
-          Google アカウント、またはメールアドレス + パスワードでログインできます。
-          アカウントがない場合は下のリンクから新規登録してください。
-        </GuidedHint>
-      </div>
-
       {/* フラッシュメッセージ（成功） */}
       {flashMessage && (
         <p


### PR DESCRIPTION
## 概要

3 件の小さなデザイン改修をまとめた PR。 デザイン専用変更で CLAUDE.md 4.2 ルールに従い admin merge。

## 変更内容

### 1. ログイン画面のブランドアイコン化

\`AuthLayout\` のヘッダーで使っていた \`< >\` SVG（lucide 風の山型アイコン）を **\`/favicon.svg\`** に差し替え（48px）。 ログイン / 新規登録 / 招待受諾 / Welcome の全画面に反映される。

### 2. ログイン画面から「FreStyle へようこそ」ヒントを削除

\`LoginPage\` 上部の \`GuidedHint\` ブロック（Google ログイン / メール + パスワードの説明）を撤去。 UI 自体で十分自明と判断。

### 3. AI 応答の完了マーカー

\`MessageBubble\` で AI 応答の末尾に **favicon を bookend 風マーカー** として表示する。 「ここで応答が終わった」ことを視覚化し、 次の発話に移れる「区切り」を示す（Claude 等の主流 AI チャット UI に倣う）。

- ストリーミング中（id が \`streaming-\` で始まる placeholder）は出さない
- done 確定済 / 履歴ロード済の応答にのみ表示
- \`opacity-60\` の控えめなサイズで視覚ノイズを最小化

### 4. 「考え中」アニメをパルス（拡大縮小）に変更

PR-AA で導入した回転（spin）が「視線を奪う」とのフィードバックを受け、 **scale 1 ↔ 1.18 + opacity 0.7 ↔ 1** を 1.6s ease-in-out で繰り返す呼吸感のあるパルスに変更。

\`\`\`css
@keyframes thinking-pulse {
  0%, 100% { transform: scale(1);    opacity: 0.7; }
  50%     { transform: scale(1.18); opacity: 1;   }
}
\`\`\`

## テスト

- AuthLayout テストを svg → img[src="/favicon.svg"] 検証に更新
- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1718 / 1718 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅