### PR TITLE
style(frontend): ホーム画面の AI チャットカードのアイコンを差し替え

### DIFF
--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
   HomeIcon,
-  SparklesIcon,
+  ChatBubbleBottomCenterTextIcon,
   CodeBracketIcon,
   DocumentTextIcon,
   DocumentChartBarIcon,
@@ -59,7 +59,7 @@ export default function MenuPage() {
           <>
             <NavCard
               to="/chat/ask-ai"
-              icon={SparklesIcon}
+              icon={ChatBubbleBottomCenterTextIcon}
               title="AI チャット"
               description="質問・要約・コード補助など、自由に対話できます。"
             />


### PR DESCRIPTION
## 概要

サイドバーの AI ナビは既に `ChatBubbleBottomCenterTextIcon` に切り替え済み。一方ホーム画面 ([MenuPage.tsx](frontend/src/pages/MenuPage.tsx)) の AI チャットカードだけ `SparklesIcon`（キラキラ）のままだったので、サイドバーと同じアイコンに統一する。

## 変更内容

- [MenuPage.tsx](frontend/src/pages/MenuPage.tsx): import / icon prop を `SparklesIcon` → `ChatBubbleBottomCenterTextIcon`

## テスト

- [x] `tsc --noEmit`
- [x] `eslint --max-warnings 0`