### PR TITLE
feat(exercises): 提出 API + テストケース採点 + 集計統計 / ユーザステータス (PR-W)

### DIFF
--- a/backend/internal/handler/exercise_submission_handler.go
+++ b/backend/internal/handler/exercise_submission_handler.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
+)
+
+// ExerciseSubmissionHandler は master_exercises に対する提出 API を扱う。
+//
+// API パス:
+//
+//	POST /api/v2/exercises/:slug/submit       コードを提出して採点
+//	GET  /api/v2/exercises/:slug/submissions  current user の履歴
+type ExerciseSubmissionHandler struct {
+	submit *usecase.SubmitMasterExerciseUseCase
+	list   *usecase.ListUserMasterSubmissionsUseCase
+}
+
+func NewExerciseSubmissionHandler(
+	submit *usecase.SubmitMasterExerciseUseCase,
+	list *usecase.ListUserMasterSubmissionsUseCase,
+) *ExerciseSubmissionHandler {
+	return &ExerciseSubmissionHandler{submit: submit, list: list}
+}
+
+type submitExerciseRequest struct {
+	Code string `json:"code" binding:"required"`
+}
+
+// Submit は POST /api/v2/exercises/:slug/submit 。
+func (h *ExerciseSubmissionHandler) Submit(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	slug := c.Param("slug")
+	if slug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slug is required"})
+		return
+	}
+	var req submitExerciseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	out, err := h.submit.Execute(c.Request.Context(), usecase.SubmitMasterExerciseInput{
+		UserID: uid,
+		Slug:   slug,
+		Code:   req.Code,
+	})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "演習問題が見つかりません"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "コードの採点に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// List は GET /api/v2/exercises/:slug/submissions 。
+func (h *ExerciseSubmissionHandler) List(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	slug := c.Param("slug")
+	if slug == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slug is required"})
+		return
+	}
+	rows, err := h.list.Execute(usecase.ListUserMasterSubmissionsInput{UserID: uid, Slug: slug})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "演習問題が見つかりません"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "履歴の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -36,8 +36,10 @@ func (r *fakeFullSubmissionRepo) ListByUserAndExercise(userID, exerciseID uint64
 	r.lastKind = kind
 	return r.listed, nil
 }
-func (r *fakeFullSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
-func (r *fakeFullSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) { return false, nil }
+func (r *fakeFullSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error) { return false, nil }
+func (r *fakeFullSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) {
+	return false, nil
+}
 func (r *fakeFullSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
 	return nil, nil
 }

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -1,0 +1,159 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// fakeFullSubmissionRepo は提出ハンドラの統合テスト用フェイク。
+type fakeFullSubmissionRepo struct {
+	created *domain.ExerciseSubmission
+	listed  []domain.ExerciseSubmission
+}
+
+func (r *fakeFullSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
+	s.ID = 42
+	r.created = s
+	return nil
+}
+func (r *fakeFullSubmissionRepo) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
+	return r.listed, nil
+}
+func (r *fakeFullSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
+func (r *fakeFullSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) { return false, nil }
+func (r *fakeFullSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
+	return nil, nil
+}
+func (r *fakeFullSubmissionRepo) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
+	return repository.ExerciseSubmissionStats{}, nil
+}
+func (r *fakeFullSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+	return nil, nil
+}
+
+// stubExecutorForHandlerTest は ExecuteCodeUseCase の代替。
+type stubExecutorForHandlerTest struct{ stdout string }
+
+func (s *stubExecutorForHandlerTest) Execute(_ context.Context, in usecase.ExecuteCodeInput) (*usecase.ExecuteCodeOutput, error) {
+	return &usecase.ExecuteCodeOutput{Stdout: s.stdout}, nil
+}
+
+func newSubmissionTestRouter(t *testing.T, exercise *domain.MasterExercise, examples []domain.MasterExerciseExample, executorOut string, listed []domain.ExerciseSubmission) (*gin.Engine, *fakeFullSubmissionRepo) {
+	t.Helper()
+	exRepo := &fakeMasterExerciseRepo{getResult: exercise}
+	exampleRepo := &fakeExampleRepo{byID: map[uint64][]domain.MasterExerciseExample{exercise.ID: examples}}
+	subRepo := &fakeFullSubmissionRepo{listed: listed}
+	executor := &stubExecutorForHandlerTest{stdout: executorOut}
+
+	h := NewExerciseSubmissionHandler(
+		usecase.NewSubmitMasterExerciseUseCase(exRepo, exampleRepo, subRepo, executor),
+		usecase.NewListUserMasterSubmissionsUseCase(exRepo, subRepo),
+	)
+	r := gin.New()
+	// テスト用に固定 user_id を context にセットしてから handler を呼ぶ。
+	r.Use(func(c *gin.Context) {
+		c.Set("currentUserID", uint64(101))
+		c.Next()
+	})
+	r.POST("/exercises/:slug/submit", h.Submit)
+	r.GET("/exercises/:slug/submissions", h.List)
+	return r, subRepo
+}
+
+func TestSubmissionHandler_Submit_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	exercise := &domain.MasterExercise{ID: 7, Slug: "php-7"}
+	examples := []domain.MasterExerciseExample{
+		{ID: 1, ExerciseID: 7, OrderIndex: 1, InputText: "", ExpectedOutput: "Hello"},
+	}
+	r, subRepo := newSubmissionTestRouter(t, exercise, examples, "Hello", nil)
+
+	body, _ := json.Marshal(map[string]string{"code": "<?php echo 'Hello';"})
+	req := httptest.NewRequest(http.MethodPost, "/exercises/php-7/submit", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if subRepo.created == nil {
+		t.Fatal("submission should have been persisted")
+	}
+	if subRepo.created.UserID != 101 {
+		t.Errorf("UserID = %d, want 101", subRepo.created.UserID)
+	}
+	if !subRepo.created.IsCorrect {
+		t.Error("IsCorrect should be true")
+	}
+}
+
+func TestSubmissionHandler_Submit_Unauthorized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	exercise := &domain.MasterExercise{ID: 7, Slug: "php-7"}
+	r, _ := newSubmissionTestRouter(t, exercise, []domain.MasterExerciseExample{
+		{ExerciseID: 7, OrderIndex: 1, ExpectedOutput: ""},
+	}, "", nil)
+	// middleware で user_id をセットせずに呼ぶシナリオを再現するため新しい engine を作る。
+	r2 := gin.New()
+	for _, route := range r.Routes() {
+		// route.HandlerFunc が登録済の handler chain なのでこのままだと再利用できない。
+		// 代わりに同じハンドラを user_id 無しの Engine に再登録する。
+		_ = route
+	}
+	// 簡素化のため: 既存 r で `currentUserID` セット前に walk できないので
+	// 認可テストは別ルータを直接組み立てる。
+	exRepo := &fakeMasterExerciseRepo{getResult: exercise}
+	exampleRepo := &fakeExampleRepo{}
+	subRepo := &fakeFullSubmissionRepo{}
+	executor := &stubExecutorForHandlerTest{}
+	h := NewExerciseSubmissionHandler(
+		usecase.NewSubmitMasterExerciseUseCase(exRepo, exampleRepo, subRepo, executor),
+		usecase.NewListUserMasterSubmissionsUseCase(exRepo, subRepo),
+	)
+	r2.POST("/exercises/:slug/submit", h.Submit)
+
+	body, _ := json.Marshal(map[string]string{"code": "<?php"})
+	req := httptest.NewRequest(http.MethodPost, "/exercises/php-7/submit", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r2.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestSubmissionHandler_List_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	exercise := &domain.MasterExercise{ID: 7, Slug: "php-7"}
+	listed := []domain.ExerciseSubmission{
+		{ID: 1, UserID: 101, ExerciseID: 7, ExerciseKind: domain.ExerciseKindMaster, IsCorrect: true},
+		{ID: 2, UserID: 101, ExerciseID: 7, ExerciseKind: domain.ExerciseKindMaster, IsCorrect: false},
+	}
+	r, _ := newSubmissionTestRouter(t, exercise, nil, "", listed)
+
+	req := httptest.NewRequest(http.MethodGet, "/exercises/php-7/submissions", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	var got []domain.ExerciseSubmission
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2", len(got))
+	}
+}

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -15,9 +15,14 @@ import (
 )
 
 // fakeFullSubmissionRepo は提出ハンドラの統合テスト用フェイク。
+// ListByUserAndExercise は呼び出し時の引数を last* に記録し、
+// handler が user_id / exercise_id / kind を正しく渡しているかをテスト側で検証できるようにする。
 type fakeFullSubmissionRepo struct {
-	created *domain.ExerciseSubmission
-	listed  []domain.ExerciseSubmission
+	created        *domain.ExerciseSubmission
+	listed         []domain.ExerciseSubmission
+	lastUserID     uint64
+	lastExerciseID uint64
+	lastKind       string
 }
 
 func (r *fakeFullSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
@@ -25,7 +30,10 @@ func (r *fakeFullSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
 	r.created = s
 	return nil
 }
-func (r *fakeFullSubmissionRepo) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
+func (r *fakeFullSubmissionRepo) ListByUserAndExercise(userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error) {
+	r.lastUserID = userID
+	r.lastExerciseID = exerciseID
+	r.lastKind = kind
 	return r.listed, nil
 }
 func (r *fakeFullSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
@@ -140,7 +148,7 @@ func TestSubmissionHandler_List_Success(t *testing.T) {
 		{ID: 1, UserID: 101, ExerciseID: 7, ExerciseKind: domain.ExerciseKindMaster, IsCorrect: true},
 		{ID: 2, UserID: 101, ExerciseID: 7, ExerciseKind: domain.ExerciseKindMaster, IsCorrect: false},
 	}
-	r, _ := newSubmissionTestRouter(t, exercise, nil, "", listed)
+	r, subRepo := newSubmissionTestRouter(t, exercise, nil, "", listed)
 
 	req := httptest.NewRequest(http.MethodGet, "/exercises/php-7/submissions", nil)
 	w := httptest.NewRecorder()
@@ -155,5 +163,15 @@ func TestSubmissionHandler_List_Success(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Errorf("len = %d, want 2", len(got))
+	}
+	// handler が repository に user_id / exercise_id / kind を正しく渡したかを検証する。
+	if subRepo.lastUserID != 101 {
+		t.Errorf("ListByUserAndExercise userID = %d, want 101", subRepo.lastUserID)
+	}
+	if subRepo.lastExerciseID != 7 {
+		t.Errorf("ListByUserAndExercise exerciseID = %d, want 7", subRepo.lastExerciseID)
+	}
+	if subRepo.lastKind != domain.ExerciseKindMaster {
+		t.Errorf("ListByUserAndExercise kind = %s, want %s", subRepo.lastKind, domain.ExerciseKindMaster)
 	}
 }

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
@@ -19,26 +20,37 @@ import (
 // 詳細は slug ベース URL（`/code-editor/php-1` のように人間可読）に揃えるため、
 // 旧 `:id` ルートは廃止し slug 必須にする（フロントは新 API に追従させる）。
 type MasterExerciseHandler struct {
-	listExercises *usecase.ListMasterExercisesUseCase
-	getExercise   *usecase.GetMasterExerciseUseCase
+	listExercises     *usecase.ListMasterExercisesUseCase
+	listWithStatus    *usecase.ListMasterExercisesWithStatusUseCase
+	getExercise       *usecase.GetMasterExerciseUseCase
 }
 
 func NewMasterExerciseHandler(
 	list *usecase.ListMasterExercisesUseCase,
+	listWithStatus *usecase.ListMasterExercisesWithStatusUseCase,
 	get *usecase.GetMasterExerciseUseCase,
 ) *MasterExerciseHandler {
-	return &MasterExerciseHandler{listExercises: list, getExercise: get}
+	return &MasterExerciseHandler{listExercises: list, listWithStatus: listWithStatus, getExercise: get}
 }
 
 // List は GET /api/v2/exercises 。query `language` で絞り込み（空なら全言語）。
+//
+// current user の提出状況（solved / in_progress / 未着手）と
+// 全ユーザ合計の集計（提出数 / 正答ユーザ数）を 1 度に返す。
+// 一覧ページでステータスバッジ + 解答率を出すために必要。
+// 未ログインの場合は status は全 ""、 stats だけ返す。
 func (h *MasterExerciseHandler) List(c *gin.Context) {
 	language := c.Query("language")
-	exercises, err := h.listExercises.Execute(language)
+	uid := middleware.CurrentUserIDOrZero(c)
+	rows, err := h.listWithStatus.Execute(usecase.ListMasterExercisesWithStatusInput{
+		UserID:   uid,
+		Language: language,
+	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "演習問題の取得に失敗しました"})
 		return
 	}
-	c.JSON(http.StatusOK, exercises)
+	c.JSON(http.StatusOK, rows)
 }
 
 // GetBySlug は GET /api/v2/exercises/:slug 。 入出力例を含む詳細を返す。

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -20,9 +20,9 @@ import (
 // 詳細は slug ベース URL（`/code-editor/php-1` のように人間可読）に揃えるため、
 // 旧 `:id` ルートは廃止し slug 必須にする（フロントは新 API に追従させる）。
 type MasterExerciseHandler struct {
-	listExercises     *usecase.ListMasterExercisesUseCase
-	listWithStatus    *usecase.ListMasterExercisesWithStatusUseCase
-	getExercise       *usecase.GetMasterExerciseUseCase
+	listExercises  *usecase.ListMasterExercisesUseCase
+	listWithStatus *usecase.ListMasterExercisesWithStatusUseCase
+	getExercise    *usecase.GetMasterExerciseUseCase
 }
 
 func NewMasterExerciseHandler(

--- a/backend/internal/handler/master_exercise_handler_test.go
+++ b/backend/internal/handler/master_exercise_handler_test.go
@@ -22,8 +22,10 @@ func (fakeSubmissionRepoForList) Create(*domain.ExerciseSubmission) error { retu
 func (fakeSubmissionRepoForList) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
 	return nil, nil
 }
-func (fakeSubmissionRepoForList) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
-func (fakeSubmissionRepoForList) HasAttempted(uint64, uint64, string) (bool, error) { return false, nil }
+func (fakeSubmissionRepoForList) HasSolved(uint64, uint64, string) (bool, error) { return false, nil }
+func (fakeSubmissionRepoForList) HasAttempted(uint64, uint64, string) (bool, error) {
+	return false, nil
+}
 func (fakeSubmissionRepoForList) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
 	return map[uint64]string{}, nil
 }

--- a/backend/internal/handler/master_exercise_handler_test.go
+++ b/backend/internal/handler/master_exercise_handler_test.go
@@ -9,9 +9,30 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
+
+// fakeSubmissionRepoForList はテスト中の status / stats が常に空で良いケース用。
+// 一覧で current user 状態を必要とするテストは別途専用 fake を定義する。
+type fakeSubmissionRepoForList struct{}
+
+func (fakeSubmissionRepoForList) Create(*domain.ExerciseSubmission) error { return nil }
+func (fakeSubmissionRepoForList) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
+	return nil, nil
+}
+func (fakeSubmissionRepoForList) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
+func (fakeSubmissionRepoForList) HasAttempted(uint64, uint64, string) (bool, error) { return false, nil }
+func (fakeSubmissionRepoForList) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
+	return map[uint64]string{}, nil
+}
+func (fakeSubmissionRepoForList) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
+	return repository.ExerciseSubmissionStats{}, nil
+}
+func (fakeSubmissionRepoForList) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+	return map[uint64]repository.ExerciseSubmissionStats{}, nil
+}
 
 // fakeMasterExerciseRepo は MasterExerciseRepository の最小スタブ。
 // language / id / slug 引数を記録して assert する。
@@ -60,8 +81,10 @@ func newMasterExerciseTestHandler(repo *fakeMasterExerciseRepo, examples *fakeEx
 	if examples == nil {
 		examples = &fakeExampleRepo{}
 	}
+	subs := fakeSubmissionRepoForList{}
 	h := NewMasterExerciseHandler(
 		usecase.NewListMasterExercisesUseCase(repo),
+		usecase.NewListMasterExercisesWithStatusUseCase(repo, subs),
 		usecase.NewGetMasterExerciseUseCase(repo, examples),
 	)
 	r := gin.New()

--- a/backend/internal/handler/routes_exercises.go
+++ b/backend/internal/handler/routes_exercises.go
@@ -6,24 +6,35 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerExerciseRoutes は運営マスタ演習問題の閲覧 + コード実行 API を登録する。
+// registerExerciseRoutes は運営マスタ演習問題の閲覧 + 提出 + 採点 API を登録する。
 //
 // 旧 `registerPhpRoutes` を「言語非依存」に汎用化したもの:
-//   - GET  /api/v2/exercises?language=php   一覧（query で言語絞り込み）
-//   - GET  /api/v2/exercises/:slug          詳細（入出力例の配列を含む、 slug ベース URL）
-//   - POST /api/v2/code/execute             コード実行（body の language で言語切替）
-//
-// 提出履歴 / 採点 / 集計統計の API は PR-W で追加。
+//   - GET  /api/v2/exercises?language=php          一覧（current user 状態 + 全体集計を含む）
+//   - GET  /api/v2/exercises/:slug                 詳細（入出力例の配列を含む、 slug ベース URL）
+//   - POST /api/v2/exercises/:slug/submit          コードを提出して採点（履歴に保存）
+//   - GET  /api/v2/exercises/:slug/submissions     current user の履歴
+//   - POST /api/v2/code/execute                    コード実行（採点せず stdout だけ返す）
 func registerExerciseRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	exerciseRepo := repository.NewMasterExerciseRepository(deps.db)
 	examplesRepo := repository.NewMasterExerciseExampleRepository(deps.db)
+	submissionsRepo := repository.NewExerciseSubmissionRepository(deps.db)
+	executor := usecase.NewExecuteCodeUseCase()
+
 	exerciseHandler := NewMasterExerciseHandler(
 		usecase.NewListMasterExercisesUseCase(exerciseRepo),
+		usecase.NewListMasterExercisesWithStatusUseCase(exerciseRepo, submissionsRepo),
 		usecase.NewGetMasterExerciseUseCase(exerciseRepo, examplesRepo),
 	)
 	g.GET("/exercises", exerciseHandler.List)
 	g.GET("/exercises/:slug", exerciseHandler.GetBySlug)
 
-	codeExecuteHandler := NewCodeExecuteHandler(usecase.NewExecuteCodeUseCase())
+	submissionHandler := NewExerciseSubmissionHandler(
+		usecase.NewSubmitMasterExerciseUseCase(exerciseRepo, examplesRepo, submissionsRepo, executor),
+		usecase.NewListUserMasterSubmissionsUseCase(exerciseRepo, submissionsRepo),
+	)
+	g.POST("/exercises/:slug/submit", submissionHandler.Submit)
+	g.GET("/exercises/:slug/submissions", submissionHandler.List)
+
+	codeExecuteHandler := NewCodeExecuteHandler(executor)
 	g.POST("/code/execute", codeExecuteHandler.Execute)
 }

--- a/backend/internal/repository/exercise_submission_repository.go
+++ b/backend/internal/repository/exercise_submission_repository.go
@@ -1,0 +1,180 @@
+package repository
+
+import (
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// ExerciseSubmissionRepository は演習提出履歴の永続化を担う。
+//
+// 履歴は append-only。ユーザ × 問題で複数行を許容し、合否や最新提出時刻を集計する。
+// 集計クエリ ( CountUsersSolved / CountTotal ) は exercise_id 単位で
+// 一覧ページの「正答者数」「提出数」表示に使う。
+type ExerciseSubmissionRepository interface {
+	// Create は新しい提出を保存する。
+	Create(submission *domain.ExerciseSubmission) error
+
+	// ListByUserAndExercise は user × (kind, exercise_id) の履歴を新しい順に返す。
+	ListByUserAndExercise(userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error)
+
+	// HasSolved は user が exercise を 1 回でも is_correct=true で解いたかを返す。
+	HasSolved(userID, exerciseID uint64, kind string) (bool, error)
+
+	// HasAttempted は user が exercise に対して 1 回でも提出したかを返す。
+	HasAttempted(userID, exerciseID uint64, kind string) (bool, error)
+
+	// BatchUserStatuses は user の (kind, exerciseIDs) について、
+	//   exercise_id -> "solved" / "in_progress" / ""
+	// を返す。一覧ページの N+1 を避ける用途。
+	// "" は未提出（map に key が存在しない）を表す。
+	BatchUserStatuses(userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error)
+
+	// ExerciseStats は exercise_id 単位の集計を返す。
+	ExerciseStats(exerciseID uint64, kind string) (ExerciseSubmissionStats, error)
+
+	// ExerciseStatsBatch は複数 exercise_id をまとめて集計する。一覧ページ用。
+	ExerciseStatsBatch(exerciseIDs []uint64, kind string) (map[uint64]ExerciseSubmissionStats, error)
+}
+
+// ExerciseSubmissionStats は問題単位の集計値。
+type ExerciseSubmissionStats struct {
+	TotalSubmissions int64 `json:"totalSubmissions"`
+	SolvedUsers      int64 `json:"solvedUsers"`
+}
+
+type exerciseSubmissionRepository struct {
+	db *gorm.DB
+}
+
+func NewExerciseSubmissionRepository(db *gorm.DB) ExerciseSubmissionRepository {
+	return &exerciseSubmissionRepository{db: db}
+}
+
+func (r *exerciseSubmissionRepository) Create(submission *domain.ExerciseSubmission) error {
+	return r.db.Create(submission).Error
+}
+
+func (r *exerciseSubmissionRepository) ListByUserAndExercise(userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error) {
+	var rows []domain.ExerciseSubmission
+	if err := r.db.
+		Where("user_id = ? AND exercise_id = ? AND exercise_kind = ?", userID, exerciseID, kind).
+		Order("submitted_at desc, id desc").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *exerciseSubmissionRepository) HasSolved(userID, exerciseID uint64, kind string) (bool, error) {
+	var count int64
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Where("user_id = ? AND exercise_id = ? AND exercise_kind = ? AND is_correct = ?", userID, exerciseID, kind, true).
+		Limit(1).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (r *exerciseSubmissionRepository) HasAttempted(userID, exerciseID uint64, kind string) (bool, error) {
+	var count int64
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Where("user_id = ? AND exercise_id = ? AND exercise_kind = ?", userID, exerciseID, kind).
+		Limit(1).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// BatchUserStatuses は 1 クエリで user × exerciseIDs の (any submission, any solved) を取り、
+// exercise_id -> "solved" / "in_progress" を返す。 結果に含まれない exercise_id は未着手扱い。
+func (r *exerciseSubmissionRepository) BatchUserStatuses(userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error) {
+	result := make(map[uint64]string, len(exerciseIDs))
+	if len(exerciseIDs) == 0 {
+		return result, nil
+	}
+	type row struct {
+		ExerciseID uint64
+		AnySolved  bool
+	}
+	var rows []row
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Select("exercise_id, BOOL_OR(is_correct) AS any_solved").
+		Where("user_id = ? AND exercise_kind = ? AND exercise_id IN ?", userID, kind, exerciseIDs).
+		Group("exercise_id").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		if r.AnySolved {
+			result[r.ExerciseID] = "solved"
+		} else {
+			result[r.ExerciseID] = "in_progress"
+		}
+	}
+	return result, nil
+}
+
+func (r *exerciseSubmissionRepository) ExerciseStats(exerciseID uint64, kind string) (ExerciseSubmissionStats, error) {
+	var stats ExerciseSubmissionStats
+	// COUNT(*) は全提出数。
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Where("exercise_id = ? AND exercise_kind = ?", exerciseID, kind).
+		Count(&stats.TotalSubmissions).Error; err != nil {
+		return stats, err
+	}
+	// COUNT(DISTINCT user_id) は正答ユーザ数。
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Where("exercise_id = ? AND exercise_kind = ? AND is_correct = ?", exerciseID, kind, true).
+		Distinct("user_id").
+		Count(&stats.SolvedUsers).Error; err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+// ExerciseStatsBatch は 2 つの GROUP BY クエリで全件まとめて集計する。
+func (r *exerciseSubmissionRepository) ExerciseStatsBatch(exerciseIDs []uint64, kind string) (map[uint64]ExerciseSubmissionStats, error) {
+	result := make(map[uint64]ExerciseSubmissionStats, len(exerciseIDs))
+	if len(exerciseIDs) == 0 {
+		return result, nil
+	}
+	// 提出数の集計。
+	type totalRow struct {
+		ExerciseID uint64
+		Total      int64
+	}
+	var totals []totalRow
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Select("exercise_id, COUNT(*) AS total").
+		Where("exercise_kind = ? AND exercise_id IN ?", kind, exerciseIDs).
+		Group("exercise_id").
+		Scan(&totals).Error; err != nil {
+		return nil, err
+	}
+	for _, t := range totals {
+		s := result[t.ExerciseID]
+		s.TotalSubmissions = t.Total
+		result[t.ExerciseID] = s
+	}
+	// 正答ユーザ数の集計（DISTINCT user_id）。
+	type solvedRow struct {
+		ExerciseID  uint64
+		SolvedUsers int64
+	}
+	var solveds []solvedRow
+	if err := r.db.Model(&domain.ExerciseSubmission{}).
+		Select("exercise_id, COUNT(DISTINCT user_id) AS solved_users").
+		Where("exercise_kind = ? AND exercise_id IN ? AND is_correct = ?", kind, exerciseIDs, true).
+		Group("exercise_id").
+		Scan(&solveds).Error; err != nil {
+		return nil, err
+	}
+	for _, s := range solveds {
+		st := result[s.ExerciseID]
+		st.SolvedUsers = s.SolvedUsers
+		result[s.ExerciseID] = st
+	}
+	return result, nil
+}

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -38,6 +38,9 @@ var disableFunctions = strings.Join([]string{
 type ExecuteCodeInput struct {
 	Code     string
 	Language string // 現時点では "php" のみ
+	// Stdin は実行時に標準入力として流す内容（テストケース採点で使う）。
+	// 空文字なら何も流さない（旧 API 互換）。
+	Stdin string
 }
 
 // ExecuteCodeOutput はコード実行の結果。
@@ -88,6 +91,9 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	if input.Stdin != "" {
+		cmd.Stdin = strings.NewReader(input.Stdin)
+	}
 
 	err := cmd.Run()
 

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -16,8 +16,8 @@ import (
 type MasterExerciseWithStatus struct {
 	domain.MasterExercise
 
-	Status string                                  `json:"status"`
-	Stats  repository.ExerciseSubmissionStats      `json:"stats"`
+	Status string                             `json:"status"`
+	Stats  repository.ExerciseSubmissionStats `json:"stats"`
 }
 
 // ListMasterExercisesWithStatusUseCase は問題一覧 + 各問題の current user 状態 + 集計を返す。

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -1,0 +1,78 @@
+package usecase
+
+import (
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// MasterExerciseWithStatus は一覧ページに渡す「問題 + 現在ユーザの状態 + 全体集計」のセット。
+//
+// Status の値:
+//   - "solved"      … current user が 1 度でも is_correct=true で解いた
+//   - "in_progress" … current user が提出はあるが正答していない
+//   - ""            … current user が未提出（未着手）
+//
+// Stats は全ユーザ合計の集計値。
+type MasterExerciseWithStatus struct {
+	domain.MasterExercise
+
+	Status string                                  `json:"status"`
+	Stats  repository.ExerciseSubmissionStats      `json:"stats"`
+}
+
+// ListMasterExercisesWithStatusUseCase は問題一覧 + 各問題の current user 状態 + 集計を返す。
+//
+// N+1 を避けるため、 user status と stats はそれぞれ batch クエリで取得する。
+type ListMasterExercisesWithStatusUseCase struct {
+	exercises   repository.MasterExerciseRepository
+	submissions repository.ExerciseSubmissionRepository
+}
+
+func NewListMasterExercisesWithStatusUseCase(
+	exercises repository.MasterExerciseRepository,
+	submissions repository.ExerciseSubmissionRepository,
+) *ListMasterExercisesWithStatusUseCase {
+	return &ListMasterExercisesWithStatusUseCase{exercises: exercises, submissions: submissions}
+}
+
+// ListMasterExercisesWithStatusInput は入力。 UserID=0 は未ログイン扱いで status は全部 ""。
+type ListMasterExercisesWithStatusInput struct {
+	UserID   uint64
+	Language string
+}
+
+func (uc *ListMasterExercisesWithStatusUseCase) Execute(in ListMasterExercisesWithStatusInput) ([]MasterExerciseWithStatus, error) {
+	exercises, err := uc.exercises.ListByLanguage(in.Language)
+	if err != nil {
+		return nil, err
+	}
+	if len(exercises) == 0 {
+		return []MasterExerciseWithStatus{}, nil
+	}
+	ids := make([]uint64, 0, len(exercises))
+	for _, e := range exercises {
+		ids = append(ids, e.ID)
+	}
+
+	statusMap := make(map[uint64]string)
+	if in.UserID != 0 {
+		statusMap, err = uc.submissions.BatchUserStatuses(in.UserID, ids, domain.ExerciseKindMaster)
+		if err != nil {
+			return nil, err
+		}
+	}
+	statsMap, err := uc.submissions.ExerciseStatsBatch(ids, domain.ExerciseKindMaster)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]MasterExerciseWithStatus, 0, len(exercises))
+	for _, e := range exercises {
+		out = append(out, MasterExerciseWithStatus{
+			MasterExercise: e,
+			Status:         statusMap[e.ID],
+			Stats:          statsMap[e.ID],
+		})
+	}
+	return out, nil
+}

--- a/backend/internal/usecase/list_user_submissions_usecase.go
+++ b/backend/internal/usecase/list_user_submissions_usecase.go
@@ -1,0 +1,38 @@
+package usecase
+
+import (
+	"fmt"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// ListUserMasterSubmissionsInput は履歴一覧 API への入力。
+type ListUserMasterSubmissionsInput struct {
+	UserID uint64
+	Slug   string
+}
+
+// ListUserMasterSubmissionsUseCase は current user の指定問題に対する提出履歴を新しい順で返す。
+type ListUserMasterSubmissionsUseCase struct {
+	exercises   repository.MasterExerciseRepository
+	submissions repository.ExerciseSubmissionRepository
+}
+
+func NewListUserMasterSubmissionsUseCase(
+	exercises repository.MasterExerciseRepository,
+	submissions repository.ExerciseSubmissionRepository,
+) *ListUserMasterSubmissionsUseCase {
+	return &ListUserMasterSubmissionsUseCase{exercises: exercises, submissions: submissions}
+}
+
+func (uc *ListUserMasterSubmissionsUseCase) Execute(in ListUserMasterSubmissionsInput) ([]domain.ExerciseSubmission, error) {
+	ex, err := uc.exercises.GetBySlug(in.Slug)
+	if err != nil {
+		return nil, err
+	}
+	if ex == nil {
+		return nil, fmt.Errorf("exercise not found: %s", in.Slug)
+	}
+	return uc.submissions.ListByUserAndExercise(in.UserID, ex.ID, domain.ExerciseKindMaster)
+}

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -126,14 +126,17 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 			Passed:         passed,
 		})
 		if !passed && allPassed {
-			// 最初の失敗を representative として記録。
+			// 最初の失敗を representative として記録し allPassed を false に倒す。
+			// 以降のループでは下の if も通らないため、 この値が representative として固定される。
 			representativeStdout = out.Stdout
 			representativeStderr = out.Stderr
 			representativeExit = out.ExitCode
 			allPassed = false
 		}
 		if allPassed {
-			// 全 pass の経路では最後の結果で上書きする（成功例の出力を残す）。
+			// 全件 pass し続けている経路。 ループのたびに最後の出力で上書きすることで、
+			// 最終的に representative が「最後に通ったテストケースの出力」になる。
+			// 1 件でも失敗したら上の if 文で allPassed=false に倒れ、 こちらは以降スキップされる。
 			representativeStdout = out.Stdout
 			representativeStderr = out.Stderr
 			representativeExit = out.ExitCode

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -1,0 +1,175 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// CodeExecutor は ExecuteCodeUseCase を抽象化したインターフェイス。
+// usecase 層が usecase 同士に直接依存するのを避け、テストでは fake に差し替える。
+type CodeExecutor interface {
+	Execute(ctx context.Context, in ExecuteCodeInput) (*ExecuteCodeOutput, error)
+}
+
+// SubmitMasterExerciseInput は提出 API への入力。
+type SubmitMasterExerciseInput struct {
+	UserID uint64
+	Slug   string
+	Code   string
+}
+
+// TestCaseResult はテストケース 1 件の採点結果。
+type TestCaseResult struct {
+	OrderIndex     int16  `json:"orderIndex"`
+	Input          string `json:"input"`
+	ExpectedOutput string `json:"expectedOutput"`
+	ActualOutput   string `json:"actualOutput"`
+	Stderr         string `json:"stderr"`
+	Passed         bool   `json:"passed"`
+}
+
+// SubmitMasterExerciseOutput は提出 API の戻り値。
+type SubmitMasterExerciseOutput struct {
+	SubmissionID uint64           `json:"submissionId"`
+	IsCorrect    bool             `json:"isCorrect"`
+	Results      []TestCaseResult `json:"results"`
+}
+
+// SubmitMasterExerciseUseCase はユーザコードを slug の master_exercise に対して
+// 採点・提出履歴に保存する。
+//
+// 採点ロジック:
+//   - examples を全件取得（OrderIndex 昇順）
+//   - 各 example の InputText を stdin に流して ExecuteCodeUseCase で実行
+//   - stdout を normalize（末尾改行 / CRLF を吸収）して expected_output と完全一致するか比較
+//   - 全件 pass で isCorrect=true。1 件でも失敗・実行エラー（exit_code != 0）なら false
+//   - 実行コスト削減のため、最初の不一致で打ち切らず全件実行（ユーザに「どこで落ちたか」を全部見せる方針）
+//
+// 履歴保存はテストケース個別ではなく、まとめて 1 行（最初に失敗した stdout / stderr / exit_code を採用）。
+type SubmitMasterExerciseUseCase struct {
+	exercises   repository.MasterExerciseRepository
+	examples    repository.MasterExerciseExampleRepository
+	submissions repository.ExerciseSubmissionRepository
+	executor    CodeExecutor
+}
+
+func NewSubmitMasterExerciseUseCase(
+	exercises repository.MasterExerciseRepository,
+	examples repository.MasterExerciseExampleRepository,
+	submissions repository.ExerciseSubmissionRepository,
+	executor CodeExecutor,
+) *SubmitMasterExerciseUseCase {
+	return &SubmitMasterExerciseUseCase{
+		exercises:   exercises,
+		examples:    examples,
+		submissions: submissions,
+		executor:    executor,
+	}
+}
+
+func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMasterExerciseInput) (*SubmitMasterExerciseOutput, error) {
+	if in.UserID == 0 {
+		return nil, fmt.Errorf("userID is required")
+	}
+	if strings.TrimSpace(in.Slug) == "" {
+		return nil, fmt.Errorf("slug is required")
+	}
+	if strings.TrimSpace(in.Code) == "" {
+		return nil, fmt.Errorf("code is required")
+	}
+
+	ex, err := uc.exercises.GetBySlug(in.Slug)
+	if err != nil {
+		return nil, err
+	}
+	if ex == nil {
+		return nil, fmt.Errorf("exercise not found: %s", in.Slug)
+	}
+	examples, err := uc.examples.ListByExerciseID(ex.ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(examples) == 0 {
+		return nil, fmt.Errorf("exercise %s has no test cases", in.Slug)
+	}
+
+	results := make([]TestCaseResult, 0, len(examples))
+	allPassed := true
+	// 履歴保存用に「最初に失敗した実行結果」を保持。 全件 pass のときは最後の結果を使う。
+	var representativeStdout, representativeStderr string
+	var representativeExit int
+
+	for _, ex := range examples {
+		out, err := uc.executor.Execute(ctx, ExecuteCodeInput{
+			Code:     in.Code,
+			Language: "php",
+			Stdin:    ex.InputText,
+		})
+		if err != nil {
+			// 実行できなかった場合は提出を保存せずエラーを返す（タイムアウト等）。
+			return nil, fmt.Errorf("execution failed: %w", err)
+		}
+		actual := normalizeOutput(out.Stdout)
+		expected := normalizeOutput(ex.ExpectedOutput)
+		passed := out.ExitCode == 0 && actual == expected
+		results = append(results, TestCaseResult{
+			OrderIndex:     ex.OrderIndex,
+			Input:          ex.InputText,
+			ExpectedOutput: ex.ExpectedOutput,
+			ActualOutput:   out.Stdout,
+			Stderr:         out.Stderr,
+			Passed:         passed,
+		})
+		if !passed && allPassed {
+			// 最初の失敗を representative として記録。
+			representativeStdout = out.Stdout
+			representativeStderr = out.Stderr
+			representativeExit = out.ExitCode
+			allPassed = false
+		}
+		if allPassed {
+			// 全 pass の経路では最後の結果で上書きする（成功例の出力を残す）。
+			representativeStdout = out.Stdout
+			representativeStderr = out.Stderr
+			representativeExit = out.ExitCode
+		}
+	}
+
+	submission := &domain.ExerciseSubmission{
+		UserID:        in.UserID,
+		ExerciseKind:  domain.ExerciseKindMaster,
+		ExerciseID:    ex.ID,
+		SubmittedCode: in.Code,
+		Stdout:        representativeStdout,
+		Stderr:        representativeStderr,
+		ExitCode:      representativeExit,
+		IsCorrect:     allPassed,
+		SubmittedAt:   time.Now().UTC(),
+	}
+	if err := uc.submissions.Create(submission); err != nil {
+		return nil, err
+	}
+
+	return &SubmitMasterExerciseOutput{
+		SubmissionID: submission.ID,
+		IsCorrect:    allPassed,
+		Results:      results,
+	}, nil
+}
+
+// normalizeOutput は stdout 比較時の表記揺れを吸収する。
+//   - CRLF / CR を LF に統一
+//   - 末尾の改行・空白をすべて除去（"42\n" と "42" を同一視）
+//
+// PHP の `echo` は末尾改行を付けない / 付けるが問題により混在するため、
+// 「末尾だけ揺れを許容」する方針で十分。 行内の空白は厳密一致。
+func normalizeOutput(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.TrimRight(s, " \t\n")
+}

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -131,10 +131,11 @@ func TestSubmitMasterExercise_OneFails(t *testing.T) {
 		{ID: 2, ExerciseID: 7, OrderIndex: 2, InputText: "2", ExpectedOutput: "2"},
 	}}
 	submissions := &fakeSubmissionRepo{}
-	// "2" のとき期待と違う出力を返して失敗にする。
+	// 1 件目を失敗させ、 失敗後も全ケースが実行されることまで検証する
+	// （短絡実装で 2 件目が呼ばれない実装に退化したらこのテストで落ちる）。
 	executor := &fakeExecutor{stdinToOut: map[string]string{
-		"1": "1",
-		"2": "wrong",
+		"1": "wrong",
+		"2": "2",
 	}}
 
 	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
@@ -143,12 +144,14 @@ func TestSubmitMasterExercise_OneFails(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.False(t, out.IsCorrect)
-	assert.True(t, out.Results[0].Passed)
-	assert.False(t, out.Results[1].Passed)
+	assert.False(t, out.Results[0].Passed)
+	assert.True(t, out.Results[1].Passed)
 	require.NotNil(t, submissions.created)
 	assert.False(t, submissions.created.IsCorrect)
-	// 失敗したケースの stdout が representative として記録されている。
+	// 最初の失敗ケースの stdout が representative として記録されている。
 	assert.Equal(t, "wrong", submissions.created.Stdout)
+	// 失敗後も全 example が実行される（短絡しない）。
+	assert.Len(t, executor.calls, 2)
 }
 
 func TestSubmitMasterExercise_NormalizeOutput(t *testing.T) {

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -39,7 +39,7 @@ func (r *fakeExampleRepo) ListByExerciseIDs([]uint64) (map[uint64][]domain.Maste
 }
 
 type fakeSubmissionRepo struct {
-	created *domain.ExerciseSubmission
+	created   *domain.ExerciseSubmission
 	createErr error
 }
 

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -1,0 +1,235 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMasterExerciseRepo は SubmitMasterExerciseUseCase テスト用のスタブ。
+type fakeMasterExerciseRepo struct {
+	get *domain.MasterExercise
+	err error
+}
+
+func (r *fakeMasterExerciseRepo) ListByLanguage(string) ([]domain.MasterExercise, error) {
+	return nil, nil
+}
+func (r *fakeMasterExerciseRepo) GetByID(uint64) (*domain.MasterExercise, error) { return r.get, r.err }
+func (r *fakeMasterExerciseRepo) GetBySlug(string) (*domain.MasterExercise, error) {
+	return r.get, r.err
+}
+
+type fakeExampleRepo struct {
+	rows []domain.MasterExerciseExample
+}
+
+func (r *fakeExampleRepo) ListByExerciseID(uint64) ([]domain.MasterExerciseExample, error) {
+	return r.rows, nil
+}
+func (r *fakeExampleRepo) ListByExerciseIDs([]uint64) (map[uint64][]domain.MasterExerciseExample, error) {
+	return nil, nil
+}
+
+type fakeSubmissionRepo struct {
+	created *domain.ExerciseSubmission
+	createErr error
+}
+
+func (r *fakeSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	r.created = s
+	s.ID = 999
+	return nil
+}
+func (r *fakeSubmissionRepo) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
+	return nil, nil
+}
+func (r *fakeSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
+func (r *fakeSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) { return false, nil }
+func (r *fakeSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
+	return nil, nil
+}
+func (r *fakeSubmissionRepo) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
+	return repository.ExerciseSubmissionStats{}, nil
+}
+func (r *fakeSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+	return nil, nil
+}
+
+// fakeExecutor は ExecuteCodeUseCase の代わり。 入力 stdin で出力を切り替える。
+type fakeExecutor struct {
+	calls []usecase.ExecuteCodeInput
+	// stdinToOut: stdin に対応する stdout を返す。 なければ空。
+	stdinToOut map[string]string
+	// runErr が non-nil なら Execute がエラーを返す。
+	runErr error
+	// 失敗ケース: 指定 stdin のとき exitCode != 0 を返す。
+	failExit map[string]int
+}
+
+func (f *fakeExecutor) Execute(_ context.Context, in usecase.ExecuteCodeInput) (*usecase.ExecuteCodeOutput, error) {
+	if f.runErr != nil {
+		return nil, f.runErr
+	}
+	f.calls = append(f.calls, in)
+	out := &usecase.ExecuteCodeOutput{Stdout: f.stdinToOut[in.Stdin]}
+	if code, ok := f.failExit[in.Stdin]; ok {
+		out.ExitCode = code
+		out.Stderr = "boom"
+	}
+	return out, nil
+}
+
+func TestSubmitMasterExercise_AllPass(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{ID: 7, Slug: "php-7", Language: "php"},
+	}
+	examples := &fakeExampleRepo{rows: []domain.MasterExerciseExample{
+		{ID: 1, ExerciseID: 7, OrderIndex: 1, InputText: "", ExpectedOutput: "Hello"},
+		{ID: 2, ExerciseID: 7, OrderIndex: 2, InputText: "x", ExpectedOutput: "x"},
+	}}
+	submissions := &fakeSubmissionRepo{}
+	executor := &fakeExecutor{stdinToOut: map[string]string{
+		"":  "Hello\n",
+		"x": "x",
+	}}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "php-7", Code: "<?php echo 'Hello';",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.IsCorrect)
+	assert.Len(t, out.Results, 2)
+	assert.True(t, out.Results[0].Passed)
+	assert.True(t, out.Results[1].Passed)
+	require.NotNil(t, submissions.created)
+	assert.Equal(t, uint64(1), submissions.created.UserID)
+	assert.Equal(t, uint64(7), submissions.created.ExerciseID)
+	assert.Equal(t, domain.ExerciseKindMaster, submissions.created.ExerciseKind)
+	assert.True(t, submissions.created.IsCorrect)
+	// 全 example に対して executor が呼ばれた。
+	assert.Len(t, executor.calls, 2)
+}
+
+func TestSubmitMasterExercise_OneFails(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{ID: 7, Slug: "php-7", Language: "php"},
+	}
+	examples := &fakeExampleRepo{rows: []domain.MasterExerciseExample{
+		{ID: 1, ExerciseID: 7, OrderIndex: 1, InputText: "1", ExpectedOutput: "1"},
+		{ID: 2, ExerciseID: 7, OrderIndex: 2, InputText: "2", ExpectedOutput: "2"},
+	}}
+	submissions := &fakeSubmissionRepo{}
+	// "2" のとき期待と違う出力を返して失敗にする。
+	executor := &fakeExecutor{stdinToOut: map[string]string{
+		"1": "1",
+		"2": "wrong",
+	}}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "php-7", Code: "<?php",
+	})
+	require.NoError(t, err)
+	assert.False(t, out.IsCorrect)
+	assert.True(t, out.Results[0].Passed)
+	assert.False(t, out.Results[1].Passed)
+	require.NotNil(t, submissions.created)
+	assert.False(t, submissions.created.IsCorrect)
+	// 失敗したケースの stdout が representative として記録されている。
+	assert.Equal(t, "wrong", submissions.created.Stdout)
+}
+
+func TestSubmitMasterExercise_NormalizeOutput(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{ID: 1, Slug: "s", Language: "php"},
+	}
+	examples := &fakeExampleRepo{rows: []domain.MasterExerciseExample{
+		{ID: 1, ExerciseID: 1, OrderIndex: 1, InputText: "", ExpectedOutput: "42"},
+	}}
+	submissions := &fakeSubmissionRepo{}
+	// 末尾に \r\n を含めても normalize で吸収される。
+	executor := &fakeExecutor{stdinToOut: map[string]string{"": "42\r\n"}}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "s", Code: "<?php",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.IsCorrect)
+}
+
+func TestSubmitMasterExercise_NonZeroExit_Fails(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{ID: 1, Slug: "s", Language: "php"},
+	}
+	examples := &fakeExampleRepo{rows: []domain.MasterExerciseExample{
+		{ID: 1, ExerciseID: 1, OrderIndex: 1, InputText: "", ExpectedOutput: "ok"},
+	}}
+	submissions := &fakeSubmissionRepo{}
+	executor := &fakeExecutor{
+		stdinToOut: map[string]string{"": "ok"},
+		failExit:   map[string]int{"": 1},
+	}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "s", Code: "<?php",
+	})
+	require.NoError(t, err)
+	// stdout は一致するが exit_code != 0 で失敗扱い。
+	assert.False(t, out.IsCorrect)
+	assert.False(t, out.Results[0].Passed)
+}
+
+func TestSubmitMasterExercise_NoExamples_Errors(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{ID: 1, Slug: "s"},
+	}
+	examples := &fakeExampleRepo{}
+	submissions := &fakeSubmissionRepo{}
+	executor := &fakeExecutor{}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
+	_, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "s", Code: "<?php",
+	})
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "no test cases"))
+}
+
+func TestSubmitMasterExercise_ExerciseNotFound(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{err: errors.New("record not found")}
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, &fakeExampleRepo{}, &fakeSubmissionRepo{}, &fakeExecutor{})
+	_, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "missing", Code: "<?php",
+	})
+	require.Error(t, err)
+}
+
+func TestSubmitMasterExercise_RequiresInput(t *testing.T) {
+	uc := usecase.NewSubmitMasterExerciseUseCase(&fakeMasterExerciseRepo{}, &fakeExampleRepo{}, &fakeSubmissionRepo{}, &fakeExecutor{})
+	_, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 0, Slug: "s", Code: "x",
+	})
+	require.Error(t, err)
+	_, err = uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "", Code: "x",
+	})
+	require.Error(t, err)
+	_, err = uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "s", Code: "  ",
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## 概要

ユーザがコード演習を提出して採点する一連のバックエンド API を追加。
PR-V で導入された `master_exercise_examples`（複数入出力例）を採点ロジックのテストケースとして活用する。

## 変更内容

### 採点ロジック ([SubmitMasterExerciseUseCase](backend/internal/usecase/submit_master_exercise_usecase.go))
- examples を全件取得し、各 example の `input_text` を stdin に流して実行
- stdout を normalize（CRLF / 末尾改行を吸収）して `expected_output` と完全一致比較
- 全件 pass で `is_correct=true`、 1 件でも失敗 / `exit_code != 0` なら false
- 全 example を実行（最初の不一致で打ち切らない）→ どこで落ちたかを全件可視化
- `ExecuteCodeUseCase` を `CodeExecutor` interface 経由で呼び、テストでは fake に差し替え

### 集計統計 ([ExerciseSubmissionRepository.ExerciseStatsBatch](backend/internal/repository/exercise_submission_repository.go))
- 提出数（`COUNT(*)`）と正答ユーザ数（`COUNT(DISTINCT user_id) WHERE is_correct`）を
  exercise_id 単位で 2 クエリにまとめて取得（一覧 N+1 回避）

### ユーザステータス ([ListMasterExercisesWithStatusUseCase](backend/internal/usecase/list_master_exercises_with_status_usecase.go))
- 一覧 API で current user の `solved / in_progress / 未着手` を 1 クエリで取得
- `BOOL_OR(is_correct)` で「1 度でも解いた」を判定

### API
- `POST /api/v2/exercises/:slug/submit`        コード提出 + 採点 + 履歴保存
- `GET  /api/v2/exercises/:slug/submissions`   current user の履歴
- `GET  /api/v2/exercises`（拡張）              `status` / `stats` を含むレスポンスへ

### ExecuteCodeUseCase の拡張
- `ExecuteCodeInput.Stdin` を追加し、 PHP CLI 実行時に標準入力を流せるように
  （旧 API は空文字渡しで互換）

## テスト

- [x] `SubmitMasterExerciseUseCase`: 全件 pass / 一部失敗 / 改行 normalize / exit_code 失敗 / example 0 件 / 入力バリデーション
- [x] `ExerciseSubmissionHandler`: Submit 成功 / 401 / 履歴一覧
- [x] `MasterExerciseHandler` (List 経路の差し替え): 既存テストは `MasterExerciseWithStatus` が `domain.MasterExercise` を embed しているため互換動作
- [x] `go build ./...` / `go test ./...` 全グリーン

## 関連

- PR-V (#1666) で追加された `master_exercise_examples` を採点に使う
- フロントエンド連携は PR-X で実装

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 演習コード提出と自動採点機能を追加
  * ユーザーの提出履歴確認機能を追加
  * 演習リストに各ユーザーの提出ステータスと統計情報を表示
  * コード実行がstdin入力に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->