### PR TITLE
fix(backend): Setpgid + Cancel を bash 実行のみに限定して PHP / Go の exit -1 問題を解消

### DIFF
--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -183,7 +183,30 @@ func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCode
 		"LC_ALL=C.UTF-8",
 	}
 
+	// bash はユーザが `sleep 30 &` のような バックグラウンド子プロセスを 起動しうる。
+	// timeout 時にそれら子孫プロセスを 確実に kill するため、 独立プロセスグループに置く。
+	configureProcessGroup(cmd)
+
 	return runCommand(cmd, input.Stdin)
+}
+
+// configureProcessGroup は cmd を独立した process group に置き、 ctx cancel 時に
+// グループ全体へ SIGKILL を送るよう設定する。 bash で バックグラウンド子孫が leak しないよう
+// に bash 実行のみで使う。 PHP / Go の `go run` は普通 子孫を起動しないため不要。
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		// -pid を渡すと プロセスグループ全体に signal が飛ぶ (POSIX)。
+		// kill が失敗しても (既に終了済 / ESRCH) ExitError 上書きを防ぐため nil を返す。
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		return nil
+	}
+	// stdout / stderr のパイプが 残ったままの子孫がいても Wait が 無限に張り付かないよう、
+	// 小さい WaitDelay を付ける。 timeout 後 1 秒で 強制 close + kill。
+	cmd.WaitDelay = 1 * time.Second
 }
 
 func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
@@ -193,22 +216,6 @@ func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}
-
-	// 子プロセスを独立したプロセスグループに置き、 timeout / context cancel 時には
-	// グループ全体に SIGKILL を投げることで、 ユーザコードが起動した バックグラウンド
-	// 子孫プロセス (例: bash で `sleep 600 &` した場合の sleep) も確実に終了させる。
-	// 既定の `exec.CommandContext` は親 PID にしか SIGKILL を送らないため。
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return os.ErrProcessDone
-		}
-		// -pid を渡すと プロセスグループ全体に signal が飛ぶ (POSIX)。
-		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-	}
-	// stdout / stderr のパイプが残ったままの子孫がいても、 Wait が無限に張り付かないよう
-	// 小さい WaitDelay を付ける。 timeout 後 1 秒で強制 close + kill。
-	cmd.WaitDelay = 1 * time.Second
 
 	err := cmd.Run()
 


### PR DESCRIPTION
## 概要

production の Go コード実行が **exit -1 (signal kill) で stdout 空** の状態で失敗する報告を修正します。

## 原因

PR #1705 (QA mode + bash 子孫 kill) で、 `runCommand` に以下を 全言語共通で 追加していました:

- `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}` (独立 process group)
- `cmd.Cancel = func() error { ... syscall.Kill(-pid, SIGKILL) ... }`
- `cmd.WaitDelay = 1 * time.Second`

bash で `sleep 30 &` 等のバックグラウンド子孫を kill するための仕組みでしたが、 **Go の `go run`** は内部で fork+exec で 「コンパイラ → 実行バイナリ」 と起動するため、 Setpgid + 独自 Cancel の組合せで signal セマンティクスが noisy になり production で exit -1 を発生させているようです。

ローカル (macOS) では再現せず、 ECS Fargate (Linux + nonroot) のみで起きる挙動でした。

## 修正

`configureProcessGroup(cmd)` ヘルパーに切り出し、 **bash 実行でのみ適用** します:

- **bash**: ユーザが バックグラウンド子孫を起動しうる → `configureProcessGroup` を呼ぶ
- **PHP / Go**: 子孫を 通常起動しない → 何も付けず Go 標準動作に戻す

加えて Cancel 内で `syscall.Kill` のエラーを `_ =` で捨てて、 既に終了済の process への `ESRCH` などが ExitError に混入しないようにしています。

## テスト

- [x] `TestExecuteCodeUseCase_Bash_TimeoutKillsBackgroundChildren` regression test 引き続き pass (1 秒で return)
- [x] PHP / Go の既存テスト 全件 pass
- [x] `go build ./...` 成功
- [ ] マージ後 backend deploy → `https://normanblog.com/code-editor/go-1` 等で Go 実行成功を確認

## CodeRabbit 指摘との関係

PR #1705 で CodeRabbit が指摘した 「timeout 時の bash 子孫プロセス残留」 は、 **bash 実行に対しては 引き続き対応済** です。 PHP / Go ではそもそもユーザがプロセスを fork する手段が無いので 対象外。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * コード実行時のタイムアウト処理とキャンセル処理の信頼性を向上させました。プロセス終了処理をより堅牢にし、実行中のコードの終了がより確実に行われるようになりました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1706)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->