### PR TITLE
fix(markdown): @tailwindcss/typography を入れて prose クラスを実体化

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -60,6 +60,7 @@
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@playwright/test": "^1.59.1",
+        "@tailwindcss/typography": "^0.5.19",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/katex": "^0.16.8",
@@ -1909,6 +1910,33 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@playwright/test": "^1.59.1",
+    "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/katex": "^0.16.8",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+import typography from '@tailwindcss/typography';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
@@ -46,5 +48,7 @@ export default {
       },
     },
   },
-  plugins: [],
+  // @tailwindcss/typography: Markdown 描画 (ノート / 教材 / AI チャット) で `prose` クラスを使う。
+  // これで `# 見出し` `表` `リスト` `引用` などが標準の Typography スタイルで描画される。
+  plugins: [typography],
 };


### PR DESCRIPTION
## バグ

ノート / 教材の Markdown レンダリングで「見出しが大きくならない」「表が枠線なしのプレーンテキスト化する」「箇条書きが行流しになる」現象が発生。

## 原因

`prose` / `prose-invert` / `prose-sm` Tailwind クラスは `@tailwindcss/typography` プラグインが提供するもの。 これが **未インストール + `tailwind.config.js` の `plugins: []` に未登録** だったため、 クラスが完全に no-op になっていた。 `<h1>` 等の HTML は ReactMarkdown が正しく出力していたが、 グローバル CSS で見出しのサイズが reset されており、 prose の override が効かず素の小さい text のまま描画されていた。

## 修正

- `npm install -D @tailwindcss/typography` を実行
- [tailwind.config.js](frontend/tailwind.config.js) に `import typography` + `plugins: [typography]` を登録

これで:
- [NoteMarkdownEditor の Preview タブ](frontend/src/components/NoteMarkdownEditor.tsx)
- [TeachingMaterialsPage の ReadOnlyMarkdown](frontend/src/pages/TeachingMaterialsPage.tsx)
- MessageBubble の MarkdownView (AI チャット)

すべてで `prose` が活き、 GitHub README 風の見出し / 表 / リスト / 引用 / コードブロックの体裁になる。

## テスト

- [x] 既存 1750 件 全 pass
- [x] `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build`