### PR TITLE
fix(markdown): コードブロックをライトテーマに揃える (GitHub README 風)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,12 +3,36 @@
 @tailwind utilities;
 
 /*
- * highlight.js の GitHub Dark テーマを import。
+ * highlight.js の GitHub Light テーマを import。
  * rehype-highlight が `<span class="hljs-keyword">` 等にトークンを分けるが、
  * 対応する CSS が無いと色付けされず読めなくなる。
- * prose のコードブロック背景は dark なので github-dark を選択。
+ * FreStyle はライトテーマ単一構成なので、 GitHub README と同じ light を採用。
  */
-@import 'highlight.js/styles/github-dark.css';
+@import 'highlight.js/styles/github.css';
+
+/*
+ * prose のコードブロックを GitHub README 風（明るい背景 + 黒文字）にする。
+ * @tailwindcss/typography の既定では <pre> は dark navy 背景になるが、
+ * FreStyle のライトテーマと噛み合わないので CSS 変数で override する。
+ *
+ * - --tw-prose-pre-bg: コードブロック全体の背景
+ * - --tw-prose-pre-code: コードブロック内のフォールバック文字色（hljs 未色付け部）
+ * - --tw-prose-pre-border: 枠線色
+ */
+.prose {
+  --tw-prose-pre-bg: var(--color-surface-2);
+  --tw-prose-pre-code: var(--color-text-primary);
+  --tw-prose-pre-border: var(--color-surface-3);
+}
+.prose pre {
+  background-color: var(--color-surface-2);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-surface-3);
+}
+.prose pre code {
+  background-color: transparent;
+  color: var(--color-text-primary);
+}
 
 /*
  * ライトテーマ単一構成（ダークモードは廃止）。


### PR DESCRIPTION
## 背景

PR #1690 で `github-dark.css` を import したが、 FreStyle はライトテーマ単一構成（白背景 + #191919 文字）なので、 ダーク背景のコードブロックがアプリ全体のトーンと噛み合わず、 また prose のデフォルト pre 背景（dark navy）と合わさってさらに読みにくくなっていた。

ユーザは GitHub README のようにライト背景のコードブロックを希望。

## 修正

### 1. highlight.js テーマを Light に切替

```diff
-@import 'highlight.js/styles/github-dark.css';
+@import 'highlight.js/styles/github.css';
```

### 2. prose の `<pre>` 背景 / 文字色を CSS 変数で override

```css
.prose {
  --tw-prose-pre-bg: var(--color-surface-2);
  --tw-prose-pre-code: var(--color-text-primary);
  --tw-prose-pre-border: var(--color-surface-3);
}
.prose pre {
  background-color: var(--color-surface-2);  /* #F5F5F4 */
  color: var(--color-text-primary);          /* #191919 */
  border: 1px solid var(--color-surface-3);  /* #E7E5E4 */
}
.prose pre code {
  background-color: transparent;
  color: var(--color-text-primary);
}
```

これで:
- ASCII art アーキテクチャ図
- サンプルコード（PHP / HTML / JSON 等）
- HTTP リクエストの構造例

すべてが GitHub README と同じトーンの **明るい背景 + 黒文字 + シンタックスハイライト** で読めるようになる。

## テスト

- [x] 1750 件 全 pass
- [x] tsc / eslint / build green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * コードブロックの表示テーマをライトテーマに変更しました
  * コードのシンタックスハイライトが正しく表示されるよう、スタイルを改善しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1691)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->