### PR TITLE
feat(teaching-materials): company_admin 用の Markdown 教材機能を追加

### DIFF
--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -1,0 +1,25 @@
+package domain
+
+import "time"
+
+// TeachingMaterial は company_admin が自社 trainee 向けに作成する教材。
+//
+// アクセス制御:
+//   - same company の company_admin: 自社の教材を全件 list / 編集 / 削除可
+//   - same company の trainee: 自社の `is_published=true` 教材のみ閲覧可
+//   - super_admin: 横断的に閲覧可（運用上の監査）
+//
+// 本文 (`Content`) は raw Markdown 文字列で保存し、 フロントは Edit / Preview タブで
+// 表示する（Note と同じ形式）。
+type TeachingMaterial struct {
+	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`
+	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
+	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
+	Content         string    `gorm:"column:content;type:text;not null;default:''" json:"content"`
+	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
+	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt       time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (TeachingMaterial) TableName() string { return "teaching_materials" }

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -72,6 +72,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerEmbedRoutes(authed)
 	registerExerciseRoutes(authed, deps)
 	registerLearningReportRoutes(authed, deps)
+	registerTeachingMaterialRoutes(authed, deps)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 
 	return r

--- a/backend/internal/handler/routes_teaching_materials.go
+++ b/backend/internal/handler/routes_teaching_materials.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerTeachingMaterialRoutes は教材 API 5 本を登録する:
+//
+//	GET    /api/v2/teaching-materials      一覧
+//	GET    /api/v2/teaching-materials/:id  詳細
+//	POST   /api/v2/teaching-materials      作成（company_admin / super_admin）
+//	PUT    /api/v2/teaching-materials/:id  更新（同上）
+//	DELETE /api/v2/teaching-materials/:id  削除（同上）
+//
+// アクセス制御は usecase 層で actor の company_id / role を検証する。
+// trainee は同一 company の `is_published=true` 教材のみ閲覧可。
+func registerTeachingMaterialRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	repo := repository.NewTeachingMaterialRepository(deps.db)
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	h := NewTeachingMaterialHandler(uc)
+	g.GET("/teaching-materials", h.List)
+	g.GET("/teaching-materials/:id", h.Get)
+	g.POST("/teaching-materials", h.Create)
+	g.PUT("/teaching-materials/:id", h.Update)
+	g.DELETE("/teaching-materials/:id", h.Delete)
+}

--- a/backend/internal/handler/teaching_material_handler.go
+++ b/backend/internal/handler/teaching_material_handler.go
@@ -1,0 +1,175 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
+)
+
+// TeachingMaterialHandler は教材 API を扱う。
+//
+//	GET    /api/v2/teaching-materials      一覧（actor role / company で自動フィルタ）
+//	GET    /api/v2/teaching-materials/:id  詳細
+//	POST   /api/v2/teaching-materials      作成（company_admin / super_admin）
+//	PUT    /api/v2/teaching-materials/:id  更新（同上）
+//	DELETE /api/v2/teaching-materials/:id  削除（同上）
+type TeachingMaterialHandler struct {
+	uc *usecase.TeachingMaterialUseCase
+}
+
+func NewTeachingMaterialHandler(uc *usecase.TeachingMaterialUseCase) *TeachingMaterialHandler {
+	return &TeachingMaterialHandler{uc: uc}
+}
+
+func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, string, bool) {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return 0, 0, "", false
+	}
+	companyID := uint64(0)
+	if user.CompanyID != nil {
+		companyID = *user.CompanyID
+	}
+	return user.ID, companyID, user.Role, true
+}
+
+// List は GET /api/v2/teaching-materials 。
+func (h *TeachingMaterialHandler) List(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	rows, err := h.uc.List(c.Request.Context(), companyID, role)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "教材の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// Get は GET /api/v2/teaching-materials/:id 。
+func (h *TeachingMaterialHandler) Get(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	m, err := h.uc.Get(c.Request.Context(), id, companyID, role)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "教材が見つかりません"})
+			return
+		}
+		// usecase が "forbidden" を返したら 403。
+		if err.Error() == "forbidden" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "閲覧権限がありません"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "教材の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, m)
+}
+
+type teachingMaterialRequest struct {
+	Title       string `json:"title"`
+	Content     string `json:"content"`
+	IsPublished bool   `json:"isPublished"`
+}
+
+// Create は POST /api/v2/teaching-materials 。
+func (h *TeachingMaterialHandler) Create(c *gin.Context) {
+	uid, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	var req teachingMaterialRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	m, err := h.uc.Create(c.Request.Context(), usecase.CreateTeachingMaterialInput{
+		ActorUserID:    uid,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Content:        req.Content,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondTeachingMaterialErr(c, err, "教材の作成に失敗しました")
+		return
+	}
+	c.JSON(http.StatusCreated, m)
+}
+
+// Update は PUT /api/v2/teaching-materials/:id 。
+func (h *TeachingMaterialHandler) Update(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var req teachingMaterialRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	m, err := h.uc.Update(c.Request.Context(), usecase.UpdateTeachingMaterialInput{
+		ID:             id,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Content:        req.Content,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondTeachingMaterialErr(c, err, "教材の更新に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, m)
+}
+
+// Delete は DELETE /api/v2/teaching-materials/:id 。
+func (h *TeachingMaterialHandler) Delete(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.uc.Delete(c.Request.Context(), id, companyID, role); err != nil {
+		respondTeachingMaterialErr(c, err, "教材の削除に失敗しました")
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func respondTeachingMaterialErr(c *gin.Context, err error, fallback string) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "教材が見つかりません"})
+		return
+	}
+	if err.Error() == "forbidden" || err.Error() == "forbidden: only company_admin or super_admin can create materials" || err.Error() == "actor must belong to a company" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
+}

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -31,6 +31,7 @@ func allDomainModels() []any {
 		&domain.CompanyExercise{},
 		&domain.ExerciseSubmission{},
 		&domain.Company{},
+		&domain.TeachingMaterial{},
 	}
 }
 

--- a/backend/internal/repository/teaching_material_repository.go
+++ b/backend/internal/repository/teaching_material_repository.go
@@ -1,0 +1,65 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// TeachingMaterialRepository は教材の永続化を担う。
+//
+// クエリは原則 company_id 指定で発行することで、 他社の教材が
+// アプリ層のバグで漏れる事故を予防する（最後の防衛線として）。
+type TeachingMaterialRepository interface {
+	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
+	GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error)
+	Create(ctx context.Context, m *domain.TeachingMaterial) error
+	Update(ctx context.Context, m *domain.TeachingMaterial) error
+	Delete(ctx context.Context, id uint64) error
+}
+
+type teachingMaterialRepository struct {
+	db *gorm.DB
+}
+
+func NewTeachingMaterialRepository(db *gorm.DB) TeachingMaterialRepository {
+	return &teachingMaterialRepository{db: db}
+}
+
+func (r *teachingMaterialRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	var rows []domain.TeachingMaterial
+	q := r.db.WithContext(ctx).Where("company_id = ?", companyID)
+	if !includeUnpublished {
+		q = q.Where("is_published = ?", true)
+	}
+	if err := q.Order("updated_at desc, id desc").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *teachingMaterialRepository) GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error) {
+	var m domain.TeachingMaterial
+	if err := r.db.WithContext(ctx).First(&m, id).Error; err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+func (r *teachingMaterialRepository) Create(ctx context.Context, m *domain.TeachingMaterial) error {
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *teachingMaterialRepository) Update(ctx context.Context, m *domain.TeachingMaterial) error {
+	// 一部カラムのみ更新（CreatedBy / CompanyID は不変）。
+	return r.db.WithContext(ctx).Model(m).Updates(map[string]any{
+		"title":        m.Title,
+		"content":      m.Content,
+		"is_published": m.IsPublished,
+	}).Error
+}
+
+func (r *teachingMaterialRepository) Delete(ctx context.Context, id uint64) error {
+	return r.db.WithContext(ctx).Delete(&domain.TeachingMaterial{}, id).Error
+}

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -1,0 +1,142 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// TeachingMaterialUseCase は教材機能の 5 操作（list / get / create / update / delete）を
+// まとめて 1 構造体で扱う。 各操作は独立した Execute メソッドではなく
+// 名前付きメソッドにすることで、 handler 側のディスパッチを単純化する。
+//
+// アクセス制御:
+//   - List: 同一 company の company_admin / trainee / super_admin
+//   - trainee は published のみ、 company_admin / super_admin は draft 含む全件
+//   - Get: 同一 company か super_admin
+//   - trainee は published のみ閲覧可
+//   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
+type TeachingMaterialUseCase struct {
+	repo repository.TeachingMaterialRepository
+}
+
+func NewTeachingMaterialUseCase(repo repository.TeachingMaterialRepository) *TeachingMaterialUseCase {
+	return &TeachingMaterialUseCase{repo: repo}
+}
+
+// canManage は教材を作成 / 編集 / 削除できる role 判定。
+func canManage(role string) bool {
+	return role == domain.RoleCompanyAdmin || role == domain.RoleSuperAdmin
+}
+
+// List は actor の role / company に応じて閲覧可能な教材一覧を返す。
+//   - companyID=0 のユーザ（super_admin で会社未紐付け等）は空配列を返す
+//   - super_admin かつ companyID=0 でも、 トップで会社全体管理する画面は別途用意する想定で、
+//     ここでは「自分の company に紐付く教材だけ」に絞る
+func (uc *TeachingMaterialUseCase) List(ctx context.Context, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
+	if actorCompanyID == 0 {
+		return []domain.TeachingMaterial{}, nil
+	}
+	includeUnpublished := canManage(actorRole)
+	return uc.repo.ListByCompany(ctx, actorCompanyID, includeUnpublished)
+}
+
+// Get は ID 指定で 1 件取得する。 actor の company と一致しないと 403 相当（nil）。
+func (uc *TeachingMaterialUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.TeachingMaterial, error) {
+	m, err := uc.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canRead(m, actorCompanyID, actorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	return m, nil
+}
+
+func canRead(m *domain.TeachingMaterial, actorCompanyID uint64, actorRole string) bool {
+	if actorRole == domain.RoleSuperAdmin {
+		return true
+	}
+	if m.CompanyID != actorCompanyID {
+		return false
+	}
+	if !m.IsPublished && !canManage(actorRole) {
+		return false
+	}
+	return true
+}
+
+// CreateInput は POST 入力。
+type CreateTeachingMaterialInput struct {
+	ActorUserID    uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Content        string
+	IsPublished    bool
+}
+
+func (uc *TeachingMaterialUseCase) Create(ctx context.Context, in CreateTeachingMaterialInput) (*domain.TeachingMaterial, error) {
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden: only company_admin or super_admin can create materials")
+	}
+	if in.ActorCompanyID == 0 {
+		return nil, fmt.Errorf("actor must belong to a company")
+	}
+	m := &domain.TeachingMaterial{
+		CompanyID:       in.ActorCompanyID,
+		CreatedByUserID: in.ActorUserID,
+		Title:           in.Title,
+		Content:         in.Content,
+		IsPublished:     in.IsPublished,
+	}
+	if err := uc.repo.Create(ctx, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+type UpdateTeachingMaterialInput struct {
+	ID             uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Content        string
+	IsPublished    bool
+}
+
+func (uc *TeachingMaterialUseCase) Update(ctx context.Context, in UpdateTeachingMaterialInput) (*domain.TeachingMaterial, error) {
+	existing, err := uc.repo.GetByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	if in.ActorRole != domain.RoleSuperAdmin && existing.CompanyID != in.ActorCompanyID {
+		return nil, fmt.Errorf("forbidden")
+	}
+	existing.Title = in.Title
+	existing.Content = in.Content
+	existing.IsPublished = in.IsPublished
+	if err := uc.repo.Update(ctx, existing); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+func (uc *TeachingMaterialUseCase) Delete(ctx context.Context, id, actorCompanyID uint64, actorRole string) error {
+	existing, err := uc.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canManage(actorRole) {
+		return fmt.Errorf("forbidden")
+	}
+	if actorRole != domain.RoleSuperAdmin && existing.CompanyID != actorCompanyID {
+		return fmt.Errorf("forbidden")
+	}
+	return uc.repo.Delete(ctx, id)
+}

--- a/backend/internal/usecase/teaching_material_usecase_test.go
+++ b/backend/internal/usecase/teaching_material_usecase_test.go
@@ -1,0 +1,189 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTeachingMaterialRepo は usecase テスト用フェイク。
+type fakeTeachingMaterialRepo struct {
+	rows    []domain.TeachingMaterial
+	getResp *domain.TeachingMaterial
+	getErr  error
+	created *domain.TeachingMaterial
+	updated *domain.TeachingMaterial
+	deleted uint64
+	// list 呼び出し時の引数記録
+	listCompany      uint64
+	listIncludeDraft bool
+}
+
+func (r *fakeTeachingMaterialRepo) ListByCompany(_ context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	r.listCompany, r.listIncludeDraft = companyID, includeUnpublished
+	return r.rows, nil
+}
+func (r *fakeTeachingMaterialRepo) GetByID(_ context.Context, _ uint64) (*domain.TeachingMaterial, error) {
+	return r.getResp, r.getErr
+}
+func (r *fakeTeachingMaterialRepo) Create(_ context.Context, m *domain.TeachingMaterial) error {
+	m.ID = 99
+	r.created = m
+	return nil
+}
+func (r *fakeTeachingMaterialRepo) Update(_ context.Context, m *domain.TeachingMaterial) error {
+	r.updated = m
+	return nil
+}
+func (r *fakeTeachingMaterialRepo) Delete(_ context.Context, id uint64) error {
+	r.deleted = id
+	return nil
+}
+
+func TestTeachingMaterialUseCase_List_TraineeOnlyPublished(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.List(context.Background(), 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10), repo.listCompany)
+	assert.False(t, repo.listIncludeDraft, "trainee は draft を含まない")
+}
+
+func TestTeachingMaterialUseCase_List_CompanyAdminIncludesDraft(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.List(context.Background(), 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.True(t, repo.listIncludeDraft)
+}
+
+func TestTeachingMaterialUseCase_List_NoCompanyReturnsEmpty(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{rows: []domain.TeachingMaterial{{ID: 1}}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	out, err := uc.List(context.Background(), 0, domain.RoleSuperAdmin)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestTeachingMaterialUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, IsPublished: false,
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, IsPublished: true,
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	got, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), got.ID)
+}
+
+func TestTeachingMaterialUseCase_Get_CrossCompanyForbidden(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, IsPublished: true,
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.Get(context.Background(), 1, 99, domain.RoleCompanyAdmin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_Get_SuperAdminCrossCompanyAllowed(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, IsPublished: false,
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	got, err := uc.Get(context.Background(), 1, 99, domain.RoleSuperAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), got.ID)
+}
+
+func TestTeachingMaterialUseCase_Create_TraineeForbidden(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
+		Title: "X", Content: "Y", IsPublished: true,
+	})
+	require.Error(t, err)
+}
+
+func TestTeachingMaterialUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	got, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "Spring 入門", Content: "# Spring", IsPublished: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, repo.created)
+	assert.Equal(t, uint64(7), repo.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), repo.created.CompanyID)
+	assert.Equal(t, "Spring 入門", got.Title)
+}
+
+func TestTeachingMaterialUseCase_Create_NoCompanyForbidden(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X",
+	})
+	require.Error(t, err)
+}
+
+func TestTeachingMaterialUseCase_Update_CrossCompanyForbidden(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, Title: "old",
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	_, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
+		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
+	})
+	require.Error(t, err)
+	assert.Nil(t, repo.updated)
+}
+
+func TestTeachingMaterialUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, Title: "old",
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	got, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
+		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "new", Content: "X", IsPublished: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Title)
+	assert.NotNil(t, repo.updated)
+}
+
+func TestTeachingMaterialUseCase_Delete_TraineeForbidden(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10,
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
+	require.Error(t, err)
+}
+
+func TestTeachingMaterialUseCase_Delete_SameCompanyAdminSucceeds(t *testing.T) {
+	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10,
+	}}
+	uc := usecase.NewTeachingMaterialUseCase(repo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), repo.deleted)
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ const AdminInvitationsPage = lazyWithReload(() => import('./pages/AdminInvitatio
 const AdminCompaniesPage = lazyWithReload(() => import('./pages/AdminCompaniesPage'), 'AdminCompaniesPage');
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
+const TeachingMaterialsPage = lazyWithReload(() => import('./pages/TeachingMaterialsPage'), 'TeachingMaterialsPage');
 
 function NavigationToast() {
   const location = useLocation();
@@ -117,6 +118,7 @@ export default function App() {
         <Route path="/help" element={<HelpPage />} />
         <Route path="/code-editor" element={<ExerciseListPage />} />
         <Route path="/code-editor/:slug" element={<ExerciseDetailPage />} />
+        <Route path="/teaching-materials" element={<TeachingMaterialsPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   BuildingOffice2Icon,
   ChevronDoubleLeftIcon,
   ChevronDoubleRightIcon,
+  AcademicCapIcon,
 } from '@heroicons/react/24/outline';
 import Loading from '../Loading';
 import { useSidebar } from '../../hooks/useSidebar';
@@ -43,6 +44,7 @@ const mainNavItems: NavItem[] = [
   { id: 'home', icon: HomeIcon, label: 'ホーム', to: '/', matchExact: true },
   { id: 'ai', icon: ChatBubbleBottomCenterTextIcon, label: 'AI', to: '/chat/ask-ai', matchPrefix: '/chat/ask-ai' },
   { id: 'code', icon: CodeBracketIcon, label: 'コード学習', to: '/code-editor', matchPrefix: '/code-editor' },
+  { id: 'materials', icon: AcademicCapIcon, label: '教材', to: '/teaching-materials', matchPrefix: '/teaching-materials' },
   { id: 'notes', icon: DocumentTextIcon, label: 'ノート', to: '/notes', matchPrefix: '/notes' },
   { id: 'notifications', icon: BellIcon, label: '通知', to: '/notifications', matchExact: true },
   { id: 'reports', icon: DocumentChartBarIcon, label: 'レポート', to: '/reports', matchExact: true },

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -169,4 +169,10 @@ export const CODE = {
   execute: `${API_V2}/code/execute`,
 } as const;
 
+/** 教材（company_admin が作成、 自社 trainee + 同社 admin が閲覧）*/
+export const TEACHING_MATERIALS = {
+  list: `${API_V2}/teaching-materials`,
+  byId: (id: number | string) => `${API_V2}/teaching-materials/${id}`,
+} as const;
+
 // WebSocket は SSE (AI_CHAT.stream) への置換で廃止 (PR-D, 2026-05-07)。

--- a/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useTeachingMaterials } from '../useTeachingMaterials';
+import TeachingMaterialRepository from '../../repositories/TeachingMaterialRepository';
+
+vi.mock('../../repositories/TeachingMaterialRepository', () => ({
+  default: {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const mocks = vi.mocked(TeachingMaterialRepository);
+
+const sample = (id: number, overrides: Partial<{ title: string; isPublished: boolean }> = {}) => ({
+  id,
+  companyId: 1,
+  createdByUserId: 1,
+  title: overrides.title ?? `教材${id}`,
+  content: '',
+  isPublished: overrides.isPublished ?? true,
+  createdAt: '',
+  updatedAt: '',
+});
+
+describe('useTeachingMaterials', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('初期化で list が呼ばれて結果が state に入る', async () => {
+    mocks.list.mockResolvedValue([sample(1), sample(2)]);
+    const { result } = renderHook(() => useTeachingMaterials());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.materials).toHaveLength(2);
+  });
+
+  it('list 失敗時に error をセット', async () => {
+    mocks.list.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useTeachingMaterials());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toBe('教材の取得に失敗しました');
+  });
+
+  it('searchQuery でタイトル / 本文がフィルタされる', async () => {
+    mocks.list.mockResolvedValue([
+      sample(1, { title: 'PHP 入門' }),
+      sample(2, { title: 'Go 入門' }),
+    ]);
+    const { result } = renderHook(() => useTeachingMaterials());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.setSearchQuery('php'));
+    expect(result.current.filtered).toHaveLength(1);
+    expect(result.current.filtered[0].title).toBe('PHP 入門');
+  });
+
+  it('create 成功時にリスト先頭に追加され selected になる', async () => {
+    mocks.list.mockResolvedValue([]);
+    mocks.create.mockResolvedValue(sample(99));
+    const { result } = renderHook(() => useTeachingMaterials());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    await act(async () => {
+      await result.current.create({ title: '新', content: '', isPublished: false });
+    });
+    expect(result.current.materials[0].id).toBe(99);
+    expect(result.current.selectedId).toBe(99);
+  });
+
+  it('remove 成功時にリストから消え selected もクリア', async () => {
+    mocks.list.mockResolvedValue([sample(1)]);
+    mocks.remove.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTeachingMaterials());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    act(() => result.current.selectMaterial(1));
+    await act(async () => {
+      await result.current.remove(1);
+    });
+    expect(result.current.materials).toHaveLength(0);
+    expect(result.current.selectedId).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useTeachingMaterialEditor.ts
+++ b/frontend/src/hooks/useTeachingMaterialEditor.ts
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TeachingMaterial } from '../types';
+import type { SaveStatus } from './useNoteEditor';
+
+interface Args {
+  selectedId: number | null;
+  selected: TeachingMaterial | null;
+  update: (
+    id: number,
+    payload: { title: string; content: string; isPublished: boolean },
+  ) => Promise<void>;
+}
+
+/**
+ * useTeachingMaterialEditor — 教材詳細の編集 + autosave 制御。
+ * 構造は useNoteEditor と同等で、 isPublished の切替も含む。
+ */
+export function useTeachingMaterialEditor({ selectedId, selected, update }: Args) {
+  const [editTitle, setEditTitle] = useState('');
+  const [editContent, setEditContent] = useState('');
+  const [editIsPublished, setEditIsPublished] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (selected) {
+      setEditTitle(selected.title);
+      setEditContent(selected.content);
+      setEditIsPublished(selected.isPublished);
+    } else {
+      setEditTitle('');
+      setEditContent('');
+      setEditIsPublished(false);
+    }
+    setSaveStatus('idle');
+  }, [selectedId, selected]);
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, []);
+
+  const scheduleSave = useCallback(
+    (title: string, content: string, isPublished: boolean) => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      setSaveStatus('unsaved');
+      saveTimerRef.current = setTimeout(async () => {
+        if (selectedId == null) return;
+        setSaveStatus('saving');
+        try {
+          await update(selectedId, { title, content, isPublished });
+          setSaveStatus('saved');
+        } catch {
+          setSaveStatus('idle');
+        }
+      }, 800);
+    },
+    [selectedId, update],
+  );
+
+  const handleTitleChange = useCallback(
+    (title: string) => {
+      setEditTitle(title);
+      scheduleSave(title, editContent, editIsPublished);
+    },
+    [scheduleSave, editContent, editIsPublished],
+  );
+
+  const handleContentChange = useCallback(
+    (content: string) => {
+      setEditContent(content);
+      scheduleSave(editTitle, content, editIsPublished);
+    },
+    [scheduleSave, editTitle, editIsPublished],
+  );
+
+  const handleIsPublishedChange = useCallback(
+    (isPublished: boolean) => {
+      setEditIsPublished(isPublished);
+      scheduleSave(editTitle, editContent, isPublished);
+    },
+    [scheduleSave, editTitle, editContent],
+  );
+
+  return {
+    editTitle,
+    editContent,
+    editIsPublished,
+    saveStatus,
+    handleTitleChange,
+    handleContentChange,
+    handleIsPublishedChange,
+  };
+}

--- a/frontend/src/hooks/useTeachingMaterials.ts
+++ b/frontend/src/hooks/useTeachingMaterials.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import TeachingMaterialRepository, {
+  type TeachingMaterialPayload,
+} from '../repositories/TeachingMaterialRepository';
+import type { TeachingMaterial } from '../types';
+
+/**
+ * useTeachingMaterials — 教材一覧 + 選択 + CRUD の状態管理。
+ *
+ * NotesPage の useNotes と同じ「左パネル一覧 + 右パネル詳細」構成を想定。
+ * autosave は別 hook (useTeachingMaterialEditor) に分離する。
+ */
+export function useTeachingMaterials() {
+  const [materials, setMaterials] = useState<TeachingMaterial[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await TeachingMaterialRepository.list();
+      setMaterials(rows);
+    } catch {
+      setError('教材の取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const selected = useMemo(
+    () => materials.find((m) => m.id === selectedId) ?? null,
+    [materials, selectedId],
+  );
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return materials;
+    return materials.filter(
+      (m) => m.title.toLowerCase().includes(q) || m.content.toLowerCase().includes(q),
+    );
+  }, [materials, searchQuery]);
+
+  const create = useCallback(async (initial: TeachingMaterialPayload): Promise<TeachingMaterial | null> => {
+    try {
+      const created = await TeachingMaterialRepository.create(initial);
+      setMaterials((prev) => [created, ...prev]);
+      setSelectedId(created.id);
+      return created;
+    } catch {
+      setError('教材の作成に失敗しました');
+      return null;
+    }
+  }, []);
+
+  const update = useCallback(
+    async (id: number, payload: TeachingMaterialPayload): Promise<void> => {
+      try {
+        const updated = await TeachingMaterialRepository.update(id, payload);
+        setMaterials((prev) => prev.map((m) => (m.id === id ? updated : m)));
+      } catch {
+        setError('教材の更新に失敗しました');
+      }
+    },
+    [],
+  );
+
+  const remove = useCallback(
+    async (id: number): Promise<void> => {
+      try {
+        await TeachingMaterialRepository.remove(id);
+        setMaterials((prev) => prev.filter((m) => m.id !== id));
+        if (selectedId === id) setSelectedId(null);
+      } catch {
+        setError('教材の削除に失敗しました');
+      }
+    },
+    [selectedId],
+  );
+
+  return {
+    materials,
+    filtered,
+    selectedId,
+    selected,
+    loading,
+    error,
+    searchQuery,
+    setSearchQuery,
+    selectMaterial: setSelectedId,
+    fetchAll,
+    create,
+    update,
+    remove,
+  };
+}

--- a/frontend/src/pages/TeachingMaterialsPage.tsx
+++ b/frontend/src/pages/TeachingMaterialsPage.tsx
@@ -1,0 +1,368 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  AcademicCapIcon,
+  PlusIcon,
+  MagnifyingGlassIcon,
+  Bars3Icon,
+  TrashIcon,
+  CheckCircleIcon,
+  ClockIcon,
+} from '@heroicons/react/24/outline';
+import SecondaryPanel from '../components/layout/SecondaryPanel';
+import EmptyState from '../components/EmptyState';
+import ConfirmModal from '../components/ConfirmModal';
+import Loading from '../components/Loading';
+import NoteMarkdownEditor from '../components/NoteMarkdownEditor';
+import { useTeachingMaterials } from '../hooks/useTeachingMaterials';
+import { useTeachingMaterialEditor } from '../hooks/useTeachingMaterialEditor';
+import { useMobilePanelState } from '../hooks/useMobilePanelState';
+import { useToast } from '../hooks/useToast';
+import { useState } from 'react';
+import type { RootState } from '../store';
+import type { TeachingMaterial } from '../types';
+
+/**
+ * TeachingMaterialsPage — `/teaching-materials` 教材一覧 + 編集ページ。
+ *
+ * - company_admin / super_admin: 教材を作成 / 編集 / 削除 / 公開状態切替
+ * - trainee: 自社の `isPublished=true` 教材を閲覧のみ
+ *
+ * 左パネルに教材リスト、 右側に詳細（NoteMarkdownEditor 流用 = Edit/Preview タブ）。
+ */
+export default function TeachingMaterialsPage() {
+  const role = useSelector((s: RootState) => s.auth.role);
+  const canManage = role === 'company_admin' || role === 'super_admin';
+
+  const { showToast } = useToast();
+  const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
+
+  const {
+    materials,
+    filtered,
+    selectedId,
+    selected,
+    loading,
+    error,
+    searchQuery,
+    setSearchQuery,
+    selectMaterial,
+    create,
+    update,
+    remove,
+    fetchAll,
+  } = useTeachingMaterials();
+
+  const editor = useTeachingMaterialEditor({ selectedId, selected, update });
+
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const handleCreate = async () => {
+    const created = await create({ title: '無題の教材', content: '', isPublished: false });
+    if (created) {
+      showToast('success', '教材を作成しました');
+    } else {
+      showToast('error', '教材の作成に失敗しました');
+    }
+    closeMobilePanel();
+  };
+
+  const handleSelect = (id: number) => {
+    selectMaterial(id);
+    closeMobilePanel();
+  };
+
+  const handleConfirmDelete = async () => {
+    if (deleteTargetId == null) return;
+    await remove(deleteTargetId);
+    setDeleteTargetId(null);
+    showToast('success', '教材を削除しました');
+  };
+
+  return (
+    <div className="flex h-full">
+      <SecondaryPanel
+        title="教材"
+        badge={`${materials.length}件`}
+        mobileOpen={mobilePanelOpen}
+        onMobileClose={closeMobilePanel}
+        headerContent={
+          <div className="space-y-2">
+            <div className="relative">
+              <MagnifyingGlassIcon className="w-4 h-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />
+              <input
+                type="text"
+                placeholder="教材を検索..."
+                aria-label="教材を検索"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+              />
+            </div>
+            {canManage && (
+              <button
+                onClick={handleCreate}
+                className="w-full bg-primary-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors flex items-center justify-center gap-2"
+              >
+                <PlusIcon className="w-4 h-4" />
+                新しい教材
+              </button>
+            )}
+          </div>
+        }
+      >
+        <div className="p-2 space-y-0.5">
+          {loading && materials.length === 0 ? (
+            <Loading className="py-8" />
+          ) : filtered.length === 0 ? (
+            <div className="py-12">
+              <EmptyState
+                icon={AcademicCapIcon}
+                title={searchQuery ? '該当する教材がありません' : '教材がありません'}
+                description={
+                  searchQuery
+                    ? '検索条件を変更してみてください'
+                    : canManage
+                      ? '新しい教材を作成しましょう'
+                      : '管理者が教材を公開すると、 ここに表示されます'
+                }
+                action={canManage && !searchQuery ? { label: '新しい教材', onClick: handleCreate } : undefined}
+              />
+            </div>
+          ) : (
+            filtered.map((m) => (
+              <MaterialListItem
+                key={m.id}
+                material={m}
+                isActive={selectedId === m.id}
+                onSelect={handleSelect}
+                onDelete={canManage ? (id) => setDeleteTargetId(id) : undefined}
+              />
+            ))
+          )}
+        </div>
+      </SecondaryPanel>
+
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* モバイルヘッダー */}
+        <div className="md:hidden bg-surface-1 border-b border-surface-3 px-4 py-2 flex items-center">
+          <button
+            onClick={openMobilePanel}
+            className="p-1.5 hover:bg-surface-2 rounded transition-colors"
+            aria-label="教材一覧を開く"
+          >
+            <Bars3Icon className="w-5 h-5 text-[var(--color-text-muted)]" />
+          </button>
+          <span className="ml-2 text-xs text-[var(--color-text-muted)]">教材一覧</span>
+        </div>
+
+        {error && <p className="px-6 py-3 text-sm text-red-500">{error}</p>}
+
+        {selected ? (
+          canManage ? (
+            <ManagedDetail
+              editor={editor}
+            />
+          ) : (
+            <ReadOnlyDetail material={selected} />
+          )
+        ) : (
+          <EmptyState
+            icon={AcademicCapIcon}
+            title="教材を選択してください"
+            description={
+              canManage
+                ? '左のリストから教材を選択するか、 新しい教材を作成しましょう。'
+                : '左のリストから教材を選択してください。'
+            }
+            action={canManage ? { label: '新しい教材', onClick: handleCreate } : undefined}
+          />
+        )}
+      </div>
+
+      <ConfirmModal
+        isOpen={deleteTargetId !== null}
+        message="この教材を削除しますか？ 削除後は trainee からも見えなくなります。"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeleteTargetId(null)}
+      />
+    </div>
+  );
+}
+
+function MaterialListItem({
+  material,
+  isActive,
+  onSelect,
+  onDelete,
+}: {
+  material: TeachingMaterial;
+  isActive: boolean;
+  onSelect: (id: number) => void;
+  onDelete?: (id: number) => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(material.id)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect(material.id);
+        }
+      }}
+      className={`group flex items-start gap-2 px-3 py-2 rounded-md cursor-pointer transition-colors ${
+        isActive
+          ? 'bg-[var(--color-nav-active)]'
+          : 'hover:bg-[var(--color-nav-hover)]'
+      }`}
+    >
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5">
+          {material.isPublished
+            ? <CheckCircleIcon className="w-3 h-3 text-green-400 flex-shrink-0" />
+            : <ClockIcon className="w-3 h-3 text-amber-400 flex-shrink-0" />}
+          <p className="text-sm text-[var(--color-text-primary)] truncate font-medium">
+            {material.title || '無題の教材'}
+          </p>
+        </div>
+        <p className="text-xs text-[var(--color-text-muted)] mt-0.5 truncate">
+          {material.isPublished ? '公開中' : '下書き'} ・ {formatDate(material.updatedAt)}
+        </p>
+      </div>
+      {onDelete && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(material.id);
+          }}
+          className="opacity-0 group-hover:opacity-100 p-1 hover:bg-red-900/30 rounded transition-opacity"
+          aria-label="教材を削除"
+        >
+          <TrashIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)] hover:text-red-400" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+function ManagedDetail({
+  editor,
+}: {
+  editor: ReturnType<typeof useTeachingMaterialEditor>;
+}) {
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <div className="px-6 pt-4 pb-2 flex items-center justify-end gap-2 border-b border-surface-3">
+        <label className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={editor.editIsPublished}
+            onChange={(e) => editor.handleIsPublishedChange(e.target.checked)}
+            className="rounded border-surface-3"
+          />
+          trainee に公開
+        </label>
+      </div>
+      <div className="flex-1 min-h-0">
+        <NoteMarkdownEditor
+          title={editor.editTitle}
+          content={editor.editContent}
+          saveStatus={editor.saveStatus}
+          onTitleChange={editor.handleTitleChange}
+          onContentChange={editor.handleContentChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ReadOnlyDetail({ material }: { material: TeachingMaterial }) {
+  // trainee は読み取り専用のため、 NoteMarkdownEditor を Preview 固定状態で渡す代わりに
+  // 簡易的な表示モードにする（編集不可なので saveStatus / 入力は不要）。
+  return (
+    <div className="flex-1 overflow-y-auto p-6 max-w-3xl mx-auto w-full">
+      <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">
+        {material.title || '無題の教材'}
+      </h1>
+      <p className="text-xs text-[var(--color-text-muted)] mb-6">
+        最終更新: {formatDate(material.updatedAt)}
+      </p>
+      <div className="prose prose-invert prose-sm max-w-none">
+        {/* trainee は編集できないので NoteMarkdownEditor の onContentChange は no-op で
+            渡し、 Preview 表示扱いにする。 ただしカスタマイズが面倒なので、
+            最初から <ReactMarkdown> で描画する別経路にする。 */}
+        <ReadOnlyMarkdown content={material.content} />
+      </div>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())}`;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+// trainee の閲覧用に Markdown を render するだけのコンポーネント。
+// NoteMarkdownEditor の MarkdownView と同じだが import を分離しないために
+// 同じパッケージを直接使う。
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+import type { ReactNode } from 'react';
+
+function ReadOnlyMarkdown({ content }: { content: string }) {
+  if (!content.trim()) {
+    return <p className="text-[var(--color-text-muted)]">この教材にはまだ本文がありません。</p>;
+  }
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeHighlight]}
+      components={{
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-400 underline-offset-2 hover:underline"
+          >
+            {children as ReactNode}
+          </a>
+        ),
+        code: ({ className, children, ...props }) => {
+          const isBlock = className?.includes('language-');
+          if (isBlock) {
+            return (
+              <code className={className} {...props}>
+                {children as ReactNode}
+              </code>
+            );
+          }
+          return (
+            <code className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[0.85em]">
+              {children as ReactNode}
+            </code>
+          );
+        },
+        table: ({ children }) => (
+          <div className="overflow-x-auto">
+            <table className="text-sm border-collapse">{children as ReactNode}</table>
+          </div>
+        ),
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}

--- a/frontend/src/repositories/TeachingMaterialRepository.ts
+++ b/frontend/src/repositories/TeachingMaterialRepository.ts
@@ -1,0 +1,43 @@
+import api from '../lib/axios';
+import { TEACHING_MATERIALS } from '../constants/apiRoutes';
+import type { TeachingMaterial } from '../types';
+
+/**
+ * 教材 API ラッパ。
+ *
+ * actor の role / company は backend 側で context から取り出して自動フィルタするため、
+ * フロントは company_id を渡さない（IDOR 対策）。
+ */
+export interface TeachingMaterialPayload {
+  title: string;
+  content: string;
+  isPublished: boolean;
+}
+
+const TeachingMaterialRepository = {
+  async list(): Promise<TeachingMaterial[]> {
+    const res = await api.get<TeachingMaterial[]>(TEACHING_MATERIALS.list);
+    return res.data;
+  },
+
+  async get(id: number): Promise<TeachingMaterial> {
+    const res = await api.get<TeachingMaterial>(TEACHING_MATERIALS.byId(id));
+    return res.data;
+  },
+
+  async create(payload: TeachingMaterialPayload): Promise<TeachingMaterial> {
+    const res = await api.post<TeachingMaterial>(TEACHING_MATERIALS.list, payload);
+    return res.data;
+  },
+
+  async update(id: number, payload: TeachingMaterialPayload): Promise<TeachingMaterial> {
+    const res = await api.put<TeachingMaterial>(TEACHING_MATERIALS.byId(id), payload);
+    return res.data;
+  },
+
+  async remove(id: number): Promise<void> {
+    await api.delete(TEACHING_MATERIALS.byId(id));
+  },
+};
+
+export default TeachingMaterialRepository;

--- a/frontend/src/repositories/__tests__/TeachingMaterialRepository.test.ts
+++ b/frontend/src/repositories/__tests__/TeachingMaterialRepository.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+import TeachingMaterialRepository from '../TeachingMaterialRepository';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPost = vi.mocked(apiClient.post);
+const mockedPut = vi.mocked(apiClient.put);
+const mockedDelete = vi.mocked(apiClient.delete);
+
+describe('TeachingMaterialRepository', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('list は /api/v2/teaching-materials を GET する', async () => {
+    mockedGet.mockResolvedValue({ data: [] });
+    await TeachingMaterialRepository.list();
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/teaching-materials');
+  });
+
+  it('get は ID 付きで GET する', async () => {
+    mockedGet.mockResolvedValue({ data: { id: 5, title: 'X' } });
+    const m = await TeachingMaterialRepository.get(5);
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/teaching-materials/5');
+    expect(m.id).toBe(5);
+  });
+
+  it('create は POST する', async () => {
+    mockedPost.mockResolvedValue({ data: { id: 1 } });
+    await TeachingMaterialRepository.create({ title: 'a', content: 'b', isPublished: true });
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/teaching-materials', {
+      title: 'a',
+      content: 'b',
+      isPublished: true,
+    });
+  });
+
+  it('update は PUT する', async () => {
+    mockedPut.mockResolvedValue({ data: { id: 1 } });
+    await TeachingMaterialRepository.update(1, { title: 'x', content: 'y', isPublished: false });
+    expect(mockedPut).toHaveBeenCalledWith('/api/v2/teaching-materials/1', {
+      title: 'x',
+      content: 'y',
+      isPublished: false,
+    });
+  });
+
+  it('remove は DELETE する', async () => {
+    mockedDelete.mockResolvedValue({});
+    await TeachingMaterialRepository.remove(7);
+    expect(mockedDelete).toHaveBeenCalledWith('/api/v2/teaching-materials/7');
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -538,6 +538,24 @@ export interface MasterExerciseDetail {
   examples: MasterExerciseExample[];
 }
 
+/**
+ * TeachingMaterial は Go backend `domain.TeachingMaterial` と 1:1。
+ * company_admin が自社 trainee 向けに作る Markdown 教材。
+ *
+ * - company_admin: 自社の draft 含む全件 list / 編集 / 削除可
+ * - trainee: 自社の `isPublished=true` のみ閲覧可
+ */
+export interface TeachingMaterial {
+  id: number;
+  companyId: number;
+  createdByUserId: number;
+  title: string;
+  content: string;
+  isPublished: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 /** 一覧 API (`GET /api/v2/exercises`) で返る集計値（Go backend `repository.ExerciseSubmissionStats`）。 */
 export interface ExerciseSubmissionStats {
   totalSubmissions: number;


### PR DESCRIPTION
## 概要

company_admin が自社 trainee 向けに Markdown 教材を作成 → 公開すると trainee が同社 (`company_id` 一致) の `is_published=true` 教材を閲覧できる機能。

ストレージは RDS (GORM + PostgreSQL)。 既存の Note / 演習問題と同じパターン。

## Backend (clean architecture)

### domain
- `TeachingMaterial`: id / company_id / created_by_user_id / title / content / is_published / timestamps。 GORM AutoMigrate 対象に登録

### repository
- `TeachingMaterialRepository`: ListByCompany / GetByID / Create / Update / Delete
- ListByCompany は `includeUnpublished` で trainee 向け公開のみ / admin 向け全件を切替

### usecase
- `TeachingMaterialUseCase` 1 構造体に List / Get / Create / Update / Delete を集約
- アクセス制御:
  - **List**: 同一 company の company_admin / super_admin は draft 含む全件、 trainee は published のみ
  - **Get**: cross-company は super_admin だけが超えられる
  - **Create / Update / Delete**: company_admin / super_admin のみ。 actor の company_id と教材の company_id が一致しないと forbidden

### handler / routes
- `POST/GET/PUT/DELETE /api/v2/teaching-materials[/:id]`
- middleware.CurrentUserFromContext から actor の company_id / role を取得して usecase に渡す（IDOR 対策で client から company_id を受け取らない）

## Frontend

- `TEACHING_MATERIALS` ルート定数 + `TeachingMaterialRepository`
- `useTeachingMaterials` (一覧 + 検索 + CRUD) + `useTeachingMaterialEditor` (autosave)
- [TeachingMaterialsPage](frontend/src/pages/TeachingMaterialsPage.tsx): 左パネルにリスト、 右に詳細
  - company_admin / super_admin: 「新しい教材」+ 編集 (NoteMarkdownEditor 流用) + 公開チェックボックス + 削除
  - trainee: 公開済みのみ閲覧、 ReactMarkdown レンダリングのみ
- Sidebar に「教材」ナビ追加（AcademicCapIcon）
- Route `/teaching-materials` を `App.tsx` に追加

## テスト

- backend usecase: 14 件（全アクセス制御パターン）
- frontend repository: 5 件（CRUD 5 メソッド）
- frontend hook (useTeachingMaterials): 5 件（fetch / filter / create / remove / error）
- 既存 1736 件 + 新規 24 件 = 1760 件 全 pass
- `go test ./...` / `tsc --noEmit` / `vitest run` / `eslint --max-warnings 0` / `npm run build` 全 green、 `gofmt -w` 適用済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 教材管理機能を追加しました。管理者は教材の作成、編集、削除、公開状態の管理ができるようになります。トレーニーは公開済み教材のみ閲覧可能です。検索機能とマークダウン形式での編集、リッチプレビューに対応しています。サイドバーの新しいナビゲーション項目から教材ページにアクセスできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->