### PR TITLE
fix(frontend): 教材エディタの cmd+z (undo) が効かない問題を修正 + Undo/Redo ボタン追加

### DIFF
--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -3,7 +3,12 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import rehypeHighlight from 'rehype-highlight';
-import { ArrowDownTrayIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowDownTrayIcon,
+  ArrowUturnLeftIcon,
+  ArrowUturnRightIcon,
+  ClipboardDocumentIcon,
+} from '@heroicons/react/24/outline';
 import type { SaveStatus } from '../hooks/useNoteEditor';
 import { useToast } from '../hooks/useToast';
 import { getNoteStats } from '../utils/noteStats';
@@ -63,6 +68,22 @@ export default function NoteMarkdownEditor({
       showToast('error', 'コピーに失敗しました');
     }
   }, [content, showToast]);
+
+  // textarea にフォーカスを戻してから document.execCommand('undo'/'redo')。
+  //
+  // controlled <textarea> でも、 ブラウザはキー入力ベースの undo 履歴を
+  // textarea 自身に保持している（外から value をリセットしない限り）。
+  // execCommand は deprecated だが、 textarea の native undo / redo 操作を
+  // プログラム的にトリガーする最も互換性の高い手段で、 主要ブラウザで動作する。
+  const handleUndo = useCallback(() => {
+    textareaRef.current?.focus();
+    document.execCommand('undo');
+  }, []);
+
+  const handleRedo = useCallback(() => {
+    textareaRef.current?.focus();
+    document.execCommand('redo');
+  }, []);
 
   const handleDownload = useCallback(() => {
     const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
@@ -129,6 +150,25 @@ export default function NoteMarkdownEditor({
           </span>
         )}
         <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={handleUndo}
+            aria-label="元に戻す (Cmd+Z / Ctrl+Z)"
+            className="p-1.5 rounded hover:bg-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+            title="元に戻す (Cmd+Z / Ctrl+Z)"
+          >
+            <ArrowUturnLeftIcon className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            onClick={handleRedo}
+            aria-label="やり直す (Cmd+Shift+Z / Ctrl+Y)"
+            className="p-1.5 rounded hover:bg-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+            title="やり直す (Cmd+Shift+Z / Ctrl+Y)"
+          >
+            <ArrowUturnRightIcon className="w-4 h-4" />
+          </button>
+          <span className="w-px h-4 bg-surface-3 mx-1" aria-hidden="true" />
           <button
             type="button"
             onClick={handleCopy}

--- a/frontend/src/hooks/__tests__/useTeachingMaterialEditor.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterialEditor.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTeachingMaterialEditor } from '../useTeachingMaterialEditor';
+import type { TeachingMaterial } from '../../types';
+
+const sample = (id: number, content = ''): TeachingMaterial => ({
+  id,
+  companyId: 1,
+  courseId: 5,
+  createdByUserId: 1,
+  title: `教材${id}`,
+  content,
+  orderInCourse: id * 10,
+  isPublished: true,
+  createdAt: '',
+  updatedAt: '',
+});
+
+describe('useTeachingMaterialEditor', () => {
+  it('selectedId が変わったときだけ editor 状態を読み直す (autosave 後の re-fetch では上書きしない)', () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+
+    // 初回: 教材5 を読み込む
+    const { result, rerender } = renderHook(
+      ({ selectedId, selected }: { selectedId: number | null; selected: TeachingMaterial | null }) =>
+        useTeachingMaterialEditor({ selectedId, selected, update }),
+      {
+        initialProps: { selectedId: 5 as number | null, selected: sample(5, '初期コンテンツ') as TeachingMaterial | null },
+      },
+    );
+
+    expect(result.current.editContent).toBe('初期コンテンツ');
+
+    // ユーザがエディタで入力した想定
+    act(() => result.current.handleContentChange('入力中の差分'));
+    expect(result.current.editContent).toBe('入力中の差分');
+
+    // autosave 後の materials 再 fetch で selected が新しい参照に置き換わる。
+    // ただし selectedId は同じ 5 なので editor 状態を上書きしてはいけない。
+    rerender({
+      selectedId: 5,
+      selected: sample(5, '初期コンテンツ'), // 新しい object reference
+    });
+    expect(result.current.editContent).toBe('入力中の差分'); // 上書きされない
+
+    // 別の教材 7 を選択 → 今度は state を入れ替える
+    rerender({
+      selectedId: 7,
+      selected: sample(7, '別教材のコンテンツ'),
+    });
+    expect(result.current.editContent).toBe('別教材のコンテンツ');
+  });
+
+  it('selectedId が null になると editor 状態をクリアする', () => {
+    const update = vi.fn().mockResolvedValue(undefined);
+    const { result, rerender } = renderHook(
+      ({ selectedId, selected }: { selectedId: number | null; selected: TeachingMaterial | null }) =>
+        useTeachingMaterialEditor({ selectedId, selected, update }),
+      {
+        initialProps: { selectedId: 5 as number | null, selected: sample(5, 'X') as TeachingMaterial | null },
+      },
+    );
+    expect(result.current.editContent).toBe('X');
+
+    rerender({ selectedId: null, selected: null });
+    expect(result.current.editContent).toBe('');
+    expect(result.current.editTitle).toBe('');
+  });
+});

--- a/frontend/src/hooks/useTeachingMaterialEditor.ts
+++ b/frontend/src/hooks/useTeachingMaterialEditor.ts
@@ -22,17 +22,31 @@ export function useTeachingMaterialEditor({ selectedId, selected, update }: Args
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // 既にエディタへロード済みの material id を覚えておくための ref。
+  // autosave 後の materials 再 fetch で `selected` ref が変わっても、
+  // ref が同じ id を指している間は editor state を上書きしない。
+  //
+  // 上書きすると、 ユーザが入力中だった差分が autosave 完了タイミングで
+  // 巻き戻り、 さらに textarea の undo 履歴が壊れて cmd+z が効かなくなる。
+  const loadedIdRef = useRef<number | null>(null);
+
   useEffect(() => {
-    if (selected) {
-      setEditTitle(selected.title);
-      setEditContent(selected.content);
-      setEditIsPublished(selected.isPublished);
-    } else {
+    if (selectedId == null) {
+      loadedIdRef.current = null;
       setEditTitle('');
       setEditContent('');
       setEditIsPublished(false);
+      setSaveStatus('idle');
+      return;
     }
-    setSaveStatus('idle');
+    if (loadedIdRef.current === selectedId) return;
+    if (selected && selected.id === selectedId) {
+      loadedIdRef.current = selectedId;
+      setEditTitle(selected.title);
+      setEditContent(selected.content);
+      setEditIsPublished(selected.isPublished);
+      setSaveStatus('idle');
+    }
   }, [selectedId, selected]);
 
   useEffect(() => {


### PR DESCRIPTION
## 概要

`/courses/:id` の company_admin 向け教材編集画面で cmd+z (undo) が押しても直前の編集に戻れない問題を修正します。 加えて、 Edit/Preview ステータスバーに **Undo / Redo ボタン** を追加して、 マウス派の操作にも対応します。

## 問題

`useTeachingMaterialEditor` の useEffect が `[selectedId, selected]` の両方に依存していたため、 **800ms autosave → API → `materials` 配列の置換** で `selected` の object reference が変わるたびに useEffect が再実行され、 `setEditContent(selected.content)` で editor 状態を上書きしていました。

これにより:

1. ユーザが入力中の差分が、 autosave 完了タイミング (約 1 秒ごと) でポストバックされた値で巻き戻る
2. controlled `<textarea>` の value がプログラム的にリセットされるため、 ブラウザが保持していた undo 履歴がクリアされ cmd+z が効かなくなる

## 修正

### 1. `useTeachingMaterialEditor` の useEffect を gate

`loadedIdRef` を追加し、 同じ material id がエディタにロード済みなら useEffect 内で setState を呼ばない (autosave 後の re-fetch を無視)。 `selectedId` が切り替わったときだけ ref を更新して新しい material をロード。

### 2. `NoteMarkdownEditor` に Undo / Redo ボタン

ステータスバーに `ArrowUturnLeftIcon` / `ArrowUturnRightIcon` のボタンを追加。 `textareaRef.current?.focus()` → `document.execCommand('undo'/'redo')` で textarea の native undo / redo をプログラム的にトリガー。 deprecated API だが、 controlled textarea の互換性は高い。

### 3. 回帰テスト

`useTeachingMaterialEditor.test.ts` を新規追加。 「同じ id の selected ref が変わっても editor 状態を上書きしない」 を vitest で固定。

## テスト

- [x] `npx tsc --noEmit` 成功
- [x] `npx eslint --max-warnings 0` 成功
- [x] `npx vitest run` (新規 2 件 + 既存全件) pass
- [x] `npm run build` 成功
- [ ] 本番デプロイ後に `/courses/5` で cmd+z / cmd+shift+z / Undo Redo ボタンが効くか確認

## 関連 Issue

なし (ユーザ報告)