### PR TITLE
feat(notes): Markdown 記法ヘルプページ + ノートからの導線

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,6 +52,7 @@
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.9.4",
         "rehype-highlight": "^7.0.2",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tippy.js": "^6.3.7",
         "tiptap-markdown": "^0.9.0"
@@ -6705,6 +6706,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -8573,6 +8588,21 @@
         "lowlight": "^3.0.0",
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.9.4",
     "rehype-highlight": "^7.0.2",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tippy.js": "^6.3.7",
     "tiptap-markdown": "^0.9.0"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ const AdminCompaniesPage = lazyWithReload(() => import('./pages/AdminCompaniesPa
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
 const TeachingMaterialsPage = lazyWithReload(() => import('./pages/TeachingMaterialsPage'), 'TeachingMaterialsPage');
+const MarkdownSyntaxHelpPage = lazyWithReload(() => import('./pages/MarkdownSyntaxHelpPage'), 'MarkdownSyntaxHelpPage');
 
 function NavigationToast() {
   const location = useLocation();
@@ -113,6 +114,7 @@ export default function App() {
         <Route path="/chat/ask-ai" element={<AskAiPage />} />
         <Route path="/chat/ask-ai/:sessionId" element={<AskAiPage />} />
         <Route path="/notes" element={<NotesPage />} />
+        <Route path="/notes/markdown-help" element={<MarkdownSyntaxHelpPage />} />
         <Route path="/notifications" element={<NotificationPage />} />
         <Route path="/reports" element={<LearningReportPage />} />
         <Route path="/help" element={<HelpPage />} />

--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeHighlight from 'rehype-highlight';
 import { ArrowDownTrayIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import type { SaveStatus } from '../hooks/useNoteEditor';
@@ -221,7 +222,7 @@ function convertLegacyContent(s: string): string {
 function MarkdownView({ content }: { content: string }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
       rehypePlugins={[rehypeHighlight]}
       components={{
         a: ({ href, children }) => (

--- a/frontend/src/pages/MarkdownSyntaxHelpPage.tsx
+++ b/frontend/src/pages/MarkdownSyntaxHelpPage.tsx
@@ -1,0 +1,256 @@
+import { Link } from 'react-router-dom';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+
+/**
+ * MarkdownSyntaxHelpPage — `/notes/markdown-help` で表示される Markdown 記法のチートシート。
+ *
+ * 構成:
+ *   - 左カラムに記法（コードブロック）/ 右カラムにレンダリング結果
+ *   - ノートの編集中に並べて参照できるように、 同じ全幅レイアウト
+ *
+ * Markdown は GitHub Flavored Markdown (remark-gfm) + remark の拡張記法をサポート。
+ * 表示はノート / 教材ページの NoteMarkdownEditor の Preview と同じレンダラーで動く前提。
+ */
+export default function MarkdownSyntaxHelpPage() {
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-5xl mx-auto space-y-6">
+      <header className="space-y-2">
+        <Link
+          to="/notes"
+          className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+        >
+          <ArrowLeftIcon className="w-3.5 h-3.5" />
+          ノートに戻る
+        </Link>
+        <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">Markdown 記法ヘルプ</h1>
+        <p className="text-sm text-[var(--color-text-tertiary)]">
+          ノート / 教材で使える Markdown の主要な記法をまとめたチートシートです。
+          コピーしてエディタに貼り付けるとそのまま動きます。
+        </p>
+      </header>
+
+      <Section title="見出し">
+        <Row code={`# 見出し 1\n## 見出し 2\n### 見出し 3`}>
+          <h1 className="text-2xl font-bold m-0 text-[var(--color-text-primary)]">見出し 1</h1>
+          <h2 className="text-xl font-semibold mt-2 text-[var(--color-text-primary)]">見出し 2</h2>
+          <h3 className="text-base font-semibold mt-2 text-[var(--color-text-primary)]">見出し 3</h3>
+        </Row>
+      </Section>
+
+      <Section title="文字装飾">
+        <Row code={`**太字** *斜体* ~~取り消し線~~\n\`インラインコード\``}>
+          <p className="m-0 text-[var(--color-text-primary)]">
+            <strong>太字</strong> <em>斜体</em> <s>取り消し線</s>{' '}
+            <code className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[0.85em]">
+              インラインコード
+            </code>
+          </p>
+        </Row>
+      </Section>
+
+      <Section title="リスト">
+        <Row
+          code={`- 順序なし 1\n- 順序なし 2\n  - ネスト\n\n1. 順序あり 1\n2. 順序あり 2`}
+        >
+          <ul className="m-0 list-disc pl-5 text-[var(--color-text-primary)]">
+            <li>順序なし 1</li>
+            <li>
+              順序なし 2
+              <ul className="list-disc pl-5">
+                <li>ネスト</li>
+              </ul>
+            </li>
+          </ul>
+          <ol className="mt-2 m-0 list-decimal pl-5 text-[var(--color-text-primary)]">
+            <li>順序あり 1</li>
+            <li>順序あり 2</li>
+          </ol>
+        </Row>
+      </Section>
+
+      <Section title="チェックリスト (GFM)">
+        <Row code={`- [ ] 未完了\n- [x] 完了`}>
+          <ul className="m-0 list-none pl-0 text-[var(--color-text-primary)]">
+            <li className="flex items-center gap-2">
+              <input type="checkbox" disabled />
+              未完了
+            </li>
+            <li className="flex items-center gap-2">
+              <input type="checkbox" disabled checked readOnly />
+              完了
+            </li>
+          </ul>
+        </Row>
+      </Section>
+
+      <Section title="リンク / 画像">
+        <Row
+          code={`[FreStyle](https://normanblog.com)\n\n![代替テキスト](https://placehold.jp/120x40.png)`}
+        >
+          <p className="m-0">
+            <a
+              href="https://normanblog.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-400 underline-offset-2 hover:underline"
+            >
+              FreStyle
+            </a>
+          </p>
+          <img
+            src="https://placehold.jp/120x40.png"
+            alt="代替テキスト"
+            className="mt-2 rounded"
+          />
+        </Row>
+      </Section>
+
+      <Section title="引用">
+        <Row code={`> 引用ブロック\n> 改行も入れられる`}>
+          <blockquote className="m-0 border-l-2 border-surface-3 pl-3 text-[var(--color-text-secondary)] italic">
+            引用ブロック<br />
+            改行も入れられる
+          </blockquote>
+        </Row>
+      </Section>
+
+      <Section title="コードブロック (言語指定)">
+        <Row
+          code={'```js\nfunction hello(name) {\n  return `Hello, ${name}!`;\n}\n```'}
+        >
+          <pre className="m-0 p-2 rounded bg-[var(--color-surface-3)] overflow-x-auto text-xs">
+            <code>
+              {`function hello(name) {\n  return \`Hello, \${name}!\`;\n}`}
+            </code>
+          </pre>
+        </Row>
+      </Section>
+
+      <Section title="表 (GFM)">
+        <Row
+          code={`| 列1 | 列2 | 列3 |\n|---|---|---|\n| a | b | c |\n| d | e | f |`}
+        >
+          <table className="m-0 text-xs border-collapse">
+            <thead>
+              <tr>
+                <th className="border border-surface-3 px-2 py-1">列1</th>
+                <th className="border border-surface-3 px-2 py-1">列2</th>
+                <th className="border border-surface-3 px-2 py-1">列3</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="border border-surface-3 px-2 py-1">a</td>
+                <td className="border border-surface-3 px-2 py-1">b</td>
+                <td className="border border-surface-3 px-2 py-1">c</td>
+              </tr>
+              <tr>
+                <td className="border border-surface-3 px-2 py-1">d</td>
+                <td className="border border-surface-3 px-2 py-1">e</td>
+                <td className="border border-surface-3 px-2 py-1">f</td>
+              </tr>
+            </tbody>
+          </table>
+        </Row>
+      </Section>
+
+      <Section title="水平線">
+        <Row code={`---`}>
+          <hr className="m-0 border-surface-3" />
+        </Row>
+      </Section>
+
+      <Section title="自動リンク (GFM)">
+        <Row code={`https://normanblog.com を直接書くだけでリンクになります`}>
+          <p className="m-0 text-[var(--color-text-primary)]">
+            <a
+              href="https://normanblog.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-400 underline-offset-2 hover:underline"
+            >
+              https://normanblog.com
+            </a>
+            を直接書くだけでリンクになります
+          </p>
+        </Row>
+      </Section>
+
+      <div className="rounded-lg border border-blue-500/30 bg-blue-500/5 p-4 text-sm text-[var(--color-text-secondary)]">
+        💡 もっと知りたい場合は{' '}
+        <a
+          href="https://github.github.com/gfm/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary-400 underline-offset-2 hover:underline"
+        >
+          GitHub Flavored Markdown 仕様
+        </a>{' '}
+        を参照してください。
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold text-[var(--color-text-secondary)] tracking-wide">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Row({ code, children }: { code: string; children: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      <CodeSnippet code={code} />
+      <div className="rounded-md border border-surface-3 bg-surface-1 p-3 prose prose-invert prose-sm max-w-none">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function CodeSnippet({ code }: { code: string }) {
+  return (
+    <div className="relative">
+      <pre className="m-0 p-3 rounded-md bg-surface-2 border border-surface-3 text-xs font-mono text-[var(--color-text-primary)] whitespace-pre-wrap break-words">
+        {code}
+      </pre>
+      <CopyButton text={code} />
+    </div>
+  );
+}
+
+import { useState } from 'react';
+import { ClipboardDocumentIcon, CheckIcon } from '@heroicons/react/24/outline';
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // クリップボード非対応環境では sileng fail。
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label="コードをコピー"
+      className="absolute top-2 right-2 p-1.5 rounded bg-surface-3/60 hover:bg-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors"
+    >
+      {copied ? (
+        <CheckIcon className="w-3.5 h-3.5 text-green-400" />
+      ) : (
+        <ClipboardDocumentIcon className="w-3.5 h-3.5" />
+      )}
+    </button>
+  );
+}

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -6,7 +6,8 @@ import EmptyState from '../components/EmptyState';
 import ConfirmModal from '../components/ConfirmModal';
 import Loading from '../components/Loading';
 import NoteSortMenu from '../components/NoteSortMenu';
-import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon, Bars3Icon } from '@heroicons/react/24/outline';
+import { DocumentTextIcon, PlusIcon, MagnifyingGlassIcon, Bars3Icon, QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
 import { useNotes } from '../hooks/useNotes';
 import { useNoteEditor } from '../hooks/useNoteEditor';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
@@ -97,6 +98,13 @@ export default function NotesPage() {
               <PlusIcon className="w-4 h-4" />
               新しいノート
             </button>
+            <Link
+              to="/notes/markdown-help"
+              className="w-full flex items-center justify-center gap-1.5 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] py-1 transition-colors"
+            >
+              <QuestionMarkCircleIcon className="w-3.5 h-3.5" />
+              Markdown 記法ヘルプ
+            </Link>
           </div>
         }
       >

--- a/frontend/src/pages/TeachingMaterialsPage.tsx
+++ b/frontend/src/pages/TeachingMaterialsPage.tsx
@@ -318,6 +318,7 @@ function pad(n: number): string {
 // 同じパッケージを直接使う。
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import rehypeHighlight from 'rehype-highlight';
 import type { ReactNode } from 'react';
 
@@ -327,7 +328,7 @@ function ReadOnlyMarkdown({ content }: { content: string }) {
   }
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
       rehypePlugins={[rehypeHighlight]}
       components={{
         a: ({ href, children }) => (

--- a/frontend/src/pages/__tests__/MarkdownSyntaxHelpPage.test.tsx
+++ b/frontend/src/pages/__tests__/MarkdownSyntaxHelpPage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MarkdownSyntaxHelpPage from '../MarkdownSyntaxHelpPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MarkdownSyntaxHelpPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('MarkdownSyntaxHelpPage', () => {
+  it('h1 にページタイトルを描画する', () => {
+    renderPage();
+    expect(
+      screen.getByRole('heading', { name: 'Markdown 記法ヘルプ', level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it('主要なセクション見出しを表示する', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: '見出し', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '文字装飾', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'リスト', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '表 (GFM)', level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'コードブロック (言語指定)', level: 2 })).toBeInTheDocument();
+  });
+
+  it('ノートに戻るリンクを表示する', () => {
+    renderPage();
+    const link = screen.getByRole('link', { name: /ノートに戻る/ });
+    expect(link).toHaveAttribute('href', '/notes');
+  });
+
+  it('コピーボタンが各 Row に配置される', () => {
+    renderPage();
+    const copyButtons = screen.getAllByRole('button', { name: 'コードをコピー' });
+    expect(copyButtons.length).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -1,6 +1,13 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render as rtlRender, screen, fireEvent, act, type RenderOptions } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactElement } from 'react';
 import NotesPage from '../NotesPage';
+
+// react-router-dom の Link が `/notes/markdown-help` 等で使われるため、
+// テストでは MemoryRouter で包む必要がある（PR #1687 で Markdown ヘルプリンク追加）。
+const render = (ui: ReactElement, options?: RenderOptions) =>
+  rtlRender(ui, { wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>, ...options });
 import { useNotes } from '../../hooks/useNotes';
 import type { Note } from '../../types';
 


### PR DESCRIPTION
## 概要

ノート / 教材編集中に Markdown 記法を確認できるチートシートページを追加。 GitHub README 風の Edit / Preview エディタに切替えてから「記法を覚えていない」ハードルが上がったので、 同じレイアウトでヘルプを参照できるように。

## 追加内容

### [/notes/markdown-help](frontend/src/pages/MarkdownSyntaxHelpPage.tsx)

- **見出し / 文字装飾 / リスト / チェックリスト / リンク・画像 / 引用 / コードブロック / 表 / 水平線 / 自動リンク** を網羅
- 左カラムにコード（**コピペ可能 / コピーボタン付き**）、 右カラムにレンダリング結果の 2 カラム比較
- GFM 拡張記法（チェックリスト・表・自動リンク）も含む
- 末尾に GFM 公式仕様へのリンク

### ノートからの導線

[NotesPage](frontend/src/pages/NotesPage.tsx) の検索 / 並び替え / 「新しいノート」ボタンの下に **「📖 Markdown 記法ヘルプ」** リンクを追加（小さめテキストリンク）。

## テスト

- MarkdownSyntaxHelpPage: 4 件（タイトル / セクション見出し / 戻るリンク / コピーボタンの個数）
- 既存 NotesPage テスト: `render` を `MemoryRouter` で包む helper に差し替え（Markdown ヘルプ Link 追加に伴う必須対応）

- [x] 全 1750 件 pass
- [x] `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build`