### PR TITLE
fix(frontend): サイドバー「コード学習」を「演習」に変更

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ interface NavItem {
 const mainNavItems: NavItem[] = [
   { id: 'home', icon: HomeIcon, label: 'ホーム', to: '/', matchExact: true },
   { id: 'ai', icon: ChatBubbleBottomCenterTextIcon, label: 'AI', to: '/chat/ask-ai', matchPrefix: '/chat/ask-ai' },
-  { id: 'code', icon: CodeBracketIcon, label: 'コード学習', to: '/code-editor', matchPrefix: '/code-editor' },
+  { id: 'code', icon: CodeBracketIcon, label: '演習', to: '/code-editor', matchPrefix: '/code-editor' },
   { id: 'courses', icon: AcademicCapIcon, label: 'コース', to: '/courses', matchPrefix: '/courses' },
   { id: 'notes', icon: DocumentTextIcon, label: 'ノート', to: '/notes', matchPrefix: '/notes' },
   { id: 'notifications', icon: BellIcon, label: '通知', to: '/notifications', matchExact: true },

--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -54,7 +54,7 @@ describe('Sidebar', () => {
     renderSidebar();
     expect(screen.getByText('ホーム')).toBeDefined();
     expect(screen.getByText('AI')).toBeDefined();
-    expect(screen.getByText('コード学習')).toBeDefined();
+    expect(screen.getByText('演習')).toBeDefined();
     expect(screen.getByText('コース')).toBeDefined();
     expect(screen.getByText('ノート')).toBeDefined();
     expect(screen.getByText('レポート')).toBeDefined();
@@ -129,10 +129,10 @@ describe('Sidebar', () => {
     expect(screen.queryByText('管理')).toBeNull();
   });
 
-  it('super_admin には trainee 向けメニュー (AI / コード学習 / ノート / レポート / コース) が表示されない', () => {
+  it('super_admin には trainee 向けメニュー (AI / 演習 / ノート / レポート / コース) が表示されない', () => {
     renderSidebar('/', true, 'super_admin');
     expect(screen.queryByText('AI')).toBeNull();
-    expect(screen.queryByText('コード学習')).toBeNull();
+    expect(screen.queryByText('演習')).toBeNull();
     expect(screen.queryByText('ノート')).toBeNull();
     expect(screen.queryByText('レポート')).toBeNull();
     expect(screen.queryByText('コース')).toBeNull();
@@ -145,7 +145,7 @@ describe('Sidebar', () => {
   it('company_admin には trainee 向けメニューも表示される', () => {
     renderSidebar('/', true, 'company_admin');
     expect(screen.getByText('AI')).toBeInTheDocument();
-    expect(screen.getByText('コード学習')).toBeInTheDocument();
+    expect(screen.getByText('演習')).toBeInTheDocument();
     expect(screen.getByText('ノート')).toBeInTheDocument();
     expect(screen.getByText('レポート')).toBeInTheDocument();
     expect(screen.getByText('管理')).toBeInTheDocument();


### PR DESCRIPTION
## 概要

新卒 受講者 が 「学習 全体 (= コース 学習)」 と 区別 しやすい 名称 (= 「演習問題 を 解く 場所」) に サイドバー ラベル を 変更。

## 変更

- `Sidebar.tsx`: コード メニュー の label を 「コード学習」 → 「演習」
- `Sidebar.test.tsx`: 期待 文字列 を 同 様 に 更新 (12 件 全 PASS)

リンク 先 (`/code-editor`) と アイコン (`CodeBracketIcon`) は 変更 なし。 純粋 文言 のみ。

## 検証

- [x] `tsc --noEmit` クリーン
- [x] `eslint --max-warnings 0` クリーン
- [x] `vitest run` 1486 件 全 PASS

## デザイン 専用 変更 ルール 適用

CLAUDE.md §4.2 "デザイン 専用 変更 の 特例" に 該当。 admin merge で 進めます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **その他**
  * サイドバーのナビゲーション項目の表示名を「コード学習」から「演習」に変更しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1719)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->