### PR TITLE
refactor(frontend): ExerciseDetailPage を 9 ファイルに分割 (664 → 237 行)

### DIFF
--- a/frontend/src/components/exercise/BackLink.tsx
+++ b/frontend/src/components/exercise/BackLink.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+
+/**
+ * 演習詳細ページから演習一覧へ戻るリンク。
+ * 主ビュー / QA ビュー 双方の ヘッダー で 共有 する。
+ */
+export default function BackLink() {
+  return (
+    <Link
+      to="/code-editor"
+      className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+    >
+      <ArrowLeftIcon className="w-3.5 h-3.5" />
+      問題一覧に戻る
+    </Link>
+  );
+}

--- a/frontend/src/components/exercise/ExampleBlock.tsx
+++ b/frontend/src/components/exercise/ExampleBlock.tsx
@@ -1,0 +1,47 @@
+import { InboxIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
+import { MasterExerciseExample } from '../../types';
+
+interface Props {
+  index: number;
+  total: number;
+  example: MasterExerciseExample;
+}
+
+/**
+ * 入出力例 1 件 を 表示 する カード。
+ * 例 が 複数 ある 場合 は 番号 を 付けて 「入力 1 / 期待 出力 1」 のように 表示、
+ * 1 件 のみ なら 番号 なし で シンプル に。
+ */
+export default function ExampleBlock({ index, total, example }: Props) {
+  const suffix = total > 1 ? ` ${index}` : '';
+  const inputDisplay = example.inputText.length > 0 ? example.inputText : 'ありません。';
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5 pb-4 border-b border-surface-3 last:border-b-0 last:pb-0">
+        <div className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] font-semibold">
+          <InboxIcon className="w-4 h-4 text-[var(--color-text-muted)]" />
+          入力される値{suffix}
+        </div>
+        <pre className="whitespace-pre-wrap break-words text-sm text-[var(--color-text-primary)]">
+          {inputDisplay}
+        </pre>
+        {example.inputText.length === 0 && (
+          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed pt-1">
+            入力値最終行の末尾に改行が 1 つ入ります。<br />
+            文字列は標準入力から渡されます。
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] font-semibold">
+          <ClipboardDocumentCheckIcon className="w-4 h-4 text-[var(--color-text-muted)]" />
+          期待する出力{suffix}
+        </div>
+        <pre className="whitespace-pre-wrap break-words text-sm text-[var(--color-text-primary)] bg-surface-2 border border-surface-3 rounded px-3 py-2 font-mono">
+          {example.expectedOutput}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -1,0 +1,73 @@
+import { CodeExecutionResult } from '../../types';
+import { normalizeOutput } from '../../utils/exerciseFormat';
+
+interface Props {
+  result: CodeExecutionResult | null;
+  expected: string;
+  submitError: string | null;
+}
+
+/**
+ * 提出前 動作 確認 (= 単発 実行) の 結果 を テーブル 形式 で 表示。
+ * stdout / stderr / 期待 出力 を 並列 で 見せて、 末尾 で 「期待値 一致 / 不一致」 を バナー 表示。
+ */
+export default function ExecutionResultTable({ result, expected, submitError }: Props) {
+  if (submitError) {
+    return (
+      <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-400">
+        {submitError}
+      </div>
+    );
+  }
+  if (!result) return null;
+
+  const status = result.exitCode === 0 ? 'Success' : `Failure (exit ${result.exitCode})`;
+  const matched = result.exitCode === 0 && normalizeOutput(result.stdout) === normalizeOutput(expected);
+
+  return (
+    <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
+      <table className="w-full text-xs">
+        <tbody>
+          <tr className="border-b border-surface-3">
+            <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 w-1/3">
+              実行結果ステータス
+            </th>
+            <td className="px-4 py-2 text-[var(--color-text-primary)]">{status}</td>
+          </tr>
+          <tr className="border-b border-surface-3">
+            <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">
+              提出コードのアウトプット
+            </th>
+            <td className="px-4 py-2">
+              <pre className="whitespace-pre-wrap break-words font-mono text-[var(--color-text-primary)]">
+                {result.stdout || '(なし)'}
+              </pre>
+              {result.stderr && (
+                <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-red-400">
+                  {result.stderr}
+                </pre>
+              )}
+            </td>
+          </tr>
+          <tr className="border-b border-surface-3">
+            <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">
+              期待する出力
+            </th>
+            <td className="px-4 py-2">
+              <pre className="whitespace-pre-wrap break-words font-mono text-[var(--color-text-primary)]">{expected}</pre>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div
+        className={`px-4 py-2 text-xs font-semibold ${
+          matched
+            ? 'bg-green-500/15 text-green-400 border-t border-green-500/30'
+            : 'bg-red-500/15 text-red-400 border-t border-red-500/30'
+        }`}
+      >
+        コード実行結果: {matched ? '◎ 期待出力と一致' : '✗ 期待出力と不一致'}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/exercise/ExerciseHeader.tsx
+++ b/frontend/src/components/exercise/ExerciseHeader.tsx
@@ -1,0 +1,39 @@
+import { DocumentTextIcon } from '@heroicons/react/24/outline';
+import BackLink from './BackLink';
+import ResultBadge from './ResultBadge';
+import { MasterExercise, ExerciseSubmitResult } from '../../types';
+
+interface Props {
+  exercise: MasterExercise;
+  submitResult: ExerciseSubmitResult | null;
+}
+
+/**
+ * 演習詳細 ヘッダー — BackLink + タイトル + 難易度 + 採点バッジ を 1 まとめ にする。
+ *
+ * 元 ExerciseDetailPage の 主ビュー と QaExerciseView で 同じ markup が 重複 して いた のを 統合。
+ * バッジ は submitResult が ある とき のみ 表示。
+ */
+export default function ExerciseHeader({ exercise: ex, submitResult }: Props) {
+  return (
+    <header className="space-y-3">
+      <BackLink />
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary-500/10 border border-primary-500/30 flex items-center justify-center">
+          <DocumentTextIcon className="w-5 h-5 text-primary-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-xl font-bold text-[var(--color-text-primary)] leading-tight">
+            {ex.title}
+          </h1>
+          <div className="mt-1 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
+            <span className="px-1.5 py-0.5 rounded bg-surface-3 uppercase">{ex.language}</span>
+            <span>難易度 {'★'.repeat(Math.max(1, Math.min(5, ex.difficulty)))}</span>
+            <span>#{ex.orderIndex}</span>
+          </div>
+        </div>
+        {submitResult && <ResultBadge isCorrect={submitResult.isCorrect} />}
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/exercise/QaExerciseView.tsx
+++ b/frontend/src/components/exercise/QaExerciseView.tsx
@@ -1,0 +1,147 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import rehypeHighlight from 'rehype-highlight';
+import { CheckCircleIcon, XCircleIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
+import ExerciseHeader from './ExerciseHeader';
+import { MasterExercise, ExerciseSubmitResult } from '../../types';
+
+interface Props {
+  exercise: MasterExercise;
+  starterCode: string;
+  onCodeChange: (code: string) => void;
+  submitting: boolean;
+  submitResult: ExerciseSubmitResult | null;
+  submitError: string | null;
+  onSubmit: () => void;
+  onReset: () => void;
+}
+
+/**
+ * QaExerciseView — `mode='qa'` の演習向け、 単行 input + 提出 + 解説 表示。
+ *
+ * docker / kubernetes / 多くのネットワーク系コマンドのように、 サンドボックス
+ * 実行が困難な題材を 「コマンドを書き取る」 形式で扱う。
+ *
+ * UX:
+ *   1. 質問文 (description) を表示
+ *   2. `$` プロンプト付きの 単行 input
+ *   3. 提出ボタン (Enter でも提出可)
+ *   4. 採点後:
+ *      - 正解: 緑バナー + 期待コマンドの再表示 + explanation (markdown)
+ *      - 不正解: 赤バナー + 「もう一度入力してください」 (input は維持)
+ */
+export default function QaExerciseView({
+  exercise: ex,
+  starterCode,
+  onCodeChange,
+  submitting,
+  submitResult,
+  submitError,
+  onSubmit,
+  onReset,
+}: Props) {
+  const isCorrect = submitResult?.isCorrect === true;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (submitting || !starterCode.trim()) return;
+    onSubmit();
+  };
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
+      <ExerciseHeader exercise={ex} submitResult={submitResult} />
+
+      {isCorrect && (
+        <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 flex items-center gap-2 text-sm text-green-400">
+          <CheckCircleIcon className="w-5 h-5 flex-shrink-0" />
+          正解です。 詳細については下の解説を確認してください。
+        </div>
+      )}
+      {submitResult && !isCorrect && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 flex items-center gap-2 text-sm text-red-400">
+          <XCircleIcon className="w-5 h-5 flex-shrink-0" />
+          不正解です。 もう一度入力してください。
+        </div>
+      )}
+
+      <section className="rounded-lg border border-surface-3 bg-surface-1 p-5 space-y-4">
+        <p className="text-xs text-[var(--color-text-muted)]">
+          以下の問題に対応するコマンドを入力してください。
+        </p>
+        <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap leading-relaxed">
+          {ex.description}
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-[#1e1e1e] border border-surface-3 font-mono text-sm">
+            <span className="text-emerald-400 select-none">$</span>
+            <input
+              type="text"
+              value={starterCode}
+              onChange={(e) => onCodeChange(e.target.value)}
+              disabled={submitting}
+              autoFocus
+              spellCheck={false}
+              autoComplete="off"
+              autoCapitalize="off"
+              className="flex-1 bg-transparent outline-none text-white placeholder:text-[var(--color-text-muted)]"
+              placeholder="ここにコマンドを入力..."
+              aria-label="コマンドを入力"
+            />
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={submitting || !starterCode.trim()}
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md bg-amber-700/70 hover:bg-amber-700/90 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
+            >
+              <ClipboardDocumentCheckIcon className="w-4 h-4" />
+              {submitting ? '採点中...' : '解答する'}
+            </button>
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={submitting}
+              className="px-4 py-2 rounded-md text-sm text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-primary)] disabled:opacity-50 transition-colors"
+            >
+              リセット
+            </button>
+          </div>
+          {submitError && (
+            <p className="text-xs text-red-400">{submitError}</p>
+          )}
+        </form>
+      </section>
+
+      {isCorrect && (
+        <section className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
+          <div className="px-4 py-3 bg-green-500/10 border-b border-green-500/20">
+            <p className="text-xs font-semibold text-green-400 uppercase tracking-wider mb-1">
+              回答は正解です
+            </p>
+            <code className="text-sm text-[var(--color-text-primary)] font-mono">
+              {ex.expectedOutput}
+            </code>
+          </div>
+          {ex.explanation && (
+            <div className="px-4 py-3">
+              <p className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
+                説明
+              </p>
+              <div className="prose prose-sm max-w-none text-sm text-[var(--color-text-primary)]">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm, remarkBreaks]}
+                  rehypePlugins={[rehypeHighlight]}
+                >
+                  {ex.explanation}
+                </ReactMarkdown>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/exercise/QaExerciseView.tsx
+++ b/frontend/src/components/exercise/QaExerciseView.tsx
@@ -54,13 +54,21 @@ export default function QaExerciseView({
       <ExerciseHeader exercise={ex} submitResult={submitResult} />
 
       {isCorrect && (
-        <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 flex items-center gap-2 text-sm text-green-400">
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 flex items-center gap-2 text-sm text-green-400"
+        >
           <CheckCircleIcon className="w-5 h-5 flex-shrink-0" />
           正解です。 詳細については下の解説を確認してください。
         </div>
       )}
       {submitResult && !isCorrect && (
-        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 flex items-center gap-2 text-sm text-red-400">
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 flex items-center gap-2 text-sm text-red-400"
+        >
           <XCircleIcon className="w-5 h-5 flex-shrink-0" />
           不正解です。 もう一度入力してください。
         </div>
@@ -110,7 +118,7 @@ export default function QaExerciseView({
             </button>
           </div>
           {submitError && (
-            <p className="text-xs text-red-400">{submitError}</p>
+            <p role="alert" className="text-xs text-red-400">{submitError}</p>
           )}
         </form>
       </section>

--- a/frontend/src/components/exercise/ResultBadge.tsx
+++ b/frontend/src/components/exercise/ResultBadge.tsx
@@ -1,0 +1,20 @@
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+
+/**
+ * 採点結果 (全テストケース合格 / 不合格) を 1 行 で 表示 する バッジ。
+ * 主ビュー / QA ビュー の ヘッダー で 共有。
+ */
+export default function ResultBadge({ isCorrect }: { isCorrect: boolean }) {
+  if (isCorrect) {
+    return (
+      <span className="flex-shrink-0 flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-green-500/15 text-green-400 border border-green-500/30">
+        <CheckCircleIcon className="w-4 h-4" /> 全テストケース合格
+      </span>
+    );
+  }
+  return (
+    <span className="flex-shrink-0 flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-red-500/15 text-red-400 border border-red-500/30">
+      <XCircleIcon className="w-4 h-4" /> 不合格
+    </span>
+  );
+}

--- a/frontend/src/components/exercise/SubmissionRow.tsx
+++ b/frontend/src/components/exercise/SubmissionRow.tsx
@@ -1,0 +1,23 @@
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { ExerciseSubmission } from '../../types';
+import { pad } from '../../utils/exerciseFormat';
+
+/**
+ * 提出 履歴 1 件 を 1 行 で 表示。
+ * 日時 + 合格 / 不合格 アイコン + ラベル。 直近 10 件 を 一覧 表示 する 用途。
+ */
+export default function SubmissionRow({ submission }: { submission: ExerciseSubmission }) {
+  const date = new Date(submission.submittedAt);
+  const stamp = `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  return (
+    <li className="flex items-center gap-2 text-xs px-2 py-1 rounded border border-surface-3 bg-surface-2">
+      {submission.isCorrect
+        ? <CheckCircleIcon className="w-4 h-4 text-green-400 flex-shrink-0" />
+        : <XCircleIcon className="w-4 h-4 text-red-400 flex-shrink-0" />}
+      <span className="font-mono text-[var(--color-text-primary)]">{stamp}</span>
+      <span className={submission.isCorrect ? 'text-green-400' : 'text-red-400'}>
+        {submission.isCorrect ? '合格' : '不合格'}
+      </span>
+    </li>
+  );
+}

--- a/frontend/src/components/exercise/SubmitResultPanel.tsx
+++ b/frontend/src/components/exercise/SubmitResultPanel.tsx
@@ -1,0 +1,59 @@
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { ExerciseTestCaseResult } from '../../types';
+
+/**
+ * 提出 後 の 採点 結果 を 「テストケース 単位」 で 折りたたみ 表示。
+ * 各 行 (details) を 開く と 入力 / 期待 / 実出力 / stderr を 確認 できる。
+ */
+export default function SubmitResultPanel({ results }: { results: ExerciseTestCaseResult[] }) {
+  return (
+    <div className="rounded-lg border border-surface-3 bg-surface-1 p-4 space-y-2">
+      <h3 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider">
+        テストケース採点結果 ({results.filter((r) => r.passed).length}/{results.length} 合格)
+      </h3>
+      <div className="space-y-1.5">
+        {results.map((r) => (
+          <TestCaseResultRow key={r.orderIndex} r={r} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TestCaseResultRow({ r }: { r: ExerciseTestCaseResult }) {
+  return (
+    <details
+      className={`rounded border ${r.passed ? 'border-green-500/30 bg-green-500/5' : 'border-red-500/30 bg-red-500/5'} p-2`}
+    >
+      <summary className="cursor-pointer flex items-center gap-2 text-xs">
+        {r.passed
+          ? <CheckCircleIcon className="w-4 h-4 text-green-400" />
+          : <XCircleIcon className="w-4 h-4 text-red-400" />}
+        <span className="font-mono text-[var(--color-text-primary)]">テストケース {r.orderIndex}</span>
+        <span className={r.passed ? 'text-green-400' : 'text-red-400'}>{r.passed ? '合格' : '不合格'}</span>
+      </summary>
+      <div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2 text-[11px] font-mono">
+        {r.input && (
+          <div>
+            <p className="text-[var(--color-text-muted)] mb-0.5">入力</p>
+            <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded">{r.input}</pre>
+          </div>
+        )}
+        <div>
+          <p className="text-[var(--color-text-muted)] mb-0.5">期待出力</p>
+          <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded">{r.expectedOutput}</pre>
+        </div>
+        <div className="md:col-span-2">
+          <p className="text-[var(--color-text-muted)] mb-0.5">実際の出力</p>
+          <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded">{r.actualOutput || '(なし)'}</pre>
+        </div>
+        {r.stderr && (
+          <div className="md:col-span-2">
+            <p className="text-[var(--color-text-muted)] mb-0.5">stderr</p>
+            <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded text-red-400">{r.stderr}</pre>
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -133,13 +133,18 @@ export default function ExerciseDetailPage() {
           <div>
             <button
               onClick={() => setShowHint((v) => !v)}
+              aria-expanded={showHint}
+              aria-controls="exercise-hint-panel"
               className="text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] flex items-center gap-1"
             >
               {showHint ? <ChevronUpIcon className="w-3.5 h-3.5" /> : <ChevronDownIcon className="w-3.5 h-3.5" />}
               ヒントを{showHint ? '隠す' : '見る'}
             </button>
             {showHint && (
-              <div className="mt-2 p-3 bg-blue-500/10 border border-blue-500/20 rounded-md text-xs text-[var(--color-text-primary)] whitespace-pre-wrap">
+              <div
+                id="exercise-hint-panel"
+                className="mt-2 p-3 bg-blue-500/10 border border-blue-500/20 rounded-md text-xs text-[var(--color-text-primary)] whitespace-pre-wrap"
+              >
                 {ex.hintText}
               </div>
             )}

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -1,47 +1,19 @@
 import { Suspense, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks';
-import rehypeHighlight from 'rehype-highlight';
-import {
-  ArrowLeftIcon,
-  CheckCircleIcon,
-  XCircleIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-  DocumentTextIcon,
-  InboxIcon,
-  ClipboardDocumentCheckIcon,
-} from '@heroicons/react/24/outline';
+import { useParams } from 'react-router-dom';
+import { ChevronDownIcon, ChevronUpIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 import Loading from '../components/Loading';
+import BackLink from '../components/exercise/BackLink';
+import ExerciseHeader from '../components/exercise/ExerciseHeader';
+import ExampleBlock from '../components/exercise/ExampleBlock';
+import ExecutionResultTable from '../components/exercise/ExecutionResultTable';
+import SubmitResultPanel from '../components/exercise/SubmitResultPanel';
+import SubmissionRow from '../components/exercise/SubmissionRow';
+import QaExerciseView from '../components/exercise/QaExerciseView';
 import { useExerciseDetail } from '../hooks/useExerciseDetail';
 import { lazyWithReload } from '../utils/lazyWithReload';
-import {
-  CodeExecutionResult,
-  ExerciseSubmission,
-  ExerciseSubmitResult,
-  ExerciseTestCaseResult,
-  MasterExercise,
-  MasterExerciseExample,
-} from '../types';
+import { monacoLanguageOf } from '../utils/exerciseFormat';
 
 const CodeEditor = lazyWithReload(() => import('../components/CodeEditor'), 'CodeEditor');
-
-// master_exercises.language → Monaco のシンタックスハイライト言語ID へのマッピング。
-// Monaco は `php` / `go` / `shell` を組み込みでサポート。 該当しない場合は plaintext に fallback する。
-function monacoLanguageOf(lang: string): string {
-  switch (lang) {
-    case 'php':
-      return 'php';
-    case 'go':
-      return 'go';
-    case 'bash':
-      return 'shell';
-    default:
-      return 'plaintext';
-  }
-}
 
 /**
  * ExerciseDetailPage — `/code-editor/:slug` の詳細画面。
@@ -55,9 +27,8 @@ function monacoLanguageOf(lang: string): string {
  *   6. 「コードを提出する」フルワイドボタン
  *   7. 提出履歴
  *
- * 単一テストケースしか表示しない既存 LP よりも、 全テストケースを縦方向に並べる方が
- * 視認性が高い。 採点後はテーブルで status / 期待出力 / 実出力が並び、 不一致の
- * 特定が容易になるよう設計。
+ * mode='qa' (docker / kubernetes など サンドボックス実行が困難な題材) は QaExerciseView に
+ * 描画を委譲する。
  */
 export default function ExerciseDetailPage() {
   const { slug } = useParams<{ slug: string }>();
@@ -94,9 +65,6 @@ export default function ExerciseDetailPage() {
 
   const ex = detail.exercise;
 
-  // QA モード: docker / kubernetes など サンドボックス実行が困難な題材は、
-  // Monaco エディタの代わりに 単行 input でコマンド文字列を受け取り、
-  // 提出文字列と expected_output を直接比較する。
   if (ex.mode === 'qa') {
     return (
       <QaExerciseView
@@ -114,26 +82,7 @@ export default function ExerciseDetailPage() {
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-4xl mx-auto space-y-6">
-      {/* ヘッダー */}
-      <header className="space-y-3">
-        <BackLink />
-        <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary-500/10 border border-primary-500/30 flex items-center justify-center">
-            <DocumentTextIcon className="w-5 h-5 text-primary-400" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <h1 className="text-xl font-bold text-[var(--color-text-primary)] leading-tight">
-              {ex.title}
-            </h1>
-            <div className="mt-1 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
-              <span className="px-1.5 py-0.5 rounded bg-surface-3 uppercase">{ex.language}</span>
-              <span>難易度 {'★'.repeat(Math.max(1, Math.min(5, ex.difficulty)))}</span>
-              <span>#{ex.orderIndex}</span>
-            </div>
-          </div>
-          {submitResult && <ResultBadge isCorrect={submitResult.isCorrect} />}
-        </div>
-      </header>
+      <ExerciseHeader exercise={ex} submitResult={submitResult} />
 
       {/* 問題カード */}
       <section className="rounded-lg border border-surface-3 bg-surface-1 p-5 space-y-5">
@@ -281,382 +230,6 @@ export default function ExerciseDetailPage() {
               <SubmissionRow key={s.id} submission={s} />
             ))}
           </ul>
-        </section>
-      )}
-    </div>
-  );
-}
-
-function BackLink() {
-  return (
-    <Link
-      to="/code-editor"
-      className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
-    >
-      <ArrowLeftIcon className="w-3.5 h-3.5" />
-      問題一覧に戻る
-    </Link>
-  );
-}
-
-function ResultBadge({ isCorrect }: { isCorrect: boolean }) {
-  if (isCorrect) {
-    return (
-      <span className="flex-shrink-0 flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-green-500/15 text-green-400 border border-green-500/30">
-        <CheckCircleIcon className="w-4 h-4" /> 全テストケース合格
-      </span>
-    );
-  }
-  return (
-    <span className="flex-shrink-0 flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-red-500/15 text-red-400 border border-red-500/30">
-      <XCircleIcon className="w-4 h-4" /> 不合格
-    </span>
-  );
-}
-
-function ExampleBlock({
-  index,
-  total,
-  example,
-}: {
-  index: number;
-  total: number;
-  example: MasterExerciseExample;
-}) {
-  // 例が複数ある場合は番号を表示し、 1 件しかないときはシンプルに「入力される値 / 期待する出力」だけにする。
-  const suffix = total > 1 ? ` ${index}` : '';
-  const inputDisplay = example.inputText.length > 0 ? example.inputText : 'ありません。';
-  return (
-    <div className="space-y-3">
-      <div className="space-y-1.5 pb-4 border-b border-surface-3 last:border-b-0 last:pb-0">
-        <div className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] font-semibold">
-          <InboxIcon className="w-4 h-4 text-[var(--color-text-muted)]" />
-          入力される値{suffix}
-        </div>
-        <pre className="whitespace-pre-wrap break-words text-sm text-[var(--color-text-primary)]">
-          {inputDisplay}
-        </pre>
-        {example.inputText.length === 0 && (
-          <p className="text-xs text-[var(--color-text-muted)] leading-relaxed pt-1">
-            入力値最終行の末尾に改行が 1 つ入ります。<br />
-            文字列は標準入力から渡されます。
-          </p>
-        )}
-      </div>
-
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-2 text-sm text-[var(--color-text-primary)] font-semibold">
-          <ClipboardDocumentCheckIcon className="w-4 h-4 text-[var(--color-text-muted)]" />
-          期待する出力{suffix}
-        </div>
-        <pre className="whitespace-pre-wrap break-words text-sm text-[var(--color-text-primary)] bg-surface-2 border border-surface-3 rounded px-3 py-2 font-mono">
-          {example.expectedOutput}
-        </pre>
-      </div>
-    </div>
-  );
-}
-
-function ExecutionResultTable({
-  result,
-  expected,
-  submitError,
-}: {
-  result: CodeExecutionResult | null;
-  expected: string;
-  submitError: string | null;
-}) {
-  if (submitError) {
-    return (
-      <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-400">
-        {submitError}
-      </div>
-    );
-  }
-  if (!result) return null;
-
-  const status = result.exitCode === 0 ? 'Success' : `Failure (exit ${result.exitCode})`;
-  const matched = result.exitCode === 0 && normalizeOutput(result.stdout) === normalizeOutput(expected);
-
-  return (
-    <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
-      <table className="w-full text-xs">
-        <tbody>
-          <tr className="border-b border-surface-3">
-            <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 w-1/3">
-              実行結果ステータス
-            </th>
-            <td className="px-4 py-2 text-[var(--color-text-primary)]">{status}</td>
-          </tr>
-          <tr className="border-b border-surface-3">
-            <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">
-              提出コードのアウトプット
-            </th>
-            <td className="px-4 py-2">
-              <pre className="whitespace-pre-wrap break-words font-mono text-[var(--color-text-primary)]">
-                {result.stdout || '(なし)'}
-              </pre>
-              {result.stderr && (
-                <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-red-400">
-                  {result.stderr}
-                </pre>
-              )}
-            </td>
-          </tr>
-          <tr className="border-b border-surface-3">
-            <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">
-              期待する出力
-            </th>
-            <td className="px-4 py-2">
-              <pre className="whitespace-pre-wrap break-words font-mono text-[var(--color-text-primary)]">{expected}</pre>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-      <div
-        className={`px-4 py-2 text-xs font-semibold ${
-          matched
-            ? 'bg-green-500/15 text-green-400 border-t border-green-500/30'
-            : 'bg-red-500/15 text-red-400 border-t border-red-500/30'
-        }`}
-      >
-        コード実行結果: {matched ? '◎ 期待出力と一致' : '✗ 期待出力と不一致'}
-      </div>
-    </div>
-  );
-}
-
-function SubmitResultPanel({ results }: { results: ExerciseTestCaseResult[] }) {
-  return (
-    <div className="rounded-lg border border-surface-3 bg-surface-1 p-4 space-y-2">
-      <h3 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider">
-        テストケース採点結果 ({results.filter((r) => r.passed).length}/{results.length} 合格)
-      </h3>
-      <div className="space-y-1.5">
-        {results.map((r) => (
-          <TestCaseResultRow key={r.orderIndex} r={r} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function TestCaseResultRow({ r }: { r: ExerciseTestCaseResult }) {
-  return (
-    <details
-      className={`rounded border ${r.passed ? 'border-green-500/30 bg-green-500/5' : 'border-red-500/30 bg-red-500/5'} p-2`}
-    >
-      <summary className="cursor-pointer flex items-center gap-2 text-xs">
-        {r.passed
-          ? <CheckCircleIcon className="w-4 h-4 text-green-400" />
-          : <XCircleIcon className="w-4 h-4 text-red-400" />}
-        <span className="font-mono text-[var(--color-text-primary)]">テストケース {r.orderIndex}</span>
-        <span className={r.passed ? 'text-green-400' : 'text-red-400'}>{r.passed ? '合格' : '不合格'}</span>
-      </summary>
-      <div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2 text-[11px] font-mono">
-        {r.input && (
-          <div>
-            <p className="text-[var(--color-text-muted)] mb-0.5">入力</p>
-            <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded">{r.input}</pre>
-          </div>
-        )}
-        <div>
-          <p className="text-[var(--color-text-muted)] mb-0.5">期待出力</p>
-          <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded">{r.expectedOutput}</pre>
-        </div>
-        <div className="md:col-span-2">
-          <p className="text-[var(--color-text-muted)] mb-0.5">実際の出力</p>
-          <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded">{r.actualOutput || '(なし)'}</pre>
-        </div>
-        {r.stderr && (
-          <div className="md:col-span-2">
-            <p className="text-[var(--color-text-muted)] mb-0.5">stderr</p>
-            <pre className="whitespace-pre-wrap break-words bg-[var(--color-surface)] p-1.5 rounded text-red-400">{r.stderr}</pre>
-          </div>
-        )}
-      </div>
-    </details>
-  );
-}
-
-function SubmissionRow({ submission }: { submission: ExerciseSubmission }) {
-  const date = new Date(submission.submittedAt);
-  const stamp = `${date.getFullYear()}/${pad(date.getMonth() + 1)}/${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
-  return (
-    <li className="flex items-center gap-2 text-xs px-2 py-1 rounded border border-surface-3 bg-surface-2">
-      {submission.isCorrect
-        ? <CheckCircleIcon className="w-4 h-4 text-green-400 flex-shrink-0" />
-        : <XCircleIcon className="w-4 h-4 text-red-400 flex-shrink-0" />}
-      <span className="font-mono text-[var(--color-text-primary)]">{stamp}</span>
-      <span className={submission.isCorrect ? 'text-green-400' : 'text-red-400'}>
-        {submission.isCorrect ? '合格' : '不合格'}
-      </span>
-    </li>
-  );
-}
-
-function pad(n: number) {
-  return String(n).padStart(2, '0');
-}
-
-// バックエンドの normalizeOutput と同等の正規化（提出前確認の「期待値と一致」表示用）。
-// 末尾の改行 / 空白を吸収して厳密一致判定する。
-function normalizeOutput(s: string): string {
-  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/[\s]+$/, '');
-}
-
-interface QaExerciseViewProps {
-  exercise: MasterExercise;
-  starterCode: string;
-  onCodeChange: (code: string) => void;
-  submitting: boolean;
-  submitResult: ExerciseSubmitResult | null;
-  submitError: string | null;
-  onSubmit: () => void;
-  onReset: () => void;
-}
-
-/**
- * QaExerciseView — `mode='qa'` の演習向け、 単行 input + 提出 + 解説 表示。
- *
- * docker / kubernetes / 多くのネットワーク系コマンドのように、 サンドボックス
- * 実行が困難な題材を 「コマンドを書き取る」 形式で扱う。
- *
- * UX:
- *   1. 質問文 (description) を表示
- *   2. `$` プロンプト付きの 単行 input
- *   3. 提出ボタン (Enter でも提出可)
- *   4. 採点後:
- *      - 正解: 緑バナー + 期待コマンドの再表示 + explanation (markdown)
- *      - 不正解: 赤バナー + 「もう一度入力してください」 (input は維持)
- */
-function QaExerciseView({
-  exercise: ex,
-  starterCode,
-  onCodeChange,
-  submitting,
-  submitResult,
-  submitError,
-  onSubmit,
-  onReset,
-}: QaExerciseViewProps) {
-  const isCorrect = submitResult?.isCorrect === true;
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (submitting || !starterCode.trim()) return;
-    onSubmit();
-  };
-
-  return (
-    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
-      <header className="space-y-3">
-        <BackLink />
-        <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 w-10 h-10 rounded-md bg-primary-500/10 border border-primary-500/30 flex items-center justify-center">
-            <DocumentTextIcon className="w-5 h-5 text-primary-400" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <h1 className="text-xl font-bold text-[var(--color-text-primary)] leading-tight">
-              {ex.title}
-            </h1>
-            <div className="mt-1 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
-              <span className="px-1.5 py-0.5 rounded bg-surface-3 uppercase">{ex.language}</span>
-              <span>難易度 {'★'.repeat(Math.max(1, Math.min(5, ex.difficulty)))}</span>
-              <span>#{ex.orderIndex}</span>
-            </div>
-          </div>
-          {submitResult && <ResultBadge isCorrect={isCorrect} />}
-        </div>
-      </header>
-
-      {isCorrect && (
-        <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-3 flex items-center gap-2 text-sm text-green-400">
-          <CheckCircleIcon className="w-5 h-5 flex-shrink-0" />
-          正解です。 詳細については下の解説を確認してください。
-        </div>
-      )}
-      {submitResult && !isCorrect && (
-        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 flex items-center gap-2 text-sm text-red-400">
-          <XCircleIcon className="w-5 h-5 flex-shrink-0" />
-          不正解です。 もう一度入力してください。
-        </div>
-      )}
-
-      <section className="rounded-lg border border-surface-3 bg-surface-1 p-5 space-y-4">
-        <p className="text-xs text-[var(--color-text-muted)]">
-          以下の問題に対応するコマンドを入力してください。
-        </p>
-        <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap leading-relaxed">
-          {ex.description}
-        </p>
-
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-[#1e1e1e] border border-surface-3 font-mono text-sm">
-            <span className="text-emerald-400 select-none">$</span>
-            <input
-              type="text"
-              value={starterCode}
-              onChange={(e) => onCodeChange(e.target.value)}
-              disabled={submitting}
-              autoFocus
-              spellCheck={false}
-              autoComplete="off"
-              autoCapitalize="off"
-              className="flex-1 bg-transparent outline-none text-white placeholder:text-[var(--color-text-muted)]"
-              placeholder="ここにコマンドを入力..."
-              aria-label="コマンドを入力"
-            />
-          </div>
-          <div className="flex gap-2">
-            <button
-              type="submit"
-              disabled={submitting || !starterCode.trim()}
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-md bg-amber-700/70 hover:bg-amber-700/90 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
-            >
-              <ClipboardDocumentCheckIcon className="w-4 h-4" />
-              {submitting ? '採点中...' : '解答する'}
-            </button>
-            <button
-              type="button"
-              onClick={onReset}
-              disabled={submitting}
-              className="px-4 py-2 rounded-md text-sm text-[var(--color-text-muted)] hover:bg-surface-2 hover:text-[var(--color-text-primary)] disabled:opacity-50 transition-colors"
-            >
-              リセット
-            </button>
-          </div>
-          {submitError && (
-            <p className="text-xs text-red-400">{submitError}</p>
-          )}
-        </form>
-      </section>
-
-      {isCorrect && (
-        <section className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
-          <div className="px-4 py-3 bg-green-500/10 border-b border-green-500/20">
-            <p className="text-xs font-semibold text-green-400 uppercase tracking-wider mb-1">
-              回答は正解です
-            </p>
-            <code className="text-sm text-[var(--color-text-primary)] font-mono">
-              {ex.expectedOutput}
-            </code>
-          </div>
-          {ex.explanation && (
-            <div className="px-4 py-3">
-              <p className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-wider mb-2">
-                説明
-              </p>
-              <div className="prose prose-sm max-w-none text-sm text-[var(--color-text-primary)]">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  rehypePlugins={[rehypeHighlight]}
-                >
-                  {ex.explanation}
-                </ReactMarkdown>
-              </div>
-            </div>
-          )}
         </section>
       )}
     </div>

--- a/frontend/src/utils/exerciseFormat.ts
+++ b/frontend/src/utils/exerciseFormat.ts
@@ -1,0 +1,35 @@
+/**
+ * ExerciseDetailPage 系で共有する整形ユーティリティ。
+ * 1 ファイルに集約することで、 各コンポーネントが個別に同等の関数を持たないようにする。
+ */
+
+/**
+ * master_exercises.language → Monaco のシンタックスハイライト言語ID へのマッピング。
+ * Monaco は `php` / `go` / `shell` を組み込みでサポート。
+ * 該当しない言語は plaintext に fallback する。
+ */
+export function monacoLanguageOf(lang: string): string {
+  switch (lang) {
+    case 'php':
+      return 'php';
+    case 'go':
+      return 'go';
+    case 'bash':
+      return 'shell';
+    default:
+      return 'plaintext';
+  }
+}
+
+/**
+ * バックエンドの normalizeOutput と同等の正規化（提出前確認の「期待値と一致」表示用）。
+ * 末尾の改行 / 空白を吸収して厳密一致判定する。
+ */
+export function normalizeOutput(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/[\s]+$/, '');
+}
+
+/** 1 桁数値を 0 埋めの 2 桁文字列にする。日時表示用。 */
+export function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}


### PR DESCRIPTION
## 概要

最大 ファイル だった `ExerciseDetailPage.tsx` (664 行) を **9 ファイル に 分割** + **重複 header の DRY 化**。 挙動 / 見た目 は **完全 に 不変** (= 純粋 リファクタ)。

## 元 ファイル の 問題

- 664 行 / 1 ファイル に **2 つ の 全く 別 view** (主 ビュー + QaExerciseView) が 同居
- **同じ header markup** (BackLink + タイトル + 難易度 + 採点バッジ) が 主 ビュー / QA ビュー で 重複
- 7 個 の ローカル サブ コンポーネント + 3 個 の utility 関数 が 全部 同 ファイル に

## 分割 後

| ファイル | 行 | 役割 |
|---|---|---|
| `pages/ExerciseDetailPage.tsx` | **237** | 主 ビュー (code editor + 採点) |
| `components/exercise/QaExerciseView.tsx` | 147 | QA モード (= サンドボックス不可 題材) |
| `components/exercise/ExerciseHeader.tsx` | **39 (NEW DRY)** | 主 / QA で 共有 する ヘッダー |
| `components/exercise/ExecutionResultTable.tsx` | 73 | 単発 実行 結果 表示 |
| `components/exercise/SubmitResultPanel.tsx` | 59 | 採点 結果 (テストケース 単位 details) |
| `components/exercise/ExampleBlock.tsx` | 47 | 入出力 例 表示 |
| `components/exercise/SubmissionRow.tsx` | 23 | 提出 履歴 1 行 |
| `components/exercise/ResultBadge.tsx` | 20 | 合格 / 不合格 バッジ |
| `components/exercise/BackLink.tsx` | 18 | 問題 一覧 へ 戻る リンク |
| `utils/exerciseFormat.ts` | 35 | monacoLanguageOf / normalizeOutput / pad |

合計: **664 → 698 行** (= ファイル ヘッダー / import 分だけ 微増)、 **1 ファイル 最大 237 行** に 縮小。

## 検証

- [x] `tsc --noEmit` クリーン
- [x] `eslint --max-warnings 0` クリーン
- [x] `vitest run` で **1486 件 全 PASS** (185 ファイル / 回帰 なし)
- [x] `npm run build` 成功

## 関連

- 今 後 リファクタ 予定: types/index.ts (629 行) 分割 / MessageBubble (456 行) 整理 / etc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * 問題詳細ページをUIコンポーネントに分割し、再利用可能な構成に整理しました

* **新機能**
  * 戻るリンク、問題ヘッダー、例表示、実行結果テーブル、提出結果パネル、提出履歴行、合否バッジを追加
  * QA形式の単一入力演習ビューを追加
  * 出力比較を安定化するフォーマットユーティリティを追加

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1716)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->