### PR TITLE
fix(frontend): サイドバー折りたたみ時に favicon を非表示にして「>>」を最上部に

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -123,20 +123,18 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
           expanded ? 'w-56' : 'w-14'
         }`}
       >
-        {/* ロゴ + トグルボタン */}
-        <div className={`flex items-center ${expanded ? 'justify-between px-3' : 'justify-center px-2'} pt-3 pb-2`}>
-          <Link
-            to="/"
-            onClick={onNavigate}
-            className="flex items-center gap-2 min-w-0"
-            aria-label="FreStyle ホーム"
-          >
-            <img src="/favicon.svg" alt="" className="w-7 h-7 flex-shrink-0" />
-            {expanded && (
+        {/* ヘッダー: 展開時 = ロゴ + 閉じる ／ 折りたたみ時 = 開くボタンのみ */}
+        {expanded ? (
+          <div className="flex items-center justify-between px-3 pt-3 pb-2">
+            <Link
+              to="/"
+              onClick={onNavigate}
+              className="flex items-center gap-2 min-w-0"
+              aria-label="FreStyle ホーム"
+            >
+              <img src="/favicon.svg" alt="" className="w-7 h-7 flex-shrink-0" />
               <span className="text-sm font-semibold text-[var(--color-text-primary)] truncate">FreStyle</span>
-            )}
-          </Link>
-          {expanded && (
+            </Link>
             <button
               onClick={() => { setExpanded(false); setAdminOpen(false); }}
               title="サイドバーを閉じる"
@@ -144,10 +142,9 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
             >
               <ChevronDoubleLeftIcon className="w-4 h-4" />
             </button>
-          )}
-        </div>
-        {!expanded && (
-          <div className="flex justify-center px-2 pb-1">
+          </div>
+        ) : (
+          <div className="flex justify-center px-2 pt-3 pb-2">
             <button
               onClick={() => setExpanded(true)}
               title="サイドバーを開く"


### PR DESCRIPTION
## 概要

折りたたみ状態のサイドバーで favicon と展開ボタンが 2 行に分かれて縦スペースを無駄遣いしていたため、 1 行にまとめる。

## 変更内容

- 展開時 (expanded): ロゴ + アプリ名 + 閉じるボタン (<<) ※既存のまま
- 折りたたみ時 (!expanded): 開くボタン (>>) のみを最上部に配置（favicon は非表示）

## 確認

- [x] tsc / vitest 1743 / eslint / build パス
- 視覚的にレイアウトのみの変更でロジック / API / DB に影響なし