### PR TITLE
feat(backend): コード実行サンドボックスを Go 対応に拡張

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 # --- Build stage ---
-FROM golang:1.26-alpine AS builder
+# 本サービス本体をビルドする stage。 ランタイム image でも Go ツールチェインを使うため
+# bookworm ベースに揃える（alpine の musl と debian の glibc は互換性がない）。
+FROM golang:1.26-bookworm AS builder
 
 WORKDIR /app
 
@@ -13,9 +15,9 @@ ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
 
 # --- Runtime stage ---
-# PHP コード実行環境のため debian-slim + php-cli を使用。
-# distroless から変更済み。コード実行時は disable_functions で危険関数を無効化する。
-FROM debian:bookworm-slim
+# サンドボックスでユーザコードを実行するため、 PHP CLI と Go ツールチェインを同居させる。
+# golang:1.26-bookworm をそのまま runtime に使い、 必要なパッケージのみ apt-install。
+FROM golang:1.26-bookworm
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends php-cli ca-certificates && \
@@ -24,8 +26,12 @@ RUN apt-get update && \
 WORKDIR /
 COPY --from=builder /out/server /server
 
-# nonroot ユーザー (UID=65532) は distroless と同じ値を踏襲
+# nonroot ユーザー (UID=65532) は distroless 互換値を踏襲。
 RUN groupadd -g 65532 nonroot && useradd -u 65532 -g nonroot -s /sbin/nologin nonroot
+
+# Go の build cache を nonroot が書ける場所に置く（共有してコンパイル高速化）。
+RUN mkdir -p /tmp/go-build-cache && chown -R nonroot:nonroot /tmp/go-build-cache
+ENV GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache
 
 USER nonroot:nonroot
 EXPOSE 8080

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	maxCodeBytes   = 64 * 1024 // 64 KB
-	execTimeout    = 5 * time.Second
+	execTimeout    = 8 * time.Second
 	maxOutputBytes = 64 * 1024 // 64 KB
 )
 
@@ -37,9 +37,8 @@ var disableFunctions = strings.Join([]string{
 // ExecuteCodeInput はコード実行の入力。
 type ExecuteCodeInput struct {
 	Code     string
-	Language string // 現時点では "php" のみ
+	Language string // "php" / "go"
 	// Stdin は実行時に標準入力として流す内容（テストケース採点で使う）。
-	// 空文字なら何も流さない（旧 API 互換）。
 	Stdin string
 }
 
@@ -51,7 +50,12 @@ type ExecuteCodeOutput struct {
 }
 
 // ExecuteCodeUseCase はユーザーコードをサンドボックスで実行する。
-// PHP CLI を使い、危険な関数を無効化・実行時間を制限する。
+//
+// PHP / Go の 2 言語サポート:
+//   - PHP: php CLI + disable_functions で危険関数を封じる
+//   - Go: go run で単一 main.go ファイルを実行。 build cache は共有して compile 時間短縮
+//
+// 共通制約: 8 秒 timeout / 64 KB code-size / 64 KB output-size。
 type ExecuteCodeUseCase struct{}
 
 func NewExecuteCodeUseCase() *ExecuteCodeUseCase {
@@ -62,9 +66,17 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 	if len(input.Code) > maxCodeBytes {
 		return nil, fmt.Errorf("コードが大きすぎます (最大 64 KB)")
 	}
-	if input.Language != "php" {
+	switch input.Language {
+	case "php":
+		return uc.executePHP(ctx, input)
+	case "go":
+		return uc.executeGo(ctx, input)
+	default:
 		return nil, fmt.Errorf("未対応の言語: %s", input.Language)
 	}
+}
+
+func (uc *ExecuteCodeUseCase) executePHP(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
 	// PHP CLI は `<?php` 開始タグが無いコードを「ただの HTML テキスト」として扱い、
 	// ソースコードをそのまま stdout に流して exit code 0 を返す。
 	// 別言語 (Java など) のコードを誤って貼り付けると「実行成功 + 出力 = 元コード」になり
@@ -77,7 +89,6 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 		}, nil
 	}
 
-	// コードを一時ファイルに書き込む
 	tmpDir := os.TempDir()
 	filename := filepath.Join(tmpDir, "code_"+uuid.NewString()+".php")
 	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
@@ -99,11 +110,52 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 		filename,
 	)
 
+	return runCommand(cmd, input.Stdin)
+}
+
+func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
+	// Go コードは `package main` + `func main()` を必須にする。
+	// 別言語のコードを「Go モード」 で投げて意味不明なコンパイルエラーになるのを避ける。
+	if !strings.Contains(input.Code, "package main") {
+		return &ExecuteCodeOutput{
+			Stdout:   "",
+			Stderr:   "Go コードには `package main` と `func main()` が必要です。",
+			ExitCode: 1,
+		}, nil
+	}
+
+	// 各リクエストごとに独立した GOPATH 用ディレクトリを作る。
+	// build cache は共有 (/tmp/go-build-cache) で compile 時間短縮。
+	tmpDir, err := os.MkdirTemp("", "go-exec-")
+	if err != nil {
+		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filename := filepath.Join(tmpDir, "main.go")
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", filename)
+	// GO111MODULE=off で単一ファイル実行（go.mod 不要）。 GOCACHE は環境共有で compile 高速化。
+	cmd.Env = append(os.Environ(),
+		"GO111MODULE=off",
+		"HOME="+tmpDir,
+	)
+
+	return runCommand(cmd, input.Stdin)
+}
+
+func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if input.Stdin != "" {
-		cmd.Stdin = strings.NewReader(input.Stdin)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
 	}
 
 	err := cmd.Run()

--- a/backend/internal/usecase/execute_code_usecase_test.go
+++ b/backend/internal/usecase/execute_code_usecase_test.go
@@ -94,3 +94,91 @@ func TestExecuteCodeUseCase_PHP_AllowsShortEchoTag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, out.ExitCode)
 }
+
+// --- Go ---
+
+func TestExecuteCodeUseCase_Go_HelloWorld(t *testing.T) {
+	_, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not found in PATH, skipping integration test")
+	}
+
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+`,
+		Language: "go",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestExecuteCodeUseCase_Go_RejectsMissingPackageMain(t *testing.T) {
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `fmt.Println("hi")`,
+		Language: "go",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.Stdout)
+	assert.NotEqual(t, 0, out.ExitCode)
+	assert.Contains(t, out.Stderr, "package main")
+}
+
+func TestExecuteCodeUseCase_Go_CompileError(t *testing.T) {
+	_, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `package main
+
+func main() {
+	undefinedFn()
+}
+`,
+		Language: "go",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, out.ExitCode)
+	// コンパイルエラーは stderr に出る
+	assert.NotEmpty(t, out.Stderr)
+}
+
+func TestExecuteCodeUseCase_Go_ReadsStdin(t *testing.T) {
+	_, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		fmt.Println("got:", scanner.Text())
+	}
+}
+`,
+		Language: "go",
+		Stdin:    "hello\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "got: hello\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}


### PR DESCRIPTION
## 概要

PHP のみだった \`ExecuteCodeUseCase\` に Go 言語の実行を追加。 ECS Dockerfile に Go ツールチェイン (\`golang:1.26-bookworm\`) を同居させ、 \`go run\` で単一ファイル実行する。

## 変更内容

### Dockerfile
- runtime stage を \`debian:bookworm-slim\` → \`golang:1.26-bookworm\` に変更
- 既存の php-cli は引き続き apt-install で同居
- Go の build cache (\`/tmp/go-build-cache\`) を nonroot 書き込み可で用意
- GOCACHE / GOMODCACHE 環境変数を設定

### ExecuteCodeUseCase
- \`Execute()\` を language で php / go に分岐
- \`executeGo()\` 新設:
  - \`package main\` 必須チェック (誤投入の早期検知)
  - 一時ディレクトリに main.go を書き出し
  - \`GO111MODULE=off\` で go.mod 不要の単一ファイル実行
  - 8 秒 timeout / 64 KB code-size / 64 KB output-size の共通制約
- 共通実行ロジックは \`runCommand\` ヘルパに抽出

### テスト
- Go HelloWorld の正常系
- package main 不在の早期エラー
- コンパイルエラーで非 0 exit code
- bufio.Scanner で stdin を読む統合テスト

## テスト結果

- [x] \`go vet ./...\` パス
- [x] \`go test ./...\` パス
- [x] \`go build ./...\` パス

## 後続作業

このマージ + ECS deploy 後、 Go 演習 8〜10 問を \`master_exercises\` テーブルに seed する（別 PR / もしくは同セッションで \`make apply-migration\`）。

## 既知の制約

- Go コードは標準ライブラリ + ファイル / OS API にフルアクセス。 ECS の VPC 内で動くため外部ネットワーク到達は限定的だが、 RDS や内部サービスへの不正アクセスは構造上可能。 学習環境としては許容、 本格的な隔離が必要なら別 PR で gVisor / Firecracker を検討。