### PR TITLE
feat(openapi): Phase 3 + 4 - 全 残り endpoint (~30) annotation + IDOR 修正 + SSE 表現

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -86,6 +86,12 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "400": {
+                        "description": "ListByCompanyID 失敗 (現状 実装 で 400 を 返す パス あり)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "401": {
                         "description": "未 認証",
                         "schema": {
@@ -99,7 +105,7 @@ const docTemplate = `{
                         }
                     },
                     "500": {
-                        "description": "DB 失敗",
+                        "description": "DB 失敗 (ListAll 経路)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -586,12 +592,12 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。",
+                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE で 配信。 OpenAPI は SSE の カスタム イベント を 完全 表現 でき ない ので レスポンス は string と して 簡略 表現。 実際 の イベント 形式 は session / token / done / error の 4 種 (詳細 は handler コメント 参照)。 エラー 系 (400/401/503) は 通常 の application/json で 返る。",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
-                    "text/plain"
+                    "text/event-stream"
                 ],
                 "tags": [
                     "ai-chat"
@@ -599,7 +605,7 @@ const docTemplate = `{
                 "summary": "AI チャット SSE ストリーミング",
                 "parameters": [
                     {
-                        "description": "sessionId / content / scene / sessionType / scenarioId / attachments",
+                        "description": "sessionId / content / scene / sessionType / scenarioId / attachments (最大 4 件)",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -616,19 +622,19 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "バリデーション",
+                        "description": "バリデーション (application/json)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "401": {
-                        "description": "未 認証",
+                        "description": "未 認証 (application/json)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "503": {
-                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub)",
+                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub、 application/json)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -833,6 +839,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "バリデーション or 実行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -1212,6 +1224,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "422": {
                         "description": "allow-list 外 ホスト",
                         "schema": {
@@ -1550,14 +1568,14 @@ const docTemplate = `{
                             }
                         }
                     },
-                    "400": {
-                        "description": "DB 失敗",
+                    "401": {
+                        "description": "未 認証",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
-                    "401": {
-                        "description": "未 認証",
+                    "500": {
+                        "description": "DB 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -19,6 +19,623 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/companies": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社 一覧 (SuperAdmin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Company"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin は 自社 のみ。 trainee 等 は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 一覧 (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ",
+                        "name": "companyId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "trainee / company 未 設定 等",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ 招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 作成",
+                "parameters": [
+                    {
+                        "description": "招待 内容 (CompanyAdmin は companyId が 上書き さ れる)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.createAdminInvReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "ロール 違反",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/invitations/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 取り消し",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "招待 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/attachments/upload-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット 添付 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "description": "filename / contentType / sizeBytes",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.aiChatAttachmentUploadURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "サイズ 上限 超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "未 サポート MIME",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "S3 presigner 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "添付 アップロード 機能 が 設定 されて いない (dev/stub)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の AI チャット セッション を 新しい 順 で 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 名義 で 新規 セッション を 作成。 IDOR 対策 で userId は body から 受け取らない。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 作成",
+                "parameters": [
+                    {
+                        "description": "title 必須",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.createSessionReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション を 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "セッション が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション の title を 更新。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション タイトル 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "title 必須",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateSessionTitleReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション を 削除。 所有者 検証 込み。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他人 の セッション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "セッション が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions/{id}/messages": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 セッション の 会話 履歴 (DynamoDB から) を 古い 順 で 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット メッセージ 一覧",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DynamoDB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/stream": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット SSE ストリーミング",
+                "parameters": [
+                    {
+                        "description": "sessionId / content / scene / sessionType / scenarioId / attachments",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.sseRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SSE stream (text/event-stream)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/cognito/callback": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
@@ -178,6 +795,669 @@ const docTemplate = `{
                 }
             }
         },
+        "/code/execute": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "code-execution"
+                ],
+                "summary": "コード サンドボックス 実行",
+                "parameters": [
+                    {
+                        "description": "コード + 言語",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.codeExecuteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション or 実行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 CompanyAdmin は 自社 固定。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}/materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 コース 配下 の 教材 を 返す。 trainee は published のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "コース内 教材 一覧",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "course id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他社 コース",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/embeds/oembed": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "embeds"
+                ],
+                "summary": "外部 URL の OGP / oEmbed メタ 取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "メタ 取得 対象 URL",
+                        "name": "url",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_infra_embed.Card"
+                        }
+                    },
+                    "400": {
+                        "description": "url 欠落 or 無効 URL",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "allow-list 外 ホスト",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部 エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "到達 不可",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習問題 一覧 (status + stats 付き)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "言語 フィルタ (例: php, go, javascript)",
+                        "name": "language",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 集計 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習問題 詳細 (slug)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "問題 slug (例: php-1)",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "slug 欠落",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 集計 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}/submissions": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の 指定 問題 へ の 提出 履歴 を 新しい 順 で 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "提出 履歴 一覧",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "問題 slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "slug 欠落",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}/submit": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の コード を 提出 し sandbox 実行 + 期待 出力 比較 で 採点。 結果 は 履歴 に append。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習 コード 提出 + 採点",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "問題 slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "提出 コード",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.submitExerciseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "code 欠落 等",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 採点 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "バックエンド と DB の 疎通 を 確認 する。 ALB / CloudWatch / 監視 から 叩く 想定。",
@@ -238,6 +1518,97 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "内部 エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "学習 レポート 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports/generate": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "月次 学習 レポート 生成 要求",
+                "parameters": [
+                    {
+                        "description": "year + month",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.requestReportReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -321,6 +1692,56 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "バリデーション エラー or DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/notes/image-upload-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "ノート 画像 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "description": "contentType (任意)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.issueUploadURLReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL"
+                        }
+                    },
+                    "400": {
+                        "description": "発行 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -738,6 +2159,121 @@ const docTemplate = `{
                 }
             }
         },
+        "/profile/{userId}/image/presigned-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 \"me\" / 数字 一致 のみ 許可 (IDOR 対策)。 body は 任意。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "プロフィール 画像 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "fileName / contentType (任意)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.issueProfileImageReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL"
+                        }
+                    },
+                    "400": {
+                        "description": "発行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/profile/{userId}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "ユーザー 統計 取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/sessions/{sessionId}/note": {
             "get": {
                 "security": [
@@ -845,9 +2381,472 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/teaching-materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 全 件 一覧 (deprecated)",
+                "deprecated": true,
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 courseId 必須。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/teaching-materials/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Attachment"
+                    }
+                },
+                "content": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "messageId": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sessionId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "scenarioId": {
+                    "type": "integer"
+                },
+                "sessionType": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Attachment": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission": {
+            "type": "object",
+            "properties": {
+                "exerciseId": {
+                    "type": "integer"
+                },
+                "exerciseKind": {
+                    "type": "string"
+                },
+                "exitCode": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isCorrect": {
+                    "type": "boolean"
+                },
+                "stderr": {
+                    "type": "string"
+                },
+                "stdout": {
+                    "type": "string"
+                },
+                "submittedAt": {
+                    "type": "string"
+                },
+                "submittedCode": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Health": {
             "type": "object",
             "properties": {
@@ -855,6 +2854,118 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.LearningReport": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "periodFrom": {
+                    "type": "string"
+                },
+                "periodTo": {
+                    "type": "string"
+                },
+                "s3Key": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "chapterId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "explanation": {
+                    "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                    "type": "string"
+                },
+                "hintText": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "mode": {
+                    "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q\u0026A 形式で扱うために導入。",
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "starterCode": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "exerciseId": {
+                    "description": "(exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で\nOrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。",
+                    "type": "integer"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "inputText": {
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "description": "OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。\n（default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）",
+                    "type": "integer"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }
@@ -888,6 +2999,20 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL": {
+            "type": "object",
+            "properties": {
+                "expiresIn": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Notification": {
             "type": "object",
             "properties": {
@@ -911,6 +3036,23 @@ const docTemplate = `{
                 },
                 "userId": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL": {
+            "type": "object",
+            "properties": {
+                "expiresIn": {
+                    "type": "integer"
+                },
+                "imageUrl": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "uploadUrl": {
+                    "type": "string"
                 }
             }
         },
@@ -964,6 +3106,271 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "description": "course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を\nAutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。",
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
+            "type": "object",
+            "properties": {
+                "averageScore": {
+                    "type": "number"
+                },
+                "longestStreak": {
+                    "type": "integer"
+                },
+                "streakDays": {
+                    "type": "integer"
+                },
+                "totalSessions": {
+                    "type": "integer"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_infra_embed.Card": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "imageUrl": {
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "Provider は \"ogp\" / \"youtube\" / \"github\" など、どの戦略で解決したかを示す。",
+                    "type": "string"
+                },
+                "siteName": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
+            "type": "object",
+            "properties": {
+                "exitCode": {
+                    "type": "integer"
+                },
+                "stderr": {
+                    "type": "string"
+                },
+                "stdout": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
+            "type": "object",
+            "properties": {
+                "examples": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"
+                    }
+                },
+                "exercise": {
+                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "chapterId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "explanation": {
+                    "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                    "type": "string"
+                },
+                "hintText": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "mode": {
+                    "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q\u0026A 形式で扱うために導入。",
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "starterCode": {
+                    "type": "string"
+                },
+                "stats": {
+                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
+            "type": "object",
+            "properties": {
+                "isCorrect": {
+                    "type": "boolean"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult"
+                    }
+                },
+                "submissionId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult": {
+            "type": "object",
+            "properties": {
+                "actualOutput": {
+                    "type": "string"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "input": {
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "passed": {
+                    "type": "boolean"
+                },
+                "stderr": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL": {
+            "type": "object",
+            "properties": {
+                "expiresIn": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "uploadUrl": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats": {
+            "type": "object",
+            "properties": {
+                "solvedUsers": {
+                    "type": "integer"
+                },
+                "totalSubmissions": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handler.aiChatAttachmentUploadURLRequest": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handler.codeExecuteRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.cognitoCallbackReq": {
             "type": "object",
             "required": [
@@ -975,6 +3382,62 @@ const docTemplate = `{
                 },
                 "invitationToken": {
                     "description": "InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で\n受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より\n優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.courseRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.createAdminInvReq": {
+            "type": "object",
+            "required": [
+                "companyId",
+                "email",
+                "role"
+            ],
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.createSessionReq": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "scenarioId": {
+                    "type": "integer"
+                },
+                "sessionType": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -1006,6 +3469,25 @@ const docTemplate = `{
                 "role": {
                     "type": "string",
                     "example": "trainee"
+                }
+            }
+        },
+        "internal_handler.issueProfileImageReq": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "fileName": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.issueUploadURLReq": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
                 }
             }
         },
@@ -1110,10 +3592,123 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_handler.requestReportReq": {
+            "type": "object",
+            "required": [
+                "month",
+                "year"
+            ],
+            "properties": {
+                "month": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1
+                },
+                "year": {
+                    "type": "integer",
+                    "maximum": 2100,
+                    "minimum": 2000
+                }
+            }
+        },
         "internal_handler.sessionNoteUpsertReq": {
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.sseAttachmentRequest": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handler.sseRequestBody": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handler.sseAttachmentRequest"
+                    }
+                },
+                "content": {
+                    "type": "string"
+                },
+                "scenarioId": {
+                    "type": "integer"
+                },
+                "scene": {
+                    "type": "string"
+                },
+                "sessionId": {
+                    "type": "integer"
+                },
+                "sessionType": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.submitExerciseRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialCreateRequest": {
+            "type": "object",
+            "required": [
+                "courseId"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -1139,6 +3734,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.updateSessionTitleReq": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "title": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12,6 +12,623 @@
     },
     "basePath": "/api/v2",
     "paths": {
+        "/admin/companies": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社 一覧 (SuperAdmin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Company"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin は 自社 のみ。 trainee 等 は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 一覧 (admin)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ",
+                        "name": "companyId",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "trainee / company 未 設定 等",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ 招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 作成",
+                "parameters": [
+                    {
+                        "description": "招待 内容 (CompanyAdmin は companyId が 上書き さ れる)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.createAdminInvReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "ロール 違反",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/invitations/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 取り消し",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "招待 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/attachments/upload-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット 添付 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "description": "filename / contentType / sizeBytes",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.aiChatAttachmentUploadURLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "サイズ 上限 超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "未 サポート MIME",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "S3 presigner 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "添付 アップロード 機能 が 設定 されて いない (dev/stub)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の AI チャット セッション を 新しい 順 で 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 名義 で 新規 セッション を 作成。 IDOR 対策 で userId は body から 受け取らない。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 作成",
+                "parameters": [
+                    {
+                        "description": "title 必須",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.createSessionReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション を 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "セッション が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション の title を 更新。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション タイトル 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "title 必須",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateSessionTitleReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション を 削除。 所有者 検証 込み。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他人 の セッション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "セッション が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions/{id}/messages": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 セッション の 会話 履歴 (DynamoDB から) を 古い 順 で 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット メッセージ 一覧",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DynamoDB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/stream": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット SSE ストリーミング",
+                "parameters": [
+                    {
+                        "description": "sessionId / content / scene / sessionType / scenarioId / attachments",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.sseRequestBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "SSE stream (text/event-stream)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "503": {
+                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/cognito/callback": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
@@ -171,6 +788,669 @@
                 }
             }
         },
+        "/code/execute": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "code-execution"
+                ],
+                "summary": "コード サンドボックス 実行",
+                "parameters": [
+                    {
+                        "description": "コード + 言語",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.codeExecuteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション or 実行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 CompanyAdmin は 自社 固定。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}/materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 コース 配下 の 教材 を 返す。 trainee は published のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "コース内 教材 一覧",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "course id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他社 コース",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/embeds/oembed": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "embeds"
+                ],
+                "summary": "外部 URL の OGP / oEmbed メタ 取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "メタ 取得 対象 URL",
+                        "name": "url",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_infra_embed.Card"
+                        }
+                    },
+                    "400": {
+                        "description": "url 欠落 or 無効 URL",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "422": {
+                        "description": "allow-list 外 ホスト",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部 エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "到達 不可",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習問題 一覧 (status + stats 付き)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "言語 フィルタ (例: php, go, javascript)",
+                        "name": "language",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 集計 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習問題 詳細 (slug)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "問題 slug (例: php-1)",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "slug 欠落",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 集計 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}/submissions": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の 指定 問題 へ の 提出 履歴 を 新しい 順 で 返す。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "提出 履歴 一覧",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "問題 slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "slug 欠落",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}/submit": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の コード を 提出 し sandbox 実行 + 期待 出力 比較 で 採点。 結果 は 履歴 に append。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習 コード 提出 + 採点",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "問題 slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "提出 コード",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.submitExerciseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput"
+                        }
+                    },
+                    "400": {
+                        "description": "code 欠落 等",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 採点 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "バックエンド と DB の 疎通 を 確認 する。 ALB / CloudWatch / 監視 から 叩く 想定。",
@@ -231,6 +1511,97 @@
                     },
                     "500": {
                         "description": "内部 エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "学習 レポート 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports/generate": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "月次 学習 レポート 生成 要求",
+                "parameters": [
+                    {
+                        "description": "year + month",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.requestReportReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -314,6 +1685,56 @@
                     },
                     "400": {
                         "description": "バリデーション エラー or DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/notes/image-upload-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notes"
+                ],
+                "summary": "ノート 画像 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "description": "contentType (任意)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.issueUploadURLReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL"
+                        }
+                    },
+                    "400": {
+                        "description": "発行 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -731,6 +2152,121 @@
                 }
             }
         },
+        "/profile/{userId}/image/presigned-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 \"me\" / 数字 一致 のみ 許可 (IDOR 対策)。 body は 任意。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "プロフィール 画像 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "fileName / contentType (任意)",
+                        "name": "body",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.issueProfileImageReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL"
+                        }
+                    },
+                    "400": {
+                        "description": "発行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/profile/{userId}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "ユーザー 統計 取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/sessions/{sessionId}/note": {
             "get": {
                 "security": [
@@ -838,9 +2374,472 @@
                     }
                 }
             }
+        },
+        "/teaching-materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 全 件 一覧 (deprecated)",
+                "deprecated": true,
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 courseId 必須。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/teaching-materials/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
+        "github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Attachment"
+                    }
+                },
+                "content": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "messageId": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "sessionId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "scenarioId": {
+                    "type": "integer"
+                },
+                "sessionType": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Attachment": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "format": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission": {
+            "type": "object",
+            "properties": {
+                "exerciseId": {
+                    "type": "integer"
+                },
+                "exerciseKind": {
+                    "type": "string"
+                },
+                "exitCode": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isCorrect": {
+                    "type": "boolean"
+                },
+                "stderr": {
+                    "type": "string"
+                },
+                "stdout": {
+                    "type": "string"
+                },
+                "submittedAt": {
+                    "type": "string"
+                },
+                "submittedCode": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Health": {
             "type": "object",
             "properties": {
@@ -848,6 +2847,118 @@
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.LearningReport": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "periodFrom": {
+                    "type": "string"
+                },
+                "periodTo": {
+                    "type": "string"
+                },
+                "s3Key": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "chapterId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "explanation": {
+                    "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                    "type": "string"
+                },
+                "hintText": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "mode": {
+                    "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q\u0026A 形式で扱うために導入。",
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "starterCode": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "exerciseId": {
+                    "description": "(exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で\nOrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。",
+                    "type": "integer"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "inputText": {
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "description": "OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。\n（default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）",
+                    "type": "integer"
+                },
+                "updatedAt": {
                     "type": "string"
                 }
             }
@@ -881,6 +2992,20 @@
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL": {
+            "type": "object",
+            "properties": {
+                "expiresIn": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Notification": {
             "type": "object",
             "properties": {
@@ -904,6 +3029,23 @@
                 },
                 "userId": {
                     "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL": {
+            "type": "object",
+            "properties": {
+                "expiresIn": {
+                    "type": "integer"
+                },
+                "imageUrl": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "uploadUrl": {
+                    "type": "string"
                 }
             }
         },
@@ -957,6 +3099,271 @@
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "description": "course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を\nAutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。",
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
+            "type": "object",
+            "properties": {
+                "averageScore": {
+                    "type": "number"
+                },
+                "longestStreak": {
+                    "type": "integer"
+                },
+                "streakDays": {
+                    "type": "integer"
+                },
+                "totalSessions": {
+                    "type": "integer"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_infra_embed.Card": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "imageUrl": {
+                    "type": "string"
+                },
+                "provider": {
+                    "description": "Provider は \"ogp\" / \"youtube\" / \"github\" など、どの戦略で解決したかを示す。",
+                    "type": "string"
+                },
+                "siteName": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
+            "type": "object",
+            "properties": {
+                "exitCode": {
+                    "type": "integer"
+                },
+                "stderr": {
+                    "type": "string"
+                },
+                "stdout": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
+            "type": "object",
+            "properties": {
+                "examples": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"
+                    }
+                },
+                "exercise": {
+                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "chapterId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "explanation": {
+                    "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                    "type": "string"
+                },
+                "hintText": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "mode": {
+                    "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q\u0026A 形式で扱うために導入。",
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "starterCode": {
+                    "type": "string"
+                },
+                "stats": {
+                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
+            "type": "object",
+            "properties": {
+                "isCorrect": {
+                    "type": "boolean"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult"
+                    }
+                },
+                "submissionId": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult": {
+            "type": "object",
+            "properties": {
+                "actualOutput": {
+                    "type": "string"
+                },
+                "expectedOutput": {
+                    "type": "string"
+                },
+                "input": {
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "passed": {
+                    "type": "boolean"
+                },
+                "stderr": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL": {
+            "type": "object",
+            "properties": {
+                "expiresIn": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "uploadUrl": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats": {
+            "type": "object",
+            "properties": {
+                "solvedUsers": {
+                    "type": "integer"
+                },
+                "totalSubmissions": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handler.aiChatAttachmentUploadURLRequest": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handler.codeExecuteRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "language": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.cognitoCallbackReq": {
             "type": "object",
             "required": [
@@ -968,6 +3375,62 @@
                 },
                 "invitationToken": {
                     "description": "InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で\n受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より\n優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.courseRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.createAdminInvReq": {
+            "type": "object",
+            "required": [
+                "companyId",
+                "email",
+                "role"
+            ],
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.createSessionReq": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "scenarioId": {
+                    "type": "integer"
+                },
+                "sessionType": {
+                    "type": "string"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -999,6 +3462,25 @@
                 "role": {
                     "type": "string",
                     "example": "trainee"
+                }
+            }
+        },
+        "internal_handler.issueProfileImageReq": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "fileName": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.issueUploadURLReq": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
                 }
             }
         },
@@ -1103,10 +3585,123 @@
                 }
             }
         },
+        "internal_handler.requestReportReq": {
+            "type": "object",
+            "required": [
+                "month",
+                "year"
+            ],
+            "properties": {
+                "month": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1
+                },
+                "year": {
+                    "type": "integer",
+                    "maximum": 2100,
+                    "minimum": 2000
+                }
+            }
+        },
         "internal_handler.sessionNoteUpsertReq": {
             "type": "object",
             "properties": {
                 "content": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.sseAttachmentRequest": {
+            "type": "object",
+            "properties": {
+                "contentType": {
+                    "type": "string"
+                },
+                "filename": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_handler.sseRequestBody": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handler.sseAttachmentRequest"
+                    }
+                },
+                "content": {
+                    "type": "string"
+                },
+                "scenarioId": {
+                    "type": "integer"
+                },
+                "scene": {
+                    "type": "string"
+                },
+                "sessionId": {
+                    "type": "integer"
+                },
+                "sessionType": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.submitExerciseRequest": {
+            "type": "object",
+            "required": [
+                "code"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialCreateRequest": {
+            "type": "object",
+            "required": [
+                "courseId"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -1132,6 +3727,17 @@
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.updateSessionTitleReq": {
+            "type": "object",
+            "required": [
+                "title"
+            ],
+            "properties": {
+                "title": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -79,6 +79,12 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "ListByCompanyID 失敗 (現状 実装 で 400 を 返す パス あり)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "401": {
                         "description": "未 認証",
                         "schema": {
@@ -92,7 +98,7 @@
                         }
                     },
                     "500": {
-                        "description": "DB 失敗",
+                        "description": "DB 失敗 (ListAll 経路)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -579,12 +585,12 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。",
+                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE で 配信。 OpenAPI は SSE の カスタム イベント を 完全 表現 でき ない ので レスポンス は string と して 簡略 表現。 実際 の イベント 形式 は session / token / done / error の 4 種 (詳細 は handler コメント 参照)。 エラー 系 (400/401/503) は 通常 の application/json で 返る。",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
-                    "text/plain"
+                    "text/event-stream"
                 ],
                 "tags": [
                     "ai-chat"
@@ -592,7 +598,7 @@
                 "summary": "AI チャット SSE ストリーミング",
                 "parameters": [
                     {
-                        "description": "sessionId / content / scene / sessionType / scenarioId / attachments",
+                        "description": "sessionId / content / scene / sessionType / scenarioId / attachments (最大 4 件)",
                         "name": "body",
                         "in": "body",
                         "required": true,
@@ -609,19 +615,19 @@
                         }
                     },
                     "400": {
-                        "description": "バリデーション",
+                        "description": "バリデーション (application/json)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "401": {
-                        "description": "未 認証",
+                        "description": "未 認証 (application/json)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "503": {
-                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub)",
+                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub、 application/json)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -826,6 +832,12 @@
                     },
                     "400": {
                         "description": "バリデーション or 実行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -1205,6 +1217,12 @@
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "422": {
                         "description": "allow-list 外 ホスト",
                         "schema": {
@@ -1543,14 +1561,14 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "DB 失敗",
+                    "401": {
+                        "description": "未 認証",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
-                    "401": {
-                        "description": "未 認証",
+                    "500": {
+                        "description": "DB 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,10 +1,217 @@
 basePath: /api/v2
 definitions:
+  github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation:
+    properties:
+      companyId:
+        type: integer
+      createdAt:
+        type: string
+      displayName:
+        type: string
+      email:
+        type: string
+      expiresAt:
+        type: string
+      id:
+        type: integer
+      role:
+        type: string
+      status:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage:
+    properties:
+      attachments:
+        items:
+          $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Attachment'
+        type: array
+      content:
+        type: string
+      createdAt:
+        type: string
+      messageId:
+        type: string
+      role:
+        type: string
+      sessionId:
+        type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: integer
+      scenarioId:
+        type: integer
+      sessionType:
+        type: string
+      title:
+        type: string
+      updatedAt:
+        type: string
+      userId:
+        type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.Attachment:
+    properties:
+      contentType:
+        type: string
+      filename:
+        type: string
+      format:
+        type: string
+      key:
+        type: string
+      kind:
+        type: string
+      sizeBytes:
+        type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.Company:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.Course:
+    properties:
+      companyId:
+        type: integer
+      createdAt:
+        type: string
+      createdByUserId:
+        type: integer
+      description:
+        type: string
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      sortOrder:
+        type: integer
+      title:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission:
+    properties:
+      exerciseId:
+        type: integer
+      exerciseKind:
+        type: string
+      exitCode:
+        type: integer
+      id:
+        type: integer
+      isCorrect:
+        type: boolean
+      stderr:
+        type: string
+      stdout:
+        type: string
+      submittedAt:
+        type: string
+      submittedCode:
+        type: string
+      userId:
+        type: integer
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Health:
     properties:
       db:
         type: string
       status:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.LearningReport:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: integer
+      periodFrom:
+        type: string
+      periodTo:
+        type: string
+      s3Key:
+        type: string
+      status:
+        type: string
+      userId:
+        type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise:
+    properties:
+      category:
+        type: string
+      chapterId:
+        type: integer
+      createdAt:
+        type: string
+      description:
+        type: string
+      difficulty:
+        type: integer
+      expectedOutput:
+        type: string
+      explanation:
+        description: |-
+          Explanation は QA モードで 正解後に表示される markdown 解説。
+          execute モードでは未使用 (空文字)。
+        type: string
+      hintText:
+        type: string
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      language:
+        type: string
+      mode:
+        description: |-
+          Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
+          'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
+          docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+        type: string
+      orderIndex:
+        type: integer
+      slug:
+        type: string
+      starterCode:
+        type: string
+      title:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample:
+    properties:
+      createdAt:
+        type: string
+      exerciseId:
+        description: |-
+          (exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で
+          OrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。
+        type: integer
+      expectedOutput:
+        type: string
+      id:
+        type: integer
+      inputText:
+        type: string
+      orderIndex:
+        description: |-
+          OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。
+          （default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）
+        type: integer
+      updatedAt:
         type: string
     type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Note:
@@ -26,6 +233,15 @@ definitions:
       userId:
         type: integer
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL:
+    properties:
+      expiresIn:
+        type: integer
+      key:
+        type: string
+      url:
+        type: string
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Notification:
     properties:
       body:
@@ -42,6 +258,17 @@ definitions:
         type: string
       userId:
         type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL:
+    properties:
+      expiresIn:
+        type: integer
+      imageUrl:
+        type: string
+      key:
+        type: string
+      uploadUrl:
+        type: string
     type: object
   github_com_norman6464_FreStyle_backend_internal_domain.ProfileView:
     properties:
@@ -78,6 +305,187 @@ definitions:
       userId:
         type: integer
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial:
+    properties:
+      companyId:
+        type: integer
+      content:
+        type: string
+      courseId:
+        description: |-
+          course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を
+          AutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。
+        type: integer
+      createdAt:
+        type: string
+      createdByUserId:
+        type: integer
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      orderInCourse:
+        type: integer
+      title:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.UserStats:
+    properties:
+      averageScore:
+        type: number
+      longestStreak:
+        type: integer
+      streakDays:
+        type: integer
+      totalSessions:
+        type: integer
+      userId:
+        type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_infra_embed.Card:
+    properties:
+      description:
+        type: string
+      imageUrl:
+        type: string
+      provider:
+        description: Provider は "ogp" / "youtube" / "github" など、どの戦略で解決したかを示す。
+        type: string
+      siteName:
+        type: string
+      title:
+        type: string
+      url:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput:
+    properties:
+      exitCode:
+        type: integer
+      stderr:
+        type: string
+      stdout:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput:
+    properties:
+      examples:
+        items:
+          $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample'
+        type: array
+      exercise:
+        $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise'
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus:
+    properties:
+      category:
+        type: string
+      chapterId:
+        type: integer
+      createdAt:
+        type: string
+      description:
+        type: string
+      difficulty:
+        type: integer
+      expectedOutput:
+        type: string
+      explanation:
+        description: |-
+          Explanation は QA モードで 正解後に表示される markdown 解説。
+          execute モードでは未使用 (空文字)。
+        type: string
+      hintText:
+        type: string
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      language:
+        type: string
+      mode:
+        description: |-
+          Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
+          'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
+          docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+        type: string
+      orderIndex:
+        type: integer
+      slug:
+        type: string
+      starterCode:
+        type: string
+      stats:
+        $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats'
+      status:
+        type: string
+      title:
+        type: string
+      updatedAt:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput:
+    properties:
+      isCorrect:
+        type: boolean
+      results:
+        items:
+          $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult'
+        type: array
+      submissionId:
+        type: integer
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult:
+    properties:
+      actualOutput:
+        type: string
+      expectedOutput:
+        type: string
+      input:
+        type: string
+      orderIndex:
+        type: integer
+      passed:
+        type: boolean
+      stderr:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL:
+    properties:
+      expiresIn:
+        type: integer
+      key:
+        type: string
+      uploadUrl:
+        type: string
+    type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats:
+    properties:
+      solvedUsers:
+        type: integer
+      totalSubmissions:
+        type: integer
+    type: object
+  internal_handler.aiChatAttachmentUploadURLRequest:
+    properties:
+      contentType:
+        type: string
+      filename:
+        type: string
+      sizeBytes:
+        type: integer
+    type: object
+  internal_handler.codeExecuteRequest:
+    properties:
+      code:
+        type: string
+      language:
+        type: string
+    required:
+    - code
+    type: object
   internal_handler.cognitoCallbackReq:
     properties:
       code:
@@ -90,6 +498,43 @@ definitions:
         type: string
     required:
     - code
+    type: object
+  internal_handler.courseRequest:
+    properties:
+      description:
+        type: string
+      isPublished:
+        type: boolean
+      sortOrder:
+        type: integer
+      title:
+        type: string
+    type: object
+  internal_handler.createAdminInvReq:
+    properties:
+      companyId:
+        type: integer
+      displayName:
+        type: string
+      email:
+        type: string
+      role:
+        type: string
+    required:
+    - companyId
+    - email
+    - role
+    type: object
+  internal_handler.createSessionReq:
+    properties:
+      scenarioId:
+        type: integer
+      sessionType:
+        type: string
+      title:
+        type: string
+    required:
+    - title
     type: object
   internal_handler.errorResponse:
     properties:
@@ -110,6 +555,18 @@ definitions:
         type: string
       role:
         example: trainee
+        type: string
+    type: object
+  internal_handler.issueProfileImageReq:
+    properties:
+      contentType:
+        type: string
+      fileName:
+        type: string
+    type: object
+  internal_handler.issueUploadURLReq:
+    properties:
+      contentType:
         type: string
     type: object
   internal_handler.meResponse:
@@ -181,9 +638,84 @@ definitions:
     required:
     - title
     type: object
+  internal_handler.requestReportReq:
+    properties:
+      month:
+        maximum: 12
+        minimum: 1
+        type: integer
+      year:
+        maximum: 2100
+        minimum: 2000
+        type: integer
+    required:
+    - month
+    - year
+    type: object
   internal_handler.sessionNoteUpsertReq:
     properties:
       content:
+        type: string
+    type: object
+  internal_handler.sseAttachmentRequest:
+    properties:
+      contentType:
+        type: string
+      filename:
+        type: string
+      key:
+        type: string
+      sizeBytes:
+        type: integer
+    type: object
+  internal_handler.sseRequestBody:
+    properties:
+      attachments:
+        items:
+          $ref: '#/definitions/internal_handler.sseAttachmentRequest'
+        type: array
+      content:
+        type: string
+      scenarioId:
+        type: integer
+      scene:
+        type: string
+      sessionId:
+        type: integer
+      sessionType:
+        type: string
+    type: object
+  internal_handler.submitExerciseRequest:
+    properties:
+      code:
+        type: string
+    required:
+    - code
+    type: object
+  internal_handler.teachingMaterialCreateRequest:
+    properties:
+      content:
+        type: string
+      courseId:
+        type: integer
+      isPublished:
+        type: boolean
+      orderInCourse:
+        type: integer
+      title:
+        type: string
+    required:
+    - courseId
+    type: object
+  internal_handler.teachingMaterialUpdateRequest:
+    properties:
+      content:
+        type: string
+      isPublished:
+        type: boolean
+      orderInCourse:
+        type: integer
+      title:
         type: string
     type: object
   internal_handler.updateProfileReq:
@@ -203,6 +735,13 @@ definitions:
       status:
         type: string
     type: object
+  internal_handler.updateSessionTitleReq:
+    properties:
+      title:
+        type: string
+    required:
+    - title
+    type: object
 info:
   contact:
     name: FreStyle Engineering
@@ -214,6 +753,403 @@ info:
   title: FreStyle Backend API
   version: "2.0"
 paths:
+  /admin/companies:
+    get:
+      description: 全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Company'
+            type: array
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 会社 一覧 (SuperAdmin)
+      tags:
+      - admin
+  /admin/invitations:
+    get:
+      description: pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin
+        は 自社 のみ。 trainee 等 は 403。
+      parameters:
+      - description: 'SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ'
+        in: query
+        name: companyId
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: trainee / company 未 設定 等
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 招待 一覧 (admin)
+      tags:
+      - admin
+    post:
+      consumes:
+      - application/json
+      description: 'SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ
+        招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。'
+      parameters:
+      - description: 招待 内容 (CompanyAdmin は companyId が 上書き さ れる)
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.createAdminInvReq'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: ロール 違反
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 招待 作成
+      tags:
+      - admin
+  /admin/invitations/{id}:
+    delete:
+      description: 指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。
+      parameters:
+      - description: 招待 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功 (本文 なし)
+        "400":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 招待 取り消し
+      tags:
+      - admin
+  /ai-chat/attachments/upload-url:
+    post:
+      consumes:
+      - application/json
+      description: ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。
+        contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document
+        4.5MB) も 事前 検証。
+      parameters:
+      - description: filename / contentType / sizeBytes
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.aiChatAttachmentUploadURLRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL'
+        "400":
+          description: バリデーション 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "413":
+          description: サイズ 上限 超過
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "415":
+          description: 未 サポート MIME
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: S3 presigner 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "503":
+          description: 添付 アップロード 機能 が 設定 されて いない (dev/stub)
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット 添付 PUT 署名 URL
+      tags:
+      - ai-chat
+  /ai-chat/sessions:
+    get:
+      description: current user の AI チャット セッション を 新しい 順 で 返す。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット セッション 一覧
+      tags:
+      - ai-chat
+    post:
+      consumes:
+      - application/json
+      description: current user 名義 で 新規 セッション を 作成。 IDOR 対策 で userId は body から 受け取らない。
+      parameters:
+      - description: title 必須
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.createSessionReq'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット セッション 作成
+      tags:
+      - ai-chat
+  /ai-chat/sessions/{id}:
+    delete:
+      description: 指定 id の セッション を 削除。 所有者 検証 込み。
+      parameters:
+      - description: セッション ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功 (本文 なし)
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 他人 の セッション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: セッション が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット セッション 削除
+      tags:
+      - ai-chat
+    get:
+      description: 指定 id の セッション を 返す。
+      parameters:
+      - description: セッション ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession'
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: セッション が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット セッション 詳細
+      tags:
+      - ai-chat
+    put:
+      consumes:
+      - application/json
+      description: 指定 id の セッション の title を 更新。
+      parameters:
+      - description: セッション ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: title 必須
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.updateSessionTitleReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット セッション タイトル 更新
+      tags:
+      - ai-chat
+  /ai-chat/sessions/{id}/messages:
+    get:
+      description: 指定 セッション の 会話 履歴 (DynamoDB から) を 古い 順 で 返す。
+      parameters:
+      - description: セッション ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage'
+            type: array
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DynamoDB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット メッセージ 一覧
+      tags:
+      - ai-chat
+  /ai-chat/stream:
+    post:
+      consumes:
+      - application/json
+      description: Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream)
+        で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント
+        形式 は session / token / done / error の 4 種。
+      parameters:
+      - description: sessionId / content / scene / sessionType / scenarioId / attachments
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.sseRequestBody'
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: SSE stream (text/event-stream)
+          schema:
+            type: string
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "503":
+          description: Bedrock / DynamoDB 未 設定 (dev/stub)
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: AI チャット SSE ストリーミング
+      tags:
+      - ai-chat
   /auth/cognito/callback:
     post:
       consumes:
@@ -322,6 +1258,433 @@ paths:
       summary: current user 情報 取得
       tags:
       - auth
+  /code/execute:
+    post:
+      consumes:
+      - application/json
+      description: trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode
+        を 返す。 language は php / go 等。
+      parameters:
+      - description: コード + 言語
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.codeExecuteRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput'
+        "400":
+          description: バリデーション or 実行 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コード サンドボックス 実行
+      tags:
+      - code-execution
+  /courses:
+    get:
+      description: current user の role / company で 自動 フィルタ。 trainee は published のみ、
+        admin 系 は draft 含む。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 一覧
+      tags:
+      - courses
+    post:
+      consumes:
+      - application/json
+      description: company_admin / super_admin の み。 CompanyAdmin は 自社 固定。
+      parameters:
+      - description: 作成 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.courseRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 作成
+      tags:
+      - courses
+  /courses/{id}:
+    delete:
+      description: 指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功 (本文 なし)
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 削除
+      tags:
+      - courses
+    get:
+      description: 指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 詳細
+      tags:
+      - courses
+    put:
+      consumes:
+      - application/json
+      description: 指定 id を 更新 (company_admin / super_admin)。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 更新 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.courseRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 更新
+      tags:
+      - courses
+  /courses/{id}/materials:
+    get:
+      description: 指定 コース 配下 の 教材 を 返す。 trainee は published のみ。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+            type: array
+        "400":
+          description: course id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 他社 コース
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース内 教材 一覧
+      tags:
+      - teaching-materials
+  /embeds/oembed:
+    get:
+      description: ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list
+        / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。
+      parameters:
+      - description: メタ 取得 対象 URL
+        in: query
+        name: url
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_infra_embed.Card'
+        "400":
+          description: url 欠落 or 無効 URL
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "422":
+          description: allow-list 外 ホスト
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 内部 エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "502":
+          description: 到達 不可
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 外部 URL の OGP / oEmbed メタ 取得
+      tags:
+      - embeds
+  /exercises:
+    get:
+      description: '運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current
+        user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。'
+      parameters:
+      - description: '言語 フィルタ (例: php, go, javascript)'
+        in: query
+        name: language
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus'
+            type: array
+        "500":
+          description: DB / 集計 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 演習問題 一覧 (status + stats 付き)
+      tags:
+      - exercises
+  /exercises/{slug}:
+    get:
+      description: 指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。
+      parameters:
+      - description: '問題 slug (例: php-1)'
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput'
+        "400":
+          description: slug 欠落
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 問題 が 見つから ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB / 集計 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 演習問題 詳細 (slug)
+      tags:
+      - exercises
+  /exercises/{slug}/submissions:
+    get:
+      description: current user の 指定 問題 へ の 提出 履歴 を 新しい 順 で 返す。
+      parameters:
+      - description: 問題 slug
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission'
+            type: array
+        "400":
+          description: slug 欠落
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 問題 が 見つから ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 提出 履歴 一覧
+      tags:
+      - exercises
+  /exercises/{slug}/submit:
+    post:
+      consumes:
+      - application/json
+      description: current user の コード を 提出 し sandbox 実行 + 期待 出力 比較 で 採点。 結果 は 履歴 に
+        append。
+      parameters:
+      - description: 問題 slug
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: 提出 コード
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.submitExerciseRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput'
+        "400":
+          description: code 欠落 等
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 問題 が 見つから ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB / 採点 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 演習 コード 提出 + 採点
+      tags:
+      - exercises
   /health:
     get:
       description: バックエンド と DB の 疎通 を 確認 する。 ALB / CloudWatch / 監視 から 叩く 想定。
@@ -367,6 +1730,64 @@ paths:
       summary: 招待 トークン 検証 (公開 / 認証 不要)
       tags:
       - invitations
+  /learning-reports:
+    get:
+      description: current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport'
+            type: array
+        "400":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 学習 レポート 一覧
+      tags:
+      - learning-reports
+  /learning-reports/generate:
+    post:
+      consumes:
+      - application/json
+      description: current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。
+        202 Accepted を 返す。
+      parameters:
+      - description: year + month
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.requestReportReq'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 月次 学習 レポート 生成 要求
+      tags:
+      - learning-reports
   /notes:
     get:
       description: current user の note を 更新 日 降順 で 返す。 IDOR 対策 で userId は 受け取らない。
@@ -490,6 +1911,38 @@ paths:
       security:
       - CookieAuth: []
       summary: ノート 更新
+      tags:
+      - notes
+  /notes/image-upload-url:
+    post:
+      consumes:
+      - application/json
+      description: current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware
+        の current user を 使う (IDOR 対策、 Phase 3 で 修正)。
+      parameters:
+      - description: contentType (任意)
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/internal_handler.issueUploadURLReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL'
+        "400":
+          description: 発行 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: ノート 画像 PUT 署名 URL
       tags:
       - notes
   /notifications:
@@ -665,6 +2118,80 @@ paths:
       summary: プロフィール 更新
       tags:
       - profile
+  /profile/{userId}/image/presigned-url:
+    post:
+      consumes:
+      - application/json
+      description: プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 "me" / 数字 一致 のみ 許可 (IDOR 対策)。
+        body は 任意。
+      parameters:
+      - description: 数字 ID または 'me'
+        in: path
+        name: userId
+        required: true
+        type: string
+      - description: fileName / contentType (任意)
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/internal_handler.issueProfileImageReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL'
+        "400":
+          description: 発行 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 他 user 指定
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: プロフィール 画像 PUT 署名 URL
+      tags:
+      - profile
+  /profile/{userId}/stats:
+    get:
+      description: 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
+      parameters:
+      - description: 数字 ID または 'me'
+        in: path
+        name: userId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats'
+        "400":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 他 user 指定
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: ユーザー 統計 取得
+      tags:
+      - profile
   /profile/me/onboarding/complete:
     post:
       description: Welcome 画面 「はじめる」 押下 で onboarded_at = NOW() に 更新。 冪等 (再 押下 で も
@@ -756,6 +2283,183 @@ paths:
       summary: セッション ノート 作成 / 更新
       tags:
       - session-notes
+  /teaching-materials:
+    get:
+      deprecated: true
+      description: backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後
+        に 削除 予定。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 全 件 一覧 (deprecated)
+      tags:
+      - teaching-materials
+    post:
+      consumes:
+      - application/json
+      description: company_admin / super_admin の み。 courseId 必須。
+      parameters:
+      - description: 作成 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.teachingMaterialCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 作成
+      tags:
+      - teaching-materials
+  /teaching-materials/{id}:
+    delete:
+      description: 指定 id の 教材 を 削除 (company_admin / super_admin)。
+      parameters:
+      - description: 教材 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功 (本文 なし)
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 教材 が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 削除
+      tags:
+      - teaching-materials
+    get:
+      description: 指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。
+      parameters:
+      - description: 教材 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 教材 が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 詳細
+      tags:
+      - teaching-materials
+    put:
+      consumes:
+      - application/json
+      description: 指定 id の 教材 を 更新 (company_admin / super_admin)。
+      parameters:
+      - description: 教材 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 更新 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.teachingMaterialUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 教材 が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 更新
+      tags:
+      - teaching-materials
 securityDefinitions:
   CookieAuth:
     description: Cognito 由来 の JWT を HttpOnly Cookie で 送る。 ログイン 後 自動 付与。

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -792,6 +792,10 @@ paths:
             items:
               $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation'
             type: array
+        "400":
+          description: ListByCompanyID 失敗 (現状 実装 で 400 を 返す パス あり)
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
         "401":
           description: 未 認証
           schema:
@@ -801,7 +805,7 @@ paths:
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":
-          description: DB 失敗
+          description: DB 失敗 (ListAll 経路)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:
@@ -1116,33 +1120,35 @@ paths:
     post:
       consumes:
       - application/json
-      description: Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream)
-        で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント
-        形式 は session / token / done / error の 4 種。
+      description: Bedrock Claude へ メッセージ を 送信 し、 token を SSE で 配信。 OpenAPI は SSE
+        の カスタム イベント を 完全 表現 でき ない ので レスポンス は string と して 簡略 表現。 実際 の イベント 形式 は session
+        / token / done / error の 4 種 (詳細 は handler コメント 参照)。 エラー 系 (400/401/503) は
+        通常 の application/json で 返る。
       parameters:
       - description: sessionId / content / scene / sessionType / scenarioId / attachments
+          (最大 4 件)
         in: body
         name: body
         required: true
         schema:
           $ref: '#/definitions/internal_handler.sseRequestBody'
       produces:
-      - text/plain
+      - text/event-stream
       responses:
         "200":
           description: SSE stream (text/event-stream)
           schema:
             type: string
         "400":
-          description: バリデーション
+          description: バリデーション (application/json)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "401":
-          description: 未 認証
+          description: 未 認証 (application/json)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "503":
-          description: Bedrock / DynamoDB 未 設定 (dev/stub)
+          description: Bedrock / DynamoDB 未 設定 (dev/stub、 application/json)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:
@@ -1280,6 +1286,10 @@ paths:
             $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput'
         "400":
           description: バリデーション or 実行 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:
@@ -1523,6 +1533,10 @@ paths:
           description: url 欠落 or 無効 URL
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
         "422":
           description: allow-list 外 ホスト
           schema:
@@ -1742,12 +1756,12 @@ paths:
             items:
               $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport'
             type: array
-        "400":
-          description: DB 失敗
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
         "401":
           description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:

--- a/backend/internal/handler/admin_company_handler.go
+++ b/backend/internal/handler/admin_company_handler.go
@@ -15,7 +15,14 @@ func NewAdminCompanyHandler(l *usecase.ListCompaniesUseCase) *AdminCompanyHandle
 	return &AdminCompanyHandler{list: l}
 }
 
-// List は GET /api/v2/admin/companies。super_admin のみアクセス可。
+// @Summary      会社 一覧 (SuperAdmin)
+// @Description  全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。
+// @Tags         admin
+// @Produce      json
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.Company
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /admin/companies [get]
+// @Security     CookieAuth
 func (h *AdminCompanyHandler) List(c *gin.Context) {
 	companies, err := h.list.Execute(c.Request.Context())
 	if err != nil {

--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -35,9 +35,10 @@ func NewAdminInvitationHandler(l *usecase.ListAdminInvitationsUseCase, c *usecas
 //	@Produce      json
 //	@Param        companyId  query     string  false  "SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ"
 //	@Success      200        {array}   github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation
+//	@Failure      400        {object}  errorResponse  "ListByCompanyID 失敗 (現状 実装 で 400 を 返す パス あり)"
 //	@Failure      401        {object}  errorResponse  "未 認証"
 //	@Failure      403        {object}  errorResponse  "trainee / company 未 設定 等"
-//	@Failure      500        {object}  errorResponse  "DB 失敗"
+//	@Failure      500        {object}  errorResponse  "DB 失敗 (ListAll 経路)"
 //	@Router       /admin/invitations [get]
 //	@Security     CookieAuth
 func (h *AdminInvitationHandler) List(c *gin.Context) {

--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -28,6 +28,18 @@ func NewAdminInvitationHandler(l *usecase.ListAdminInvitationsUseCase, c *usecas
 //
 // 旧実装は ?companyId= クエリ必須だったが、フロントが渡していなかったため
 // 常に 400 を返していた。current user の role / company_id から自動解決する設計に修正。
+//
+//	@Summary      招待 一覧 (admin)
+//	@Description  pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin は 自社 のみ。 trainee 等 は 403。
+//	@Tags         admin
+//	@Produce      json
+//	@Param        companyId  query     string  false  "SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ"
+//	@Success      200        {array}   github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation
+//	@Failure      401        {object}  errorResponse  "未 認証"
+//	@Failure      403        {object}  errorResponse  "trainee / company 未 設定 等"
+//	@Failure      500        {object}  errorResponse  "DB 失敗"
+//	@Router       /admin/invitations [get]
+//	@Security     CookieAuth
 func (h *AdminInvitationHandler) List(c *gin.Context) {
 	user := middleware.CurrentUserFromContext(c)
 	if user == nil {
@@ -89,6 +101,19 @@ type createAdminInvReq struct {
 // この境界を backend で確実に守ることで、フロント UI を経由しない API 呼び出しでも
 // SuperAdmin が間違って trainee を直接招待することや、CompanyAdmin が他社に
 // 招待を出すことを防ぐ。フロント UI は UX 改善として同じルールで選択肢を絞る。
+//
+//	@Summary      招待 作成
+//	@Description  SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ 招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。
+//	@Tags         admin
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body      createAdminInvReq  true  "招待 内容 (CompanyAdmin は companyId が 上書き さ れる)"
+//	@Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation
+//	@Failure      400   {object}  errorResponse  "バリデーション"
+//	@Failure      401   {object}  errorResponse  "未 認証"
+//	@Failure      403   {object}  errorResponse  "ロール 違反"
+//	@Router       /admin/invitations [post]
+//	@Security     CookieAuth
 func (h *AdminInvitationHandler) Create(c *gin.Context) {
 	user := middleware.CurrentUserFromContext(c)
 	if user == nil {
@@ -140,6 +165,15 @@ func (h *AdminInvitationHandler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, got)
 }
 
+// @Summary      招待 取り消し
+// @Description  指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。
+// @Tags         admin
+// @Produce      json
+// @Param        id  path  int  true  "招待 ID"
+// @Success      204  "成功 (本文 なし)"
+// @Failure      400  {object}  errorResponse  "DB 失敗"
+// @Router       /admin/invitations/{id} [delete]
+// @Security     CookieAuth
 func (h *AdminInvitationHandler) Cancel(c *gin.Context) {
 	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
 	if err := h.cancel.Execute(c.Request.Context(), id); err != nil {

--- a/backend/internal/handler/ai_chat_attachment_handler.go
+++ b/backend/internal/handler/ai_chat_attachment_handler.go
@@ -40,6 +40,21 @@ type aiChatAttachmentUploadURLRequest struct {
 //   - 401: 未認証
 //   - 413: サイズ上限超過
 //   - 415: 未サポートの MIME
+//     @Summary      AI チャット 添付 PUT 署名 URL
+//     @Description  ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。
+//     @Tags         ai-chat
+//     @Accept       json
+//     @Produce      json
+//     @Param        body  body      aiChatAttachmentUploadURLRequest  true  "filename / contentType / sizeBytes"
+//     @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL
+//     @Failure      400   {object}  errorResponse  "バリデーション 失敗"
+//     @Failure      401   {object}  errorResponse  "未 認証"
+//     @Failure      413   {object}  errorResponse  "サイズ 上限 超過"
+//     @Failure      415   {object}  errorResponse  "未 サポート MIME"
+//     @Failure      503   {object}  errorResponse  "添付 アップロード 機能 が 設定 されて いない (dev/stub)"
+//     @Failure      500   {object}  errorResponse  "S3 presigner 失敗"
+//     @Router       /ai-chat/attachments/upload-url [post]
+//     @Security     CookieAuth
 func (h *AiChatAttachmentHandler) IssueUploadURL(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {

--- a/backend/internal/handler/ai_chat_handler.go
+++ b/backend/internal/handler/ai_chat_handler.go
@@ -39,8 +39,15 @@ func NewAiChatHandler(
 	}
 }
 
-// GetSessions は GET /ai-chat/sessions
-// userId はクライアントから受け取らず、middleware の current user を使う。
+// @Summary      AI チャット セッション 一覧
+// @Description  current user の AI チャット セッション を 新しい 順 で 返す。
+// @Tags         ai-chat
+// @Produce      json
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /ai-chat/sessions [get]
+// @Security     CookieAuth
 func (h *AiChatHandler) GetSessions(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -61,8 +68,17 @@ type createSessionReq struct {
 	ScenarioID  *uint64 `json:"scenarioId"`
 }
 
-// CreateSession は POST /ai-chat/sessions
-// userId はクライアントから受け取らず current user で固定する（IDOR 対策）。
+// @Summary      AI チャット セッション 作成
+// @Description  current user 名義 で 新規 セッション を 作成。 IDOR 対策 で userId は body から 受け取らない。
+// @Tags         ai-chat
+// @Accept       json
+// @Produce      json
+// @Param        body  body      createSessionReq  true  "title 必須"
+// @Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Router       /ai-chat/sessions [post]
+// @Security     CookieAuth
 func (h *AiChatHandler) CreateSession(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -97,7 +113,17 @@ func parseSessionID(c *gin.Context) (uint64, bool) {
 	return id, true
 }
 
-// GetSession は GET /ai-chat/sessions/:id
+// @Summary      AI チャット セッション 詳細
+// @Description  指定 id の セッション を 返す。
+// @Tags         ai-chat
+// @Produce      json
+// @Param        id  path      int  true  "セッション ID"
+// @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      404  {object}  errorResponse  "セッション が ない"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /ai-chat/sessions/{id} [get]
+// @Security     CookieAuth
 func (h *AiChatHandler) GetSession(c *gin.Context) {
 	id, ok := parseSessionID(c)
 	if !ok {
@@ -119,7 +145,18 @@ type updateSessionTitleReq struct {
 	Title string `json:"title" binding:"required"`
 }
 
-// UpdateSessionTitle は PUT /ai-chat/sessions/:id
+// @Summary      AI チャット セッション タイトル 更新
+// @Description  指定 id の セッション の title を 更新。
+// @Tags         ai-chat
+// @Accept       json
+// @Produce      json
+// @Param        id    path      int                      true  "セッション ID"
+// @Param        body  body      updateSessionTitleReq    true  "title 必須"
+// @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      500   {object}  errorResponse  "DB 失敗"
+// @Router       /ai-chat/sessions/{id} [put]
+// @Security     CookieAuth
 func (h *AiChatHandler) UpdateSessionTitle(c *gin.Context) {
 	id, ok := parseSessionID(c)
 	if !ok {
@@ -138,7 +175,19 @@ func (h *AiChatHandler) UpdateSessionTitle(c *gin.Context) {
 	c.JSON(http.StatusOK, s)
 }
 
-// DeleteSession は DELETE /ai-chat/sessions/:id
+// @Summary      AI チャット セッション 削除
+// @Description  指定 id の セッション を 削除。 所有者 検証 込み。
+// @Tags         ai-chat
+// @Produce      json
+// @Param        id  path  int  true  "セッション ID"
+// @Success      204  "成功 (本文 なし)"
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "他人 の セッション"
+// @Failure      404  {object}  errorResponse  "セッション が ない"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /ai-chat/sessions/{id} [delete]
+// @Security     CookieAuth
 func (h *AiChatHandler) DeleteSession(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -164,7 +213,16 @@ func (h *AiChatHandler) DeleteSession(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// GetMessages は GET /ai-chat/sessions/:id/messages
+// @Summary      AI チャット メッセージ 一覧
+// @Description  指定 セッション の 会話 履歴 (DynamoDB から) を 古い 順 で 返す。
+// @Tags         ai-chat
+// @Produce      json
+// @Param        id  path      int  true  "セッション ID"
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      500  {object}  errorResponse  "DynamoDB 失敗"
+// @Router       /ai-chat/sessions/{id}/messages [get]
+// @Security     CookieAuth
 func (h *AiChatHandler) GetMessages(c *gin.Context) {
 	id, ok := parseSessionID(c)
 	if !ok {

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -65,15 +65,15 @@ type sseAttachmentRequest struct {
 const maxAttachmentsPerMessage = 4
 
 // @Summary      AI チャット SSE ストリーミング
-// @Description  Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。
+// @Description  Bedrock Claude へ メッセージ を 送信 し、 token を SSE で 配信。 OpenAPI は SSE の カスタム イベント を 完全 表現 でき ない ので レスポンス は string と して 簡略 表現。 実際 の イベント 形式 は session / token / done / error の 4 種 (詳細 は handler コメント 参照)。 エラー 系 (400/401/503) は 通常 の application/json で 返る。
 // @Tags         ai-chat
 // @Accept       json
-// @Produce      plain
-// @Param        body  body  sseRequestBody  true  "sessionId / content / scene / sessionType / scenarioId / attachments"
+// @Produce      text/event-stream
+// @Param        body  body  sseRequestBody  true  "sessionId / content / scene / sessionType / scenarioId / attachments (最大 4 件)"
 // @Success      200   {string}  string  "SSE stream (text/event-stream)"
-// @Failure      400   {object}  errorResponse  "バリデーション"
-// @Failure      401   {object}  errorResponse  "未 認証"
-// @Failure      503   {object}  errorResponse  "Bedrock / DynamoDB 未 設定 (dev/stub)"
+// @Failure      400   {object}  errorResponse  "バリデーション (application/json)"
+// @Failure      401   {object}  errorResponse  "未 認証 (application/json)"
+// @Failure      503   {object}  errorResponse  "Bedrock / DynamoDB 未 設定 (dev/stub、 application/json)"
 // @Router       /ai-chat/stream [post]
 // @Security     CookieAuth
 func (h *AiChatSseHandler) Handle(c *gin.Context) {

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -64,12 +64,18 @@ type sseAttachmentRequest struct {
 // UI / 課金観点で 4 枚に絞っている（仕様検討で確定）。
 const maxAttachmentsPerMessage = 4
 
-// Handle は POST /api/v2/ai-chat/stream。
-//
-// gin.Context.SSEvent は `Content-Type: text/event-stream` を自動でセットしないため、
-// 明示的にヘッダを付けて、`c.Writer.Flush()` を伴う書き込みでバッチを流す。
-// HTTP/1.1 chunked transfer で送るのが SSE の前提。CloudFront / ALB のバッファリングは
-// 標準で SSE をサポートしている（`X-Accel-Buffering: no` も併せて立てる）。
+// @Summary      AI チャット SSE ストリーミング
+// @Description  Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。
+// @Tags         ai-chat
+// @Accept       json
+// @Produce      plain
+// @Param        body  body  sseRequestBody  true  "sessionId / content / scene / sessionType / scenarioId / attachments"
+// @Success      200   {string}  string  "SSE stream (text/event-stream)"
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      503   {object}  errorResponse  "Bedrock / DynamoDB 未 設定 (dev/stub)"
+// @Router       /ai-chat/stream [post]
+// @Security     CookieAuth
 func (h *AiChatSseHandler) Handle(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -35,6 +35,7 @@ type codeExecuteRequest struct {
 // @Param        body  body      codeExecuteRequest  true  "コード + 言語"
 // @Success      200   {object}  usecase.ExecuteCodeOutput
 // @Failure      400   {object}  errorResponse  "バリデーション or 実行 失敗"
+// @Failure      401   {object}  errorResponse  "未 認証"
 // @Router       /code/execute [post]
 // @Security     CookieAuth
 func (h *CodeExecuteHandler) Execute(c *gin.Context) {

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -27,6 +27,16 @@ type codeExecuteRequest struct {
 	Language string `json:"language"`
 }
 
+// @Summary      コード サンドボックス 実行
+// @Description  trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。
+// @Tags         code-execution
+// @Accept       json
+// @Produce      json
+// @Param        body  body      codeExecuteRequest  true  "コード + 言語"
+// @Success      200   {object}  usecase.ExecuteCodeOutput
+// @Failure      400   {object}  errorResponse  "バリデーション or 実行 失敗"
+// @Router       /code/execute [post]
+// @Security     CookieAuth
 func (h *CodeExecuteHandler) Execute(c *gin.Context) {
 	var req codeExecuteRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -39,6 +39,15 @@ func (h *CourseHandler) actorContext(c *gin.Context) (uint64, uint64, string, bo
 	return user.ID, companyID, user.Role, true
 }
 
+// @Summary      コース 一覧
+// @Description  current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。
+// @Tags         courses
+// @Produce      json
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /courses [get]
+// @Security     CookieAuth
 func (h *CourseHandler) List(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -52,6 +61,18 @@ func (h *CourseHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
+// @Summary      コース 詳細
+// @Description  指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。
+// @Tags         courses
+// @Produce      json
+// @Param        id  path      int  true  "コース ID"
+// @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id} [get]
+// @Security     CookieAuth
 func (h *CourseHandler) Get(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -77,6 +98,18 @@ type courseRequest struct {
 	IsPublished bool   `json:"isPublished"`
 }
 
+// @Summary      コース 作成
+// @Description  company_admin / super_admin の み。 CompanyAdmin は 自社 固定。
+// @Tags         courses
+// @Accept       json
+// @Produce      json
+// @Param        body  body      courseRequest  true  "作成 内容"
+// @Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Router       /courses [post]
+// @Security     CookieAuth
 func (h *CourseHandler) Create(c *gin.Context) {
 	uid, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -103,6 +136,20 @@ func (h *CourseHandler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, course)
 }
 
+// @Summary      コース 更新
+// @Description  指定 id を 更新 (company_admin / super_admin)。
+// @Tags         courses
+// @Accept       json
+// @Produce      json
+// @Param        id    path      int            true  "コース ID"
+// @Param        body  body      courseRequest  true  "更新 内容"
+// @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Failure      404   {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id} [put]
+// @Security     CookieAuth
 func (h *CourseHandler) Update(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -134,6 +181,18 @@ func (h *CourseHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, course)
 }
 
+// @Summary      コース 削除
+// @Description  指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。
+// @Tags         courses
+// @Produce      json
+// @Param        id  path  int  true  "コース ID"
+// @Success      204  "成功 (本文 なし)"
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id} [delete]
+// @Security     CookieAuth
 func (h *CourseHandler) Delete(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {

--- a/backend/internal/handler/embed_handler.go
+++ b/backend/internal/handler/embed_handler.go
@@ -26,6 +26,18 @@ func NewEmbedHandler(f *embed.Fetcher) *EmbedHandler {
 //   - ErrUnsupportedHost → 422
 //   - ErrUnreachable     → 502
 //   - その他             → 500
+//     @Summary      外部 URL の OGP / oEmbed メタ 取得
+//     @Description  ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。
+//     @Tags         embeds
+//     @Produce      json
+//     @Param        url  query  string  true  "メタ 取得 対象 URL"
+//     @Success      200  {object}  embed.Card
+//     @Failure      400  {object}  errorResponse  "url 欠落 or 無効 URL"
+//     @Failure      422  {object}  errorResponse  "allow-list 外 ホスト"
+//     @Failure      502  {object}  errorResponse  "到達 不可"
+//     @Failure      500  {object}  errorResponse  "内部 エラー"
+//     @Router       /embeds/oembed [get]
+//     @Security     CookieAuth
 func (h *EmbedHandler) Resolve(c *gin.Context) {
 	raw := c.Query("url")
 	if raw == "" {

--- a/backend/internal/handler/embed_handler.go
+++ b/backend/internal/handler/embed_handler.go
@@ -22,17 +22,23 @@ func NewEmbedHandler(f *embed.Fetcher) *EmbedHandler {
 //
 // ?url= が必須クエリパラメータ。fetcher が allow-list / SSRF ガードを担う。
 // 失敗時のステータスマップ:
+//
 //   - ErrInvalidURL      → 400
+//
 //   - ErrUnsupportedHost → 422
+//
 //   - ErrUnreachable     → 502
+//
 //   - その他             → 500
+//
 //     @Summary      外部 URL の OGP / oEmbed メタ 取得
 //     @Description  ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。
 //     @Tags         embeds
 //     @Produce      json
-//     @Param        url  query  string  true  "メタ 取得 対象 URL"
-//     @Success      200  {object}  embed.Card
+//     @Param        url  query     string  true  "メタ 取得 対象 URL"
+//     @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_infra_embed.Card
 //     @Failure      400  {object}  errorResponse  "url 欠落 or 無効 URL"
+//     @Failure      401  {object}  errorResponse  "未 認証"
 //     @Failure      422  {object}  errorResponse  "allow-list 外 ホスト"
 //     @Failure      502  {object}  errorResponse  "到達 不可"
 //     @Failure      500  {object}  errorResponse  "内部 エラー"

--- a/backend/internal/handler/exercise_submission_handler.go
+++ b/backend/internal/handler/exercise_submission_handler.go
@@ -32,7 +32,20 @@ type submitExerciseRequest struct {
 	Code string `json:"code" binding:"required"`
 }
 
-// Submit は POST /api/v2/exercises/:slug/submit 。
+// @Summary      演習 コード 提出 + 採点
+// @Description  current user の コード を 提出 し sandbox 実行 + 期待 出力 比較 で 採点。 結果 は 履歴 に append。
+// @Tags         exercises
+// @Accept       json
+// @Produce      json
+// @Param        slug  path      string                  true  "問題 slug"
+// @Param        body  body      submitExerciseRequest   true  "提出 コード"
+// @Success      200   {object}  usecase.SubmitMasterExerciseOutput
+// @Failure      400   {object}  errorResponse  "code 欠落 等"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      404   {object}  errorResponse  "問題 が 見つから ない"
+// @Failure      500   {object}  errorResponse  "DB / 採点 失敗"
+// @Router       /exercises/{slug}/submit [post]
+// @Security     CookieAuth
 func (h *ExerciseSubmissionHandler) Submit(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -65,7 +78,18 @@ func (h *ExerciseSubmissionHandler) Submit(c *gin.Context) {
 	c.JSON(http.StatusOK, out)
 }
 
-// List は GET /api/v2/exercises/:slug/submissions 。
+// @Summary      提出 履歴 一覧
+// @Description  current user の 指定 問題 へ の 提出 履歴 を 新しい 順 で 返す。
+// @Tags         exercises
+// @Produce      json
+// @Param        slug  path      string  true  "問題 slug"
+// @Success      200   {array}   github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission
+// @Failure      400   {object}  errorResponse  "slug 欠落"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      404   {object}  errorResponse  "問題 が 見つから ない"
+// @Failure      500   {object}  errorResponse  "DB 失敗"
+// @Router       /exercises/{slug}/submissions [get]
+// @Security     CookieAuth
 func (h *ExerciseSubmissionHandler) List(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {

--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -23,8 +23,8 @@ func NewLearningReportHandler(l *usecase.ListLearningReportsUseCase, r *usecase.
 // @Tags         learning-reports
 // @Produce      json
 // @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.LearningReport
-// @Failure      400  {object}  errorResponse  "DB 失敗"
 // @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
 // @Router       /learning-reports [get]
 // @Security     CookieAuth
 func (h *LearningReportHandler) List(c *gin.Context) {
@@ -35,7 +35,7 @@ func (h *LearningReportHandler) List(c *gin.Context) {
 	}
 	rows, err := h.list.Execute(c.Request.Context(), uid)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, rows)

--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -18,8 +18,15 @@ func NewLearningReportHandler(l *usecase.ListLearningReportsUseCase, r *usecase.
 	return &LearningReportHandler{list: l, request: r}
 }
 
-// List は current user の learning report 一覧を返す。
-// userId はクライアントから受け取らない（IDOR 対策）。
+// @Summary      学習 レポート 一覧
+// @Description  current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。
+// @Tags         learning-reports
+// @Produce      json
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.LearningReport
+// @Failure      400  {object}  errorResponse  "DB 失敗"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Router       /learning-reports [get]
+// @Security     CookieAuth
 func (h *LearningReportHandler) List(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -43,7 +50,17 @@ type requestReportReq struct {
 	Month int `json:"month" binding:"required,min=1,max=12"`
 }
 
-// Request は current user で月次 learning report 生成を要求する。
+// @Summary      月次 学習 レポート 生成 要求
+// @Description  current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。
+// @Tags         learning-reports
+// @Accept       json
+// @Produce      json
+// @Param        body  body      requestReportReq  true  "year + month"
+// @Success      202   {object}  github_com_norman6464_FreStyle_backend_internal_domain.LearningReport
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Router       /learning-reports/generate [post]
+// @Security     CookieAuth
 func (h *LearningReportHandler) Request(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -39,6 +39,16 @@ func NewMasterExerciseHandler(
 // 全ユーザ合計の集計（提出数 / 正答ユーザ数）を 1 度に返す。
 // 一覧ページでステータスバッジ + 解答率を出すために必要。
 // 未ログインの場合は status は全 ""、 stats だけ返す。
+//
+//	@Summary      演習問題 一覧 (status + stats 付き)
+//	@Description  運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。
+//	@Tags         exercises
+//	@Produce      json
+//	@Param        language  query     string  false  "言語 フィルタ (例: php, go, javascript)"
+//	@Success      200       {array}   usecase.MasterExerciseWithStatus
+//	@Failure      500       {object}  errorResponse  "DB / 集計 失敗"
+//	@Router       /exercises [get]
+//	@Security     CookieAuth
 func (h *MasterExerciseHandler) List(c *gin.Context) {
 	language := c.Query("language")
 	uid := middleware.CurrentUserIDOrZero(c)
@@ -57,6 +67,18 @@ func (h *MasterExerciseHandler) List(c *gin.Context) {
 //
 // `gorm.ErrRecordNotFound` のときだけ 404 を返し、 それ以外の DB / 集計エラーは 500 として
 // 区別する。 全部 404 にすると本物の障害を「該当なし」と誤検知して上流に隠してしまうため。
+//
+//	@Summary      演習問題 詳細 (slug)
+//	@Description  指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。
+//	@Tags         exercises
+//	@Produce      json
+//	@Param        slug  path      string  true  "問題 slug (例: php-1)"
+//	@Success      200   {object}  usecase.GetMasterExerciseDetailOutput
+//	@Failure      400   {object}  errorResponse  "slug 欠落"
+//	@Failure      404   {object}  errorResponse  "問題 が 見つから ない"
+//	@Failure      500   {object}  errorResponse  "DB / 集計 失敗"
+//	@Router       /exercises/{slug} [get]
+//	@Security     CookieAuth
 func (h *MasterExerciseHandler) GetBySlug(c *gin.Context) {
 	slug := c.Param("slug")
 	if slug == "" {

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -40,9 +42,11 @@ func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
 		return
 	}
 	var req issueUploadURLReq
-	if err := c.ShouldBindJSON(&req); err != nil {
-		// body 無し / 一部 だけ は 許容 (contentType は 任意)
-		req = issueUploadURLReq{}
+	// body 無し (EOF) は 許容 する が、 不正 JSON / 型 違い は 400 で 弾く
+	// (silently masking malformed JSON を 避ける)。
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
 	}
 	got, err := h.issue.Execute(c.Request.Context(), uid, req.ContentType)
 	if err != nil {

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -15,18 +16,35 @@ func NewNoteImageHandler(i *usecase.IssueNoteImageUploadURLUseCase) *NoteImageHa
 	return &NoteImageHandler{issue: i}
 }
 
+// issueUploadURLReq は body 受け取り。 userId は **受け取らない** (current user
+// を middleware 経由 で 強制)。 OpenAPI Phase 3 で IDOR を 修正。
 type issueUploadURLReq struct {
-	UserID      uint64 `json:"userId" binding:"required"`
 	ContentType string `json:"contentType"`
 }
 
+// @Summary      ノート 画像 PUT 署名 URL
+// @Description  current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。
+// @Tags         notes
+// @Accept       json
+// @Produce      json
+// @Param        body  body      issueUploadURLReq  false  "contentType (任意)"
+// @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL
+// @Failure      400   {object}  errorResponse  "発行 失敗"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Router       /notes/image-upload-url [post]
+// @Security     CookieAuth
 func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
-	var req issueUploadURLReq
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	got, err := h.issue.Execute(c.Request.Context(), req.UserID, req.ContentType)
+	var req issueUploadURLReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// body 無し / 一部 だけ は 許容 (contentType は 任意)
+		req = issueUploadURLReq{}
+	}
+	got, err := h.issue.Execute(c.Request.Context(), uid, req.ContentType)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handler/profile_image_handler.go
+++ b/backend/internal/handler/profile_image_handler.go
@@ -52,6 +52,20 @@ func (h *ProfileImageHandler) resolveUserID(c *gin.Context) (uint64, error) {
 
 // IssueUploadURL は POST /profile/:userId/image/presigned-url。
 // クライアントは { fileName, contentType } を送り、 { uploadUrl, imageUrl, key, expiresIn } を受け取る。
+//
+//	@Summary      プロフィール 画像 PUT 署名 URL
+//	@Description  プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 "me" / 数字 一致 のみ 許可 (IDOR 対策)。 body は 任意。
+//	@Tags         profile
+//	@Accept       json
+//	@Produce      json
+//	@Param        userId  path      string                 true   "数字 ID または 'me'"
+//	@Param        body    body      issueProfileImageReq   false  "fileName / contentType (任意)"
+//	@Success      200     {object}  github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL
+//	@Failure      400     {object}  errorResponse  "発行 失敗"
+//	@Failure      401     {object}  errorResponse  "未 認証"
+//	@Failure      403     {object}  errorResponse  "他 user 指定"
+//	@Router       /profile/{userId}/image/presigned-url [post]
+//	@Security     CookieAuth
 func (h *ProfileImageHandler) IssueUploadURL(c *gin.Context) {
 	uid, err := h.resolveUserID(c)
 	if err != nil {

--- a/backend/internal/handler/teaching_material_handler.go
+++ b/backend/internal/handler/teaching_material_handler.go
@@ -41,6 +41,17 @@ func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, 
 
 // List は backward-compat 用 GET /api/v2/teaching-materials 。 frontend がコース対応に
 // 切り替わったら削除予定。
+//
+//	@Summary      教材 全 件 一覧 (deprecated)
+//	@Description  backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。
+//	@Tags         teaching-materials
+//	@Produce      json
+//	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+//	@Failure      401  {object}  errorResponse  "未 認証"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /teaching-materials [get]
+//	@Security     CookieAuth
+//	@Deprecated
 func (h *TeachingMaterialHandler) List(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -56,6 +67,19 @@ func (h *TeachingMaterialHandler) List(c *gin.Context) {
 
 // ListByCourse は GET /api/v2/courses/:id/materials 。 コース配下の教材を返す。
 // path param `:id` はコース ID（ルート競合を避けるため materials path 側で `:id` を流用）。
+//
+//	@Summary      コース内 教材 一覧
+//	@Description  指定 コース 配下 の 教材 を 返す。 trainee は published のみ。
+//	@Tags         teaching-materials
+//	@Produce      json
+//	@Param        id  path      int  true  "コース ID"
+//	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+//	@Failure      400  {object}  errorResponse  "course id 不正"
+//	@Failure      401  {object}  errorResponse  "未 認証"
+//	@Failure      403  {object}  errorResponse  "他社 コース"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /courses/{id}/materials [get]
+//	@Security     CookieAuth
 func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -74,7 +98,18 @@ func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
-// Get は GET /api/v2/teaching-materials/:id 。
+// @Summary      教材 詳細
+// @Description  指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。
+// @Tags         teaching-materials
+// @Produce      json
+// @Param        id  path      int  true  "教材 ID"
+// @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "教材 が ない"
+// @Router       /teaching-materials/{id} [get]
+// @Security     CookieAuth
 func (h *TeachingMaterialHandler) Get(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -117,7 +152,18 @@ type teachingMaterialUpdateRequest struct {
 	IsPublished   bool   `json:"isPublished"`
 }
 
-// Create は POST /api/v2/teaching-materials 。 body の courseId 必須。
+// @Summary      教材 作成
+// @Description  company_admin / super_admin の み。 courseId 必須。
+// @Tags         teaching-materials
+// @Accept       json
+// @Produce      json
+// @Param        body  body      teachingMaterialCreateRequest  true  "作成 内容"
+// @Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Router       /teaching-materials [post]
+// @Security     CookieAuth
 func (h *TeachingMaterialHandler) Create(c *gin.Context) {
 	uid, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -145,7 +191,20 @@ func (h *TeachingMaterialHandler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, m)
 }
 
-// Update は PUT /api/v2/teaching-materials/:id 。
+// @Summary      教材 更新
+// @Description  指定 id の 教材 を 更新 (company_admin / super_admin)。
+// @Tags         teaching-materials
+// @Accept       json
+// @Produce      json
+// @Param        id    path      int                            true  "教材 ID"
+// @Param        body  body      teachingMaterialUpdateRequest  true  "更新 内容"
+// @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Failure      404   {object}  errorResponse  "教材 が ない"
+// @Router       /teaching-materials/{id} [put]
+// @Security     CookieAuth
 func (h *TeachingMaterialHandler) Update(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {
@@ -177,7 +236,18 @@ func (h *TeachingMaterialHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, m)
 }
 
-// Delete は DELETE /api/v2/teaching-materials/:id 。
+// @Summary      教材 削除
+// @Description  指定 id の 教材 を 削除 (company_admin / super_admin)。
+// @Tags         teaching-materials
+// @Produce      json
+// @Param        id  path  int  true  "教材 ID"
+// @Success      204  "成功 (本文 なし)"
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "教材 が ない"
+// @Router       /teaching-materials/{id} [delete]
+// @Security     CookieAuth
 func (h *TeachingMaterialHandler) Delete(c *gin.Context) {
 	_, companyID, role, ok := h.actorContext(c)
 	if !ok {

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -44,6 +44,17 @@ func (h *UserStatsHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	return uid, nil
 }
 
+// @Summary      ユーザー 統計 取得
+// @Description  指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
+// @Tags         profile
+// @Produce      json
+// @Param        userId  path      string  true  "数字 ID または 'me'"
+// @Success      200     {object}  github_com_norman6464_FreStyle_backend_internal_domain.UserStats
+// @Failure      401     {object}  errorResponse  "未 認証"
+// @Failure      403     {object}  errorResponse  "他 user 指定"
+// @Failure      400     {object}  errorResponse  "DB 失敗"
+// @Router       /profile/{userId}/stats [get]
+// @Security     CookieAuth
 func (h *UserStatsHandler) Get(c *gin.Context) {
 	uid, err := h.resolveUserID(c)
 	if err != nil {

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -4,6 +4,746 @@
  */
 
 export interface paths {
+    "/admin/companies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 会社 一覧 (SuperAdmin)
+         * @description 全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.Company"][];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 招待 一覧 (admin)
+         * @description pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin は 自社 のみ。 trainee 等 は 403。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ */
+                    companyId?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"][];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description trainee / company 未 設定 等 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * 招待 作成
+         * @description SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ 招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description 招待 内容 (CompanyAdmin は companyId が 上書き さ れる) */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.createAdminInvReq"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description ロール 違反 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/invitations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 招待 取り消し
+         * @description 指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 招待 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功 (本文 なし) */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description DB 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ai-chat/attachments/upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * AI チャット 添付 PUT 署名 URL
+         * @description ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description filename / contentType / sizeBytes */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.aiChatAttachmentUploadURLRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL"];
+                    };
+                };
+                /** @description バリデーション 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description サイズ 上限 超過 */
+                413: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 サポート MIME */
+                415: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description S3 presigner 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 添付 アップロード 機能 が 設定 されて いない (dev/stub) */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ai-chat/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * AI チャット セッション 一覧
+         * @description current user の AI チャット セッション を 新しい 順 で 返す。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"][];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * AI チャット セッション 作成
+         * @description current user 名義 で 新規 セッション を 作成。 IDOR 対策 で userId は body から 受け取らない。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description title 必須 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.createSessionReq"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ai-chat/sessions/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * AI チャット セッション 詳細
+         * @description 指定 id の セッション を 返す。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description セッション ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"];
+                    };
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description セッション が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * AI チャット セッション タイトル 更新
+         * @description 指定 id の セッション の title を 更新。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description セッション ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description title 必須 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.updateSessionTitleReq"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * AI チャット セッション 削除
+         * @description 指定 id の セッション を 削除。 所有者 検証 込み。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description セッション ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功 (本文 なし) */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 他人 の セッション */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description セッション が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ai-chat/sessions/{id}/messages": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * AI チャット メッセージ 一覧
+         * @description 指定 セッション の 会話 履歴 (DynamoDB から) を 古い 順 で 返す。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description セッション ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage"][];
+                    };
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DynamoDB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ai-chat/stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * AI チャット SSE ストリーミング
+         * @description Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description sessionId / content / scene / sessionType / scenarioId / attachments */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.sseRequestBody"];
+                };
+            };
+            responses: {
+                /** @description SSE stream (text/event-stream) */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": string;
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description Bedrock / DynamoDB 未 設定 (dev/stub) */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/plain": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/cognito/callback": {
         parameters: {
             query?: never;
@@ -255,6 +995,813 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/code/execute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * コード サンドボックス 実行
+         * @description trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description コード + 言語 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.codeExecuteRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"];
+                    };
+                };
+                /** @description バリデーション or 実行 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/courses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * コース 一覧
+         * @description current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.Course"][];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * コース 作成
+         * @description company_admin / super_admin の み。 CompanyAdmin は 自社 固定。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description 作成 内容 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.courseRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.Course"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/courses/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * コース 詳細
+         * @description 指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description コース ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.Course"];
+                    };
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description コース が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * コース 更新
+         * @description 指定 id を 更新 (company_admin / super_admin)。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description コース ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description 更新 内容 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.courseRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.Course"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description コース が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * コース 削除
+         * @description 指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description コース ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功 (本文 なし) */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description コース が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/courses/{id}/materials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * コース内 教材 一覧
+         * @description 指定 コース 配下 の 教材 を 返す。 trainee は published のみ。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description コース ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"][];
+                    };
+                };
+                /** @description course id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 他社 コース */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/embeds/oembed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 外部 URL の OGP / oEmbed メタ 取得
+         * @description ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description メタ 取得 対象 URL */
+                    url: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_infra_embed.Card"];
+                    };
+                };
+                /** @description url 欠落 or 無効 URL */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description allow-list 外 ホスト */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部 エラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 到達 不可 */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/exercises": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 演習問題 一覧 (status + stats 付き)
+         * @description 運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description 言語 フィルタ (例: php, go, javascript) */
+                    language?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"][];
+                    };
+                };
+                /** @description DB / 集計 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/exercises/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 演習問題 詳細 (slug)
+         * @description 指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 問題 slug (例: php-1) */
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput"];
+                    };
+                };
+                /** @description slug 欠落 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 問題 が 見つから ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB / 集計 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/exercises/{slug}/submissions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 提出 履歴 一覧
+         * @description current user の 指定 問題 へ の 提出 履歴 を 新しい 順 で 返す。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 問題 slug */
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission"][];
+                    };
+                };
+                /** @description slug 欠落 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 問題 が 見つから ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/exercises/{slug}/submit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 演習 コード 提出 + 採点
+         * @description current user の コード を 提出 し sandbox 実行 + 期待 出力 比較 で 採点。 結果 は 履歴 に append。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 問題 slug */
+                    slug: string;
+                };
+                cookie?: never;
+            };
+            /** @description 提出 コード */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.submitExerciseRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput"];
+                    };
+                };
+                /** @description code 欠落 等 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 問題 が 見つから ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB / 採点 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -363,6 +1910,125 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/learning-reports": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 学習 レポート 一覧
+         * @description current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"][];
+                    };
+                };
+                /** @description DB 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learning-reports/generate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 月次 学習 レポート 生成 要求
+         * @description current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description year + month */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.requestReportReq"];
+                };
+            };
+            responses: {
+                /** @description Accepted */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/notes": {
         parameters: {
             query?: never;
@@ -441,6 +2107,68 @@ export interface paths {
                     };
                 };
                 /** @description バリデーション エラー or DB 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notes/image-upload-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ノート 画像 PUT 署名 URL
+         * @description current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description contentType (任意) */
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.issueUploadURLReq"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL"];
+                    };
+                };
+                /** @description 発行 失敗 */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -991,6 +2719,149 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/profile/{userId}/image/presigned-url": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * プロフィール 画像 PUT 署名 URL
+         * @description プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 "me" / 数字 一致 のみ 許可 (IDOR 対策)。 body は 任意。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 数字 ID または 'me' */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            /** @description fileName / contentType (任意) */
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.issueProfileImageReq"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL"];
+                    };
+                };
+                /** @description 発行 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 他 user 指定 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/profile/{userId}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ユーザー 統計 取得
+         * @description 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 数字 ID または 'me' */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserStats"];
+                    };
+                };
+                /** @description DB 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 他 user 指定 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/sessions/{sessionId}/note": {
         parameters: {
             query?: never;
@@ -1109,13 +2980,449 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/teaching-materials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 教材 全 件 一覧 (deprecated)
+         * @deprecated
+         * @description backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"][];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * 教材 作成
+         * @description company_admin / super_admin の み。 courseId 必須。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description 作成 内容 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.teachingMaterialCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teaching-materials/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 教材 詳細
+         * @description 指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 教材 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"];
+                    };
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 教材 が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * 教材 更新
+         * @description 指定 id の 教材 を 更新 (company_admin / super_admin)。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 教材 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description 更新 内容 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.teachingMaterialUpdateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"];
+                    };
+                };
+                /** @description バリデーション */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 教材 が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * 教材 削除
+         * @description 指定 id の 教材 を 削除 (company_admin / super_admin)。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 教材 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功 (本文 なし) */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 操作 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 教材 が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        "github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation": {
+            companyId?: number;
+            createdAt?: string;
+            displayName?: string;
+            email?: string;
+            expiresAt?: string;
+            id?: number;
+            role?: string;
+            status?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage": {
+            attachments?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.Attachment"][];
+            content?: string;
+            createdAt?: string;
+            messageId?: string;
+            role?: string;
+            sessionId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession": {
+            createdAt?: string;
+            id?: number;
+            scenarioId?: number;
+            sessionType?: string;
+            title?: string;
+            updatedAt?: string;
+            userId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.Attachment": {
+            contentType?: string;
+            filename?: string;
+            format?: string;
+            key?: string;
+            kind?: string;
+            sizeBytes?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
+            createdAt?: string;
+            id?: number;
+            name?: string;
+            updatedAt?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+            companyId?: number;
+            createdAt?: string;
+            createdByUserId?: number;
+            description?: string;
+            id?: number;
+            isPublished?: boolean;
+            sortOrder?: number;
+            title?: string;
+            updatedAt?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission": {
+            exerciseId?: number;
+            exerciseKind?: string;
+            exitCode?: number;
+            id?: number;
+            isCorrect?: boolean;
+            stderr?: string;
+            stdout?: string;
+            submittedAt?: string;
+            submittedCode?: string;
+            userId?: number;
+        };
         "github_com_norman6464_FreStyle_backend_internal_domain.Health": {
             db?: string;
             status?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.LearningReport": {
+            createdAt?: string;
+            id?: number;
+            periodFrom?: string;
+            periodTo?: string;
+            s3Key?: string;
+            status?: string;
+            userId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise": {
+            category?: string;
+            chapterId?: number;
+            createdAt?: string;
+            description?: string;
+            difficulty?: number;
+            expectedOutput?: string;
+            /**
+             * @description Explanation は QA モードで 正解後に表示される markdown 解説。
+             *     execute モードでは未使用 (空文字)。
+             */
+            explanation?: string;
+            hintText?: string;
+            id?: number;
+            isPublished?: boolean;
+            language?: string;
+            /**
+             * @description Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
+             *     'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
+             *     docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+             */
+            mode?: string;
+            orderIndex?: number;
+            slug?: string;
+            starterCode?: string;
+            title?: string;
+            updatedAt?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample": {
+            createdAt?: string;
+            /**
+             * @description (exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で
+             *     OrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。
+             */
+            exerciseId?: number;
+            expectedOutput?: string;
+            id?: number;
+            inputText?: string;
+            /**
+             * @description OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。
+             *     （default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）
+             */
+            orderIndex?: number;
+            updatedAt?: string;
         };
         "github_com_norman6464_FreStyle_backend_internal_domain.Note": {
             content?: string;
@@ -1127,6 +3434,11 @@ export interface components {
             updatedAt?: string;
             userId?: number;
         };
+        "github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL": {
+            expiresIn?: number;
+            key?: string;
+            url?: string;
+        };
         "github_com_norman6464_FreStyle_backend_internal_domain.Notification": {
             body?: string;
             createdAt?: string;
@@ -1135,6 +3447,12 @@ export interface components {
             title?: string;
             type?: string;
             userId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL": {
+            expiresIn?: number;
+            imageUrl?: string;
+            key?: string;
+            uploadUrl?: string;
         };
         "github_com_norman6464_FreStyle_backend_internal_domain.ProfileView": {
             avatarUrl?: string;
@@ -1157,6 +3475,108 @@ export interface components {
             updatedAt?: string;
             userId?: number;
         };
+        "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
+            companyId?: number;
+            content?: string;
+            /**
+             * @description course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を
+             *     AutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。
+             */
+            courseId?: number;
+            createdAt?: string;
+            createdByUserId?: number;
+            id?: number;
+            isPublished?: boolean;
+            orderInCourse?: number;
+            title?: string;
+            updatedAt?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
+            averageScore?: number;
+            longestStreak?: number;
+            streakDays?: number;
+            totalSessions?: number;
+            userId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_infra_embed.Card": {
+            description?: string;
+            imageUrl?: string;
+            /** @description Provider は "ogp" / "youtube" / "github" など、どの戦略で解決したかを示す。 */
+            provider?: string;
+            siteName?: string;
+            title?: string;
+            url?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
+            exitCode?: number;
+            stderr?: string;
+            stdout?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
+            examples?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"][];
+            exercise?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise"];
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
+            category?: string;
+            chapterId?: number;
+            createdAt?: string;
+            description?: string;
+            difficulty?: number;
+            expectedOutput?: string;
+            /**
+             * @description Explanation は QA モードで 正解後に表示される markdown 解説。
+             *     execute モードでは未使用 (空文字)。
+             */
+            explanation?: string;
+            hintText?: string;
+            id?: number;
+            isPublished?: boolean;
+            language?: string;
+            /**
+             * @description Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
+             *     'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
+             *     docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+             */
+            mode?: string;
+            orderIndex?: number;
+            slug?: string;
+            starterCode?: string;
+            stats?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"];
+            status?: string;
+            title?: string;
+            updatedAt?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
+            isCorrect?: boolean;
+            results?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult"][];
+            submissionId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult": {
+            actualOutput?: string;
+            expectedOutput?: string;
+            input?: string;
+            orderIndex?: number;
+            passed?: boolean;
+            stderr?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL": {
+            expiresIn?: number;
+            key?: string;
+            uploadUrl?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats": {
+            solvedUsers?: number;
+            totalSubmissions?: number;
+        };
+        "internal_handler.aiChatAttachmentUploadURLRequest": {
+            contentType?: string;
+            filename?: string;
+            sizeBytes?: number;
+        };
+        "internal_handler.codeExecuteRequest": {
+            code: string;
+            language?: string;
+        };
         "internal_handler.cognitoCallbackReq": {
             code: string;
             /**
@@ -1165,6 +3585,23 @@ export interface components {
              *     優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。
              */
             invitationToken?: string;
+        };
+        "internal_handler.courseRequest": {
+            description?: string;
+            isPublished?: boolean;
+            sortOrder?: number;
+            title?: string;
+        };
+        "internal_handler.createAdminInvReq": {
+            companyId: number;
+            displayName?: string;
+            email: string;
+            role: string;
+        };
+        "internal_handler.createSessionReq": {
+            scenarioId?: number;
+            sessionType?: string;
+            title: string;
         };
         "internal_handler.errorResponse": {
             /** @example unauthorized */
@@ -1179,6 +3616,13 @@ export interface components {
             displayName?: string;
             /** @example trainee */
             role?: string;
+        };
+        "internal_handler.issueProfileImageReq": {
+            contentType?: string;
+            fileName?: string;
+        };
+        "internal_handler.issueUploadURLReq": {
+            contentType?: string;
         };
         "internal_handler.meResponse": {
             /** @example abc-123-uuid */
@@ -1222,8 +3666,42 @@ export interface components {
             isPublic?: boolean;
             title: string;
         };
+        "internal_handler.requestReportReq": {
+            month: number;
+            year: number;
+        };
         "internal_handler.sessionNoteUpsertReq": {
             content?: string;
+        };
+        "internal_handler.sseAttachmentRequest": {
+            contentType?: string;
+            filename?: string;
+            key?: string;
+            sizeBytes?: number;
+        };
+        "internal_handler.sseRequestBody": {
+            attachments?: components["schemas"]["internal_handler.sseAttachmentRequest"][];
+            content?: string;
+            scenarioId?: number;
+            scene?: string;
+            sessionId?: number;
+            sessionType?: string;
+        };
+        "internal_handler.submitExerciseRequest": {
+            code: string;
+        };
+        "internal_handler.teachingMaterialCreateRequest": {
+            content?: string;
+            courseId: number;
+            isPublished?: boolean;
+            orderInCourse?: number;
+            title?: string;
+        };
+        "internal_handler.teachingMaterialUpdateRequest": {
+            content?: string;
+            isPublished?: boolean;
+            orderInCourse?: number;
+            title?: string;
         };
         "internal_handler.updateProfileReq": {
             avatarUrl?: string;
@@ -1234,6 +3712,9 @@ export interface components {
             iconUrl?: string;
             name?: string;
             status?: string;
+        };
+        "internal_handler.updateSessionTitleReq": {
+            title: string;
         };
     };
     responses: never;

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -84,6 +84,15 @@ export interface paths {
                         "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"][];
                     };
                 };
+                /** @description ListByCompanyID 失敗 (現状 実装 で 400 を 返す パス あり) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
                 /** @description 未 認証 */
                 401: {
                     headers: {
@@ -102,7 +111,7 @@ export interface paths {
                         "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
-                /** @description DB 失敗 */
+                /** @description DB 失敗 (ListAll 経路) */
                 500: {
                     headers: {
                         [name: string]: unknown;
@@ -684,7 +693,7 @@ export interface paths {
         put?: never;
         /**
          * AI チャット SSE ストリーミング
-         * @description Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。
+         * @description Bedrock Claude へ メッセージ を 送信 し、 token を SSE で 配信。 OpenAPI は SSE の カスタム イベント を 完全 表現 でき ない ので レスポンス は string と して 簡略 表現。 実際 の イベント 形式 は session / token / done / error の 4 種 (詳細 は handler コメント 参照)。 エラー 系 (400/401/503) は 通常 の application/json で 返る。
          */
         post: {
             parameters: {
@@ -693,7 +702,7 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            /** @description sessionId / content / scene / sessionType / scenarioId / attachments */
+            /** @description sessionId / content / scene / sessionType / scenarioId / attachments (最大 4 件) */
             requestBody: {
                 content: {
                     "application/json": components["schemas"]["internal_handler.sseRequestBody"];
@@ -706,34 +715,34 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "text/plain": string;
+                        "text/event-stream": string;
                     };
                 };
-                /** @description バリデーション */
+                /** @description バリデーション (application/json) */
                 400: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "text/plain": components["schemas"]["internal_handler.errorResponse"];
+                        "text/event-stream": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
-                /** @description 未 認証 */
+                /** @description 未 認証 (application/json) */
                 401: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "text/plain": components["schemas"]["internal_handler.errorResponse"];
+                        "text/event-stream": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
-                /** @description Bedrock / DynamoDB 未 設定 (dev/stub) */
+                /** @description Bedrock / DynamoDB 未 設定 (dev/stub、 application/json) */
                 503: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "text/plain": components["schemas"]["internal_handler.errorResponse"];
+                        "text/event-stream": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
             };
@@ -1033,6 +1042,15 @@ export interface paths {
                 };
                 /** @description バリデーション or 実行 失敗 */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -1477,6 +1495,15 @@ export interface paths {
                 };
                 /** @description url 欠落 or 無効 URL */
                 400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -1939,8 +1966,8 @@ export interface paths {
                         "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"][];
                     };
                 };
-                /** @description DB 失敗 */
-                400: {
+                /** @description 未 認証 */
+                401: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -1948,8 +1975,8 @@ export interface paths {
                         "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
-                /** @description 未 認証 */
-                401: {
+                /** @description DB 失敗 */
+                500: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -86,6 +86,16 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "ListByCompanyID 失敗 (現状 実装 で 400 を 返す パス あり)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "未 認証",
                         "content": {
@@ -107,7 +117,7 @@
                         }
                     },
                     "500": {
-                        "description": "DB 失敗",
+                        "description": "DB 失敗 (ListAll 経路)",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -703,7 +713,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。",
+                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE で 配信。 OpenAPI は SSE の カスタム イベント を 完全 表現 でき ない ので レスポンス は string と して 簡略 表現。 実際 の イベント 形式 は session / token / done / error の 4 種 (詳細 は handler コメント 参照)。 エラー 系 (400/401/503) は 通常 の application/json で 返る。",
                 "tags": [
                     "ai-chat"
                 ],
@@ -716,14 +726,14 @@
                             }
                         }
                     },
-                    "description": "sessionId / content / scene / sessionType / scenarioId / attachments",
+                    "description": "sessionId / content / scene / sessionType / scenarioId / attachments (最大 4 件)",
                     "required": true
                 },
                 "responses": {
                     "200": {
                         "description": "SSE stream (text/event-stream)",
                         "content": {
-                            "text/plain": {
+                            "text/event-stream": {
                                 "schema": {
                                     "type": "string"
                                 }
@@ -731,9 +741,9 @@
                         }
                     },
                     "400": {
-                        "description": "バリデーション",
+                        "description": "バリデーション (application/json)",
                         "content": {
-                            "text/plain": {
+                            "text/event-stream": {
                                 "schema": {
                                     "$ref": "#/components/schemas/internal_handler.errorResponse"
                                 }
@@ -741,9 +751,9 @@
                         }
                     },
                     "401": {
-                        "description": "未 認証",
+                        "description": "未 認証 (application/json)",
                         "content": {
-                            "text/plain": {
+                            "text/event-stream": {
                                 "schema": {
                                     "$ref": "#/components/schemas/internal_handler.errorResponse"
                                 }
@@ -751,9 +761,9 @@
                         }
                     },
                     "503": {
-                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub)",
+                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub、 application/json)",
                         "content": {
-                            "text/plain": {
+                            "text/event-stream": {
                                 "schema": {
                                     "$ref": "#/components/schemas/internal_handler.errorResponse"
                                 }
@@ -999,6 +1009,16 @@
                     },
                     "400": {
                         "description": "バリデーション or 実行 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1479,6 +1499,16 @@
                             }
                         }
                     },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
                     "422": {
                         "description": "allow-list 外 ホスト",
                         "content": {
@@ -1905,8 +1935,8 @@
                             }
                         }
                     },
-                    "400": {
-                        "description": "DB 失敗",
+                    "401": {
+                        "description": "未 認証",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1915,8 +1945,8 @@
                             }
                         }
                     },
-                    "401": {
-                        "description": "未 認証",
+                    "500": {
+                        "description": "DB 失敗",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -11,6 +11,758 @@
         "version": "2.0"
     },
     "paths": {
+        "/admin/companies": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社 一覧 (SuperAdmin)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.Company"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/invitations": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin は 自社 のみ。 trainee 等 は 403。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 一覧 (admin)",
+                "parameters": [
+                    {
+                        "description": "SuperAdmin の とき のみ 有効: 特定 company の 招待 のみ",
+                        "name": "companyId",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "trainee / company 未 設定 等",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ 招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 作成",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.createAdminInvReq"
+                            }
+                        }
+                    },
+                    "description": "招待 内容 (CompanyAdmin は companyId が 上書き さ れる)",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "ロール 違反",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/invitations/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "招待 取り消し",
+                "parameters": [
+                    {
+                        "description": "招待 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/attachments/upload-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット 添付 PUT 署名 URL",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.aiChatAttachmentUploadURLRequest"
+                            }
+                        }
+                    },
+                    "description": "filename / contentType / sizeBytes",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "サイズ 上限 超過",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "未 サポート MIME",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "S3 presigner 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "添付 アップロード 機能 が 設定 されて いない (dev/stub)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の AI チャット セッション を 新しい 順 で 返す。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 名義 で 新規 セッション を 作成。 IDOR 対策 で userId は body から 受け取らない。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 作成",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.createSessionReq"
+                            }
+                        }
+                    },
+                    "description": "title 必須",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション を 返す。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 詳細",
+                "parameters": [
+                    {
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "セッション が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション の title を 更新。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション タイトル 更新",
+                "parameters": [
+                    {
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.updateSessionTitleReq"
+                            }
+                        }
+                    },
+                    "description": "title 必須",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の セッション を 削除。 所有者 検証 込み。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット セッション 削除",
+                "parameters": [
+                    {
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "他人 の セッション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "セッション が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/sessions/{id}/messages": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 セッション の 会話 履歴 (DynamoDB から) を 古い 順 で 返す。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット メッセージ 一覧",
+                "parameters": [
+                    {
+                        "description": "セッション ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DynamoDB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ai-chat/stream": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "Bedrock Claude へ メッセージ を 送信 し、 token を SSE (text/event-stream) で 配信。 OpenAPI は SSE を 完全 表現 でき ない ので レスポンス は 200 string と して 簡略 化。 実際 の イベント 形式 は session / token / done / error の 4 種。",
+                "tags": [
+                    "ai-chat"
+                ],
+                "summary": "AI チャット SSE ストリーミング",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.sseRequestBody"
+                            }
+                        }
+                    },
+                    "description": "sessionId / content / scene / sessionType / scenarioId / attachments",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "SSE stream (text/event-stream)",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Bedrock / DynamoDB 未 設定 (dev/stub)",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/auth/cognito/callback": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
@@ -211,6 +963,839 @@
                 }
             }
         },
+        "/code/execute": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。",
+                "tags": [
+                    "code-execution"
+                ],
+                "summary": "コード サンドボックス 実行",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.codeExecuteRequest"
+                            }
+                        }
+                    },
+                    "description": "コード + 言語",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション or 実行 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/courses": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。",
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 CompanyAdmin は 自社 固定。",
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 作成",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.courseRequest"
+                            }
+                        }
+                    },
+                    "description": "作成 内容",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。",
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 詳細",
+                "parameters": [
+                    {
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 更新 (company_admin / super_admin)。",
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 更新",
+                "parameters": [
+                    {
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.courseRequest"
+                            }
+                        }
+                    },
+                    "description": "更新 内容",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。",
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 削除",
+                "parameters": [
+                    {
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}/materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 コース 配下 の 教材 を 返す。 trainee は published のみ。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "コース内 教材 一覧",
+                "parameters": [
+                    {
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "course id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "他社 コース",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/embeds/oembed": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。",
+                "tags": [
+                    "embeds"
+                ],
+                "summary": "外部 URL の OGP / oEmbed メタ 取得",
+                "parameters": [
+                    {
+                        "description": "メタ 取得 対象 URL",
+                        "name": "url",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_infra_embed.Card"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "url 欠落 or 無効 URL",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "allow-list 外 ホスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部 エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "到達 不可",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。",
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習問題 一覧 (status + stats 付き)",
+                "parameters": [
+                    {
+                        "description": "言語 フィルタ (例: php, go, javascript)",
+                        "name": "language",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 集計 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。",
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習問題 詳細 (slug)",
+                "parameters": [
+                    {
+                        "description": "問題 slug (例: php-1)",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "slug 欠落",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 集計 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}/submissions": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の 指定 問題 へ の 提出 履歴 を 新しい 順 で 返す。",
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "提出 履歴 一覧",
+                "parameters": [
+                    {
+                        "description": "問題 slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "slug 欠落",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/{slug}/submit": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の コード を 提出 し sandbox 実行 + 期待 出力 比較 で 採点。 結果 は 履歴 に append。",
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習 コード 提出 + 採点",
+                "parameters": [
+                    {
+                        "description": "問題 slug",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.submitExerciseRequest"
+                            }
+                        }
+                    },
+                    "description": "提出 コード",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "code 欠落 等",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "問題 が 見つから ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB / 採点 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "description": "バックエンド と DB の 疎通 を 確認 する。 ALB / CloudWatch / 監視 から 叩く 想定。",
@@ -283,6 +1868,112 @@
                     },
                     "500": {
                         "description": "内部 エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。",
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "学習 レポート 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports/generate": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。",
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "月次 学習 レポート 生成 要求",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.requestReportReq"
+                            }
+                        }
+                    },
+                    "description": "year + month",
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -377,6 +2068,62 @@
                     },
                     "400": {
                         "description": "バリデーション エラー or DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/notes/image-upload-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。",
+                "tags": [
+                    "notes"
+                ],
+                "summary": "ノート 画像 PUT 署名 URL",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.issueUploadURLReq"
+                            }
+                        }
+                    },
+                    "description": "contentType (任意)"
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "発行 失敗",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -890,6 +2637,150 @@
                 }
             }
         },
+        "/profile/{userId}/image/presigned-url": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 \"me\" / 数字 一致 のみ 許可 (IDOR 対策)。 body は 任意。",
+                "tags": [
+                    "profile"
+                ],
+                "summary": "プロフィール 画像 PUT 署名 URL",
+                "parameters": [
+                    {
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.issueProfileImageReq"
+                            }
+                        }
+                    },
+                    "description": "fileName / contentType (任意)"
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "発行 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/profile/{userId}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
+                "tags": [
+                    "profile"
+                ],
+                "summary": "ユーザー 統計 取得",
+                "parameters": [
+                    {
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/sessions/{sessionId}/note": {
             "get": {
                 "security": [
@@ -1022,6 +2913,352 @@
                     }
                 }
             }
+        },
+        "/teaching-materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 全 件 一覧 (deprecated)",
+                "deprecated": true,
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 courseId 必須。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 作成",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.teachingMaterialCreateRequest"
+                            }
+                        }
+                    },
+                    "description": "作成 内容",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/teaching-materials/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 詳細",
+                "parameters": [
+                    {
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 更新 (company_admin / super_admin)。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 更新",
+                "parameters": [
+                    {
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.teachingMaterialUpdateRequest"
+                            }
+                        }
+                    },
+                    "description": "更新 内容",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 削除 (company_admin / super_admin)。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 削除",
+                "parameters": [
+                    {
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "servers": [
@@ -1039,6 +3276,194 @@
             }
         },
         "schemas": {
+            "github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation": {
+                "type": "object",
+                "properties": {
+                    "companyId": {
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "expiresAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "role": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.AiChatMessage": {
+                "type": "object",
+                "properties": {
+                    "attachments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.Attachment"
+                        }
+                    },
+                    "content": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "messageId": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string"
+                    },
+                    "sessionId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.AiChatSession": {
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "scenarioId": {
+                        "type": "integer"
+                    },
+                    "sessionType": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.Attachment": {
+                "type": "object",
+                "properties": {
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "format": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "type": "string"
+                    },
+                    "sizeBytes": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+                "type": "object",
+                "properties": {
+                    "companyId": {
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "createdByUserId": {
+                        "type": "integer"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "sortOrder": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission": {
+                "type": "object",
+                "properties": {
+                    "exerciseId": {
+                        "type": "integer"
+                    },
+                    "exerciseKind": {
+                        "type": "string"
+                    },
+                    "exitCode": {
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isCorrect": {
+                        "type": "boolean"
+                    },
+                    "stderr": {
+                        "type": "string"
+                    },
+                    "stdout": {
+                        "type": "string"
+                    },
+                    "submittedAt": {
+                        "type": "string"
+                    },
+                    "submittedCode": {
+                        "type": "string"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_domain.Health": {
                 "type": "object",
                 "properties": {
@@ -1046,6 +3471,118 @@
                         "type": "string"
                     },
                     "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.LearningReport": {
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "periodFrom": {
+                        "type": "string"
+                    },
+                    "periodTo": {
+                        "type": "string"
+                    },
+                    "s3Key": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string"
+                    },
+                    "chapterId": {
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "difficulty": {
+                        "type": "integer"
+                    },
+                    "expectedOutput": {
+                        "type": "string"
+                    },
+                    "explanation": {
+                        "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                        "type": "string"
+                    },
+                    "hintText": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。",
+                        "type": "string"
+                    },
+                    "orderIndex": {
+                        "type": "integer"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "starterCode": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample": {
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "exerciseId": {
+                        "description": "(exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で\nOrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。",
+                        "type": "integer"
+                    },
+                    "expectedOutput": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "inputText": {
+                        "type": "string"
+                    },
+                    "orderIndex": {
+                        "description": "OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。\n（default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）",
+                        "type": "integer"
+                    },
+                    "updatedAt": {
                         "type": "string"
                     }
                 }
@@ -1079,6 +3616,20 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL": {
+                "type": "object",
+                "properties": {
+                    "expiresIn": {
+                        "type": "integer"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_domain.Notification": {
                 "type": "object",
                 "properties": {
@@ -1102,6 +3653,23 @@
                     },
                     "userId": {
                         "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.ProfileImageUploadURL": {
+                "type": "object",
+                "properties": {
+                    "expiresIn": {
+                        "type": "integer"
+                    },
+                    "imageUrl": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "uploadUrl": {
+                        "type": "string"
                     }
                 }
             },
@@ -1155,6 +3723,271 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
+                "type": "object",
+                "properties": {
+                    "companyId": {
+                        "type": "integer"
+                    },
+                    "content": {
+                        "type": "string"
+                    },
+                    "courseId": {
+                        "description": "course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を\nAutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。",
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "createdByUserId": {
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "orderInCourse": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
+                "type": "object",
+                "properties": {
+                    "averageScore": {
+                        "type": "number"
+                    },
+                    "longestStreak": {
+                        "type": "integer"
+                    },
+                    "streakDays": {
+                        "type": "integer"
+                    },
+                    "totalSessions": {
+                        "type": "integer"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_infra_embed.Card": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "imageUrl": {
+                        "type": "string"
+                    },
+                    "provider": {
+                        "description": "Provider は \"ogp\" / \"youtube\" / \"github\" など、どの戦略で解決したかを示す。",
+                        "type": "string"
+                    },
+                    "siteName": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
+                "type": "object",
+                "properties": {
+                    "exitCode": {
+                        "type": "integer"
+                    },
+                    "stderr": {
+                        "type": "string"
+                    },
+                    "stdout": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
+                "type": "object",
+                "properties": {
+                    "examples": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"
+                        }
+                    },
+                    "exercise": {
+                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string"
+                    },
+                    "chapterId": {
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "difficulty": {
+                        "type": "integer"
+                    },
+                    "expectedOutput": {
+                        "type": "string"
+                    },
+                    "explanation": {
+                        "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                        "type": "string"
+                    },
+                    "hintText": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。",
+                        "type": "string"
+                    },
+                    "orderIndex": {
+                        "type": "integer"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "starterCode": {
+                        "type": "string"
+                    },
+                    "stats": {
+                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
+                "type": "object",
+                "properties": {
+                    "isCorrect": {
+                        "type": "boolean"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult"
+                        }
+                    },
+                    "submissionId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.TestCaseResult": {
+                "type": "object",
+                "properties": {
+                    "actualOutput": {
+                        "type": "string"
+                    },
+                    "expectedOutput": {
+                        "type": "string"
+                    },
+                    "input": {
+                        "type": "string"
+                    },
+                    "orderIndex": {
+                        "type": "integer"
+                    },
+                    "passed": {
+                        "type": "boolean"
+                    },
+                    "stderr": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL": {
+                "type": "object",
+                "properties": {
+                    "expiresIn": {
+                        "type": "integer"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "uploadUrl": {
+                        "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats": {
+                "type": "object",
+                "properties": {
+                    "solvedUsers": {
+                        "type": "integer"
+                    },
+                    "totalSubmissions": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "internal_handler.aiChatAttachmentUploadURLRequest": {
+                "type": "object",
+                "properties": {
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "sizeBytes": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "internal_handler.codeExecuteRequest": {
+                "type": "object",
+                "required": [
+                    "code"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    },
+                    "language": {
+                        "type": "string"
+                    }
+                }
+            },
             "internal_handler.cognitoCallbackReq": {
                 "type": "object",
                 "required": [
@@ -1166,6 +3999,62 @@
                     },
                     "invitationToken": {
                         "description": "InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で\n受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より\n優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。",
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.courseRequest": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "sortOrder": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.createAdminInvReq": {
+                "type": "object",
+                "required": [
+                    "companyId",
+                    "email",
+                    "role"
+                ],
+                "properties": {
+                    "companyId": {
+                        "type": "integer"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.createSessionReq": {
+                "type": "object",
+                "required": [
+                    "title"
+                ],
+                "properties": {
+                    "scenarioId": {
+                        "type": "integer"
+                    },
+                    "sessionType": {
+                        "type": "string"
+                    },
+                    "title": {
                         "type": "string"
                     }
                 }
@@ -1197,6 +4086,25 @@
                     "role": {
                         "type": "string",
                         "example": "trainee"
+                    }
+                }
+            },
+            "internal_handler.issueProfileImageReq": {
+                "type": "object",
+                "properties": {
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "fileName": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.issueUploadURLReq": {
+                "type": "object",
+                "properties": {
+                    "contentType": {
+                        "type": "string"
                     }
                 }
             },
@@ -1301,10 +4209,123 @@
                     }
                 }
             },
+            "internal_handler.requestReportReq": {
+                "type": "object",
+                "required": [
+                    "month",
+                    "year"
+                ],
+                "properties": {
+                    "month": {
+                        "type": "integer",
+                        "maximum": 12,
+                        "minimum": 1
+                    },
+                    "year": {
+                        "type": "integer",
+                        "maximum": 2100,
+                        "minimum": 2000
+                    }
+                }
+            },
             "internal_handler.sessionNoteUpsertReq": {
                 "type": "object",
                 "properties": {
                     "content": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.sseAttachmentRequest": {
+                "type": "object",
+                "properties": {
+                    "contentType": {
+                        "type": "string"
+                    },
+                    "filename": {
+                        "type": "string"
+                    },
+                    "key": {
+                        "type": "string"
+                    },
+                    "sizeBytes": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "internal_handler.sseRequestBody": {
+                "type": "object",
+                "properties": {
+                    "attachments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/internal_handler.sseAttachmentRequest"
+                        }
+                    },
+                    "content": {
+                        "type": "string"
+                    },
+                    "scenarioId": {
+                        "type": "integer"
+                    },
+                    "scene": {
+                        "type": "string"
+                    },
+                    "sessionId": {
+                        "type": "integer"
+                    },
+                    "sessionType": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.submitExerciseRequest": {
+                "type": "object",
+                "required": [
+                    "code"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.teachingMaterialCreateRequest": {
+                "type": "object",
+                "required": [
+                    "courseId"
+                ],
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "courseId": {
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "orderInCourse": {
+                        "type": "integer"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.teachingMaterialUpdateRequest": {
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "orderInCourse": {
+                        "type": "integer"
+                    },
+                    "title": {
                         "type": "string"
                     }
                 }
@@ -1330,6 +4351,17 @@
                         "type": "string"
                     },
                     "status": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.updateSessionTitleReq": {
+                "type": "object",
+                "required": [
+                    "title"
+                ],
+                "properties": {
+                    "title": {
                         "type": "string"
                     }
                 }


### PR DESCRIPTION
## 概要

OpenAPI 段階 導入 の 仕上げ。 Phase 3 (REST 残り) + Phase 4 (SSE / 添付 upload) を 1 PR に まとめ、 backend の **全 39 path / ~50 endpoint** が spec に 載る 状態 に なる。 frontend の `src/generated/api.ts` も 自動 追従。

## 追加 endpoint

- /exercises (一覧 / 詳細 / 提出 / 履歴)
- /courses + /courses/{id}/materials + /teaching-materials/{id} (CRUD)
- /admin/companies, /admin/invitations (List / Create / Cancel)
- /ai-chat/sessions (5 endpoint) + /ai-chat/attachments/upload-url + /ai-chat/stream (SSE)
- /learning-reports + /generate
- /profile/{userId}/stats + /image/presigned-url
- /code/execute (sandbox 実行)
- /embeds/oembed (OGP)
- /notes/image-upload-url

## IDOR 修正

NoteImageHandler.IssueUploadURL も body の userId 受け取り を 撤回 し middleware.CurrentUserIDOrZero(c) で 強制。 Phase 2 で session_note を 直した のと 同 パターン。

## SSE の OpenAPI 表現

/ai-chat/stream は text/event-stream で 4 種類 (session / token / done / error) の カスタム イベント を 流す が、 OpenAPI 2.0/3.x は SSE の カスタム イベント を 表現 でき ない。 `@Produce plain` + `@Success 200 string` で 「SSE stream を 返す」 と 簡略 表現 し、 詳細 形式 は `@Description` に 記載。

## テスト

- [x] gofmt / vet / build / test / staticcheck 緑
- [x] `make openapi` で 39 path 生成
- [x] frontend `npm run openapi:generate` 緑 (~1500 行 の api.ts)
- [x] frontend `tsc --noEmit` 緑

## 関連

- PR #1725 / #1726 (Phase 1, merged)
- PR #1727 (Phase 2, merged)
- 教材 章 028 「OpenAPI で API 契約」 は 本 PR merge 後 に 別 PR で 追加 予定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * API ドキュメンテーション（OpenAPI/Swagger 仕様）を大幅に拡張し、複数のエンドポイント（管理系、AI チャット、学習レポート、教材管理など）の詳細な仕様を明確化しました。

* **Bug Fixes**
  * ノート画像アップロード機能における認証ロジックを改善し、セキュリティ対策を強化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->