### PR TITLE
fix(frontend): モバイルのハンバーガーボタン + drawer を 右側に統一

### DIFF
--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -26,11 +26,12 @@ export default function AppShell() {
     <div className="h-screen flex bg-surface overflow-hidden">
       <SkipLink targetId="main-content" />
 
-      {/* モバイル用ハンバーガー（サイドバーが閉じているときのみ表示） */}
+      {/* モバイル用ハンバーガー（サイドバーが閉じているときのみ表示）
+          右上に配置。 mobile レイアウトでは サイドバーは drawer として 左から滑り出す。 */}
       {!mobileMenuOpen && (
         <button
           onClick={() => setMobileMenuOpen(true)}
-          className="md:hidden fixed top-3 left-3 z-30 p-2 bg-[var(--color-nav)] border border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] rounded-md transition-colors shadow-sm"
+          className="md:hidden fixed top-3 right-3 z-30 p-2 bg-[var(--color-nav)] border border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] rounded-md transition-colors shadow-sm"
           aria-label="メニュー"
         >
           <Bars3Icon className="w-5 h-5" />
@@ -45,10 +46,12 @@ export default function AppShell() {
         />
       )}
 
-      {/* モバイルサイドバー */}
+      {/* モバイルナビゲーションメニュー
+          ハンバーガーが右上にあるので、 drawer も右から 滑り出す方が 視線移動が短く 自然。
+          desktop は変わらず 左固定の Sidebar (`md:hidden` で 切替え)。 */}
       <div
-        className={`fixed inset-y-0 left-0 z-50 transform transition-transform duration-200 md:hidden ${
-          mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'
+        className={`fixed inset-y-0 right-0 z-50 transform transition-transform duration-200 md:hidden ${
+          mobileMenuOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >
         <Sidebar onNavigate={() => setMobileMenuOpen(false)} />


### PR DESCRIPTION
## 概要

モバイルの ナビゲーションメニュー UX を 改善:
- ハンバーガーボタン: top-left → **top-right**
- Drawer: 左から滑り出す → **右から滑り出す**

ユーザ要望: 「モバイルではハンバーガーボタン右上、 そこから ナビゲーションメニュー」

## 変更

`AppShell.tsx` のクラス変更だけ:

```diff
- className="md:hidden fixed top-3 left-3 z-30 ..."
+ className="md:hidden fixed top-3 right-3 z-30 ..."

- className="fixed inset-y-0 left-0 z-50 ... ${mobileMenuOpen ? 'translate-x-0' : '-translate-x-full'}"
+ className="fixed inset-y-0 right-0 z-50 ... ${mobileMenuOpen ? 'translate-x-0' : 'translate-x-full'}"
```

desktop (≥ 768px) は **影響なし** (`md:hidden` で 切替え)。

## UX 効果

- 親指の操作範囲 (右下〜右上) に近く 片手操作が楽
- ハンバーガー → drawer の 視線移動が 右側で完結
- 一般的なモバイルアプリの UX に揃う

## テスト

- [x] tsc / eslint / build / Sidebar.mobile.test (3 件) 成功
- [ ] デプロイ後 モバイルブラウザで 動作確認

design-only な変更で、 ロジック / API / DB に影響なし。