### PR TITLE
fix(learning-reports): /api/v2/learning-reports 404 修正 + 管理サブメニューを役職で出し分け

### DIFF
--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -34,12 +34,16 @@ func (h *LearningReportHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
+// requestReportReq は POST /learning-reports/generate のリクエスト body。
+//
+// フロントエンドは月次サマリの生成しか叩かないため、 期間指定は year + month の
+// 1 形式に揃える。 バックエンド側で月初〜翌月初の period を組み立てて usecase に渡す。
 type requestReportReq struct {
-	PeriodFrom string `json:"periodFrom" binding:"required"`
-	PeriodTo   string `json:"periodTo" binding:"required"`
+	Year  int `json:"year"  binding:"required,min=2000,max=2100"`
+	Month int `json:"month" binding:"required,min=1,max=12"`
 }
 
-// Request は current user で report 生成を要求する。
+// Request は current user で月次 learning report 生成を要求する。
 func (h *LearningReportHandler) Request(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -51,16 +55,10 @@ func (h *LearningReportHandler) Request(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	from, err := time.Parse(time.RFC3339, req.PeriodFrom)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "periodFrom must be RFC3339"})
-		return
-	}
-	to, err := time.Parse(time.RFC3339, req.PeriodTo)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "periodTo must be RFC3339"})
-		return
-	}
+	// year + month → 月初 [00:00:00 UTC] 〜 翌月初 [00:00:00 UTC] の期間に変換。
+	// レポート集計の実装が PeriodFrom <= submitted_at < PeriodTo の半開区間で扱う前提。
+	from := time.Date(req.Year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 1, 0)
 	got, err := h.request.Execute(c.Request.Context(), usecase.RequestLearningReportInput{
 		UserID: uid, PeriodFrom: from, PeriodTo: to,
 	})

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -71,6 +71,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerAdminRoutes(authed, deps)
 	registerEmbedRoutes(authed)
 	registerExerciseRoutes(authed, deps)
+	registerLearningReportRoutes(authed, deps)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 
 	return r

--- a/backend/internal/handler/routes_learning_report.go
+++ b/backend/internal/handler/routes_learning_report.go
@@ -1,0 +1,25 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerLearningReportRoutes は月次学習レポートの取得 / 生成要求を登録する。
+//
+//	GET  /api/v2/learning-reports             current user のレポート一覧
+//	POST /api/v2/learning-reports/generate    `{year, month}` で月次レポート生成を要求
+//
+// 生成は SQS にキューする非同期ジョブで、 当面は stub enqueuer を使用する
+// （実 SQS 接続は別 PR / 別 infra で導入予定）。
+func registerLearningReportRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	repo := repository.NewLearningReportRepository(deps.db)
+	queue := repository.NewStubSqsEnqueuer()
+	h := NewLearningReportHandler(
+		usecase.NewListLearningReportsUseCase(repo),
+		usecase.NewRequestLearningReportUseCase(repo, queue),
+	)
+	g.GET("/learning-reports", h.List)
+	g.POST("/learning-reports/generate", h.Request)
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -22,6 +22,11 @@ interface SubItem {
   label: string;
   to: string;
   matchPrefix?: string;
+  /**
+   * このサブメニューを表示できる役職集合。
+   * undefined のときは全 admin（super_admin / company_admin 両方）に表示する。
+   */
+  allowedRoles?: ReadonlyArray<'super_admin' | 'company_admin'>;
 }
 
 interface NavItem {
@@ -57,7 +62,15 @@ const adminNavItem: NavItem = {
   label: '管理',
   matchPrefix: '/admin',
   subItems: [
-    { label: '会社一覧', to: '/admin/companies', matchPrefix: '/admin/companies' },
+    // 会社一覧は全テナントの管理画面なので運営 (super_admin) 専用。
+    // company_admin が見えると越権が起きる印象を与えるため非表示にする。
+    {
+      label: '会社一覧',
+      to: '/admin/companies',
+      matchPrefix: '/admin/companies',
+      allowedRoles: ['super_admin'],
+    },
+    // 招待管理は自社内で trainee を招待する操作のため company_admin / super_admin 双方が利用する。
     { label: '招待管理', to: '/admin/invitations', matchPrefix: '/admin/invitations' },
   ],
 };
@@ -194,7 +207,12 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
               {/* 管理サブメニュー */}
               {expanded && adminOpen && (
                 <div className="ml-4 space-y-0.5">
-                  {adminNavItem.subItems?.map((sub) => {
+                  {adminNavItem.subItems
+                    ?.filter((sub) => {
+                      if (!sub.allowedRoles) return true;
+                      return role !== null && sub.allowedRoles.includes(role as 'super_admin' | 'company_admin');
+                    })
+                    .map((sub) => {
                     const subActive = sub.matchPrefix
                       ? location.pathname.startsWith(sub.matchPrefix)
                       : location.pathname === sub.to;

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -90,13 +90,20 @@ describe('Sidebar', () => {
     expect(screen.getByText('管理')).toBeInTheDocument();
   });
 
-  it('admin メニュークリックでサブメニューが展開される', () => {
-    renderSidebar('/', true);
+  it('super_admin の管理メニューには会社一覧と招待管理が表示される', () => {
+    renderSidebar('/', true, 'super_admin');
     fireEvent.click(screen.getByText('管理'));
     expect(screen.getByText('会社一覧')).toBeInTheDocument();
     expect(screen.getByText('招待管理')).toBeInTheDocument();
     // シナリオ管理は廃止済（コア機能整理）
     expect(screen.queryByText('シナリオ管理')).toBeNull();
+  });
+
+  it('company_admin の管理メニューには招待管理のみが表示され、会社一覧は出ない', () => {
+    renderSidebar('/', true, 'company_admin');
+    fireEvent.click(screen.getByText('管理'));
+    expect(screen.queryByText('会社一覧')).toBeNull();
+    expect(screen.getByText('招待管理')).toBeInTheDocument();
   });
 
   it('非 admin ユーザーには管理メニューが表示されない', () => {


### PR DESCRIPTION
## 概要

ユーザ報告の 2 件を修正します。 backend ルート登録 + フロント役職ガードでロジックを伴うため、 通常通り CodeRabbit レビューしてマージしてください（admin merge せず）。

## 修正内容

### 1. \`/api/v2/learning-reports\` が常に 404

\`LearningReportHandler\` は実装済みだったが、 \`router.go\` の \`registerXxxRoutes\` シリーズに登録漏れがあり、 list / generate のどちらも 404 を返していた。

- \`backend/internal/handler/routes_learning_report.go\` を新設して両エンドポイントを register
- \`router.go\` で \`registerLearningReportRoutes(authed, deps)\` を追加
- \`Request\` ハンドラのリクエスト形式をフロントが既に送っている \`{year, month}\` に変更:
  - 旧: \`{periodFrom, periodTo}\` (RFC3339)
  - 新: \`{year, month}\`（バックエンドで月初〜翌月初の半開区間に変換）

### 2. company_admin に「会社一覧」が表示される

会社一覧は全テナントを横断する運営（super_admin）専用画面なので、 company_admin に見えると越権の印象を与える。 \`SubItem\` に \`allowedRoles\` を導入して role 単位で出し分け:

| サブメニュー | super_admin | company_admin |
|---|---|---|
| 会社一覧 | ✅ | ❌（非表示） |
| 招待管理 | ✅ | ✅ |

## テスト

- \`go build ./... / go test ./...\` ✅
- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1719 / 1719 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅
- Sidebar テストを super_admin / company_admin の 2 ケースに分割

## 関連 Issue

- ユーザ報告: AI チャット内で \`api.normanblog.com/api/v2/learning-reports\` 系が 404
- ユーザ報告: company_admin に「会社一覧」メニューが表示される

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 月次学習レポートの生成機能を追加。年月を指定してレポート生成をリクエストできます
- 生成済みの学習レポート一覧表示機能を追加
- 管理メニューで権限レベルに応じた項目の表示・非表示を実装

## テスト
- 権限別のメニュー表示テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->