### PR TITLE
refactor(backend): UserRepository を Clean Architecture 物理 分離 (POC) + 旧 repository を legacyrepository に 改名

### DIFF
--- a/backend/internal/adapter/persistence/user_repository.go
+++ b/backend/internal/adapter/persistence/user_repository.go
@@ -1,4 +1,10 @@
-package repository
+// Package persistence は usecase 層 が 定義 した port (interface) に 対 する 永続化
+// 実装 (GORM / DynamoDB / S3 presigner 等) を 集約 する。
+//
+// Clean Architecture の Interface Adapters 層 の うち「persistence 関心 事」 担当 部分。
+// usecase 側 は ここ を 知ら ず、 wiring (router.go) で `persistence.NewXxxRepository(...)`
+// を 呼んで 実装 を 組み立て、 各 usecase に 注入 する。
+package persistence
 
 import (
 	"context"
@@ -6,31 +12,17 @@ import (
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
 )
 
-// UserRepository は users テーブルへのアクセスを提供する。
-type UserRepository interface {
-	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
-	FindByID(ctx context.Context, id uint64) (*domain.User, error)
-	Create(ctx context.Context, user *domain.User) error
-	// UpdateDisplayName は ProfilePage の「氏名」変更、 および OIDC ログイン時に
-	// 旧 displayName=email を id_token の name claim で自動補正するときに呼ばれる。
-	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
-	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。
-	UpdateRole(ctx context.Context, userID uint64, role string) error
-	// UpdateCompanyID は既存ユーザーが招待を受けて company に紐付くときに呼ばれる。
-	UpdateCompanyID(ctx context.Context, userID uint64, companyID uint64) error
-	// MarkOnboarded は Welcome 画面の「はじめる」ボタン押下時に呼ばれ、
-	// onboarded_at = NOW() に更新する。冪等（既に値が入っていても上書きしない）。
-	MarkOnboarded(ctx context.Context, userID uint64) error
-}
-
+// userRepository は [repository.UserRepository] の GORM 実装。
 type userRepository struct {
 	db *gorm.DB
 }
 
-func NewUserRepository(db *gorm.DB) UserRepository {
+// NewUserRepository は GORM ベース の [repository.UserRepository] を 返す。
+func NewUserRepository(db *gorm.DB) repository.UserRepository {
 	return &userRepository{db: db}
 }
 

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -10,8 +10,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 // AuthHandler は Cognito 関連の認証エンドポイントを提供する。
@@ -22,7 +23,7 @@ import (
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
 	users          repository.UserRepository
-	invitations    repository.AdminInvitationRepository
+	invitations    legacyrepository.AdminInvitationRepository
 	cognitoCfg     *config.CognitoConfig
 	tokens         *cognito.TokenExchanger
 }
@@ -32,7 +33,7 @@ type AuthHandler struct {
 func NewAuthHandler(
 	getCurrentUser *usecase.GetCurrentUserUseCase,
 	users repository.UserRepository,
-	invitations repository.AdminInvitationRepository,
+	invitations legacyrepository.AdminInvitationRepository,
 	cognitoCfg *config.CognitoConfig,
 ) *AuthHandler {
 	return &AuthHandler{

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -43,10 +43,10 @@ func (r *fakeFullSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, err
 func (r *fakeFullSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
 	return nil, nil
 }
-func (r *fakeFullSubmissionRepo) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
-	return repository.ExerciseSubmissionStats{}, nil
+func (r *fakeFullSubmissionRepo) ExerciseStats(uint64, string) (legacyrepository.ExerciseSubmissionStats, error) {
+	return legacyrepository.ExerciseSubmissionStats{}, nil
 }
-func (r *fakeFullSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+func (r *fakeFullSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]legacyrepository.ExerciseSubmissionStats, error) {
 	return nil, nil
 }
 

--- a/backend/internal/handler/master_exercise_handler_test.go
+++ b/backend/internal/handler/master_exercise_handler_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
@@ -29,11 +29,11 @@ func (fakeSubmissionRepoForList) HasAttempted(uint64, uint64, string) (bool, err
 func (fakeSubmissionRepoForList) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
 	return map[uint64]string{}, nil
 }
-func (fakeSubmissionRepoForList) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
-	return repository.ExerciseSubmissionStats{}, nil
+func (fakeSubmissionRepoForList) ExerciseStats(uint64, string) (legacyrepository.ExerciseSubmissionStats, error) {
+	return legacyrepository.ExerciseSubmissionStats{}, nil
 }
-func (fakeSubmissionRepoForList) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
-	return map[uint64]repository.ExerciseSubmissionStats{}, nil
+func (fakeSubmissionRepoForList) ExerciseStatsBatch([]uint64, string) (map[uint64]legacyrepository.ExerciseSubmissionStats, error) {
+	return map[uint64]legacyrepository.ExerciseSubmissionStats{}, nil
 }
 
 // fakeMasterExerciseRepo は MasterExerciseRepository の最小スタブ。

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 const (

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -8,8 +8,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 // ProfileHandler は GET / PUT /profile/:userId(or "me") を提供する。

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -5,11 +5,13 @@ import (
 	"log"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/bedrock"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
 )
 
@@ -19,7 +21,7 @@ type routeDeps struct {
 	cfg           *config.Config
 	userRepo      repository.UserRepository
 	bedrockClient *bedrock.Client
-	msgRepo       repository.AiChatMessageRepository
+	msgRepo       legacyrepository.AiChatMessageRepository
 }
 
 // NewRouter は API ルーティングを組み立てる。
@@ -40,7 +42,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 		log.Printf("WARN: Bedrock client init failed (AI chat WS will be unavailable): %v", err)
 	}
 
-	msgRepo, err := repository.NewAiChatMessageRepository(ctx, cfg.DynamoDB.Region, cfg.DynamoDB.AiChatTable)
+	msgRepo, err := legacyrepository.NewAiChatMessageRepository(ctx, cfg.DynamoDB.Region, cfg.DynamoDB.AiChatTable)
 	if err != nil {
 		log.Printf("WARN: DynamoDB client init failed (AI chat WS will be unavailable): %v", err)
 	}
@@ -48,7 +50,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	deps := &routeDeps{
 		db:            db,
 		cfg:           cfg,
-		userRepo:      repository.NewUserRepository(db),
+		userRepo:      persistence.NewUserRepository(db),
 		bedrockClient: bc,
 		msgRepo:       msgRepo,
 	}
@@ -81,6 +83,6 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 
 // registerHealthRoutes は認証不要のヘルスチェック (/api/v2/health) を登録する。
 func registerHealthRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	h := NewHealthHandler(usecase.NewCheckHealthUseCase(repository.NewHealthRepository(deps.db)))
+	h := NewHealthHandler(usecase.NewCheckHealthUseCase(legacyrepository.NewHealthRepository(deps.db)))
 	g.GET("/health", h.Get)
 }

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/infra/ses"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -15,13 +15,13 @@ import (
 func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	// Company 一覧 (SuperAdmin 専用)
 	companyHandler := NewAdminCompanyHandler(
-		usecase.NewListCompaniesUseCase(repository.NewCompanyRepository(deps.db)),
+		usecase.NewListCompaniesUseCase(legacyrepository.NewCompanyRepository(deps.db)),
 	)
 	g.GET("/admin/companies", companyHandler.List)
 
 	// AdminInvitation — SES マジックリンク方式（Path B）。
 	// Cognito 事前作成は撤去し、ここでは UUID token を発行 + SES で独自メールを送る。
-	adminInvRepo := repository.NewAdminInvitationRepository(deps.db)
+	adminInvRepo := legacyrepository.NewAdminInvitationRepository(deps.db)
 
 	var sender usecase.MagicLinkSender
 	var linkBuilder usecase.LinkBuilder

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -12,7 +12,7 @@ import (
 // callback / refresh-token は HttpOnly Cookie の発行・更新を行うため middleware.JWTAuth の対象外。
 func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
-	invitations := repository.NewAdminInvitationRepository(deps.db)
+	invitations := legacyrepository.NewAdminInvitationRepository(deps.db)
 	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito)
 
 	g.POST("/auth/cognito/logout", authHandler.Logout)

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	infraS3 "github.com/norman6464/FreStyle/backend/internal/infra/s3"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // registerChatRoutes は AI チャットセッションの REST + SSE エンドポイントを登録する。
 // WebSocket は registerWebSocketRoutes 側で別途登録する（SSE 移行完了まで並行運用）。
 func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	aiSessionRepo := repository.NewAiChatSessionRepository(deps.db)
+	aiSessionRepo := legacyrepository.NewAiChatSessionRepository(deps.db)
 	aiHandler := NewAiChatHandler(
 		usecase.NewGetAiChatSessionsByUserIDUseCase(aiSessionRepo),
 		usecase.NewCreateAiChatSessionUseCase(aiSessionRepo),
@@ -53,18 +53,18 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 
 // newAiChatAttachmentPresignerOrFallback は本番経路では infra/s3.Presigner を、
 // dev / NOTE_IMAGES_BUCKET 未設定時は stub presigner を返す。Note 系と同じ fail open。
-func newAiChatAttachmentPresignerOrFallback(deps *routeDeps) repository.AiChatAttachmentPresigner {
+func newAiChatAttachmentPresignerOrFallback(deps *routeDeps) legacyrepository.AiChatAttachmentPresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {
 		log.Printf("[ai-chat-attachment] NOTE_IMAGES_BUCKET unset — using stub presigner (DEV)")
-		return repository.NewStubAiChatAttachmentPresigner("stub-bucket")
+		return legacyrepository.NewStubAiChatAttachmentPresigner("stub-bucket")
 	}
 	pre, err := infraS3.NewPresigner(context.Background(), deps.cfg.S3.Region, bucket)
 	if err != nil {
 		log.Printf("[ai-chat-attachment] failed to init S3 presigner (%v) — falling back to stub", err)
-		return repository.NewStubAiChatAttachmentPresigner(bucket)
+		return legacyrepository.NewStubAiChatAttachmentPresigner(bucket)
 	}
-	return repository.NewAiChatAttachmentPresigner(pre)
+	return legacyrepository.NewAiChatAttachmentPresigner(pre)
 }
 
 // newAiChatAttachmentDownloaderOrNil は本番では S3 GetObject downloader を返す。

--- a/backend/internal/handler/routes_courses.go
+++ b/backend/internal/handler/routes_courses.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -18,8 +18,8 @@ import (
 // アクセス制御は usecase 層で actor の company_id / role を検証する。
 // trainee は同一 company の `is_published=true` コースのみ閲覧可。
 func registerCourseRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	courseRepo := repository.NewCourseRepository(deps.db)
-	materialRepo := repository.NewTeachingMaterialRepository(deps.db)
+	courseRepo := legacyrepository.NewCourseRepository(deps.db)
+	materialRepo := legacyrepository.NewTeachingMaterialRepository(deps.db)
 
 	courseUC := usecase.NewCourseUseCase(courseRepo, materialRepo)
 	courseHandler := NewCourseHandler(courseUC)

--- a/backend/internal/handler/routes_exercises.go
+++ b/backend/internal/handler/routes_exercises.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -15,9 +15,9 @@ import (
 //   - GET  /api/v2/exercises/:slug/submissions     current user の履歴
 //   - POST /api/v2/code/execute                    コード実行（採点せず stdout だけ返す）
 func registerExerciseRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	exerciseRepo := repository.NewMasterExerciseRepository(deps.db)
-	examplesRepo := repository.NewMasterExerciseExampleRepository(deps.db)
-	submissionsRepo := repository.NewExerciseSubmissionRepository(deps.db)
+	exerciseRepo := legacyrepository.NewMasterExerciseRepository(deps.db)
+	examplesRepo := legacyrepository.NewMasterExerciseExampleRepository(deps.db)
+	submissionsRepo := legacyrepository.NewExerciseSubmissionRepository(deps.db)
 	executor := usecase.NewExecuteCodeUseCase()
 
 	exerciseHandler := NewMasterExerciseHandler(

--- a/backend/internal/handler/routes_invitation_public.go
+++ b/backend/internal/handler/routes_invitation_public.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -13,8 +13,8 @@ import (
 // 認可は無し（受諾前にユーザーが踏むため）。token が無効・期限切れの場合は 404 を返し、
 // 「招待が存在するかどうか」のメタ情報を漏らさない。
 func registerInvitationPublicRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	invRepo := repository.NewAdminInvitationRepository(deps.db)
-	companies := repository.NewCompanyRepository(deps.db)
+	invRepo := legacyrepository.NewAdminInvitationRepository(deps.db)
+	companies := legacyrepository.NewCompanyRepository(deps.db)
 	h := NewPublicInvitationHandler(usecase.NewValidateInvitationTokenUseCase(invRepo, companies))
 	g.GET("/invitations/accept/:token", h.Validate)
 }

--- a/backend/internal/handler/routes_learning_report.go
+++ b/backend/internal/handler/routes_learning_report.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -14,8 +14,8 @@ import (
 // 生成は SQS にキューする非同期ジョブで、 当面は stub enqueuer を使用する
 // （実 SQS 接続は別 PR / 別 infra で導入予定）。
 func registerLearningReportRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	repo := repository.NewLearningReportRepository(deps.db)
-	queue := repository.NewStubSqsEnqueuer()
+	repo := legacyrepository.NewLearningReportRepository(deps.db)
+	queue := legacyrepository.NewStubSqsEnqueuer()
 	h := NewLearningReportHandler(
 		usecase.NewListLearningReportsUseCase(repo),
 		usecase.NewRequestLearningReportUseCase(repo, queue),

--- a/backend/internal/handler/routes_note.go
+++ b/backend/internal/handler/routes_note.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	infraS3 "github.com/norman6464/FreStyle/backend/internal/infra/s3"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // registerNoteRoutes は Note CRUD・Note 画像 presigned URL・SessionNote のエンドポイントを登録する。
 func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	// Phase 10: Note CRUD
-	noteRepo := repository.NewNoteRepository(deps.db)
+	noteRepo := legacyrepository.NewNoteRepository(deps.db)
 	noteHandler := NewNoteHandler(
 		usecase.NewListNotesByUserIDUseCase(noteRepo),
 		usecase.NewCreateNoteUseCase(noteRepo),
@@ -32,7 +32,7 @@ func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.POST("/notes/images/upload-url", noteImageHandler.IssueUploadURL)
 
 	// Phase 12: SessionNote (セッション固有ノート)
-	sessionNoteRepo := repository.NewSessionNoteRepository(deps.db)
+	sessionNoteRepo := legacyrepository.NewSessionNoteRepository(deps.db)
 	sessionNoteHandler := NewSessionNoteHandler(
 		usecase.NewGetSessionNoteUseCase(sessionNoteRepo),
 		usecase.NewUpsertSessionNoteUseCase(sessionNoteRepo),
@@ -44,16 +44,16 @@ func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
 // newNoteImagePresignerOrFallback は本番では infra/s3.Presigner で real な PUT presign を返し、
 // NOTE_IMAGES_BUCKET 未設定 (ローカル / dev) の場合だけ stub にフォールバックする。
 // presigner 失敗時も fail open で stub に降格 (Note image 機能だけ利用不可になる)。
-func newNoteImagePresignerOrFallback(deps *routeDeps) repository.NoteImagePresigner {
+func newNoteImagePresignerOrFallback(deps *routeDeps) legacyrepository.NoteImagePresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {
 		log.Printf("[note-image] NOTE_IMAGES_BUCKET unset — using stub presigner (DEV)")
-		return repository.NewStubNoteImagePresigner("stub-bucket")
+		return legacyrepository.NewStubNoteImagePresigner("stub-bucket")
 	}
 	pre, err := infraS3.NewPresigner(context.Background(), deps.cfg.S3.Region, bucket)
 	if err != nil {
 		log.Printf("[note-image] failed to init S3 presigner (%v) — falling back to stub", err)
-		return repository.NewStubNoteImagePresigner(bucket)
+		return legacyrepository.NewStubNoteImagePresigner(bucket)
 	}
-	return repository.NewNoteImagePresigner(pre)
+	return legacyrepository.NewNoteImagePresigner(pre)
 }

--- a/backend/internal/handler/routes_profile.go
+++ b/backend/internal/handler/routes_profile.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	infraS3 "github.com/norman6464/FreStyle/backend/internal/infra/s3"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // registerProfileRoutes は profile / user-stats 関連の REST エンドポイントを登録する。
 func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	// Phase 5: プロフィール
-	profileRepo := repository.NewProfileRepository(deps.db)
+	profileRepo := legacyrepository.NewProfileRepository(deps.db)
 	profileHandler := NewProfileHandler(
 		usecase.NewGetProfileUseCase(profileRepo),
 		usecase.NewUpdateProfileUseCase(profileRepo),
@@ -36,7 +36,7 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 
 	// Phase 6: ユーザー統計
 	statsHandler := NewUserStatsHandler(
-		usecase.NewGetUserStatsUseCase(repository.NewUserStatsRepository(deps.db)),
+		usecase.NewGetUserStatsUseCase(legacyrepository.NewUserStatsRepository(deps.db)),
 	)
 	// 旧 path /user-stats/:userId と Spring 風 /users/:userId/stats の両方を提供する。
 	g.GET("/user-stats/:userId", statsHandler.Get)
@@ -53,20 +53,20 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 //
 // 配信 URL のベース (CDN) は config.S3.NoteImagesCDNBase を最優先で使う。
 // 未指定なら virtual-hosted-style (https://<bucket>.s3.<region>.amazonaws.com) で組み立てる。
-func newProfileImagePresignerOrFallback(deps *routeDeps) repository.ProfileImagePresigner {
+func newProfileImagePresignerOrFallback(deps *routeDeps) legacyrepository.ProfileImagePresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {
 		log.Printf("[profile] NOTE_IMAGES_BUCKET unset — using stub presigner (DEV)")
-		return repository.NewStubProfileImagePresigner("stub-bucket", deps.cfg.S3.NoteImagesCDNBase)
+		return legacyrepository.NewStubProfileImagePresigner("stub-bucket", deps.cfg.S3.NoteImagesCDNBase)
 	}
 	pre, err := infraS3.NewPresigner(context.Background(), deps.cfg.S3.Region, bucket)
 	if err != nil {
 		log.Printf("[profile] failed to init S3 presigner (%v) — falling back to stub", err)
-		return repository.NewStubProfileImagePresigner(bucket, deps.cfg.S3.NoteImagesCDNBase)
+		return legacyrepository.NewStubProfileImagePresigner(bucket, deps.cfg.S3.NoteImagesCDNBase)
 	}
 	cdnBase := deps.cfg.S3.NoteImagesCDNBase
 	if cdnBase == "" {
 		cdnBase = "https://" + bucket + ".s3." + deps.cfg.S3.Region + ".amazonaws.com"
 	}
-	return repository.NewProfileImagePresigner(pre, cdnBase)
+	return legacyrepository.NewProfileImagePresigner(pre, cdnBase)
 }

--- a/backend/internal/handler/routes_social.go
+++ b/backend/internal/handler/routes_social.go
@@ -2,14 +2,14 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // registerSocialRoutes は通知の REST エンドポイントを登録する。
 // Friendship / フォロー機能は削除済み。
 func registerSocialRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	notificationRepo := repository.NewNotificationRepository(deps.db)
+	notificationRepo := legacyrepository.NewNotificationRepository(deps.db)
 	notificationHandler := NewNotificationHandler(
 		usecase.NewListNotificationsUseCase(notificationRepo),
 		usecase.NewMarkNotificationReadUseCase(notificationRepo),

--- a/backend/internal/handler/routes_teaching_materials.go
+++ b/backend/internal/handler/routes_teaching_materials.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -19,8 +19,8 @@ import (
 // アクセス制御は usecase 層で actor の company_id / role を検証する。
 // trainee は同一 company の `is_published=true` 教材かつ所属コースが published のときのみ閲覧可。
 func registerTeachingMaterialRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	courseRepo := repository.NewCourseRepository(deps.db)
-	materialRepo := repository.NewTeachingMaterialRepository(deps.db)
+	courseRepo := legacyrepository.NewCourseRepository(deps.db)
+	materialRepo := legacyrepository.NewTeachingMaterialRepository(deps.db)
 	uc := usecase.NewTeachingMaterialUseCase(materialRepo, courseRepo)
 	h := NewTeachingMaterialHandler(uc)
 	g.GET("/teaching-materials", h.List) // backward-compat（frontend のコース対応後に削除予定）

--- a/backend/internal/legacyrepository/admin_invitation_repository.go
+++ b/backend/internal/legacyrepository/admin_invitation_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/ai_chat_attachment_repository.go
+++ b/backend/internal/legacyrepository/ai_chat_attachment_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/ai_chat_message_repository.go
+++ b/backend/internal/legacyrepository/ai_chat_message_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/ai_chat_session_repository.go
+++ b/backend/internal/legacyrepository/ai_chat_session_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/company_repository.go
+++ b/backend/internal/legacyrepository/company_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/course_repository.go
+++ b/backend/internal/legacyrepository/course_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/exercise_submission_repository.go
+++ b/backend/internal/legacyrepository/exercise_submission_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"

--- a/backend/internal/legacyrepository/health_repository.go
+++ b/backend/internal/legacyrepository/health_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/learning_report_repository.go
+++ b/backend/internal/legacyrepository/learning_report_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/master_exercise_example_repository.go
+++ b/backend/internal/legacyrepository/master_exercise_example_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"

--- a/backend/internal/legacyrepository/master_exercise_repository.go
+++ b/backend/internal/legacyrepository/master_exercise_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"

--- a/backend/internal/legacyrepository/note_image_repository.go
+++ b/backend/internal/legacyrepository/note_image_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/note_repository.go
+++ b/backend/internal/legacyrepository/note_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/notification_repository.go
+++ b/backend/internal/legacyrepository/notification_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/profile_image_repository.go
+++ b/backend/internal/legacyrepository/profile_image_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/profile_repository.go
+++ b/backend/internal/legacyrepository/profile_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/session_note_repository.go
+++ b/backend/internal/legacyrepository/session_note_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/teaching_material_repository.go
+++ b/backend/internal/legacyrepository/teaching_material_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/legacyrepository/user_stats_repository.go
+++ b/backend/internal/legacyrepository/user_stats_repository.go
@@ -1,4 +1,4 @@
-package repository
+package legacyrepository
 
 import (
 	"context"

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -9,14 +9,14 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type ListAdminInvitationsUseCase struct {
-	repo repository.AdminInvitationRepository
+	repo legacyrepository.AdminInvitationRepository
 }
 
-func NewListAdminInvitationsUseCase(r repository.AdminInvitationRepository) *ListAdminInvitationsUseCase {
+func NewListAdminInvitationsUseCase(r legacyrepository.AdminInvitationRepository) *ListAdminInvitationsUseCase {
 	return &ListAdminInvitationsUseCase{repo: r}
 }
 
@@ -56,7 +56,7 @@ type MailBuilder func(magicLink, displayName, companyName, role string) (subject
 type LinkBuilder func(token string) string
 
 type CreateAdminInvitationUseCase struct {
-	repo        repository.AdminInvitationRepository
+	repo        legacyrepository.AdminInvitationRepository
 	sender      MagicLinkSender
 	buildLink   LinkBuilder
 	buildMail   MailBuilder
@@ -67,7 +67,7 @@ type CreateAdminInvitationUseCase struct {
 // NewCreateAdminInvitationUseCase は SES マジックリンク方式の招待作成 usecase を組み立てる。
 // sender が nil のときはメール送信をスキップする（ローカル開発時のフォールバック）。
 func NewCreateAdminInvitationUseCase(
-	r repository.AdminInvitationRepository,
+	r legacyrepository.AdminInvitationRepository,
 	sender MagicLinkSender,
 	buildLink LinkBuilder,
 	buildMail MailBuilder,
@@ -131,10 +131,10 @@ func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdm
 }
 
 type CancelAdminInvitationUseCase struct {
-	repo repository.AdminInvitationRepository
+	repo legacyrepository.AdminInvitationRepository
 }
 
-func NewCancelAdminInvitationUseCase(r repository.AdminInvitationRepository) *CancelAdminInvitationUseCase {
+func NewCancelAdminInvitationUseCase(r legacyrepository.AdminInvitationRepository) *CancelAdminInvitationUseCase {
 	return &CancelAdminInvitationUseCase{repo: r}
 }
 

--- a/backend/internal/usecase/ai_chat_usecase.go
+++ b/backend/internal/usecase/ai_chat_usecase.go
@@ -5,15 +5,15 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // GetAiChatSessionsByUserIDUseCase は指定ユーザーの AI チャットセッション一覧を返す。
 type GetAiChatSessionsByUserIDUseCase struct {
-	sessions repository.AiChatSessionRepository
+	sessions legacyrepository.AiChatSessionRepository
 }
 
-func NewGetAiChatSessionsByUserIDUseCase(s repository.AiChatSessionRepository) *GetAiChatSessionsByUserIDUseCase {
+func NewGetAiChatSessionsByUserIDUseCase(s legacyrepository.AiChatSessionRepository) *GetAiChatSessionsByUserIDUseCase {
 	return &GetAiChatSessionsByUserIDUseCase{sessions: s}
 }
 
@@ -23,10 +23,10 @@ func (u *GetAiChatSessionsByUserIDUseCase) Execute(ctx context.Context, userID u
 
 // CreateAiChatSessionUseCase は新規セッションを作成する。
 type CreateAiChatSessionUseCase struct {
-	sessions repository.AiChatSessionRepository
+	sessions legacyrepository.AiChatSessionRepository
 }
 
-func NewCreateAiChatSessionUseCase(s repository.AiChatSessionRepository) *CreateAiChatSessionUseCase {
+func NewCreateAiChatSessionUseCase(s legacyrepository.AiChatSessionRepository) *CreateAiChatSessionUseCase {
 	return &CreateAiChatSessionUseCase{sessions: s}
 }
 
@@ -58,10 +58,10 @@ func (u *CreateAiChatSessionUseCase) Execute(ctx context.Context, in CreateAiCha
 
 // GetAiChatSessionUseCase は単一セッションを返す。
 type GetAiChatSessionUseCase struct {
-	sessions repository.AiChatSessionRepository
+	sessions legacyrepository.AiChatSessionRepository
 }
 
-func NewGetAiChatSessionUseCase(s repository.AiChatSessionRepository) *GetAiChatSessionUseCase {
+func NewGetAiChatSessionUseCase(s legacyrepository.AiChatSessionRepository) *GetAiChatSessionUseCase {
 	return &GetAiChatSessionUseCase{sessions: s}
 }
 
@@ -71,10 +71,10 @@ func (u *GetAiChatSessionUseCase) Execute(ctx context.Context, id uint64) (*doma
 
 // UpdateAiChatSessionTitleUseCase はセッションタイトルを更新する。
 type UpdateAiChatSessionTitleUseCase struct {
-	sessions repository.AiChatSessionRepository
+	sessions legacyrepository.AiChatSessionRepository
 }
 
-func NewUpdateAiChatSessionTitleUseCase(s repository.AiChatSessionRepository) *UpdateAiChatSessionTitleUseCase {
+func NewUpdateAiChatSessionTitleUseCase(s legacyrepository.AiChatSessionRepository) *UpdateAiChatSessionTitleUseCase {
 	return &UpdateAiChatSessionTitleUseCase{sessions: s}
 }
 
@@ -87,10 +87,10 @@ func (u *UpdateAiChatSessionTitleUseCase) Execute(ctx context.Context, id uint64
 
 // DeleteAiChatSessionUseCase はセッションを削除する。
 type DeleteAiChatSessionUseCase struct {
-	sessions repository.AiChatSessionRepository
+	sessions legacyrepository.AiChatSessionRepository
 }
 
-func NewDeleteAiChatSessionUseCase(s repository.AiChatSessionRepository) *DeleteAiChatSessionUseCase {
+func NewDeleteAiChatSessionUseCase(s legacyrepository.AiChatSessionRepository) *DeleteAiChatSessionUseCase {
 	return &DeleteAiChatSessionUseCase{sessions: s}
 }
 
@@ -107,10 +107,10 @@ func (u *DeleteAiChatSessionUseCase) Execute(ctx context.Context, id uint64, use
 
 // GetAiChatMessagesUseCase は DynamoDB からセッションのメッセージ一覧を返す。
 type GetAiChatMessagesUseCase struct {
-	messages repository.AiChatMessageRepository
+	messages legacyrepository.AiChatMessageRepository
 }
 
-func NewGetAiChatMessagesUseCase(m repository.AiChatMessageRepository) *GetAiChatMessagesUseCase {
+func NewGetAiChatMessagesUseCase(m legacyrepository.AiChatMessageRepository) *GetAiChatMessagesUseCase {
 	return &GetAiChatMessagesUseCase{messages: m}
 }
 

--- a/backend/internal/usecase/company_usecase.go
+++ b/backend/internal/usecase/company_usecase.go
@@ -4,14 +4,14 @@ import (
 	"context"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type ListCompaniesUseCase struct {
-	repo repository.CompanyRepository
+	repo legacyrepository.CompanyRepository
 }
 
-func NewListCompaniesUseCase(r repository.CompanyRepository) *ListCompaniesUseCase {
+func NewListCompaniesUseCase(r legacyrepository.CompanyRepository) *ListCompaniesUseCase {
 	return &ListCompaniesUseCase{repo: r}
 }
 

--- a/backend/internal/usecase/complete_onboarding_usecase.go
+++ b/backend/internal/usecase/complete_onboarding_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 // CompleteOnboardingUseCase はユーザーが Welcome 画面の「はじめる」を押した時に

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // CourseUseCase はコース機能の操作（list / get / create / update / delete）を
@@ -18,11 +18,11 @@ import (
 //   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
 //   - Delete: コース内の教材も同時に削除する（cascade）
 type CourseUseCase struct {
-	courses   repository.CourseRepository
-	materials repository.TeachingMaterialRepository
+	courses   legacyrepository.CourseRepository
+	materials legacyrepository.TeachingMaterialRepository
 }
 
-func NewCourseUseCase(courses repository.CourseRepository, materials repository.TeachingMaterialRepository) *CourseUseCase {
+func NewCourseUseCase(courses legacyrepository.CourseRepository, materials legacyrepository.TeachingMaterialRepository) *CourseUseCase {
 	return &CourseUseCase{courses: courses, materials: materials}
 }
 

--- a/backend/internal/usecase/get_current_user_usecase.go
+++ b/backend/internal/usecase/get_current_user_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 // GetCurrentUserUseCase は Cognito sub から現在のユーザー情報を引く。

--- a/backend/internal/usecase/get_master_exercise_usecase.go
+++ b/backend/internal/usecase/get_master_exercise_usecase.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // GetMasterExerciseDetailOutput は詳細ページに渡す問題本体 + 入出力例セット。
@@ -22,13 +22,13 @@ type GetMasterExerciseDetailOutput struct {
 // 旧 API は `:id` ベースだったが、 人間可読な URL `/code-editor/php-1` を実現するため
 // 主導線を slug に切替える。 ID ベースの挙動も互換用に Execute / GetByID で残す。
 type GetMasterExerciseUseCase struct {
-	repo     repository.MasterExerciseRepository
-	examples repository.MasterExerciseExampleRepository
+	repo     legacyrepository.MasterExerciseRepository
+	examples legacyrepository.MasterExerciseExampleRepository
 }
 
 func NewGetMasterExerciseUseCase(
-	repo repository.MasterExerciseRepository,
-	examples repository.MasterExerciseExampleRepository,
+	repo legacyrepository.MasterExerciseRepository,
+	examples legacyrepository.MasterExerciseExampleRepository,
 ) *GetMasterExerciseUseCase {
 	return &GetMasterExerciseUseCase{repo: repo, examples: examples}
 }

--- a/backend/internal/usecase/health_usecase.go
+++ b/backend/internal/usecase/health_usecase.go
@@ -4,16 +4,16 @@ import (
 	"context"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // CheckHealthUseCase はバックエンドの稼働状態を判定するユースケース。
 // DB 到達性を確認し、UP/DOWN を返す。
 type CheckHealthUseCase struct {
-	repo repository.HealthRepository
+	repo legacyrepository.HealthRepository
 }
 
-func NewCheckHealthUseCase(repo repository.HealthRepository) *CheckHealthUseCase {
+func NewCheckHealthUseCase(repo legacyrepository.HealthRepository) *CheckHealthUseCase {
 	return &CheckHealthUseCase{repo: repo}
 }
 

--- a/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
+++ b/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // IssueAiChatAttachmentUploadURLUseCase は AI チャット添付の S3 PUT presigned URL を発行する。
@@ -17,10 +17,10 @@ import (
 // 上限チェックを usecase 層で行うのは「presigned URL を発行する前に 413 を返す」ためで、
 // クライアント側の不正利用や typo を S3 アップロード前の早い段階で弾く目的。
 type IssueAiChatAttachmentUploadURLUseCase struct {
-	presigner repository.AiChatAttachmentPresigner
+	presigner legacyrepository.AiChatAttachmentPresigner
 }
 
-func NewIssueAiChatAttachmentUploadURLUseCase(p repository.AiChatAttachmentPresigner) *IssueAiChatAttachmentUploadURLUseCase {
+func NewIssueAiChatAttachmentUploadURLUseCase(p legacyrepository.AiChatAttachmentPresigner) *IssueAiChatAttachmentUploadURLUseCase {
 	return &IssueAiChatAttachmentUploadURLUseCase{presigner: p}
 }
 
@@ -57,7 +57,7 @@ var ErrAttachmentUnsupportedType = errors.New("attachment: unsupported content t
 // ErrAttachmentTooLarge はサイズ上限超過。
 var ErrAttachmentTooLarge = errors.New("attachment: file too large")
 
-func (u *IssueAiChatAttachmentUploadURLUseCase) Execute(ctx context.Context, in IssueAiChatAttachmentUploadURLInput) (*repository.AiChatAttachmentUploadURL, error) {
+func (u *IssueAiChatAttachmentUploadURLUseCase) Execute(ctx context.Context, in IssueAiChatAttachmentUploadURLInput) (*legacyrepository.AiChatAttachmentUploadURL, error) {
 	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
 	}

--- a/backend/internal/usecase/learning_report_usecase.go
+++ b/backend/internal/usecase/learning_report_usecase.go
@@ -6,14 +6,14 @@ import (
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type ListLearningReportsUseCase struct {
-	repo repository.LearningReportRepository
+	repo legacyrepository.LearningReportRepository
 }
 
-func NewListLearningReportsUseCase(r repository.LearningReportRepository) *ListLearningReportsUseCase {
+func NewListLearningReportsUseCase(r legacyrepository.LearningReportRepository) *ListLearningReportsUseCase {
 	return &ListLearningReportsUseCase{repo: r}
 }
 
@@ -25,11 +25,11 @@ func (u *ListLearningReportsUseCase) Execute(ctx context.Context, userID uint64)
 }
 
 type RequestLearningReportUseCase struct {
-	repo  repository.LearningReportRepository
-	queue repository.SqsEnqueuer
+	repo  legacyrepository.LearningReportRepository
+	queue legacyrepository.SqsEnqueuer
 }
 
-func NewRequestLearningReportUseCase(r repository.LearningReportRepository, q repository.SqsEnqueuer) *RequestLearningReportUseCase {
+func NewRequestLearningReportUseCase(r legacyrepository.LearningReportRepository, q legacyrepository.SqsEnqueuer) *RequestLearningReportUseCase {
 	return &RequestLearningReportUseCase{repo: r, queue: q}
 }
 

--- a/backend/internal/usecase/list_master_exercises_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_usecase.go
@@ -2,7 +2,7 @@ package usecase
 
 import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // ListMasterExercisesUseCase は指定言語の運営マスタ演習問題一覧を返す。
@@ -10,10 +10,10 @@ import (
 // 旧 ListPhpExercisesUseCase の汎用版。言語固定の API（例: /php/exercises）を
 // 残しつつ、本 usecase は language を引数で受け取って多言語対応の準備をする。
 type ListMasterExercisesUseCase struct {
-	repo repository.MasterExerciseRepository
+	repo legacyrepository.MasterExerciseRepository
 }
 
-func NewListMasterExercisesUseCase(repo repository.MasterExerciseRepository) *ListMasterExercisesUseCase {
+func NewListMasterExercisesUseCase(repo legacyrepository.MasterExerciseRepository) *ListMasterExercisesUseCase {
 	return &ListMasterExercisesUseCase{repo: repo}
 }
 

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -16,7 +16,7 @@ import (
 type MasterExerciseWithStatus struct {
 	domain.MasterExercise
 
-	Status string                             `json:"status"`
+	Status string                                   `json:"status"`
 	Stats  legacyrepository.ExerciseSubmissionStats `json:"stats"`
 }
 

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -2,7 +2,7 @@ package usecase
 
 import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // MasterExerciseWithStatus は一覧ページに渡す「問題 + 現在ユーザの状態 + 全体集計」のセット。
@@ -17,20 +17,20 @@ type MasterExerciseWithStatus struct {
 	domain.MasterExercise
 
 	Status string                             `json:"status"`
-	Stats  repository.ExerciseSubmissionStats `json:"stats"`
+	Stats  legacyrepository.ExerciseSubmissionStats `json:"stats"`
 }
 
 // ListMasterExercisesWithStatusUseCase は問題一覧 + 各問題の current user 状態 + 集計を返す。
 //
 // N+1 を避けるため、 user status と stats はそれぞれ batch クエリで取得する。
 type ListMasterExercisesWithStatusUseCase struct {
-	exercises   repository.MasterExerciseRepository
-	submissions repository.ExerciseSubmissionRepository
+	exercises   legacyrepository.MasterExerciseRepository
+	submissions legacyrepository.ExerciseSubmissionRepository
 }
 
 func NewListMasterExercisesWithStatusUseCase(
-	exercises repository.MasterExerciseRepository,
-	submissions repository.ExerciseSubmissionRepository,
+	exercises legacyrepository.MasterExerciseRepository,
+	submissions legacyrepository.ExerciseSubmissionRepository,
 ) *ListMasterExercisesWithStatusUseCase {
 	return &ListMasterExercisesWithStatusUseCase{exercises: exercises, submissions: submissions}
 }

--- a/backend/internal/usecase/list_user_submissions_usecase.go
+++ b/backend/internal/usecase/list_user_submissions_usecase.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // ListUserMasterSubmissionsInput は履歴一覧 API への入力。
@@ -15,13 +15,13 @@ type ListUserMasterSubmissionsInput struct {
 
 // ListUserMasterSubmissionsUseCase は current user の指定問題に対する提出履歴を新しい順で返す。
 type ListUserMasterSubmissionsUseCase struct {
-	exercises   repository.MasterExerciseRepository
-	submissions repository.ExerciseSubmissionRepository
+	exercises   legacyrepository.MasterExerciseRepository
+	submissions legacyrepository.ExerciseSubmissionRepository
 }
 
 func NewListUserMasterSubmissionsUseCase(
-	exercises repository.MasterExerciseRepository,
-	submissions repository.ExerciseSubmissionRepository,
+	exercises legacyrepository.MasterExerciseRepository,
+	submissions legacyrepository.ExerciseSubmissionRepository,
 ) *ListUserMasterSubmissionsUseCase {
 	return &ListUserMasterSubmissionsUseCase{exercises: exercises, submissions: submissions}
 }

--- a/backend/internal/usecase/note_image_usecase.go
+++ b/backend/internal/usecase/note_image_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type IssueNoteImageUploadURLUseCase struct {
-	presigner repository.NoteImagePresigner
+	presigner legacyrepository.NoteImagePresigner
 }
 
-func NewIssueNoteImageUploadURLUseCase(p repository.NoteImagePresigner) *IssueNoteImageUploadURLUseCase {
+func NewIssueNoteImageUploadURLUseCase(p legacyrepository.NoteImagePresigner) *IssueNoteImageUploadURLUseCase {
 	return &IssueNoteImageUploadURLUseCase{presigner: p}
 }
 

--- a/backend/internal/usecase/note_usecase.go
+++ b/backend/internal/usecase/note_usecase.go
@@ -10,7 +10,9 @@ import (
 
 var ErrNoteForbidden = errors.New("forbidden")
 
-type ListNotesByUserIDUseCase struct{ repo legacyrepository.NoteRepository }
+type ListNotesByUserIDUseCase struct {
+	repo legacyrepository.NoteRepository
+}
 
 func NewListNotesByUserIDUseCase(r legacyrepository.NoteRepository) *ListNotesByUserIDUseCase {
 	return &ListNotesByUserIDUseCase{repo: r}
@@ -23,7 +25,9 @@ func (u *ListNotesByUserIDUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-type CreateNoteUseCase struct{ repo legacyrepository.NoteRepository }
+type CreateNoteUseCase struct {
+	repo legacyrepository.NoteRepository
+}
 
 func NewCreateNoteUseCase(r legacyrepository.NoteRepository) *CreateNoteUseCase {
 	return &CreateNoteUseCase{repo: r}
@@ -57,7 +61,9 @@ func (u *CreateNoteUseCase) Execute(ctx context.Context, in CreateNoteInput) (*d
 	return n, nil
 }
 
-type UpdateNoteUseCase struct{ repo legacyrepository.NoteRepository }
+type UpdateNoteUseCase struct {
+	repo legacyrepository.NoteRepository
+}
 
 func NewUpdateNoteUseCase(r legacyrepository.NoteRepository) *UpdateNoteUseCase {
 	return &UpdateNoteUseCase{repo: r}
@@ -98,7 +104,9 @@ func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*d
 	return existing, nil
 }
 
-type DeleteNoteUseCase struct{ repo legacyrepository.NoteRepository }
+type DeleteNoteUseCase struct {
+	repo legacyrepository.NoteRepository
+}
 
 func NewDeleteNoteUseCase(r legacyrepository.NoteRepository) *DeleteNoteUseCase {
 	return &DeleteNoteUseCase{repo: r}

--- a/backend/internal/usecase/note_usecase.go
+++ b/backend/internal/usecase/note_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 var ErrNoteForbidden = errors.New("forbidden")
 
-type ListNotesByUserIDUseCase struct{ repo repository.NoteRepository }
+type ListNotesByUserIDUseCase struct{ repo legacyrepository.NoteRepository }
 
-func NewListNotesByUserIDUseCase(r repository.NoteRepository) *ListNotesByUserIDUseCase {
+func NewListNotesByUserIDUseCase(r legacyrepository.NoteRepository) *ListNotesByUserIDUseCase {
 	return &ListNotesByUserIDUseCase{repo: r}
 }
 
@@ -23,9 +23,9 @@ func (u *ListNotesByUserIDUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-type CreateNoteUseCase struct{ repo repository.NoteRepository }
+type CreateNoteUseCase struct{ repo legacyrepository.NoteRepository }
 
-func NewCreateNoteUseCase(r repository.NoteRepository) *CreateNoteUseCase {
+func NewCreateNoteUseCase(r legacyrepository.NoteRepository) *CreateNoteUseCase {
 	return &CreateNoteUseCase{repo: r}
 }
 
@@ -57,9 +57,9 @@ func (u *CreateNoteUseCase) Execute(ctx context.Context, in CreateNoteInput) (*d
 	return n, nil
 }
 
-type UpdateNoteUseCase struct{ repo repository.NoteRepository }
+type UpdateNoteUseCase struct{ repo legacyrepository.NoteRepository }
 
-func NewUpdateNoteUseCase(r repository.NoteRepository) *UpdateNoteUseCase {
+func NewUpdateNoteUseCase(r legacyrepository.NoteRepository) *UpdateNoteUseCase {
 	return &UpdateNoteUseCase{repo: r}
 }
 
@@ -98,9 +98,9 @@ func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*d
 	return existing, nil
 }
 
-type DeleteNoteUseCase struct{ repo repository.NoteRepository }
+type DeleteNoteUseCase struct{ repo legacyrepository.NoteRepository }
 
-func NewDeleteNoteUseCase(r repository.NoteRepository) *DeleteNoteUseCase {
+func NewDeleteNoteUseCase(r legacyrepository.NoteRepository) *DeleteNoteUseCase {
 	return &DeleteNoteUseCase{repo: r}
 }
 

--- a/backend/internal/usecase/notification_usecase.go
+++ b/backend/internal/usecase/notification_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type ListNotificationsUseCase struct {
-	repo repository.NotificationRepository
+	repo legacyrepository.NotificationRepository
 }
 
-func NewListNotificationsUseCase(r repository.NotificationRepository) *ListNotificationsUseCase {
+func NewListNotificationsUseCase(r legacyrepository.NotificationRepository) *ListNotificationsUseCase {
 	return &ListNotificationsUseCase{repo: r}
 }
 
@@ -24,10 +24,10 @@ func (u *ListNotificationsUseCase) Execute(ctx context.Context, userID uint64) (
 }
 
 type MarkNotificationReadUseCase struct {
-	repo repository.NotificationRepository
+	repo legacyrepository.NotificationRepository
 }
 
-func NewMarkNotificationReadUseCase(r repository.NotificationRepository) *MarkNotificationReadUseCase {
+func NewMarkNotificationReadUseCase(r legacyrepository.NotificationRepository) *MarkNotificationReadUseCase {
 	return &MarkNotificationReadUseCase{repo: r}
 }
 
@@ -42,10 +42,10 @@ func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, userID, id ui
 }
 
 type MarkAllNotificationsReadUseCase struct {
-	repo repository.NotificationRepository
+	repo legacyrepository.NotificationRepository
 }
 
-func NewMarkAllNotificationsReadUseCase(r repository.NotificationRepository) *MarkAllNotificationsReadUseCase {
+func NewMarkAllNotificationsReadUseCase(r legacyrepository.NotificationRepository) *MarkAllNotificationsReadUseCase {
 	return &MarkAllNotificationsReadUseCase{repo: r}
 }
 
@@ -57,10 +57,10 @@ func (u *MarkAllNotificationsReadUseCase) Execute(ctx context.Context, userID ui
 }
 
 type CountUnreadNotificationsUseCase struct {
-	repo repository.NotificationRepository
+	repo legacyrepository.NotificationRepository
 }
 
-func NewCountUnreadNotificationsUseCase(r repository.NotificationRepository) *CountUnreadNotificationsUseCase {
+func NewCountUnreadNotificationsUseCase(r legacyrepository.NotificationRepository) *CountUnreadNotificationsUseCase {
 	return &CountUnreadNotificationsUseCase{repo: r}
 }
 

--- a/backend/internal/usecase/profile_image_usecase.go
+++ b/backend/internal/usecase/profile_image_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type IssueProfileImageUploadURLUseCase struct {
-	presigner repository.ProfileImagePresigner
+	presigner legacyrepository.ProfileImagePresigner
 }
 
-func NewIssueProfileImageUploadURLUseCase(p repository.ProfileImagePresigner) *IssueProfileImageUploadURLUseCase {
+func NewIssueProfileImageUploadURLUseCase(p legacyrepository.ProfileImagePresigner) *IssueProfileImageUploadURLUseCase {
 	return &IssueProfileImageUploadURLUseCase{presigner: p}
 }
 

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type GetProfileUseCase struct {
-	profiles repository.ProfileRepository
+	profiles legacyrepository.ProfileRepository
 }
 
-func NewGetProfileUseCase(p repository.ProfileRepository) *GetProfileUseCase {
+func NewGetProfileUseCase(p legacyrepository.ProfileRepository) *GetProfileUseCase {
 	return &GetProfileUseCase{profiles: p}
 }
 
@@ -24,10 +24,10 @@ func (u *GetProfileUseCase) Execute(ctx context.Context, userID uint64) (*domain
 }
 
 type UpdateProfileUseCase struct {
-	profiles repository.ProfileRepository
+	profiles legacyrepository.ProfileRepository
 }
 
-func NewUpdateProfileUseCase(p repository.ProfileRepository) *UpdateProfileUseCase {
+func NewUpdateProfileUseCase(p legacyrepository.ProfileRepository) *UpdateProfileUseCase {
 	return &UpdateProfileUseCase{profiles: p}
 }
 

--- a/backend/internal/usecase/repository/user.go
+++ b/backend/internal/usecase/repository/user.go
@@ -1,0 +1,38 @@
+// Package repository は usecase 層 が 依存 する 永続化 境界 (port) を 定義 する。
+//
+// Clean Architecture の Use Case 層 が「自分 が 必要 と する 抽象」 を ここ で 宣言 し、
+// 実装 は [github.com/norman6464/FreStyle/backend/internal/adapter/persistence]
+// 配下 で 提供 さ れる (依存 方向: usecase ← persistence、 DIP)。
+//
+// 1 boundary = 1 fat interface の 方針 で 配置 する (Clean Architecture 通常 流儀)。
+// 単一 メソッド の port (例: Presigner / Enqueuer / Publisher) は Effective Go 流 の
+// -er 命名 で 別 ファイル に 配置 して 良い。
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// UserRepository は users テーブル へ の アクセス を 提供 する。
+//
+// 旧 internal/repository/user_repository.go を Clean Architecture 構造 に 沿って
+// usecase 層 (port) と adapter 層 (実装) に 物理 分離 した うえ で、 interface 定義
+// を こちら に 移植 した もの。 メソッド 個別 の WHY は impl 側 (persistence.userRepository)
+// の メソッド コメント を 参照。
+type UserRepository interface {
+	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
+	FindByID(ctx context.Context, id uint64) (*domain.User, error)
+	Create(ctx context.Context, user *domain.User) error
+	// UpdateDisplayName は ProfilePage の「氏名」変更、 および OIDC ログイン時に
+	// 旧 displayName=email を id_token の name claim で自動補正するときに呼ばれる。
+	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
+	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。
+	UpdateRole(ctx context.Context, userID uint64, role string) error
+	// UpdateCompanyID は既存ユーザーが招待を受けて company に紐付くときに呼ばれる。
+	UpdateCompanyID(ctx context.Context, userID uint64, companyID uint64) error
+	// MarkOnboarded は Welcome 画面の「はじめる」ボタン押下時に呼ばれ、
+	// onboarded_at = NOW() に更新する。冪等（既に値が入っていても上書きしない）。
+	MarkOnboarded(ctx context.Context, userID uint64) error
+}

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/infra/bedrock"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // StreamingBedrockClient は Bedrock の streaming 呼び出し抽象。
@@ -44,15 +44,15 @@ type StreamEvent struct {
 // SendAiMessageStreamUseCase は WebSocket 版 (SendAiMessageUseCase) の streaming 版。
 // 互換のため両方を残し、フロントが対応した順から SSE に切り替える。
 type SendAiMessageStreamUseCase struct {
-	sessions      repository.AiChatSessionRepository
-	messages      repository.AiChatMessageRepository
+	sessions      legacyrepository.AiChatSessionRepository
+	messages      legacyrepository.AiChatMessageRepository
 	bedrockClient StreamingBedrockClient
 	attachments   AttachmentDownloader
 }
 
 func NewSendAiMessageStreamUseCase(
-	sessions repository.AiChatSessionRepository,
-	messages repository.AiChatMessageRepository,
+	sessions legacyrepository.AiChatSessionRepository,
+	messages legacyrepository.AiChatMessageRepository,
 	bc StreamingBedrockClient,
 	dl AttachmentDownloader,
 ) *SendAiMessageStreamUseCase {

--- a/backend/internal/usecase/session_note_usecase.go
+++ b/backend/internal/usecase/session_note_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type GetSessionNoteUseCase struct {
-	repo repository.SessionNoteRepository
+	repo legacyrepository.SessionNoteRepository
 }
 
-func NewGetSessionNoteUseCase(r repository.SessionNoteRepository) *GetSessionNoteUseCase {
+func NewGetSessionNoteUseCase(r legacyrepository.SessionNoteRepository) *GetSessionNoteUseCase {
 	return &GetSessionNoteUseCase{repo: r}
 }
 
@@ -24,10 +24,10 @@ func (u *GetSessionNoteUseCase) Execute(ctx context.Context, sessionID uint64) (
 }
 
 type UpsertSessionNoteUseCase struct {
-	repo repository.SessionNoteRepository
+	repo legacyrepository.SessionNoteRepository
 }
 
-func NewUpsertSessionNoteUseCase(r repository.SessionNoteRepository) *UpsertSessionNoteUseCase {
+func NewUpsertSessionNoteUseCase(r legacyrepository.SessionNoteRepository) *UpsertSessionNoteUseCase {
 	return &UpsertSessionNoteUseCase{repo: r}
 }
 

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // CodeExecutor は ExecuteCodeUseCase を抽象化したインターフェイス。
@@ -57,16 +57,16 @@ type SubmitMasterExerciseOutput struct {
 //
 // 履歴保存はテストケース個別ではなく、まとめて 1 行（最初に失敗した stdout / stderr / exit_code を採用）。
 type SubmitMasterExerciseUseCase struct {
-	exercises   repository.MasterExerciseRepository
-	examples    repository.MasterExerciseExampleRepository
-	submissions repository.ExerciseSubmissionRepository
+	exercises   legacyrepository.MasterExerciseRepository
+	examples    legacyrepository.MasterExerciseExampleRepository
+	submissions legacyrepository.ExerciseSubmissionRepository
 	executor    CodeExecutor
 }
 
 func NewSubmitMasterExerciseUseCase(
-	exercises repository.MasterExerciseRepository,
-	examples repository.MasterExerciseExampleRepository,
-	submissions repository.ExerciseSubmissionRepository,
+	exercises legacyrepository.MasterExerciseRepository,
+	examples legacyrepository.MasterExerciseExampleRepository,
+	submissions legacyrepository.ExerciseSubmissionRepository,
 	executor CodeExecutor,
 ) *SubmitMasterExerciseUseCase {
 	return &SubmitMasterExerciseUseCase{

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,10 +58,10 @@ func (r *fakeSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) 
 func (r *fakeSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
 	return nil, nil
 }
-func (r *fakeSubmissionRepo) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
-	return repository.ExerciseSubmissionStats{}, nil
+func (r *fakeSubmissionRepo) ExerciseStats(uint64, string) (legacyrepository.ExerciseSubmissionStats, error) {
+	return legacyrepository.ExerciseSubmissionStats{}, nil
 }
-func (r *fakeSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+func (r *fakeSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]legacyrepository.ExerciseSubmissionStats, error) {
 	return nil, nil
 }
 

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // TeachingMaterialUseCase は教材機能の 5 操作（list / get / create / update / delete）を
@@ -21,11 +21,11 @@ import (
 //   - Get: 同一 company か super_admin、 trainee は published のみ閲覧可
 //   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
 type TeachingMaterialUseCase struct {
-	repo    repository.TeachingMaterialRepository
-	courses repository.CourseRepository
+	repo    legacyrepository.TeachingMaterialRepository
+	courses legacyrepository.CourseRepository
 }
 
-func NewTeachingMaterialUseCase(repo repository.TeachingMaterialRepository, courses repository.CourseRepository) *TeachingMaterialUseCase {
+func NewTeachingMaterialUseCase(repo legacyrepository.TeachingMaterialRepository, courses legacyrepository.CourseRepository) *TeachingMaterialUseCase {
 	return &TeachingMaterialUseCase{repo: repo, courses: courses}
 }
 

--- a/backend/internal/usecase/user_stats_usecase.go
+++ b/backend/internal/usecase/user_stats_usecase.go
@@ -5,14 +5,14 @@ import (
 	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 type GetUserStatsUseCase struct {
-	stats repository.UserStatsRepository
+	stats legacyrepository.UserStatsRepository
 }
 
-func NewGetUserStatsUseCase(s repository.UserStatsRepository) *GetUserStatsUseCase {
+func NewGetUserStatsUseCase(s legacyrepository.UserStatsRepository) *GetUserStatsUseCase {
 	return &GetUserStatsUseCase{stats: s}
 }
 

--- a/backend/internal/usecase/validate_invitation_token_usecase.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/repository"
+	"github.com/norman6464/FreStyle/backend/internal/legacyrepository"
 )
 
 // ValidateInvitationTokenUseCase はマジックリンク受諾画面で token を検証する。
@@ -17,13 +17,13 @@ import (
 //   - 本人がメールから踏んでくる前提なので email は本人が知っている
 //   - 万一 token が漏れた場合の被害局所化（招待先 email を覗かれない）
 type ValidateInvitationTokenUseCase struct {
-	invitations repository.AdminInvitationRepository
-	companies   repository.CompanyRepository
+	invitations legacyrepository.AdminInvitationRepository
+	companies   legacyrepository.CompanyRepository
 }
 
 func NewValidateInvitationTokenUseCase(
-	invitations repository.AdminInvitationRepository,
-	companies repository.CompanyRepository,
+	invitations legacyrepository.AdminInvitationRepository,
+	companies legacyrepository.CompanyRepository,
 ) *ValidateInvitationTokenUseCase {
 	return &ValidateInvitationTokenUseCase{invitations: invitations, companies: companies}
 }


### PR DESCRIPTION
## 概要

通常 の Clean Architecture (Uncle Bob) に 準拠 し、 repository の **interface (port) と 実装 (adapter) を 物理 的 に 別 パッケージ に 分離** する 第 一 歩。 まず `UserRepository` だけ を POC と して 移行 し、 残り 19 repo は 別 PR (PR B) で 同じ パターン で 順次 移行 する。

背景: 教材 chapter 002 で 「Go の 慣習 で interface と 実装 を 同 パッケージ に 置く のが 標準」 と 書いて いた が、 これは Effective Go に そう 書いて あった わけ ではなく **誤った 主張**。 Uncle Bob の Clean Architecture 通常 流儀 は port を Use Case 層 が 所有 する。 教材 と 実 コード の 両方 を 是正 する。

## 変更 内容

### 新規 配置 (Clean Architecture 通常 流儀)

| 役割 | 配置 | パッケージ 名 |
|---|---|---|
| Repository **interface** (port) | `backend/internal/usecase/repository/` | `repository` |
| Repository **実装** (GORM / DynamoDB / S3) | `backend/internal/adapter/persistence/` | `persistence` |

- `internal/usecase/repository/user.go` 新規: `UserRepository` (fat / 7 メソッド) interface を 移植
- `internal/adapter/persistence/user_repository.go` 新規: `userRepository` struct + `NewUserRepository(db) repository.UserRepository`
- 旧 `internal/repository/user_repository.go` を 削除

### 旧 配置 を 改名 (deprecated)

- `internal/repository/` → `internal/legacyrepository/` (git mv で 履歴 保持、 19 ファイル)
- 残り 19 ファイル の package 宣言 を `package legacyrepository` に 一括 更新
- 利用 側 全 36 ファイル の import path と 型 参照 を sed で 一括 置換 (`repository.XxxRepository` → `legacyrepository.XxxRepository`)
- UserRepository を 使う 6 ファイル (handler 3 + middleware 1 + usecase 2) は 新 path を import

### 設計 判断

- **fat interface (7 メソッド) のまま 維持**: Clean Architecture は interface の 粒度 を 規定 して おらず、 Uncle Bob の 本 でも 1 boundary = 1 fat interface が 標準。 ISP 違反 では ない (同じ entity の cohesive な 操作 群)
- **Effective Go の `-er` は 単一 メソッド の interface に だけ 課される 規約** で、 multi-method は 規約 外 (`sort.Interface` / `http.Handler` が 前例)。 `Presigner` / `Enqueuer` / `Publisher` の よう に 単一 責務 の port は 引き続き -er 命名
- **legacyrepository の 改名 のみ** (package 名 と path 変更)、 中身 は 触らない の で 機能 影響 ゼロ

### CLAUDE.md / 教材

- ローカル CLAUDE.md (gitignore) に §2.6 「Repository 配置 規約」 を 追記
- norman6464/frestyle-teaching-materials の chapter 002 を 修正 (commit `471ff60`)
  - §1 各層 責務 表 を 新 構造 に 更新
  - §3.4 を 全面 書き直し (旧 「Go の 慣習」 主張 を 撤回、 通常 の Clean Architecture 流儀 を 解説、 UserRepository interface 全文 + 実装 全文 を 引用)
  - §5 ディレクトリ 構成 図 を 新 構造 に 更新
  - §8 新 機能 の 置き 場所 フロー を 新 構造 に 更新
  - §9 Q1 を 新 ガイダンス に 差し替え
- course 5 全 28 SQL を 本番 RDS に 再 適用 済 (CLAUDE.md §7-bis の DELETE トラップ 遵守)

## テスト

- [x] `cd backend && go build ./...` 緑
- [x] `cd backend && go vet ./...` 緑
- [x] `cd backend && go test ./...` 既存 テスト 全 通過
- [ ] 本番 ECS デプロイ 後 に `GET /api/v2/health` 200 確認
- [ ] 本番 normanblog.com で 認証 ログイン (UserRepository 経由) と /me 取得 が 通る こと
- [x] 教材 https://normanblog.com/courses/5 で 全 27 章 表示 確認 (RDS 再 同期 で 28 SQL 適用 済)

## 関連

- 教材 変更: norman6464/frestyle-teaching-materials commit `471ff60`
- 後続 PR B (別 セッション): 残り 19 repo を 同じ パターン で 新 構造 に 移行 + @see 風 GoDoc 追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * リポジトリレイヤー内の実装を新規パッケージに移行し、コード構造を整理しました。
  * ハンドラーとユースケース層全体での依存関係を更新しました。
  * ユーザー永続化に関するインターフェースを新規追加し、データアクセス層の抽象化を改善しました。
  * テストユーティリティをリポジトリ変更に対応させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1721)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->