### PR TITLE
fix(docs): PR #1730 マージ後の CodeRabbit / Copilot 指摘 5 件 を follow-up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,12 +10,18 @@ DATABASE_URL=
 
 # 個別 設定 (DATABASE_URL 未 設定 時 の フォールバック / ローカル の docker postgres など)。
 # 通常は DATABASE_URL を使うため不要。
+#
+# DB_SSLMODE の値:
+#   - require  : 本番 / staging で 旧 RDS 等 の TLS 必須 DB に つなぐ場合
+#   - disable  : ローカル docker postgres など TLS 設定 が ない DB の場合
+#   未指定なら backend (config.go) の getEnvOrDefault で "require" になるので、
+#   ローカル docker 利用時は明示的に DB_SSLMODE=disable に書き換えること。
 DB_HOST=
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=
 DB_NAME=fre_style
-DB_SSLMODE=require
+DB_SSLMODE=disable
 
 # AWS Cognito
 COGNITO_CLIENT_ID=your-cognito-client-id

--- a/backend/README.md
+++ b/backend/README.md
@@ -51,14 +51,18 @@ go run ./cmd/server
 ```
 
 DATABASE_URL の取得方法:
-- ローカル: `~/.config/aws/` 等で credentials 設定後、 `aws secretsmanager get-secret-value --region ap-northeast-1 --secret-id frestyle-prod/database-url --query SecretString --output text`
-- 各自の Supabase project を使う場合: Dashboard → 上部 `Connect` → `Direct` タブ → `Transaction pooler` の URI
+- **ローカル / dev 開発**: 各自で Supabase project を作成し、 Dashboard → 上部 `Connect` → `Direct` タブ → `Transaction pooler` の URI を取得。 個人 dev 用 secret に保存する場合は `frestyle-dev/database-url` のように環境 prefix を分けることを推奨（本番 secret `frestyle-prod/database-url` をローカルから参照すると誤更新リスクあり）
+- **CI / staging**: AWS Secrets Manager の対応する `<env>/database-url` から取得:
+  ```bash
+  aws secretsmanager get-secret-value --region ap-northeast-1 \
+    --secret-id <env>/database-url --query SecretString --output text
+  ```
 
 確認:
 
 ```bash
 curl http://localhost:8080/
-# => {"message":"FreStyle Go backend (Phase 0 bootstrap)"}
+# => {"message":"FreStyle Go backend"}
 ```
 
 ## ビルド（Docker）

--- a/frontend/src/hooks/useBackendHealth.ts
+++ b/frontend/src/hooks/useBackendHealth.ts
@@ -3,9 +3,15 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 /**
  * バックエンド (`/api/v2/health`) の死活ヘルスチェック。
  *
- * 用途: 毎日 22:00〜翌 07:00 JST の scheduled-stop 窓や突発障害で ECS / ALB が
- * 落ちているときに、フロント側で「メンテナンス中ページ」へ切り替えるための
- * シグナルを返す。
+ * 用途: 突発障害 / デプロイ中の rolling update 谷間 / Supabase 側のメンテ等で
+ * ECS / ALB / DB が落ちているときに、フロント側で「メンテナンス中ページ」へ
+ * 切り替えるためのシグナルを返す。
+ *
+ * 経緯: 2026-05 まで存在した「毎日 22:00〜翌 07:00 JST に ECS / ALB / RDS を
+ * 停止する scheduled-stop ワークフロー」は Supabase 移行 (PR #1730) で廃止。
+ * 現在は 24/7 稼働だが、 デプロイ中 / 突発障害 / Cognito 連携障害 等で
+ * 一時的に backend が応答しないケースがあるため、 本ヘルスチェックは継続して
+ * 機能する。
  *
  * 仕様:
  *   - 初期値は `'unknown'`。最初の 1 回のチェックが完了するまでアプリ本体は

--- a/frontend/src/pages/MaintenancePage.tsx
+++ b/frontend/src/pages/MaintenancePage.tsx
@@ -3,8 +3,13 @@
  *
  * 表示条件: useBackendHealth が `'unhealthy'` のとき App.tsx が本ページを描画する。
  * 主な発生源:
- *   - 毎日 22:00 JST の scheduled-stop で ECS / ALB / RDS が destroy される時間帯
+ *   - cd-backend デプロイ中の rolling update 谷間 (= 数秒〜1 分)
  *   - 突発的な ECS 障害 / ALB 設定ミス / DNS 解決失敗
+ *   - Supabase 側のメンテナンス / 接続エラー
+ *
+ * 経緯: 2026-05 まで「毎日 22:00 JST の scheduled-stop で ECS / ALB / RDS を
+ * destroy する時間帯」が発生源だったが、 Supabase 移行 (PR #1730) で
+ * scheduled-stop / scheduled-start ワークフローを廃止。 現在は 24/7 稼働。
  *
  * 自動復帰: 親 (useBackendHealth) が 15 秒間隔で health を叩き続け、応答が
  * 返るようになった瞬間に App 側で `<Routes>` 表示に戻る。


### PR DESCRIPTION
## 概要

PR #1730 (= scheduled-stop 廃止 + README / .env.example 更新) を緊急 admin merge した際に、 CodeRabbit + Copilot が出した **inline 指摘 5 件** (= docs nit 系) に対応。

## 指摘 と 修正

| # | 場所 | 指摘 元 / 重大度 | 内容 | 修正 |
|---|---|---|---|---|
| 1 | `.env.example:12` | CodeRabbit 🟠 Major | DB_SSLMODE=require と ローカル fallback 説明が矛盾 | 値 (require/disable) の意味を コメントで明示 + デフォルトを `disable` に |
| 2 | `backend/README.md:55` | CodeRabbit 🟠 Major | 本番 secret `frestyle-prod/database-url` をローカル手順で参照 = 誤更新リスク | ローカル / dev は 「各自 Supabase + `<env>/database-url` 形式」 を推奨 / CI は `<env>/database-url` プレースホルダー |
| 3 | `README.md:372` | CodeRabbit 🟡 Minor | 動作確認のレスポンス例不一致 | backend/README.md (#4) を統一して解消 |
| 4 | `backend/README.md:55` | Copilot 🟡 Minor | "(Phase 0 bootstrap)" 文言が現実装 (`router.go`) と不一致 | `{"message":"FreStyle Go backend"}` に統一 |
| 5 | `useBackendHealth.ts` / `MaintenancePage.tsx` | Copilot 🟡 Minor | scheduled-stop 前提コメント残存 (README で廃止と書いたのに) | 「2026-05 廃止 / 現在は 24/7 稼働」 経緯コメント追加 + 用途を rolling deploy / 突発障害 / Supabase メンテに更新 |

## テスト

- [x] frontend lint / `tsc --noEmit` pass (= コメント のみ で 壊れない)
- [x] backend は触っていない (= docs のみ)
- [x] \`grep \"scheduled-stop\\|Phase 0 bootstrap\"\` で active な参照が残っていないこと確認 (= 全 て 歴史 的 経緯 の 説明 として 残存)

## 関連

- PR #1730 (= 緊急 admin merge した PR / 本 PR の 元 になった 5 件 の inline 指摘)
- norman6464/frestyle-infrastructure#56-58 (= Supabase 移行 PR シリーズ)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 環境別のデータベース接続設定手順を明確化しました。
  * ローカル開発環境での設定手順とCI/ステージング環境での設定方法をドキュメント化しました。
  * バックエンド稼働状況に関する説明を更新しました。

* **Chores**
  * データベース接続のデフォルト設定を簡素化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->