### PR TITLE
perf(backend): Dockerfile に GOCACHE warmup を追加して Go 演習の cold compile を高速化

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,6 +33,19 @@ RUN groupadd -g 65532 nonroot && useradd -u 65532 -g nonroot -s /sbin/nologin no
 RUN mkdir -p /tmp/go-build-cache && chown -R nonroot:nonroot /tmp/go-build-cache
 ENV GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache
 
+# GOCACHE warmup:
+# 学習者の最初の `go run` で cold compile を 走らせると ECS Fargate の I/O 遅延で
+# 6-8 秒かかり 初回の体験を著しく損なう。 image build 時に hello-world を 1 回
+# `go run` して fmt / runtime / os 等の標準パッケージをプリコンパイルしておくと、
+# 以降の cold start でも 実行は ~1 秒台に収まる。
+#
+# nonroot 切替前に warmup する (cache 所有者を nonroot に揃えるため最後に chown)。
+RUN printf 'package main\nimport "fmt"\nfunc main() { fmt.Println("warmup") }\n' > /tmp/warmup.go && \
+    GOCACHE=/tmp/go-build-cache GO111MODULE=off HOME=/tmp \
+        go run /tmp/warmup.go > /dev/null 2>&1 && \
+    rm /tmp/warmup.go && \
+    chown -R nonroot:nonroot /tmp/go-build-cache
+
 USER nonroot:nonroot
 EXPOSE 8080
 


### PR DESCRIPTION
## 概要

ECS Fargate の ephemeral storage I/O 遅さで Go 演習の最初の `go run` が 6-8 秒かかる問題に対し、 **image build 時に GOCACHE を warmup** することで cold compile を ~1 秒台に短縮します。

## 背景

PR #1707 で execTimeout を 15 秒に伸ばして 緊急回避しましたが、 「最初の実行で 6 秒待たされる」 のは UX として不快なので、 根本的には cold compile 自体を速くしたい。

`go run` の遅さの大部分は **fmt / runtime / os などの標準パッケージを 毎回コンパイル + リンク** するため。 image build 時に 1 回 `go run hello-world` を 走らせれば 標準ライブラリの ビルドキャッシュ (`*.a` files) が `/tmp/go-build-cache` に 焼き込まれます。

## 修正

```dockerfile
RUN printf 'package main\nimport "fmt"\nfunc main() { fmt.Println("warmup") }\n' > /tmp/warmup.go && \
    GOCACHE=/tmp/go-build-cache GO111MODULE=off HOME=/tmp \
        go run /tmp/warmup.go > /dev/null 2>&1 && \
    rm /tmp/warmup.go && \
    chown -R nonroot:nonroot /tmp/go-build-cache
```

## 想定効果

| 状態 | Before | After |
|---|---|---|
| 初回 cold compile (image start 直後) | 6-8 秒 | ~1-2 秒 (見込み) |
| 2 回目以降 (warm cache) | ~1 秒 | ~1 秒 (変わらず) |
| image サイズ | x | +50MB 程度 (許容) |

## テスト

- [x] Dockerfile syntax 確認
- [ ] マージ + deploy 後に Go 演習を本番で実行 → 1 秒台で終わるかベンチ確認

## デザイン専用ではないが影響範囲が小さい

Dockerfile の image build 時の warmup 処理だけで、 ロジック変更なし。 deploy で即時反映する。