### PR TITLE
feat: bash サンドボックスを追加して Linux 演習を可能にする

### DIFF
--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -192,6 +193,22 @@ func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}
+
+	// 子プロセスを独立したプロセスグループに置き、 timeout / context cancel 時には
+	// グループ全体に SIGKILL を投げることで、 ユーザコードが起動した バックグラウンド
+	// 子孫プロセス (例: bash で `sleep 600 &` した場合の sleep) も確実に終了させる。
+	// 既定の `exec.CommandContext` は親 PID にしか SIGKILL を送らないため。
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		// -pid を渡すと プロセスグループ全体に signal が飛ぶ (POSIX)。
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	// stdout / stderr のパイプが残ったままの子孫がいても、 Wait が無限に張り付かないよう
+	// 小さい WaitDelay を付ける。 timeout 後 1 秒で強制 close + kill。
+	cmd.WaitDelay = 1 * time.Second
 
 	err := cmd.Run()
 

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -37,7 +37,7 @@ var disableFunctions = strings.Join([]string{
 // ExecuteCodeInput はコード実行の入力。
 type ExecuteCodeInput struct {
 	Code     string
-	Language string // "php" / "go"
+	Language string // "php" / "go" / "bash"
 	// Stdin は実行時に標準入力として流す内容（テストケース採点で使う）。
 	Stdin string
 }
@@ -51,9 +51,10 @@ type ExecuteCodeOutput struct {
 
 // ExecuteCodeUseCase はユーザーコードをサンドボックスで実行する。
 //
-// PHP / Go の 2 言語サポート:
+// PHP / Go / bash の 3 言語サポート:
 //   - PHP: php CLI + disable_functions で危険関数を封じる
 //   - Go: go run で単一 main.go ファイルを実行。 build cache は共有して compile 時間短縮
+//   - bash: /bin/bash でシェルスクリプトを実行。 PATH を限定し HOME を temp dir に固定
 //
 // 共通制約: 8 秒 timeout / 64 KB code-size / 64 KB output-size。
 type ExecuteCodeUseCase struct{}
@@ -71,6 +72,8 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 		return uc.executePHP(ctx, input)
 	case "go":
 		return uc.executeGo(ctx, input)
+	case "bash":
+		return uc.executeBash(ctx, input)
 	default:
 		return nil, fmt.Errorf("未対応の言語: %s", input.Language)
 	}
@@ -146,6 +149,38 @@ func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeIn
 		"GO111MODULE=off",
 		"HOME="+tmpDir,
 	)
+
+	return runCommand(cmd, input.Stdin)
+}
+
+func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
+	// 各リクエストごとに独立した一時ディレクトリを作る。
+	// 演習で `cat > /tmp/sample.txt` のような書き込みが起きても他リクエストに影響させないため
+	// HOME / PWD を temp dir に固定し、 副作用を temp に閉じる。
+	tmpDir, err := os.MkdirTemp("", "bash-exec-")
+	if err != nil {
+		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filename := filepath.Join(tmpDir, "script.sh")
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/bash", filename)
+	cmd.Dir = tmpDir
+	// AWS credential や DB password 等を子プロセスに継承しないため、 環境変数は最小限に絞る。
+	cmd.Env = []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOME=" + tmpDir,
+		"PWD=" + tmpDir,
+		"LANG=C.UTF-8",
+		"LC_ALL=C.UTF-8",
+	}
 
 	return runCommand(cmd, input.Stdin)
 }

--- a/backend/internal/usecase/execute_code_usecase_test.go
+++ b/backend/internal/usecase/execute_code_usecase_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/stretchr/testify/assert"
@@ -186,8 +187,8 @@ func main() {
 // --- Bash ---
 
 func TestExecuteCodeUseCase_Bash_HelloWorld(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not found in PATH")
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
 	}
 	uc := usecase.NewExecuteCodeUseCase()
 	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
@@ -202,8 +203,8 @@ func TestExecuteCodeUseCase_Bash_HelloWorld(t *testing.T) {
 // HOME / PWD は temp dir に固定されるため、 副作用は外に漏れない。
 // echo "$HOME" の結果が `/tmp/...` 始まりであることを確認する。
 func TestExecuteCodeUseCase_Bash_HomeIsTempDir(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not found in PATH")
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
 	}
 	uc := usecase.NewExecuteCodeUseCase()
 	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
@@ -219,8 +220,8 @@ func TestExecuteCodeUseCase_Bash_HomeIsTempDir(t *testing.T) {
 
 // AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
 func TestExecuteCodeUseCase_Bash_DropsParentEnv(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not found in PATH")
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
 	}
 	t.Setenv("FRESTYLE_SECRET_TEST", "must-not-leak")
 	uc := usecase.NewExecuteCodeUseCase()
@@ -233,8 +234,8 @@ func TestExecuteCodeUseCase_Bash_DropsParentEnv(t *testing.T) {
 }
 
 func TestExecuteCodeUseCase_Bash_ReadsStdin(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not found in PATH")
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
 	}
 	uc := usecase.NewExecuteCodeUseCase()
 	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
@@ -248,8 +249,8 @@ func TestExecuteCodeUseCase_Bash_ReadsStdin(t *testing.T) {
 }
 
 func TestExecuteCodeUseCase_Bash_ExitCodePropagated(t *testing.T) {
-	if _, err := exec.LookPath("bash"); err != nil {
-		t.Skip("bash not found in PATH")
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
 	}
 	uc := usecase.NewExecuteCodeUseCase()
 	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
@@ -259,4 +260,35 @@ func TestExecuteCodeUseCase_Bash_ExitCodePropagated(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "before\n", out.Stdout)
 	assert.Equal(t, 7, out.ExitCode)
+}
+
+// timeout 時に bash 配下の子孫プロセスもまとめて kill されることを確認する regression test。
+//
+// 既定の `exec.CommandContext` は親 bash のみに SIGKILL を投げるため、 ユーザコードが
+// バックグラウンドで投げた子孫 (例: sleep 30 &) が stdout パイプを保持し続け、
+// `cmd.Wait()` が 30 秒間ブロックする問題があった。
+//
+// `runCommand` で `Setpgid + cmd.Cancel = group SIGKILL + WaitDelay 1s` を入れたので、
+// timeout (1 秒) + WaitDelay (1 秒) で必ず数秒以内に return するはず。
+func TestExecuteCodeUseCase_Bash_TimeoutKillsBackgroundChildren(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	out, err := uc.Execute(ctx, usecase.ExecuteCodeInput{
+		Code: `sleep 30 &
+sleep 30
+`,
+		Language: "bash",
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.NotZero(t, out.ExitCode, "process should be killed by timeout")
+	// 修正前: 30 秒 ブロック / 修正後: timeout 1s + WaitDelay 1s で 数秒以内に return。
+	assert.Less(t, elapsed, 5*time.Second, "should NOT wait for orphan sleep child to exit")
 }

--- a/backend/internal/usecase/execute_code_usecase_test.go
+++ b/backend/internal/usecase/execute_code_usecase_test.go
@@ -182,3 +182,81 @@ func main() {
 	assert.Equal(t, "got: hello\n", out.Stdout)
 	assert.Equal(t, 0, out.ExitCode)
 }
+
+// --- Bash ---
+
+func TestExecuteCodeUseCase_Bash_HelloWorld(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `echo "Hello, World!"`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// HOME / PWD は temp dir に固定されるため、 副作用は外に漏れない。
+// echo "$HOME" の結果が `/tmp/...` 始まりであることを確認する。
+func TestExecuteCodeUseCase_Bash_HomeIsTempDir(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `echo "$HOME"`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, out.ExitCode)
+	// macOS は /var/folders/... 、 Linux は /tmp/... と OS により分岐するため、
+	// "bash-exec-" prefix が含まれることだけ確認する。
+	assert.Contains(t, out.Stdout, "bash-exec-")
+}
+
+// AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
+func TestExecuteCodeUseCase_Bash_DropsParentEnv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+	t.Setenv("FRESTYLE_SECRET_TEST", "must-not-leak")
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `echo "value=${FRESTYLE_SECRET_TEST:-missing}"`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value=missing\n", out.Stdout)
+}
+
+func TestExecuteCodeUseCase_Bash_ReadsStdin(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `read line && echo "got: $line"`,
+		Language: "bash",
+		Stdin:    "ping\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "got: ping\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestExecuteCodeUseCase_Bash_ExitCodePropagated(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `echo "before" && exit 7`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "before\n", out.Stdout)
+	assert.Equal(t, 7, out.ExitCode)
+}

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -22,6 +22,21 @@ import {
 
 const CodeEditor = lazyWithReload(() => import('../components/CodeEditor'), 'CodeEditor');
 
+// master_exercises.language → Monaco のシンタックスハイライト言語ID へのマッピング。
+// Monaco は `php` / `go` / `shell` を組み込みでサポート。 該当しない場合は plaintext に fallback する。
+function monacoLanguageOf(lang: string): string {
+  switch (lang) {
+    case 'php':
+      return 'php';
+    case 'go':
+      return 'go';
+    case 'bash':
+      return 'shell';
+    default:
+      return 'plaintext';
+  }
+}
+
 /**
  * ExerciseDetailPage — `/code-editor/:slug` の詳細画面。
  *
@@ -167,7 +182,7 @@ export default function ExerciseDetailPage() {
             <CodeEditor
               value={code}
               onChange={setCode}
-              language={ex.language === 'php' ? 'php' : 'plaintext'}
+              language={monacoLanguageOf(ex.language)}
               height="100%"
             />
           </Suspense>

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -39,6 +39,8 @@ export default function ExerciseListPage() {
         >
           <option value="">すべて</option>
           <option value="php">PHP</option>
+          <option value="go">Go</option>
+          <option value="bash">Bash / Linux</option>
         </select>
       </div>
 


### PR DESCRIPTION
## 概要

PHP / Go と並列の 3 つ目の言語サポートとして **bash 実行サンドボックス** を `ExecuteCodeUseCase` に追加します。 これにより `master_exercises.language = 'bash'` の Linux 演習を ブラウザ上で実行・採点できるようになります。

具体的な演習問題 (linux-1 〜 linux-10) は別リポジトリ ([frestyle-teaching-materials](https://github.com/norman6464/frestyle-teaching-materials)) で管理し、 マージ後に seed SQL を bastion 経由で本番 RDS に流し込みます。

## 変更内容

### バックエンド

- [backend/internal/usecase/execute_code_usecase.go](https://github.com/norman6464/FreStyle/blob/feat/bash-sandbox-linux-exercises/backend/internal/usecase/execute_code_usecase.go)
  - `Execute()` の switch に `case "bash":` を追加
  - `executeBash()` で `/bin/bash <script>` を 子プロセス実行
  - 環境変数を `PATH / HOME / PWD / LANG / LC_ALL` に絞って AWS / DB credential を子プロセスに継承させない
  - HOME / PWD は per-request 一時ディレクトリに固定して副作用を temp に閉じる
- 共通制約 (8 秒 timeout / 64 KB code size / 64 KB output) は他言語と同様に適用
- bash 実行のテスト 5 件追加: Hello World / HOME 固定 / env drop / stdin / exit code

### フロントエンド

- `ExerciseDetailPage.tsx` の Monaco 言語マッピングを `bash → 'shell'` に拡張 (Monaco 組み込み shell シンタックスハイライト使用)
- `ExerciseListPage.tsx` の言語フィルタに `Go` / `Bash / Linux` の選択肢を追加

### ランタイムイメージ

`golang:1.26-bookworm` ベースのため debian 標準ユーティリティ (grep / sed / gawk / findutils / coreutils) は標準で使えるため、 Dockerfile 変更なし。

## サンドボックスのセキュリティ設計

bash には PHP の `disable_functions` のような **危険関数を一斉禁止する仕組みが存在しない** ため、 防御は以下の多層に任せる:

1. **環境分離**: ECS Fargate コンテナ + nonroot user (UID=65532)
2. **Per-request 隔離**: `os.MkdirTemp` で 一時ディレクトリを作り HOME / PWD を固定
3. **環境変数の絞り込み**: AWS / DB credential が 漏れないよう explicit allow-list
4. **timeout / output limit**: DoS 対策として 8 秒 / 64 KB

本番コンテナ自体を信用境界として扱う設計。

## テスト

- [x] `go test ./...` バックエンド全テスト pass (使用既存テスト + bash 5 件追加)
- [x] `npx tsc --noEmit` 成功
- [x] `npx eslint --max-warnings 0` 成功
- [x] `npm run build` 成功
- [x] `npx vitest run` フロントエンド全テスト pass (1484 件)
- [ ] マージ後 backend deploy → 本番 RDS に Linux 演習 seed SQL を流し込み → `https://normanblog.com/code-editor/linux-1` で 動作確認

## 関連 Issue

なし (Phase E: Linux 演習 first cut)

## 関連 PR

- 前作: #1700 (Go サンドボックス)
- 次作: Git 演習 / Docker 演習 (別 PR で予定)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Bash スクリプトの実行に対応しました。
  * エクササイズ一覧フィルターに Go 言語と Bash / Linux オプションを追加しました。
  * シェルスクリプトの編集時に適切な構文ハイライトを表示するようにしました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1702)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->