### PR TITLE
ci: scheduled-stop / scheduled-start を Supabase 版で復活

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -1,0 +1,255 @@
+name: Scheduled - Start (recreate ALB + ECS at morning)
+
+# 目的: 毎日 07:00 JST (22:00 UTC) に ALB と ECS を再作成して稼働開始。
+#       scheduled-stop.yml と対になる。
+#
+# 流れ:
+#   1) ROLLBACK_COMPLETE で残った stale stack を self-heal で削除
+#   2) ALB を CFn deploy（新しい AWS DNS 名が払い出される）
+#   3) ECS を CFn deploy（DATABASE_URL は Secrets Manager から inject）
+#   4) Route 53 で api.normanblog.com の Alias レコードを新 ALB に更新
+#      (normanblog.com の Hosted Zone Z02128031IOUNFFKBRXXE)
+#   5) services-stable wait + ヘルスチェック
+#
+# 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+#
+# 2026-05 Supabase 移行 後 の 構成:
+#   - DB は Supabase (24/7 稼働、CFn 管理外)
+#   - 旧 RDS / 旧 nightly snapshot 復元 step は 削除済
+#   - ECS の DATABASE_URL は Secrets Manager (`frestyle-prod/database-url`) から
+#     ECS Task Secrets 経由 で 注入 (env var ではなく secret として)
+
+on:
+  schedule:
+    # 07:00 JST = 22:00 UTC（前日）、毎日
+    - cron: '0 22 * * *'
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '手動実行時は "start" と入力'
+        required: true
+        type: string
+
+env:
+  AWS_REGION: ap-northeast-1
+  STACK_PFX: frestyle-prod
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+  IAC_REPO: norman6464/frestyle-infrastructure
+  # Supabase Transaction pooler URL を保存した Secrets Manager の name
+  DATABASE_URL_SECRET_NAME: frestyle-prod/database-url
+  # Route 53: normanblog.com の権威 Hosted Zone（CloudFront も同ゾーンに紐付いている正規ゾーン）
+  R53_HOSTED_ZONE_ID: Z02128031IOUNFFKBRXXE
+  R53_RECORD_NAME: api.normanblog.com
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  start:
+    name: Recreate ALB + ECS
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Verify input (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm }}" != "start" ]; then
+            echo "ERROR: confirm に 'start' と入力されていません"
+            exit 1
+          fi
+
+      - name: Checkout frestyle-infrastructure
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.IAC_REPO }}
+          token: ${{ secrets.IAC_REPO_TOKEN }}
+          path: iac
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: frestyle-scheduled-start
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Cleanup stale ROLLBACK_COMPLETE stacks (self-healing)
+        run: |
+          # 前夜の scheduled-stop / 前回の cd-backend が ROLLBACK_COMPLETE で残っていると
+          # 今回の deploy が "stack cannot be updated" で失敗する。先に削除しておく。
+          for STACK in $STACK_PFX-ecs $STACK_PFX-alb; do
+            STATUS=$(aws cloudformation describe-stacks --region $AWS_REGION \
+              --stack-name $STACK --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "ABSENT")
+            case "$STATUS" in
+              ROLLBACK_COMPLETE|UPDATE_ROLLBACK_COMPLETE|CREATE_FAILED)
+                echo "Stack $STACK is in $STATUS — deleting before redeploy"
+                aws cloudformation delete-stack --region $AWS_REGION --stack-name $STACK
+                aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $STACK || true
+                ;;
+              *)
+                echo "Stack $STACK status=$STATUS (no cleanup needed)"
+                ;;
+            esac
+          done
+
+      - name: Deploy ALB stack
+        run: |
+          ALB_SG=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sg \
+            --query 'Stacks[0].Outputs[?OutputKey==`AlbSecurityGroupId`].OutputValue' --output text)
+          aws cloudformation deploy --region $AWS_REGION \
+            --stack-name $STACK_PFX-alb \
+            --template-file iac/infrastructure/cloudformation/templates/runtime/alb.yml \
+            --parameter-overrides Environment=prod AlbSecurityGroupId=$ALB_SG \
+            --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
+            --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
+
+      - name: Resolve dependent stack outputs
+        id: deps
+        run: |
+          ECS_SG=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sg \
+            --query 'Stacks[0].Outputs[?OutputKey==`EcsServiceSecurityGroupId`].OutputValue' --output text)
+          TG_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-alb \
+            --query 'Stacks[0].Outputs[?OutputKey==`TargetGroupArn`].OutputValue' --output text)
+          S3_BUCKET=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-s3 \
+            --query 'Stacks[0].Outputs[?OutputKey==`NoteImagesBucketName`].OutputValue' --output text)
+          SQS_URL=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-sqs \
+            --query 'Stacks[0].Outputs[?OutputKey==`ReportQueueUrl`].OutputValue' --output text)
+          EXEC_ROLE=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-iam \
+            --query 'Stacks[0].Outputs[?OutputKey==`TaskExecutionRoleArn`].OutputValue' --output text)
+          TASK_ROLE=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-iam \
+            --query 'Stacks[0].Outputs[?OutputKey==`TaskRoleArn`].OutputValue' --output text)
+          # Supabase 接続 URL の Secret ARN (Transaction pooler / port 6543)
+          DB_URL_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
+            --secret-id "$DATABASE_URL_SECRET_NAME" --query 'ARN' --output text 2>/dev/null)
+          if [ -z "$DB_URL_ARN" ] || [ "$DB_URL_ARN" = "None" ]; then
+            echo "::error::DATABASE_URL_SECRET_NAME=$DATABASE_URL_SECRET_NAME を Secrets Manager で見つけられませんでした"
+            exit 1
+          fi
+          COG_SEC_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
+            --secret-id $STACK_PFX/cognito-client-secret --query 'ARN' --output text)
+          ALB_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-alb \
+            --query 'Stacks[0].Outputs[?OutputKey==`LoadBalancerArn`].OutputValue' --output text)
+          ALB_DNS=$(aws elbv2 describe-load-balancers --region $AWS_REGION \
+            --load-balancer-arns "$ALB_ARN" \
+            --query 'LoadBalancers[0].DNSName' --output text)
+          # ALB の CanonicalHostedZoneId（Route 53 Alias レコードで参照する固定値）
+          ALB_HOSTED_ZONE_ID=$(aws elbv2 describe-load-balancers --region $AWS_REGION \
+            --load-balancer-arns "$ALB_ARN" \
+            --query 'LoadBalancers[0].CanonicalHostedZoneId' --output text)
+
+          {
+            echo "ecs_sg=$ECS_SG"
+            echo "tg_arn=$TG_ARN"
+            echo "s3_bucket=$S3_BUCKET"
+            echo "sqs_url=$SQS_URL"
+            echo "exec_role=$EXEC_ROLE"
+            echo "task_role=$TASK_ROLE"
+            echo "db_url_arn=$DB_URL_ARN"
+            echo "cog_sec_arn=$COG_SEC_ARN"
+            echo "alb_dns=$ALB_DNS"
+            echo "alb_hosted_zone_id=$ALB_HOSTED_ZONE_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Deploy ECS stack
+        env:
+          ECS_SG: ${{ steps.deps.outputs.ecs_sg }}
+          TG_ARN: ${{ steps.deps.outputs.tg_arn }}
+          S3_BUCKET: ${{ steps.deps.outputs.s3_bucket }}
+          SQS_URL: ${{ steps.deps.outputs.sqs_url }}
+          EXEC_ROLE: ${{ steps.deps.outputs.exec_role }}
+          TASK_ROLE: ${{ steps.deps.outputs.task_role }}
+          DB_URL_ARN: ${{ steps.deps.outputs.db_url_arn }}
+          COG_SEC_ARN: ${{ steps.deps.outputs.cog_sec_arn }}
+        run: |
+          # DBHost / DBPasswordSecretArn は Supabase 運用 では 空文字 で 明示 的 に 渡す
+          # (CFn の 前回値 retain を 回避 する ため)。
+          aws cloudformation deploy --region $AWS_REGION \
+            --stack-name $STACK_PFX-ecs \
+            --template-file iac/infrastructure/cloudformation/templates/runtime/ecs.yml \
+            --parameter-overrides \
+              Environment=prod \
+              EcsServiceSecurityGroupId="$ECS_SG" \
+              TargetGroupArn="$TG_ARN" \
+              DatabaseUrlSecretArn="$DB_URL_ARN" \
+              DBHost= \
+              DBPasswordSecretArn= \
+              CognitoClientId="${{ secrets.COGNITO_CLIENT_ID }}" \
+              CognitoClientSecretArn="$COG_SEC_ARN" \
+              NoteImagesBucket="$S3_BUCKET" \
+              SqsReportQueueUrl="$SQS_URL" \
+              ExecutionRoleArn="$EXEC_ROLE" \
+              TaskRoleArn="$TASK_ROLE" \
+            --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
+            --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
+
+      - name: Upsert Route 53 Alias record (api.normanblog.com → ALB)
+        env:
+          ALB_DNS: ${{ steps.deps.outputs.alb_dns }}
+          ALB_HOSTED_ZONE_ID: ${{ steps.deps.outputs.alb_hosted_zone_id }}
+        run: |
+          if [ -z "$ALB_DNS" ] || [ -z "$ALB_HOSTED_ZONE_ID" ]; then
+            echo "::error::ALB_DNS or ALB_HOSTED_ZONE_ID is empty"
+            exit 1
+          fi
+          # ALB の DNSName を Alias の DNSName にそのまま使う
+          # (CanonicalHostedZoneId 経由で AWS が解決する)
+          CHANGE_BATCH=$(jq -n \
+            --arg name "$R53_RECORD_NAME" \
+            --arg dns "$ALB_DNS" \
+            --arg hz "$ALB_HOSTED_ZONE_ID" \
+            '{
+              Comment: "Upsert api.normanblog.com Alias to ALB by scheduled-start.yml",
+              Changes: [{
+                Action: "UPSERT",
+                ResourceRecordSet: {
+                  Name: $name,
+                  Type: "A",
+                  AliasTarget: {
+                    HostedZoneId: $hz,
+                    DNSName: $dns,
+                    EvaluateTargetHealth: false
+                  }
+                }
+              }]
+            }')
+          CHANGE_ID=$(aws route53 change-resource-record-sets --region $AWS_REGION \
+            --hosted-zone-id "$R53_HOSTED_ZONE_ID" \
+            --change-batch "$CHANGE_BATCH" \
+            --query 'ChangeInfo.Id' --output text)
+          echo "Change submitted: $CHANGE_ID"
+          # Route 53 への伝播完了を待つ（INSYNC になるまで最大 60 秒）
+          aws route53 wait resource-record-sets-changed --id "$CHANGE_ID"
+          echo "✅ DNS record api.normanblog.com -> $ALB_DNS is INSYNC"
+
+      - name: Wait for ECS service to stabilize
+        run: |
+          aws ecs wait services-stable --region $AWS_REGION \
+            --cluster $STACK_PFX --services $STACK_PFX-svc
+
+      - name: Health check via ALB DNS (Route 53 伝播前でも確認可)
+        env:
+          ALB_DNS: ${{ steps.deps.outputs.alb_dns }}
+        run: |
+          for i in 1 2 3 4 5; do
+            if curl -fsS "http://$ALB_DNS/api/v2/health"; then
+              echo "✅ Healthy"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "❌ Health check failed after 5 attempts"
+          exit 1
+
+      - name: Summary
+        run: |
+          echo "☀️ Morning start complete at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -45,6 +45,13 @@ permissions:
   id-token: write
   contents: read
 
+# scheduled-stop / scheduled-start / cd-backend が CFn deploy/delete で 競合 すると
+# "stack cannot be updated" や resource race で 失敗 する ため、 ECS / ALB を 触る
+# workflow は 同一 concurrency group で 相互 排他 する。
+concurrency:
+  group: frestyle-prod-runtime-stacks
+  cancel-in-progress: false
+
 jobs:
   start:
     name: Recreate ALB + ECS
@@ -54,8 +61,10 @@ jobs:
     steps:
       - name: Verify input (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          CONFIRM_INPUT: ${{ inputs.confirm }}
         run: |
-          if [ "${{ inputs.confirm }}" != "start" ]; then
+          if [ "$CONFIRM_INPUT" != "start" ]; then
             echo "ERROR: confirm に 'start' と入力されていません"
             exit 1
           fi

--- a/.github/workflows/scheduled-stop.yml
+++ b/.github/workflows/scheduled-stop.yml
@@ -37,6 +37,13 @@ permissions:
   id-token: write
   contents: read
 
+# scheduled-stop / scheduled-start / cd-backend が CFn deploy/delete で 競合 すると
+# "stack cannot be updated" や resource race で 失敗 する ため、 ECS / ALB を 触る
+# workflow は 同一 concurrency group で 相互 排他 する。
+concurrency:
+  group: frestyle-prod-runtime-stacks
+  cancel-in-progress: false
+
 jobs:
   stop:
     name: Destroy ECS + ALB
@@ -46,8 +53,10 @@ jobs:
     steps:
       - name: Verify input (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          CONFIRM_INPUT: ${{ inputs.confirm }}
         run: |
-          if [ "${{ inputs.confirm }}" != "stop" ]; then
+          if [ "$CONFIRM_INPUT" != "stop" ]; then
             echo "ERROR: confirm に 'stop' と入力されていません"
             exit 1
           fi

--- a/.github/workflows/scheduled-stop.yml
+++ b/.github/workflows/scheduled-stop.yml
@@ -1,0 +1,93 @@
+name: Scheduled - Stop (destroy ECS + ALB at night)
+
+# 目的: 毎日 22:00 JST (13:00 UTC) に ECS + ALB を destroy してコスト節約。
+#       翌朝 scheduled-start.yml が ALB と ECS を再作成する。
+#
+# 順序:
+#   1) ECS destroy（DB connection を全断するため最初に）
+#   2) ALB destroy
+#
+# 復旧は scheduled-start.yml が翌日 07:00 JST に自動実行。
+# 緊急で起こしたい場合は手動で `gh workflow run scheduled-start.yml -f confirm=start` を叩く。
+#
+# 認証: GitHub OIDC + IAM Role (frestyle-prod-github-actions-role)
+#
+# 2026-05 Supabase 移行 後 の 構成:
+#   - DB は Supabase (24/7 稼働、 CFn 管理外、 destroy 対象 外)
+#   - 旧 RDS / nightly snapshot 関連 step は 全て 削除済
+#   - 残るは ECS + ALB の destroy のみ (Supabase 自体 は 別 サービス なので 影響 なし)
+
+on:
+  schedule:
+    # 22:00 JST = 13:00 UTC、毎日
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '手動実行時は "stop" と入力'
+        required: true
+        type: string
+
+env:
+  AWS_REGION: ap-northeast-1
+  STACK_PFX: frestyle-prod
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  stop:
+    name: Destroy ECS + ALB
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Verify input (workflow_dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ inputs.confirm }}" != "stop" ]; then
+            echo "ERROR: confirm に 'stop' と入力されていません"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
+          role-session-name: frestyle-scheduled-stop
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Destroy ECS stack
+        run: |
+          if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $STACK_PFX-ecs >/dev/null 2>&1; then
+            echo "Deleting $STACK_PFX-ecs ..."
+            aws cloudformation delete-stack --region $AWS_REGION --stack-name $STACK_PFX-ecs
+            aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $STACK_PFX-ecs
+            echo "✅ ECS deleted"
+          else
+            echo "ECS stack already absent, skip"
+          fi
+
+      - name: Destroy ALB stack
+        run: |
+          if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $STACK_PFX-alb >/dev/null 2>&1; then
+            echo "Deleting $STACK_PFX-alb ..."
+            aws cloudformation delete-stack --region $AWS_REGION --stack-name $STACK_PFX-alb
+            aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $STACK_PFX-alb
+            echo "✅ ALB deleted"
+          else
+            echo "ALB stack already absent, skip"
+          fi
+
+      # Summary は非クリティカル。GitHub Actions IAM Role に
+      # cloudformation:ListStacks 権限が無くても本筋 (ECS / ALB destroy) は完了済み。
+      # 失敗で workflow 全体を red にしないため continue-on-error / `|| true` で吸収する。
+      - name: Summary
+        continue-on-error: true
+        run: |
+          echo "🌙 Cost-saving stop complete at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          aws cloudformation list-stacks --region $AWS_REGION \
+            --query 'StackSummaries[?starts_with(StackName, `frestyle-prod-`) && StackStatus != `DELETE_COMPLETE`].[StackName,StackStatus]' \
+            --output table || echo "(ListStacks denied; not fatal)"


### PR DESCRIPTION
## 概要

PR #1730 で Supabase 移行残骸として削除した `scheduled-stop.yml` / `scheduled-start.yml` を、 **RDS 関連 step を除いた構成** で再導入する。

ECS + ALB のみを 22:00 JST に destroy / 07:00 JST に再作成するコスト節約サイクル。 DB は Supabase で 24/7 稼働しているため CFn 管理外で影響なし。

## 変更内容

### `scheduled-stop.yml` (RDS あり版との差分)

- RDS instance identifier 解決 step 削除
- DeletionProtection 自動 OFF step 削除
- nightly snapshot 作成 step 削除
- RDS stack destroy step 削除
- 古い snapshot cleanup step 削除
- timeout を 60 分 → 30 分 に短縮
- 残ったのは ECS destroy → ALB destroy → Summary の 3 step のみ

### `scheduled-start.yml` (RDS あり版との差分)

- RDS restore from snapshot step 削除
- RDS stack output (`DBHost` / `DBPort` / `DBName` / `DBPasswordSecretArn`) 解決削除
- `MasterUserSecretArn` の 3 段階 fallback 解決削除
- ECS deploy の `--parameter-overrides` を `DatabaseUrlSecretArn` 中心に変更
- `DBHost` / `DBPasswordSecretArn` は空文字で明示 (CFn 前回値 retain 回避)
- `CognitoRedirectUri` / `TokenUri` / `JwkSetUri` は現 `ecs.yml` から削除済なので渡さない

### cron スケジュール (旧版と同一)

- `scheduled-stop.yml`: 毎日 22:00 JST (`0 13 * * *`)
- `scheduled-start.yml`: 毎日 07:00 JST (`0 22 * * *`)
- `workflow_dispatch` も維持 (手動起動用)

## テスト

- [ ] マージ後 GitHub Actions サイドバーに `Scheduled - Stop` / `Scheduled - Start` が出現することを確認
- [ ] 手動で `gh workflow run "Scheduled - Start" -f confirm=start` を実行して ALB + ECS が再作成されることを確認 (現在 stop 済のため、 PR マージ後に実施)
- [ ] 次回 22:00 JST cron で stop が走り、 翌 07:00 JST cron で start が走ることを確認

## 関連 Issue

- PR #1730 (削除した PR): https://github.com/norman6464/FreStyle/pull/1730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * インフラストラクチャの自動化機能を強化しました。ALBとECSの自動再構築と定期的な削除処理が追加され、システムの安定性確保とリソース効率の最適化が実現されました。定期的なメンテナンスがスケジューラーにより自動実行されるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/norman6464/FreStyle/pull/1732?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->