### PR TITLE
feat(frontend): Toast 再設計 + テーブル内 inline code バッククォート除去 + 他社プロダクト名表現の除去

### DIFF
--- a/backend/internal/handler/routes_embed.go
+++ b/backend/internal/handler/routes_embed.go
@@ -6,7 +6,7 @@ import (
 )
 
 // registerEmbedRoutes は外部 URL の OGP / oEmbed メタ情報取得エンドポイントを登録する。
-// Note エディタの埋め込みカード機能（Zenn 互換 markdown PR F）から利用される。
+// Note エディタの埋め込みカード機能（Markdown 互換拡張 PR F）から利用される。
 func registerEmbedRoutes(g *gin.RouterGroup) {
 	h := NewEmbedHandler(embed.NewFetcher())
 	g.GET("/embeds/oembed", h.Resolve)

--- a/frontend/src/components/MarkdownTableOfContents.tsx
+++ b/frontend/src/components/MarkdownTableOfContents.tsx
@@ -8,7 +8,7 @@ interface TocItem {
 }
 
 /**
- * MarkdownTableOfContents — Zenn 風の目次サイドバー。
+ * MarkdownTableOfContents — 拡張記法風の目次サイドバー。
  *
  * Markdown 本文から heading (#, ##, ###) を抽出し、 rehype-slug が生成する id と
  * 同じアルゴリズム（github-slugger）で anchor を組み立てる。

--- a/frontend/src/components/MermaidNodeView.tsx
+++ b/frontend/src/components/MermaidNodeView.tsx
@@ -9,7 +9,7 @@ import { logger } from '../lib/logger';
  * - mermaid は約 600KB のため dynamic import で初回利用時のみロードする
  *   (Note 編集ページに mermaid を含まないユーザーへの bundle インパクト回避)
  * - parse 失敗時は raw コードブロックをそのまま表示する
- * - Zenn 制約 (公式 docs より) を踏襲:
+ * - 拡張記法 制約 (公式 docs より) を踏襲:
  *     - 1 ブロック 2000 文字以内
  *     - クリックイベントは無効
  *
@@ -44,7 +44,7 @@ export default function MermaidNodeView({ node }: Props) {
         const mermaid = (await import('mermaid')).default;
         mermaid.initialize({
           startOnLoad: false,
-          // Zenn の制約に合わせて click event を発火させない
+          // その制約に合わせて click event を発火させない
           securityLevel: 'strict',
         });
         const id = `mermaid-${Math.random().toString(36).slice(2, 9)}`;

--- a/frontend/src/components/ServiceEmbedNodeView.tsx
+++ b/frontend/src/components/ServiceEmbedNodeView.tsx
@@ -1,7 +1,7 @@
 /**
  * YouTube / Twitter (X) / GitHub permalink などのサービス専用埋め込み NodeView。
  *
- * Zenn 仕様:
+ * 拡張記法:
  *   - YouTube: 動画 URL 単独行 → iframe
  *   - Twitter (X): ポスト URL 単独行 → blockquote (twitter widget)
  *   - GitHub: ファイル/permalink URL 単独行 → コードブロック (#L行範囲指定 もサポート)

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,5 +1,10 @@
 import { useEffect } from 'react';
-import { CheckCircleIcon, ExclamationCircleIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  InformationCircleIcon,
+  XMarkIcon,
+} from '@heroicons/react/24/outline';
 
 export type ToastType = 'success' | 'error' | 'info';
 
@@ -16,14 +21,28 @@ const ICON_MAP = {
 };
 
 const COLOR_MAP = {
-  success: 'border-emerald-500 bg-emerald-900/20 text-emerald-400',
-  error: 'border-rose-500 bg-rose-900/20 text-rose-400',
-  info: 'border-primary-500 bg-primary-900/20 text-primary-400',
+  // 既存の色設計（emerald / rose / primary）を維持しつつ、 ライトテーマでも
+  // 読めるように背景は淡色 + 文字は濃色のコントラスト。
+  success: 'border-emerald-400 bg-emerald-50 text-emerald-700',
+  error: 'border-rose-400 bg-rose-50 text-rose-700',
+  info: 'border-primary-400 bg-primary-50 text-primary-700',
 };
 
+const ICON_COLOR_MAP = {
+  success: 'text-emerald-500',
+  error: 'text-rose-500',
+  info: 'text-primary-500',
+};
+
+/**
+ * Toast — 画面上部から落ちてバウンドする通知。
+ *
+ * 配置は ToastContainer 側（fixed top center）。 本コンポーネントは見た目と
+ * 4 秒オートクローズ + アニメーションのみ責任を持つ。
+ */
 export default function Toast({ type, message, onClose }: ToastProps) {
   useEffect(() => {
-    const timer = setTimeout(onClose, 3000);
+    const timer = setTimeout(onClose, 4000);
     return () => clearTimeout(timer);
   }, [onClose]);
 
@@ -32,10 +51,18 @@ export default function Toast({ type, message, onClose }: ToastProps) {
   return (
     <div
       role="alert"
-      className={`flex items-center gap-2 px-4 py-3 rounded-lg border shadow-lg ${COLOR_MAP[type]} animate-fade-in`}
+      className={`pointer-events-auto flex items-start gap-3 px-5 py-3.5 rounded-lg border shadow-xl min-w-[280px] max-w-md ${COLOR_MAP[type]} animate-toast-drop`}
     >
-      <Icon className="w-5 h-5 flex-shrink-0" />
-      <p className="text-sm">{message}</p>
+      <Icon className={`w-6 h-6 flex-shrink-0 ${ICON_COLOR_MAP[type]}`} />
+      <p className="text-sm leading-relaxed flex-1">{message}</p>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="閉じる"
+        className="-mr-1 -mt-0.5 p-1 rounded hover:bg-black/5 transition-colors"
+      >
+        <XMarkIcon className="w-4 h-4" />
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -1,13 +1,20 @@
 import Toast from './Toast';
 import { useToast } from '../hooks/useToast';
 
+/**
+ * 画面上部中央に Toast を積む。 pointer-events-none で本体クリックを邪魔しないように
+ * しつつ、 Toast 1 つ 1 つは pointer-events-auto で閉じるボタンを押せる。
+ */
 export default function ToastContainer() {
   const { toasts, removeToast } = useToast();
 
   if (toasts.length === 0) return null;
 
   return (
-    <div aria-live="polite" className="fixed bottom-4 right-4 z-50 space-y-2">
+    <div
+      aria-live="polite"
+      className="pointer-events-none fixed top-4 left-1/2 -translate-x-1/2 z-50 flex flex-col items-center gap-2 w-full max-w-md px-4"
+    >
       {toasts.map((toast) => (
         <Toast
           key={toast.id}

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -26,12 +26,12 @@ describe('Toast', () => {
     expect(screen.getByText('お知らせ')).toBeInTheDocument();
   });
 
-  it('3秒後にonCloseが呼ばれる', () => {
+  it('4秒後にonCloseが呼ばれる', () => {
     const onClose = vi.fn();
     render(<Toast type="success" message="テスト" onClose={onClose} />);
     expect(onClose).not.toHaveBeenCalled();
     act(() => {
-      vi.advanceTimersByTime(3000);
+      vi.advanceTimersByTime(4000);
     });
     expect(onClose).toHaveBeenCalled();
   });
@@ -46,11 +46,11 @@ describe('Toast', () => {
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('3秒未満ではonCloseが呼ばれない', () => {
+  it('4秒未満ではonCloseが呼ばれない', () => {
     const onClose = vi.fn();
     render(<Toast type="success" message="テスト" onClose={onClose} />);
     act(() => {
-      vi.advanceTimersByTime(2999);
+      vi.advanceTimersByTime(3999);
     });
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/frontend/src/extensions/CalloutExtension.ts
+++ b/frontend/src/extensions/CalloutExtension.ts
@@ -20,18 +20,18 @@ import CalloutNodeView from '../components/CalloutNodeView';
 export type CalloutType = 'info' | 'warning' | 'error' | 'success';
 
 /**
- * Zenn の `:::message` / `:::message alert` を CalloutExtension にマッピングする。
+ * 拡張記法の `:::message` / `:::message alert` を CalloutExtension にマッピングする。
  * info  ↔ :::message
  * error ↔ :::message alert
- * warning / success は info にフォールバック（Zenn 標準が info / alert の 2 種のため）。
+ * warning / success は info にフォールバック（標準が info / alert の 2 種のため）。
  */
-type ZennCalloutVariant = 'info' | 'alert';
+type CalloutVariant = 'info' | 'alert';
 
-function zennVariantFromCalloutType(t: CalloutType): ZennCalloutVariant {
+function variantFromCalloutType(t: CalloutType): CalloutVariant {
   return t === 'error' || t === 'warning' ? 'alert' : 'info';
 }
 
-function calloutTypeFromZennVariant(v: ZennCalloutVariant): CalloutType {
+function calloutTypeFromVariant(v: CalloutVariant): CalloutType {
   return v === 'alert' ? 'error' : 'info';
 }
 
@@ -73,7 +73,7 @@ export const Callout = Node.create({
   },
 
   /**
-   * tiptap-markdown 連携。Zenn `:::message` / `:::message alert` 記法を
+   * tiptap-markdown 連携。拡張記法 `:::message` / `:::message alert` 記法を
    * Callout ノードと相互変換する。
    *
    * - serialize: Tiptap callout → markdown `:::message [alert]\n...content...\n:::`
@@ -84,7 +84,7 @@ export const Callout = Node.create({
     return {
       markdown: {
         serialize(state: import('prosemirror-markdown').MarkdownSerializerState, node: import('prosemirror-model').Node) {
-          const variant = zennVariantFromCalloutType((node.attrs.type as CalloutType) || 'info');
+          const variant = variantFromCalloutType((node.attrs.type as CalloutType) || 'info');
           state.write(variant === 'alert' ? ':::message alert\n' : ':::message\n');
           state.renderContent(node);
           state.ensureNewLine();
@@ -99,8 +99,8 @@ export const Callout = Node.create({
                 const token = tokens[idx];
                 if (token.nesting === 1) {
                   const params = token.info.trim();
-                  const variant: ZennCalloutVariant = /\balert\b/.test(params) ? 'alert' : 'info';
-                  const calloutType = calloutTypeFromZennVariant(variant);
+                  const variant: CalloutVariant = /\balert\b/.test(params) ? 'alert' : 'info';
+                  const calloutType = calloutTypeFromVariant(variant);
                   const emoji = variant === 'alert' ? '⚠️' : '💡';
                   return `<div data-callout="" data-callout-type="${calloutType}" data-callout-emoji="${emoji}" class="callout">\n`;
                 }

--- a/frontend/src/extensions/EmbedCardExtension.ts
+++ b/frontend/src/extensions/EmbedCardExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Zenn 互換の埋め込みカード extension。
+ * Markdown 互換の埋め込みカード extension。
  *
  * 仕様:
  *   - markdown 入力で `@[card](https://example.com)` を Tiptap embedCard node に変換

--- a/frontend/src/extensions/EmojiShortcodeExtension.ts
+++ b/frontend/src/extensions/EmojiShortcodeExtension.ts
@@ -1,7 +1,7 @@
 /**
  * `:smile:` のような絵文字 shortcode を Unicode 絵文字に変換する拡張。
  *
- * Zenn の絵文字補完（`:` トリガで候補を出す UI 補完）は SlashCommand 系で
+ * その絵文字補完（`:` トリガで候補を出す UI 補完）は SlashCommand 系で
  * 別途実装する余地を残し、本 PR では markdown 入力時の自動置換のみを実装する。
  *
  * 実装:

--- a/frontend/src/extensions/FootnoteExtension.ts
+++ b/frontend/src/extensions/FootnoteExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Zenn 互換の脚注 extension。
+ * Markdown 互換の脚注 extension。
  *
  * markdown 入力:
  *   本文[^1] / 本文^[インライン脚注]

--- a/frontend/src/extensions/MathExtension.ts
+++ b/frontend/src/extensions/MathExtension.ts
@@ -1,7 +1,7 @@
 /**
  * KaTeX 数式 Tiptap extensions。
  *
- * Zenn 互換: `$$...$$` (block) / `$...$` (inline) を KaTeX で描画する。
+ * Markdown 互換: `$$...$$` (block) / `$...$` (inline) を KaTeX で描画する。
  * 構成:
  *   - MathBlock: ProseMirror node (block)
  *   - MathInline: ProseMirror node (inline / atom)

--- a/frontend/src/extensions/MermaidExtension.ts
+++ b/frontend/src/extensions/MermaidExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Zenn 互換 Mermaid ダイアグラム拡張。
+ * Markdown 互換 Mermaid ダイアグラム拡張。
  *
  * 設計:
  * - markdown 入力では ```mermaid ... ``` のフェンスコードブロックとして書かれる

--- a/frontend/src/extensions/ServiceEmbedExtension.ts
+++ b/frontend/src/extensions/ServiceEmbedExtension.ts
@@ -1,5 +1,5 @@
 /**
- * Zenn 仕様の URL 単独行 → サービス専用埋め込み変換。
+ * 拡張記法の URL 単独行 → サービス専用埋め込み変換。
  *
  * 対応:
  *   - YouTube      ( youtu.be / youtube.com/watch?v= )
@@ -110,7 +110,7 @@ export const ServiceEmbed = Node.create({
       markdown: {
         serialize(state: MarkdownSerializerState, node: PMNode) {
           const url = (node.attrs.url as string) || '';
-          // Zenn の表記に合わせて URL 単独行で書き戻す。
+          // その表記に合わせて URL 単独行で書き戻す。
           state.write(url);
           state.closeBlock(node);
         },

--- a/frontend/src/extensions/ToggleListExtension.ts
+++ b/frontend/src/extensions/ToggleListExtension.ts
@@ -32,7 +32,7 @@ export const ToggleSummary = Node.create({
   addStorage() {
     return {
       markdown: {
-        // toggleSummary の中身は Zenn では `:::details タイトル` の "タイトル" 部に直接書くため、
+        // toggleSummary の中身は 拡張記法では `:::details タイトル` の "タイトル" 部に直接書くため、
         // markdown-serialize としては個別に何も書かない（toggleList 側で attrs.title として吸収する）。
         serialize() {
           // no-op: serialize is handled by parent toggleList
@@ -106,7 +106,7 @@ export const ToggleList = Node.create({
   },
 
   /**
-   * Zenn `:::details タイトル` 記法 ↔ Tiptap toggleList の相互変換。
+   * 拡張記法 `:::details タイトル` 記法 ↔ Tiptap toggleList の相互変換。
    *
    * - serialize:
    *     :::details {summary のテキスト}

--- a/frontend/src/hooks/__tests__/useProfileEdit.test.ts
+++ b/frontend/src/hooks/__tests__/useProfileEdit.test.ts
@@ -4,12 +4,21 @@ import { useProfileEdit } from '../useProfileEdit';
 
 const mockFetchProfile = vi.fn();
 const mockUpdateProfile = vi.fn();
+const mockShowToast = vi.fn();
 
 vi.mock('../../repositories/ProfileRepository', () => ({
   default: {
     fetchProfile: (...args: unknown[]) => mockFetchProfile(...args),
     updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
   },
+}));
+
+vi.mock('../useToast', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+    toasts: [],
+    removeToast: vi.fn(),
+  }),
 }));
 
 const fixtureProfile = {
@@ -24,6 +33,7 @@ const fixtureProfile = {
 describe('useProfileEdit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockShowToast.mockReset();
     mockFetchProfile.mockResolvedValue({ ...fixtureProfile });
     mockUpdateProfile.mockResolvedValue({ ...fixtureProfile });
   });
@@ -67,7 +77,7 @@ describe('useProfileEdit', () => {
     expect(result.current.form.displayName).toBe('新しい名前');
   });
 
-  it('handleUpdate成功時に成功メッセージが表示される', async () => {
+  it('handleUpdate成功時に Toast で成功メッセージが表示される', async () => {
     const { result } = renderHook(() => useProfileEdit());
 
     await waitFor(() => {
@@ -78,8 +88,9 @@ describe('useProfileEdit', () => {
       await result.current.handleUpdate();
     });
 
-    expect(result.current.message?.type).toBe('success');
-    expect(result.current.message?.text).toBe('プロフィールを更新しました。');
+    // 成功時はインラインメッセージはクリアされ、 Toast 経由で通知される。
+    expect(result.current.message).toBeNull();
+    expect(mockShowToast).toHaveBeenCalledWith('success', 'プロフィールを更新しました。');
   });
 
   it('handleUpdate失敗時にエラーメッセージが表示される', async () => {

--- a/frontend/src/hooks/useBlockEditor.ts
+++ b/frontend/src/hooks/useBlockEditor.ts
@@ -8,12 +8,12 @@ import { resolveNoteContent } from '../utils/noteContentFormat';
 interface UseBlockEditorOptions {
   /** Note.content (markdown 文字列 or 旧 Tiptap JSON 文字列 or 旧 Markdown 文字列)。 */
   content: string;
-  /** エディタ更新時に呼ばれる。値は Zenn 互換 Markdown 文字列。 */
+  /** エディタ更新時に呼ばれる。値は Markdown 互換 Markdown 文字列。 */
   onChange: (markdown: string) => void;
 }
 
 /**
- * Tiptap エディタを Zenn 互換 Markdown 入出力で使うための共通フック。
+ * Tiptap エディタを Markdown 互換 Markdown 入出力で使うための共通フック。
  *
  * 入力 (content) の解釈:
  *   1. 空文字 → 空エディタ
@@ -53,7 +53,7 @@ export function useBlockEditor({ content, onChange }: UseBlockEditorOptions) {
       : never,
     onUpdate: ({ editor }) => {
       // tiptap-markdown が editor.storage.markdown.getMarkdown() を提供する。
-      // 旧実装は JSON.stringify(editor.getJSON()) を保存していたが、Zenn markdown の
+      // 旧実装は JSON.stringify(editor.getJSON()) を保存していたが、拡張記法 markdown の
       // 持ち出しやすさ・diff レビュー性を優先して Markdown 文字列保存に切り替える。
       const md = editor.storage.markdown.getMarkdown() as string;
       lastEmittedMarkdown.current = md;

--- a/frontend/src/hooks/useProfileEdit.ts
+++ b/frontend/src/hooks/useProfileEdit.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import ProfileRepository from '../repositories/ProfileRepository';
+import { useToast } from './useToast';
 import type { FormMessage, Profile } from '../types';
 
 /**
@@ -21,9 +22,12 @@ const EMPTY_FORM: ProfileForm = {
 
 export function useProfileEdit() {
   const [form, setForm] = useState<ProfileForm>(EMPTY_FORM);
+  // 失敗系（取得エラー / バリデーション）はインライン表示を維持。
+  // 成功系（更新しました）は Toast で通知する（画面上部からバウンドで降りてくる）。
   const [message, setMessage] = useState<FormMessage | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const { showToast } = useToast();
 
   useEffect(() => {
     const loadProfile = async () => {
@@ -56,13 +60,15 @@ export function useProfileEdit() {
     setSubmitting(true);
     try {
       await ProfileRepository.updateProfile(form);
-      setMessage({ type: 'success', text: 'プロフィールを更新しました。' });
+      // 成功時はインラインメッセージを消して Toast を出す。
+      setMessage(null);
+      showToast('success', 'プロフィールを更新しました。');
     } catch {
       setMessage({ type: 'error', text: '通信エラーが発生しました。' });
     } finally {
       setSubmitting(false);
     }
-  }, [form]);
+  }, [form, showToast]);
 
   return {
     form,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,15 @@
   background-color: transparent;
   color: var(--color-text-primary);
 }
+/*
+ * @tailwindcss/typography は inline code (`<code>`) の前後に ::before / ::after で
+ * バッククォート (`) を装飾として自動挿入する。 これがテーブルセル内などで
+ * 「`GET`」のように リテラルなバッククォートとして見えてしまうので打ち消す。
+ */
+.prose code::before,
+.prose code::after {
+  content: "" !important;
+}
 
 /*
  * ライトテーマ単一構成（ダークモードは廃止）。

--- a/frontend/src/pages/TeachingMaterialsPage.tsx
+++ b/frontend/src/pages/TeachingMaterialsPage.tsx
@@ -284,7 +284,7 @@ function ManagedDetail({
 }
 
 function ReadOnlyDetail({ material }: { material: TeachingMaterial }) {
-  // Zenn 風 2 カラム: 左 = 本文 (max-w-3xl 程度) / 右 = sticky な目次サイドバー。
+  // 拡張記法風 2 カラム: 左 = 本文 (max-w-3xl 程度) / 右 = sticky な目次サイドバー。
   // スクロールバーは画面右端に出したいので、 スクロールコンテナは width 制限せず、
   // 内側のグリッドで本文・目次の幅を制御する。
   return (

--- a/frontend/src/pages/__tests__/ProfilePage.test.tsx
+++ b/frontend/src/pages/__tests__/ProfilePage.test.tsx
@@ -13,6 +13,10 @@ vi.mock('../../hooks/useProfileImageUpload', () => ({
 
 vi.mock('../../repositories/ProfileRepository');
 
+vi.mock('../../hooks/useToast', () => ({
+  useToast: () => ({ showToast: vi.fn(), toasts: [], removeToast: vi.fn() }),
+}));
+
 vi.mock('../../repositories/ProfileStatsRepository', () => ({
   default: {
     fetchStats: vi.fn().mockResolvedValue({

--- a/frontend/src/utils/editorExtensions.ts
+++ b/frontend/src/utils/editorExtensions.ts
@@ -110,9 +110,9 @@ export function createEditorExtensions() {
     EmojiShortcode,
     // tiptap-markdown は editor.storage.markdown.getMarkdown() / setContent(md) を提供する。
     // - html: false       editor 内の生 HTML 出力を抑制し pure な Markdown シリアライズに統一
-    // - tightLists: true  リストアイテム間の空行を出力しない (Zenn / GitHub 準拠)
-    // - bulletListMarker  Zenn のサンプルが `-` で統一されているのに合わせる
-    // - linkify: false    URL の自動リンク化はしない（Zenn 風の「URL 行 → カード」は別 PR で扱う）
+    // - tightLists: true  リストアイテム間の空行を出力しない (拡張記法 / GitHub 準拠)
+    // - bulletListMarker  拡張記法のサンプルが `-` で統一されているのに合わせる
+    // - linkify: false    URL の自動リンク化はしない（拡張記法風の「URL 行 → カード」は別 PR で扱う）
     Markdown.configure({
       html: false,
       tightLists: true,

--- a/frontend/src/utils/noteContentFormat.ts
+++ b/frontend/src/utils/noteContentFormat.ts
@@ -2,7 +2,7 @@
  * Note エディタのコンテンツ形式判定 / 変換ユーティリティ。
  *
  * 設計方針:
- * - 新規ノートは Zenn 互換 Markdown で保存する（tiptap-markdown が双方向変換を担当）
+ * - 新規ノートは Markdown 互換 Markdown で保存する（tiptap-markdown が双方向変換を担当）
  * - 過去のノートは Tiptap JSON 文字列で保存されているので、判別して Tiptap が読める形に渡す
  * - 過去の旧 Markdown (見出し/リストのみ) は isLegacyMarkdown で判別し markdownToTiptap で
  *   先に Tiptap JSON に変換した上で editor に渡す

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -31,6 +31,8 @@ export default {
         'fade-in': 'fadeIn 0.15s ease-in',
         'scale-in': 'scaleIn 0.2s ease-out',
         'skeleton': 'skeleton 1.5s ease-in-out infinite',
+        // Toast 用: 上から落ちてバウンドする 0.6s のアニメーション。
+        'toast-drop': 'toastDrop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
       },
       keyframes: {
         fadeIn: {
@@ -44,6 +46,12 @@ export default {
         skeleton: {
           '0%': { backgroundPosition: '200% 0' },
           '100%': { backgroundPosition: '-200% 0' },
+        },
+        toastDrop: {
+          '0%': { transform: 'translateY(-120%)', opacity: '0' },
+          '60%': { transform: 'translateY(12px)', opacity: '1' },
+          '80%': { transform: 'translateY(-6px)' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
         },
       },
     },


### PR DESCRIPTION
## 概要

- Toast を画面上部中央から落ちてバウンドするアニメーション付きに刷新
- @tailwindcss/typography が inline code 前後に挿入する装飾用バッククォートを打ち消し
- プロフィール更新の成功メッセージを Toast 経由に統一
- コード / 技術ドキュメント / PR タイトル本文から他社プロダクト名（Zenn / paiza 等）を排除

## 変更内容

### Toast 再設計
- 配置を画面上部中央 `top-4 left-1/2 -translate-x-1/2` に
- アニメーションを `cubic-bezier(0.34, 1.56, 0.64, 1)` 0.6s の drop-and-bounce
- 4 秒オートクローズ + ×ボタンで手動クローズ
- ライトテーマでも読みやすい配色（border + 淡色背景 + 濃色テキスト）
- `useProfileEdit.handleUpdate` 成功時は Toast 経由に変更

### inline code バッククォート除去
- `.prose code::before` / `::after` を `content: ""` で打ち消し
- テーブルセル内の inline code が「`GET`」のように表示される問題を解消

### 他社プロダクト名表現の除去（重要）
- CLAUDE.md に新ルール 3.1.1 を追加
- 過去 PR タイトル / 本文から該当表現を機能ベースの表現に置換
- フロントエンドの comments と Zenn-prefixed 識別子を rename
- 業務分析（market analysis）系の docs は競合比較が前提のため対象外

## テスト

- [x] \`npx tsc --noEmit\` パス
- [x] \`npx vitest run\` 1743 tests パス
- [x] \`npx eslint --max-warnings 0\` パス
- [x] \`npm run build\` パス

## 関連 Issue

なし（ユーザー直接要望）