### PR TITLE
fix(frontend): 演習 実行 結果 の 「Success/Failure」 を 色 + アイコン 付き 表示

### DIFF
--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -1,3 +1,4 @@
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { CodeExecutionResult } from '../../types';
 import { normalizeOutput } from '../../utils/exerciseFormat';
 
@@ -10,6 +11,10 @@ interface Props {
 /**
  * 提出前 動作 確認 (= 単発 実行) の 結果 を テーブル 形式 で 表示。
  * stdout / stderr / 期待 出力 を 並列 で 見せて、 末尾 で 「期待値 一致 / 不一致」 を バナー 表示。
+ *
+ * 「実行 ステータス」 は exit code に 応じて 色 + アイコン を 付ける:
+ *   - exit 0 → 緑 + ✓ (Success) で 「コンパイル / 実行 は 通った」 を 視覚 化
+ *   - exit != 0 → 赤 + ✗ (Failure) で 「コンパイル or 実行 で 失敗 した」 を 強調
  */
 export default function ExecutionResultTable({ result, expected, submitError }: Props) {
   if (submitError) {
@@ -21,8 +26,8 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
   }
   if (!result) return null;
 
-  const status = result.exitCode === 0 ? 'Success' : `Failure (exit ${result.exitCode})`;
-  const matched = result.exitCode === 0 && normalizeOutput(result.stdout) === normalizeOutput(expected);
+  const isSuccess = result.exitCode === 0;
+  const matched = isSuccess && normalizeOutput(result.stdout) === normalizeOutput(expected);
 
   return (
     <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
@@ -32,7 +37,19 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
             <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 w-1/3">
               実行結果ステータス
             </th>
-            <td className="px-4 py-2 text-[var(--color-text-primary)]">{status}</td>
+            <td className="px-4 py-2">
+              {isSuccess ? (
+                <span className="inline-flex items-center gap-1 font-semibold text-green-400">
+                  <CheckCircleIcon className="w-4 h-4" />
+                  Success
+                </span>
+              ) : (
+                <span className="inline-flex items-center gap-1 font-semibold text-red-400">
+                  <XCircleIcon className="w-4 h-4" />
+                  Failure (exit {result.exitCode})
+                </span>
+              )}
+            </td>
           </tr>
           <tr className="border-b border-surface-3">
             <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">


### PR DESCRIPTION
## 概要

スクリーンショット 報告 (Hello, Go 演習) で 「Success と なって いる が 緑色 が ない」 と 指摘。 新卒 が 実行 の 成否 を パッと 判別 できる よう、 ExecutionResultTable の status 表示 に **色 + アイコン** を 付ける。

## 変更

| 状態 | Before | After |
|---|---|---|
| exit 0 | プレーン テキスト 「Success」 | **緑 + ✓ + 「Success」** |
| exit != 0 | プレーン テキスト 「Failure (exit N)」 | **赤 + ✗ + 「Failure (exit N)」** |

純粋 デザイン 変更 / ロジック 変更 ゼロ。

## 検証

- [x] tsc / eslint クリーン
- [x] vitest 1486 件 全 PASS
- [x] npm run build 成功

## デザイン 専用 変更 ルール (CLAUDE.md §4.2) 適用

admin merge で 進めます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## UI改善

* **Style**
  * 実行結果ステータスの表示を改善しました。成功時は緑色のチェックマーク付き「成功」、失敗時は赤色のXアイコン付き「失敗（終了コード）」と表示されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1720)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->