### PR TITLE
feat(frontend): コース → 教材 の 2 階層 UI に刷新

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,7 +33,8 @@ const AdminInvitationsPage = lazyWithReload(() => import('./pages/AdminInvitatio
 const AdminCompaniesPage = lazyWithReload(() => import('./pages/AdminCompaniesPage'), 'AdminCompaniesPage');
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
-const TeachingMaterialsPage = lazyWithReload(() => import('./pages/TeachingMaterialsPage'), 'TeachingMaterialsPage');
+const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
+const CourseDetailPage = lazyWithReload(() => import('./pages/CourseDetailPage'), 'CourseDetailPage');
 const MarkdownSyntaxHelpPage = lazyWithReload(() => import('./pages/MarkdownSyntaxHelpPage'), 'MarkdownSyntaxHelpPage');
 
 function NavigationToast() {
@@ -107,7 +108,10 @@ export default function App() {
         <Route path="/help" element={<HelpPage />} />
         <Route path="/code-editor" element={<ExerciseListPage />} />
         <Route path="/code-editor/:slug" element={<ExerciseDetailPage />} />
-        <Route path="/teaching-materials" element={<TeachingMaterialsPage />} />
+        <Route path="/courses" element={<CoursesListPage />} />
+        <Route path="/courses/:id" element={<CourseDetailPage />} />
+        {/* 旧 /teaching-materials へのアクセスは /courses に redirect */}
+        <Route path="/teaching-materials" element={<CoursesListPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -44,7 +44,7 @@ const mainNavItems: NavItem[] = [
   { id: 'home', icon: HomeIcon, label: 'ホーム', to: '/', matchExact: true },
   { id: 'ai', icon: ChatBubbleBottomCenterTextIcon, label: 'AI', to: '/chat/ask-ai', matchPrefix: '/chat/ask-ai' },
   { id: 'code', icon: CodeBracketIcon, label: 'コード学習', to: '/code-editor', matchPrefix: '/code-editor' },
-  { id: 'materials', icon: AcademicCapIcon, label: '教材', to: '/teaching-materials', matchPrefix: '/teaching-materials' },
+  { id: 'courses', icon: AcademicCapIcon, label: 'コース', to: '/courses', matchPrefix: '/courses' },
   { id: 'notes', icon: DocumentTextIcon, label: 'ノート', to: '/notes', matchPrefix: '/notes' },
   { id: 'notifications', icon: BellIcon, label: '通知', to: '/notifications', matchExact: true },
   { id: 'reports', icon: DocumentChartBarIcon, label: 'レポート', to: '/reports', matchExact: true },

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -167,10 +167,19 @@ export const CODE = {
   execute: `${API_V2}/code/execute`,
 } as const;
 
-/** 教材（company_admin が作成、 自社 trainee + 同社 admin が閲覧）*/
+/** コース（company_admin が作成、 自社 trainee + 同社 admin が閲覧）*/
+export const COURSES = {
+  list: `${API_V2}/courses`,
+  byId: (id: number | string) => `${API_V2}/courses/${id}`,
+  /** GET /api/v2/courses/:id/materials — コース内教材一覧 */
+  materials: (id: number | string) => `${API_V2}/courses/${id}/materials`,
+} as const;
+
+/** 教材 個別 CRUD（コース配下）*/
 export const TEACHING_MATERIALS = {
-  list: `${API_V2}/teaching-materials`,
   byId: (id: number | string) => `${API_V2}/teaching-materials/${id}`,
+  /** POST /api/v2/teaching-materials — body の courseId 必須 */
+  create: `${API_V2}/teaching-materials`,
 } as const;
 
 // WebSocket は SSE (AI_CHAT.stream) への置換で廃止 (PR-D, 2026-05-07)。

--- a/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
@@ -1,11 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useTeachingMaterials } from '../useTeachingMaterials';
+import CourseRepository from '../../repositories/CourseRepository';
 import TeachingMaterialRepository from '../../repositories/TeachingMaterialRepository';
+
+vi.mock('../../repositories/CourseRepository', () => ({
+  default: {
+    list: vi.fn(),
+    get: vi.fn(),
+    listMaterials: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
 
 vi.mock('../../repositories/TeachingMaterialRepository', () => ({
   default: {
-    list: vi.fn(),
     get: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
@@ -13,14 +24,20 @@ vi.mock('../../repositories/TeachingMaterialRepository', () => ({
   },
 }));
 
-const mocks = vi.mocked(TeachingMaterialRepository);
+const courseMocks = vi.mocked(CourseRepository);
+const materialMocks = vi.mocked(TeachingMaterialRepository);
 
-const sample = (id: number, overrides: Partial<{ title: string; isPublished: boolean }> = {}) => ({
+const sample = (
+  id: number,
+  overrides: Partial<{ title: string; isPublished: boolean; orderInCourse: number }> = {},
+) => ({
   id,
   companyId: 1,
+  courseId: 5,
   createdByUserId: 1,
   title: overrides.title ?? `教材${id}`,
   content: '',
+  orderInCourse: overrides.orderInCourse ?? id * 10,
   isPublished: overrides.isPublished ?? true,
   createdAt: '',
   updatedAt: '',
@@ -29,48 +46,63 @@ const sample = (id: number, overrides: Partial<{ title: string; isPublished: boo
 describe('useTeachingMaterials', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('初期化で list が呼ばれて結果が state に入る', async () => {
-    mocks.list.mockResolvedValue([sample(1), sample(2)]);
-    const { result } = renderHook(() => useTeachingMaterials());
+  it('courseId が null なら API は呼ばれず空配列のまま', async () => {
+    const { result } = renderHook(() => useTeachingMaterials(null));
     await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(courseMocks.listMaterials).not.toHaveBeenCalled();
+    expect(result.current.materials).toEqual([]);
+  });
+
+  it('courseId 指定で listMaterials が呼ばれて結果が state に入る', async () => {
+    courseMocks.listMaterials.mockResolvedValue([sample(1), sample(2)]);
+    const { result } = renderHook(() => useTeachingMaterials(5));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(courseMocks.listMaterials).toHaveBeenCalledWith(5);
     expect(result.current.materials).toHaveLength(2);
   });
 
-  it('list 失敗時に error をセット', async () => {
-    mocks.list.mockRejectedValue(new Error('boom'));
-    const { result } = renderHook(() => useTeachingMaterials());
+  it('listMaterials 失敗時に error をセット', async () => {
+    courseMocks.listMaterials.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useTeachingMaterials(5));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBe('教材の取得に失敗しました');
   });
 
   it('searchQuery でタイトル / 本文がフィルタされる', async () => {
-    mocks.list.mockResolvedValue([
+    courseMocks.listMaterials.mockResolvedValue([
       sample(1, { title: 'PHP 入門' }),
       sample(2, { title: 'Go 入門' }),
     ]);
-    const { result } = renderHook(() => useTeachingMaterials());
+    const { result } = renderHook(() => useTeachingMaterials(5));
     await waitFor(() => expect(result.current.loading).toBe(false));
     act(() => result.current.setSearchQuery('php'));
     expect(result.current.filtered).toHaveLength(1);
     expect(result.current.filtered[0].title).toBe('PHP 入門');
   });
 
-  it('create 成功時にリスト先頭に追加され selected になる', async () => {
-    mocks.list.mockResolvedValue([]);
-    mocks.create.mockResolvedValue(sample(99));
-    const { result } = renderHook(() => useTeachingMaterials());
+  it('create 成功時にリストに追加され selected になる', async () => {
+    courseMocks.listMaterials.mockResolvedValue([]);
+    materialMocks.create.mockResolvedValue(sample(99, { orderInCourse: 100 }));
+    const { result } = renderHook(() => useTeachingMaterials(5));
     await waitFor(() => expect(result.current.loading).toBe(false));
     await act(async () => {
-      await result.current.create({ title: '新', content: '', isPublished: false });
+      await result.current.create({
+        title: '新',
+        content: '',
+        orderInCourse: 100,
+        isPublished: false,
+      });
     });
+    expect(materialMocks.create).toHaveBeenCalledWith(expect.objectContaining({ courseId: 5 }));
+    expect(result.current.materials).toHaveLength(1);
     expect(result.current.materials[0].id).toBe(99);
     expect(result.current.selectedId).toBe(99);
   });
 
   it('remove 成功時にリストから消え selected もクリア', async () => {
-    mocks.list.mockResolvedValue([sample(1)]);
-    mocks.remove.mockResolvedValue(undefined);
-    const { result } = renderHook(() => useTeachingMaterials());
+    courseMocks.listMaterials.mockResolvedValue([sample(1)]);
+    materialMocks.remove.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useTeachingMaterials(5));
     await waitFor(() => expect(result.current.loading).toBe(false));
     act(() => result.current.selectMaterial(1));
     await act(async () => {

--- a/frontend/src/hooks/useCourses.ts
+++ b/frontend/src/hooks/useCourses.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import CourseRepository, {
+  type CoursePayload,
+} from '../repositories/CourseRepository';
+import type { Course } from '../types';
+
+/**
+ * useCourses — コース一覧 + 検索 + CRUD の状態管理。
+ *
+ * trainee は published のみ、 company_admin / super_admin は draft 含む全件を取得する
+ * （フィルタは backend 側）。
+ */
+export function useCourses() {
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await CourseRepository.list();
+      setCourses(rows);
+    } catch {
+      setError('コースの取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const filtered = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return courses;
+    return courses.filter(
+      (c) => c.title.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
+    );
+  }, [courses, searchQuery]);
+
+  const create = useCallback(async (initial: CoursePayload): Promise<Course | null> => {
+    try {
+      const created = await CourseRepository.create(initial);
+      setCourses((prev) => [...prev, created].sort(byOrderThenId));
+      return created;
+    } catch {
+      setError('コースの作成に失敗しました');
+      return null;
+    }
+  }, []);
+
+  const update = useCallback(
+    async (id: number, payload: CoursePayload): Promise<Course | null> => {
+      try {
+        const updated = await CourseRepository.update(id, payload);
+        setCourses((prev) => prev.map((c) => (c.id === id ? updated : c)).sort(byOrderThenId));
+        return updated;
+      } catch {
+        setError('コースの更新に失敗しました');
+        return null;
+      }
+    },
+    [],
+  );
+
+  const remove = useCallback(async (id: number): Promise<void> => {
+    try {
+      await CourseRepository.remove(id);
+      setCourses((prev) => prev.filter((c) => c.id !== id));
+    } catch {
+      setError('コースの削除に失敗しました');
+    }
+  }, []);
+
+  return {
+    courses,
+    filtered,
+    loading,
+    error,
+    searchQuery,
+    setSearchQuery,
+    fetchAll,
+    create,
+    update,
+    remove,
+  };
+}
+
+// 並び順は backend 側と同じ: sort_order 昇順 → id 昇順
+function byOrderThenId(a: Course, b: Course): number {
+  if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+  return a.id - b.id;
+}

--- a/frontend/src/hooks/useTeachingMaterialEditor.ts
+++ b/frontend/src/hooks/useTeachingMaterialEditor.ts
@@ -7,7 +7,7 @@ interface Args {
   selected: TeachingMaterial | null;
   update: (
     id: number,
-    payload: { title: string; content: string; isPublished: boolean },
+    payload: { title: string; content: string; orderInCourse: number; isPublished: boolean },
   ) => Promise<void>;
 }
 
@@ -46,17 +46,22 @@ export function useTeachingMaterialEditor({ selectedId, selected, update }: Args
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       setSaveStatus('unsaved');
       saveTimerRef.current = setTimeout(async () => {
-        if (selectedId == null) return;
+        if (selectedId == null || !selected) return;
         setSaveStatus('saving');
         try {
-          await update(selectedId, { title, content, isPublished });
+          await update(selectedId, {
+            title,
+            content,
+            orderInCourse: selected.orderInCourse,
+            isPublished,
+          });
           setSaveStatus('saved');
         } catch {
           setSaveStatus('idle');
         }
       }, 800);
     },
-    [selectedId, update],
+    [selectedId, selected, update],
   );
 
   const handleTitleChange = useCallback(

--- a/frontend/src/hooks/useTeachingMaterials.ts
+++ b/frontend/src/hooks/useTeachingMaterials.ts
@@ -1,16 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import CourseRepository from '../repositories/CourseRepository';
 import TeachingMaterialRepository, {
-  type TeachingMaterialPayload,
+  type TeachingMaterialCreatePayload,
+  type TeachingMaterialUpdatePayload,
 } from '../repositories/TeachingMaterialRepository';
 import type { TeachingMaterial } from '../types';
 
 /**
- * useTeachingMaterials — 教材一覧 + 選択 + CRUD の状態管理。
+ * useTeachingMaterials — 指定コース配下の教材一覧 + 選択 + CRUD の状態管理。
  *
- * NotesPage の useNotes と同じ「左パネル一覧 + 右パネル詳細」構成を想定。
- * autosave は別 hook (useTeachingMaterialEditor) に分離する。
+ * `courseId` が 0 / null なら何もせず空配列を保持する（routing で `/courses/:id` に
+ * 入った瞬間にコース ID が確定する想定）。 autosave は別 hook (useTeachingMaterialEditor) に分離。
  */
-export function useTeachingMaterials() {
+export function useTeachingMaterials(courseId: number | null) {
   const [materials, setMaterials] = useState<TeachingMaterial[]>([]);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
@@ -18,17 +20,22 @@ export function useTeachingMaterials() {
   const [searchQuery, setSearchQuery] = useState('');
 
   const fetchAll = useCallback(async () => {
+    if (!courseId) {
+      setMaterials([]);
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
-      const rows = await TeachingMaterialRepository.list();
+      const rows = await CourseRepository.listMaterials(courseId);
       setMaterials(rows);
     } catch {
       setError('教材の取得に失敗しました');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [courseId]);
 
   useEffect(() => {
     fetchAll();
@@ -47,23 +54,30 @@ export function useTeachingMaterials() {
     );
   }, [materials, searchQuery]);
 
-  const create = useCallback(async (initial: TeachingMaterialPayload): Promise<TeachingMaterial | null> => {
-    try {
-      const created = await TeachingMaterialRepository.create(initial);
-      setMaterials((prev) => [created, ...prev]);
-      setSelectedId(created.id);
-      return created;
-    } catch {
-      setError('教材の作成に失敗しました');
-      return null;
-    }
-  }, []);
+  const create = useCallback(
+    async (initial: Omit<TeachingMaterialCreatePayload, 'courseId'>): Promise<TeachingMaterial | null> => {
+      if (!courseId) {
+        setError('コースが選択されていません');
+        return null;
+      }
+      try {
+        const created = await TeachingMaterialRepository.create({ ...initial, courseId });
+        setMaterials((prev) => [...prev, created].sort(byOrderThenId));
+        setSelectedId(created.id);
+        return created;
+      } catch {
+        setError('教材の作成に失敗しました');
+        return null;
+      }
+    },
+    [courseId],
+  );
 
   const update = useCallback(
-    async (id: number, payload: TeachingMaterialPayload): Promise<void> => {
+    async (id: number, payload: TeachingMaterialUpdatePayload): Promise<void> => {
       try {
         const updated = await TeachingMaterialRepository.update(id, payload);
-        setMaterials((prev) => prev.map((m) => (m.id === id ? updated : m)));
+        setMaterials((prev) => prev.map((m) => (m.id === id ? updated : m)).sort(byOrderThenId));
       } catch {
         setError('教材の更新に失敗しました');
       }
@@ -99,4 +113,9 @@ export function useTeachingMaterials() {
     update,
     remove,
   };
+}
+
+function byOrderThenId(a: TeachingMaterial, b: TeachingMaterial): number {
+  if (a.orderInCourse !== b.orderInCourse) return a.orderInCourse - b.orderInCourse;
+  return a.id - b.id;
 }

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -1,5 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   AcademicCapIcon,
   PlusIcon,
@@ -8,6 +9,7 @@ import {
   TrashIcon,
   CheckCircleIcon,
   ClockIcon,
+  ArrowLeftIcon,
 } from '@heroicons/react/24/outline';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
 import EmptyState from '../components/EmptyState';
@@ -19,24 +21,32 @@ import { useTeachingMaterials } from '../hooks/useTeachingMaterials';
 import { useTeachingMaterialEditor } from '../hooks/useTeachingMaterialEditor';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
 import { useToast } from '../hooks/useToast';
-import { useState } from 'react';
+import CourseRepository from '../repositories/CourseRepository';
 import type { RootState } from '../store';
-import type { TeachingMaterial } from '../types';
+import type { Course, TeachingMaterial } from '../types';
 
 /**
- * TeachingMaterialsPage — `/teaching-materials` 教材一覧 + 編集ページ。
+ * CourseDetailPage — `/courses/:id` 配下の教材一覧 + 編集ページ。
  *
- * - company_admin / super_admin: 教材を作成 / 編集 / 削除 / 公開状態切替
- * - trainee: 自社の `isPublished=true` 教材を閲覧のみ
+ * - company_admin / super_admin: コース内教材を作成 / 編集 / 削除 / 公開状態切替
+ * - trainee: published コース + published 教材のみ閲覧
  *
  * 左パネルに教材リスト、 右側に詳細（NoteMarkdownEditor 流用 = Edit/Preview タブ）。
  */
-export default function TeachingMaterialsPage() {
+export default function CourseDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const courseId = id ? Number(id) : null;
+  const navigate = useNavigate();
+
   const role = useSelector((s: RootState) => s.auth.role);
   const canManage = role === 'company_admin' || role === 'super_admin';
 
   const { showToast } = useToast();
   const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
+
+  const [course, setCourse] = useState<Course | null>(null);
+  const [courseLoading, setCourseLoading] = useState(true);
+  const [courseError, setCourseError] = useState<string | null>(null);
 
   const {
     materials,
@@ -51,19 +61,34 @@ export default function TeachingMaterialsPage() {
     create,
     update,
     remove,
-    fetchAll,
-  } = useTeachingMaterials();
+  } = useTeachingMaterials(courseId);
 
   const editor = useTeachingMaterialEditor({ selectedId, selected, update });
 
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
 
   useEffect(() => {
-    fetchAll();
-  }, [fetchAll]);
+    if (!courseId) return;
+    setCourseLoading(true);
+    CourseRepository.get(courseId)
+      .then((c) => setCourse(c))
+      .catch(() => setCourseError('コースの取得に失敗しました'))
+      .finally(() => setCourseLoading(false));
+  }, [courseId]);
+
+  // 次の order_in_course を計算（既存の最大値 + 10）。
+  const nextOrder = useMemo(() => {
+    if (materials.length === 0) return 100;
+    return Math.max(...materials.map((m) => m.orderInCourse)) + 10;
+  }, [materials]);
 
   const handleCreate = async () => {
-    const created = await create({ title: '無題の教材', content: '', isPublished: false });
+    const created = await create({
+      title: '無題の教材',
+      content: '',
+      orderInCourse: nextOrder,
+      isPublished: false,
+    });
     if (created) {
       showToast('success', '教材を作成しました');
     } else {
@@ -72,8 +97,8 @@ export default function TeachingMaterialsPage() {
     closeMobilePanel();
   };
 
-  const handleSelect = (id: number) => {
-    selectMaterial(id);
+  const handleSelect = (mid: number) => {
+    selectMaterial(mid);
     closeMobilePanel();
   };
 
@@ -84,15 +109,48 @@ export default function TeachingMaterialsPage() {
     showToast('success', '教材を削除しました');
   };
 
+  if (!courseId) {
+    return (
+      <EmptyState
+        icon={AcademicCapIcon}
+        title="コースが指定されていません"
+        description="コース一覧から選択してください。"
+        action={{ label: 'コース一覧へ', onClick: () => navigate('/courses') }}
+      />
+    );
+  }
+
+  if (courseLoading) {
+    return <Loading className="h-full" />;
+  }
+
+  if (courseError || !course) {
+    return (
+      <EmptyState
+        icon={AcademicCapIcon}
+        title="コースが見つかりませんでした"
+        description={courseError ?? '権限がないか、 コースが削除された可能性があります。'}
+        action={{ label: 'コース一覧へ', onClick: () => navigate('/courses') }}
+      />
+    );
+  }
+
   return (
     <div className="flex h-full">
       <SecondaryPanel
-        title="教材"
+        title={course.title || '無題のコース'}
         badge={`${materials.length}件`}
         mobileOpen={mobilePanelOpen}
         onMobileClose={closeMobilePanel}
         headerContent={
           <div className="space-y-2">
+            <Link
+              to="/courses"
+              className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+            >
+              <ArrowLeftIcon className="w-3.5 h-3.5" />
+              コース一覧
+            </Link>
             <div className="relative">
               <MagnifyingGlassIcon className="w-4 h-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)]" />
               <input
@@ -141,7 +199,7 @@ export default function TeachingMaterialsPage() {
                 material={m}
                 isActive={selectedId === m.id}
                 onSelect={handleSelect}
-                onDelete={canManage ? (id) => setDeleteTargetId(id) : undefined}
+                onDelete={canManage ? (mid) => setDeleteTargetId(mid) : undefined}
               />
             ))
           )}
@@ -158,16 +216,14 @@ export default function TeachingMaterialsPage() {
           >
             <Bars3Icon className="w-5 h-5 text-[var(--color-text-muted)]" />
           </button>
-          <span className="ml-2 text-xs text-[var(--color-text-muted)]">教材一覧</span>
+          <span className="ml-2 text-xs text-[var(--color-text-muted)]">{course.title}</span>
         </div>
 
         {error && <p className="px-6 py-3 text-sm text-red-500">{error}</p>}
 
         {selected ? (
           canManage ? (
-            <ManagedDetail
-              editor={editor}
-            />
+            <ManagedDetail editor={editor} />
           ) : (
             <ReadOnlyDetail material={selected} />
           )
@@ -284,9 +340,6 @@ function ManagedDetail({
 }
 
 function ReadOnlyDetail({ material }: { material: TeachingMaterial }) {
-  // 拡張記法風 2 カラム: 左 = 本文 (max-w-3xl 程度) / 右 = sticky な目次サイドバー。
-  // スクロールバーは画面右端に出したいので、 スクロールコンテナは width 制限せず、
-  // 内側のグリッドで本文・目次の幅を制御する。
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-6xl px-6 py-6 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_240px] gap-8">
@@ -323,8 +376,6 @@ function pad(n: number): string {
 }
 
 // trainee の閲覧用に Markdown を render するだけのコンポーネント。
-// NoteMarkdownEditor の MarkdownView と同じだが import を分離しないために
-// 同じパッケージを直接使う。
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';

--- a/frontend/src/pages/CoursesListPage.tsx
+++ b/frontend/src/pages/CoursesListPage.tsx
@@ -1,0 +1,328 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  AcademicCapIcon,
+  PlusIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import EmptyState from '../components/EmptyState';
+import Loading from '../components/Loading';
+import ConfirmModal from '../components/ConfirmModal';
+import { useCourses } from '../hooks/useCourses';
+import { useToast } from '../hooks/useToast';
+import type { RootState } from '../store';
+import type { Course } from '../types';
+
+/**
+ * CoursesListPage — `/courses` コース一覧ページ。
+ *
+ * - company_admin / super_admin: コースを作成 / 編集 / 削除可
+ * - trainee: published コースを閲覧のみ（クリックすると `/courses/:id` 詳細へ）
+ *
+ * カードグリッドで表示し、 各カードに教材数 / 公開状態 / 説明文を出す。
+ */
+export default function CoursesListPage() {
+  const role = useSelector((s: RootState) => s.auth.role);
+  const canManage = role === 'company_admin' || role === 'super_admin';
+
+  const { showToast } = useToast();
+  const navigate = useNavigate();
+
+  const { filtered, courses, loading, error, searchQuery, setSearchQuery, create, update, remove } =
+    useCourses();
+
+  const [editTarget, setEditTarget] = useState<Course | 'new' | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+
+  const handleConfirmDelete = async () => {
+    if (deleteTargetId == null) return;
+    await remove(deleteTargetId);
+    setDeleteTargetId(null);
+    showToast('success', 'コースを削除しました');
+  };
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-6xl mx-auto space-y-6">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">コース</h1>
+          <p className="text-sm text-[var(--color-text-tertiary)] mt-1">
+            学習コースの一覧。 各コースをクリックすると配下の教材を閲覧できます。
+          </p>
+        </div>
+        {canManage && (
+          <button
+            onClick={() => setEditTarget('new')}
+            className="bg-primary-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors flex items-center gap-2"
+          >
+            <PlusIcon className="w-4 h-4" />
+            新しいコース
+          </button>
+        )}
+      </header>
+
+      <div className="relative max-w-md">
+        <input
+          type="text"
+          placeholder="コースを検索..."
+          aria-label="コースを検索"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+        />
+      </div>
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      {loading && courses.length === 0 ? (
+        <Loading className="py-12" />
+      ) : filtered.length === 0 ? (
+        <EmptyState
+          icon={AcademicCapIcon}
+          title={searchQuery ? '該当するコースがありません' : 'コースがありません'}
+          description={
+            searchQuery
+              ? '検索条件を変更してみてください'
+              : canManage
+                ? '最初のコースを作成しましょう'
+                : '管理者がコースを公開すると、 ここに表示されます'
+          }
+          action={
+            canManage && !searchQuery
+              ? { label: '新しいコース', onClick: () => setEditTarget('new') }
+              : undefined
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((c) => (
+            <CourseCard
+              key={c.id}
+              course={c}
+              canManage={canManage}
+              onOpen={() => navigate(`/courses/${c.id}`)}
+              onEdit={() => setEditTarget(c)}
+              onDelete={() => setDeleteTargetId(c.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {editTarget !== null && (
+        <CourseFormModal
+          initial={editTarget === 'new' ? null : editTarget}
+          onClose={() => setEditTarget(null)}
+          onSubmit={async (payload) => {
+            if (editTarget === 'new') {
+              const created = await create(payload);
+              if (created) {
+                showToast('success', 'コースを作成しました');
+                setEditTarget(null);
+              }
+            } else {
+              const updated = await update(editTarget.id, payload);
+              if (updated) {
+                showToast('success', 'コースを更新しました');
+                setEditTarget(null);
+              }
+            }
+          }}
+        />
+      )}
+
+      <ConfirmModal
+        isOpen={deleteTargetId !== null}
+        message="このコースを削除しますか？ 配下の教材もすべて削除されます。 この操作は元に戻せません。"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDeleteTargetId(null)}
+        isDanger={true}
+      />
+    </div>
+  );
+}
+
+function CourseCard({
+  course,
+  canManage,
+  onOpen,
+  onEdit,
+  onDelete,
+}: {
+  course: Course;
+  canManage: boolean;
+  onOpen: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className="group bg-surface-1 border border-surface-3 rounded-lg p-4 cursor-pointer hover:border-primary-500/50 hover:shadow-md transition-all"
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {course.isPublished ? (
+            <CheckCircleIcon className="w-4 h-4 text-green-500 flex-shrink-0" />
+          ) : (
+            <ClockIcon className="w-4 h-4 text-amber-500 flex-shrink-0" />
+          )}
+          <h2 className="text-base font-semibold text-[var(--color-text-primary)] truncate">
+            {course.title || '無題のコース'}
+          </h2>
+        </div>
+        {canManage && (
+          <div className="opacity-0 group-hover:opacity-100 flex items-center gap-1 transition-opacity">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
+              className="p-1 rounded hover:bg-surface-3 text-[var(--color-text-muted)]"
+              aria-label="コースを編集"
+            >
+              <PencilSquareIcon className="w-4 h-4" />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              className="p-1 rounded hover:bg-red-900/30 text-[var(--color-text-muted)] hover:text-red-400"
+              aria-label="コースを削除"
+            >
+              <TrashIcon className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+      <p className="text-xs text-[var(--color-text-muted)] mb-3">
+        {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
+      </p>
+      <p className="text-sm text-[var(--color-text-secondary)] line-clamp-3 min-h-[3.6em]">
+        {course.description || 'コース説明が未設定です'}
+      </p>
+    </div>
+  );
+}
+
+interface CourseFormProps {
+  initial: Course | null;
+  onClose: () => void;
+  onSubmit: (payload: {
+    title: string;
+    description: string;
+    sortOrder: number;
+    isPublished: boolean;
+  }) => Promise<void>;
+}
+
+function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [sortOrder, setSortOrder] = useState(initial?.sortOrder ?? 100);
+  const [isPublished, setIsPublished] = useState(initial?.isPublished ?? false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSubmitting(true);
+    try {
+      await onSubmit({ title: title.trim(), description: description.trim(), sortOrder, isPublished });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-1 rounded-lg shadow-xl border border-surface-3 max-w-lg w-full p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+          {initial ? 'コースを編集' : '新しいコース'}
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">タイトル *</span>
+            <input
+              required
+              maxLength={200}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded text-sm focus:outline-none focus:border-primary-500"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">説明</span>
+            <textarea
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="このコースで学べる内容の概要"
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded text-sm focus:outline-none focus:border-primary-500 resize-y"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">並び順 (昇順)</span>
+            <input
+              type="number"
+              value={sortOrder}
+              onChange={(e) => setSortOrder(Number(e.target.value) || 0)}
+              className="w-32 px-3 py-1.5 bg-surface-2 border border-surface-3 rounded text-sm focus:outline-none focus:border-primary-500"
+            />
+            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
+              小さい値が上に来ます。 既定: 100
+            </span>
+          </label>
+          <label className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+            <input
+              type="checkbox"
+              checked={isPublished}
+              onChange={(e) => setIsPublished(e.target.checked)}
+            />
+            trainee に公開
+          </label>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm text-[var(--color-text-muted)] hover:bg-surface-2 rounded"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={!title.trim() || submitting}
+              className="bg-primary-500 text-white px-4 py-1.5 rounded text-sm font-medium hover:bg-primary-600 transition-colors disabled:opacity-50"
+            >
+              {submitting ? '保存中...' : initial ? '更新' : '作成'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/frontend/src/repositories/CourseRepository.ts
+++ b/frontend/src/repositories/CourseRepository.ts
@@ -1,0 +1,49 @@
+import api from '../lib/axios';
+import { COURSES } from '../constants/apiRoutes';
+import type { Course, TeachingMaterial } from '../types';
+
+/**
+ * コース API ラッパ。
+ *
+ * actor の role / company は backend 側で context から取り出して自動フィルタするため、
+ * フロントは companyId を渡さない（IDOR 対策）。
+ */
+export interface CoursePayload {
+  title: string;
+  description: string;
+  sortOrder: number;
+  isPublished: boolean;
+}
+
+const CourseRepository = {
+  async list(): Promise<Course[]> {
+    const res = await api.get<Course[]>(COURSES.list);
+    return res.data;
+  },
+
+  async get(id: number): Promise<Course> {
+    const res = await api.get<Course>(COURSES.byId(id));
+    return res.data;
+  },
+
+  async listMaterials(courseId: number): Promise<TeachingMaterial[]> {
+    const res = await api.get<TeachingMaterial[]>(COURSES.materials(courseId));
+    return res.data;
+  },
+
+  async create(payload: CoursePayload): Promise<Course> {
+    const res = await api.post<Course>(COURSES.list, payload);
+    return res.data;
+  },
+
+  async update(id: number, payload: CoursePayload): Promise<Course> {
+    const res = await api.put<Course>(COURSES.byId(id), payload);
+    return res.data;
+  },
+
+  async remove(id: number): Promise<void> {
+    await api.delete(COURSES.byId(id));
+  },
+};
+
+export default CourseRepository;

--- a/frontend/src/repositories/TeachingMaterialRepository.ts
+++ b/frontend/src/repositories/TeachingMaterialRepository.ts
@@ -3,34 +3,40 @@ import { TEACHING_MATERIALS } from '../constants/apiRoutes';
 import type { TeachingMaterial } from '../types';
 
 /**
- * 教材 API ラッパ。
+ * 教材 API ラッパ（個別 CRUD）。
  *
+ * 一覧取得はコース配下なので CourseRepository.listMaterials を使う。
  * actor の role / company は backend 側で context から取り出して自動フィルタするため、
- * フロントは company_id を渡さない（IDOR 対策）。
+ * フロントは companyId を渡さない（IDOR 対策）。
  */
-export interface TeachingMaterialPayload {
+export interface TeachingMaterialCreatePayload {
+  /** 所属コース ID（必須）。 */
+  courseId: number;
   title: string;
   content: string;
+  orderInCourse: number;
+  isPublished: boolean;
+}
+
+export interface TeachingMaterialUpdatePayload {
+  title: string;
+  content: string;
+  orderInCourse: number;
   isPublished: boolean;
 }
 
 const TeachingMaterialRepository = {
-  async list(): Promise<TeachingMaterial[]> {
-    const res = await api.get<TeachingMaterial[]>(TEACHING_MATERIALS.list);
-    return res.data;
-  },
-
   async get(id: number): Promise<TeachingMaterial> {
     const res = await api.get<TeachingMaterial>(TEACHING_MATERIALS.byId(id));
     return res.data;
   },
 
-  async create(payload: TeachingMaterialPayload): Promise<TeachingMaterial> {
-    const res = await api.post<TeachingMaterial>(TEACHING_MATERIALS.list, payload);
+  async create(payload: TeachingMaterialCreatePayload): Promise<TeachingMaterial> {
+    const res = await api.post<TeachingMaterial>(TEACHING_MATERIALS.create, payload);
     return res.data;
   },
 
-  async update(id: number, payload: TeachingMaterialPayload): Promise<TeachingMaterial> {
+  async update(id: number, payload: TeachingMaterialUpdatePayload): Promise<TeachingMaterial> {
     const res = await api.put<TeachingMaterial>(TEACHING_MATERIALS.byId(id), payload);
     return res.data;
   },

--- a/frontend/src/repositories/__tests__/TeachingMaterialRepository.test.ts
+++ b/frontend/src/repositories/__tests__/TeachingMaterialRepository.test.ts
@@ -20,12 +20,6 @@ const mockedDelete = vi.mocked(apiClient.delete);
 describe('TeachingMaterialRepository', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('list は /api/v2/teaching-materials を GET する', async () => {
-    mockedGet.mockResolvedValue({ data: [] });
-    await TeachingMaterialRepository.list();
-    expect(mockedGet).toHaveBeenCalledWith('/api/v2/teaching-materials');
-  });
-
   it('get は ID 付きで GET する', async () => {
     mockedGet.mockResolvedValue({ data: { id: 5, title: 'X' } });
     const m = await TeachingMaterialRepository.get(5);
@@ -33,22 +27,36 @@ describe('TeachingMaterialRepository', () => {
     expect(m.id).toBe(5);
   });
 
-  it('create は POST する', async () => {
+  it('create は courseId を含めて POST する', async () => {
     mockedPost.mockResolvedValue({ data: { id: 1 } });
-    await TeachingMaterialRepository.create({ title: 'a', content: 'b', isPublished: true });
-    expect(mockedPost).toHaveBeenCalledWith('/api/v2/teaching-materials', {
+    await TeachingMaterialRepository.create({
+      courseId: 5,
       title: 'a',
       content: 'b',
+      orderInCourse: 100,
+      isPublished: true,
+    });
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/teaching-materials', {
+      courseId: 5,
+      title: 'a',
+      content: 'b',
+      orderInCourse: 100,
       isPublished: true,
     });
   });
 
   it('update は PUT する', async () => {
     mockedPut.mockResolvedValue({ data: { id: 1 } });
-    await TeachingMaterialRepository.update(1, { title: 'x', content: 'y', isPublished: false });
+    await TeachingMaterialRepository.update(1, {
+      title: 'x',
+      content: 'y',
+      orderInCourse: 110,
+      isPublished: false,
+    });
     expect(mockedPut).toHaveBeenCalledWith('/api/v2/teaching-materials/1', {
       title: 'x',
       content: 'y',
+      orderInCourse: 110,
       isPublished: false,
     });
   });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -533,18 +533,40 @@ export interface MasterExerciseDetail {
 }
 
 /**
- * TeachingMaterial は Go backend `domain.TeachingMaterial` と 1:1。
- * company_admin が自社 trainee 向けに作る Markdown 教材。
+ * Course は教材を束ねる「コース（プロジェクト）」。 backend `domain.Course` と 1:1。
+ *
+ * 階層: Company 1 ── * Course 1 ── * TeachingMaterial
  *
  * - company_admin: 自社の draft 含む全件 list / 編集 / 削除可
- * - trainee: 自社の `isPublished=true` のみ閲覧可
+ * - trainee: 自社の `isPublished=true` コースのみ閲覧可
  */
-export interface TeachingMaterial {
+export interface Course {
   id: number;
   companyId: number;
   createdByUserId: number;
   title: string;
+  description: string;
+  sortOrder: number;
+  isPublished: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * TeachingMaterial は Go backend `domain.TeachingMaterial` と 1:1。
+ * 必ず 1 つの Course に所属する Markdown 教材。
+ *
+ * - company_admin: 自社の draft 含む全件 list / 編集 / 削除可
+ * - trainee: 自社の `isPublished=true` 教材かつ所属コース published のみ閲覧可
+ */
+export interface TeachingMaterial {
+  id: number;
+  companyId: number;
+  courseId: number;
+  createdByUserId: number;
+  title: string;
   content: string;
+  orderInCourse: number;
   isPublished: boolean;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 概要

backend で Course 階層を導入した PR #1694 に合わせて、 フロントエンドもコース → 教材 の 2 階層構造に再設計する。

## 画面構成

- \`/courses\`            コース一覧（カードグリッド）+ 作成 / 編集 / 削除
- \`/courses/:id\`        コース詳細 = 配下教材の一覧 + Edit / Preview エディタ
- \`/teaching-materials\` 旧 URL は \`/courses\` に redirect

## 変更内容

### 型 / API
- \`Course\` 型を types に追加、 \`TeachingMaterial\` に \`courseId\` / \`orderInCourse\` を追加
- \`apiRoutes.COURSES\` を追加 (list / byId / materials)
- \`apiRoutes.TEACHING_MATERIALS\` から \`list\` を撤去（コース配下に移行）

### Repository / Hook
- \`CourseRepository\` を新設（list / get / listMaterials / create / update / remove）
- \`TeachingMaterialRepository\` を course-aware に書き換え（create に courseId 必須）
- \`useCourses\` を新設
- \`useTeachingMaterials(courseId)\` に signature 変更（コース指定で listMaterials を呼ぶ）

### Page
- \`CoursesListPage\`（新規）: カードグリッドで一覧、 company_admin はモーダルで作成 / 編集
- \`CourseDetailPage\`（旧 \`TeachingMaterialsPage\` をリネーム + リファクタ）: URL の \`:id\` を courseId として教材一覧 + 編集

### サイドバー
- 「教材 → /teaching-materials」を「コース → /courses」に変更

## テスト

- [x] \`npx tsc --noEmit\` パス
- [x] \`npx vitest run\` 1743 tests パス
- [x] \`npx eslint --max-warnings 0\` パス
- [x] \`npm run build\` パス

## 後続作業

- 旧 \`GET /teaching-materials\` backward-compat エンドポイントの撤去（frontend cutover 完了確認後）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コース管理機能を追加（コースの一覧表示、詳細表示、作成、編集、削除に対応）
  * 各コースに属する教材を管理できるようになりました
  * サイドバーナビゲーションを「教材」から「コース」に更新

* **リファクタリング**
  * 教材管理をコース単位でのスコープに変更
  * API の教材エンドポイントを再構成

* **テスト**
  * 関連するテストケースを拡充

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1695)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->