### PR TITLE
docs(backend): 全 usecase に @see 風 GoDoc を 追加 + 教材 20 chapter の 旧 構造 参照 を 修正

### DIFF
--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -12,6 +12,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// ListAdminInvitationsUseCase は 招待 一覧 を 取得 する Use Case。
+// 依存 port: [repository.AdminInvitationRepository] (一覧 取得 を 委譲)。
 type ListAdminInvitationsUseCase struct {
 	repo repository.AdminInvitationRepository
 }
@@ -55,6 +57,8 @@ type MailBuilder func(magicLink, displayName, companyName, role string) (subject
 // infra/ses.MagicLinkURL を直接渡す。
 type LinkBuilder func(token string) string
 
+// CreateAdminInvitationUseCase は 新規 招待 を 発行 + マジック リンク メール を 送る Use Case。
+// 依存 port: [repository.AdminInvitationRepository] (DB 永続化) + [MagicLinkSender] (SES 経由 の メール 送信)。
 type CreateAdminInvitationUseCase struct {
 	repo        repository.AdminInvitationRepository
 	sender      MagicLinkSender
@@ -130,6 +134,8 @@ func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdm
 	return inv, nil
 }
 
+// CancelAdminInvitationUseCase は 既存 招待 の status を canceled に 更新 する Use Case。
+// 依存 port: [repository.AdminInvitationRepository]。
 type CancelAdminInvitationUseCase struct {
 	repo repository.AdminInvitationRepository
 }

--- a/backend/internal/usecase/ai_chat_usecase.go
+++ b/backend/internal/usecase/ai_chat_usecase.go
@@ -9,6 +9,7 @@ import (
 )
 
 // GetAiChatSessionsByUserIDUseCase は指定ユーザーの AI チャットセッション一覧を返す。
+// 依存 port: [repository.AiChatSessionRepository]。
 type GetAiChatSessionsByUserIDUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -22,6 +23,8 @@ func (u *GetAiChatSessionsByUserIDUseCase) Execute(ctx context.Context, userID u
 }
 
 // CreateAiChatSessionUseCase は新規セッションを作成する。
+// 依存 port: [repository.AiChatSessionRepository]。 章 014 で 解説 する Clean Architecture
+// 手書き DI の 標準 例。
 type CreateAiChatSessionUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -57,6 +60,7 @@ func (u *CreateAiChatSessionUseCase) Execute(ctx context.Context, in CreateAiCha
 }
 
 // GetAiChatSessionUseCase は単一セッションを返す。
+// 依存 port: [repository.AiChatSessionRepository]。
 type GetAiChatSessionUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -70,6 +74,7 @@ func (u *GetAiChatSessionUseCase) Execute(ctx context.Context, id uint64) (*doma
 }
 
 // UpdateAiChatSessionTitleUseCase はセッションタイトルを更新する。
+// 依存 port: [repository.AiChatSessionRepository]。
 type UpdateAiChatSessionTitleUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -86,6 +91,7 @@ func (u *UpdateAiChatSessionTitleUseCase) Execute(ctx context.Context, id uint64
 }
 
 // DeleteAiChatSessionUseCase はセッションを削除する。
+// 依存 port: [repository.AiChatSessionRepository]。 削除 前 に FindByID で 所有者 検証。
 type DeleteAiChatSessionUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -106,6 +112,7 @@ func (u *DeleteAiChatSessionUseCase) Execute(ctx context.Context, id uint64, use
 }
 
 // GetAiChatMessagesUseCase は DynamoDB からセッションのメッセージ一覧を返す。
+// 依存 port: [repository.AiChatMessageRepository] (DynamoDB 実装)。
 type GetAiChatMessagesUseCase struct {
 	messages repository.AiChatMessageRepository
 }

--- a/backend/internal/usecase/company_usecase.go
+++ b/backend/internal/usecase/company_usecase.go
@@ -7,6 +7,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// ListCompaniesUseCase は 全 company を 返す Use Case。 SuperAdmin 専用 画面 用。
+// 依存 port: [repository.CompanyRepository]。
 type ListCompaniesUseCase struct {
 	repo repository.CompanyRepository
 }

--- a/backend/internal/usecase/complete_onboarding_usecase.go
+++ b/backend/internal/usecase/complete_onboarding_usecase.go
@@ -14,6 +14,9 @@ import (
 //   - 既に値が入っているユーザーに対しても 200 を返す（冪等）。repo の MarkOnboarded が
 //     IS NULL ガード付きなので二度押しでも初回日時は保持される。
 //   - userID は handler で current user から渡す前提（API は自分自身しか変更不可）。
+//
+// CompleteOnboardingUseCase は Welcome 画面 押下 後 の onboarded_at 記録 を 行う。
+// 依存 port: [repository.UserRepository] (MarkOnboarded を 使用)。
 type CompleteOnboardingUseCase struct {
 	users repository.UserRepository
 }

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -17,6 +17,9 @@ import (
 //   - Get: 同一 company か super_admin（trainee は published のみ）
 //   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
 //   - Delete: コース内の教材も同時に削除する（cascade）
+//
+// 依存 port: [repository.CourseRepository] + [repository.TeachingMaterialRepository]
+// (削除 時 の cascade 用)。 章 002 §6 で 「単純 CRUD は 1 構造体 集約 OK」 の 例 と して 解説。
 type CourseUseCase struct {
 	courses   repository.CourseRepository
 	materials repository.TeachingMaterialRepository

--- a/backend/internal/usecase/get_current_user_usecase.go
+++ b/backend/internal/usecase/get_current_user_usecase.go
@@ -8,6 +8,7 @@ import (
 )
 
 // GetCurrentUserUseCase は Cognito sub から現在のユーザー情報を引く。
+// 依存 port: [repository.UserRepository] (FindByCognitoSub を 使用)。
 type GetCurrentUserUseCase struct {
 	users repository.UserRepository
 }

--- a/backend/internal/usecase/get_master_exercise_usecase.go
+++ b/backend/internal/usecase/get_master_exercise_usecase.go
@@ -22,6 +22,9 @@ type GetMasterExerciseDetailOutput struct {
 //
 // 旧 API は `:id` ベースだったが、 人間可読な URL `/code-editor/php-1` を実現するため
 // 主導線を slug に切替える。 ID ベースの挙動も互換用に Execute / GetByID で残す。
+//
+// 依存 port: [repository.MasterExerciseRepository] (exercise 本体) +
+// [repository.MasterExerciseExampleRepository] (入出力例 セット)。
 type GetMasterExerciseUseCase struct {
 	repo     repository.MasterExerciseRepository
 	examples repository.MasterExerciseExampleRepository

--- a/backend/internal/usecase/health_usecase.go
+++ b/backend/internal/usecase/health_usecase.go
@@ -9,6 +9,7 @@ import (
 
 // CheckHealthUseCase はバックエンドの稼働状態を判定するユースケース。
 // DB 到達性を確認し、UP/DOWN を返す。
+// 依存 port: [repository.HealthRepository] (sql.DB.Ping を 内部 実行)。
 type CheckHealthUseCase struct {
 	repo repository.HealthRepository
 }

--- a/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
+++ b/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
@@ -16,6 +16,8 @@ import (
 //
 // 上限チェックを usecase 層で行うのは「presigned URL を発行する前に 413 を返す」ためで、
 // クライアント側の不正利用や typo を S3 アップロード前の早い段階で弾く目的。
+//
+// 依存 port: [repository.AiChatAttachmentPresigner] (S3 presigned URL 生成)。
 type IssueAiChatAttachmentUploadURLUseCase struct {
 	presigner repository.AiChatAttachmentPresigner
 }

--- a/backend/internal/usecase/learning_report_usecase.go
+++ b/backend/internal/usecase/learning_report_usecase.go
@@ -9,6 +9,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// ListLearningReportsUseCase は current user の レポート 一覧 を 返す。
+// 依存 port: [repository.LearningReportRepository]。
 type ListLearningReportsUseCase struct {
 	repo repository.LearningReportRepository
 }
@@ -24,6 +26,9 @@ func (u *ListLearningReportsUseCase) Execute(ctx context.Context, userID uint64)
 	return u.repo.ListByUserID(ctx, userID)
 }
 
+// RequestLearningReportUseCase は レポート 生成 ジョブ を 受け付けて DB に pending 行 を 作り、
+// SQS に enqueue する。 章 008 で 解説 する 「2 つ の port を 直列 に 呼ぶ」 例。
+// 依存 port: [repository.LearningReportRepository] (DB) + [repository.SqsEnqueuer] (キュー)。
 type RequestLearningReportUseCase struct {
 	repo  repository.LearningReportRepository
 	queue repository.SqsEnqueuer

--- a/backend/internal/usecase/list_master_exercises_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_usecase.go
@@ -11,6 +11,8 @@ import (
 //
 // 旧 ListPhpExercisesUseCase の汎用版。言語固定の API（例: /php/exercises）を
 // 残しつつ、本 usecase は language を引数で受け取って多言語対応の準備をする。
+//
+// 依存 port: [repository.MasterExerciseRepository]。
 type ListMasterExercisesUseCase struct {
 	repo repository.MasterExerciseRepository
 }

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -25,6 +25,9 @@ type MasterExerciseWithStatus struct {
 // ListMasterExercisesWithStatusUseCase は問題一覧 + 各問題の current user 状態 + 集計を返す。
 //
 // N+1 を避けるため、 user status と stats はそれぞれ batch クエリで取得する。
+//
+// 依存 port: [repository.MasterExerciseRepository] + [repository.ExerciseSubmissionRepository]
+// (BatchUserStatuses / ExerciseStatsBatch で N+1 回避)。
 type ListMasterExercisesWithStatusUseCase struct {
 	exercises   repository.MasterExerciseRepository
 	submissions repository.ExerciseSubmissionRepository

--- a/backend/internal/usecase/list_user_submissions_usecase.go
+++ b/backend/internal/usecase/list_user_submissions_usecase.go
@@ -15,6 +15,8 @@ type ListUserMasterSubmissionsInput struct {
 }
 
 // ListUserMasterSubmissionsUseCase は current user の指定問題に対する提出履歴を新しい順で返す。
+// 依存 port: [repository.MasterExerciseRepository] (slug 解決) +
+// [repository.ExerciseSubmissionRepository] (履歴 取得)。
 type ListUserMasterSubmissionsUseCase struct {
 	exercises   repository.MasterExerciseRepository
 	submissions repository.ExerciseSubmissionRepository

--- a/backend/internal/usecase/note_image_usecase.go
+++ b/backend/internal/usecase/note_image_usecase.go
@@ -8,6 +8,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// IssueNoteImageUploadURLUseCase は ノート 画像 用 S3 PUT 署名付き URL を 発行 する。
+// 依存 port: [repository.NoteImagePresigner] (S3 presigned URL 生成)。
 type IssueNoteImageUploadURLUseCase struct {
 	presigner repository.NoteImagePresigner
 }

--- a/backend/internal/usecase/note_usecase.go
+++ b/backend/internal/usecase/note_usecase.go
@@ -10,6 +10,8 @@ import (
 
 var ErrNoteForbidden = errors.New("forbidden")
 
+// ListNotesByUserIDUseCase は current user の ノート 一覧 を 返す。
+// 依存 port: [repository.NoteRepository]。
 type ListNotesByUserIDUseCase struct {
 	repo repository.NoteRepository
 }
@@ -25,6 +27,8 @@ func (u *ListNotesByUserIDUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
+// CreateNoteUseCase は 新規 ノート を 作成 する。
+// 依存 port: [repository.NoteRepository]。
 type CreateNoteUseCase struct {
 	repo repository.NoteRepository
 }
@@ -61,6 +65,8 @@ func (u *CreateNoteUseCase) Execute(ctx context.Context, in CreateNoteInput) (*d
 	return n, nil
 }
 
+// UpdateNoteUseCase は ノート を 更新 する (所有者 検証 込み)。
+// 依存 port: [repository.NoteRepository] (FindByID で 所有者 検証 → Update)。
 type UpdateNoteUseCase struct {
 	repo repository.NoteRepository
 }
@@ -104,6 +110,8 @@ func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*d
 	return existing, nil
 }
 
+// DeleteNoteUseCase は ノート を 削除 する。 repo 側 で 所有者 検証 を 行う。
+// 依存 port: [repository.NoteRepository] (Delete に userID を 渡して WHERE 絞り込み)。
 type DeleteNoteUseCase struct {
 	repo repository.NoteRepository
 }

--- a/backend/internal/usecase/notification_usecase.go
+++ b/backend/internal/usecase/notification_usecase.go
@@ -8,6 +8,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// ListNotificationsUseCase は current user の 通知 一覧 を 返す。
+// 依存 port: [repository.NotificationRepository]。
 type ListNotificationsUseCase struct {
 	repo repository.NotificationRepository
 }
@@ -23,6 +25,8 @@ func (u *ListNotificationsUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
+// MarkNotificationReadUseCase は 単一 通知 を 既読 化 する (所有者 検証 込み)。
+// 依存 port: [repository.NotificationRepository]。
 type MarkNotificationReadUseCase struct {
 	repo repository.NotificationRepository
 }
@@ -41,6 +45,8 @@ func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, userID, id ui
 	return u.repo.MarkRead(ctx, userID, id)
 }
 
+// MarkAllNotificationsReadUseCase は current user の 全 通知 を 一括 既読 化 する。
+// 依存 port: [repository.NotificationRepository]。
 type MarkAllNotificationsReadUseCase struct {
 	repo repository.NotificationRepository
 }
@@ -56,6 +62,8 @@ func (u *MarkAllNotificationsReadUseCase) Execute(ctx context.Context, userID ui
 	return u.repo.MarkAllRead(ctx, userID)
 }
 
+// CountUnreadNotificationsUseCase は current user の 未読 通知 数 を 返す (バッジ 表示 用)。
+// 依存 port: [repository.NotificationRepository]。
 type CountUnreadNotificationsUseCase struct {
 	repo repository.NotificationRepository
 }

--- a/backend/internal/usecase/profile_image_usecase.go
+++ b/backend/internal/usecase/profile_image_usecase.go
@@ -8,6 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// IssueProfileImageUploadURLUseCase は profile アイコン 用 S3 PUT 署名 付き URL を 発行 する。
+// 章 009 で 解説 する Presigner port の 標準 例。
+// 依存 port: [repository.ProfileImagePresigner] (S3 presigned URL 生成)。
 type IssueProfileImageUploadURLUseCase struct {
 	presigner repository.ProfileImagePresigner
 }

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -8,6 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// GetProfileUseCase は 指定 user の プロフィール を 返す。 章 002 §3.3 で 解説 する
+// DIP の 標準 例 (usecase は port だけ 知って GORM を 知ら ない)。
+// 依存 port: [repository.ProfileRepository] (FindByUserID)。
 type GetProfileUseCase struct {
 	profiles repository.ProfileRepository
 }
@@ -23,6 +26,8 @@ func (u *GetProfileUseCase) Execute(ctx context.Context, userID uint64) (*domain
 	return u.profiles.FindByUserID(ctx, userID)
 }
 
+// UpdateProfileUseCase は プロフィール の 任意 フィールド を upsert する。
+// 依存 port: [repository.ProfileRepository] (Upsert)。
 type UpdateProfileUseCase struct {
 	profiles repository.ProfileRepository
 }

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -42,7 +42,12 @@ type StreamEvent struct {
 }
 
 // SendAiMessageStreamUseCase は WebSocket 版 (SendAiMessageUseCase) の streaming 版。
-// 互換のため両方を残し、フロントが対応した順から SSE に切り替える。
+// 互換のため両方を残し、フロントが対応した順から SSE に切り替える。 章 006 で SSE / Bedrock
+// streaming を 解説。
+//
+// 依存 port: [repository.AiChatSessionRepository] (RDB session 確認) +
+// [repository.AiChatMessageRepository] (DynamoDB メッセージ 永続化) +
+// [StreamingBedrockClient] (Bedrock token 配信) + [AttachmentDownloader] (S3 添付 取得、 nil OK)。
 type SendAiMessageStreamUseCase struct {
 	sessions      repository.AiChatSessionRepository
 	messages      repository.AiChatMessageRepository

--- a/backend/internal/usecase/session_note_usecase.go
+++ b/backend/internal/usecase/session_note_usecase.go
@@ -8,6 +8,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// GetSessionNoteUseCase は AI チャット セッション 紐付き の ノート を 取得 する。
+// 依存 port: [repository.SessionNoteRepository]。
 type GetSessionNoteUseCase struct {
 	repo repository.SessionNoteRepository
 }
@@ -23,6 +25,8 @@ func (u *GetSessionNoteUseCase) Execute(ctx context.Context, sessionID uint64) (
 	return u.repo.FindBySessionID(ctx, sessionID)
 }
 
+// UpsertSessionNoteUseCase は セッション ノート を upsert する (新規 or 更新)。
+// 依存 port: [repository.SessionNoteRepository]。
 type UpsertSessionNoteUseCase struct {
 	repo repository.SessionNoteRepository
 }

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -56,6 +56,10 @@ type SubmitMasterExerciseOutput struct {
 //     実行コスト削減のため、最初の不一致で打ち切らず全件実行（ユーザに「どこで落ちたか」を全部見せる方針）。
 //
 // 履歴保存はテストケース個別ではなく、まとめて 1 行（最初に失敗した stdout / stderr / exit_code を採用）。
+//
+// 依存 port: [repository.MasterExerciseRepository] (slug → exercise) +
+// [repository.MasterExerciseExampleRepository] (入出力 例) +
+// [repository.ExerciseSubmissionRepository] (履歴 保存) + [CodeExecutor] (sandbox 実行)。
 type SubmitMasterExerciseUseCase struct {
 	exercises   repository.MasterExerciseRepository
 	examples    repository.MasterExerciseExampleRepository

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -20,6 +20,9 @@ import (
 //     trainee は所属コースが is_published=false の場合は閲覧不可
 //   - Get: 同一 company か super_admin、 trainee は published のみ閲覧可
 //   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
+//
+// 依存 port: [repository.TeachingMaterialRepository] + [repository.CourseRepository]
+// (course との 整合性 検証 用)。 章 003 で 全 体 walk-through、 章 022 で 詳細 解説。
 type TeachingMaterialUseCase struct {
 	repo    repository.TeachingMaterialRepository
 	courses repository.CourseRepository

--- a/backend/internal/usecase/user_stats_usecase.go
+++ b/backend/internal/usecase/user_stats_usecase.go
@@ -8,6 +8,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// GetUserStatsUseCase は user の マイページ 集計 (合計 セッション 数 / 平均 スコア 等) を 返す。
+// 依存 port: [repository.UserStatsRepository] (Raw SQL で 集計)。
 type GetUserStatsUseCase struct {
 	stats repository.UserStatsRepository
 }

--- a/backend/internal/usecase/validate_invitation_token_usecase.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase.go
@@ -16,6 +16,9 @@ import (
 // 成功時は ValidatedInvitation (DTO) を返す。email は含めない:
 //   - 本人がメールから踏んでくる前提なので email は本人が知っている
 //   - 万一 token が漏れた場合の被害局所化（招待先 email を覗かれない）
+//
+// 依存 port: [repository.AdminInvitationRepository] (token 検証) +
+// [repository.CompanyRepository] (company 名 取得)。
 type ValidateInvitationTokenUseCase struct {
 	invitations repository.AdminInvitationRepository
 	companies   repository.CompanyRepository


### PR DESCRIPTION
## 概要

Clean Architecture 移行 シリーズ (PR #1721 / #1722 / #1723) の **仕上げ ドキュメント PR**。 backend コード の 振る舞い は 完全 不変、 純粋 に **コメント** と **教材** を 整える のみ。

## 変更 内容

### A. backend usecase に @see 風 GoDoc を 追加 (24 ファイル / 40 struct)

各 usecase struct の 直前 コメント に `// 依存 port: [repository.XxxRepository]` を 追加。 Go 1.19+ の GoDoc は `[pkg.Name]` 形式 で **自動 リンク 化** さ れる ので、 IDE / pkg.go.dev で 「どの port を 使う か」 が 1 クリック で 飛べる。

対象:
- admin_invitation (3 struct) / ai_chat (6 struct) / complete_onboarding / get_current_user / get_master_exercise / health / company / course
- learning_report (2 struct、 後者 は 2 port 並列) / list_master_exercises / list_master_exercises_with_status / list_user_submissions
- note_image / note (4 struct で repo 共有) / notification (4 struct) / profile_image / profile (2 struct) / session_note (2 struct)
- user_stats / validate_invitation_token / teaching_material / submit_master_exercise / send_ai_message_stream / issue_ai_chat_attachment_upload_url

純粋 に doc コメント 追加 の み で、 振る舞い / signature は 完全 不変。

### B. 教材 chapter 002〜027 の 旧 構造 参照 を 修正 (20 chapter)

PR #1721 + #1722 で backend を 新 構造 に 移行 した 結果、 教材 内 の 「全文 引用」 「import path」 「ファイル パス 参照」 が 旧 構造 (`backend/internal/repository/`) の まま に なって いた 箇所 を 全 chapter で 修正:

- 「全文 引用」 セクション は **port (interface 宣言) と adapter (実装 + コンストラクタ + メソッド) の 2 つ の code block に 明示 的 に 分割**
- import path は `internal/repository` → `internal/usecase/repository` / `internal/adapter/persistence` に 振り 分け
- ファイル パス 言及 は `backend/internal/adapter/persistence/X.go` 形式 に 統一
- chapter 014 §10 演習 Q1 も 「FreStyle は 全 20 port を usecase/repository/ に 集約 完了 (2026-05)」 に 更新

修正 した chapter: 002 / 003 / 006 / 008 / 009 / 010 / 011 / 013 / 014 / 015 / 016 / 017 / 018 / 020 / 022 / 023 / 024 / 025 / 026 / 027 (= 20 chapter)

教材 は `norman6464/frestyle-teaching-materials` commit \`0ea227c\` で 反映 + course 5 全 28 SQL を 本番 RDS に 再 適用 済 (CLAUDE.md §7-bis DELETE トラップ 遵守)。

## テスト

- [x] \`go build ./...\` 緑
- [x] \`go vet ./...\` 緑
- [x] \`go test ./...\` 既存 テスト 全 通過
- [x] gofmt 適用 済
- [x] 教材 https://normanblog.com/courses/5 全 27 章 表示 確認 (RDS 28 SQL 同期 済)

## 関連

- PR #1721 (UserRepository POC、 merged)
- PR #1722 (残り 19 repo 一括 + legacyrepository 撤去、 merged)
- PR #1723 (ctx 統一、 merged)
- これ で Clean Architecture 移行 シリーズ + 仕上げ ドキュメント が 完了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ノート機能を追加しました。ユーザーは個人的なノートを作成、編集、削除、および管理できるようになります。

* **Documentation**
  * 複数のユースケースにドキュメントコメントを追加し、機能説明と依存関係を明確化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->