### PR TITLE
fix(backend) + feat: Go timeout を 15s に拡張 + サイドバーメニューにメールアドレスを表示

### DIFF
--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -20,10 +20,13 @@ func (Profile) TableName() string { return "profiles" }
 // ProfileView は handler 層で users.display_name と Profile を合成した DTO。
 // フロントの「プロフィール表示」が期待する単一オブジェクトの形。
 type ProfileView struct {
-	UserID      uint64    `json:"userId"`
-	DisplayName string    `json:"displayName"`
-	Bio         string    `json:"bio"`
-	AvatarURL   string    `json:"avatarUrl"`
-	Status      string    `json:"status"`
-	UpdatedAt   time.Time `json:"updatedAt"`
+	UserID      uint64 `json:"userId"`
+	DisplayName string `json:"displayName"`
+	// Email は users.email を そのまま返す。 frontend の sidebar ユーザーメニューで
+	// 「ログイン中のメールアドレスを 表示する」 用途で参照する。
+	Email     string    `json:"email"`
+	Bio       string    `json:"bio"`
+	AvatarURL string    `json:"avatarUrl"`
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updatedAt"`
 }

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -142,6 +142,7 @@ func (h *ProfileHandler) buildView(c *gin.Context, uid uint64) (*domain.ProfileV
 	user, _ := h.users.FindByID(c.Request.Context(), uid)
 	if user != nil {
 		view.DisplayName = user.DisplayName
+		view.Email = user.Email
 	}
 	return view, nil
 }

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -15,8 +15,13 @@ import (
 )
 
 const (
-	maxCodeBytes   = 64 * 1024 // 64 KB
-	execTimeout    = 8 * time.Second
+	maxCodeBytes = 64 * 1024 // 64 KB
+	// execTimeout は PHP / bash の デフォルト 上限。 起動 + 実行が ~ms オーダー。
+	execTimeout = 8 * time.Second
+	// goExecTimeout は Go 専用。 `go run` は コンパイル + リンク + 実行 が走るため、
+	// ECS Fargate の ephemeral storage I/O 遅さも勘案して 余裕を持たせる。
+	// production の cold compile は ~6-8s の実測がある。
+	goExecTimeout  = 15 * time.Second
 	maxOutputBytes = 64 * 1024 // 64 KB
 )
 
@@ -141,7 +146,8 @@ func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeIn
 		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	// Go は コンパイル + 実行 が走るため timeout を 専用の 長めの値で取る。
+	ctx, cancel := context.WithTimeout(ctx, goExecTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "run", filename)

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -105,15 +105,19 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
   const [expanded, setExpanded] = useState(true);
   // 管理サブメニューの開閉
   const [adminOpen, setAdminOpen] = useState(false);
-  // sidebar bottom のユーザーメニュー用 (アバター / 名前)
-  const [profile, setProfile] = useState<{ displayName: string; avatarUrl: string | null } | null>(null);
+  // sidebar bottom のユーザーメニュー用 (アバター / 名前 / email)
+  const [profile, setProfile] = useState<{ displayName: string; avatarUrl: string | null; email: string } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     ProfileRepository.fetchProfile()
       .then((p) => {
         if (cancelled) return;
-        setProfile({ displayName: p.displayName ?? '', avatarUrl: p.avatarUrl ?? null });
+        setProfile({
+          displayName: p.displayName ?? '',
+          avatarUrl: p.avatarUrl ?? null,
+          email: p.email ?? '',
+        });
       })
       .catch(() => { /* sidebar 表示が壊れない最低限のフォールバックは下で行う */ });
     return () => {
@@ -261,6 +265,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
             expanded={expanded}
             displayName={profile?.displayName ?? ''}
             avatarUrl={profile?.avatarUrl}
+            email={profile?.email ?? ''}
             subText={roleLabel(role)}
             onLogout={() => { onNavigate?.(); handleLogout(); }}
             onNavigate={onNavigate}

--- a/frontend/src/components/layout/SidebarUserMenu.tsx
+++ b/frontend/src/components/layout/SidebarUserMenu.tsx
@@ -11,6 +11,8 @@ interface SidebarUserMenuProps {
   expanded: boolean;
   displayName: string;
   avatarUrl?: string | null;
+  /** ログインユーザのメールアドレス。 dropdown の最上段に identity 表示として出す */
+  email?: string;
   /** 任意のサブテキスト（例: ロール名）。 collapsed 時は非表示 */
   subText?: string | null;
   onLogout: () => void;
@@ -30,6 +32,7 @@ export default function SidebarUserMenu({
   expanded,
   displayName,
   avatarUrl,
+  email,
   subText,
   onLogout,
   onNavigate,
@@ -97,9 +100,20 @@ export default function SidebarUserMenu({
           // 1 文字ずつ折り返される。 collapsed のときは固定幅 w-44 (176px) で
           // 右側 (サイドバー外) に突き出させる。
           className={`absolute bottom-full mb-2 bg-surface-1 border border-surface-3 rounded-lg shadow-lg overflow-hidden z-50 animate-fade-in ${
-            expanded ? 'left-0 right-0' : 'left-0 w-44'
+            expanded ? 'left-0 right-0' : 'left-0 w-56'
           }`}
         >
+          {email && (
+            <>
+              <div
+                className="px-3 py-2 text-xs text-[var(--color-text-secondary)] truncate"
+                title={email}
+              >
+                {email}
+              </div>
+              <div className="border-t border-surface-3" />
+            </>
+          )}
           <button
             type="button"
             role="menuitem"

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -289,6 +289,8 @@ export interface Note {
 export interface Profile {
   userId: number;
   displayName: string;
+  /** ログインユーザのメールアドレス。 sidebar のユーザーメニューで表示する。 */
+  email: string;
   bio: string;
   avatarUrl: string;
   status: string;


### PR DESCRIPTION
## 概要

2 つの修正を 1 PR にまとめます。 どちらも user-visible な改善で、 deploy で即時反映が望ましいため:

1. **Go 実行 timeout 拡張** (緊急): production の Go 実行が 8 秒ジャストで timeout して `Failure (exit -1)` になる問題
2. **サイドバーのユーザーメニューにメールアドレス表示** (UI 改善): 設定/ログアウトの dropdown にログイン中の email を 表示

## 1. Go execution timeout (8s → 15s)

### 背景

PR #1706 で Setpgid 問題を解消したが、 production logs を見ると Go 実行が 依然として 8 秒で timeout していた:

```
POST /api/v2/code/execute  | 200 |  8.09s
POST /api/v2/code/execute  | 200 |  8.07s
POST /api/v2/code/execute  | 200 |  8.06s
```

ローカル (macOS) では Go cold compile は 2 秒で済むが、 ECS Fargate の ephemeral storage I/O 遅さ + Go コンパイル工程で 8 秒に収まらない。

### 修正

`goExecTimeout = 15 * time.Second` を新設し、 executeGo 専用に適用。 PHP / bash は 8 秒のまま (起動 + 実行が ms オーダー)。

```go
const (
    execTimeout    = 8 * time.Second   // PHP / bash
    goExecTimeout  = 15 * time.Second  // Go (cold compile 余裕)
)
```

## 2. サイドバーメニューに メールアドレス表示

ユーザ要望: アバター → クリックで開く dropdown の最上段に メールアドレスを 表示。

### 変更

- **backend**: `domain.ProfileView` に `Email` フィールド追加 + `profile_handler.buildView` で users.email をセット
- **frontend**:
  - `Profile` 型に `email: string` 追加
  - `Sidebar.tsx` で fetch した email を `SidebarUserMenu` に渡す
  - `SidebarUserMenu.tsx` の dropdown 最上段に email を **truncate 表示** (overflow 時は title 属性で full 表示)
  - collapsed 状態の dropdown 幅を `w-44 → w-56` に拡張 (email が入る幅を確保)

## テスト

- [x] `go test ./internal/usecase/ -run TestExecuteCodeUseCase_Go` 全件 pass
- [x] `go test ./internal/handler/` 全件 pass
- [x] `npx tsc --noEmit` 成功
- [x] `npx eslint --max-warnings 0` 成功
- [x] `npx vitest run` Sidebar 関連 15 件 pass
- [x] `npm run build` 成功
- [ ] マージ後 backend + frontend deploy → Go 実行が 15 秒以内に成功 / dropdown に email 表示

## 関連

- PR #1706 (前回 hotfix) で Setpgid 問題は解決、 残ったのが timeout 問題
- 将来的な Judge0 / Piston / 自前コンパイル先 切り出しは 別途検討