### PR TITLE
feat(profile): 「ニックネーム」を「氏名」に統一し OIDC name で自動補完

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -266,6 +266,9 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 		return false
 	}
 	email, _ := claims["email"].(string)
+	// OIDC (Google など) 経由のログインでは id_token に `name` が含まれる。
+	// Cognito User Pool の SRP ログインだと無いこともあるので空許容。
+	oidcName, _ := claims["name"].(string)
 	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
 	isCognitoAdmin := middleware.IsAdminFromGroups(groups)
 
@@ -285,6 +288,15 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 
 	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
 	if existing != nil {
+		// 既存ユーザの DisplayName が「email そのまま」になっている場合は
+		// id_token の `name` claim で上書きする（旧フローで email を仮の displayName として
+		// 入れていたユーザを OIDC ログイン時に氏名へ自動補正する）。
+		// ユーザが明示的にプロフィールを書き換えている場合（displayName != email）は触らない。
+		if oidcName != "" && existing.Email != "" && existing.DisplayName == existing.Email {
+			if err := h.users.UpdateDisplayName(c.Request.Context(), existing.ID, oidcName); err != nil {
+				log.Printf("upsertUserFromIDToken: backfill displayName failed userID=%d: %v", existing.ID, err)
+			}
+		}
 		// 既存ユーザー: 招待 / Cognito group の状態で role / company を更新する。
 		// 重要な制約:
 		//   - super_admin は何があっても降格しない（招待での降格は不可、別途 admin API でのみ降格可）
@@ -323,7 +335,12 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 	role := domain.RoleTrainee
 	var companyID *uint64
 	var acceptedInvID uint64
+	// displayName の優先順位: 招待 displayName > OIDC `name` claim > email （フォールバック）。
+	// email をそのまま displayName に詰めるのは「氏名がどうしても取れないとき」だけにする。
 	displayName := email
+	if oidcName != "" {
+		displayName = oidcName
+	}
 
 	if isCognitoAdmin {
 		role = domain.RoleSuperAdmin

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -396,7 +396,7 @@ func TestUpsertUserFromIDToken_NewUser_InvitationNameTrumpsOIDCName(t *testing.T
 	}
 	h := newTestAuthHandler(users, invs)
 	idToken := makeIDToken(t, map[string]any{
-		"sub":   "g-2", "email": "u@example.com", "name": "Google Name",
+		"sub": "g-2", "email": "u@example.com", "name": "Google Name",
 	})
 
 	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -13,13 +13,15 @@ import (
 
 // fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
 type fakeUserRepo struct {
-	existingBySub    map[string]*domain.User
-	created          *domain.User
-	createErr        error
-	updateRoleID     uint64
-	updateRoleVal    string
-	updateCompanyID  uint64
-	updateCompanyVal uint64
+	existingBySub        map[string]*domain.User
+	created              *domain.User
+	createErr            error
+	updateRoleID         uint64
+	updateRoleVal        string
+	updateCompanyID      uint64
+	updateCompanyVal     uint64
+	updateDisplayNameID  uint64
+	updateDisplayNameVal string
 }
 
 func (r *fakeUserRepo) FindByCognitoSub(_ context.Context, sub string) (*domain.User, error) {
@@ -39,7 +41,10 @@ func (r *fakeUserRepo) Create(_ context.Context, u *domain.User) error {
 	r.created = u
 	return nil
 }
-func (r *fakeUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error { return nil }
+func (r *fakeUserRepo) UpdateDisplayName(_ context.Context, id uint64, name string) error {
+	r.updateDisplayNameID, r.updateDisplayNameVal = id, name
+	return nil
+}
 func (r *fakeUserRepo) UpdateRole(_ context.Context, id uint64, role string) error {
 	r.updateRoleID, r.updateRoleVal = id, role
 	return nil
@@ -347,3 +352,122 @@ func TestUpsertUserFromIDToken_ExistingSuperAdmin_NotDowngradedByInvitation(t *t
 
 // dummy: 使用していないが strings import のリンタを満たすために残す（今後 assert で使う）
 var _ = strings.Contains
+
+// 新規ユーザ作成時に id_token の `name` claim が DisplayName に使われる（email にフォールバックしない）。
+func TestUpsertUserFromIDToken_NewUser_UsesOIDCNameOverEmail(t *testing.T) {
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{
+		pendingByEmail: map[string]*domain.AdminInvitation{
+			"taro@example.com": {
+				ID: 1, CompanyID: 10, Email: "taro@example.com",
+				Role: domain.RoleTrainee, Status: domain.InvitationStatusPending,
+				// 招待 displayName が空だと OIDC name が採用される。
+			},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "google-1",
+		"email": "taro@example.com",
+		"name":  "山田 太郎",
+	})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+		t.Fatal("must be allowed")
+	}
+	if users.created == nil {
+		t.Fatal("expected user created")
+	}
+	if users.created.DisplayName != "山田 太郎" {
+		t.Errorf("DisplayName = %q, want 山田 太郎 (OIDC name)", users.created.DisplayName)
+	}
+}
+
+// 招待 displayName が指定されているときは招待値が優先で OIDC name は無視。
+func TestUpsertUserFromIDToken_NewUser_InvitationNameTrumpsOIDCName(t *testing.T) {
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{
+		pendingByEmail: map[string]*domain.AdminInvitation{
+			"u@example.com": {
+				ID: 1, CompanyID: 10, Email: "u@example.com",
+				Role: domain.RoleTrainee, DisplayName: "招待された名前", Status: domain.InvitationStatusPending,
+			},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "g-2", "email": "u@example.com", "name": "Google Name",
+	})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+		t.Fatal("must be allowed")
+	}
+	if users.created.DisplayName != "招待された名前" {
+		t.Errorf("DisplayName = %q, want 招待された名前", users.created.DisplayName)
+	}
+}
+
+// name claim が無いケースは email にフォールバックする（後方互換）。
+func TestUpsertUserFromIDToken_NewUser_NoOIDCName_FallsBackToEmail(t *testing.T) {
+	users := &fakeUserRepo{}
+	invs := &fakeInvitationRepo{
+		pendingByEmail: map[string]*domain.AdminInvitation{
+			"a@example.com": {
+				ID: 1, CompanyID: 10, Email: "a@example.com",
+				Role: domain.RoleTrainee, Status: domain.InvitationStatusPending,
+			},
+		},
+	}
+	h := newTestAuthHandler(users, invs)
+	idToken := makeIDToken(t, map[string]any{"sub": "g-3", "email": "a@example.com"})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+		t.Fatal("must be allowed")
+	}
+	if users.created.DisplayName != "a@example.com" {
+		t.Errorf("DisplayName = %q, want a@example.com (fallback)", users.created.DisplayName)
+	}
+}
+
+// 既存ユーザの DisplayName が email と一致 + id_token に name → name で上書きされる。
+func TestUpsertUserFromIDToken_ExistingUser_BackfillDisplayNameFromOIDC(t *testing.T) {
+	existing := &domain.User{
+		ID: 5, CognitoSub: "exists",
+		Email: "old@example.com", DisplayName: "old@example.com",
+		Role: domain.RoleTrainee,
+	}
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"exists": existing}}
+	h := newTestAuthHandler(users, &fakeInvitationRepo{})
+	idToken := makeIDToken(t, map[string]any{
+		"sub": "exists", "email": "old@example.com", "name": "本名 太郎",
+	})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+		t.Fatal("must be allowed")
+	}
+	if users.updateDisplayNameID != 5 || users.updateDisplayNameVal != "本名 太郎" {
+		t.Errorf("expected backfill UpdateDisplayName(5, '本名 太郎'), got id=%d val=%q",
+			users.updateDisplayNameID, users.updateDisplayNameVal)
+	}
+}
+
+// 既存ユーザが既にプロフィール編集済（DisplayName != email）なら OIDC name で上書きしない。
+func TestUpsertUserFromIDToken_ExistingUser_NoBackfillIfDisplayNameCustomized(t *testing.T) {
+	existing := &domain.User{
+		ID: 5, CognitoSub: "exists",
+		Email: "u@example.com", DisplayName: "ユーザ自身が編集した名前",
+		Role: domain.RoleTrainee,
+	}
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"exists": existing}}
+	h := newTestAuthHandler(users, &fakeInvitationRepo{})
+	idToken := makeIDToken(t, map[string]any{
+		"sub": "exists", "email": "u@example.com", "name": "Google Name",
+	})
+
+	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+		t.Fatal("must be allowed")
+	}
+	if users.updateDisplayNameVal != "" {
+		t.Errorf("expected no backfill, but UpdateDisplayName called with %q", users.updateDisplayNameVal)
+	}
+}

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -14,7 +14,8 @@ type UserRepository interface {
 	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
 	FindByID(ctx context.Context, id uint64) (*domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
-	// UpdateDisplayName は ProfilePage の「ニックネーム」変更で呼ばれる。
+	// UpdateDisplayName は ProfilePage の「氏名」変更、 および OIDC ログイン時に
+	// 旧 displayName=email を id_token の name claim で自動補正するときに呼ばれる。
 	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
 	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。
 	UpdateRole(ctx context.Context, userID uint64, role string) error

--- a/frontend/src/hooks/__tests__/useProfileEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileEdit.test.ts
@@ -175,7 +175,7 @@ describe('useProfileEdit', () => {
     });
   });
 
-  it('ニックネームが空の場合エラーメッセージが表示されAPIが呼ばれない', async () => {
+  it('氏名が空の場合エラーメッセージが表示されAPIが呼ばれない', async () => {
     const { result } = renderHook(() => useProfileEdit());
 
     await waitFor(() => {
@@ -191,11 +191,11 @@ describe('useProfileEdit', () => {
     });
 
     expect(result.current.message?.type).toBe('error');
-    expect(result.current.message?.text).toBe('ニックネームを入力してください。');
+    expect(result.current.message?.text).toBe('氏名を入力してください。');
     expect(mockUpdateProfile).not.toHaveBeenCalled();
   });
 
-  it('ニックネームが空白のみの場合エラーメッセージが表示されAPIが呼ばれない', async () => {
+  it('氏名が空白のみの場合エラーメッセージが表示されAPIが呼ばれない', async () => {
     const { result } = renderHook(() => useProfileEdit());
 
     await waitFor(() => {
@@ -211,7 +211,7 @@ describe('useProfileEdit', () => {
     });
 
     expect(result.current.message?.type).toBe('error');
-    expect(result.current.message?.text).toBe('ニックネームを入力してください。');
+    expect(result.current.message?.text).toBe('氏名を入力してください。');
     expect(mockUpdateProfile).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/hooks/useProfileEdit.ts
+++ b/frontend/src/hooks/useProfileEdit.ts
@@ -3,8 +3,12 @@ import ProfileRepository from '../repositories/ProfileRepository';
 import type { FormMessage, Profile } from '../types';
 
 /**
- * useProfileEdit — ProfilePage で「ニックネーム / 自己紹介 / アイコン / ステータス」
+ * useProfileEdit — ProfilePage で「氏名 / 自己紹介 / アイコン / ステータス」
  * の編集を扱う。フォーム形は backend `domain.ProfileView` のサブセット。
+ *
+ * displayName は OIDC ログイン時に id_token の `name` claim を初期値として
+ * セットするため（auth_handler.upsertUserFromIDToken）、 通常は氏名がそのまま入る。
+ * ユーザは ProfilePage 上で自由に書き換え可能。
  */
 type ProfileForm = Pick<Profile, 'displayName' | 'bio' | 'avatarUrl' | 'status'>;
 
@@ -46,7 +50,7 @@ export function useProfileEdit() {
 
   const handleUpdate = useCallback(async () => {
     if (!form.displayName.trim()) {
-      setMessage({ type: 'error', text: 'ニックネームを入力してください。' });
+      setMessage({ type: 'error', text: '氏名を入力してください。' });
       return;
     }
     setSubmitting(true);

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -81,7 +81,7 @@ export default function ProfilePage() {
           className="space-y-4"
         >
           <InputField
-            label="ニックネーム"
+            label="氏名"
             name="displayName"
             value={form.displayName}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => updateField('displayName', e.target.value)}

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -62,7 +62,7 @@ describe('ProfilePage', () => {
     });
   });
 
-  it('プロファイル取得後にニックネーム欄が表示される', async () => {
+  it('プロファイル取得後に氏名欄が表示される', async () => {
     mockedRepo.fetchProfile.mockResolvedValue({ userId: 1, displayName: 'テストユーザー', bio: '自己紹介文', avatarUrl: '', status: '', updatedAt: '2026-04-28T00:00:00Z' });
 
     render(<ProfilePage />);


### PR DESCRIPTION
## 概要

プロフィールページの表示名を「ニックネーム」概念から「氏名」に統一する。 これまでは新規ユーザ作成時に email をそのまま `displayName` として詰めていたため、 プロフィールを開くと自分のメールアドレスが氏名欄に表示される UX 上の問題があった。

OIDC (Google など) 経由のログインでは id_token に `name` claim が含まれるので、 これを氏名の初期値として採用する。 旧来の email-as-displayName ユーザは、 次回 OIDC ログイン時に自動補正される。

email カラム自体は users テーブルに残す（auth / 招待で必要）。

## 変更内容

### Backend ([auth_handler.go](backend/internal/handler/auth_handler.go))

- id_token の `name` claim を読み取り `oidcName` として保持
- **新規ユーザ作成時**の displayName 優先順位を `招待 > OIDC name > email` に変更
- **既存ユーザログイン時**、 `displayName == email` のケースに限り `name` claim で上書き
  - ユーザがプロフィール編集済（`displayName != email`）なら上書きしない（変更を尊重）
  - email も無いケースは無動作（誤判定回避）

### Frontend ([ProfilePage.tsx](frontend/src/pages/ProfilePage.tsx) / [useProfileEdit.ts](frontend/src/hooks/useProfileEdit.ts))

- ラベル「ニックネーム」→「氏名」
- バリデーションメッセージも追従（「ニックネームを入力してください」→「氏名を入力してください」）

## テスト

新規 backend tests:
- 新規ユーザ: OIDC name が email より優先される
- 新規ユーザ: 招待 displayName が OIDC name より優先される
- 新規ユーザ: name claim 無しは email にフォールバック（後方互換）
- 既存ユーザ: displayName == email + name claim あり → 自動補正される
- 既存ユーザ: displayName != email（編集済）→ 上書きしない

フロント既存テスト 2 件の「ニックネーム」文言を「氏名」に追従。

- [x] `go build ./...` / `go test ./...`
- [x] `tsc --noEmit` / `vitest run` (1718 件 全 pass) / `eslint --max-warnings 0` / `npm run build`

## 移行

- DB マイグレーション不要（カラム変更なし）
- 旧ユーザは「次回 OIDC ログイン」のタイミングで自動補正される