### PR TITLE
style(ai-chat): 考え中アバターを強調 + 応答開始後は上部アバターを非表示

### DIFF
--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -131,7 +131,9 @@ export default memo(function MessageBubble({
 
   // アシスタント / 他者のメッセージ: フラット、本文に Markdown。
   // 本文が空のときは SSE で最初の token が来るまでの「考え中」状態とみなし、
-  // favicon を回しながら "考え中..." ラベルを出す（Claude / ChatGPT 同様の UX）。
+  // favicon をパルスさせながら "考え中..." ラベルを出す（Claude / ChatGPT 同様の UX）。
+  // 最初の token が来た瞬間に上部のアバターアイコンは消し、本文と末尾の bookend マーカーで
+  // 「処理中 → 応答中 → 完了」の状態遷移を視覚化する。
   const isThinking = type === 'text' && content.trim() === '';
   return (
     <div
@@ -141,14 +143,18 @@ export default memo(function MessageBubble({
       role="article"
       aria-label={senderName ? `${senderName}のメッセージ` : 'AIのメッセージ'}
     >
-      <div className="flex-shrink-0 w-7 h-7 rounded-full bg-[var(--color-surface-2)] flex items-center justify-center">
+      {isThinking ? (
         <img
           src="/favicon.svg"
           alt=""
           aria-hidden="true"
-          className={`w-4 h-4 ${isThinking ? 'animate-thinking' : ''}`}
+          className="w-5 h-5 flex-shrink-0 animate-thinking"
         />
-      </div>
+      ) : (
+        // 応答開始後はアバター枠を持たず本文を左端から始める。
+        // ただし flex のレイアウトが崩れないよう同サイズの空きを確保する。
+        <span className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
+      )}
       <div className="flex-1 min-w-0">
         {senderName && (
           <p className="text-xs text-[var(--color-text-muted)] mb-1">{senderName}</p>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -37,16 +37,16 @@
 
 /*
  * AI チャットの「考え中...」インジケータ用アニメーション。
- * favicon (3 つの青い三角) を「呼吸」のように緩やかに拡大 / 縮小させて「処理中」を可視化する。
- * 回転よりも視線を奪わず、長い思考中も気にならない緩やかな鼓動感に寄せる。
+ * favicon (3 つの青い三角) を呼吸のように拡大縮小 + フェードさせて「処理中」を可視化する。
+ * scale 0.85 ↔ 1.25 / opacity 0.25 ↔ 1 とコントラストを大きめに付け、 視認しやすい呼吸感に。
  */
 @keyframes thinking-pulse {
   0%, 100% {
-    transform: scale(1);
-    opacity: 0.7;
+    transform: scale(0.85);
+    opacity: 0.25;
   }
   50% {
-    transform: scale(1.18);
+    transform: scale(1.25);
     opacity: 1;
   }
 }


### PR DESCRIPTION
## 概要

AI チャットの「考え中→応答中→完了」の状態遷移をより明確に伝えるための 3 点リファイン。 デザイン専用変更で CLAUDE.md 4.2 ルールにより admin merge。

## 変更内容

### 1. 灰色の丸背景を撤去

旧: アバターを \`bg-[var(--color-surface-2)]\` の \`rounded-full\` 枠で囲っていた

新: favicon 単体をそのままアバターとして表示（ブランドアイコンが地に直接乗る）。 サイズも 16px → 20px に拡大。

### 2. 「考え中」アニメのコントラスト強化

\`thinking-pulse\` のコントラストを大きめに変更:

| パラメータ | 旧 | 新 |
|---|---|---|
| transform: scale | 1.0 ↔ 1.18 | **0.85 ↔ 1.25** |
| opacity | 0.7 ↔ 1.0 | **0.25 ↔ 1.0** |

「ほとんど動いていない」印象を解消し、 はっきり呼吸している感じに。

### 3. 応答開始後は上部アバターを非表示

ストリーミング 1 文字目が届いた瞬間（\`content !== ''\`）に上部アバターを消し、 本文だけが残る形に。 末尾の完了マーカー（bookend favicon）は据え置きで「ここで応答が完了した」を視覚化。

レイアウト崩れ防止のため、 アバター非表示時も同サイズ (20px) の透明スペーサーを残す。

## テスト

- \`npx tsc --noEmit\` ✅
- \`npx vitest run\` ✅ 1718 / 1718 passed
- \`npx eslint src --max-warnings 0\` ✅
- \`npm run build\` ✅