### PR TITLE
fix(markdown): prose-invert を外してライトテーマで読める色に

### DIFF
--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -133,7 +133,7 @@ export default function NoteMarkdownEditor({
             className="w-full h-full resize-none p-4 rounded-md bg-surface-1 border border-surface-3 text-sm font-mono text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500/50 transition-colors"
           />
         ) : (
-          <div className="w-full h-full overflow-y-auto p-4 rounded-md bg-surface-1 border border-surface-3 prose prose-invert prose-sm max-w-none">
+          <div className="w-full h-full overflow-y-auto p-4 rounded-md bg-surface-1 border border-surface-3 prose prose-sm max-w-none">
             {displayContent.trim() ? (
               <MarkdownView content={displayContent} />
             ) : (

--- a/frontend/src/pages/MarkdownSyntaxHelpPage.tsx
+++ b/frontend/src/pages/MarkdownSyntaxHelpPage.tsx
@@ -207,7 +207,7 @@ function Row({ code, children }: { code: string; children: React.ReactNode }) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
       <CodeSnippet code={code} />
-      <div className="rounded-md border border-surface-3 bg-surface-1 p-3 prose prose-invert prose-sm max-w-none">
+      <div className="rounded-md border border-surface-3 bg-surface-1 p-3 prose prose-sm max-w-none">
         {children}
       </div>
     </div>

--- a/frontend/src/pages/TeachingMaterialsPage.tsx
+++ b/frontend/src/pages/TeachingMaterialsPage.tsx
@@ -293,7 +293,7 @@ function ReadOnlyDetail({ material }: { material: TeachingMaterial }) {
       <p className="text-xs text-[var(--color-text-muted)] mb-6">
         最終更新: {formatDate(material.updatedAt)}
       </p>
-      <div className="prose prose-invert prose-sm max-w-none">
+      <div className="prose prose-sm max-w-none">
         {/* trainee は編集できないので NoteMarkdownEditor の onContentChange は no-op で
             渡し、 Preview 表示扱いにする。 ただしカスタマイズが面倒なので、
             最初から <ReactMarkdown> で描画する別経路にする。 */}


### PR DESCRIPTION
## バグ

PR #1688 で `@tailwindcss/typography` を入れて prose を有効化したところ、 ノート / 教材の Markdown レンダリングが **文字がほぼ見えない状態** になってしまった。

## 原因

3 箇所で `prose prose-invert prose-sm` と書いていたが、 FreStyle のテーマはライト:
- `--color-surface-1: #FFFFFF`
- `--color-text-primary: #191919`

`prose-invert` は **ダークテーマ用**（白に近い文字色を強制）なので、 白背景のカード上で「白に近い文字色」になり読めなくなっていた。

## 修正

3 箇所から `prose-invert` を削除し、 デフォルトの `prose` のみに。 これで Tailwind Typography の標準ライトテーマ（白背景 + 濃いグレーの文字）が適用される。

対象ファイル:
- [NoteMarkdownEditor.tsx](frontend/src/components/NoteMarkdownEditor.tsx) (Preview タブ)
- [TeachingMaterialsPage.tsx](frontend/src/pages/TeachingMaterialsPage.tsx) (trainee 用 ReadOnlyMarkdown)
- [MarkdownSyntaxHelpPage.tsx](frontend/src/pages/MarkdownSyntaxHelpPage.tsx) (各 Section の右カラム)

`MessageBubble` は元から `prose-invert` なしなので変更不要。

## テスト

- [x] 1750 件 全 pass
- [x] tsc / build green