### PR TITLE
feat(frontend): サイドバー下部にユーザーメニュー + /settings ページを新設

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ const AcceptInvitationPage = lazyWithReload(() => import('./pages/AcceptInvitati
 
 // 認証必要ページ
 const MenuPage = lazyWithReload(() => import('./pages/MenuPage'), 'MenuPage');
-const ProfilePage = lazyWithReload(() => import('./pages/ProfilePage'), 'ProfilePage');
+const SettingsPage = lazyWithReload(() => import('./pages/SettingsPage'), 'SettingsPage');
 const AskAiPage = lazyWithReload(() => import('./pages/AskAiPage'), 'AskAiPage');
 const NotesPage = lazyWithReload(() => import('./pages/NotesPage'), 'NotesPage');
 const NotificationPage = lazyWithReload(() => import('./pages/NotificationPage'), 'NotificationPage');
@@ -98,7 +98,9 @@ export default function App() {
         }
       >
         <Route path="/" element={<MenuPage />} />
-        <Route path="/profile/me" element={<ProfilePage />} />
+        <Route path="/settings" element={<SettingsPage />} />
+        {/* 旧 /profile/me は /settings に統合（後方互換のため redirect 相当として SettingsPage を出す） */}
+        <Route path="/profile/me" element={<SettingsPage />} />
         <Route path="/chat/ask-ai" element={<AskAiPage />} />
         <Route path="/chat/ask-ai/:sessionId" element={<AskAiPage />} />
         <Route path="/notes" element={<NotesPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, ComponentType, SVGProps } from 'react';
+import { useEffect, useState, ComponentType, SVGProps } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
@@ -7,8 +7,6 @@ import {
   DocumentTextIcon,
   BellIcon,
   DocumentChartBarIcon,
-  UserCircleIcon,
-  ArrowLeftOnRectangleIcon,
   CodeBracketIcon,
   BuildingOffice2Icon,
   ChevronDoubleLeftIcon,
@@ -16,7 +14,9 @@ import {
   AcademicCapIcon,
 } from '@heroicons/react/24/outline';
 import Loading from '../Loading';
+import SidebarUserMenu from './SidebarUserMenu';
 import { useSidebar } from '../../hooks/useSidebar';
+import ProfileRepository from '../../repositories/ProfileRepository';
 import type { RootState } from '../../store';
 
 interface SubItem {
@@ -54,10 +54,6 @@ const mainNavItems: NavItem[] = [
 // super_admin は企業管理に専念するロールで、trainee 向け学習機能は表示しない。
 const SUPER_ADMIN_MAIN_NAV_IDS = new Set(['home', 'notifications']);
 
-const bottomNavItems: NavItem[] = [
-  { id: 'profile', icon: UserCircleIcon, label: 'プロフィール', to: '/profile/me', matchExact: true },
-];
-
 const adminNavItem: NavItem = {
   id: 'admin',
   icon: BuildingOffice2Icon,
@@ -88,6 +84,16 @@ function isActive(item: NavItem, pathname: string): boolean {
   return false;
 }
 
+// SidebarUserMenu の subText に出すロール表記。
+function roleLabel(role: string | null): string {
+  switch (role) {
+    case 'super_admin': return '運営管理者';
+    case 'company_admin': return '会社管理者';
+    case 'trainee': return '受講者';
+    default: return '';
+  }
+}
+
 export default function Sidebar({ onNavigate }: SidebarProps) {
   const location = useLocation();
   const { handleLogout, loggingOut } = useSidebar();
@@ -99,6 +105,21 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   const [expanded, setExpanded] = useState(true);
   // 管理サブメニューの開閉
   const [adminOpen, setAdminOpen] = useState(false);
+  // sidebar bottom のユーザーメニュー用 (アバター / 名前)
+  const [profile, setProfile] = useState<{ displayName: string; avatarUrl: string | null } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    ProfileRepository.fetchProfile()
+      .then((p) => {
+        if (cancelled) return;
+        setProfile({ displayName: p.displayName ?? '', avatarUrl: p.avatarUrl ?? null });
+      })
+      .catch(() => { /* sidebar 表示が壊れない最低限のフォールバックは下で行う */ });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // super_admin は trainee 向けメニュー（AI / コード / ノート / レポート）を非表示。
   const visibleMainNavItems = isSuperAdmin
@@ -177,29 +198,6 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
             );
           })}
 
-          <div className="my-2 border-t border-surface-3" />
-
-          {/* プロフィール */}
-          {bottomNavItems.map((item) => {
-            const active = isActive(item, location.pathname);
-            return (
-              <Link
-                key={item.id}
-                to={item.to!}
-                onClick={onNavigate}
-                title={!expanded ? item.label : undefined}
-                className={`flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium transition-colors duration-150 ${
-                  active
-                    ? 'bg-[var(--color-nav-active)] text-[var(--color-text-primary)]'
-                    : 'text-[var(--color-text-tertiary)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]'
-                }`}
-              >
-                <item.icon className="w-5 h-5 flex-shrink-0" />
-                {expanded && <span className="truncate">{item.label}</span>}
-              </Link>
-            );
-          })}
-
           {/* 管理メニュー (admin only) */}
           {isAdmin && (
             <>
@@ -257,16 +255,16 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
           )}
         </nav>
 
-        {/* ログアウト（ダークモード切替は廃止） */}
-        <div className="px-2 py-3 border-t border-surface-3 space-y-0.5">
-          <button
-            onClick={() => { onNavigate?.(); handleLogout(); }}
-            title="ログアウト"
-            className="flex items-center gap-3 px-2 py-2 rounded-md text-sm font-medium text-[var(--color-text-muted)] hover:bg-red-900/30 hover:text-red-400 transition-colors duration-150 w-full"
-          >
-            <ArrowLeftOnRectangleIcon className="w-5 h-5 flex-shrink-0" />
-            {expanded && <span>ログアウト</span>}
-          </button>
+        {/* ユーザーメニュー（アバター + 名前 → クリックで 設定 / ログアウト） */}
+        <div className="px-2 py-3 border-t border-surface-3">
+          <SidebarUserMenu
+            expanded={expanded}
+            displayName={profile?.displayName ?? ''}
+            avatarUrl={profile?.avatarUrl}
+            subText={roleLabel(role)}
+            onLogout={() => { onNavigate?.(); handleLogout(); }}
+            onNavigate={onNavigate}
+          />
         </div>
       </aside>
     </>

--- a/frontend/src/components/layout/SidebarUserMenu.tsx
+++ b/frontend/src/components/layout/SidebarUserMenu.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Cog6ToothIcon,
+  ArrowLeftOnRectangleIcon,
+  ChevronUpDownIcon,
+} from '@heroicons/react/24/outline';
+import Avatar from '../Avatar';
+
+interface SidebarUserMenuProps {
+  expanded: boolean;
+  displayName: string;
+  avatarUrl?: string | null;
+  /** 任意のサブテキスト（例: ロール名）。 collapsed 時は非表示 */
+  subText?: string | null;
+  onLogout: () => void;
+  onNavigate?: () => void;
+}
+
+/**
+ * SidebarUserMenu — Sidebar 最下部に置く「ユーザーボタン」 + クリックでドロップダウン。
+ *
+ * 展開時: アバター + 名前 + サブテキスト + ChevronUpDown
+ * 折りたたみ時: アバターのみ
+ *
+ * クリックで上方向に menu が開く（ボタンが下端なので逆さに表示）。
+ * メニュー項目: 設定 (`/settings`) / ログアウト
+ */
+export default function SidebarUserMenu({
+  expanded,
+  displayName,
+  avatarUrl,
+  subText,
+  onLogout,
+  onNavigate,
+}: SidebarUserMenuProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  // クリックアウトサイドで閉じる。 button 自体のクリックは含めず逆判定する。
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!wrapRef.current) return;
+      if (e.target instanceof Node && wrapRef.current.contains(e.target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const handleSettings = () => {
+    setOpen(false);
+    onNavigate?.();
+    navigate('/settings');
+  };
+
+  const handleLogout = () => {
+    setOpen(false);
+    onLogout();
+  };
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        title={!expanded ? displayName : undefined}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className={`w-full flex items-center gap-2 px-2 py-2 rounded-md hover:bg-[var(--color-nav-hover)] transition-colors ${
+          expanded ? 'justify-between' : 'justify-center'
+        }`}
+      >
+        <div className={`flex items-center gap-2 min-w-0 ${expanded ? '' : 'justify-center'}`}>
+          <Avatar name={displayName || 'U'} src={avatarUrl ?? undefined} size="sm" />
+          {expanded && (
+            <div className="text-left min-w-0">
+              <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
+                {displayName || 'ユーザー'}
+              </p>
+              {subText && (
+                <p className="text-xs text-[var(--color-text-muted)] truncate">{subText}</p>
+              )}
+            </div>
+          )}
+        </div>
+        {expanded && <ChevronUpDownIcon className="w-4 h-4 text-[var(--color-text-muted)] flex-shrink-0" />}
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute bottom-full left-0 right-0 mb-2 bg-surface-1 border border-surface-3 rounded-lg shadow-lg overflow-hidden z-50 animate-fade-in"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handleSettings}
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors"
+          >
+            <Cog6ToothIcon className="w-4 h-4" />
+            設定
+          </button>
+          <div className="border-t border-surface-3" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={handleLogout}
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-muted)] hover:bg-red-900/10 hover:text-red-500 transition-colors"
+          >
+            <ArrowLeftOnRectangleIcon className="w-4 h-4" />
+            ログアウト
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/__tests__/Sidebar.mobile.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.mobile.test.tsx
@@ -14,6 +14,15 @@ vi.mock('../../../hooks/useSidebar', () => ({
   }),
 }));
 
+vi.mock('../../../repositories/ProfileRepository', () => ({
+  default: {
+    fetchProfile: vi.fn().mockResolvedValue({
+      userId: 1, displayName: 'テストユーザー', bio: '', avatarUrl: '', status: '',
+    }),
+    updateProfile: vi.fn(),
+  },
+}));
+
 function createTestStore() {
   return configureStore({
     reducer: { auth: authReducer },
@@ -39,10 +48,14 @@ describe('Sidebar モバイル動作', () => {
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it('ログアウトクリック時にonNavigateが呼ばれる', () => {
+  it('ユーザーメニューからログアウトクリック時にonNavigateが呼ばれる', () => {
     const onNavigate = vi.fn();
     renderSidebar(onNavigate);
-    fireEvent.click(screen.getByText('ログアウト'));
+    // ユーザーボタンを押して dropdown を開く
+    const userButton = screen.getAllByRole('button').find((b) => b.getAttribute('aria-haspopup') === 'menu');
+    expect(userButton).toBeDefined();
+    fireEvent.click(userButton!);
+    fireEvent.click(screen.getByRole('menuitem', { name: /ログアウト/ }));
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -11,6 +11,17 @@ vi.mock('../../../hooks/useSidebar', () => ({
   useSidebar: () => mockUseSidebar(),
 }));
 
+// Sidebar はマウント時に ProfileRepository.fetchProfile を呼んで user メニュー (avatar / 名前) を出す。
+// テストでは固定値を返すモックに差し替える。
+vi.mock('../../../repositories/ProfileRepository', () => ({
+  default: {
+    fetchProfile: vi.fn().mockResolvedValue({
+      userId: 1, displayName: 'テストユーザー', bio: '', avatarUrl: '', status: '',
+    }),
+    updateProfile: vi.fn(),
+  },
+}));
+
 function createTestStore(isAdmin = false, role: string | null = null) {
   return configureStore({
     reducer: { auth: authReducer },
@@ -44,9 +55,10 @@ describe('Sidebar', () => {
     expect(screen.getByText('ホーム')).toBeDefined();
     expect(screen.getByText('AI')).toBeDefined();
     expect(screen.getByText('コード学習')).toBeDefined();
+    expect(screen.getByText('コース')).toBeDefined();
     expect(screen.getByText('ノート')).toBeDefined();
     expect(screen.getByText('レポート')).toBeDefined();
-    expect(screen.getByText('プロフィール')).toBeDefined();
+    // プロフィールは sidebar bottom のユーザーメニュー（クリックで開くドロップダウン）に移動済。
   });
 
   it('削除済み機能のリンクは表示されない', () => {
@@ -57,9 +69,15 @@ describe('Sidebar', () => {
     expect(screen.queryByText('スコア履歴')).toBeNull();
   });
 
-  it('ログアウトボタンを表示する', () => {
+  it('ユーザーメニューを開くと「設定」「ログアウト」が表示される', async () => {
     renderSidebar();
-    expect(screen.getByText('ログアウト')).toBeDefined();
+    // 初期表示ではログアウトボタンは非表示（ドロップダウンの中）。
+    expect(screen.queryByText('ログアウト')).toBeNull();
+    // ユーザーボタン（aria-haspopup="menu"）をクリックすると展開する。
+    const userButton = screen.getByRole('button', { expanded: false, name: /./ });
+    fireEvent.click(userButton);
+    expect(screen.getByRole('menuitem', { name: /設定/ })).toBeDefined();
+    expect(screen.getByRole('menuitem', { name: /ログアウト/ })).toBeDefined();
   });
 
   it('ホームルートでホームがアクティブになる', () => {
@@ -111,16 +129,16 @@ describe('Sidebar', () => {
     expect(screen.queryByText('管理')).toBeNull();
   });
 
-  it('super_admin には trainee 向けメニュー (AI / コード学習 / ノート / レポート) が表示されない', () => {
+  it('super_admin には trainee 向けメニュー (AI / コード学習 / ノート / レポート / コース) が表示されない', () => {
     renderSidebar('/', true, 'super_admin');
     expect(screen.queryByText('AI')).toBeNull();
     expect(screen.queryByText('コード学習')).toBeNull();
     expect(screen.queryByText('ノート')).toBeNull();
     expect(screen.queryByText('レポート')).toBeNull();
-    // ホーム / 通知 / プロフィール / 管理は表示される
+    expect(screen.queryByText('コース')).toBeNull();
+    // ホーム / 通知 / 管理は表示される
     expect(screen.getByText('ホーム')).toBeInTheDocument();
     expect(screen.getByText('通知')).toBeInTheDocument();
-    expect(screen.getByText('プロフィール')).toBeInTheDocument();
     expect(screen.getByText('管理')).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,68 @@
+import { UserCircleIcon } from '@heroicons/react/24/outline';
+import ProfilePage from './ProfilePage';
+
+/**
+ * SettingsPage — `/settings` 配下の設定ページ。
+ *
+ * 左に設定カテゴリのサブメニュー、 右に選択中カテゴリのコンテンツ。
+ * 現状はカテゴリが「プロフィール」のみ。 将来「アカウント」「プライバシー」「通知設定」等を
+ * 追加するときは、 SETTINGS_SECTIONS に追加して右側のコンテンツ条件分岐に追記する。
+ */
+const SETTINGS_SECTIONS = [
+  {
+    id: 'profile',
+    label: 'プロフィール',
+    icon: UserCircleIcon,
+  },
+  // 将来:
+  // { id: 'account', label: 'アカウント', icon: ... },
+  // { id: 'privacy', label: 'プライバシー', icon: ... },
+] as const;
+
+type SectionId = (typeof SETTINGS_SECTIONS)[number]['id'];
+
+export default function SettingsPage() {
+  // 現状はカテゴリが 1 つしかないので、 アクティブカテゴリは固定で「profile」 とする。
+  // useState を入れる準備はしてあるので、 カテゴリ追加時は state を導入。
+  const activeSection: SectionId = 'profile';
+
+  return (
+    <div className="flex h-full">
+      {/* 左サブメニュー */}
+      <aside className="w-56 flex-shrink-0 border-r border-surface-3 bg-surface-1 p-4 hidden md:block">
+        <h1 className="text-lg font-bold text-[var(--color-text-primary)] mb-4">設定</h1>
+        <nav className="space-y-0.5">
+          {SETTINGS_SECTIONS.map((section) => {
+            const Icon = section.icon;
+            const active = activeSection === section.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                aria-current={active ? 'page' : undefined}
+                className={`flex items-center gap-2 w-full px-2 py-2 rounded-md text-sm transition-colors ${
+                  active
+                    ? 'bg-[var(--color-nav-active)] text-[var(--color-text-primary)] font-medium'
+                    : 'text-[var(--color-text-tertiary)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                <Icon className="w-4 h-4 flex-shrink-0" />
+                <span>{section.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
+
+      {/* 右コンテンツ */}
+      <div className="flex-1 min-w-0 overflow-y-auto">
+        {/* モバイル用ヘッダ（左サブメニューが隠れるとき） */}
+        <div className="md:hidden border-b border-surface-3 px-4 py-3 bg-surface-1">
+          <h1 className="text-lg font-bold text-[var(--color-text-primary)]">設定 / プロフィール</h1>
+        </div>
+
+        {activeSection === 'profile' && <ProfilePage />}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

サイドバー中央の「プロフィール」を撤去し、 サイドバー下部の ユーザーメニュー (アバター + 名前 + ドロップダウン) に集約。 プロフィール編集は \`/settings\` 配下に移動し、 将来「アカウント / プライバシー / 通知」等のサブメニュー追加に対応できる構造にする。

## 変更内容

### サイドバー下部のユーザーメニュー
- \`SidebarUserMenu\` 新設
  - 展開時: アバター + 表示名 + ロール + ChevronUpDown
  - 折りたたみ時: アバターのみ
  - クリックで上方向に開くドロップダウン: 設定 / ログアウト
  - クリックアウトサイドで自動 close

### Sidebar 整理
- 「プロフィール」をメインナビから撤去
- 旧ログアウトボタンを SidebarUserMenu に置換
- ProfileRepository.fetchProfile で名前 / アバター取得

### /settings ページ
- \`SettingsPage\` 新設（左サブメニュー + 右コンテンツの 2 カラム）
- 現状は「プロフィール」サブメニューのみ表示（拡張可能）
- 右側は既存 ProfilePage を埋め込み（hooks をそのまま流用）
- \`/settings\` 新規ルート + \`/profile/me\` も同じ画面を出す（後方互換）

### テスト
- Sidebar 系テストを ドロップダウン経由のログアウトに合わせて書き換え

## テスト

- [x] \`npx tsc --noEmit\` パス
- [x] \`npx vitest run\` 1484 tests パス
- [x] \`npx eslint --max-warnings 0\` パス
- [x] \`npm run build\` パス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 新しい設定ページを追加しました。プロフィール情報の管理が統合されました。
  * サイドバーにユーザープロフィール（表示名とアバター）を表示するようになりました。
  * サイドバーの下部にユーザーメニュードロップダウンを追加しました。設定とログアウトにアクセス可能です。
  * `/profile/me`へのアクセスは設定ページにリダイレクトされます。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1699)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->