### PR TITLE
feat: QA mode を追加して Docker 演習を可能にする + Submit usecase の言語判定 / examples fallback を修正

### DIFF
--- a/backend/internal/domain/master_exercise.go
+++ b/backend/internal/domain/master_exercise.go
@@ -13,21 +13,28 @@ import "time"
 // `ChapterID` は将来 PR-H1 で chapters テーブルが入ったとき、章末演習として
 // 紐付けるための任意 FK。本 PR では NULL のまま運用する。
 type MasterExercise struct {
-	ID             uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
-	Slug           string    `gorm:"size:64;not null;uniqueIndex" json:"slug"`
-	Language       string    `gorm:"size:32;not null;index" json:"language"`
-	OrderIndex     int       `gorm:"not null;default:0" json:"orderIndex"`
-	Category       string    `gorm:"size:64;not null" json:"category"`
-	Title          string    `gorm:"size:200;not null" json:"title"`
-	Description    string    `gorm:"type:text;not null" json:"description"`
-	StarterCode    string    `gorm:"type:text;not null" json:"starterCode"`
-	HintText       string    `gorm:"type:text" json:"hintText"`
-	ExpectedOutput string    `gorm:"type:text" json:"expectedOutput"`
-	Difficulty     int16     `gorm:"type:smallint;not null;default:1" json:"difficulty"`
-	IsPublished    bool      `gorm:"not null;default:true" json:"isPublished"`
-	ChapterID      *uint64   `gorm:"column:chapter_id" json:"chapterId,omitempty"`
-	CreatedAt      time.Time `json:"createdAt"`
-	UpdatedAt      time.Time `json:"updatedAt"`
+	ID             uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
+	Slug           string `gorm:"size:64;not null;uniqueIndex" json:"slug"`
+	Language       string `gorm:"size:32;not null;index" json:"language"`
+	OrderIndex     int    `gorm:"not null;default:0" json:"orderIndex"`
+	Category       string `gorm:"size:64;not null" json:"category"`
+	Title          string `gorm:"size:200;not null" json:"title"`
+	Description    string `gorm:"type:text;not null" json:"description"`
+	StarterCode    string `gorm:"type:text;not null" json:"starterCode"`
+	HintText       string `gorm:"type:text" json:"hintText"`
+	ExpectedOutput string `gorm:"type:text" json:"expectedOutput"`
+	// Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
+	// 'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
+	// docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+	Mode string `gorm:"size:16;not null;default:'execute'" json:"mode"`
+	// Explanation は QA モードで 正解後に表示される markdown 解説。
+	// execute モードでは未使用 (空文字)。
+	Explanation string    `gorm:"type:text;not null;default:''" json:"explanation"`
+	Difficulty  int16     `gorm:"type:smallint;not null;default:1" json:"difficulty"`
+	IsPublished bool      `gorm:"not null;default:true" json:"isPublished"`
+	ChapterID   *uint64   `gorm:"column:chapter_id" json:"chapterId,omitempty"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 func (MasterExercise) TableName() string { return "master_exercises" }
@@ -38,4 +45,10 @@ const (
 	ExerciseLanguageSql = "sql"
 	ExerciseLanguageGo  = "go"
 	ExerciseLanguageJs  = "javascript"
+)
+
+// 採点モード定数。 frontend の入力 UI 切替えと、 backend の採点ロジック切替えの両方で使う。
+const (
+	ExerciseModeExecute = "execute"
+	ExerciseModeQA      = "qa"
 )

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -47,10 +47,10 @@ type SubmitMasterExerciseOutput struct {
 //   - mode='qa' の場合: コードを実行せず、 提出文字列と ExpectedOutput を trim 比較するだけ。
 //     docker / kubernetes など サンドボックス実行が困難な題材向け。
 //   - mode='execute' (default) の場合:
-//       - master_exercise_examples が登録されていれば 各 example の InputText を stdin に
-//         流して ExecuteCodeUseCase で実行し、 stdout を normalize して expected_output と比較
-//       - examples が無ければ exercise 自身の ExpectedOutput を 単一テストケースとして使う
-//         (linux / git / go 等の seed.py 経由で投入された演習向け)
+//   - master_exercise_examples が登録されていれば 各 example の InputText を stdin に
+//     流して ExecuteCodeUseCase で実行し、 stdout を normalize して expected_output と比較
+//   - examples が無ければ exercise 自身の ExpectedOutput を 単一テストケースとして使う
+//     (linux / git / go 等の seed.py 経由で投入された演習向け)
 //     stdout を normalize（末尾改行 / CRLF を吸収）して expected_output と完全一致するか比較。
 //     全件 pass で isCorrect=true。1 件でも失敗・実行エラー（exit_code != 0）なら false。
 //     実行コスト削減のため、最初の不一致で打ち切らず全件実行（ユーザに「どこで落ちたか」を全部見せる方針）。

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -44,11 +44,16 @@ type SubmitMasterExerciseOutput struct {
 // 採点・提出履歴に保存する。
 //
 // 採点ロジック:
-//   - examples を全件取得（OrderIndex 昇順）
-//   - 各 example の InputText を stdin に流して ExecuteCodeUseCase で実行
-//   - stdout を normalize（末尾改行 / CRLF を吸収）して expected_output と完全一致するか比較
-//   - 全件 pass で isCorrect=true。1 件でも失敗・実行エラー（exit_code != 0）なら false
-//   - 実行コスト削減のため、最初の不一致で打ち切らず全件実行（ユーザに「どこで落ちたか」を全部見せる方針）
+//   - mode='qa' の場合: コードを実行せず、 提出文字列と ExpectedOutput を trim 比較するだけ。
+//     docker / kubernetes など サンドボックス実行が困難な題材向け。
+//   - mode='execute' (default) の場合:
+//       - master_exercise_examples が登録されていれば 各 example の InputText を stdin に
+//         流して ExecuteCodeUseCase で実行し、 stdout を normalize して expected_output と比較
+//       - examples が無ければ exercise 自身の ExpectedOutput を 単一テストケースとして使う
+//         (linux / git / go 等の seed.py 経由で投入された演習向け)
+//     stdout を normalize（末尾改行 / CRLF を吸収）して expected_output と完全一致するか比較。
+//     全件 pass で isCorrect=true。1 件でも失敗・実行エラー（exit_code != 0）なら false。
+//     実行コスト削減のため、最初の不一致で打ち切らず全件実行（ユーザに「どこで落ちたか」を全部見せる方針）。
 //
 // 履歴保存はテストケース個別ではなく、まとめて 1 行（最初に失敗した stdout / stderr / exit_code を採用）。
 type SubmitMasterExerciseUseCase struct {
@@ -90,12 +95,26 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 	if ex == nil {
 		return nil, fmt.Errorf("exercise not found: %s", in.Slug)
 	}
+
+	// QA モード: コード実行せず、 提出文字列と ExpectedOutput を直接比較する。
+	if ex.Mode == domain.ExerciseModeQA {
+		return uc.submitQA(in, ex)
+	}
+
 	examples, err := uc.examples.ListByExerciseID(ex.ID)
 	if err != nil {
 		return nil, err
 	}
+	// examples が登録されていない演習 (seed.py 経由で投入された linux / git / go 等)
+	// は exercise 自身の ExpectedOutput を 単一の仮想テストケースとして使う。
+	// stdin は空、 OrderIndex=1 として扱う。
 	if len(examples) == 0 {
-		return nil, fmt.Errorf("exercise %s has no test cases", in.Slug)
+		examples = []domain.MasterExerciseExample{{
+			ExerciseID:     ex.ID,
+			OrderIndex:     1,
+			InputText:      "",
+			ExpectedOutput: ex.ExpectedOutput,
+		}}
 	}
 
 	results := make([]TestCaseResult, 0, len(examples))
@@ -104,23 +123,23 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 	var representativeStdout, representativeStderr string
 	var representativeExit int
 
-	for _, ex := range examples {
+	for _, tc := range examples {
 		out, err := uc.executor.Execute(ctx, ExecuteCodeInput{
 			Code:     in.Code,
-			Language: "php",
-			Stdin:    ex.InputText,
+			Language: ex.Language,
+			Stdin:    tc.InputText,
 		})
 		if err != nil {
 			// 実行できなかった場合は提出を保存せずエラーを返す（タイムアウト等）。
 			return nil, fmt.Errorf("execution failed: %w", err)
 		}
 		actual := normalizeOutput(out.Stdout)
-		expected := normalizeOutput(ex.ExpectedOutput)
+		expected := normalizeOutput(tc.ExpectedOutput)
 		passed := out.ExitCode == 0 && actual == expected
 		results = append(results, TestCaseResult{
-			OrderIndex:     ex.OrderIndex,
-			Input:          ex.InputText,
-			ExpectedOutput: ex.ExpectedOutput,
+			OrderIndex:     tc.OrderIndex,
+			Input:          tc.InputText,
+			ExpectedOutput: tc.ExpectedOutput,
 			ActualOutput:   out.Stdout,
 			Stderr:         out.Stderr,
 			Passed:         passed,
@@ -162,6 +181,42 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 		SubmissionID: submission.ID,
 		IsCorrect:    allPassed,
 		Results:      results,
+	}, nil
+}
+
+// submitQA は QA モードの採点。 提出文字列と ExpectedOutput を normalize 比較するだけで
+// コード実行は行わない。 docker / kubernetes など サンドボックス実行が困難な題材向け。
+func (uc *SubmitMasterExerciseUseCase) submitQA(in SubmitMasterExerciseInput, ex *domain.MasterExercise) (*SubmitMasterExerciseOutput, error) {
+	expected := normalizeOutput(ex.ExpectedOutput)
+	actual := normalizeOutput(in.Code)
+	isCorrect := actual == expected
+
+	submission := &domain.ExerciseSubmission{
+		UserID:        in.UserID,
+		ExerciseKind:  domain.ExerciseKindMaster,
+		ExerciseID:    ex.ID,
+		SubmittedCode: in.Code,
+		Stdout:        in.Code,
+		Stderr:        "",
+		ExitCode:      0,
+		IsCorrect:     isCorrect,
+		SubmittedAt:   time.Now().UTC(),
+	}
+	if err := uc.submissions.Create(submission); err != nil {
+		return nil, err
+	}
+
+	return &SubmitMasterExerciseOutput{
+		SubmissionID: submission.ID,
+		IsCorrect:    isCorrect,
+		Results: []TestCaseResult{{
+			OrderIndex:     1,
+			Input:          "",
+			ExpectedOutput: ex.ExpectedOutput,
+			ActualOutput:   in.Code,
+			Stderr:         "",
+			Passed:         isCorrect,
+		}},
 	}, nil
 }
 

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -3,7 +3,6 @@ package usecase_test
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -196,20 +195,114 @@ func TestSubmitMasterExercise_NonZeroExit_Fails(t *testing.T) {
 	assert.False(t, out.Results[0].Passed)
 }
 
-func TestSubmitMasterExercise_NoExamples_Errors(t *testing.T) {
+// examples が登録されていない演習 (seed.py 経由で投入された linux/git/go 等) は
+// exercise 自身の ExpectedOutput を 単一テストケースとして fallback する。
+func TestSubmitMasterExercise_NoExamples_FallbackToExerciseExpected(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
-		get: &domain.MasterExercise{ID: 1, Slug: "s"},
+		get: &domain.MasterExercise{
+			ID: 1, Slug: "linux-1", Language: "bash",
+			ExpectedOutput: "Hello, Linux!",
+		},
 	}
-	examples := &fakeExampleRepo{}
+	examples := &fakeExampleRepo{} // empty
 	submissions := &fakeSubmissionRepo{}
-	executor := &fakeExecutor{}
+	executor := &fakeExecutor{stdinToOut: map[string]string{"": "Hello, Linux!\n"}}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "linux-1", Code: `echo "Hello, Linux!"`,
+	})
+	require.NoError(t, err)
+	assert.True(t, out.IsCorrect)
+	assert.Len(t, out.Results, 1)
+	// fallback は exercise.Language を passed する (旧実装のように "php" 固定ではない)。
+	assert.Len(t, executor.calls, 1)
+	assert.Equal(t, "bash", executor.calls[0].Language)
+}
+
+// SubmitMasterExerciseUseCase が exercise.Language を ExecuteCodeInput に正しく渡しているか。
+// 旧実装は "php" 固定だったため、 Go / bash / Linux 演習が正しく実行できない不具合があった。
+func TestSubmitMasterExercise_PassesExerciseLanguage(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{ID: 9, Slug: "go-1", Language: "go"},
+	}
+	examples := &fakeExampleRepo{rows: []domain.MasterExerciseExample{
+		{ID: 1, ExerciseID: 9, OrderIndex: 1, InputText: "", ExpectedOutput: "Hello, Go!"},
+	}}
+	submissions := &fakeSubmissionRepo{}
+	executor := &fakeExecutor{stdinToOut: map[string]string{"": "Hello, Go!\n"}}
 
 	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, examples, submissions, executor)
 	_, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
-		UserID: 1, Slug: "s", Code: "<?php",
+		UserID: 1, Slug: "go-1", Code: "package main",
 	})
-	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no test cases"))
+	require.NoError(t, err)
+	require.Len(t, executor.calls, 1)
+	assert.Equal(t, "go", executor.calls[0].Language)
+}
+
+func TestSubmitMasterExercise_QA_Correct(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{
+			ID: 100, Slug: "docker-1", Language: "shell",
+			Mode:           domain.ExerciseModeQA,
+			ExpectedOutput: "docker run hello-world",
+		},
+	}
+	submissions := &fakeSubmissionRepo{}
+	executor := &fakeExecutor{}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, &fakeExampleRepo{}, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "docker-1", Code: "docker run hello-world",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.IsCorrect)
+	require.Len(t, out.Results, 1)
+	assert.True(t, out.Results[0].Passed)
+	// QA モードは executor を呼ばない。
+	assert.Empty(t, executor.calls)
+	require.NotNil(t, submissions.created)
+	assert.True(t, submissions.created.IsCorrect)
+}
+
+func TestSubmitMasterExercise_QA_Wrong(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{
+			ID: 100, Slug: "docker-1", Language: "shell",
+			Mode:           domain.ExerciseModeQA,
+			ExpectedOutput: "docker run hello-world",
+		},
+	}
+	submissions := &fakeSubmissionRepo{}
+	executor := &fakeExecutor{}
+
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, &fakeExampleRepo{}, submissions, executor)
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "docker-1", Code: "docker run nginx",
+	})
+	require.NoError(t, err)
+	assert.False(t, out.IsCorrect)
+	assert.False(t, out.Results[0].Passed)
+	assert.Empty(t, executor.calls)
+}
+
+// QA モードでも 末尾改行 / 空白の差異は normalize で吸収する。
+func TestSubmitMasterExercise_QA_NormalizesTrailingWhitespace(t *testing.T) {
+	exRepo := &fakeMasterExerciseRepo{
+		get: &domain.MasterExercise{
+			ID: 100, Slug: "docker-1", Language: "shell",
+			Mode:           domain.ExerciseModeQA,
+			ExpectedOutput: "git init",
+		},
+	}
+	submissions := &fakeSubmissionRepo{}
+	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, &fakeExampleRepo{}, submissions, &fakeExecutor{})
+	out, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
+		UserID: 1, Slug: "docker-1", Code: "git init   \n",
+	})
+	require.NoError(t, err)
+	assert.True(t, out.IsCorrect)
 }
 
 func TestSubmitMasterExercise_ExerciseNotFound(t *testing.T) {

--- a/frontend/src/components/layout/SidebarUserMenu.tsx
+++ b/frontend/src/components/layout/SidebarUserMenu.tsx
@@ -92,15 +92,21 @@ export default function SidebarUserMenu({
       {open && (
         <div
           role="menu"
-          className="absolute bottom-full left-0 right-0 mb-2 bg-surface-1 border border-surface-3 rounded-lg shadow-lg overflow-hidden z-50 animate-fade-in"
+          // collapsed (w-14 = 56px) のサイドバーで left-0 right-0 を使うと、
+          // dropdown 自体が 56px に縮み、 「設定 / ログアウト」 の文字が
+          // 1 文字ずつ折り返される。 collapsed のときは固定幅 w-44 (176px) で
+          // 右側 (サイドバー外) に突き出させる。
+          className={`absolute bottom-full mb-2 bg-surface-1 border border-surface-3 rounded-lg shadow-lg overflow-hidden z-50 animate-fade-in ${
+            expanded ? 'left-0 right-0' : 'left-0 w-44'
+          }`}
         >
           <button
             type="button"
             role="menuitem"
             onClick={handleSettings}
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors"
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors whitespace-nowrap"
           >
-            <Cog6ToothIcon className="w-4 h-4" />
+            <Cog6ToothIcon className="w-4 h-4 flex-shrink-0" />
             設定
           </button>
           <div className="border-t border-surface-3" />
@@ -108,9 +114,9 @@ export default function SidebarUserMenu({
             type="button"
             role="menuitem"
             onClick={handleLogout}
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-muted)] hover:bg-red-900/10 hover:text-red-500 transition-colors"
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--color-text-muted)] hover:bg-red-900/10 hover:text-red-500 transition-colors whitespace-nowrap"
           >
-            <ArrowLeftOnRectangleIcon className="w-4 h-4" />
+            <ArrowLeftOnRectangleIcon className="w-4 h-4 flex-shrink-0" />
             ログアウト
           </button>
         </div>

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -1,5 +1,9 @@
 import { Suspense, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import rehypeHighlight from 'rehype-highlight';
 import {
   ArrowLeftIcon,
   CheckCircleIcon,
@@ -16,7 +20,9 @@ import { lazyWithReload } from '../utils/lazyWithReload';
 import {
   CodeExecutionResult,
   ExerciseSubmission,
+  ExerciseSubmitResult,
   ExerciseTestCaseResult,
+  MasterExercise,
   MasterExerciseExample,
 } from '../types';
 
@@ -87,6 +93,24 @@ export default function ExerciseDetailPage() {
   }
 
   const ex = detail.exercise;
+
+  // QA モード: docker / kubernetes など サンドボックス実行が困難な題材は、
+  // Monaco エディタの代わりに 単行 input でコマンド文字列を受け取り、
+  // 提出文字列と expected_output を直接比較する。
+  if (ex.mode === 'qa') {
+    return (
+      <QaExerciseView
+        exercise={ex}
+        starterCode={code}
+        onCodeChange={setCode}
+        submitting={submitting}
+        submitResult={submitResult}
+        submitError={submitError}
+        onSubmit={submitCode}
+        onReset={resetCode}
+      />
+    );
+  }
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-4xl mx-auto space-y-6">
@@ -455,4 +479,162 @@ function pad(n: number) {
 // 末尾の改行 / 空白を吸収して厳密一致判定する。
 function normalizeOutput(s: string): string {
   return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/[\s]+$/, '');
+}
+
+interface QaExerciseViewProps {
+  exercise: MasterExercise;
+  starterCode: string;
+  onCodeChange: (code: string) => void;
+  submitting: boolean;
+  submitResult: ExerciseSubmitResult | null;
+  submitError: string | null;
+  onSubmit: () => void;
+  onReset: () => void;
+}
+
+/**
+ * QaExerciseView — `mode='qa'` の演習向け、 単行 input + 提出 + 解説 表示。
+ *
+ * docker / kubernetes / 多くのネットワーク系コマンドのように、 サンドボックス
+ * 実行が困難な題材を 「コマンドを書き取る」 形式で扱う。
+ *
+ * UX:
+ *   1. 質問文 (description) を表示
+ *   2. `$` プロンプト付きの 単行 input
+ *   3. 提出ボタン (Enter でも提出可)
+ *   4. 採点後:
+ *      - 正解: 緑バナー + 期待コマンドの再表示 + explanation (markdown)
+ *      - 不正解: 赤バナー + 「もう一度入力してください」 (input は維持)
+ */
+function QaExerciseView({
+  exercise: ex,
+  starterCode,
+  onCodeChange,
+  submitting,
+  submitResult,
+  submitError,
+  onSubmit,
+  onReset,
+}: QaExerciseViewProps) {
+  const isCorrect = submitResult?.isCorrect === true;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting || !starterCode.trim()) return;
+    onSubmit();
+  };
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
+      <header className="space-y-3">
+        <BackLink />
+        <div className="flex items-start gap-3">
+          <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary-500/10 border border-primary-500/30 flex items-center justify-center">
+            <DocumentTextIcon className="w-5 h-5 text-primary-400" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h1 className="text-xl font-bold text-[var(--color-text-primary)] leading-tight">
+              {ex.title}
+            </h1>
+            <div className="mt-1 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+              <span className="px-1.5 py-0.5 rounded bg-surface-3 uppercase">{ex.language}</span>
+              <span>難易度 {'★'.repeat(Math.max(1, Math.min(5, ex.difficulty)))}</span>
+              <span>#{ex.orderIndex}</span>
+            </div>
+          </div>
+          {submitResult && <ResultBadge isCorrect={isCorrect} />}
+        </div>
+      </header>
+
+      {isCorrect && (
+        <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 flex items-center gap-2 text-sm text-green-400">
+          <CheckCircleIcon className="w-5 h-5 flex-shrink-0" />
+          正解です。 詳細については下の解説を確認してください。
+        </div>
+      )}
+      {submitResult && !isCorrect && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 flex items-center gap-2 text-sm text-red-400">
+          <XCircleIcon className="w-5 h-5 flex-shrink-0" />
+          不正解です。 もう一度入力してください。
+        </div>
+      )}
+
+      <section className="rounded-lg border border-surface-3 bg-surface-1 p-5 space-y-4">
+        <p className="text-xs text-[var(--color-text-muted)]">
+          適切な語句を入力して、 文の空欄を埋めてください。
+        </p>
+        <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap leading-relaxed">
+          {ex.description}
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-[#1e1e1e] border border-surface-3 font-mono text-sm">
+            <span className="text-emerald-400 select-none">$</span>
+            <input
+              type="text"
+              value={starterCode}
+              onChange={(e) => onCodeChange(e.target.value)}
+              disabled={submitting}
+              autoFocus
+              spellCheck={false}
+              autoComplete="off"
+              autoCapitalize="off"
+              className="flex-1 bg-transparent outline-none text-white placeholder:text-[var(--color-text-muted)]"
+              placeholder="ここにコマンドを入力..."
+              aria-label="コマンドを入力"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={submitting || !starterCode.trim()}
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md bg-amber-700/70 hover:bg-amber-700/90 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
+            >
+              <ClipboardDocumentCheckIcon className="w-4 h-4" />
+              {submitting ? '採点中...' : '解答する'}
+            </button>
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={submitting}
+              className="px-4 py-2 rounded-md text-sm text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-primary)] disabled:opacity-50 transition-colors"
+            >
+              リセット
+            </button>
+          </div>
+          {submitError && (
+            <p className="text-xs text-red-400">{submitError}</p>
+          )}
+        </form>
+      </section>
+
+      {isCorrect && (
+        <section className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
+          <div className="px-4 py-3 bg-green-500/10 border-b border-green-500/20">
+            <p className="text-xs font-semibold text-green-400 uppercase tracking-wider mb-1">
+              回答は正解です
+            </p>
+            <code className="text-sm text-[var(--color-text-primary)] font-mono">
+              {ex.expectedOutput}
+            </code>
+          </div>
+          {ex.explanation && (
+            <div className="px-4 py-3">
+              <p className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
+                説明
+              </p>
+              <div className="prose prose-sm max-w-none text-sm text-[var(--color-text-primary)]">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm, remarkBreaks]}
+                  rehypePlugins={[rehypeHighlight]}
+                >
+                  {ex.explanation}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -561,7 +561,7 @@ function QaExerciseView({
 
       <section className="rounded-lg border border-surface-3 bg-surface-1 p-5 space-y-4">
         <p className="text-xs text-[var(--color-text-muted)]">
-          適切な語句を入力して、 文の空欄を埋めてください。
+          以下の問題に対応するコマンドを入力してください。
         </p>
         <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap leading-relaxed">
           {ex.description}

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -41,6 +41,7 @@ export default function ExerciseListPage() {
           <option value="php">PHP</option>
           <option value="go">Go</option>
           <option value="bash">Bash / Linux</option>
+          <option value="docker">Docker</option>
         </select>
       </div>
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -497,6 +497,16 @@ export interface MasterExercise {
   starterCode: string;
   hintText: string;
   expectedOutput: string;
+  /**
+   * 採点モード。 'execute' (default) はサンドボックスでコードを実行し stdout を比較、
+   * 'qa' はコード実行をせず提出文字列と expectedOutput を直接比較する。
+   * docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+   */
+  mode: 'execute' | 'qa';
+  /**
+   * QA モードで 正解後に表示される markdown 解説。 execute モードでは未使用 (空文字)。
+   */
+  explanation: string;
   difficulty: number;
   isPublished: boolean;
   chapterId?: number | null;


### PR DESCRIPTION
## 概要

サンドボックス実行が困難な **docker / kubernetes / network 系** の題材を、 「コマンドを書き取る」 形式の Q&A 演習として 既存 `master_exercises` に同居させる仕組みを追加します。

合わせて、 `SubmitMasterExerciseUseCase` の以下の **既存不具合** を修正します:

1. `Language` がハードコードで `"php"` 固定 → Go / bash 演習が提出時に PHP として実行されてエラー
2. `master_exercise_examples` が空の演習 (seed.py 経由の Linux / Git / Go 30 件) は 「no test cases」 で 提出時にエラー

## DB スキーマ変更 (GORM AutoMigrate)

`master_exercises` に 2 カラム追加:

| カラム | 型 | 既定値 | 用途 |
|---|---|---|---|
| `mode` | `VARCHAR(16) NOT NULL` | `'execute'` | `'execute'` (default) または `'qa'` |
| `explanation` | `TEXT NOT NULL` | `''` | QA mode で 正解後に表示する markdown 解説 |

既存 41 行は AutoMigrate により default 値で自動 backfill。

## Backend 変更

### `domain.MasterExercise`
- `Mode` / `Explanation` フィールド追加
- `ExerciseModeExecute` / `ExerciseModeQA` 定数追加

### `SubmitMasterExerciseUseCase` (`backend/internal/usecase/submit_master_exercise_usecase.go`)
- `ex.Mode == 'qa'` のときは `submitQA` に分岐し、 コード実行せず Code と ExpectedOutput を normalize して直接 trim 比較
- `'execute'` でも examples が空なら exercise 自身の ExpectedOutput を **単一 virtual テストケース** として fallback (Linux / Git / Go の 30 件で必要)
- `ExecuteCodeInput.Language` に `exercise.Language` を渡す (旧 `"php"` ハードコード撤去)

### テスト追加 (5 件)
- `TestSubmitMasterExercise_QA_Correct`: QA mode で 正解時に executor が呼ばれず IsCorrect=true
- `TestSubmitMasterExercise_QA_Wrong`: QA mode で 不正解
- `TestSubmitMasterExercise_QA_NormalizesTrailingWhitespace`: 末尾空白を吸収
- `TestSubmitMasterExercise_NoExamples_FallbackToExerciseExpected`: examples 空時に exercise の ExpectedOutput を fallback (旧テストの「no test cases エラー」 を置き換え)
- `TestSubmitMasterExercise_PassesExerciseLanguage`: ExecuteCodeInput.Language が exercise.Language ベースになっている

## Frontend 変更

### `types/index.ts`
- `MasterExercise` に `mode` / `explanation` を追加

### `ExerciseDetailPage.tsx`
- `QaExerciseView` コンポーネントを追加し、 `ex.mode === 'qa'` で early-return
- UI: 質問文 + `$ [text input]` + 解答ボタン + (採点後) 期待コマンド + explanation (`react-markdown` で描画)
- 不正解時は input をクリアせず再挑戦可能

### `ExerciseListPage.tsx`
- 言語フィルタに `Docker` を追加

## 教材コンテンツ

別リポジトリ [`frestyle-teaching-materials`](https://github.com/norman6464/frestyle-teaching-materials) に以下を追加 (本 PR とは別 commit):

- `exercises/docker/docker-1.md` 〜 `docker-10.md` (Q&A 形式 10 問)
- `exercises/_scripts/seed.py` を `mode` / `explanation` frontmatter 対応に拡張

カリキュラム: docker run / ps / ps -a / images / pull / stop / rm / rmi / logs / build の 10 コマンドを 暗記レベルで問う。

## テスト

- [x] `go test ./...` バックエンド全テスト pass (新規 5 件 + 既存)
- [x] `npx tsc --noEmit` 成功
- [x] `npx eslint --max-warnings 0` 成功
- [x] `npx vitest run` フロントエンド 1486 件全 pass
- [x] `npm run build` 成功
- [ ] マージ後 backend deploy → seed SQL 適用 → `https://normanblog.com/code-editor/docker-1` で QA UI 動作確認

## 関連

- Phase G (Docker) の方針: ユーザ承認済 (Q&A 形式)
- 既存問題の修正も同梱: Linux / Git / Go の 30 件は 提出ボタン押すと no examples で エラーだった点を併せて治す

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 採点モードを追加：「実行」モードと「QA」モードから選択可能
  * QAモードで正解後に説明を表示
  * QAモード用の新しいUI を実装
  * 言語フィルターにDockerオプションを追加
  * コード採点ロジックを改善し、より正確な結果を提供

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1705)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->