### PR TITLE
fix(markdown): highlight.js の github-dark テーマを import してコードブロックを読める色に

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,14 @@
 @tailwind utilities;
 
 /*
+ * highlight.js の GitHub Dark テーマを import。
+ * rehype-highlight が `<span class="hljs-keyword">` 等にトークンを分けるが、
+ * 対応する CSS が無いと色付けされず読めなくなる。
+ * prose のコードブロック背景は dark なので github-dark を選択。
+ */
+@import 'highlight.js/styles/github-dark.css';
+
+/*
  * ライトテーマ単一構成（ダークモードは廃止）。
  *
  * カラー設計（モノクロ最小主義）:


### PR DESCRIPTION
## バグ

ノート / 教材 / Markdown ヘルプの **コードブロック (\` \` \`〜\` \` \`)** が、 ダーク背景に「光るバー」状の文字として描画され、 中身が見えない状態だった。

## 原因

`rehype-highlight` は `<span class="hljs-keyword">` `<span class="hljs-string">` 等にトークンを分割するが、 対応する **highlight.js の CSS テーマが import されていなかった** ため hljs-* クラスに色が付かず、 親要素のテキスト色を継承して背景と同化していた。

カスタム `.code-block-wrapper pre .hljs-*` の色定義は [index.css](frontend/src/index.css) に存在するが、 これは旧 TipTap BlockEditor のコードブロックラッパー専用で、 `react-markdown` 側の素の `<pre><code>` には適用されない。

## 修正

[frontend/src/index.css](frontend/src/index.css) の先頭に追加:

```css
@import 'highlight.js/styles/github-dark.css';
```

これで rehype-highlight が出力するすべての hljs-* クラスに GitHub の Dark テーマと同じトークン色が当たり、 コードが読めるようになる。

`prose` のコードブロックはデフォルトで dark 背景になっているため、 `github-dark` が一番自然な組み合わせ。

## テスト

- [x] 1750 件 全 pass
- [x] tsc / build green