### PR TITLE
feat(notes): ソートをドロップダウン化 + エディタを Markdown (Edit/Preview) に切替

### DIFF
--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import { ArrowDownTrayIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
+import type { SaveStatus } from '../hooks/useNoteEditor';
+import { useToast } from '../hooks/useToast';
+import { tiptapToMarkdown } from '../utils/tiptapToMarkdown';
+import { getNoteStats } from '../utils/noteStats';
+import WordCount from './WordCount';
+import LineCount from './LineCount';
+import ReadingTime from './ReadingTime';
+
+interface NoteMarkdownEditorProps {
+  title: string;
+  content: string;
+  saveStatus: SaveStatus;
+  onTitleChange: (title: string) => void;
+  onContentChange: (content: string) => void;
+}
+
+const SAVE_STATUS_CONFIG: Record<Exclude<SaveStatus, 'idle'>, { label: string; color: string }> = {
+  unsaved: { label: '未保存', color: 'text-amber-500' },
+  saving: { label: '保存中...', color: 'text-[var(--color-text-muted)]' },
+  saved: { label: '保存済み', color: 'text-emerald-500' },
+};
+
+/**
+ * NoteMarkdownEditor — GitHub README 風の Edit / Preview タブ付き Markdown エディタ。
+ *
+ * 旧実装（BlockEditor + TipTap）から切替: ノートは生 Markdown 文字列として保存され、
+ * Preview タブで react-markdown レンダリングする。
+ *
+ * 互換性:
+ *   - 旧データは TipTap JSON で保存されているので、 ロード時に
+ *     `{"type":"doc"...` で始まる文字列を検出した場合は tiptapToMarkdown で
+ *     変換した結果を初期表示にする（ユーザが保存し直すと Markdown 化される）
+ *   - 完全な双方向同期はしない（Preview の WYSIWYG 編集は不可）
+ */
+export default function NoteMarkdownEditor({
+  title,
+  content,
+  saveStatus,
+  onTitleChange,
+  onContentChange,
+}: NoteMarkdownEditorProps) {
+  const [tab, setTab] = useState<'edit' | 'preview'>('edit');
+  const titleRef = useRef<HTMLInputElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { showToast } = useToast();
+
+  // 旧 TipTap JSON データの自動 markdown 化（初回ロード時のみ反映）。
+  // ユーザが編集 → 保存すると content が markdown で上書きされ、 以降この分岐は通らない。
+  const displayContent = useMemo(() => convertLegacyContent(content), [content]);
+  const lastConvertedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (
+      content !== displayContent &&
+      lastConvertedRef.current !== content &&
+      isLikelyTiptapJson(content)
+    ) {
+      // 一度だけ親に通知して store を markdown 化する。
+      lastConvertedRef.current = content;
+      onContentChange(displayContent);
+    }
+  }, [content, displayContent, onContentChange]);
+
+  const stats = useMemo(() => getNoteStats(displayContent), [displayContent]);
+
+  const handleTitleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      textareaRef.current?.focus();
+    }
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(displayContent);
+      showToast('success', 'Markdown をコピーしました');
+    } catch {
+      showToast('error', 'コピーに失敗しました');
+    }
+  }, [displayContent, showToast]);
+
+  const handleDownload = useCallback(() => {
+    const blob = new Blob([displayContent], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${title || '無題'}.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, [displayContent, title]);
+
+  return (
+    <div className="flex flex-col h-full p-6 max-w-3xl mx-auto w-full">
+      <input
+        ref={titleRef}
+        type="text"
+        value={title}
+        onChange={(e) => onTitleChange(e.target.value)}
+        onKeyDown={handleTitleKeyDown}
+        placeholder="無題"
+        aria-label="ノートのタイトル"
+        className="text-2xl font-bold text-[var(--color-text-primary)] bg-transparent border-none outline-none w-full mb-4 placeholder:text-[var(--color-text-faint)]"
+      />
+
+      <div className="flex items-center gap-1 mb-3">
+        <TabButton active={tab === 'edit'} onClick={() => setTab('edit')}>
+          Edit
+        </TabButton>
+        <TabButton active={tab === 'preview'} onClick={() => setTab('preview')}>
+          Preview
+        </TabButton>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-hidden">
+        {tab === 'edit' ? (
+          <textarea
+            ref={textareaRef}
+            value={displayContent}
+            onChange={(e) => onContentChange(e.target.value)}
+            placeholder="# 見出し&#10;&#10;Markdown でノートを書きましょう..."
+            spellCheck={false}
+            className="w-full h-full resize-none p-4 rounded-md bg-surface-1 border border-surface-3 text-sm font-mono text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500/50 transition-colors"
+          />
+        ) : (
+          <div className="w-full h-full overflow-y-auto p-4 rounded-md bg-surface-1 border border-surface-3 prose prose-invert prose-sm max-w-none">
+            {displayContent.trim() ? (
+              <MarkdownView content={displayContent} />
+            ) : (
+              <p className="text-[var(--color-text-muted)] italic">プレビューするコンテンツがありません</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 pt-3 mt-3 border-t border-surface-3" aria-label="ノート統計">
+        <WordCount charCount={stats.charCount} />
+        <LineCount lineCount={stats.lineCount} />
+        <ReadingTime charCount={stats.charCount} />
+        {saveStatus !== 'idle' && (
+          <span className={`text-xs ${SAVE_STATUS_CONFIG[saveStatus].color}`} aria-label="保存状態">
+            {SAVE_STATUS_CONFIG[saveStatus].label}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label="Markdown をコピー"
+            className="p-1.5 rounded hover:bg-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+            title="Markdown をコピー"
+          >
+            <ClipboardDocumentIcon className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            aria-label="Markdown でダウンロード"
+            className="p-1.5 rounded hover:bg-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+            title="Markdown でダウンロード"
+          >
+            <ArrowDownTrayIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`px-3 py-1 text-xs rounded-md transition-colors ${
+        active
+          ? 'bg-surface-2 text-[var(--color-text-primary)]'
+          : 'text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-secondary)]'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// 旧データが TipTap JSON で保存されているケースを検出する。
+function isLikelyTiptapJson(s: string): boolean {
+  if (!s) return false;
+  const trimmed = s.trim();
+  if (!trimmed.startsWith('{')) return false;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === 'object' && parsed.type === 'doc';
+  } catch {
+    return false;
+  }
+}
+
+function convertLegacyContent(s: string): string {
+  return isLikelyTiptapJson(s) ? tiptapToMarkdown(s) : s;
+}
+
+function MarkdownView({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeHighlight]}
+      components={{
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-400 underline-offset-2 hover:underline"
+          >
+            {children as ReactNode}
+          </a>
+        ),
+        code: ({ className, children, ...props }) => {
+          const isBlock = className?.includes('language-');
+          if (isBlock) {
+            return (
+              <code className={className} {...props}>
+                {children as ReactNode}
+              </code>
+            );
+          }
+          return (
+            <code className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[0.85em]">
+              {children as ReactNode}
+            </code>
+          );
+        },
+        table: ({ children }) => (
+          <div className="overflow-x-auto">
+            <table className="text-sm border-collapse">{children as ReactNode}</table>
+          </div>
+        ),
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/components/NoteSortMenu.tsx
+++ b/frontend/src/components/NoteSortMenu.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react';
+import { ArrowsUpDownIcon, CheckIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
+import { NOTE_SORT_OPTIONS, type NoteSortOption } from '../constants/sortOptions';
+
+interface NoteSortMenuProps {
+  selected: NoteSortOption;
+  onChange: (value: NoteSortOption) => void;
+}
+
+/**
+ * NoteSortMenu — ノート一覧の「並べ替え」をドロップダウンメニューで選択する。
+ *
+ * 旧: タブ風の SortSelector（4 つのボタンを横並び）
+ * 新: 1 行の「並べ替え: <現在の選択> ▾」ボタンを押すとメニューが開き、
+ *     チェックマーク付きの一覧から選ぶ。 Notion の並べ替えメニューに近い見た目。
+ *
+ * メニュー外クリックで閉じる。
+ */
+export default function NoteSortMenu({ selected, onChange }: NoteSortMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  const currentLabel =
+    NOTE_SORT_OPTIONS.find((o) => o.value === selected)?.label ?? NOTE_SORT_OPTIONS[0].label;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="w-full flex items-center justify-between gap-2 px-2.5 py-1.5 rounded-md text-xs text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors"
+      >
+        <span className="flex items-center gap-1.5">
+          <ArrowsUpDownIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
+          並べ替え
+        </span>
+        <span className="flex items-center gap-1 text-[var(--color-text-muted)]">
+          {currentLabel}
+          <ChevronDownIcon className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+        </span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label="並べ替えオプション"
+          className="absolute z-20 left-0 right-0 mt-1 rounded-md border border-surface-3 bg-[var(--color-surface)] shadow-lg overflow-hidden"
+        >
+          {NOTE_SORT_OPTIONS.map(({ value, label }) => {
+            const isSelected = selected === value;
+            return (
+              <button
+                key={value}
+                role="menuitemradio"
+                aria-checked={isSelected}
+                onClick={() => {
+                  onChange(value);
+                  setOpen(false);
+                }}
+                className={`w-full flex items-center justify-between gap-2 px-3 py-1.5 text-xs transition-colors ${
+                  isSelected
+                    ? 'text-[var(--color-text-primary)] bg-surface-2'
+                    : 'text-[var(--color-text-secondary)] hover:bg-surface-2'
+                }`}
+              >
+                <span>{label}</span>
+                {isSelected && <CheckIcon className="w-3.5 h-3.5 text-primary-400" />}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NoteMarkdownEditor from '../NoteMarkdownEditor';
+import { ToastProvider } from '../ToastProvider';
+
+function renderEditor(props: Partial<React.ComponentProps<typeof NoteMarkdownEditor>> = {}) {
+  const defaults: React.ComponentProps<typeof NoteMarkdownEditor> = {
+    title: 'タイトル',
+    content: '# 見出し\n\n本文',
+    saveStatus: 'idle',
+    onTitleChange: vi.fn(),
+    onContentChange: vi.fn(),
+  };
+  return render(
+    <ToastProvider>
+      <NoteMarkdownEditor {...defaults} {...props} />
+    </ToastProvider>,
+  );
+}
+
+function getMarkdownTextarea(): HTMLTextAreaElement {
+  const ta = document.querySelector('textarea');
+  if (!ta) throw new Error('textarea not found');
+  return ta;
+}
+
+describe('NoteMarkdownEditor', () => {
+  it('Edit タブで textarea に Markdown を表示する', () => {
+    renderEditor();
+    expect(getMarkdownTextarea().value).toBe('# 見出し\n\n本文');
+  });
+
+  it('Preview タブをクリックすると Markdown レンダリングが表示される', () => {
+    renderEditor();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    // Markdown の見出しがレンダリングされ、 textarea は消える
+    expect(screen.getByRole('heading', { name: '見出し' })).toBeInTheDocument();
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+
+  it('Edit タブに戻ると textarea が再表示される', () => {
+    renderEditor();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(getMarkdownTextarea().value).toBe('# 見出し\n\n本文');
+  });
+
+  it('textarea を変更すると onContentChange が呼ばれる', () => {
+    const onContentChange = vi.fn();
+    renderEditor({ onContentChange });
+    fireEvent.change(getMarkdownTextarea(), { target: { value: '新しい内容' } });
+    expect(onContentChange).toHaveBeenCalledWith('新しい内容');
+  });
+
+  it('TipTap JSON のレガシー content は Markdown に変換して表示される', () => {
+    const tiptapJson = JSON.stringify({
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 1 }, content: [{ type: 'text', text: '旧データ' }] },
+      ],
+    });
+    const onContentChange = vi.fn();
+    renderEditor({ content: tiptapJson, onContentChange });
+    // textarea には変換後の Markdown が出る
+    expect(getMarkdownTextarea().value).toBe('# 旧データ');
+    // 自動的に親に通知して store を Markdown 化する
+    expect(onContentChange).toHaveBeenCalledWith('# 旧データ');
+  });
+
+  it('空コンテンツの Preview は案内文を出す', () => {
+    renderEditor({ content: '   ' });
+    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    expect(screen.getByText('プレビューするコンテンツがありません')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/NoteSortMenu.test.tsx
+++ b/frontend/src/components/__tests__/NoteSortMenu.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NoteSortMenu from '../NoteSortMenu';
+
+describe('NoteSortMenu', () => {
+  it('現在の選択ラベルがトリガーに表示される', () => {
+    render(<NoteSortMenu selected="title" onChange={() => {}} />);
+    expect(screen.getByText('タイトル順')).toBeInTheDocument();
+  });
+
+  it('クリックでメニューが開き 4 件のオプションが表示される', () => {
+    render(<NoteSortMenu selected="default" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /並べ替え/ }));
+    const menu = screen.getByRole('menu');
+    const items = menu.querySelectorAll('[role="menuitemradio"]');
+    expect(items).toHaveLength(4);
+  });
+
+  it('オプションを選ぶと onChange が呼ばれメニューが閉じる', () => {
+    const onChange = vi.fn();
+    render(<NoteSortMenu selected="default" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: /並べ替え/ }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /タイトル順/ }));
+    expect(onChange).toHaveBeenCalledWith('title');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('外側クリックでメニューが閉じる', () => {
+    render(
+      <div>
+        <NoteSortMenu selected="default" onChange={() => {}} />
+        <button>外側</button>
+      </div>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /並べ替え/ }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole('button', { name: '外側' }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from 'react';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import NoteListItem from '../components/NoteListItem';
-import NoteEditor from '../components/NoteEditor';
+import NoteMarkdownEditor from '../components/NoteMarkdownEditor';
 import EmptyState from '../components/EmptyState';
 import ConfirmModal from '../components/ConfirmModal';
 import Loading from '../components/Loading';
-import SortSelector from '../components/SortSelector';
-import { NOTE_SORT_OPTIONS } from '../constants/sortOptions';
+import NoteSortMenu from '../components/NoteSortMenu';
 import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline';
 import { useNotes } from '../hooks/useNotes';
 import { useNoteEditor } from '../hooks/useNoteEditor';
@@ -90,11 +89,7 @@ export default function NotesPage() {
                 className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
               />
             </div>
-            <SortSelector
-              options={NOTE_SORT_OPTIONS}
-              selected={noteSort}
-              onChange={setNoteSort}
-            />
+            <NoteSortMenu selected={noteSort} onChange={setNoteSort} />
             <button
               onClick={handleCreateNote}
               className="w-full bg-primary-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
@@ -150,10 +145,9 @@ export default function NotesPage() {
         </div>
 
         {selectedNote ? (
-          <NoteEditor
+          <NoteMarkdownEditor
             title={editTitle}
             content={editContent}
-            noteId={selectedNoteId}
             saveStatus={saveStatus}
             onTitleChange={handleTitleChange}
             onContentChange={handleContentChange}

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -106,7 +106,9 @@ describe('NotesPage', () => {
     });
     render(<NotesPage />);
     expect(screen.getByDisplayValue('選択ノート')).toBeInTheDocument();
-    expect(screen.getByTestId('block-editor')).toBeInTheDocument();
+    // Edit / Preview タブが表示されることを確認（旧 block-editor から markdown editor へ）
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
   });
 
   it('新しいノートボタンでcreateNoteが呼ばれる', async () => {


### PR DESCRIPTION
## 概要

ユーザ要望に従い:
1. ノート一覧の並び替え UI をタブ → 業界標準 SaaS 風のドロップダウンメニューに
2. ノート編集を TipTap (業界標準 SaaS 風 WYSIWYG) → GitHub README 風の Markdown (Edit / Preview タブ) に切替

## ノート一覧のソート UI

旧: 4 つのタブ（デフォルト / 古い順 / タイトル順 / 作成日新しい順）を横並びで panel ヘッダーに常時表示

新: [NoteSortMenu](frontend/src/components/NoteSortMenu.tsx) — 「並べ替え: 〈現在の選択〉 ▾」ボタンを 1 行で表示。 クリックでドロップダウンが開き、 チェックマーク付きでオプション選択。 メニュー外クリックで閉じる。

## ノートエディタの全面書き換え

旧: BlockEditor (TipTap) で 業界標準 SaaS 風 WYSIWYG 編集

新: [NoteMarkdownEditor](frontend/src/components/NoteMarkdownEditor.tsx) — GitHub README 風の Edit / Preview タブ
- **Edit タブ**: `<textarea>` で生 Markdown を直接編集
- **Preview タブ**: `react-markdown` + `remark-gfm` + `rehype-highlight` でレンダリング
- Copy / Download (.md) ボタンは継続提供

### 旧データ互換

既存ノートは TipTap JSON 文字列で保存されているため、 ロード時に `{"type":"doc"...` を検出すると `tiptapToMarkdown` で変換した結果を初期表示にし、 親に通知して store を Markdown 文字列に置き換える。 ユーザが保存し直せば DB 上の `content` カラムも Markdown 化される。

## テスト

- `NoteSortMenu`: 4 件（ラベル表示 / 開閉 / onChange / 外側クリック閉じ）
- `NoteMarkdownEditor`: 6 件（Edit/Preview 切替 / change イベント / TipTap JSON の自動 Markdown 化 / 空コンテンツ案内）
- `NotesPage` 既存テスト: block-editor → Edit/Preview ボタン assert に追従

- [x] `tsc --noEmit`
- [x] `vitest run`（1734 件 全 pass）
- [x] `eslint --max-warnings 0`
- [x] `npm run build`

## 注意

- AI チャット側など他機能では BlockEditor / TipTap を引き続き使用するため、 これらのファイルや `package.json` の依存は本 PR では触らない。
- ノート content の DB 保存形式が「TipTap JSON または Markdown 文字列」になるが、 表示時に自動変換するため移行は不要。
