### PR TITLE
feat(backend): Supabase 移行 Phase 1 - DATABASE_URL + pgbouncer 互換 サポート

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # =========================
 # データベース
 # =========================
-# Supabase の transaction pooler URL を 推奨 (本番 / staging)。
-# 例: postgresql://postgres.xxxxx:PASSWORD@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true
-# DATABASE_URL が セット されて いる と DB_HOST 等 は 無視 さ れる。
+# Supabase の transaction pooler URL を 推奨 (本番 / staging)。 TLS 必須 (= sslmode=require)。
+# 例: postgresql://postgres.xxxxx:PASSWORD@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true&sslmode=require
+# DATABASE_URL がセットされていると DB_HOST 等は無視される。
 DATABASE_URL=
 
 # 個別 設定 (DATABASE_URL 未 設定 時 の フォールバック / ローカル 開発 用)

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,20 @@
+# =========================
+# データベース
+# =========================
+# Supabase の transaction pooler URL を 推奨 (本番 / staging)。
+# 例: postgresql://postgres.xxxxx:PASSWORD@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true
+# DATABASE_URL が セット されて いる と DB_HOST 等 は 無視 さ れる。
+DATABASE_URL=
+
+# 個別 設定 (DATABASE_URL 未 設定 時 の フォールバック / ローカル 開発 用)
+# RDS / ローカル PostgreSQL に 直接 つなぐ 場合 は こちら を 使う。
+DB_HOST=
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=
+DB_NAME=fre_style
+DB_SSLMODE=require
+
 # AWS Cognito
 COGNITO_CLIENT_ID=your-cognito-client-id
 COGNITO_CLIENT_SECRET=your-cognito-client-secret

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -8,6 +8,14 @@ import (
 type Config struct {
 	AppEnv     string
 	ServerPort string
+
+	// DatabaseURL は Supabase 等 の マネージド Postgres 用 の 完全 接続 文字 列。
+	// 例: "postgresql://postgres.xxxx:pwd@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
+	// 環境 変数 DATABASE_URL が セット されて いる と こちら を 優先 し、 個別 の DB_HOST 等 は 無視 する。
+	// RDS から Supabase へ の 段階 移行 用 (= URL を 切り替える だけ で 接続 先 を 変えられる)。
+	DatabaseURL string
+
+	// 個別 接続 設定 (DATABASE_URL 未 セット 時 の フォールバック / ローカル 開発 用)
 	DBHost     string
 	DBPort     string
 	DBUser     string
@@ -65,15 +73,16 @@ type CognitoConfig struct {
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		AppEnv:     getEnvOrDefault("APP_ENV", "local"),
-		ServerPort: getEnvOrDefault("PORT", "8080"),
-		DBHost:     os.Getenv("DB_HOST"),
-		DBPort:     getEnvOrDefault("DB_PORT", "5432"),
-		DBUser:     getEnvOrDefault("DB_USER", "postgres"),
-		DBPassword: os.Getenv("DB_PASSWORD"),
-		DBName:     getEnvOrDefault("DB_NAME", "fre_style"),
-		DBSSLMode:  getEnvOrDefault("DB_SSLMODE", "require"),
-		AppBaseURL: getEnvOrDefault("APP_BASE_URL", ""),
+		AppEnv:      getEnvOrDefault("APP_ENV", "local"),
+		ServerPort:  getEnvOrDefault("PORT", "8080"),
+		DatabaseURL: os.Getenv("DATABASE_URL"),
+		DBHost:      os.Getenv("DB_HOST"),
+		DBPort:      getEnvOrDefault("DB_PORT", "5432"),
+		DBUser:      getEnvOrDefault("DB_USER", "postgres"),
+		DBPassword:  os.Getenv("DB_PASSWORD"),
+		DBName:      getEnvOrDefault("DB_NAME", "fre_style"),
+		DBSSLMode:   getEnvOrDefault("DB_SSLMODE", "require"),
+		AppBaseURL:  getEnvOrDefault("APP_BASE_URL", ""),
 		Cognito: CognitoConfig{
 			ClientID:     os.Getenv("COGNITO_CLIENT_ID"),
 			ClientSecret: os.Getenv("COGNITO_CLIENT_SECRET"),
@@ -115,13 +124,21 @@ func Load() (*Config, error) {
 			FromAddress: os.Getenv("SES_FROM_ADDRESS"),
 		},
 	}
-	if cfg.DBHost == "" {
-		return nil, fmt.Errorf("DB_HOST is required")
+	// DATABASE_URL が セット されて いれ ば そちら 優先 / DB_HOST フォールバック で
+	// 少なくとも どちら か は 設定 されて いる 必要 が ある。
+	if cfg.DatabaseURL == "" && cfg.DBHost == "" {
+		return nil, fmt.Errorf("DATABASE_URL or DB_HOST is required")
 	}
 	return cfg, nil
 }
 
+// PostgresDSN は GORM に 渡す DSN を 返す。
+// DATABASE_URL (例: Supabase pooler の "postgresql://..." 形式) が あれば そのまま 返す。
+// 無ければ 旧 RDS 形式 の 個別 設定 から DSN を 組み立てる (= 後方 互換)。
 func (c *Config) PostgresDSN() string {
+	if c.DatabaseURL != "" {
+		return c.DatabaseURL
+	}
 	return fmt.Sprintf(
 		"host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
 		c.DBHost, c.DBPort, c.DBUser, c.DBPassword, c.DBName, c.DBSSLMode,

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -10,8 +10,8 @@ type Config struct {
 	ServerPort string
 
 	// DatabaseURL は Supabase 等 の マネージド Postgres 用 の 完全 接続 文字 列。
-	// 例: "postgresql://postgres.xxxx:pwd@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true"
-	// 環境 変数 DATABASE_URL が セット されて いる と こちら を 優先 し、 個別 の DB_HOST 等 は 無視 する。
+	// 例: "postgresql://postgres.xxxx:pwd@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true&sslmode=require"
+	// 環境 変数 DATABASE_URL がセットされていると こちらを 優先 し、 個別 の DB_HOST 等 は 無視 する。
 	// RDS から Supabase へ の 段階 移行 用 (= URL を 切り替える だけ で 接続 先 を 変えられる)。
 	DatabaseURL string
 
@@ -124,7 +124,7 @@ func Load() (*Config, error) {
 			FromAddress: os.Getenv("SES_FROM_ADDRESS"),
 		},
 	}
-	// DATABASE_URL が セット されて いれ ば そちら 優先 / DB_HOST フォールバック で
+	// DATABASE_URL がセットされていればそちら 優先 / DB_HOST フォールバック で
 	// 少なくとも どちら か は 設定 されて いる 必要 が ある。
 	if cfg.DatabaseURL == "" && cfg.DBHost == "" {
 		return nil, fmt.Errorf("DATABASE_URL or DB_HOST is required")

--- a/backend/internal/infra/database/postgres.go
+++ b/backend/internal/infra/database/postgres.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
@@ -47,10 +48,44 @@ func NewPostgres(cfg *config.Config) (*gorm.DB, error) {
 }
 
 // isPgBouncerDSN は DSN が Supabase transaction pooler 等 の pgbouncer 経由 か を 判定 する。
-// 判定 基準: URL 形式 で "pgbouncer=true" クエリ パラメータ が 付いて いる か、
-// または ホスト 名 に "pooler.supabase.com" が 含まれる か。
+//
+// 判定 基準 (順 番 に):
+//  1. URL 形式 (postgres:// / postgresql://) なら net/url で parse し、 query string の
+//     pgbouncer=true / ホスト 名 が pooler.supabase.com を 含む かを 厳密 に 見る。
+//     これ により パスワード / path に 偶然 "pgbouncer=true" の 文字 列 が 含まれて も
+//     false positive に なら ない。
+//  2. key=value 形式 (host=... user=...) なら host= の 値 だけ を 切り 出して 判定。
 func isPgBouncerDSN(dsn string) bool {
-	d := strings.ToLower(dsn)
-	return strings.Contains(d, "pgbouncer=true") ||
-		strings.Contains(d, "pooler.supabase.com")
+	trimmed := strings.TrimSpace(dsn)
+	lower := strings.ToLower(trimmed)
+
+	// 1. URL 形式
+	if strings.HasPrefix(lower, "postgres://") || strings.HasPrefix(lower, "postgresql://") {
+		u, err := url.Parse(trimmed)
+		if err != nil {
+			return false
+		}
+		if u.Query().Get("pgbouncer") == "true" {
+			return true
+		}
+		if strings.Contains(strings.ToLower(u.Host), "pooler.supabase.com") {
+			return true
+		}
+		return false
+	}
+
+	// 2. key=value 形式 (= 旧 RDS DSN フォールバック)
+	// "host=foo.pooler.supabase.com" を 検知 する ため、 host= キー だけ を 厳密 に 取る。
+	for _, kv := range strings.Fields(trimmed) {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		k := strings.ToLower(kv[:eq])
+		v := strings.ToLower(kv[eq+1:])
+		if k == "host" && strings.Contains(v, "pooler.supabase.com") {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/infra/database/postgres.go
+++ b/backend/internal/infra/database/postgres.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"gorm.io/driver/postgres"
@@ -9,11 +10,28 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// NewPostgres は GORM で PostgreSQL に 接続 する。
+//
+// DATABASE_URL が "pgbouncer=true" を 含む (= Supabase transaction pooler 接続) 場合 は
+// GORM の prepared statement キャッシュ を 無効 化 + driver 側 で simple query protocol を
+// 強制 する。 transaction-mode の pgbouncer は 接続 単位 の prepared statement を サポート
+// し ない ため、 デフォルト の まま だ と "prepared statement does not exist" エラー が
+// ランダム に 発生 する。
 func NewPostgres(cfg *config.Config) (*gorm.DB, error) {
 	gormCfg := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
 	}
-	db, err := gorm.Open(postgres.Open(cfg.PostgresDSN()), gormCfg)
+
+	dsn := cfg.PostgresDSN()
+	pgCfg := postgres.Config{
+		DSN: dsn,
+	}
+	if isPgBouncerDSN(dsn) {
+		gormCfg.PrepareStmt = false
+		pgCfg.PreferSimpleProtocol = true
+	}
+
+	db, err := gorm.Open(postgres.New(pgCfg), gormCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open postgres: %w", err)
 	}
@@ -26,4 +44,13 @@ func NewPostgres(cfg *config.Config) (*gorm.DB, error) {
 	sqlDB.SetMaxOpenConns(10)
 
 	return db, nil
+}
+
+// isPgBouncerDSN は DSN が Supabase transaction pooler 等 の pgbouncer 経由 か を 判定 する。
+// 判定 基準: URL 形式 で "pgbouncer=true" クエリ パラメータ が 付いて いる か、
+// または ホスト 名 に "pooler.supabase.com" が 含まれる か。
+func isPgBouncerDSN(dsn string) bool {
+	d := strings.ToLower(dsn)
+	return strings.Contains(d, "pgbouncer=true") ||
+		strings.Contains(d, "pooler.supabase.com")
 }


### PR DESCRIPTION
## 概要

RDS → Supabase の 段階 移行 の **第 一 歩**。 backend が \`DATABASE_URL\` env を 受け取り、 Supabase transaction pooler (pgbouncer) と 互換 動作 する。 既存 の RDS 経由 (DB_HOST / DB_USER 等) と **並列 サポート** な ので、 env var を 切替 える だけ で 接続 先 を 変えられる。 RDS は 削除 し ない の で 即 ロール バック 可能。

## 変更 内容

### \`backend/internal/infra/config/config.go\`
- \`Config.DatabaseURL\` フィールド 新設 (= env \`DATABASE_URL\`)
- \`Load()\` で セット されて いれ ば 優先、 個別 \`DB_HOST\` 等 は フォールバック
- \`PostgresDSN()\` が DATABASE_URL を そのまま 返す (Supabase pooler URL 形式 を 受け取る)
- バリデーション: DATABASE_URL or DB_HOST どちら か 必須

### \`backend/internal/infra/database/postgres.go\`
- \`isPgBouncerDSN(dsn)\` ヘルパ で DSN が Supabase pooler 経由 か 判定
- pgbouncer 経由 の とき:
  - \`gorm.Config.PrepareStmt = false\` (= GORM の prepared statement キャッシュ 無効)
  - \`postgres.Config.PreferSimpleProtocol = true\` (= driver の extended protocol 無効)
- これら を 設定 し ない と \"prepared statement does not exist\" が ランダム 発生 する (= pgbouncer transaction mode の 既知 制約)

### \`.env.example\`
- DATABASE_URL を トップ に 配置 + Supabase URL 形式 の 例 を 記載
- 個別 設定 (DB_HOST 等) は フォールバック と して 残す

### CLAUDE.md (gitignore 済、 コミット せず)
- §6.2 を Supabase 手順 と RDS 手順 の **並記** に 更新
- §6.2.3 「移行 状態」 表 を 追加 (Phase 1〜7 の チェック リスト)

## 互換 性

- **DATABASE_URL を セット し ない**: 既存 RDS 接続 と 完全 互換、 挙動 不変 (= デプロイ し ても 何 も 変わら ない)
- **DATABASE_URL を セット する**: Supabase pooler 接続 + pgbouncer 互換 設定 が 自動 適用

これ により **「PR を merge → デプロイ → 問題 なし」 を 先 に 確認 してから、 後日 env var を 切り替える」** という 安全 な フェーズ 分け が 可能。

## テスト

- [x] gofmt / vet / build / test / staticcheck 緑
- [x] \`make verify\` 緑
- [ ] 本番 ECS デプロイ 後 に \`GET /api/v2/health\` が 200 (= 既存 RDS 接続 が 変わら ず 動く)

## 次 ステップ (この PR merge 後)

1. **Supabase project 作成** (resjimkalto89890@gmail.com アカウント、 ap-northeast-1 Tokyo)
2. 接続 文字 列 を AWS Secrets Manager に 保存
3. ECS task definition に DATABASE_URL env を 追加 (PR 2)
4. データ 移行 (pg_dump RDS → psql restore Supabase)
5. 本番 検証 (= 1〜2 日)
6. RDS / bastion 廃止 (\`make destroy-rds\` + \`make destroy-bastion\`)
7. 教材 / CFn / docs を Supabase 前提 に 更新

詳細 は CLAUDE.md §6.2 を 参照。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベース接続設定を改善し、環境変数の優先順位を明確化しました。
  * pgbouncer経由の接続時に接続パフォーマンスを最適化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->