### PR TITLE
fix(frontend): メンテナンスページの 「定期メンテナンス時間帯」 カードを削除

### DIFF
--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ArrowPathIcon, ClockIcon } from '@heroicons/react/24/outline';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
 
 interface MaintenancePageProps {
   /** 「再試行」ボタンが押されたときに呼ぶ。useBackendHealth.recheck を渡す。 */
@@ -31,9 +31,8 @@ export default function MaintenancePage({ onRetry }: MaintenancePageProps) {
     window.setTimeout(() => setRetrying(false), 1500);
   };
 
-  // バックエンドが停止する時間帯 (JST 22:00〜翌 07:00) を表示。本サービスは scheduled-stop で
-  // 毎日この帯に止まることがアナウンスされている前提のため、ユーザーに「いつ戻るか」の
-  // 期待値を示すことで体験を悪くしないようにする。
+  // 「定期メンテナンス時間帯」の案内カードは ユーザ要望で 削除。
+  // サーバ状態のみシンプルに知らせ、 再試行ボタンで 復帰を試みてもらう。
   return (
     <div className="min-h-screen flex items-center justify-center bg-[var(--color-surface-1)] px-6">
       <div className="max-w-lg w-full text-center">
@@ -54,19 +53,6 @@ export default function MaintenancePage({ onRetry }: MaintenancePageProps) {
           <br />
           自動的に再接続を試みていますので、しばらくお待ちください。
         </p>
-
-        <div className="flex items-start gap-3 px-4 py-3 rounded-lg border border-[var(--color-surface-3)] bg-[var(--color-surface-2)] text-left mb-6">
-          <ClockIcon className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0 mt-0.5" />
-          <div className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-            <p className="font-medium text-[var(--color-text-secondary)] mb-1">
-              定期メンテナンス時間帯
-            </p>
-            <p>
-              料金節約のため、毎日 <strong>22:00〜翌 07:00 JST</strong> はサービスを停止しています。
-              この時間帯の利用はできません。
-            </p>
-          </div>
-        </div>
 
         <button
           type="button"


### PR DESCRIPTION
## 概要

メンテナンスページから 「定期メンテナンス時間帯 / 料金節約のため、 毎日 22:00〜翌 07:00 JST はサービスを停止しています。」 のカードを 削除します。

ユーザ要望:
> このメンテナンスページの定期メンテナンス時間帯 ... はいらないのです。

## 修正

`MaintenancePage.tsx`:
- ClockIcon + 案内カードの div を 削除
- ClockIcon の import を 削除

これで メンテナンスページは:
- favicon + 「ただいまメンテナンス中です」 + 説明文
- 再試行ボタン
- (環境変数あれば) サポート連絡先

の シンプル構成になります。

## テスト

- [x] `npx tsc --noEmit` 成功
- [x] `npx eslint --max-warnings 0` 成功
- [x] `npm run build` 成功

design-only 変更 (CSS / className すらなく、 要素削除のみ)。 admin merge 予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * メンテナンスページの表示を改善しました。これまで表示されていた定期メンテナンス時間帯の情報カードを削除し、メンテナンス通知と再試行ボタンのみが表示されるようになりました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1712)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->