### PR TITLE
chore: .gitignore に frestyle-teaching-materials を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ frestyle-infrastructure/
 # PdM 用プライベートリポ（FreStyle 配下に clone する運用、本リポの管理対象外）
 frestyle-pdm/
 
+# 教材コンテンツ（Markdown 原本）の管理用プライベートリポ（FreStyle 配下に clone する運用、本リポの管理対象外）
+frestyle-teaching-materials/
+
 # IntelliJ IDEA / GoLand
 .idea/
 


### PR DESCRIPTION
## 概要

教材 Markdown 原本管理用のプライベートリポ \`frestyle-teaching-materials\` を FreStyle 直下に clone する運用にしたため、 git の管理対象外であることを宣言する（PdM リポと同じ扱い）。

\`\`\`
/Users/kounotakushin/Desktop/FreStyle/
├── frestyle-pdm/                  ← 既に gitignore 済
├── frestyle-teaching-materials/   ← 新規追加
└── ...
\`\`\`

## 変更内容

\`.gitignore\` に \`frestyle-teaching-materials/\` を 1 行追加するだけ。

## テスト

不要（gitignore 追加のみ・ロジック変更なし）。