### PR TITLE
chore(frontend): AskAiPage コメントから 3rd party プロダクト名を除去

### DIFF
--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -304,7 +304,7 @@ export default function AskAiPage() {
           </div>
         )}
 
-        {/* 入力エリア: 角丸カード風 (paiza / 主要 AI チャットの compose UI に倣う) */}
+        {/* 入力エリア: 角丸カード風 (主要 AI チャットの compose UI に倣う) */}
         <div className="px-4 pb-4 pt-2">
           <div className="max-w-3xl mx-auto">
             <MessageInput onSend={handleSend} />


### PR DESCRIPTION
## 概要

著作権配慮のため AskAiPage の入力エリア注釈から特定サービス名への言及を除去。

## 変更内容

- [AskAiPage.tsx:307](frontend/src/pages/AskAiPage.tsx#L307): `(3rd party プロダクト / 主要 AI チャット...)` → `(主要 AI チャット...)`
