### PR TITLE
refactor(backend): MasterExercise / Submission レガシー API に context.Context を 通す (CodeRabbit #1722 follow-up)

### DIFF
--- a/backend/internal/adapter/persistence/exercise_submission_repository.go
+++ b/backend/internal/adapter/persistence/exercise_submission_repository.go
@@ -1,6 +1,8 @@
 package persistence
 
 import (
+	"context"
+
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
@@ -16,13 +18,13 @@ func NewExerciseSubmissionRepository(db *gorm.DB) repository.ExerciseSubmissionR
 	return &exerciseSubmissionRepository{db: db}
 }
 
-func (r *exerciseSubmissionRepository) Create(submission *domain.ExerciseSubmission) error {
-	return r.db.Create(submission).Error
+func (r *exerciseSubmissionRepository) Create(ctx context.Context, submission *domain.ExerciseSubmission) error {
+	return r.db.WithContext(ctx).Create(submission).Error
 }
 
-func (r *exerciseSubmissionRepository) ListByUserAndExercise(userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error) {
+func (r *exerciseSubmissionRepository) ListByUserAndExercise(ctx context.Context, userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error) {
 	var rows []domain.ExerciseSubmission
-	if err := r.db.
+	if err := r.db.WithContext(ctx).
 		Where("user_id = ? AND exercise_id = ? AND exercise_kind = ?", userID, exerciseID, kind).
 		Order("submitted_at desc, id desc").
 		Find(&rows).Error; err != nil {
@@ -31,9 +33,9 @@ func (r *exerciseSubmissionRepository) ListByUserAndExercise(userID, exerciseID 
 	return rows, nil
 }
 
-func (r *exerciseSubmissionRepository) HasSolved(userID, exerciseID uint64, kind string) (bool, error) {
+func (r *exerciseSubmissionRepository) HasSolved(ctx context.Context, userID, exerciseID uint64, kind string) (bool, error) {
 	var count int64
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Where("user_id = ? AND exercise_id = ? AND exercise_kind = ? AND is_correct = ?", userID, exerciseID, kind, true).
 		Limit(1).
 		Count(&count).Error; err != nil {
@@ -42,9 +44,9 @@ func (r *exerciseSubmissionRepository) HasSolved(userID, exerciseID uint64, kind
 	return count > 0, nil
 }
 
-func (r *exerciseSubmissionRepository) HasAttempted(userID, exerciseID uint64, kind string) (bool, error) {
+func (r *exerciseSubmissionRepository) HasAttempted(ctx context.Context, userID, exerciseID uint64, kind string) (bool, error) {
 	var count int64
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Where("user_id = ? AND exercise_id = ? AND exercise_kind = ?", userID, exerciseID, kind).
 		Limit(1).
 		Count(&count).Error; err != nil {
@@ -55,7 +57,7 @@ func (r *exerciseSubmissionRepository) HasAttempted(userID, exerciseID uint64, k
 
 // BatchUserStatuses は 1 クエリで user × exerciseIDs の (any submission, any solved) を取り、
 // exercise_id -> "solved" / "in_progress" を返す。 結果に含まれない exercise_id は未着手扱い。
-func (r *exerciseSubmissionRepository) BatchUserStatuses(userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error) {
+func (r *exerciseSubmissionRepository) BatchUserStatuses(ctx context.Context, userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error) {
 	result := make(map[uint64]string, len(exerciseIDs))
 	if len(exerciseIDs) == 0 {
 		return result, nil
@@ -65,7 +67,7 @@ func (r *exerciseSubmissionRepository) BatchUserStatuses(userID uint64, exercise
 		AnySolved  bool
 	}
 	var rows []row
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Select("exercise_id, BOOL_OR(is_correct) AS any_solved").
 		Where("user_id = ? AND exercise_kind = ? AND exercise_id IN ?", userID, kind, exerciseIDs).
 		Group("exercise_id").
@@ -82,16 +84,16 @@ func (r *exerciseSubmissionRepository) BatchUserStatuses(userID uint64, exercise
 	return result, nil
 }
 
-func (r *exerciseSubmissionRepository) ExerciseStats(exerciseID uint64, kind string) (repository.ExerciseSubmissionStats, error) {
+func (r *exerciseSubmissionRepository) ExerciseStats(ctx context.Context, exerciseID uint64, kind string) (repository.ExerciseSubmissionStats, error) {
 	var stats repository.ExerciseSubmissionStats
 	// COUNT(*) は全提出数。
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Where("exercise_id = ? AND exercise_kind = ?", exerciseID, kind).
 		Count(&stats.TotalSubmissions).Error; err != nil {
 		return stats, err
 	}
 	// COUNT(DISTINCT user_id) は正答ユーザ数。
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Where("exercise_id = ? AND exercise_kind = ? AND is_correct = ?", exerciseID, kind, true).
 		Distinct("user_id").
 		Count(&stats.SolvedUsers).Error; err != nil {
@@ -101,7 +103,7 @@ func (r *exerciseSubmissionRepository) ExerciseStats(exerciseID uint64, kind str
 }
 
 // ExerciseStatsBatch は 2 つの GROUP BY クエリで全件まとめて集計する。
-func (r *exerciseSubmissionRepository) ExerciseStatsBatch(exerciseIDs []uint64, kind string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+func (r *exerciseSubmissionRepository) ExerciseStatsBatch(ctx context.Context, exerciseIDs []uint64, kind string) (map[uint64]repository.ExerciseSubmissionStats, error) {
 	result := make(map[uint64]repository.ExerciseSubmissionStats, len(exerciseIDs))
 	if len(exerciseIDs) == 0 {
 		return result, nil
@@ -112,7 +114,7 @@ func (r *exerciseSubmissionRepository) ExerciseStatsBatch(exerciseIDs []uint64, 
 		Total      int64
 	}
 	var totals []totalRow
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Select("exercise_id, COUNT(*) AS total").
 		Where("exercise_kind = ? AND exercise_id IN ?", kind, exerciseIDs).
 		Group("exercise_id").
@@ -130,7 +132,7 @@ func (r *exerciseSubmissionRepository) ExerciseStatsBatch(exerciseIDs []uint64, 
 		SolvedUsers int64
 	}
 	var solveds []solvedRow
-	if err := r.db.Model(&domain.ExerciseSubmission{}).
+	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Select("exercise_id, COUNT(DISTINCT user_id) AS solved_users").
 		Where("exercise_kind = ? AND exercise_id IN ? AND is_correct = ?", kind, exerciseIDs, true).
 		Group("exercise_id").

--- a/backend/internal/adapter/persistence/master_exercise_example_repository.go
+++ b/backend/internal/adapter/persistence/master_exercise_example_repository.go
@@ -1,6 +1,8 @@
 package persistence
 
 import (
+	"context"
+
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
@@ -17,9 +19,9 @@ func NewMasterExerciseExampleRepository(db *gorm.DB) repository.MasterExerciseEx
 	return &masterExerciseExampleRepository{db: db}
 }
 
-func (r *masterExerciseExampleRepository) ListByExerciseID(exerciseID uint64) ([]domain.MasterExerciseExample, error) {
+func (r *masterExerciseExampleRepository) ListByExerciseID(ctx context.Context, exerciseID uint64) ([]domain.MasterExerciseExample, error) {
 	var examples []domain.MasterExerciseExample
-	if err := r.db.
+	if err := r.db.WithContext(ctx).
 		Where("exercise_id = ?", exerciseID).
 		Order("order_index asc, id asc").
 		Find(&examples).Error; err != nil {
@@ -30,13 +32,13 @@ func (r *masterExerciseExampleRepository) ListByExerciseID(exerciseID uint64) ([
 
 // ListByExerciseIDs は複数 exercise_id をまとめて取得し、 exercise_id ごとに
 // グルーピングした map を返す。 リストページで N+1 を避けるため。
-func (r *masterExerciseExampleRepository) ListByExerciseIDs(exerciseIDs []uint64) (map[uint64][]domain.MasterExerciseExample, error) {
+func (r *masterExerciseExampleRepository) ListByExerciseIDs(ctx context.Context, exerciseIDs []uint64) (map[uint64][]domain.MasterExerciseExample, error) {
 	result := make(map[uint64][]domain.MasterExerciseExample, len(exerciseIDs))
 	if len(exerciseIDs) == 0 {
 		return result, nil
 	}
 	var examples []domain.MasterExerciseExample
-	if err := r.db.
+	if err := r.db.WithContext(ctx).
 		Where("exercise_id IN ?", exerciseIDs).
 		Order("exercise_id asc, order_index asc, id asc").
 		Find(&examples).Error; err != nil {

--- a/backend/internal/adapter/persistence/master_exercise_repository.go
+++ b/backend/internal/adapter/persistence/master_exercise_repository.go
@@ -1,6 +1,8 @@
 package persistence
 
 import (
+	"context"
+
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
@@ -16,9 +18,9 @@ func NewMasterExerciseRepository(db *gorm.DB) repository.MasterExerciseRepositor
 	return &masterExerciseRepository{db: db}
 }
 
-func (r *masterExerciseRepository) ListByLanguage(language string) ([]domain.MasterExercise, error) {
+func (r *masterExerciseRepository) ListByLanguage(ctx context.Context, language string) ([]domain.MasterExercise, error) {
 	var exercises []domain.MasterExercise
-	q := r.db.Where("is_published = ?", true)
+	q := r.db.WithContext(ctx).Where("is_published = ?", true)
 	if language != "" {
 		q = q.Where("language = ?", language)
 	}
@@ -28,17 +30,17 @@ func (r *masterExerciseRepository) ListByLanguage(language string) ([]domain.Mas
 	return exercises, nil
 }
 
-func (r *masterExerciseRepository) GetByID(id uint64) (*domain.MasterExercise, error) {
+func (r *masterExerciseRepository) GetByID(ctx context.Context, id uint64) (*domain.MasterExercise, error) {
 	var exercise domain.MasterExercise
-	if err := r.db.First(&exercise, id).Error; err != nil {
+	if err := r.db.WithContext(ctx).First(&exercise, id).Error; err != nil {
 		return nil, err
 	}
 	return &exercise, nil
 }
 
-func (r *masterExerciseRepository) GetBySlug(slug string) (*domain.MasterExercise, error) {
+func (r *masterExerciseRepository) GetBySlug(ctx context.Context, slug string) (*domain.MasterExercise, error) {
 	var exercise domain.MasterExercise
-	if err := r.db.Where("slug = ?", slug).First(&exercise).Error; err != nil {
+	if err := r.db.WithContext(ctx).Where("slug = ?", slug).First(&exercise).Error; err != nil {
 		return nil, err
 	}
 	return &exercise, nil

--- a/backend/internal/handler/exercise_submission_handler.go
+++ b/backend/internal/handler/exercise_submission_handler.go
@@ -77,7 +77,7 @@ func (h *ExerciseSubmissionHandler) List(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "slug is required"})
 		return
 	}
-	rows, err := h.list.Execute(usecase.ListUserMasterSubmissionsInput{UserID: uid, Slug: slug})
+	rows, err := h.list.Execute(c.Request.Context(), usecase.ListUserMasterSubmissionsInput{UserID: uid, Slug: slug})
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "演習問題が見つかりません"})

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -25,28 +25,30 @@ type fakeFullSubmissionRepo struct {
 	lastKind       string
 }
 
-func (r *fakeFullSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
+func (r *fakeFullSubmissionRepo) Create(_ context.Context, s *domain.ExerciseSubmission) error {
 	s.ID = 42
 	r.created = s
 	return nil
 }
-func (r *fakeFullSubmissionRepo) ListByUserAndExercise(userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error) {
+func (r *fakeFullSubmissionRepo) ListByUserAndExercise(_ context.Context, userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error) {
 	r.lastUserID = userID
 	r.lastExerciseID = exerciseID
 	r.lastKind = kind
 	return r.listed, nil
 }
-func (r *fakeFullSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error) { return false, nil }
-func (r *fakeFullSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) {
+func (r *fakeFullSubmissionRepo) HasSolved(context.Context, uint64, uint64, string) (bool, error) {
 	return false, nil
 }
-func (r *fakeFullSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
+func (r *fakeFullSubmissionRepo) HasAttempted(context.Context, uint64, uint64, string) (bool, error) {
+	return false, nil
+}
+func (r *fakeFullSubmissionRepo) BatchUserStatuses(context.Context, uint64, []uint64, string) (map[uint64]string, error) {
 	return nil, nil
 }
-func (r *fakeFullSubmissionRepo) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
+func (r *fakeFullSubmissionRepo) ExerciseStats(context.Context, uint64, string) (repository.ExerciseSubmissionStats, error) {
 	return repository.ExerciseSubmissionStats{}, nil
 }
-func (r *fakeFullSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+func (r *fakeFullSubmissionRepo) ExerciseStatsBatch(context.Context, []uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
 	return nil, nil
 }
 

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -42,7 +42,7 @@ func NewMasterExerciseHandler(
 func (h *MasterExerciseHandler) List(c *gin.Context) {
 	language := c.Query("language")
 	uid := middleware.CurrentUserIDOrZero(c)
-	rows, err := h.listWithStatus.Execute(usecase.ListMasterExercisesWithStatusInput{
+	rows, err := h.listWithStatus.Execute(c.Request.Context(), usecase.ListMasterExercisesWithStatusInput{
 		UserID:   uid,
 		Language: language,
 	})
@@ -63,7 +63,7 @@ func (h *MasterExerciseHandler) GetBySlug(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "slug is required"})
 		return
 	}
-	detail, err := h.getExercise.ExecuteBySlug(slug)
+	detail, err := h.getExercise.ExecuteBySlug(c.Request.Context(), slug)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "演習問題が見つかりません"})

--- a/backend/internal/handler/master_exercise_handler_test.go
+++ b/backend/internal/handler/master_exercise_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -18,21 +19,25 @@ import (
 // 一覧で current user 状態を必要とするテストは別途専用 fake を定義する。
 type fakeSubmissionRepoForList struct{}
 
-func (fakeSubmissionRepoForList) Create(*domain.ExerciseSubmission) error { return nil }
-func (fakeSubmissionRepoForList) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
+func (fakeSubmissionRepoForList) Create(context.Context, *domain.ExerciseSubmission) error {
+	return nil
+}
+func (fakeSubmissionRepoForList) ListByUserAndExercise(context.Context, uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
 	return nil, nil
 }
-func (fakeSubmissionRepoForList) HasSolved(uint64, uint64, string) (bool, error) { return false, nil }
-func (fakeSubmissionRepoForList) HasAttempted(uint64, uint64, string) (bool, error) {
+func (fakeSubmissionRepoForList) HasSolved(context.Context, uint64, uint64, string) (bool, error) {
 	return false, nil
 }
-func (fakeSubmissionRepoForList) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
+func (fakeSubmissionRepoForList) HasAttempted(context.Context, uint64, uint64, string) (bool, error) {
+	return false, nil
+}
+func (fakeSubmissionRepoForList) BatchUserStatuses(context.Context, uint64, []uint64, string) (map[uint64]string, error) {
 	return map[uint64]string{}, nil
 }
-func (fakeSubmissionRepoForList) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
+func (fakeSubmissionRepoForList) ExerciseStats(context.Context, uint64, string) (repository.ExerciseSubmissionStats, error) {
 	return repository.ExerciseSubmissionStats{}, nil
 }
-func (fakeSubmissionRepoForList) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+func (fakeSubmissionRepoForList) ExerciseStatsBatch(context.Context, []uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
 	return map[uint64]repository.ExerciseSubmissionStats{}, nil
 }
 
@@ -46,19 +51,19 @@ type fakeMasterExerciseRepo struct {
 	gotSlug      string
 }
 
-func (r *fakeMasterExerciseRepo) ListByLanguage(language string) ([]domain.MasterExercise, error) {
+func (r *fakeMasterExerciseRepo) ListByLanguage(_ context.Context, language string) ([]domain.MasterExercise, error) {
 	r.listLanguage = language
 	return r.listResult, nil
 }
 
-func (r *fakeMasterExerciseRepo) GetByID(_ uint64) (*domain.MasterExercise, error) {
+func (r *fakeMasterExerciseRepo) GetByID(_ context.Context, _ uint64) (*domain.MasterExercise, error) {
 	if r.getErr != nil {
 		return nil, r.getErr
 	}
 	return r.getResult, nil
 }
 
-func (r *fakeMasterExerciseRepo) GetBySlug(slug string) (*domain.MasterExercise, error) {
+func (r *fakeMasterExerciseRepo) GetBySlug(_ context.Context, slug string) (*domain.MasterExercise, error) {
 	r.gotSlug = slug
 	if r.getErr != nil {
 		return nil, r.getErr
@@ -71,11 +76,11 @@ type fakeExampleRepo struct {
 	byID map[uint64][]domain.MasterExerciseExample
 }
 
-func (r *fakeExampleRepo) ListByExerciseID(exerciseID uint64) ([]domain.MasterExerciseExample, error) {
+func (r *fakeExampleRepo) ListByExerciseID(_ context.Context, exerciseID uint64) ([]domain.MasterExerciseExample, error) {
 	return r.byID[exerciseID], nil
 }
 
-func (r *fakeExampleRepo) ListByExerciseIDs(_ []uint64) (map[uint64][]domain.MasterExerciseExample, error) {
+func (r *fakeExampleRepo) ListByExerciseIDs(context.Context, []uint64) (map[uint64][]domain.MasterExerciseExample, error) {
 	return r.byID, nil
 }
 

--- a/backend/internal/usecase/get_master_exercise_usecase.go
+++ b/backend/internal/usecase/get_master_exercise_usecase.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -34,8 +35,8 @@ func NewGetMasterExerciseUseCase(
 }
 
 // Execute は ID 指定で取得する旧 API 互換。 examples は付かない。
-func (uc *GetMasterExerciseUseCase) Execute(id uint64) (*domain.MasterExercise, error) {
-	return uc.repo.GetByID(id)
+func (uc *GetMasterExerciseUseCase) Execute(ctx context.Context, id uint64) (*domain.MasterExercise, error) {
+	return uc.repo.GetByID(ctx, id)
 }
 
 // ExecuteBySlug は slug ベースの詳細ページ向け。 examples を含めて 1 度に返す。
@@ -43,15 +44,15 @@ func (uc *GetMasterExerciseUseCase) Execute(id uint64) (*domain.MasterExercise, 
 // `GetBySlug` が GORM の `gorm.ErrRecordNotFound` を返した場合は handler 側で 404 に分岐できるよう
 // そのまま伝搬する。 nil チェックは GORM が `(nil, nil)` を返さない前提だが、 リポジトリ実装の
 // バグや fake で `ex == nil` が起きたときの nil pointer panic を防ぐため defensive に弾いておく。
-func (uc *GetMasterExerciseUseCase) ExecuteBySlug(slug string) (*GetMasterExerciseDetailOutput, error) {
-	ex, err := uc.repo.GetBySlug(slug)
+func (uc *GetMasterExerciseUseCase) ExecuteBySlug(ctx context.Context, slug string) (*GetMasterExerciseDetailOutput, error) {
+	ex, err := uc.repo.GetBySlug(ctx, slug)
 	if err != nil {
 		return nil, err
 	}
 	if ex == nil {
 		return nil, fmt.Errorf("exercise not found: %s", slug)
 	}
-	examples, err := uc.examples.ListByExerciseID(ex.ID)
+	examples, err := uc.examples.ListByExerciseID(ctx, ex.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/list_master_exercises_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_usecase.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"context"
+
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
@@ -18,6 +20,6 @@ func NewListMasterExercisesUseCase(repo repository.MasterExerciseRepository) *Li
 }
 
 // Execute は language 指定があれば該当言語のみ、空文字なら全言語の問題を返す。
-func (uc *ListMasterExercisesUseCase) Execute(language string) ([]domain.MasterExercise, error) {
-	return uc.repo.ListByLanguage(language)
+func (uc *ListMasterExercisesUseCase) Execute(ctx context.Context, language string) ([]domain.MasterExercise, error) {
+	return uc.repo.ListByLanguage(ctx, language)
 }

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"context"
+
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
@@ -41,8 +43,8 @@ type ListMasterExercisesWithStatusInput struct {
 	Language string
 }
 
-func (uc *ListMasterExercisesWithStatusUseCase) Execute(in ListMasterExercisesWithStatusInput) ([]MasterExerciseWithStatus, error) {
-	exercises, err := uc.exercises.ListByLanguage(in.Language)
+func (uc *ListMasterExercisesWithStatusUseCase) Execute(ctx context.Context, in ListMasterExercisesWithStatusInput) ([]MasterExerciseWithStatus, error) {
+	exercises, err := uc.exercises.ListByLanguage(ctx, in.Language)
 	if err != nil {
 		return nil, err
 	}
@@ -56,12 +58,12 @@ func (uc *ListMasterExercisesWithStatusUseCase) Execute(in ListMasterExercisesWi
 
 	statusMap := make(map[uint64]string)
 	if in.UserID != 0 {
-		statusMap, err = uc.submissions.BatchUserStatuses(in.UserID, ids, domain.ExerciseKindMaster)
+		statusMap, err = uc.submissions.BatchUserStatuses(ctx, in.UserID, ids, domain.ExerciseKindMaster)
 		if err != nil {
 			return nil, err
 		}
 	}
-	statsMap, err := uc.submissions.ExerciseStatsBatch(ids, domain.ExerciseKindMaster)
+	statsMap, err := uc.submissions.ExerciseStatsBatch(ctx, ids, domain.ExerciseKindMaster)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/list_user_submissions_usecase.go
+++ b/backend/internal/usecase/list_user_submissions_usecase.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -26,13 +27,13 @@ func NewListUserMasterSubmissionsUseCase(
 	return &ListUserMasterSubmissionsUseCase{exercises: exercises, submissions: submissions}
 }
 
-func (uc *ListUserMasterSubmissionsUseCase) Execute(in ListUserMasterSubmissionsInput) ([]domain.ExerciseSubmission, error) {
-	ex, err := uc.exercises.GetBySlug(in.Slug)
+func (uc *ListUserMasterSubmissionsUseCase) Execute(ctx context.Context, in ListUserMasterSubmissionsInput) ([]domain.ExerciseSubmission, error) {
+	ex, err := uc.exercises.GetBySlug(ctx, in.Slug)
 	if err != nil {
 		return nil, err
 	}
 	if ex == nil {
 		return nil, fmt.Errorf("exercise not found: %s", in.Slug)
 	}
-	return uc.submissions.ListByUserAndExercise(in.UserID, ex.ID, domain.ExerciseKindMaster)
+	return uc.submissions.ListByUserAndExercise(ctx, in.UserID, ex.ID, domain.ExerciseKindMaster)
 }

--- a/backend/internal/usecase/repository/exercise_submission.go
+++ b/backend/internal/usecase/repository/exercise_submission.go
@@ -1,6 +1,10 @@
 package repository
 
-import "github.com/norman6464/FreStyle/backend/internal/domain"
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
 
 // ExerciseSubmissionRepository は演習提出履歴の永続化を担う。
 //
@@ -8,32 +12,34 @@ import "github.com/norman6464/FreStyle/backend/internal/domain"
 // 集計クエリ ( CountUsersSolved / CountTotal ) は exercise_id 単位で
 // 一覧ページの「正答者数」「提出数」表示に使う。
 //
+// 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける。
+//
 // 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
 // exerciseSubmissionRepository (GORM)。
 type ExerciseSubmissionRepository interface {
 	// Create は新しい提出を保存する。
-	Create(submission *domain.ExerciseSubmission) error
+	Create(ctx context.Context, submission *domain.ExerciseSubmission) error
 
 	// ListByUserAndExercise は user × (kind, exercise_id) の履歴を新しい順に返す。
-	ListByUserAndExercise(userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error)
+	ListByUserAndExercise(ctx context.Context, userID, exerciseID uint64, kind string) ([]domain.ExerciseSubmission, error)
 
 	// HasSolved は user が exercise を 1 回でも is_correct=true で解いたかを返す。
-	HasSolved(userID, exerciseID uint64, kind string) (bool, error)
+	HasSolved(ctx context.Context, userID, exerciseID uint64, kind string) (bool, error)
 
 	// HasAttempted は user が exercise に対して 1 回でも提出したかを返す。
-	HasAttempted(userID, exerciseID uint64, kind string) (bool, error)
+	HasAttempted(ctx context.Context, userID, exerciseID uint64, kind string) (bool, error)
 
 	// BatchUserStatuses は user の (kind, exerciseIDs) について、
 	//   exercise_id -> "solved" / "in_progress"
 	// を返す。一覧ページの N+1 を避ける用途。
 	// 未提出は map に key が存在しないこと で 表す。
-	BatchUserStatuses(userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error)
+	BatchUserStatuses(ctx context.Context, userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error)
 
 	// ExerciseStats は exercise_id 単位の集計を返す。
-	ExerciseStats(exerciseID uint64, kind string) (ExerciseSubmissionStats, error)
+	ExerciseStats(ctx context.Context, exerciseID uint64, kind string) (ExerciseSubmissionStats, error)
 
 	// ExerciseStatsBatch は複数 exercise_id をまとめて集計する。一覧ページ用。
-	ExerciseStatsBatch(exerciseIDs []uint64, kind string) (map[uint64]ExerciseSubmissionStats, error)
+	ExerciseStatsBatch(ctx context.Context, exerciseIDs []uint64, kind string) (map[uint64]ExerciseSubmissionStats, error)
 }
 
 // ExerciseSubmissionStats は問題単位の集計値。

--- a/backend/internal/usecase/repository/master_exercise.go
+++ b/backend/internal/usecase/repository/master_exercise.go
@@ -1,6 +1,10 @@
 package repository
 
-import "github.com/norman6464/FreStyle/backend/internal/domain"
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
 
 // MasterExerciseRepository は運営マスタ演習問題（旧 php_exercises 由来）の永続化を担う。
 //
@@ -8,10 +12,13 @@ import "github.com/norman6464/FreStyle/backend/internal/domain"
 // 言語フィルタは `ListByLanguage(language string)` で行い、PHP 専用 API は
 // usecase 層で `language="php"` を渡して既存挙動と互換を保つ。
 //
+// 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける
+// (キャンセル / タイムアウト / トレース ID 伝搬 の ため)。
+//
 // 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
 // masterExerciseRepository (GORM)。
 type MasterExerciseRepository interface {
-	ListByLanguage(language string) ([]domain.MasterExercise, error)
-	GetByID(id uint64) (*domain.MasterExercise, error)
-	GetBySlug(slug string) (*domain.MasterExercise, error)
+	ListByLanguage(ctx context.Context, language string) ([]domain.MasterExercise, error)
+	GetByID(ctx context.Context, id uint64) (*domain.MasterExercise, error)
+	GetBySlug(ctx context.Context, slug string) (*domain.MasterExercise, error)
 }

--- a/backend/internal/usecase/repository/master_exercise.go
+++ b/backend/internal/usecase/repository/master_exercise.go
@@ -9,7 +9,7 @@ import (
 // MasterExerciseRepository は運営マスタ演習問題（旧 php_exercises 由来）の永続化を担う。
 //
 // 旧 PhpExerciseRepository を language 引数を受け取れる形に汎用化したもの。
-// 言語フィルタは `ListByLanguage(language string)` で行い、PHP 専用 API は
+// 言語フィルタは ListByLanguage で行い、PHP 専用 API は
 // usecase 層で `language="php"` を渡して既存挙動と互換を保つ。
 //
 // 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける

--- a/backend/internal/usecase/repository/master_exercise_example.go
+++ b/backend/internal/usecase/repository/master_exercise_example.go
@@ -1,6 +1,10 @@
 package repository
 
-import "github.com/norman6464/FreStyle/backend/internal/domain"
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
 
 // MasterExerciseExampleRepository は MasterExercise に紐付く入出力例の永続化を担う。
 //
@@ -8,9 +12,11 @@ import "github.com/norman6464/FreStyle/backend/internal/domain"
 // 詳細画面では特定 exercise の全 example を表示し、採点 usecase では同じ全件を
 // テストケースとしてループ実行する。
 //
+// 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける。
+//
 // 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
 // masterExerciseExampleRepository (GORM)。
 type MasterExerciseExampleRepository interface {
-	ListByExerciseID(exerciseID uint64) ([]domain.MasterExerciseExample, error)
-	ListByExerciseIDs(exerciseIDs []uint64) (map[uint64][]domain.MasterExerciseExample, error)
+	ListByExerciseID(ctx context.Context, exerciseID uint64) ([]domain.MasterExerciseExample, error)
+	ListByExerciseIDs(ctx context.Context, exerciseIDs []uint64) (map[uint64][]domain.MasterExerciseExample, error)
 }

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -88,7 +88,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 		return nil, fmt.Errorf("code is required")
 	}
 
-	ex, err := uc.exercises.GetBySlug(in.Slug)
+	ex, err := uc.exercises.GetBySlug(ctx, in.Slug)
 	if err != nil {
 		return nil, err
 	}
@@ -98,10 +98,10 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 
 	// QA モード: コード実行せず、 提出文字列と ExpectedOutput を直接比較する。
 	if ex.Mode == domain.ExerciseModeQA {
-		return uc.submitQA(in, ex)
+		return uc.submitQA(ctx, in, ex)
 	}
 
-	examples, err := uc.examples.ListByExerciseID(ex.ID)
+	examples, err := uc.examples.ListByExerciseID(ctx, ex.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 		IsCorrect:     allPassed,
 		SubmittedAt:   time.Now().UTC(),
 	}
-	if err := uc.submissions.Create(submission); err != nil {
+	if err := uc.submissions.Create(ctx, submission); err != nil {
 		return nil, err
 	}
 
@@ -186,7 +186,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 
 // submitQA は QA モードの採点。 提出文字列と ExpectedOutput を normalize 比較するだけで
 // コード実行は行わない。 docker / kubernetes など サンドボックス実行が困難な題材向け。
-func (uc *SubmitMasterExerciseUseCase) submitQA(in SubmitMasterExerciseInput, ex *domain.MasterExercise) (*SubmitMasterExerciseOutput, error) {
+func (uc *SubmitMasterExerciseUseCase) submitQA(ctx context.Context, in SubmitMasterExerciseInput, ex *domain.MasterExercise) (*SubmitMasterExerciseOutput, error) {
 	expected := normalizeOutput(ex.ExpectedOutput)
 	actual := normalizeOutput(in.Code)
 	isCorrect := actual == expected
@@ -202,7 +202,7 @@ func (uc *SubmitMasterExerciseUseCase) submitQA(in SubmitMasterExerciseInput, ex
 		IsCorrect:     isCorrect,
 		SubmittedAt:   time.Now().UTC(),
 	}
-	if err := uc.submissions.Create(submission); err != nil {
+	if err := uc.submissions.Create(ctx, submission); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -18,11 +18,13 @@ type fakeMasterExerciseRepo struct {
 	err error
 }
 
-func (r *fakeMasterExerciseRepo) ListByLanguage(string) ([]domain.MasterExercise, error) {
+func (r *fakeMasterExerciseRepo) ListByLanguage(context.Context, string) ([]domain.MasterExercise, error) {
 	return nil, nil
 }
-func (r *fakeMasterExerciseRepo) GetByID(uint64) (*domain.MasterExercise, error) { return r.get, r.err }
-func (r *fakeMasterExerciseRepo) GetBySlug(string) (*domain.MasterExercise, error) {
+func (r *fakeMasterExerciseRepo) GetByID(context.Context, uint64) (*domain.MasterExercise, error) {
+	return r.get, r.err
+}
+func (r *fakeMasterExerciseRepo) GetBySlug(context.Context, string) (*domain.MasterExercise, error) {
 	return r.get, r.err
 }
 
@@ -30,10 +32,10 @@ type fakeExampleRepo struct {
 	rows []domain.MasterExerciseExample
 }
 
-func (r *fakeExampleRepo) ListByExerciseID(uint64) ([]domain.MasterExerciseExample, error) {
+func (r *fakeExampleRepo) ListByExerciseID(context.Context, uint64) ([]domain.MasterExerciseExample, error) {
 	return r.rows, nil
 }
-func (r *fakeExampleRepo) ListByExerciseIDs([]uint64) (map[uint64][]domain.MasterExerciseExample, error) {
+func (r *fakeExampleRepo) ListByExerciseIDs(context.Context, []uint64) (map[uint64][]domain.MasterExerciseExample, error) {
 	return nil, nil
 }
 
@@ -42,7 +44,7 @@ type fakeSubmissionRepo struct {
 	createErr error
 }
 
-func (r *fakeSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
+func (r *fakeSubmissionRepo) Create(_ context.Context, s *domain.ExerciseSubmission) error {
 	if r.createErr != nil {
 		return r.createErr
 	}
@@ -50,18 +52,22 @@ func (r *fakeSubmissionRepo) Create(s *domain.ExerciseSubmission) error {
 	s.ID = 999
 	return nil
 }
-func (r *fakeSubmissionRepo) ListByUserAndExercise(uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
+func (r *fakeSubmissionRepo) ListByUserAndExercise(context.Context, uint64, uint64, string) ([]domain.ExerciseSubmission, error) {
 	return nil, nil
 }
-func (r *fakeSubmissionRepo) HasSolved(uint64, uint64, string) (bool, error)    { return false, nil }
-func (r *fakeSubmissionRepo) HasAttempted(uint64, uint64, string) (bool, error) { return false, nil }
-func (r *fakeSubmissionRepo) BatchUserStatuses(uint64, []uint64, string) (map[uint64]string, error) {
+func (r *fakeSubmissionRepo) HasSolved(context.Context, uint64, uint64, string) (bool, error) {
+	return false, nil
+}
+func (r *fakeSubmissionRepo) HasAttempted(context.Context, uint64, uint64, string) (bool, error) {
+	return false, nil
+}
+func (r *fakeSubmissionRepo) BatchUserStatuses(context.Context, uint64, []uint64, string) (map[uint64]string, error) {
 	return nil, nil
 }
-func (r *fakeSubmissionRepo) ExerciseStats(uint64, string) (repository.ExerciseSubmissionStats, error) {
+func (r *fakeSubmissionRepo) ExerciseStats(context.Context, uint64, string) (repository.ExerciseSubmissionStats, error) {
 	return repository.ExerciseSubmissionStats{}, nil
 }
-func (r *fakeSubmissionRepo) ExerciseStatsBatch([]uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
+func (r *fakeSubmissionRepo) ExerciseStatsBatch(context.Context, []uint64, string) (map[uint64]repository.ExerciseSubmissionStats, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## 概要

PR #1722 で CodeRabbit が 「ctx を 受け取って いない レガシー repository メソッド」 を 2 件 (major) 指摘 した もの の フォロー アップ。 当時 は 「signature 不変 の 構造 移行 が ゴール」 と reject 説明 して 別 PR 化 した。 本 PR で 全 22 repository メソッド を **context.Context 受け取り に 統一** する。

これ に より:

- HTTP リクエスト の キャンセル (ブラウザ タブ 閉じる 等) が DB クエリ レベル まで 伝搬 する
- 上流 で `context.WithTimeout(...)` を かければ DB / SDK レベル で 強制 タイム アウト できる
- ECS タスク 停止 時 の graceful shutdown が 機能 する
- トレース ID / リクエスト 単位 の メタ データ が ctx 経由 で 一貫 して 流れる

## 変更 内容

### interface 変更 (3 ファイル)

| ファイル | 影響 メソッド |
|---|---|
| `usecase/repository/master_exercise.go` | ListByLanguage / GetByID / GetBySlug (3 個) |
| `usecase/repository/master_exercise_example.go` | ListByExerciseID / ListByExerciseIDs (2 個) |
| `usecase/repository/exercise_submission.go` | Create / ListByUserAndExercise / HasSolved / HasAttempted / BatchUserStatuses / ExerciseStats / ExerciseStatsBatch (7 個) |

全 メソッド の 第 1 引数 を `ctx context.Context` に 変更。

### impl 変更 (3 ファイル / `adapter/persistence/`)

- `master_exercise_repository.go` / `master_exercise_example_repository.go` / `exercise_submission_repository.go`
- 各 GORM 呼び出し を `r.db.WithContext(ctx).XXX(...)` に 変更

### 呼び出し 元 (5 usecase + 2 handler)

| 層 | ファイル |
|---|---|
| usecase | get_master_exercise / list_master_exercises / list_master_exercises_with_status / list_user_submissions / submit_master_exercise |
| handler | master_exercise_handler (List / GetBySlug) / exercise_submission_handler (List) |

handler は `c.Request.Context()` を usecase Execute に 渡し、 usecase は 下流 の repository に そのまま 引き 継ぐ チェーン。

### テスト (3 ファイル)

- `internal/usecase/submit_master_exercise_usecase_test.go`
- `internal/handler/exercise_submission_handler_test.go`
- `internal/handler/master_exercise_handler_test.go`

各 fake repository の signature を ctx 付き に 同期。 behavior は 不変。

## 設計 判断

- **振る舞い は 完全 不変**。 純粋 に signature に ctx を 追加 し `WithContext(ctx)` を 通す だけ
- usecase Execute / ExecuteBySlug も ctx を 受ける 形 に 統一 (handler から の `c.Request.Context()` を そのまま 引き 継ぐ チェーン)
- 既存 の DB アクセス が ない 純粋 関数 (`normalizeOutput` 等) は ctx を 受け取らない (関数 設計 と して も 不要)

## テスト

- [x] `go build ./...` 緑
- [x] `go vet ./...` 緑
- [x] `go test ./...` 既存 テスト 全 通過 (handler / middleware / usecase / cognito / embed / ses)
- [x] gofmt 適用 済
- [ ] 本番 ECS デプロイ 後 に `GET /api/v2/health` 200 確認
- [ ] 本番 で `/api/v2/exercises` 一覧 と `/api/v2/exercises/:slug` 詳細 が 正常 動作 する こと

## 関連

- PR #1722 (Clean Architecture 移行 一括 + CodeRabbit が ctx を 指摘 した もの)
- これ で 全 22 repository メソッド が ctx 受け取り に 統一 さ れ、 Clean Architecture + DIP の I/O 境界 が 完全 に 整う

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * リクエストコンテキストの伝播を改善し、タイムアウトおよびキャンセル処理の追従性を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->