### PR TITLE
feat(backend): コース概念導入 (2 階層: Course → TeachingMaterial) + メンテページ favicon 差し替え

### DIFF
--- a/backend/internal/domain/course.go
+++ b/backend/internal/domain/course.go
@@ -1,0 +1,27 @@
+package domain
+
+import "time"
+
+// Course は教材を束ねる「コース（プロジェクト）」。
+//
+// 階層: Company 1 ── * Course 1 ── * TeachingMaterial
+//
+// アクセス制御:
+//   - same company の company_admin: 自社のコースを全件 list / 編集 / 削除可
+//   - same company の trainee: 自社の `is_published=true` コースのみ閲覧可
+//   - super_admin: 横断的に閲覧可（運用上の監査）
+//
+// 並び順は `SortOrder` で明示的に指定する（同値時は ID 昇順）。
+type Course struct {
+	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`
+	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
+	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
+	Description     string    `gorm:"column:description;type:text;not null;default:''" json:"description"`
+	SortOrder       int       `gorm:"column:sort_order;not null;default:100" json:"sortOrder"`
+	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
+	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt       time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (Course) TableName() string { return "courses" }

--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -3,20 +3,26 @@ package domain
 import "time"
 
 // TeachingMaterial は company_admin が自社 trainee 向けに作成する教材。
+// 必ず 1 つの Course に所属する（独立した教材は許容しない）。
 //
 // アクセス制御:
 //   - same company の company_admin: 自社の教材を全件 list / 編集 / 削除可
 //   - same company の trainee: 自社の `is_published=true` 教材のみ閲覧可
+//     （所属コースが `is_published=false` の場合も非表示）
 //   - super_admin: 横断的に閲覧可（運用上の監査）
 //
 // 本文 (`Content`) は raw Markdown 文字列で保存し、 フロントは Edit / Preview タブで
 // 表示する（Note と同じ形式）。
+//
+// `OrderInCourse` はコース内での並び順。 同値時は ID 昇順。
 type TeachingMaterial struct {
 	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
 	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`
+	CourseID        uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
 	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
 	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
 	Content         string    `gorm:"column:content;type:text;not null;default:''" json:"content"`
+	OrderInCourse   int       `gorm:"column:order_in_course;not null;default:100" json:"orderInCourse"`
 	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
 	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`
 	UpdatedAt       time.Time `gorm:"column:updated_at" json:"updatedAt"`

--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -16,8 +16,8 @@ import "time"
 //
 // `OrderInCourse` はコース内での並び順。 同値時は ID 昇順。
 type TeachingMaterial struct {
-	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
-	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`
+	ID        uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyID uint64 `gorm:"column:company_id;not null;index" json:"companyId"`
 	// course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を
 	// AutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。
 	CourseID        uint64    `gorm:"column:course_id;index" json:"courseId"`

--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -18,7 +18,9 @@ import "time"
 type TeachingMaterial struct {
 	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
 	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`
-	CourseID        uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
+	// course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を
+	// AutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。
+	CourseID        uint64    `gorm:"column:course_id;index" json:"courseId"`
 	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
 	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
 	Content         string    `gorm:"column:content;type:text;not null;default:''" json:"content"`

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -1,0 +1,164 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
+)
+
+// CourseHandler はコース API を扱う。
+//
+//	GET    /api/v2/courses        一覧（actor role / company で自動フィルタ）
+//	GET    /api/v2/courses/:id    詳細
+//	POST   /api/v2/courses        作成（company_admin / super_admin）
+//	PUT    /api/v2/courses/:id    更新（同上）
+//	DELETE /api/v2/courses/:id    削除（配下教材も cascade で削除）
+type CourseHandler struct {
+	uc *usecase.CourseUseCase
+}
+
+func NewCourseHandler(uc *usecase.CourseUseCase) *CourseHandler {
+	return &CourseHandler{uc: uc}
+}
+
+func (h *CourseHandler) actorContext(c *gin.Context) (uint64, uint64, string, bool) {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return 0, 0, "", false
+	}
+	companyID := uint64(0)
+	if user.CompanyID != nil {
+		companyID = *user.CompanyID
+	}
+	return user.ID, companyID, user.Role, true
+}
+
+func (h *CourseHandler) List(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	rows, err := h.uc.List(c.Request.Context(), companyID, role)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "コースの取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+func (h *CourseHandler) Get(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	course, err := h.uc.Get(c.Request.Context(), id, companyID, role)
+	if err != nil {
+		respondCourseErr(c, err, "コースの取得に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, course)
+}
+
+type courseRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	SortOrder   int    `json:"sortOrder"`
+	IsPublished bool   `json:"isPublished"`
+}
+
+func (h *CourseHandler) Create(c *gin.Context) {
+	uid, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	var req courseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	course, err := h.uc.Create(c.Request.Context(), usecase.CreateCourseInput{
+		ActorUserID:    uid,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Description:    req.Description,
+		SortOrder:      req.SortOrder,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondCourseErr(c, err, "コースの作成に失敗しました")
+		return
+	}
+	c.JSON(http.StatusCreated, course)
+}
+
+func (h *CourseHandler) Update(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var req courseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	course, err := h.uc.Update(c.Request.Context(), usecase.UpdateCourseInput{
+		ID:             id,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Description:    req.Description,
+		SortOrder:      req.SortOrder,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondCourseErr(c, err, "コースの更新に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, course)
+}
+
+func (h *CourseHandler) Delete(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.uc.Delete(c.Request.Context(), id, companyID, role); err != nil {
+		respondCourseErr(c, err, "コースの削除に失敗しました")
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func respondCourseErr(c *gin.Context, err error, fallback string) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "コースが見つかりません"})
+		return
+	}
+	if err.Error() == "forbidden" || err.Error() == "forbidden: only company_admin or super_admin can create courses" || err.Error() == "actor must belong to a company" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -72,6 +72,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerEmbedRoutes(authed)
 	registerExerciseRoutes(authed, deps)
 	registerLearningReportRoutes(authed, deps)
+	registerCourseRoutes(authed, deps)
 	registerTeachingMaterialRoutes(authed, deps)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 

--- a/backend/internal/handler/routes_courses.go
+++ b/backend/internal/handler/routes_courses.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerCourseRoutes はコース API + コース配下教材一覧 API を登録する。
+//
+//	GET    /api/v2/courses                          一覧
+//	GET    /api/v2/courses/:id                      詳細
+//	POST   /api/v2/courses                          作成（company_admin / super_admin）
+//	PUT    /api/v2/courses/:id                      更新（同上）
+//	DELETE /api/v2/courses/:id                      削除（配下教材も cascade で削除）
+//	GET    /api/v2/courses/:courseId/materials      コース内教材一覧
+//
+// アクセス制御は usecase 層で actor の company_id / role を検証する。
+// trainee は同一 company の `is_published=true` コースのみ閲覧可。
+func registerCourseRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	courseRepo := repository.NewCourseRepository(deps.db)
+	materialRepo := repository.NewTeachingMaterialRepository(deps.db)
+
+	courseUC := usecase.NewCourseUseCase(courseRepo, materialRepo)
+	courseHandler := NewCourseHandler(courseUC)
+
+	materialUC := usecase.NewTeachingMaterialUseCase(materialRepo, courseRepo)
+	materialHandler := NewTeachingMaterialHandler(materialUC)
+
+	g.GET("/courses", courseHandler.List)
+	g.GET("/courses/:id", courseHandler.Get)
+	g.POST("/courses", courseHandler.Create)
+	g.PUT("/courses/:id", courseHandler.Update)
+	g.DELETE("/courses/:id", courseHandler.Delete)
+	g.GET("/courses/:id/materials", materialHandler.ListByCourse)
+}

--- a/backend/internal/handler/routes_teaching_materials.go
+++ b/backend/internal/handler/routes_teaching_materials.go
@@ -6,21 +6,24 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerTeachingMaterialRoutes は教材 API 5 本を登録する:
+// registerTeachingMaterialRoutes は教材個別 API を登録する:
 //
-//	GET    /api/v2/teaching-materials      一覧
 //	GET    /api/v2/teaching-materials/:id  詳細
-//	POST   /api/v2/teaching-materials      作成（company_admin / super_admin）
+//	POST   /api/v2/teaching-materials      作成（company_admin / super_admin、 body の courseId 必須）
 //	PUT    /api/v2/teaching-materials/:id  更新（同上）
 //	DELETE /api/v2/teaching-materials/:id  削除（同上）
 //
+// コース配下の教材一覧 (`GET /api/v2/courses/:id/materials`) は
+// registerCourseRoutes 側で登録する（コース ACL の参照を簡潔にするため）。
+//
 // アクセス制御は usecase 層で actor の company_id / role を検証する。
-// trainee は同一 company の `is_published=true` 教材のみ閲覧可。
+// trainee は同一 company の `is_published=true` 教材かつ所属コースが published のときのみ閲覧可。
 func registerTeachingMaterialRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	repo := repository.NewTeachingMaterialRepository(deps.db)
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	courseRepo := repository.NewCourseRepository(deps.db)
+	materialRepo := repository.NewTeachingMaterialRepository(deps.db)
+	uc := usecase.NewTeachingMaterialUseCase(materialRepo, courseRepo)
 	h := NewTeachingMaterialHandler(uc)
-	g.GET("/teaching-materials", h.List)
+	g.GET("/teaching-materials", h.List) // backward-compat（frontend のコース対応後に削除予定）
 	g.GET("/teaching-materials/:id", h.Get)
 	g.POST("/teaching-materials", h.Create)
 	g.PUT("/teaching-materials/:id", h.Update)

--- a/backend/internal/handler/teaching_material_handler.go
+++ b/backend/internal/handler/teaching_material_handler.go
@@ -13,11 +13,11 @@ import (
 
 // TeachingMaterialHandler は教材 API を扱う。
 //
-//	GET    /api/v2/teaching-materials      一覧（actor role / company で自動フィルタ）
-//	GET    /api/v2/teaching-materials/:id  詳細
-//	POST   /api/v2/teaching-materials      作成（company_admin / super_admin）
-//	PUT    /api/v2/teaching-materials/:id  更新（同上）
-//	DELETE /api/v2/teaching-materials/:id  削除（同上）
+//	GET    /api/v2/courses/:courseId/materials      コース内一覧（actor role で自動フィルタ）
+//	GET    /api/v2/teaching-materials/:id           詳細
+//	POST   /api/v2/teaching-materials               作成（company_admin / super_admin、 course_id 必須）
+//	PUT    /api/v2/teaching-materials/:id           更新（同上）
+//	DELETE /api/v2/teaching-materials/:id           削除（同上）
 type TeachingMaterialHandler struct {
 	uc *usecase.TeachingMaterialUseCase
 }
@@ -39,7 +39,8 @@ func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, 
 	return user.ID, companyID, user.Role, true
 }
 
-// List は GET /api/v2/teaching-materials 。
+// List は backward-compat 用 GET /api/v2/teaching-materials 。 frontend がコース対応に
+// 切り替わったら削除予定。
 func (h *TeachingMaterialHandler) List(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -48,6 +49,26 @@ func (h *TeachingMaterialHandler) List(c *gin.Context) {
 	rows, err := h.uc.List(c.Request.Context(), companyID, role)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "教材の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// ListByCourse は GET /api/v2/courses/:id/materials 。 コース配下の教材を返す。
+// path param `:id` はコース ID（ルート競合を避けるため materials path 側で `:id` を流用）。
+func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	courseID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid course id"})
+		return
+	}
+	rows, err := h.uc.ListByCourse(c.Request.Context(), courseID, companyID, role)
+	if err != nil {
+		respondTeachingMaterialErr(c, err, "教材の取得に失敗しました")
 		return
 	}
 	c.JSON(http.StatusOK, rows)
@@ -81,19 +102,28 @@ func (h *TeachingMaterialHandler) Get(c *gin.Context) {
 	c.JSON(http.StatusOK, m)
 }
 
-type teachingMaterialRequest struct {
-	Title       string `json:"title"`
-	Content     string `json:"content"`
-	IsPublished bool   `json:"isPublished"`
+type teachingMaterialCreateRequest struct {
+	CourseID      uint64 `json:"courseId" binding:"required"`
+	Title         string `json:"title"`
+	Content       string `json:"content"`
+	OrderInCourse int    `json:"orderInCourse"`
+	IsPublished   bool   `json:"isPublished"`
 }
 
-// Create は POST /api/v2/teaching-materials 。
+type teachingMaterialUpdateRequest struct {
+	Title         string `json:"title"`
+	Content       string `json:"content"`
+	OrderInCourse int    `json:"orderInCourse"`
+	IsPublished   bool   `json:"isPublished"`
+}
+
+// Create は POST /api/v2/teaching-materials 。 body の courseId 必須。
 func (h *TeachingMaterialHandler) Create(c *gin.Context) {
 	uid, companyID, role, ok := h.actorContext(c)
 	if !ok {
 		return
 	}
-	var req teachingMaterialRequest
+	var req teachingMaterialCreateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -102,8 +132,10 @@ func (h *TeachingMaterialHandler) Create(c *gin.Context) {
 		ActorUserID:    uid,
 		ActorCompanyID: companyID,
 		ActorRole:      role,
+		CourseID:       req.CourseID,
 		Title:          req.Title,
 		Content:        req.Content,
+		OrderInCourse:  req.OrderInCourse,
 		IsPublished:    req.IsPublished,
 	})
 	if err != nil {
@@ -124,7 +156,7 @@ func (h *TeachingMaterialHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	var req teachingMaterialRequest
+	var req teachingMaterialUpdateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -135,6 +167,7 @@ func (h *TeachingMaterialHandler) Update(c *gin.Context) {
 		ActorRole:      role,
 		Title:          req.Title,
 		Content:        req.Content,
+		OrderInCourse:  req.OrderInCourse,
 		IsPublished:    req.IsPublished,
 	})
 	if err != nil {

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -31,6 +31,7 @@ func allDomainModels() []any {
 		&domain.CompanyExercise{},
 		&domain.ExerciseSubmission{},
 		&domain.Company{},
+		&domain.Course{},
 		&domain.TeachingMaterial{},
 	}
 }

--- a/backend/internal/repository/course_repository.go
+++ b/backend/internal/repository/course_repository.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// CourseRepository はコースの永続化を担う。
+//
+// 教材と同様、 クエリは原則 company_id 指定で発行することで、 他社のコースが
+// アプリ層のバグで漏れる事故を予防する。
+type CourseRepository interface {
+	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.Course, error)
+	GetByID(ctx context.Context, id uint64) (*domain.Course, error)
+	Create(ctx context.Context, c *domain.Course) error
+	Update(ctx context.Context, c *domain.Course) error
+	Delete(ctx context.Context, id uint64) error
+}
+
+type courseRepository struct {
+	db *gorm.DB
+}
+
+func NewCourseRepository(db *gorm.DB) CourseRepository {
+	return &courseRepository{db: db}
+}
+
+func (r *courseRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.Course, error) {
+	var rows []domain.Course
+	q := r.db.WithContext(ctx).Where("company_id = ?", companyID)
+	if !includeUnpublished {
+		q = q.Where("is_published = ?", true)
+	}
+	if err := q.Order("sort_order asc, id asc").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *courseRepository) GetByID(ctx context.Context, id uint64) (*domain.Course, error) {
+	var c domain.Course
+	if err := r.db.WithContext(ctx).First(&c, id).Error; err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *courseRepository) Create(ctx context.Context, c *domain.Course) error {
+	return r.db.WithContext(ctx).Create(c).Error
+}
+
+func (r *courseRepository) Update(ctx context.Context, c *domain.Course) error {
+	// 一部カラムのみ更新（CreatedBy / CompanyID は不変）。
+	return r.db.WithContext(ctx).Model(c).Updates(map[string]any{
+		"title":        c.Title,
+		"description":  c.Description,
+		"sort_order":   c.SortOrder,
+		"is_published": c.IsPublished,
+	}).Error
+}
+
+func (r *courseRepository) Delete(ctx context.Context, id uint64) error {
+	return r.db.WithContext(ctx).Delete(&domain.Course{}, id).Error
+}

--- a/backend/internal/repository/teaching_material_repository.go
+++ b/backend/internal/repository/teaching_material_repository.go
@@ -12,11 +12,15 @@ import (
 // クエリは原則 company_id 指定で発行することで、 他社の教材が
 // アプリ層のバグで漏れる事故を予防する（最後の防衛線として）。
 type TeachingMaterialRepository interface {
+	// ListByCompany は backward-compat: 旧 GET /teaching-materials エンドポイント
+	// 用に company 内全教材を返す。 frontend がコース対応に切り替わったら削除予定。
 	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
+	ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
 	GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error)
 	Create(ctx context.Context, m *domain.TeachingMaterial) error
 	Update(ctx context.Context, m *domain.TeachingMaterial) error
 	Delete(ctx context.Context, id uint64) error
+	DeleteByCourse(ctx context.Context, courseID uint64) error
 }
 
 type teachingMaterialRepository struct {
@@ -27,6 +31,7 @@ func NewTeachingMaterialRepository(db *gorm.DB) TeachingMaterialRepository {
 	return &teachingMaterialRepository{db: db}
 }
 
+// ListByCompany は backward-compat 用。 frontend のコース対応完了後に削除予定。
 func (r *teachingMaterialRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
 	var rows []domain.TeachingMaterial
 	q := r.db.WithContext(ctx).Where("company_id = ?", companyID)
@@ -34,6 +39,19 @@ func (r *teachingMaterialRepository) ListByCompany(ctx context.Context, companyI
 		q = q.Where("is_published = ?", true)
 	}
 	if err := q.Order("updated_at desc, id desc").Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *teachingMaterialRepository) ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	var rows []domain.TeachingMaterial
+	q := r.db.WithContext(ctx).Where("course_id = ?", courseID)
+	if !includeUnpublished {
+		q = q.Where("is_published = ?", true)
+	}
+	// コース内の並び順は order_in_course → id 昇順。
+	if err := q.Order("order_in_course asc, id asc").Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
@@ -52,14 +70,21 @@ func (r *teachingMaterialRepository) Create(ctx context.Context, m *domain.Teach
 }
 
 func (r *teachingMaterialRepository) Update(ctx context.Context, m *domain.TeachingMaterial) error {
-	// 一部カラムのみ更新（CreatedBy / CompanyID は不変）。
+	// 一部カラムのみ更新（CreatedBy / CompanyID / CourseID は不変）。
 	return r.db.WithContext(ctx).Model(m).Updates(map[string]any{
-		"title":        m.Title,
-		"content":      m.Content,
-		"is_published": m.IsPublished,
+		"title":           m.Title,
+		"content":         m.Content,
+		"order_in_course": m.OrderInCourse,
+		"is_published":    m.IsPublished,
 	}).Error
 }
 
 func (r *teachingMaterialRepository) Delete(ctx context.Context, id uint64) error {
 	return r.db.WithContext(ctx).Delete(&domain.TeachingMaterial{}, id).Error
+}
+
+// DeleteByCourse は指定 course に属する教材を全削除する。 コース削除時の
+// cascade 用（FK の ON DELETE は GORM AutoMigrate で安定しないので明示的に消す）。
+func (r *teachingMaterialRepository) DeleteByCourse(ctx context.Context, courseID uint64) error {
+	return r.db.WithContext(ctx).Where("course_id = ?", courseID).Delete(&domain.TeachingMaterial{}).Error
 }

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -1,0 +1,140 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/repository"
+)
+
+// CourseUseCase はコース機能の操作（list / get / create / update / delete）を
+// 1 構造体で扱う。 内部ヘルパは teaching_material_usecase の canManage を共有する。
+//
+// アクセス制御:
+//   - List: 同一 company の company_admin / trainee / super_admin
+//     trainee は published のみ、 company_admin / super_admin は draft 含む全件
+//   - Get: 同一 company か super_admin（trainee は published のみ）
+//   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
+//   - Delete: コース内の教材も同時に削除する（cascade）
+type CourseUseCase struct {
+	courses   repository.CourseRepository
+	materials repository.TeachingMaterialRepository
+}
+
+func NewCourseUseCase(courses repository.CourseRepository, materials repository.TeachingMaterialRepository) *CourseUseCase {
+	return &CourseUseCase{courses: courses, materials: materials}
+}
+
+func (uc *CourseUseCase) List(ctx context.Context, actorCompanyID uint64, actorRole string) ([]domain.Course, error) {
+	if actorCompanyID == 0 {
+		return []domain.Course{}, nil
+	}
+	includeUnpublished := canManage(actorRole)
+	return uc.courses.ListByCompany(ctx, actorCompanyID, includeUnpublished)
+}
+
+func (uc *CourseUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.Course, error) {
+	c, err := uc.courses.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canReadCourse(c, actorCompanyID, actorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	return c, nil
+}
+
+func canReadCourse(c *domain.Course, actorCompanyID uint64, actorRole string) bool {
+	if actorRole == domain.RoleSuperAdmin {
+		return true
+	}
+	if c.CompanyID != actorCompanyID {
+		return false
+	}
+	if !c.IsPublished && !canManage(actorRole) {
+		return false
+	}
+	return true
+}
+
+type CreateCourseInput struct {
+	ActorUserID    uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Description    string
+	SortOrder      int
+	IsPublished    bool
+}
+
+func (uc *CourseUseCase) Create(ctx context.Context, in CreateCourseInput) (*domain.Course, error) {
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden: only company_admin or super_admin can create courses")
+	}
+	if in.ActorCompanyID == 0 {
+		return nil, fmt.Errorf("actor must belong to a company")
+	}
+	c := &domain.Course{
+		CompanyID:       in.ActorCompanyID,
+		CreatedByUserID: in.ActorUserID,
+		Title:           in.Title,
+		Description:     in.Description,
+		SortOrder:       in.SortOrder,
+		IsPublished:     in.IsPublished,
+	}
+	if err := uc.courses.Create(ctx, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type UpdateCourseInput struct {
+	ID             uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Description    string
+	SortOrder      int
+	IsPublished    bool
+}
+
+func (uc *CourseUseCase) Update(ctx context.Context, in UpdateCourseInput) (*domain.Course, error) {
+	existing, err := uc.courses.GetByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	if in.ActorRole != domain.RoleSuperAdmin && existing.CompanyID != in.ActorCompanyID {
+		return nil, fmt.Errorf("forbidden")
+	}
+	existing.Title = in.Title
+	existing.Description = in.Description
+	existing.SortOrder = in.SortOrder
+	existing.IsPublished = in.IsPublished
+	if err := uc.courses.Update(ctx, existing); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+// Delete はコースとその配下の教材を同時に削除する。 教材は repository の
+// DeleteByCourse で一括削除（cascade 相当）。
+func (uc *CourseUseCase) Delete(ctx context.Context, id, actorCompanyID uint64, actorRole string) error {
+	existing, err := uc.courses.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canManage(actorRole) {
+		return fmt.Errorf("forbidden")
+	}
+	if actorRole != domain.RoleSuperAdmin && existing.CompanyID != actorCompanyID {
+		return fmt.Errorf("forbidden")
+	}
+	if err := uc.materials.DeleteByCourse(ctx, id); err != nil {
+		return err
+	}
+	return uc.courses.Delete(ctx, id)
+}

--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -1,0 +1,134 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCourseUseCase_List_TraineeOnlyPublished(t *testing.T) {
+	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.List(context.Background(), 10, domain.RoleTrainee)
+	require.NoError(t, err)
+}
+
+func TestCourseUseCase_List_NoCompanyReturnsEmpty(t *testing.T) {
+	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	out, err := uc.List(context.Background(), 0, domain.RoleSuperAdmin)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestCourseUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Get(context.Background(), 5, 10, domain.RoleTrainee)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestCourseUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Get(context.Background(), 5, 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), got.ID)
+}
+
+func TestCourseUseCase_Get_CrossCompanyForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Get(context.Background(), 5, 99, domain.RoleCompanyAdmin)
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Create_TraineeForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
+		Title: "Web 基礎",
+	})
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "Web 基礎", Description: "HTTP / REST", SortOrder: 10, IsPublished: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, crepo.created)
+	assert.Equal(t, uint64(7), crepo.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), crepo.created.CompanyID)
+	assert.Equal(t, "Web 基礎", got.Title)
+	assert.Equal(t, 10, got.SortOrder)
+}
+
+func TestCourseUseCase_Create_NoCompanyForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X",
+	})
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Update_CrossCompanyForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
+		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
+	})
+	require.Error(t, err)
+	assert.Nil(t, crepo.updated)
+}
+
+func TestCourseUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
+		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "new", Description: "X", SortOrder: 200, IsPublished: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Title)
+	assert.NotNil(t, crepo.updated)
+}
+
+func TestCourseUseCase_Delete_TraineeForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Delete_SameCompanyAdminCascadesMaterials(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), crepo.deleted)
+	assert.Equal(t, uint64(1), mrepo.deletedByCo, "コース配下の教材も cascade で削除される")
+}

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -12,18 +12,21 @@ import (
 // まとめて 1 構造体で扱う。 各操作は独立した Execute メソッドではなく
 // 名前付きメソッドにすることで、 handler 側のディスパッチを単純化する。
 //
+// 教材は必ず Course に所属する前提のため、 list は Course 単位、 create は course_id 必須。
+//
 // アクセス制御:
 //   - List: 同一 company の company_admin / trainee / super_admin
-//   - trainee は published のみ、 company_admin / super_admin は draft 含む全件
-//   - Get: 同一 company か super_admin
-//   - trainee は published のみ閲覧可
+//     trainee は published のみ、 company_admin / super_admin は draft 含む全件
+//     trainee は所属コースが is_published=false の場合は閲覧不可
+//   - Get: 同一 company か super_admin、 trainee は published のみ閲覧可
 //   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
 type TeachingMaterialUseCase struct {
-	repo repository.TeachingMaterialRepository
+	repo    repository.TeachingMaterialRepository
+	courses repository.CourseRepository
 }
 
-func NewTeachingMaterialUseCase(repo repository.TeachingMaterialRepository) *TeachingMaterialUseCase {
-	return &TeachingMaterialUseCase{repo: repo}
+func NewTeachingMaterialUseCase(repo repository.TeachingMaterialRepository, courses repository.CourseRepository) *TeachingMaterialUseCase {
+	return &TeachingMaterialUseCase{repo: repo, courses: courses}
 }
 
 // canManage は教材を作成 / 編集 / 削除できる role 判定。
@@ -31,10 +34,8 @@ func canManage(role string) bool {
 	return role == domain.RoleCompanyAdmin || role == domain.RoleSuperAdmin
 }
 
-// List は actor の role / company に応じて閲覧可能な教材一覧を返す。
-//   - companyID=0 のユーザ（super_admin で会社未紐付け等）は空配列を返す
-//   - super_admin かつ companyID=0 でも、 トップで会社全体管理する画面は別途用意する想定で、
-//     ここでは「自分の company に紐付く教材だけ」に絞る
+// List は backward-compat 用。 既存 frontend が GET /teaching-materials を直接叩くため、
+// company 内の全教材を返す。 frontend がコース対応に切り替わったら削除予定。
 func (uc *TeachingMaterialUseCase) List(ctx context.Context, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
 	if actorCompanyID == 0 {
 		return []domain.TeachingMaterial{}, nil
@@ -43,23 +44,46 @@ func (uc *TeachingMaterialUseCase) List(ctx context.Context, actorCompanyID uint
 	return uc.repo.ListByCompany(ctx, actorCompanyID, includeUnpublished)
 }
 
+// ListByCourse は指定コース配下の教材を返す。 actor の role / company を検証してから
+// repository を呼ぶ。 trainee はコース自体が is_published=true の場合のみ閲覧可。
+func (uc *TeachingMaterialUseCase) ListByCourse(ctx context.Context, courseID, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
+	course, err := uc.courses.GetByID(ctx, courseID)
+	if err != nil {
+		return nil, err
+	}
+	if !canReadCourse(course, actorCompanyID, actorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	includeUnpublished := canManage(actorRole)
+	return uc.repo.ListByCourse(ctx, courseID, includeUnpublished)
+}
+
 // Get は ID 指定で 1 件取得する。 actor の company と一致しないと 403 相当（nil）。
+// 所属コース自体が trainee に対して非公開なら閲覧不可。
 func (uc *TeachingMaterialUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.TeachingMaterial, error) {
 	m, err := uc.repo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
-	if !canRead(m, actorCompanyID, actorRole) {
+	course, err := uc.courses.GetByID(ctx, m.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if !canRead(m, course, actorCompanyID, actorRole) {
 		return nil, fmt.Errorf("forbidden")
 	}
 	return m, nil
 }
 
-func canRead(m *domain.TeachingMaterial, actorCompanyID uint64, actorRole string) bool {
+func canRead(m *domain.TeachingMaterial, course *domain.Course, actorCompanyID uint64, actorRole string) bool {
 	if actorRole == domain.RoleSuperAdmin {
 		return true
 	}
 	if m.CompanyID != actorCompanyID {
+		return false
+	}
+	// 所属コースも閲覧可能でないと教材も見せない（trainee は published コース内の published 教材のみ）。
+	if !canReadCourse(course, actorCompanyID, actorRole) {
 		return false
 	}
 	if !m.IsPublished && !canManage(actorRole) {
@@ -68,13 +92,15 @@ func canRead(m *domain.TeachingMaterial, actorCompanyID uint64, actorRole string
 	return true
 }
 
-// CreateInput は POST 入力。
+// CreateInput は POST 入力。 CourseID は必須（所属コース）。
 type CreateTeachingMaterialInput struct {
 	ActorUserID    uint64
 	ActorCompanyID uint64
 	ActorRole      string
+	CourseID       uint64
 	Title          string
 	Content        string
+	OrderInCourse  int
 	IsPublished    bool
 }
 
@@ -85,11 +111,24 @@ func (uc *TeachingMaterialUseCase) Create(ctx context.Context, in CreateTeaching
 	if in.ActorCompanyID == 0 {
 		return nil, fmt.Errorf("actor must belong to a company")
 	}
+	if in.CourseID == 0 {
+		return nil, fmt.Errorf("course_id is required")
+	}
+	// コースの存在 / company 一致を確認する。
+	course, err := uc.courses.GetByID(ctx, in.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if in.ActorRole != domain.RoleSuperAdmin && course.CompanyID != in.ActorCompanyID {
+		return nil, fmt.Errorf("forbidden")
+	}
 	m := &domain.TeachingMaterial{
-		CompanyID:       in.ActorCompanyID,
+		CompanyID:       course.CompanyID,
+		CourseID:        in.CourseID,
 		CreatedByUserID: in.ActorUserID,
 		Title:           in.Title,
 		Content:         in.Content,
+		OrderInCourse:   in.OrderInCourse,
 		IsPublished:     in.IsPublished,
 	}
 	if err := uc.repo.Create(ctx, m); err != nil {
@@ -104,6 +143,7 @@ type UpdateTeachingMaterialInput struct {
 	ActorRole      string
 	Title          string
 	Content        string
+	OrderInCourse  int
 	IsPublished    bool
 }
 
@@ -120,6 +160,7 @@ func (uc *TeachingMaterialUseCase) Update(ctx context.Context, in UpdateTeaching
 	}
 	existing.Title = in.Title
 	existing.Content = in.Content
+	existing.OrderInCourse = in.OrderInCourse
 	existing.IsPublished = in.IsPublished
 	if err := uc.repo.Update(ctx, existing); err != nil {
 		return nil, err

--- a/backend/internal/usecase/teaching_material_usecase_test.go
+++ b/backend/internal/usecase/teaching_material_usecase_test.go
@@ -8,23 +8,28 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 // fakeTeachingMaterialRepo は usecase テスト用フェイク。
 type fakeTeachingMaterialRepo struct {
-	rows    []domain.TeachingMaterial
-	getResp *domain.TeachingMaterial
-	getErr  error
-	created *domain.TeachingMaterial
-	updated *domain.TeachingMaterial
-	deleted uint64
-	// list 呼び出し時の引数記録
-	listCompany      uint64
-	listIncludeDraft bool
+	rows           []domain.TeachingMaterial
+	getResp        *domain.TeachingMaterial
+	getErr         error
+	created        *domain.TeachingMaterial
+	updated        *domain.TeachingMaterial
+	deleted        uint64
+	deletedByCo    uint64
+	listCourseID   uint64
+	listIncludeAll bool
 }
 
-func (r *fakeTeachingMaterialRepo) ListByCompany(_ context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
-	r.listCompany, r.listIncludeDraft = companyID, includeUnpublished
+func (r *fakeTeachingMaterialRepo) ListByCompany(_ context.Context, _ uint64, _ bool) ([]domain.TeachingMaterial, error) {
+	return r.rows, nil
+}
+
+func (r *fakeTeachingMaterialRepo) ListByCourse(_ context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	r.listCourseID, r.listIncludeAll = courseID, includeUnpublished
 	return r.rows, nil
 }
 func (r *fakeTeachingMaterialRepo) GetByID(_ context.Context, _ uint64) (*domain.TeachingMaterial, error) {
@@ -43,147 +48,227 @@ func (r *fakeTeachingMaterialRepo) Delete(_ context.Context, id uint64) error {
 	r.deleted = id
 	return nil
 }
-
-func TestTeachingMaterialUseCase_List_TraineeOnlyPublished(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
-	_, err := uc.List(context.Background(), 10, domain.RoleTrainee)
-	require.NoError(t, err)
-	assert.Equal(t, uint64(10), repo.listCompany)
-	assert.False(t, repo.listIncludeDraft, "trainee は draft を含まない")
+func (r *fakeTeachingMaterialRepo) DeleteByCourse(_ context.Context, courseID uint64) error {
+	r.deletedByCo = courseID
+	return nil
 }
 
-func TestTeachingMaterialUseCase_List_CompanyAdminIncludesDraft(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
-	_, err := uc.List(context.Background(), 10, domain.RoleCompanyAdmin)
-	require.NoError(t, err)
-	assert.True(t, repo.listIncludeDraft)
+// fakeCourseRepo は course 依存をスタブ化する。
+type fakeCourseRepo struct {
+	rows    []domain.Course
+	getResp *domain.Course
+	getErr  error
+	created *domain.Course
+	updated *domain.Course
+	deleted uint64
 }
 
-func TestTeachingMaterialUseCase_List_NoCompanyReturnsEmpty(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{rows: []domain.TeachingMaterial{{ID: 1}}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
-	out, err := uc.List(context.Background(), 0, domain.RoleSuperAdmin)
+func (r *fakeCourseRepo) ListByCompany(_ context.Context, _ uint64, _ bool) ([]domain.Course, error) {
+	return r.rows, nil
+}
+func (r *fakeCourseRepo) GetByID(_ context.Context, _ uint64) (*domain.Course, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	return r.getResp, nil
+}
+func (r *fakeCourseRepo) Create(_ context.Context, c *domain.Course) error {
+	c.ID = 88
+	r.created = c
+	return nil
+}
+func (r *fakeCourseRepo) Update(_ context.Context, c *domain.Course) error {
+	r.updated = c
+	return nil
+}
+func (r *fakeCourseRepo) Delete(_ context.Context, id uint64) error {
+	r.deleted = id
+	return nil
+}
+
+func TestTeachingMaterialUseCase_ListByCourse_TraineeOnlyPublished(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleTrainee)
 	require.NoError(t, err)
-	assert.Empty(t, out)
+	assert.Equal(t, uint64(5), mrepo.listCourseID)
+	assert.False(t, mrepo.listIncludeAll, "trainee は draft を含まない")
+}
+
+func TestTeachingMaterialUseCase_ListByCourse_TraineeCannotSeeUnpublishedCourse(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleTrainee)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_ListByCourse_CompanyAdminIncludesDraft(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.True(t, mrepo.listIncludeAll)
 }
 
 func TestTeachingMaterialUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10, IsPublished: false,
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
 func TestTeachingMaterialUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10, IsPublished: true,
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), got.ID)
 }
 
 func TestTeachingMaterialUseCase_Get_CrossCompanyForbidden(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10, IsPublished: true,
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Get(context.Background(), 1, 99, domain.RoleCompanyAdmin)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
 func TestTeachingMaterialUseCase_Get_SuperAdminCrossCompanyAllowed(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10, IsPublished: false,
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Get(context.Background(), 1, 99, domain.RoleSuperAdmin)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(1), got.ID)
 }
 
 func TestTeachingMaterialUseCase_Create_TraineeForbidden(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
-		Title: "X", Content: "Y", IsPublished: true,
+		CourseID: 5, Title: "X", Content: "Y", IsPublished: true,
 	})
 	require.Error(t, err)
 }
 
 func TestTeachingMaterialUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
-		Title: "Spring 入門", Content: "# Spring", IsPublished: true,
+		CourseID: 5, Title: "Spring 入門", Content: "# Spring", IsPublished: true,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, repo.created)
-	assert.Equal(t, uint64(7), repo.created.CreatedByUserID)
-	assert.Equal(t, uint64(10), repo.created.CompanyID)
+	require.NotNil(t, mrepo.created)
+	assert.Equal(t, uint64(7), mrepo.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), mrepo.created.CompanyID)
+	assert.Equal(t, uint64(5), mrepo.created.CourseID)
 	assert.Equal(t, "Spring 入門", got.Title)
 }
 
+func TestTeachingMaterialUseCase_Create_MissingCourseIDForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "course_id")
+}
+
+func TestTeachingMaterialUseCase_Create_CrossCompanyCourseForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 99}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		CourseID: 5, Title: "X",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
 func TestTeachingMaterialUseCase_Create_NoCompanyForbidden(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
-		Title: "X",
+		CourseID: 5, Title: "X",
 	})
 	require.Error(t, err)
 }
 
 func TestTeachingMaterialUseCase_Update_CrossCompanyForbidden(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10, Title: "old",
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
 		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
 	})
 	require.Error(t, err)
-	assert.Nil(t, repo.updated)
+	assert.Nil(t, mrepo.updated)
 }
 
 func TestTeachingMaterialUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10, Title: "old",
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
-		Title: "new", Content: "X", IsPublished: true,
+		Title: "new", Content: "X", OrderInCourse: 200, IsPublished: true,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "new", got.Title)
-	assert.NotNil(t, repo.updated)
+	assert.Equal(t, 200, got.OrderInCourse)
+	assert.NotNil(t, mrepo.updated)
 }
 
 func TestTeachingMaterialUseCase_Delete_TraineeForbidden(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10,
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5,
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
 	require.Error(t, err)
 }
 
 func TestTeachingMaterialUseCase_Delete_SameCompanyAdminSucceeds(t *testing.T) {
-	repo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
-		ID: 1, CompanyID: 10,
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5,
 	}}
-	uc := usecase.NewTeachingMaterialUseCase(repo)
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), repo.deleted)
+	assert.Equal(t, uint64(1), mrepo.deleted)
 }
+
+// 念のため: gorm 依存を import で残すための no-op（一部 import path 揃え用）。
+var _ = gorm.ErrRecordNotFound

--- a/backend/migrations/0004_courses.sql
+++ b/backend/migrations/0004_courses.sql
@@ -1,0 +1,72 @@
+-- 0004_courses.sql
+-- PR-A: コース概念の導入
+--
+-- 1. courses テーブルを作成（GORM AutoMigrate と同じスキーマ）
+-- 2. teaching_materials に course_id / order_in_course カラムを追加
+-- 3. 各 company ごとに「Web 基礎」コースを作成し、 既存教材をそこに移管
+-- 4. course_id を NOT NULL に確定
+--
+-- 適用先: 本番 (RDS) は EC2 踏み台経由で psql -f
+-- 冪等性: IF NOT EXISTS / DO ブロックで guard
+
+BEGIN;
+
+-- 1. courses テーブル
+CREATE TABLE IF NOT EXISTS courses (
+  id                   BIGSERIAL PRIMARY KEY,
+  company_id           BIGINT NOT NULL,
+  created_by_user_id   BIGINT NOT NULL,
+  title                VARCHAR(200) NOT NULL DEFAULT '',
+  description          TEXT NOT NULL DEFAULT '',
+  sort_order           INT NOT NULL DEFAULT 100,
+  is_published         BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_courses_company_id ON courses(company_id);
+
+-- 2. teaching_materials に course_id / order_in_course カラムを追加（nullable で先に追加）
+ALTER TABLE teaching_materials
+  ADD COLUMN IF NOT EXISTS course_id        BIGINT,
+  ADD COLUMN IF NOT EXISTS order_in_course  INT NOT NULL DEFAULT 100;
+
+CREATE INDEX IF NOT EXISTS idx_teaching_materials_course_id ON teaching_materials(course_id);
+
+-- 3. 各 company ごとに「Web 基礎」コースを作成（既存教材がある company のみ）
+--    教材作成者の中で最も古い user_id を created_by_user_id に流用する。
+DO $$
+DECLARE
+  rec RECORD;
+  new_course_id BIGINT;
+BEGIN
+  FOR rec IN
+    SELECT company_id, MIN(created_by_user_id) AS owner_user_id
+    FROM teaching_materials
+    WHERE course_id IS NULL
+    GROUP BY company_id
+  LOOP
+    INSERT INTO courses (company_id, created_by_user_id, title, description, sort_order, is_published, created_at, updated_at)
+    VALUES (
+      rec.company_id,
+      rec.owner_user_id,
+      'Web 基礎',
+      'Web の基本的な知識（HTTP / URI / HTML / REST）を学ぶコース。',
+      10,
+      TRUE,
+      NOW(),
+      NOW()
+    )
+    RETURNING id INTO new_course_id;
+
+    UPDATE teaching_materials
+       SET course_id = new_course_id
+     WHERE company_id = rec.company_id AND course_id IS NULL;
+  END LOOP;
+END $$;
+
+-- 4. course_id を NOT NULL に確定（残った NULL があるなら ALTER は失敗するので手当てが必要）
+ALTER TABLE teaching_materials
+  ALTER COLUMN course_id SET NOT NULL;
+
+COMMIT;

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { WrenchScrewdriverIcon, ArrowPathIcon, ClockIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon, ClockIcon } from '@heroicons/react/24/outline';
 
 interface MaintenancePageProps {
   /** 「再試行」ボタンが押されたときに呼ぶ。useBackendHealth.recheck を渡す。 */
@@ -37,8 +37,14 @@ export default function MaintenancePage({ onRetry }: MaintenancePageProps) {
   return (
     <div className="min-h-screen flex items-center justify-center bg-[var(--color-surface-1)] px-6">
       <div className="max-w-lg w-full text-center">
-        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber-500/15 text-amber-400 mb-6">
-          <WrenchScrewdriverIcon className="w-8 h-8" />
+        <div className="inline-flex items-center justify-center w-16 h-16 mb-6">
+          <img
+            src="/favicon.svg"
+            alt="FreStyle"
+            className="w-12 h-12"
+            width={48}
+            height={48}
+          />
         </div>
         <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-3">
           ただいまメンテナンス中です


### PR DESCRIPTION
## 概要

- 教材を「コース（プロジェクト）」単位で束ねる **2 階層スキーマ** を導入（バックエンドのみ）
- 既存の単独教材は migration で各 company の「Web 基礎」コースに自動移管
- メンテナンスページのアイコンを ブランド favicon.svg に差し替え

## 変更内容

### バックエンド: Course エンティティ
- `domain.Course` を新設（id / company_id / created_by_user_id / title / description / sort_order / is_published）
- `cover_image_url` は意図的に持たない（後で必要なら別 PR）
- `repository.CourseRepository` (interface + impl)
- `usecase.CourseUseCase` (List / Get / Create / Update / Delete)
- `handler.CourseHandler` + `routes_courses.go`
- AutoMigrate に `Course` を追加

### バックエンド: TeachingMaterial の課程化
- `course_id` (NOT NULL) と `order_in_course` を追加
- ListByCourse(課程内一覧) / DeleteByCourse(cascade 削除用) を repository に追加
- usecase の Get / Create / Update は course_id 必須化
- 既存 `List` (company 内全件) は backward-compat として残し、 frontend 切替後に削除予定

### Migration: 0004_courses.sql
- `courses` テーブル作成
- `teaching_materials` に `course_id` / `order_in_course` 追加
- 各 company の既存教材を「Web 基礎」コース（is_published=true）に移管
- course_id を NOT NULL に確定

### フロント: メンテページ favicon
- `WrenchScrewdriverIcon` → `<img src="/favicon.svg">`
- 装飾の amber 背景円を撤去（ライトテーマ単一構成と整合）

## 追加 API

\`\`\`
GET    /api/v2/courses                      コース一覧
GET    /api/v2/courses/:id                  コース詳細
POST   /api/v2/courses                      作成（company_admin / super_admin）
PUT    /api/v2/courses/:id                  更新（同上）
DELETE /api/v2/courses/:id                  削除（配下教材も cascade）
GET    /api/v2/courses/:id/materials        コース内教材一覧
\`\`\`

## アクセス制御

- **trainee**: 同一 company の `is_published=true` コースのみ閲覧可。 教材は所属コースが published かつ教材自身が published の場合のみ
- **company_admin**: 自社のコース・教材を全件管理可
- **super_admin**: 横断的に閲覧 / 操作可

## テスト

- [x] `go vet ./...` パス
- [x] `go test ./...` パス（usecase 単体テストで ACL を網羅）
- [x] `go build ./...` パス
- [x] `npx tsc --noEmit` (frontend MaintenancePage 改修のため) パス

## デプロイ手順

1. このPRを admin merge
2. 本番 RDS に migration 0004_courses.sql を適用（EC2 踏み台経由）
3. backend deploy
4. frontend deploy（MaintenancePage の favicon 反映）

## 関連 Issue

なし（ユーザー直接要望）

## 後続 PR

- PR-B (frontend): `/courses` 一覧 + `/courses/:id` 詳細 + 既存 `TeachingMaterialsPage` をコース対応に置換

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コース管理機能を追加：コースの作成・編集・削除・表示が可能になりました
  * 教材をコースに関連付け：教材がコース単位で整理・表示されるようになりました
  * コース内での教材順序付け：教材の表示順序をカスタマイズできるようになりました
  * ロールベースのアクセス制御：管理者と受講者で異なるコース・教材へのアクセス権限を設定できるようになりました

* **その他**
  * UI アイコンを更新

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1694)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->