### PR TITLE
fix(notes): タイトルで IME 変換中の Enter で本文にフォーカスを移さない

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -52,7 +52,10 @@ export default memo(function AiSessionListItem({
               value={editingTitle}
               onChange={(e) => onEditingTitleChange(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && editingTitle.trim()) onSaveTitle(id);
+                // IME 変換中の Enter は確定操作として透過させる（誤って保存しない）。
+                if (e.key === 'Enter' && !e.nativeEvent.isComposing && editingTitle.trim()) {
+                  onSaveTitle(id);
+                }
                 if (e.key === 'Escape') onCancelEdit();
               }}
               className="flex-1 text-xs px-2 py-1 border border-[var(--color-border-hover)] rounded focus:outline-none focus:ring-1 focus:ring-primary-400"

--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -68,11 +68,14 @@ export default function NoteMarkdownEditor({
 
   const stats = useMemo(() => getNoteStats(displayContent), [displayContent]);
 
-  const handleTitleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      textareaRef.current?.focus();
-    }
+  const handleTitleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>) => {
+    // IME 変換中の Enter（日本語入力の確定）はフォーカス移動しない。
+    // ここを判定しないと「変換確定の Enter」で textarea にフォーカスが飛び、
+    // 直前の未確定文字列（"ついて" など）がそのまま textarea に入力されてしまう。
+    if (e.key !== 'Enter') return;
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+    e.preventDefault();
+    textareaRef.current?.focus();
   }, []);
 
   const handleCopy = useCallback(async () => {

--- a/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
@@ -72,4 +72,22 @@ describe('NoteMarkdownEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
     expect(screen.getByText('プレビューするコンテンツがありません')).toBeInTheDocument();
   });
+
+  // IME 変換中の Enter（日本語入力の確定）はフォーカス移動しない（誤って textarea に飛んで
+  // 未確定文字列が紛れ込む事故の再発防止）。
+  it('タイトルで IME 変換中の Enter は textarea にフォーカスを移さない', () => {
+    renderEditor();
+    const titleInput = screen.getByRole('textbox', { name: 'ノートのタイトル' });
+    titleInput.focus();
+    fireEvent.keyDown(titleInput, { key: 'Enter', isComposing: true });
+    expect(document.activeElement).toBe(titleInput);
+  });
+
+  it('タイトルで通常の Enter は textarea にフォーカスを移す', () => {
+    renderEditor();
+    const titleInput = screen.getByRole('textbox', { name: 'ノートのタイトル' });
+    titleInput.focus();
+    fireEvent.keyDown(titleInput, { key: 'Enter' });
+    expect(document.activeElement).toBe(getMarkdownTextarea());
+  });
 });


### PR DESCRIPTION
## バグ

新ノートエディタ ([NoteMarkdownEditor](frontend/src/components/NoteMarkdownEditor.tsx)) のタイトル入力で、 日本語 IME 変換中に変換確定の Enter を押すと textarea にフォーカスが飛んでしまい、 直前まで未確定だった文字列が textarea にそのまま入力される事故が起きていた。

**再現例**: タイトル「Node.jsについて」で「につい」まで打って IME で「ついて」を変換 → Enter 確定 → タイトルが「Node.js」のまま、 本文に「ついて」が挿入される。

## 修正

`handleTitleKeyDown` で `e.nativeEvent.isComposing`（および keyCode 229）をチェックし、 変換中の Enter は通常の確定操作として透過させる。 通常の Enter のみ textarea へのフォーカス移動を実行する。

同じ IME バグが [AiSessionListItem](frontend/src/components/AiSessionListItem.tsx) の「セッションタイトル編集」にもあった（変換確定で `onSaveTitle` が誤発火）ので合わせて修正。

## テスト

新規 2 件:
- IME 変換中 Enter で textarea にフォーカスが移らないこと
- 通常 Enter で textarea にフォーカスが移ること

- [x] `tsc --noEmit`
- [x] `vitest run`（1736 件 全 pass）
- [x] `npm run build`