### PR TITLE
refactor: backend Go の冗長コメントを短縮・自明コメントを削除

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,9 +11,7 @@
 //
 // @BasePath        /api/v2
 //
-// host / schemes は spec に 焼き込まず、 Swagger UI が ロード 元 と 同じ origin
-// (本番 = api.normanblog.com、 ローカル = localhost:8080 等) を 自動 で 使う ように
-// する。 そう しない と ローカル 開発 で 「Try it out」 が 本番 を 叩いて しまう。
+// host / schemes は spec に焼き込まない（ローカルの「Try it out」が本番を叩かないようにするため）。
 //
 // @securityDefinitions.apikey  CookieAuth
 // @in                          header
@@ -24,7 +22,7 @@ package main
 import (
 	"log"
 
-	_ "github.com/norman6464/FreStyle/backend/docs" // swag init で 生成 さ れる OpenAPI spec
+	_ "github.com/norman6464/FreStyle/backend/docs" // swag init で生成される OpenAPI spec
 	"github.com/norman6464/FreStyle/backend/internal/handler"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"github.com/norman6464/FreStyle/backend/internal/infra/database"
@@ -42,9 +40,6 @@ func main() {
 	}
 
 	// Go domain を「正」とする AutoMigrate。
-	// RESET_DB=true なら DROP SCHEMA → CREATE SCHEMA で完全リセット後 AutoMigrate。
-	// 詳細は backend/internal/infra/database/migrate.go と
-	// docs/16-go-schema-design.md (frestyle-infrastructure) を参照。
 	if err := database.Migrate(db); err != nil {
 		log.Fatalf("migrate failed: %v", err)
 	}

--- a/backend/internal/adapter/persistence/admin_invitation_repository.go
+++ b/backend/internal/adapter/persistence/admin_invitation_repository.go
@@ -13,13 +13,11 @@ import (
 // adminInvitationRepository は [repository.AdminInvitationRepository] の GORM 実装。
 type adminInvitationRepository struct{ db *gorm.DB }
 
-// NewAdminInvitationRepository は GORM ベース の [repository.AdminInvitationRepository] を 返す。
 func NewAdminInvitationRepository(db *gorm.DB) repository.AdminInvitationRepository {
 	return &adminInvitationRepository{db: db}
 }
 
-// 一覧 API は「未承諾の招待」を返すため pending 以外（accepted / canceled）は除外する。
-// 監査目的で行は物理削除せず status のみ更新している。
+// pending 以外（accepted / canceled）は除外する（行は物理削除せず status のみ更新）。
 func (r *adminInvitationRepository) ListAll(ctx context.Context) ([]domain.AdminInvitation, error) {
 	var rows []domain.AdminInvitation
 	err := r.db.WithContext(ctx).
@@ -42,8 +40,7 @@ func (r *adminInvitationRepository) FindPendingByEmail(ctx context.Context, emai
 		Where("email = ? AND status = ?", email, domain.InvitationStatusPending).
 		Order("created_at DESC").First(&row).Error
 	if err != nil {
-		// レコードが無いケースは「招待ユーザーではない通常サインアップ」なので nil, nil を返す
-		// （呼び出し側でデフォルトロールにフォールバックする想定）
+		// 該当なしは招待ユーザーでない通常サインアップなので nil, nil を返す。
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
@@ -57,13 +54,8 @@ func (r *adminInvitationRepository) FindPendingByToken(ctx context.Context, toke
 		return nil, nil
 	}
 	var row domain.AdminInvitation
-	// expires_at は招待作成時に必ず未来の値を入れる前提（usecase 側で 7 日後をセット）。
-	// 期限切れを DB 側で弾くことで「フロントで時刻がズレていても安全」な検証になる。
-	//
-	// 時刻比較は DB 関数（NOW() / UTC_TIMESTAMP()）ではなく Go 側で生成した UTC 現在時刻を
-	// パラメータバインドで渡す。理由:
-	//   - DB エンジン横断のポータビリティ（PostgreSQL には UTC_TIMESTAMP() が無い）
-	//   - GORM が time.Time を timestamptz として扱うため、DB のローカル TZ 設定に依存しない
+	// 期限切れは DB 側で弾く。比較は DB 関数でなく Go の UTC 現在時刻をバインドする
+	// （DB エンジン非依存 / ローカル TZ 設定に左右されない）。
 	err := r.db.WithContext(ctx).
 		Where("token = ? AND status = ? AND expires_at > ?", token, domain.InvitationStatusPending, time.Now().UTC()).
 		First(&row).Error

--- a/backend/internal/adapter/persistence/ai_chat_attachment_repository.go
+++ b/backend/internal/adapter/persistence/ai_chat_attachment_repository.go
@@ -9,8 +9,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// aiChatAttachmentPresigner は [repository.AiChatAttachmentPresigner] を 満たす
-// S3 プレゼンタ。 ai-chat/{userId}/{uuid}.{ext} 形式 の キー で PUT URL を 発行 する。
+// aiChatAttachmentPresigner は AI チャット添付用の S3 presigner（ai-chat/{userId}/{uuid}.{ext} キー）。
 type aiChatAttachmentPresigner struct {
 	pre s3Presigner
 }
@@ -25,10 +24,7 @@ func NewStubAiChatAttachmentPresigner(bucket string) repository.AiChatAttachment
 	return &aiChatAttachmentPresigner{pre: &stubPresigner{bucket: bucket}}
 }
 
-// Generate は ai-chat/{userId}/{uuid}.{ext} のキーで PUT presigned URL を返す。
-//
-// filename は拡張子推定 / オブジェクト名表示用にだけ使い、key には埋めない（衝突回避と
-// インジェクション対策）。
+// Generate は PUT presigned URL を返す。filename は拡張子推定にだけ使い key には埋めない（衝突 / インジェクション回避）。
 func (p *aiChatAttachmentPresigner) Generate(ctx context.Context, userID uint64, filename, contentType string) (*repository.AiChatAttachmentUploadURL, error) {
 	if userID == 0 {
 		return nil, fmt.Errorf("userID is required")

--- a/backend/internal/adapter/persistence/ai_chat_message_repository.go
+++ b/backend/internal/adapter/persistence/ai_chat_message_repository.go
@@ -21,8 +21,7 @@ type aiChatMessageRepository struct {
 	table string
 }
 
-// NewAiChatMessageRepository は DynamoDB クライアントを組み立てて
-// [repository.AiChatMessageRepository] を 返す。
+// NewAiChatMessageRepository は DynamoDB クライアントを組み立てて返す。
 func NewAiChatMessageRepository(ctx context.Context, region, table string) (repository.AiChatMessageRepository, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {
@@ -34,11 +33,8 @@ func NewAiChatMessageRepository(ctx context.Context, region, table string) (repo
 	}, nil
 }
 
-// dynamoItem は DynamoDB に保存するアイテムの形式。
-//
-// Attachments は domain.Attachment と 1:1 だが、BlobData（一時バイト列）は永続化しない。
-// 既存メッセージは attachments 列が無いまま保存されており、Unmarshal で空スライスに
-// なるよう omitempty で扱う。
+// dynamoItem は DynamoDB に保存するアイテム形式。BlobData は永続化せず、
+// attachments 列が無い既存メッセージのため omitempty で扱う。
 type dynamoItem struct {
 	SessionID   string         `dynamodbav:"sessionId"`
 	MessageID   string         `dynamodbav:"messageId"`

--- a/backend/internal/adapter/persistence/ai_chat_session_repository.go
+++ b/backend/internal/adapter/persistence/ai_chat_session_repository.go
@@ -11,7 +11,6 @@ import (
 // aiChatSessionRepository は [repository.AiChatSessionRepository] の GORM 実装。
 type aiChatSessionRepository struct{ db *gorm.DB }
 
-// NewAiChatSessionRepository は GORM ベース の [repository.AiChatSessionRepository] を 返す。
 func NewAiChatSessionRepository(db *gorm.DB) repository.AiChatSessionRepository {
 	return &aiChatSessionRepository{db: db}
 }

--- a/backend/internal/adapter/persistence/company_repository.go
+++ b/backend/internal/adapter/persistence/company_repository.go
@@ -11,7 +11,6 @@ import (
 // companyRepository は [repository.CompanyRepository] の GORM 実装。
 type companyRepository struct{ db *gorm.DB }
 
-// NewCompanyRepository は GORM ベース の [repository.CompanyRepository] を 返す。
 func NewCompanyRepository(db *gorm.DB) repository.CompanyRepository {
 	return &companyRepository{db: db}
 }

--- a/backend/internal/adapter/persistence/course_repository.go
+++ b/backend/internal/adapter/persistence/course_repository.go
@@ -13,7 +13,6 @@ type courseRepository struct {
 	db *gorm.DB
 }
 
-// NewCourseRepository は GORM ベース の [repository.CourseRepository] を 返す。
 func NewCourseRepository(db *gorm.DB) repository.CourseRepository {
 	return &courseRepository{db: db}
 }
@@ -43,7 +42,7 @@ func (r *courseRepository) Create(ctx context.Context, c *domain.Course) error {
 }
 
 func (r *courseRepository) Update(ctx context.Context, c *domain.Course) error {
-	// 一部カラムのみ更新（CreatedBy / CompanyID は不変）。
+	// CreatedBy / CompanyID は不変なので更新対象から外す。
 	return r.db.WithContext(ctx).Model(c).Updates(map[string]any{
 		"title":        c.Title,
 		"description":  c.Description,

--- a/backend/internal/adapter/persistence/exercise_submission_repository.go
+++ b/backend/internal/adapter/persistence/exercise_submission_repository.go
@@ -13,7 +13,6 @@ type exerciseSubmissionRepository struct {
 	db *gorm.DB
 }
 
-// NewExerciseSubmissionRepository は GORM ベース の [repository.ExerciseSubmissionRepository] を 返す。
 func NewExerciseSubmissionRepository(db *gorm.DB) repository.ExerciseSubmissionRepository {
 	return &exerciseSubmissionRepository{db: db}
 }
@@ -55,8 +54,7 @@ func (r *exerciseSubmissionRepository) HasAttempted(ctx context.Context, userID,
 	return count > 0, nil
 }
 
-// BatchUserStatuses は 1 クエリで user × exerciseIDs の (any submission, any solved) を取り、
-// exercise_id -> "solved" / "in_progress" を返す。 結果に含まれない exercise_id は未着手扱い。
+// BatchUserStatuses は 1 クエリで exercise_id -> "solved" / "in_progress" を返す（結果に無い id は未着手）。
 func (r *exerciseSubmissionRepository) BatchUserStatuses(ctx context.Context, userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error) {
 	result := make(map[uint64]string, len(exerciseIDs))
 	if len(exerciseIDs) == 0 {
@@ -86,13 +84,11 @@ func (r *exerciseSubmissionRepository) BatchUserStatuses(ctx context.Context, us
 
 func (r *exerciseSubmissionRepository) ExerciseStats(ctx context.Context, exerciseID uint64, kind string) (repository.ExerciseSubmissionStats, error) {
 	var stats repository.ExerciseSubmissionStats
-	// COUNT(*) は全提出数。
 	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Where("exercise_id = ? AND exercise_kind = ?", exerciseID, kind).
 		Count(&stats.TotalSubmissions).Error; err != nil {
 		return stats, err
 	}
-	// COUNT(DISTINCT user_id) は正答ユーザ数。
 	if err := r.db.WithContext(ctx).Model(&domain.ExerciseSubmission{}).
 		Where("exercise_id = ? AND exercise_kind = ? AND is_correct = ?", exerciseID, kind, true).
 		Distinct("user_id").
@@ -108,7 +104,6 @@ func (r *exerciseSubmissionRepository) ExerciseStatsBatch(ctx context.Context, e
 	if len(exerciseIDs) == 0 {
 		return result, nil
 	}
-	// 提出数の集計。
 	type totalRow struct {
 		ExerciseID uint64
 		Total      int64
@@ -126,7 +121,6 @@ func (r *exerciseSubmissionRepository) ExerciseStatsBatch(ctx context.Context, e
 		s.TotalSubmissions = t.Total
 		result[t.ExerciseID] = s
 	}
-	// 正答ユーザ数の集計（DISTINCT user_id）。
 	type solvedRow struct {
 		ExerciseID  uint64
 		SolvedUsers int64

--- a/backend/internal/adapter/persistence/health_repository.go
+++ b/backend/internal/adapter/persistence/health_repository.go
@@ -12,7 +12,6 @@ type healthRepository struct {
 	db *gorm.DB
 }
 
-// NewHealthRepository は GORM ベース の [repository.HealthRepository] を 返す。
 func NewHealthRepository(db *gorm.DB) repository.HealthRepository {
 	return &healthRepository{db: db}
 }

--- a/backend/internal/adapter/persistence/learning_report_repository.go
+++ b/backend/internal/adapter/persistence/learning_report_repository.go
@@ -11,7 +11,6 @@ import (
 // learningReportRepository は [repository.LearningReportRepository] の GORM 実装。
 type learningReportRepository struct{ db *gorm.DB }
 
-// NewLearningReportRepository は GORM ベース の [repository.LearningReportRepository] を 返す。
 func NewLearningReportRepository(db *gorm.DB) repository.LearningReportRepository {
 	return &learningReportRepository{db: db}
 }
@@ -26,11 +25,9 @@ func (r *learningReportRepository) Create(ctx context.Context, lr *domain.Learni
 	return r.db.WithContext(ctx).Create(lr).Error
 }
 
-// stubEnqueuer は [repository.SqsEnqueuer] の no-op 実装。
-// 本番 経路 の SQS SendMessage 実装 は 別 PR で 追加。
+// stubEnqueuer は [repository.SqsEnqueuer] の no-op 実装（本番の SQS 実装は別 PR）。
 type stubEnqueuer struct{}
 
-// NewStubSqsEnqueuer は test / dev 用 の [repository.SqsEnqueuer] stub を 返す。
 func NewStubSqsEnqueuer() repository.SqsEnqueuer { return &stubEnqueuer{} }
 
 func (e *stubEnqueuer) Enqueue(_ context.Context, _ uint64) error { return nil }

--- a/backend/internal/adapter/persistence/master_exercise_example_repository.go
+++ b/backend/internal/adapter/persistence/master_exercise_example_repository.go
@@ -13,8 +13,6 @@ type masterExerciseExampleRepository struct {
 	db *gorm.DB
 }
 
-// NewMasterExerciseExampleRepository は GORM ベース の
-// [repository.MasterExerciseExampleRepository] を 返す。
 func NewMasterExerciseExampleRepository(db *gorm.DB) repository.MasterExerciseExampleRepository {
 	return &masterExerciseExampleRepository{db: db}
 }
@@ -30,8 +28,7 @@ func (r *masterExerciseExampleRepository) ListByExerciseID(ctx context.Context, 
 	return examples, nil
 }
 
-// ListByExerciseIDs は複数 exercise_id をまとめて取得し、 exercise_id ごとに
-// グルーピングした map を返す。 リストページで N+1 を避けるため。
+// ListByExerciseIDs は複数 exercise_id をまとめて取得し exercise_id ごとに map 化する（N+1 回避）。
 func (r *masterExerciseExampleRepository) ListByExerciseIDs(ctx context.Context, exerciseIDs []uint64) (map[uint64][]domain.MasterExerciseExample, error) {
 	result := make(map[uint64][]domain.MasterExerciseExample, len(exerciseIDs))
 	if len(exerciseIDs) == 0 {

--- a/backend/internal/adapter/persistence/master_exercise_repository.go
+++ b/backend/internal/adapter/persistence/master_exercise_repository.go
@@ -13,7 +13,6 @@ type masterExerciseRepository struct {
 	db *gorm.DB
 }
 
-// NewMasterExerciseRepository は GORM ベース の [repository.MasterExerciseRepository] を 返す。
 func NewMasterExerciseRepository(db *gorm.DB) repository.MasterExerciseRepository {
 	return &masterExerciseRepository{db: db}
 }

--- a/backend/internal/adapter/persistence/note_image_repository.go
+++ b/backend/internal/adapter/persistence/note_image_repository.go
@@ -9,8 +9,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// noteImagePresigner は [repository.NoteImagePresigner] を 満たす infra/s3.Presigner
-// ラッパ。 notes/{userId}/{epochNs}.bin 形式 の キー で PUT URL を 発行 する。
+// noteImagePresigner は note 画像用の S3 presigner（notes/{userId}/{epochNs}.bin キー）。
 type noteImagePresigner struct {
 	pre s3Presigner
 }
@@ -21,7 +20,6 @@ func NewNoteImagePresigner(p s3Presigner) repository.NoteImagePresigner {
 }
 
 // NewStubNoteImagePresigner は test / dev 用 stub。
-// 本番では NewNoteImagePresigner(infra/s3.NewPresigner(...)) を使うこと。
 func NewStubNoteImagePresigner(bucket string) repository.NoteImagePresigner {
 	return &noteImagePresigner{pre: &stubPresigner{bucket: bucket}}
 }

--- a/backend/internal/adapter/persistence/note_repository.go
+++ b/backend/internal/adapter/persistence/note_repository.go
@@ -11,7 +11,6 @@ import (
 // noteRepository は [repository.NoteRepository] の GORM 実装。
 type noteRepository struct{ db *gorm.DB }
 
-// NewNoteRepository は GORM ベース の [repository.NoteRepository] を 返す。
 func NewNoteRepository(db *gorm.DB) repository.NoteRepository { return &noteRepository{db: db} }
 
 func (r *noteRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.Note, error) {

--- a/backend/internal/adapter/persistence/notification_repository.go
+++ b/backend/internal/adapter/persistence/notification_repository.go
@@ -11,7 +11,6 @@ import (
 // notificationRepository は [repository.NotificationRepository] の GORM 実装。
 type notificationRepository struct{ db *gorm.DB }
 
-// NewNotificationRepository は GORM ベース の [repository.NotificationRepository] を 返す。
 func NewNotificationRepository(db *gorm.DB) repository.NotificationRepository {
 	return &notificationRepository{db: db}
 }
@@ -45,11 +44,9 @@ func (r *notificationRepository) CountUnread(ctx context.Context, userID uint64)
 	return n, err
 }
 
-// stubSnsPublisher は [repository.SnsPublisher] の no-op 実装。
-// 本番 経路 の SNS Publish 実装 は 別 PR で 追加。
+// stubSnsPublisher は [repository.SnsPublisher] の no-op 実装（本番の SNS 実装は別 PR）。
 type stubSnsPublisher struct{}
 
-// NewStubSnsPublisher は test / dev 用 の [repository.SnsPublisher] stub を 返す。
 func NewStubSnsPublisher() repository.SnsPublisher { return &stubSnsPublisher{} }
 
 func (p *stubSnsPublisher) Publish(_ context.Context, _ uint64, _, _ string) error { return nil }

--- a/backend/internal/adapter/persistence/profile_image_repository.go
+++ b/backend/internal/adapter/persistence/profile_image_repository.go
@@ -10,21 +10,18 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// profileImagePresigner は [repository.ProfileImagePresigner] を 満たす S3 プレゼンタ。
-// profiles/{userId}/{epochNs}{ext} 形式 の キー で PUT URL を 発行 する。
+// profileImagePresigner は profile アイコン用の S3 presigner（profiles/{userId}/{epochNs}{ext} キー）。
 type profileImagePresigner struct {
 	pre    s3Presigner
 	cdnURL string
 }
 
-// NewProfileImagePresigner は infra/s3.Presigner を受けて real な presigner を返す。
-// cdnURL は配信用ベース URL (CloudFront / S3 virtual-hosted-style)。
+// NewProfileImagePresigner は本番経路。cdnURL は配信用ベース URL（CloudFront / S3）。
 func NewProfileImagePresigner(p s3Presigner, cdnURL string) repository.ProfileImagePresigner {
 	return &profileImagePresigner{pre: p, cdnURL: strings.TrimRight(cdnURL, "/")}
 }
 
-// NewStubProfileImagePresigner は test / dev 用の stub。
-// 本番では NewProfileImagePresigner(infra/s3.NewPresigner(...), cdnURL) を使う。
+// NewStubProfileImagePresigner は test / dev 用 stub。
 func NewStubProfileImagePresigner(bucket, cdnURL string) repository.ProfileImagePresigner {
 	return &profileImagePresigner{
 		pre:    &stubPresigner{bucket: bucket},
@@ -53,8 +50,7 @@ func (p *profileImagePresigner) Generate(ctx context.Context, userID uint64, fil
 	}, nil
 }
 
-// guessExt は fileName または contentType から「.png」「.jpg」などの拡張子を返す。
-// 純粋関数化することで usecase 経由で間接的にテストできる。
+// guessExt は fileName または contentType から拡張子を返す。
 func guessExt(fileName, contentType string) string {
 	if i := strings.LastIndex(fileName, "."); i != -1 && i < len(fileName)-1 {
 		return strings.ToLower(fileName[i:])

--- a/backend/internal/adapter/persistence/profile_repository.go
+++ b/backend/internal/adapter/persistence/profile_repository.go
@@ -12,7 +12,6 @@ import (
 // profileRepository は [repository.ProfileRepository] の GORM 実装。
 type profileRepository struct{ db *gorm.DB }
 
-// NewProfileRepository は GORM ベース の [repository.ProfileRepository] を 返す。
 func NewProfileRepository(db *gorm.DB) repository.ProfileRepository {
 	return &profileRepository{db: db}
 }

--- a/backend/internal/adapter/persistence/s3_presigner.go
+++ b/backend/internal/adapter/persistence/s3_presigner.go
@@ -6,17 +6,13 @@ import (
 	"time"
 )
 
-// s3Presigner は infra/s3.Presigner と同等の interface を minimal に切り出した型。
-// persistence パッケージ が infra/s3 パッケージ に 直接 依存 しない よう dep direction
-// を 反転 (依存性 逆転 原則)。 profile_image / note_image / ai_chat_attachment の
-// 3 つ の presigner が 共通 で 使う。
+// s3Presigner は infra/s3.Presigner と同等の minimal interface（persistence が infra/s3 に
+// 直接依存しないよう依存方向を反転する）。3 つの presigner が共通で使う。
 type s3Presigner interface {
 	PresignPut(ctx context.Context, key, contentType string) (url string, ttl time.Duration, err error)
 }
 
-// stubPresigner は profile_image / note_image / ai_chat_attachment の test / dev 用
-// に 共有 さ れる stub 実装。 本番 経路 で は infra/s3.NewPresigner が s3Presigner を
-// 満たす。
+// stubPresigner は presigner 共通の test / dev 用 stub（本番では infra/s3.NewPresigner が s3Presigner を満たす）。
 type stubPresigner struct{ bucket string }
 
 func (s *stubPresigner) PresignPut(_ context.Context, key, _ string) (string, time.Duration, error) {

--- a/backend/internal/adapter/persistence/session_note_repository.go
+++ b/backend/internal/adapter/persistence/session_note_repository.go
@@ -12,7 +12,6 @@ import (
 // sessionNoteRepository は [repository.SessionNoteRepository] の GORM 実装。
 type sessionNoteRepository struct{ db *gorm.DB }
 
-// NewSessionNoteRepository は GORM ベース の [repository.SessionNoteRepository] を 返す。
 func NewSessionNoteRepository(db *gorm.DB) repository.SessionNoteRepository {
 	return &sessionNoteRepository{db: db}
 }

--- a/backend/internal/adapter/persistence/teaching_material_repository.go
+++ b/backend/internal/adapter/persistence/teaching_material_repository.go
@@ -13,12 +13,11 @@ type teachingMaterialRepository struct {
 	db *gorm.DB
 }
 
-// NewTeachingMaterialRepository は GORM ベース の [repository.TeachingMaterialRepository] を 返す。
 func NewTeachingMaterialRepository(db *gorm.DB) repository.TeachingMaterialRepository {
 	return &teachingMaterialRepository{db: db}
 }
 
-// ListByCompany は backward-compat 用。 frontend のコース対応完了後に削除予定。
+// ListByCompany は backward-compat 用（コース対応完了後に削除予定）。
 func (r *teachingMaterialRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
 	var rows []domain.TeachingMaterial
 	q := r.db.WithContext(ctx).Where("company_id = ?", companyID)
@@ -37,7 +36,6 @@ func (r *teachingMaterialRepository) ListByCourse(ctx context.Context, courseID 
 	if !includeUnpublished {
 		q = q.Where("is_published = ?", true)
 	}
-	// コース内の並び順は order_in_course → id 昇順。
 	if err := q.Order("order_in_course asc, id asc").Find(&rows).Error; err != nil {
 		return nil, err
 	}
@@ -57,7 +55,7 @@ func (r *teachingMaterialRepository) Create(ctx context.Context, m *domain.Teach
 }
 
 func (r *teachingMaterialRepository) Update(ctx context.Context, m *domain.TeachingMaterial) error {
-	// 一部カラムのみ更新（CreatedBy / CompanyID / CourseID は不変）。
+	// CreatedBy / CompanyID / CourseID は不変なので更新対象から外す。
 	return r.db.WithContext(ctx).Model(m).Updates(map[string]any{
 		"title":           m.Title,
 		"content":         m.Content,
@@ -70,8 +68,7 @@ func (r *teachingMaterialRepository) Delete(ctx context.Context, id uint64) erro
 	return r.db.WithContext(ctx).Delete(&domain.TeachingMaterial{}, id).Error
 }
 
-// DeleteByCourse は指定 course に属する教材を全削除する。 コース削除時の
-// cascade 用（FK の ON DELETE は GORM AutoMigrate で安定しないので明示的に消す）。
+// DeleteByCourse はコース削除時の cascade 用に配下教材を全削除する（FK に頼らず明示削除）。
 func (r *teachingMaterialRepository) DeleteByCourse(ctx context.Context, courseID uint64) error {
 	return r.db.WithContext(ctx).Where("course_id = ?", courseID).Delete(&domain.TeachingMaterial{}).Error
 }

--- a/backend/internal/adapter/persistence/user_repository.go
+++ b/backend/internal/adapter/persistence/user_repository.go
@@ -1,9 +1,5 @@
-// Package persistence は usecase 層 が 定義 した port (interface) に 対 する 永続化
-// 実装 (GORM / DynamoDB / S3 presigner 等) を 集約 する。
-//
-// Clean Architecture の Interface Adapters 層 の うち「persistence 関心 事」 担当 部分。
-// usecase 側 は ここ を 知ら ず、 wiring (router.go) で `persistence.NewXxxRepository(...)`
-// を 呼んで 実装 を 組み立て、 各 usecase に 注入 する。
+// Package persistence は usecase 層が定義した port の永続化実装
+// （GORM / DynamoDB / S3 presigner 等）を集約する。wiring は router.go で行う。
 package persistence
 
 import (
@@ -21,7 +17,6 @@ type userRepository struct {
 	db *gorm.DB
 }
 
-// NewUserRepository は GORM ベース の [repository.UserRepository] を 返す。
 func NewUserRepository(db *gorm.DB) repository.UserRepository {
 	return &userRepository{db: db}
 }
@@ -76,8 +71,7 @@ func (r *userRepository) UpdateCompanyID(ctx context.Context, userID uint64, com
 }
 
 func (r *userRepository) MarkOnboarded(ctx context.Context, userID uint64) error {
-	// 冪等性: 既に onboarded_at が入っているレコードには上書きしない（IS NULL でガード）。
-	// これで「Welcome 画面に戻ってもう一度押された」場合でも初回日時を保持できる。
+	// IS NULL ガードで二度押しでも初回日時を保持する（冪等）。
 	now := time.Now().UTC()
 	return r.db.WithContext(ctx).
 		Model(&domain.User{}).

--- a/backend/internal/adapter/persistence/user_stats_repository.go
+++ b/backend/internal/adapter/persistence/user_stats_repository.go
@@ -11,13 +11,11 @@ import (
 // userStatsRepository は [repository.UserStatsRepository] の GORM 実装。
 type userStatsRepository struct{ db *gorm.DB }
 
-// NewUserStatsRepository は GORM ベース の [repository.UserStatsRepository] を 返す。
 func NewUserStatsRepository(db *gorm.DB) repository.UserStatsRepository {
 	return &userStatsRepository{db: db}
 }
 
-// Compute は ai_chat_sessions と score_cards から集計。
-// SQL は最小限に留め、追加のメトリクスは後続 PR で拡張する。
+// Compute は score_cards から提出数 / 平均スコアを集計する。
 func (r *userStatsRepository) Compute(ctx context.Context, userID uint64) (*domain.UserStats, error) {
 	stats := &domain.UserStats{UserID: userID}
 	row := r.db.WithContext(ctx).Raw(

--- a/backend/internal/domain/admin_invitation.go
+++ b/backend/internal/domain/admin_invitation.go
@@ -9,13 +9,8 @@ type AdminInvitation struct {
 	Role        string `gorm:"column:role" json:"role"`
 	DisplayName string `gorm:"column:display_name" json:"displayName"`
 	Status      string `gorm:"column:status" json:"status"`
-	// Token はマジックリンク用の不透明 UUID。SES で送信するメールに ?token=<UUID> として埋め込み、
-	// 受諾画面で照合する。漏洩時の被害局所化のため一招待につき 1 値・受諾後は無効化（status=accepted で参照不可に）。
-	// json では返さない（管理 UI でも露出させない方針。受諾フローでのみ使う秘匿値）。
-	//
-	// *string にしている理由: GORM AutoMigrate で UNIQUE INDEX を張るとき、既存 pending 行は
-	// token がまだ無い（後続 PR-B で backfill 予定）。MariaDB の UNIQUE 制約は空文字 '' 同士は
-	// 重複扱いになるが NULL 同士は重複扱いにならないため、未設定値は NULL にする必要がある。
+	// Token はマジックリンク用の不透明 UUID（秘匿値なので json では返さない）。
+	// 未設定値を NULL にして UNIQUE 制約に引っかけないため *string にしている。
 	Token     *string   `gorm:"column:token;uniqueIndex;size:64" json:"-"`
 	ExpiresAt time.Time `gorm:"column:expires_at" json:"expiresAt"`
 	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`

--- a/backend/internal/domain/ai_chat.go
+++ b/backend/internal/domain/ai_chat.go
@@ -2,7 +2,7 @@ package domain
 
 import "time"
 
-// AiChatSession は AI チャットの 1 セッション
+// AiChatSession は AI チャットの 1 セッション。
 type AiChatSession struct {
 	ID          uint64    `gorm:"primaryKey" json:"id"`
 	UserID      uint64    `gorm:"column:user_id;index" json:"userId"`
@@ -20,12 +20,7 @@ const (
 	AiChatSessionTypePractice = "practice"
 )
 
-// AiChatMessage は AI チャットの 1 メッセージ。実体は DynamoDB に保存されるが、
-// API ではこの形で返却する。
-//
-// Attachments はユーザー発話に紐付く画像 / ドキュメント等の添付ファイル群。
-// S3 のオブジェクトキーとメタデータだけを保存し、実体バイト列 (BlobData) は
-// DynamoDB / JSON への永続化対象外（Bedrock 呼び出し直前に S3 から取得して詰める）。
+// AiChatMessage は AI チャットの 1 メッセージ。実体は DynamoDB に保存し、API ではこの形で返す。
 type AiChatMessage struct {
 	SessionID   uint64       `json:"sessionId"`
 	MessageID   string       `json:"messageId"`
@@ -36,19 +31,8 @@ type AiChatMessage struct {
 }
 
 // Attachment は AI チャット送信時の添付ファイル。
-//
-// Kind:
-//   - "image": Bedrock の content[].image ブロックに詰めて vision 入力にする
-//   - "document": 将来の PR-G2 で PDF / CSV を扱う際の値（PR-G1 では未使用）
-//
-// Format は AWS Bedrock Converse API が要求する短い文字列。
-//   - 画像: "png" / "jpeg" / "gif" / "webp"
-//   - ドキュメント (PR-G2 以降): "pdf" / "csv" / "txt" など
-//
-// SizeBytes は S3 アップロード後の確認用メタ。Bedrock 上限超過時は handler で 400 を返す。
-//
-// BlobData は usecase が Bedrock に渡す直前に S3 GetObject で詰める一時フィールド。
-// JSON / DynamoDB には永続化しないため `json:"-"` と repository 側 dynamoItem 除外で扱う。
+// Format は Bedrock Converse API が要求する短い文字列（"png" / "jpeg" など）。
+// BlobData は Bedrock 呼び出し直前に S3 から詰める一時フィールドで、永続化はしない。
 type Attachment struct {
 	Key         string `json:"key"`
 	Filename    string `json:"filename"`

--- a/backend/internal/domain/base.go
+++ b/backend/internal/domain/base.go
@@ -1,27 +1,10 @@
-// Package domain は FreStyle の純粋なドメイン構造体・列挙・定数を集める層。
-//
-// クリーンアーキテクチャ的観点:
-//   - domain は他のどの層にも依存しない (純粋なロジックのみ)
-//   - usecase / repository / handler が domain を参照する
-//   - GORM tag は本来 infrastructure 関心ごとだが、本プロジェクトでは
-//     pragmatic な妥協として domain 構造体に直書きする運用にしている
-//     （DTO ↔ DB Entity の二重定義を避け、移行コストを抑えるため）
-//   - DB スキーマは Go domain を「正」として AutoMigrate で構築する
-//     （詳細: docs/16-go-schema-design.md @ frestyle-infrastructure）
+// Package domain は他層に依存しない純粋なドメイン構造体・列挙・定数を集める。
+// GORM tag は pragmatic な妥協として domain に直書きし、DB スキーマは AutoMigrate で構築する。
 package domain
 
 import "time"
 
-// BaseEntity は全ての永続化ドメイン共通のフィールドをまとめる埋め込み用構造体。
-// 各 entity は無名フィールドとして埋め込んで使う:
-//
-//	type User struct {
-//	    BaseEntity
-//	    ...
-//	}
-//
-// 主キー / タイムスタンプの規約をプロジェクト全体で統一することで、
-// 「テーブルによって id 型が違う」「updated_at がないテーブルがある」のような不揃いを防ぐ。
+// BaseEntity は永続化ドメイン共通の主キー / タイムスタンプを埋め込みで提供する。
 type BaseEntity struct {
 	ID        uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
 	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime" json:"createdAt"`

--- a/backend/internal/domain/company_exercise.go
+++ b/backend/internal/domain/company_exercise.go
@@ -2,14 +2,8 @@ package domain
 
 import "time"
 
-// CompanyExercise は CompanyAdmin が自社の trainee 向けに作成する独自問題。
-//
-// MasterExercise（運営共通）との違い:
-//   - `CompanyID` が必須（自社内だけで閲覧可能、他社からは見えない）
-//   - 採点ルール / レビュアー / 公開範囲設定など将来の拡張は本テーブルにだけ加える
-//   - 提出履歴は `ExerciseSubmission.ExerciseKind = "company"` で参照
-//
-// PR-H3 ではテーブル定義のみ。CRUD API / 管理 UI は PR-H1 以降で追加する。
+// CompanyExercise は CompanyAdmin が自社 trainee 向けに作る独自問題（自社内のみ閲覧可）。
+// 提出履歴は ExerciseSubmission.ExerciseKind = "company" で参照する。
 type CompanyExercise struct {
 	ID             uint64     `gorm:"primaryKey;autoIncrement" json:"id"`
 	CompanyID      uint64     `gorm:"column:company_id;not null;index" json:"companyId"`

--- a/backend/internal/domain/course.go
+++ b/backend/internal/domain/course.go
@@ -2,16 +2,8 @@ package domain
 
 import "time"
 
-// Course は教材を束ねる「コース（プロジェクト）」。
-//
-// 階層: Company 1 ── * Course 1 ── * TeachingMaterial
-//
-// アクセス制御:
-//   - same company の company_admin: 自社のコースを全件 list / 編集 / 削除可
-//   - same company の trainee: 自社の `is_published=true` コースのみ閲覧可
-//   - super_admin: 横断的に閲覧可（運用上の監査）
-//
-// 並び順は `SortOrder` で明示的に指定する（同値時は ID 昇順）。
+// Course は教材を束ねるコース。階層は Company 1 ── * Course 1 ── * TeachingMaterial。
+// trainee は自社の is_published=true のみ閲覧可。並び順は SortOrder（同値時 ID 昇順）。
 type Course struct {
 	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
 	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`

--- a/backend/internal/domain/exercise_submission.go
+++ b/backend/internal/domain/exercise_submission.go
@@ -2,15 +2,8 @@ package domain
 
 import "time"
 
-// ExerciseSubmission は trainee がコード演習に提出したコード + 実行結果の 1 件。
-//
-// 設計上のポイント:
-//   - master_exercises / company_exercises は別テーブルなので polymorphic にする必要がある。
-//     `ExerciseKind` で参照先テーブルを判定する（FK は張らずアプリ層で整合性を担保）。
-//   - 提出は append-only で履歴として残す。trainee 1 人 × 1 問題に対し複数行を許容。
-//   - ダッシュボード集計は (user_id, submitted_at DESC) インデックスで高速化。
-//
-// PR-H3 ではテーブル定義のみ。提出 API / 採点ロジックは別 PR で追加する。
+// ExerciseSubmission は trainee がコード演習に提出したコード + 実行結果の 1 件（append-only）。
+// 参照先テーブルは ExerciseKind で判定する polymorphic 設計（FK は張らずアプリ層で担保）。
 type ExerciseSubmission struct {
 	ID            uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
 	UserID        uint64    `gorm:"column:user_id;not null;index:idx_submissions_user_at,priority:1" json:"userId"`
@@ -28,6 +21,6 @@ func (ExerciseSubmission) TableName() string { return "exercise_submissions" }
 
 // ExerciseKind* は ExerciseSubmission.ExerciseKind の許容値。
 const (
-	ExerciseKindMaster  = "master"  // 運営共通の master_exercises を指す
-	ExerciseKindCompany = "company" // 会社作成の company_exercises を指す
+	ExerciseKindMaster  = "master"
+	ExerciseKindCompany = "company"
 )

--- a/backend/internal/domain/health.go
+++ b/backend/internal/domain/health.go
@@ -1,7 +1,6 @@
 package domain
 
-// Health はバックエンドの稼働状態を表すドメインモデル。
-// Spring Boot 側の /actuator/health 相当。
+// Health はバックエンドの稼働状態を表す。
 type Health struct {
 	Status   string `json:"status"`
 	DBStatus string `json:"db"`

--- a/backend/internal/domain/master_exercise.go
+++ b/backend/internal/domain/master_exercise.go
@@ -2,16 +2,7 @@ package domain
 
 import "time"
 
-// MasterExercise は運営（FreStyle 側）が用意した練習問題のマスタエンティティ。
-//
-// 旧 `php_exercises` を「言語非依存の汎用テーブル」に拡張したもの。
-// `language` 列で 'php' / 'sql' / 'go' / 'js' などを表現し、テーブル単位での分割は行わない。
-//
-// CompanyAdmin が自社向けに作る独自問題は別テーブル `CompanyExercise` で扱う
-// （提出履歴は両者を `ExerciseSubmission.ExerciseKind` で polymorphic に参照）。
-//
-// `ChapterID` は将来 PR-H1 で chapters テーブルが入ったとき、章末演習として
-// 紐付けるための任意 FK。本 PR では NULL のまま運用する。
+// MasterExercise は運営が用意した練習問題のマスタ。Language 列で言語を表現し言語非依存に扱う。
 type MasterExercise struct {
 	ID             uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
 	Slug           string `gorm:"size:64;not null;uniqueIndex" json:"slug"`
@@ -23,12 +14,9 @@ type MasterExercise struct {
 	StarterCode    string `gorm:"type:text;not null" json:"starterCode"`
 	HintText       string `gorm:"type:text" json:"hintText"`
 	ExpectedOutput string `gorm:"type:text" json:"expectedOutput"`
-	// Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
-	// 'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
-	// docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
+	// Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。
 	Mode string `gorm:"size:16;not null;default:'execute'" json:"mode"`
-	// Explanation は QA モードで 正解後に表示される markdown 解説。
-	// execute モードでは未使用 (空文字)。
+	// Explanation は qa モードで正解後に表示する markdown 解説。
 	Explanation string    `gorm:"type:text;not null;default:''" json:"explanation"`
 	Difficulty  int16     `gorm:"type:smallint;not null;default:1" json:"difficulty"`
 	IsPublished bool      `gorm:"not null;default:true" json:"isPublished"`
@@ -39,7 +27,7 @@ type MasterExercise struct {
 
 func (MasterExercise) TableName() string { return "master_exercises" }
 
-// 演習問題の対応言語の文字列定数。新規追加時は usecase / フロント側の許容セットも揃える。
+// 対応言語の定数。追加時は usecase / フロント側の許容セットも揃える。
 const (
 	ExerciseLanguagePhp = "php"
 	ExerciseLanguageSql = "sql"
@@ -47,7 +35,7 @@ const (
 	ExerciseLanguageJs  = "javascript"
 )
 
-// 採点モード定数。 frontend の入力 UI 切替えと、 backend の採点ロジック切替えの両方で使う。
+// 採点モードの定数。
 const (
 	ExerciseModeExecute = "execute"
 	ExerciseModeQA      = "qa"

--- a/backend/internal/domain/master_exercise_example.go
+++ b/backend/internal/domain/master_exercise_example.go
@@ -2,24 +2,13 @@ package domain
 
 import "time"
 
-// MasterExerciseExample は MasterExercise に紐付く「入力例 / 期待出力例」の 1 ペア。
-//
-// 1 つの問題に対して複数のテストケース（入力例 1, 入力例 2, ...）を表現する。
-// 採点はこの example 全件をコードに食わせて期待出力と一致するか比較するロジックで行う
-// （採点 usecase は別 PR で実装予定）。
-//
-// 設計上のポイント:
-//   - ExerciseID は master_exercises への FK だが、 GORM Constraint でカスケード削除を強制する
-//     よりはアプリ層 / マイグレーションで明示削除する方針（運営は基本的に問題を物理削除しない）
-//   - InputText は標準入力に流す内容。問題によっては入力なし（空文字）でも成立する
-//   - 表示 / 採点順序は OrderIndex で安定ソート
+// MasterExerciseExample は MasterExercise に紐付く入力例 / 期待出力例の 1 ペア。
+// 1 問に複数ケースを持ち、表示 / 採点順序は OrderIndex で安定ソートする。
 type MasterExerciseExample struct {
 	ID uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
-	// (exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で
-	// OrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。
+	// (exercise_id, order_index) の UNIQUE で同一問題内の OrderIndex 衝突を DB レベルで弾く。
 	ExerciseID uint64 `gorm:"column:exercise_id;not null;uniqueIndex:idx_examples_exercise_order,priority:1" json:"exerciseId"`
-	// OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。
-	// （default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）
+	// DEFAULT を持たせない（default:0 だと未指定 INSERT が 0 で衝突するため）。
 	OrderIndex     int16     `gorm:"column:order_index;type:smallint;not null;uniqueIndex:idx_examples_exercise_order,priority:2" json:"orderIndex"`
 	InputText      string    `gorm:"column:input_text;type:text;not null;default:''" json:"inputText"`
 	ExpectedOutput string    `gorm:"column:expected_output;type:text;not null" json:"expectedOutput"`

--- a/backend/internal/domain/note.go
+++ b/backend/internal/domain/note.go
@@ -2,10 +2,7 @@ package domain
 
 import "time"
 
-// Note は学習メモを表す。フロント NotesPage / SessionNote 機能のドメインモデル。
-//
-// IsPinned はユーザーがピン留めしたかどうか（ピン留めは並び順で先頭に固定する用途）。
-// IsPublic は他ユーザーに公開するかどうか。両者は独立した属性。
+// Note は学習メモ。IsPinned と IsPublic は独立した属性。
 type Note struct {
 	ID        uint64    `gorm:"primaryKey" json:"id"`
 	UserID    uint64    `gorm:"column:user_id;index" json:"userId"`

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -2,11 +2,7 @@ package domain
 
 import "time"
 
-// Profile は users テーブルとは別管理のプロフィール拡張情報。
-//
-// Status はユーザーが任意で公開できるショートメッセージ（例: 「学習中」「取り込み中」）。
-// users.display_name は別テーブル管理だが、フロントは「プロフィール表示」で両者を
-// 合わせて使うため、handler 層で join して返す前提。
+// Profile は users とは別管理のプロフィール拡張情報。
 type Profile struct {
 	UserID    uint64    `gorm:"primaryKey;column:user_id" json:"userId"`
 	Bio       string    `gorm:"column:bio" json:"bio"`
@@ -17,16 +13,13 @@ type Profile struct {
 
 func (Profile) TableName() string { return "profiles" }
 
-// ProfileView は handler 層で users.display_name と Profile を合成した DTO。
-// フロントの「プロフィール表示」が期待する単一オブジェクトの形。
+// ProfileView は users.display_name と Profile を合成した表示用 DTO。
 type ProfileView struct {
-	UserID      uint64 `json:"userId"`
-	DisplayName string `json:"displayName"`
-	// Email は users.email を そのまま返す。 frontend の sidebar ユーザーメニューで
-	// 「ログイン中のメールアドレスを 表示する」 用途で参照する。
-	Email     string    `json:"email"`
-	Bio       string    `json:"bio"`
-	AvatarURL string    `json:"avatarUrl"`
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	UserID      uint64    `json:"userId"`
+	DisplayName string    `json:"displayName"`
+	Email       string    `json:"email"`
+	Bio         string    `json:"bio"`
+	AvatarURL   string    `json:"avatarUrl"`
+	Status      string    `json:"status"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }

--- a/backend/internal/domain/profile_image.go
+++ b/backend/internal/domain/profile_image.go
@@ -1,8 +1,7 @@
 package domain
 
 // ProfileImageUploadURL は profile アイコン用の S3 直接アップロード URL を表す。
-// フロントの ProfileRepository.getImagePresignedUrl が期待する形式
-// （uploadUrl: PUT 対象、imageUrl: アップロード後に表示する URL）に合わせる。
+// UploadURL は PUT 対象、ImageURL はアップロード後に表示する URL。
 type ProfileImageUploadURL struct {
 	UploadURL string `json:"uploadUrl"`
 	ImageURL  string `json:"imageUrl"`

--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -2,24 +2,12 @@ package domain
 
 import "time"
 
-// TeachingMaterial は company_admin が自社 trainee 向けに作成する教材。
-// 必ず 1 つの Course に所属する（独立した教材は許容しない）。
-//
-// アクセス制御:
-//   - same company の company_admin: 自社の教材を全件 list / 編集 / 削除可
-//   - same company の trainee: 自社の `is_published=true` 教材のみ閲覧可
-//     （所属コースが `is_published=false` の場合も非表示）
-//   - super_admin: 横断的に閲覧可（運用上の監査）
-//
-// 本文 (`Content`) は raw Markdown 文字列で保存し、 フロントは Edit / Preview タブで
-// 表示する（Note と同じ形式）。
-//
-// `OrderInCourse` はコース内での並び順。 同値時は ID 昇順。
+// TeachingMaterial は company_admin が自社 trainee 向けに作る教材。必ず 1 つの Course に所属する。
+// 本文は raw Markdown 文字列。コース内の並び順は OrderInCourse（同値時 ID 昇順）。
 type TeachingMaterial struct {
 	ID        uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
 	CompanyID uint64 `gorm:"column:company_id;not null;index" json:"companyId"`
-	// course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を
-	// AutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。
+	// NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD COLUMN 対策）。
 	CourseID        uint64    `gorm:"column:course_id;index" json:"courseId"`
 	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
 	Title           string    `gorm:"column:title;not null;default:''" json:"title"`

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -3,7 +3,6 @@ package domain
 import "time"
 
 // User はアプリケーション利用者のドメインモデル。
-// Spring Boot 側の entity.User と同じカラム構造を踏襲する。
 type User struct {
 	ID          uint64  `gorm:"primaryKey" json:"id"`
 	CognitoSub  string  `gorm:"column:cognito_sub;uniqueIndex" json:"cognitoSub"`
@@ -11,8 +10,7 @@ type User struct {
 	DisplayName string  `gorm:"column:display_name" json:"displayName"`
 	CompanyID   *uint64 `gorm:"column:company_id" json:"companyId,omitempty"`
 	Role        string  `gorm:"column:role" json:"role"`
-	// OnboardedAt は Welcome 画面の完了日時。NULL なら初回ログイン直後の Welcome を表示する。
-	// 一度値が入ったら二度と変えない（再オンボーディングは別 issue）。
+	// OnboardedAt は Welcome 完了日時。NULL なら Welcome を表示する。一度入ったら変えない。
 	OnboardedAt *time.Time `gorm:"column:onboarded_at" json:"onboardedAt,omitempty"`
 	CreatedAt   time.Time  `gorm:"column:created_at" json:"createdAt"`
 	UpdatedAt   time.Time  `gorm:"column:updated_at" json:"updatedAt"`

--- a/backend/internal/domain/user_stats.go
+++ b/backend/internal/domain/user_stats.go
@@ -1,7 +1,6 @@
 package domain
 
-// UserStats は集計済みのユーザー統計。テーブル直結ではなく
-// セッション・スコアからの計算結果として扱う。
+// UserStats はセッション・スコアから計算する集計済みユーザー統計（テーブル直結ではない）。
 type UserStats struct {
 	UserID        uint64  `json:"userId"`
 	TotalSessions int     `json:"totalSessions"`

--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -20,14 +20,8 @@ func NewAdminInvitationHandler(l *usecase.ListAdminInvitationsUseCase, c *usecas
 	return &AdminInvitationHandler{list: l, create: c, cancel: x}
 }
 
-// List は GET /api/v2/admin/invitations。
-// 認可と scope 判定:
-//   - SuperAdmin (運営): 全社横断 → ListAll() / ?companyId= 指定で絞り込みも可
-//   - CompanyAdmin     : 自社の company_id で自動フィルタ → ListByCompanyID()
-//   - その他           : 403 Forbidden
-//
-// 旧実装は ?companyId= クエリ必須だったが、フロントが渡していなかったため
-// 常に 400 を返していた。current user の role / company_id から自動解決する設計に修正。
+// List は招待一覧を返す。SuperAdmin は全社横断（?companyId= で絞り込み可）、
+// CompanyAdmin は自社のみ、それ以外は 403。
 //
 //	@Summary      招待 一覧 (admin)
 //	@Description  pending な 招待 を 返す。 SuperAdmin は 全社 (?companyId= で 絞り込み 可)、 CompanyAdmin は 自社 のみ。 trainee 等 は 403。
@@ -91,17 +85,8 @@ type createAdminInvReq struct {
 	DisplayName string `json:"displayName"`
 }
 
-// Create は POST /api/v2/admin/invitations。
-//
-// 認可ルール（SoD）:
-//   - SuperAdmin: company_admin の招待のみ可能。trainee の招待は CompanyAdmin に任せる。
-//     （運営が顧客企業の trainee 全員を直接管理するのは実運用に合わないため）
-//   - CompanyAdmin: 自社の trainee の招待のみ可能。company_id は自社に固定する。
-//   - その他: 403
-//
-// この境界を backend で確実に守ることで、フロント UI を経由しない API 呼び出しでも
-// SuperAdmin が間違って trainee を直接招待することや、CompanyAdmin が他社に
-// 招待を出すことを防ぐ。フロント UI は UX 改善として同じルールで選択肢を絞る。
+// Create は招待を作成する。SoD: SuperAdmin は company_admin のみ、CompanyAdmin は自社の trainee のみ招待可。
+// この境界は backend で確実に守り、UI を経由しない呼び出しでも越権招待を防ぐ。
 //
 //	@Summary      招待 作成
 //	@Description  SES マジック リンク で 招待 メール を 送る。 SoD: SuperAdmin は company_admin のみ 招待 可、 CompanyAdmin は trainee のみ 自社 に 招待 可。

--- a/backend/internal/handler/ai_chat_attachment_handler.go
+++ b/backend/internal/handler/ai_chat_attachment_handler.go
@@ -10,13 +10,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// AiChatAttachmentHandler は AI チャット添付の S3 PUT presigned URL を発行する HTTP handler。
-//
-// フロントの送信フロー:
-//  1. ユーザーが画像 / ドキュメントを + ボタンで選ぶ
-//  2. POST /api/v2/ai-chat/attachments/upload-url で presigned PUT URL を取得
-//  3. 同 URL に PUT で実体を直アップロード
-//  4. SSE 送信 (POST /api/v2/ai-chat/stream) の attachments[] に key とメタを詰める
+// AiChatAttachmentHandler は AI チャット添付の S3 PUT presigned URL を発行する。
 type AiChatAttachmentHandler struct {
 	issueUseCase *usecase.IssueAiChatAttachmentUploadURLUseCase
 }
@@ -31,30 +25,24 @@ type aiChatAttachmentUploadURLRequest struct {
 	SizeBytes   int64  `json:"sizeBytes"`
 }
 
-// IssueUploadURL は POST /api/v2/ai-chat/attachments/upload-url。
+// IssueUploadURL は添付の PUT presigned URL を発行する。
+// 4xx は 400（バリデーション）/ 401 / 413（サイズ超過）/ 415（未対応 MIME）。
 //
-// 戻り値: { uploadUrl, key, expiresIn }。
-//
-// 4xx 応答:
-//   - 400: contentType / filename / sizeBytes バリデーション失敗
-//   - 401: 未認証
-//   - 413: サイズ上限超過
-//   - 415: 未サポートの MIME
-//     @Summary      AI チャット 添付 PUT 署名 URL
-//     @Description  ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。
-//     @Tags         ai-chat
-//     @Accept       json
-//     @Produce      json
-//     @Param        body  body      aiChatAttachmentUploadURLRequest  true  "filename / contentType / sizeBytes"
-//     @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL
-//     @Failure      400   {object}  errorResponse  "バリデーション 失敗"
-//     @Failure      401   {object}  errorResponse  "未 認証"
-//     @Failure      413   {object}  errorResponse  "サイズ 上限 超過"
-//     @Failure      415   {object}  errorResponse  "未 サポート MIME"
-//     @Failure      503   {object}  errorResponse  "添付 アップロード 機能 が 設定 されて いない (dev/stub)"
-//     @Failure      500   {object}  errorResponse  "S3 presigner 失敗"
-//     @Router       /ai-chat/attachments/upload-url [post]
-//     @Security     CookieAuth
+//	@Summary      AI チャット 添付 PUT 署名 URL
+//	@Description  ai-chat/{userId}/{uuid}.{ext} の キー で S3 PUT 用 presigned URL を 発行。 contentType は image/png 等 の 許容 セット のみ。 sizeBytes 上限 (image 5MB / document 4.5MB) も 事前 検証。
+//	@Tags         ai-chat
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body      aiChatAttachmentUploadURLRequest  true  "filename / contentType / sizeBytes"
+//	@Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_usecase_repository.AiChatAttachmentUploadURL
+//	@Failure      400   {object}  errorResponse  "バリデーション 失敗"
+//	@Failure      401   {object}  errorResponse  "未 認証"
+//	@Failure      413   {object}  errorResponse  "サイズ 上限 超過"
+//	@Failure      415   {object}  errorResponse  "未 サポート MIME"
+//	@Failure      503   {object}  errorResponse  "添付 アップロード 機能 が 設定 されて いない (dev/stub)"
+//	@Failure      500   {object}  errorResponse  "S3 presigner 失敗"
+//	@Router       /ai-chat/attachments/upload-url [post]
+//	@Security     CookieAuth
 func (h *AiChatAttachmentHandler) IssueUploadURL(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)
 	if uid == 0 {
@@ -95,7 +83,7 @@ func (h *AiChatAttachmentHandler) IssueUploadURL(c *gin.Context) {
 		case errors.Is(err, usecase.ErrAttachmentTooLarge):
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": err.Error()})
 		default:
-			// 内部エラー（presigner 障害等）は詳細を漏らさず 500。原因は server log にだけ残す。
+			// 内部エラーは詳細を漏らさず 500。原因は server log にだけ残す。
 			log.Printf("ai-chat-attachment: presigned URL issue failed: %v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		}

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -16,24 +16,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// AiChatSseHandler は AI チャット用の Server-Sent Events エンドポイント。
-//
-// 送信フォーマット (text/event-stream):
-//
-//	event: session
-//	data: {"id": 42, "title": "...", ...}
-//
-//	event: token
-//	data: {"sessionId": 42, "delta": "ご"}
-//
-//	event: done
-//	data: {"sessionId": 42, "id": "uuid", "createdAt": "...", "content": "ご質問..."}
-//
-//	event: error
-//	data: {"message": "..."}
-//
-// クライアントは fetch + ReadableStream で line-based に読む（標準の EventSource は POST に
-// 対応しないため、本実装では fetch ベースで送る）。
+// AiChatSseHandler は AI チャット用の SSE エンドポイント。
+// イベントは session / token / done / error の 4 種。
+// EventSource は POST 非対応なのでクライアントは fetch + ReadableStream で読む。
 type AiChatSseHandler struct {
 	sendStream *usecase.SendAiMessageStreamUseCase
 }
@@ -51,8 +36,7 @@ type sseRequestBody struct {
 	Attachments []sseAttachmentRequest `json:"attachments"`
 }
 
-// sseAttachmentRequest はフロントが事前に S3 へアップロード済みの添付ファイルを参照する。
-// 実体バイトは含まず、key とメタだけ送って backend が S3 GetObject で取り出す。
+// sseAttachmentRequest は S3 へアップロード済みの添付参照（key とメタのみ、実体は backend が取得）。
 type sseAttachmentRequest struct {
 	Key         string `json:"key"`
 	Filename    string `json:"filename"`
@@ -60,8 +44,7 @@ type sseAttachmentRequest struct {
 	SizeBytes   int64  `json:"sizeBytes"`
 }
 
-// 1 リクエストあたりの添付上限。Bedrock 仕様（image 20 / document 5）に対し、
-// UI / 課金観点で 4 枚に絞っている（仕様検討で確定）。
+// maxAttachmentsPerMessage は 1 リクエストの添付上限（UI / 課金観点で 4 枚に絞る）。
 const maxAttachmentsPerMessage = 4
 
 // @Summary      AI チャット SSE ストリーミング
@@ -114,8 +97,7 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 	c.Writer.WriteHeader(http.StatusOK)
 	flushOrPanic(c.Writer)
 
-	// usecase の context は client 切断で cancel される c.Request.Context() を渡す。
-	// goroutine が長時間生きないように切断検知を伝播させる。
+	// client 切断で cancel される ctx を usecase に渡し、goroutine リークを防ぐ。
 	ctx, cancel := context.WithCancel(c.Request.Context())
 	defer cancel()
 
@@ -133,8 +115,7 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 		return
 	}
 
-	// keepalive: 15 秒ごとにコメント行 ":\n\n" を送って ALB / CloudFront のアイドルタイムアウト
-	// （既定 60 秒）で切断されるのを防ぐ。
+	// keepalive: 15 秒ごとにコメント行を送り、ALB / CloudFront のアイドルタイムアウトを防ぐ。
 	keep := time.NewTicker(15 * time.Second)
 	defer keep.Stop()
 
@@ -151,7 +132,6 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 			c.Writer.Flush()
 		case ev, ok := <-stream:
 			if !ok {
-				// usecase 側の channel が close した = 完了（FinalMessage で done 通知済）
 				return
 			}
 			if ev.Err != nil {
@@ -189,11 +169,7 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 	}
 }
 
-// writeSSEEvent は 1 イベントを SSE フォーマットで書き出す。
-//
-// 仕様: `event:` 行の後に空行 / `data:` 行 / 空行で 1 イベント完結。
-// 改行を含む payload は `data:` 行を分割する必要があるが、ここでは JSON を 1 行で
-// 出すので分割不要。
+// writeSSEEvent は 1 イベントを SSE フォーマット（event: 行 + data: 行 + 空行）で書き出す。
 func writeSSEEvent(w gin.ResponseWriter, event string, payload any) {
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -215,9 +191,7 @@ func writeSSEEvent(w gin.ResponseWriter, event string, payload any) {
 	w.Flush()
 }
 
-// flushOrPanic は最初のヘッダ送信で flush できないと SSE 自体機能しないので
-// 開発時の bug を早期発見するため panic させる。本番では gin の ResponseWriter は
-// 必ず Flusher を実装するので発生しない。
+// flushOrPanic は flush 不可なら panic する（SSE が機能しない bug を開発時に早期発見するため）。
 func flushOrPanic(w gin.ResponseWriter) {
 	if f, ok := any(w).(interface{ Flush() }); ok {
 		f.Flush()
@@ -228,17 +202,9 @@ func flushOrPanic(w gin.ResponseWriter) {
 	}
 }
 
-// buildAttachmentsFromRequest はリクエスト body の attachments[] を domain.Attachment に変換する。
-//
-// 各添付について:
-//   - key / contentType 必須
-//   - contentType は usecase.AllowedAttachmentContentTypes に含まれる必要あり
-//   - sizeBytes は MIME ごとの上限以下
-//   - key は **userID 配下の S3 prefix** `ai-chat/{userID}/` に必ず属する
-//     （他ユーザーの添付や他 prefix の S3 オブジェクトをサーバ側で読まされるのを防止）
-//
-// バリデーションを SSE handler 側で 1 回通すのは「presigned URL 取得を経由したか」を
-// 軽く再確認する目的（プロンプトインジェクションで任意 S3 オブジェクトを読み出させない）。
+// buildAttachmentsFromRequest はリクエストの attachments[] を検証して domain.Attachment に変換する。
+// contentType / sizeBytes の検証に加え、key が ai-chat/{userID}/ prefix に属することを必須にして
+// 他ユーザーや他 prefix の S3 オブジェクトをサーバ側で読まされるのを防ぐ。
 func buildAttachmentsFromRequest(userID uint64, reqs []sseAttachmentRequest) ([]domain.Attachment, error) {
 	if len(reqs) == 0 {
 		return nil, nil

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -15,10 +15,7 @@ import (
 )
 
 // AuthHandler は Cognito 関連の認証エンドポイントを提供する。
-// Spring Boot の CognitoAuthController に相当。
-//
-// HTTP / OAuth2 通信の詳細は infra/cognito.TokenExchanger に切り出してあり、
-// このハンドラは HTTP プロトコル境界とユーザー upsert ロジックだけを持つ。
+// OAuth2 通信は infra/cognito.TokenExchanger に切り出し、ここは HTTP 境界と user upsert だけを持つ。
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
 	users          repository.UserRepository
@@ -49,13 +46,8 @@ func NewAuthHandler(
 	}
 }
 
-// Me は現在ログイン中のユーザー情報を返す。
-// レスポンスは domain.User の各フィールド + 派生 `isAdmin` / `groups` を含める。
-// isAdmin の判定:
-//  1. Cognito の `cognito:groups` claim に "admin" が含まれている (Spring Boot 時代と同等)
-//  2. または DB users.role が super_admin / company_admin
-//
-// 上記いずれかで true。フロントは `isAdmin` を見て管理画面の表示可否を決める。
+// Me は現在ログイン中のユーザー情報（+ 派生 isAdmin / groups）を返す。
+// isAdmin は Cognito groups に "admin" を含むか、DB role が super_admin / company_admin なら true。
 //
 //	@Summary      current user 情報 取得
 //	@Description  Cookie 認証 を 元 に 現在 ログイン 中 の user 情報 (id / email / role / isAdmin / onboarded 等) を 返す。
@@ -86,8 +78,7 @@ func (h *AuthHandler) Me(c *gin.Context) {
 	isAdmin := middleware.IsAdminFromGroups(groups) ||
 		user.Role == domain.RoleSuperAdmin ||
 		user.Role == domain.RoleCompanyAdmin
-	// access_token に admin グループがあるが DB role が未昇格の場合はここで同期する。
-	// Google federated ユーザーはログイン時の upsert で groups が取れないケースがある。
+	// Cognito group admin だが DB role が未昇格なら同期する（federated ユーザー対策）。
 	if middleware.IsAdminFromGroups(groups) && user.Role != domain.RoleSuperAdmin && user.Role != domain.RoleCompanyAdmin {
 		if h.users != nil {
 			_ = h.users.UpdateRole(c.Request.Context(), user.ID, domain.RoleSuperAdmin)
@@ -104,7 +95,7 @@ func (h *AuthHandler) Me(c *gin.Context) {
 		"updatedAt":   user.UpdatedAt,
 		"groups":      groups,
 		"isAdmin":     isAdmin,
-		// onboarded: フロントが /welcome リダイレクト判定に使う（true なら Welcome 表示済）。
+		// onboarded: フロントの /welcome リダイレクト判定に使う。
 		"onboarded": user.OnboardedAt != nil,
 	})
 }
@@ -124,18 +115,12 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 
 type cognitoCallbackReq struct {
 	Code string `json:"code" binding:"required"`
-	// InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で
-	// 受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より
-	// 優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。
+	// InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。
 	InvitationToken string `json:"invitationToken"`
 }
 
-// Callback は Cognito Hosted UI から戻ってきた認可コードをアクセストークンに交換し、
-// HttpOnly Cookie に格納する。Spring Boot の CognitoAuthController#callback 相当。
-//
-// 招待ゲート: 新規ユーザー（DB に sub が無い）は「Cognito group admin」または
-// 「pending な invitation 受信者」のいずれかでない限り、ログインを拒否する（403）。
-// これによりトレイニー / company_admin は必ず上位ロールからの招待経由でないとアカウントを作れない。
+// Callback は認可コードを token に交換して HttpOnly Cookie に格納する。
+// 招待ゲート: 新規ユーザーは Cognito group admin か pending invitation 受信者でなければ 403 で拒否する。
 //
 //	@Summary      Cognito callback (認可 コード → token 交換)
 //	@Description  Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。
@@ -166,12 +151,8 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
 	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
-	// 初回ログインで users 行が無いと /auth/me が 404 になるため自動で upsert する。
-	// id_token の payload から sub / email / cognito:groups を取り出して同期する:
-	//   - 招待 OR Cognito group "admin" のいずれかが真なら create（role は招待 / group に従う）
-	//   - 既存ユーザーは Cognito group が変わっていれば role を update する
-	// 上記いずれでもない（=招待なし & Cognito admin でもない）新規ユーザーはログイン拒否し、
-	// 直前にセットした Cookie をクリアしてセッションを残さない。
+	// 初回ログインで users 行が無いと /auth/me が 404 になるため upsert する。
+	// 拒否された新規ユーザーは Cookie をクリアしてセッションを残さない。
 	if allowed := h.upsertUserFromIDToken(c, tok.IDToken, req.InvitationToken); !allowed {
 		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusForbidden, gin.H{
@@ -203,8 +184,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 
 	tok, err := h.tokens.RefreshAccessToken(c.Request.Context(), rt)
 	if err != nil {
-		// refresh_token が無効と判明した時はログイン状態をクリアして 401。
-		// それ以外（502: Cognito 不到達など）は Cookie を残してリトライ余地を残す。
+		// refresh_token 無効は Cookie クリアして 401。それ以外（502 等）は Cookie を残す。
 		var exErr *cognito.TokenExchangeError
 		if errors.As(err, &exErr) {
 			log.Printf("cognito refresh: status=%d body=%s", exErr.HTTPStatus, exErr.Body)
@@ -218,14 +198,9 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	}
 
 	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
-	// refresh_token grant でも id_token が返る場合は DB role を同期する。
-	// Google federated ユーザーは ID token に cognito:groups が含まれないことがあるため
-	// access_token の claims からも昇格を試みる。
-	// refresh は既存ユーザーが対象のため、招待ゲート（戻り値 false）はここでは無視する
-	// — DB から削除されたユーザーが refresh する稀ケースは別途 401 にすべきだが、本 PR の
-	// スコープ外として既存挙動を維持する。
+	// id_token があれば DB role を同期する。無ければ access_token の claims から昇格を試みる
+	// （federated ユーザーは id_token に groups が無いことがある）。refresh は既存ユーザー前提。
 	if tok.IDToken != "" {
-		// refresh は既存ユーザー前提で、新規招待を引く必要はないため invitationToken は空文字を渡す。
 		_ = h.upsertUserFromIDToken(c, tok.IDToken, "")
 	} else {
 		h.syncRoleFromAccessToken(c, tok.AccessToken)
@@ -269,8 +244,7 @@ func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (in
 	case errors.Is(err, cognito.ErrNotConfigured):
 		return http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"}, true
 	case errors.As(err, &exErr):
-		// 本物の理由 (invalid_grant / invalid_client / redirect_uri_mismatch 等) を残す。
-		// クライアントには簡素なエラーだけ返す。
+		// 本物の理由は log に残し、クライアントには簡素なエラーだけ返す。
 		log.Printf("cognito %s: token exchange status=%d body=%s redirect_uri=%s client_id_set=%t client_secret_set=%t",
 			op, exErr.HTTPStatus, exErr.Body, h.cognitoCfg.RedirectURI, h.cognitoCfg.ClientID != "", h.cognitoCfg.ClientSecret != "")
 		return http.StatusUnauthorized, gin.H{"error": "token_exchange_failed"}, true
@@ -286,20 +260,13 @@ func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (in
 	}
 }
 
-// upsertUserFromIDToken は id_token の claim を見て users 行を新規作成 / role 更新する。
-// 戻り値 allowed:
-//   - true : 既存ユーザー、または「Cognito group admin / pending invitation あり」で新規作成成功
-//   - false: 「招待なし & Cognito admin でもない」新規ユーザー（ログイン拒否）または create 失敗
-//
-// invitationToken はマジックリンク経由の不透明 token（任意）。指定がある場合は email より
-// 優先して照合する（同 email に複数 pending invitation がある異常系での誤一致を防ぐ）。
-//
-// 招待ゲートを usecase ではなく handler 層に置いているのは、認可境界（Cookie 発行 / 401-403 を返す責務）が
-// HTTP 層であり、ユーザーが拒否された理由を上位ハンドラが直接知る必要があるため。
+// upsertUserFromIDToken は id_token の claim から users 行を新規作成 / role 更新する。
+// allowed=false は「招待なし & Cognito admin でもない」新規ユーザー（ログイン拒否）または create 失敗。
+// invitationToken 指定時は email より優先して照合する（同 email 複数 pending での誤一致防止）。
+// 招待ゲートを handler 層に置くのは、Cookie 発行 / 401-403 を返す認可境界が HTTP 層だから。
 func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationToken string) (allowed bool) {
 	claims, err := middleware.DecodeClaims(idToken)
 	if err != nil || h.users == nil {
-		// claims を読めない / users repo 無し は内部エラー扱い。Cookie はクリアして拒否する。
 		return false
 	}
 	sub, _ := claims["sub"].(string)
@@ -307,16 +274,12 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 		return false
 	}
 	email, _ := claims["email"].(string)
-	// OIDC (Google など) 経由のログインでは id_token に `name` が含まれる。
-	// Cognito User Pool の SRP ログインだと無いこともあるので空許容。
+	// OIDC 経由は id_token に name を含む（Cognito SRP では無いこともあるので空許容）。
 	oidcName, _ := claims["name"].(string)
 	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
 	isCognitoAdmin := middleware.IsAdminFromGroups(groups)
 
-	// 招待検索（既存ユーザーの role 昇格・新規ユーザー作成の両方で使う）。
-	// 優先順位:
-	//   1. invitationToken が指定されていれば FindPendingByToken で照合（マジックリンク経由）
-	//   2. 1 で見つからない場合は email でフォールバック検索（旧フロー互換）
+	// 招待検索: invitationToken 優先、無ければ email でフォールバック。
 	var inv *domain.AdminInvitation
 	if h.invitations != nil {
 		if invitationToken != "" {
@@ -329,25 +292,20 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 
 	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
 	if existing != nil {
-		// 既存ユーザの DisplayName が「email そのまま」になっている場合は
-		// id_token の `name` claim で上書きする（旧フローで email を仮の displayName として
-		// 入れていたユーザを OIDC ログイン時に氏名へ自動補正する）。
-		// ユーザが明示的にプロフィールを書き換えている場合（displayName != email）は触らない。
+		// DisplayName が email のまま（旧フローの仮値）なら OIDC name で自動補正する。
+		// ユーザーが明示的に書き換えている場合は触らない。
 		if oidcName != "" && existing.Email != "" && existing.DisplayName == existing.Email {
 			if err := h.users.UpdateDisplayName(c.Request.Context(), existing.ID, oidcName); err != nil {
 				log.Printf("upsertUserFromIDToken: backfill displayName failed userID=%d: %v", existing.ID, err)
 			}
 		}
-		// 既存ユーザー: 招待 / Cognito group の状態で role / company を更新する。
-		// 重要な制約:
-		//   - super_admin は何があっても降格しない（招待での降格は不可、別途 admin API でのみ降格可）
-		//   - 招待による昇格は trainee → company_admin のみ（trainee → super_admin / company_admin → super_admin はしない）
-		//   - Cognito group admin は最強で super_admin に昇格する
+		// role 更新の制約: super_admin は降格しない / 招待昇格は trainee → company_admin のみ /
+		// Cognito group admin は super_admin に昇格する。
 		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
 			_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
 		}
 		if inv != nil && existing.Role != domain.RoleSuperAdmin {
-			// 役割昇格: trainee → company_admin だけ反映する（同一 role / 降格は skip）。
+			// 昇格は trainee → company_admin だけ反映する。
 			if existing.Role == domain.RoleTrainee && inv.Role == domain.RoleCompanyAdmin {
 				if err := h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleCompanyAdmin); err != nil {
 					log.Printf("upsertUserFromIDToken: existing user role upgrade failed userID=%d: %v", existing.ID, err)
@@ -355,13 +313,13 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 					log.Printf("upsertUserFromIDToken: existing user upgraded trainee→company_admin userID=%d email=%s", existing.ID, email)
 				}
 			}
-			// company 紐付け: 招待の company_id と異なる、または未設定なら更新する。
+			// company 紐付け: 招待の company_id と異なる / 未設定なら更新する。
 			if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
 				if err := h.users.UpdateCompanyID(c.Request.Context(), existing.ID, inv.CompanyID); err != nil {
 					log.Printf("upsertUserFromIDToken: existing user company update failed userID=%d: %v", existing.ID, err)
 				}
 			}
-			// 招待を accepted にマーク（再利用防止 + 監査）
+			// 招待を accepted にマーク（再利用防止 + 監査）。
 			_ = h.invitations.UpdateStatus(c.Request.Context(), inv.ID, domain.InvitationStatusAccepted)
 		}
 		return true
@@ -376,8 +334,7 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 	role := domain.RoleTrainee
 	var companyID *uint64
 	var acceptedInvID uint64
-	// displayName の優先順位: 招待 displayName > OIDC `name` claim > email （フォールバック）。
-	// email をそのまま displayName に詰めるのは「氏名がどうしても取れないとき」だけにする。
+	// displayName の優先順位: 招待 displayName > OIDC name > email（フォールバック）。
 	displayName := email
 	if oidcName != "" {
 		displayName = oidcName
@@ -408,7 +365,7 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 		log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
 		return false
 	}
-	// 招待を accepted にマーク（履歴・監査）
+	// 招待を accepted にマーク（履歴・監査）。
 	if h.invitations != nil && acceptedInvID != 0 {
 		_ = h.invitations.UpdateStatus(c.Request.Context(), acceptedInvID, domain.InvitationStatusAccepted)
 	}

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -8,12 +8,6 @@ import (
 )
 
 // CodeExecuteHandler は trainee が書いたコードをサーバ側サンドボックスで実行する。
-//
-//	POST /api/v2/code/execute
-//	Body: { "code": "...", "language": "php" }
-//
-// 旧 `/api/v2/php/execute` から汎用化した（body に language を持たせる設計は元から
-// あったので、path 側を言語非依存に揃えた）。
 type CodeExecuteHandler struct {
 	executeCode *usecase.ExecuteCodeUseCase
 }
@@ -45,8 +39,7 @@ func (h *CodeExecuteHandler) Execute(c *gin.Context) {
 		return
 	}
 	if req.Language == "" {
-		// language 未指定はデフォルト php（既存挙動維持）。多言語対応で trainee が
-		// 明示的に言語を切り替える UI ができるまでの暫定措置。
+		// language 未指定はデフォルト php（既存挙動維持）。
 		req.Language = "php"
 	}
 

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -11,13 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// CourseHandler はコース API を扱う。
-//
-//	GET    /api/v2/courses        一覧（actor role / company で自動フィルタ）
-//	GET    /api/v2/courses/:id    詳細
-//	POST   /api/v2/courses        作成（company_admin / super_admin）
-//	PUT    /api/v2/courses/:id    更新（同上）
-//	DELETE /api/v2/courses/:id    削除（配下教材も cascade で削除）
+// CourseHandler はコースの CRUD API を扱う。
 type CourseHandler struct {
 	uc *usecase.CourseUseCase
 }

--- a/backend/internal/handler/embed_handler.go
+++ b/backend/internal/handler/embed_handler.go
@@ -18,32 +18,22 @@ func NewEmbedHandler(f *embed.Fetcher) *EmbedHandler {
 	return &EmbedHandler{fetcher: f}
 }
 
-// Resolve は GET /api/v2/embeds/oembed?url=...
+// Resolve は ?url= の OGP / oEmbed を解決して返す。
+// 失敗は InvalidURL→400 / UnsupportedHost→422 / Unreachable→502 / その他→500 にマップする。
 //
-// ?url= が必須クエリパラメータ。fetcher が allow-list / SSRF ガードを担う。
-// 失敗時のステータスマップ:
-//
-//   - ErrInvalidURL      → 400
-//
-//   - ErrUnsupportedHost → 422
-//
-//   - ErrUnreachable     → 502
-//
-//   - その他             → 500
-//
-//     @Summary      外部 URL の OGP / oEmbed メタ 取得
-//     @Description  ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。
-//     @Tags         embeds
-//     @Produce      json
-//     @Param        url  query     string  true  "メタ 取得 対象 URL"
-//     @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_infra_embed.Card
-//     @Failure      400  {object}  errorResponse  "url 欠落 or 無効 URL"
-//     @Failure      401  {object}  errorResponse  "未 認証"
-//     @Failure      422  {object}  errorResponse  "allow-list 外 ホスト"
-//     @Failure      502  {object}  errorResponse  "到達 不可"
-//     @Failure      500  {object}  errorResponse  "内部 エラー"
-//     @Router       /embeds/oembed [get]
-//     @Security     CookieAuth
+//	@Summary      外部 URL の OGP / oEmbed メタ 取得
+//	@Description  ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list / SSRF / DNS rebinding 対策 は infra/embed.Fetcher が 担う。
+//	@Tags         embeds
+//	@Produce      json
+//	@Param        url  query     string  true  "メタ 取得 対象 URL"
+//	@Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_infra_embed.Card
+//	@Failure      400  {object}  errorResponse  "url 欠落 or 無効 URL"
+//	@Failure      401  {object}  errorResponse  "未 認証"
+//	@Failure      422  {object}  errorResponse  "allow-list 外 ホスト"
+//	@Failure      502  {object}  errorResponse  "到達 不可"
+//	@Failure      500  {object}  errorResponse  "内部 エラー"
+//	@Router       /embeds/oembed [get]
+//	@Security     CookieAuth
 func (h *EmbedHandler) Resolve(c *gin.Context) {
 	raw := c.Query("url")
 	if raw == "" {

--- a/backend/internal/handler/exercise_submission_handler.go
+++ b/backend/internal/handler/exercise_submission_handler.go
@@ -10,12 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// ExerciseSubmissionHandler は master_exercises に対する提出 API を扱う。
-//
-// API パス:
-//
-//	POST /api/v2/exercises/:slug/submit       コードを提出して採点
-//	GET  /api/v2/exercises/:slug/submissions  current user の履歴
+// ExerciseSubmissionHandler は master_exercises に対する提出 / 履歴 API を扱う。
 type ExerciseSubmissionHandler struct {
 	submit *usecase.SubmitMasterExerciseUseCase
 	list   *usecase.ListUserMasterSubmissionsUseCase

--- a/backend/internal/handler/health_handler.go
+++ b/backend/internal/handler/health_handler.go
@@ -9,7 +9,6 @@ import (
 )
 
 // HealthHandler は /api/v2/health エンドポイントを提供する。
-// Spring Boot の /actuator/health と並行運用する。
 type HealthHandler struct {
 	uc *usecase.CheckHealthUseCase
 }
@@ -18,7 +17,7 @@ func NewHealthHandler(uc *usecase.CheckHealthUseCase) *HealthHandler {
 	return &HealthHandler{uc: uc}
 }
 
-// Get は /api/v2/health の GET ハンドラ。 DB 疎通 を 確認 し UP / DOWN を 返す。
+// Get は DB 疎通を確認し UP / DOWN を返す。
 //
 //	@Summary      ヘルスチェック
 //	@Description  バックエンド と DB の 疎通 を 確認 する。 ALB / CloudWatch / 監視 から 叩く 想定。

--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -41,10 +41,7 @@ func (h *LearningReportHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
-// requestReportReq は POST /learning-reports/generate のリクエスト body。
-//
-// フロントエンドは月次サマリの生成しか叩かないため、 期間指定は year + month の
-// 1 形式に揃える。 バックエンド側で月初〜翌月初の period を組み立てて usecase に渡す。
+// requestReportReq は月次レポート生成 body。year + month から月初〜翌月初の period を組み立てる。
 type requestReportReq struct {
 	Year  int `json:"year"  binding:"required,min=2000,max=2100"`
 	Month int `json:"month" binding:"required,min=1,max=12"`
@@ -72,8 +69,7 @@ func (h *LearningReportHandler) Request(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	// year + month → 月初 [00:00:00 UTC] 〜 翌月初 [00:00:00 UTC] の期間に変換。
-	// レポート集計の実装が PeriodFrom <= submitted_at < PeriodTo の半開区間で扱う前提。
+	// year + month を月初〜翌月初の半開区間 [PeriodFrom, PeriodTo) に変換する。
 	from := time.Date(req.Year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
 	to := from.AddDate(0, 1, 0)
 	got, err := h.request.Execute(c.Request.Context(), usecase.RequestLearningReportInput{

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -10,15 +10,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// MasterExerciseHandler は運営マスタ演習問題（master_exercises）の一覧 / 取得を返す。
-//
-// API パスは言語非依存:
-//
-//	GET /api/v2/exercises?language=php   一覧
-//	GET /api/v2/exercises/:slug          詳細（入出力例の配列を含む）
-//
-// 詳細は slug ベース URL（`/code-editor/php-1` のように人間可読）に揃えるため、
-// 旧 `:id` ルートは廃止し slug 必須にする（フロントは新 API に追従させる）。
+// MasterExerciseHandler は運営マスタ演習問題の一覧 / 詳細を返す（詳細は slug ベース URL）。
 type MasterExerciseHandler struct {
 	listExercises  *usecase.ListMasterExercisesUseCase
 	listWithStatus *usecase.ListMasterExercisesWithStatusUseCase
@@ -33,12 +25,8 @@ func NewMasterExerciseHandler(
 	return &MasterExerciseHandler{listExercises: list, listWithStatus: listWithStatus, getExercise: get}
 }
 
-// List は GET /api/v2/exercises 。query `language` で絞り込み（空なら全言語）。
-//
-// current user の提出状況（solved / in_progress / 未着手）と
-// 全ユーザ合計の集計（提出数 / 正答ユーザ数）を 1 度に返す。
-// 一覧ページでステータスバッジ + 解答率を出すために必要。
-// 未ログインの場合は status は全 ""、 stats だけ返す。
+// List は演習問題一覧を query language で絞り込んで返す。
+// current user の提出状況と全ユーザ集計を同時に返す（未ログイン時は status 空）。
 //
 //	@Summary      演習問題 一覧 (status + stats 付き)
 //	@Description  運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。
@@ -63,10 +51,8 @@ func (h *MasterExerciseHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
-// GetBySlug は GET /api/v2/exercises/:slug 。 入出力例を含む詳細を返す。
-//
-// `gorm.ErrRecordNotFound` のときだけ 404 を返し、 それ以外の DB / 集計エラーは 500 として
-// 区別する。 全部 404 にすると本物の障害を「該当なし」と誤検知して上流に隠してしまうため。
+// GetBySlug は入出力例を含む詳細を返す。
+// NotFound だけ 404、それ以外の DB エラーは 500 にして本物の障害を「該当なし」と誤検知させない。
 //
 //	@Summary      演習問題 詳細 (slug)
 //	@Description  指定 slug の 演習 問題 + 入 出力 例 一覧 を 返す。 詳細 画面 用。

--- a/backend/internal/handler/middleware/auth_cookie.go
+++ b/backend/internal/handler/middleware/auth_cookie.go
@@ -6,28 +6,20 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// 認証 Cookie 関連の定数。値はフロントエンド側 (Cognito callback / axios withCredentials)
-// と整合させる必要があるため、変えるときは双方を同期更新すること。
+// 認証 Cookie 関連の定数。フロント側の設定と同期更新すること。
 const (
-	// CookieRefreshToken は Cognito から取得した refresh_token を格納する Cookie 名。
-	// CookieAccessToken は jwt.go に定義済み（middleware 全体で再利用）。
+	// CookieRefreshToken は refresh_token を格納する Cookie 名（CookieAccessToken は jwt.go）。
 	CookieRefreshToken = "refresh_token"
 
-	// AccessTokenDefaultMaxAgeSeconds は Cognito レスポンスに expires_in が
-	// 含まれていなかったときの fallback (1 時間)。Cognito User Pool の標準寿命と一致。
+	// AccessTokenDefaultMaxAgeSeconds は expires_in 不在時の fallback（1 時間）。
 	AccessTokenDefaultMaxAgeSeconds = 3600
 
-	// RefreshTokenMaxAgeSeconds は refresh_token Cookie の寿命 (30 日)。
-	// Cognito User Pool の refresh-token-validity 設定と整合させる。
+	// RefreshTokenMaxAgeSeconds は refresh_token Cookie の寿命（30 日）。
 	RefreshTokenMaxAgeSeconds = 30 * 24 * 3600
 )
 
 // SetAccessTokenCookie は HttpOnly + Secure + SameSite=None で access_token を設定する。
-// maxAgeSeconds が 0 以下の場合は AccessTokenDefaultMaxAgeSeconds に丸める。
-//
-// Cognito refresh / callback 双方で同じヘッダー設定が必要だったため共通化した。
-// 旧実装では SetSameSite と SetCookie の組み合わせが各 handler に散在し
-// 設定漏れリスクがあったため、責務を 1 箇所に集約する。
+// maxAgeSeconds が 0 以下なら AccessTokenDefaultMaxAgeSeconds に丸める。
 func SetAccessTokenCookie(c *gin.Context, accessToken string, maxAgeSeconds int) {
 	if maxAgeSeconds <= 0 {
 		maxAgeSeconds = AccessTokenDefaultMaxAgeSeconds

--- a/backend/internal/handler/middleware/cors.go
+++ b/backend/internal/handler/middleware/cors.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// 許可するオリジン。Spring Boot の CorsConfig と同じ値を Go 側でも維持する。
+// allowedOrigins は CORS で許可するオリジン。
 var allowedOrigins = map[string]struct{}{
 	"https://normanblog.com":                                          {},
 	"http://normanblog.com":                                           {},
@@ -21,17 +21,13 @@ const (
 	maxAge       = "3600"
 )
 
-// IsAllowedOrigin は WebSocket Upgrader.CheckOrigin など CORS middleware の外でも
-// 同じ allowlist を使えるようにするヘルパ。
+// IsAllowedOrigin は CORS middleware 外からも同じ allowlist を使えるようにするヘルパ。
 func IsAllowedOrigin(origin string) bool {
 	_, ok := allowedOrigins[origin]
 	return ok
 }
 
-// CORS は Gin 用の CORS middleware。
-// 許可リストにある Origin のみ Access-Control-Allow-Origin を返し、
-// allowCredentials=true で動作するようにする。
-// Preflight (OPTIONS) は本 middleware 内で 204 で返して終端する。
+// CORS は許可リストの Origin のみ credentials 付きで許可し、Preflight は 204 で終端する。
 func CORS() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		origin := c.GetHeader("Origin")

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -10,18 +10,11 @@ import (
 
 const (
 	ContextKeyCurrentUserID = "currentUserID"
-	// ContextKeyCurrentUser は JWTAuth の後段でセットされる *domain.User。
-	// handler 側で role / company_id を見たいケース (admin scope の判定など) で利用する。
+	// ContextKeyCurrentUser は handler が role / company_id を見るための *domain.User。
 	ContextKeyCurrentUser = "currentUser"
 )
 
-// CurrentUser は JWTAuth の後段で動く middleware。
-// JWTAuth が context に詰めた cognito sub から users 行を引き、
-// `currentUserID` を context にセットする。
-//
-// これにより handler は `middleware.CurrentUserIDOrZero(c)` で
-// 認証済みユーザーの users.id を取り出せる。
-// 個別 handler が `:userId` path / `?userId=` クエリを要求しなくても済む。
+// CurrentUser は cognito sub から users 行を引いて currentUserID / currentUser を context にセットする。
 func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, ok := c.Get(ContextKeyCognitoSub)
@@ -50,10 +43,7 @@ func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
 	}
 }
 
-// CurrentUserIDOrZero は middleware.CurrentUser がセットした users.id を取り出す。
-// 設定されていなければ 0 を返す（呼び出し側でガードする）。
-// 名前で「未設定なら 0」と明示することで、Must プレフィックスから連想される
-// 「不在なら panic / abort」挙動と取り違えないようにする意図。
+// CurrentUserIDOrZero は CurrentUser がセットした users.id を返す（未設定なら 0）。
 func CurrentUserIDOrZero(c *gin.Context) uint64 {
 	v, ok := c.Get(ContextKeyCurrentUserID)
 	if !ok {
@@ -63,8 +53,7 @@ func CurrentUserIDOrZero(c *gin.Context) uint64 {
 	return id
 }
 
-// CurrentUserFromContext は CurrentUser middleware が保存した *domain.User を返す。
-// 未セット / 型不一致のときは nil。handler 側で role / company_id を扱うために使う。
+// CurrentUserFromContext は CurrentUser が保存した *domain.User を返す（未セット時は nil）。
 func CurrentUserFromContext(c *gin.Context) *domain.User {
 	v, ok := c.Get(ContextKeyCurrentUser)
 	if !ok {

--- a/backend/internal/handler/middleware/jwt.go
+++ b/backend/internal/handler/middleware/jwt.go
@@ -18,15 +18,11 @@ const (
 	CookieAccessToken       = "access_token"
 )
 
-// AdminGroupName は Cognito User Pool 上の admin グループ名。
-// resjimkalto89890@gmail.com など管理者ユーザーが所属する。
-// AWS Cognito の group 名は case-sensitive。Pool 2 (ap-northeast-1_TkRen4lyD) の
-// 既存 group `admin` (小文字) を Spring Boot 時代から踏襲している。
+// AdminGroupName は Cognito User Pool 上の admin グループ名（case-sensitive）。
 const AdminGroupName = "admin"
 
 // JWTAuth は HttpOnly Cookie の access_token を検証する Gin middleware。
-// 現状は payload (claims) の base64 デコードのみで、署名 (JWKS) 検証は別 issue で実装する。
-// ハンドラから c.Get(ContextKeyCognitoSub) で本物の Cognito sub を取れる。
+// 現状は payload の base64 デコードのみで、署名（JWKS）検証は別 issue。
 func JWTAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token, err := c.Cookie(CookieAccessToken)
@@ -48,8 +44,7 @@ func JWTAuth() gin.HandlerFunc {
 		if email, ok := claims["email"].(string); ok {
 			c.Set(ContextKeyEmail, email)
 		}
-		// cognito:groups は []string として claim に入る。Spring Boot 時代と同じ
-		// "ADMIN" group を見て管理者判定する想定。
+		// cognito:groups は admin 判定に使う。
 		if raw, ok := claims["cognito:groups"]; ok {
 			groups := ToStringSliceFromClaim(raw)
 			c.Set(ContextKeyCognitoGroups, groups)
@@ -58,9 +53,7 @@ func JWTAuth() gin.HandlerFunc {
 	}
 }
 
-// ToStringSliceFromClaim は claim の `cognito:groups` を []string に変換する。
-// JSON unmarshal 結果が []any なので逐次 string assert する。
-// auth_handler 等の外部からも使うため exported。
+// ToStringSliceFromClaim は claim の cognito:groups を []string に変換する。
 func ToStringSliceFromClaim(v any) []string {
 	arr, ok := v.([]any)
 	if !ok {
@@ -91,11 +84,7 @@ func IsAdminFromGroups(groups []string) bool {
 	return slices.Contains(groups, AdminGroupName)
 }
 
-// DecodeClaims は JWT (3 セグメント) の payload 部だけを base64url デコードして
-// claim マップに変換する。署名検証は行わない（JWKS 検証は別 issue）。
-//
-// middleware.JWTAuth と auth_handler.Callback の両方で利用される共通ヘルパー。
-// 以前は各所に同等実装が複製されていたが DRY 化のため 1 箇所に集約。
+// DecodeClaims は JWT の payload 部を base64url デコードして claim マップに変換する（署名検証はしない）。
 func DecodeClaims(token string) (map[string]any, error) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {

--- a/backend/internal/handler/note_handler.go
+++ b/backend/internal/handler/note_handler.go
@@ -26,8 +26,7 @@ func NewNoteHandler(
 	return &NoteHandler{list: l, create: c, update: u, del: d}
 }
 
-// List は current user の note 一覧を返す。
-// userId はクライアントから受け取らない（IDOR 対策）。
+// List は current user の note 一覧を返す（userId は受け取らない、IDOR 対策）。
 //
 //	@Summary      自分 の ノート 一覧
 //	@Description  current user の note を 更新 日 降順 で 返す。 IDOR 対策 で userId は 受け取らない。

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -18,8 +18,7 @@ func NewNoteImageHandler(i *usecase.IssueNoteImageUploadURLUseCase) *NoteImageHa
 	return &NoteImageHandler{issue: i}
 }
 
-// issueUploadURLReq は body 受け取り。 userId は **受け取らない** (current user
-// を middleware 経由 で 強制)。 OpenAPI Phase 3 で IDOR を 修正。
+// issueUploadURLReq は body 受け取り。userId は受け取らず middleware の current user を使う（IDOR 対策）。
 type issueUploadURLReq struct {
 	ContentType string `json:"contentType"`
 }
@@ -42,8 +41,7 @@ func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
 		return
 	}
 	var req issueUploadURLReq
-	// body 無し (EOF) は 許容 する が、 不正 JSON / 型 違い は 400 で 弾く
-	// (silently masking malformed JSON を 避ける)。
+	// body 無し (EOF) は許容するが、不正 JSON は 400 で弾く。
 	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/handler/onboarding_handler.go
+++ b/backend/internal/handler/onboarding_handler.go
@@ -9,9 +9,6 @@ import (
 )
 
 // OnboardingHandler は Welcome 画面の完了通知を受ける認証必須エンドポイント。
-// 別途 ProfileHandler に同居させる選択肢もあったが、責務（onboarding 状態管理）が
-// 明確に独立しているので別 handler に切り出す（将来「再オンボーディング」「skipped」
-// などのバリエーションが増えても影響範囲を局所化できる）。
 type OnboardingHandler struct {
 	complete *usecase.CompleteOnboardingUseCase
 }
@@ -20,9 +17,7 @@ func NewOnboardingHandler(complete *usecase.CompleteOnboardingUseCase) *Onboardi
 	return &OnboardingHandler{complete: complete}
 }
 
-// Complete は POST /api/v2/profile/me/onboarding/complete。
-// 自分自身の users.onboarded_at を NOW() に更新する。
-// repo 側で IS NULL ガード付きなので冪等（複数回呼んでも初回日時が保持される）。
+// Complete は自分自身の users.onboarded_at を更新する（IS NULL ガードで冪等）。
 //
 //	@Summary      オンボーディング 完了 通知
 //	@Description  Welcome 画面 「はじめる」 押下 で onboarded_at = NOW() に 更新。 冪等 (再 押下 で も 初回 日時 保持)。

--- a/backend/internal/handler/openapi_types.go
+++ b/backend/internal/handler/openapi_types.go
@@ -1,8 +1,5 @@
-// これら の 型 は handler コード から 直接 参照 さ れず、 swaggo (= `make openapi`)
-// が doc コメント 内 の `@Success` / `@Failure` の `{object}` 識別子 と して
-// 名前 解決 する。 そのため staticcheck の U1000 (unused) 警告 を ファイル 全体 で
-// 抑止 する。 該当 型 を 実際 に handler から JSON marshal に 使う ように なれば
-// この 抑止 は 不要。
+// このファイルの型は handler から直接参照されず、swaggo が @Success / @Failure の
+// {object} 識別子として名前解決するためだけに存在する（U1000 を抑止する）。
 
 //lint:file-ignore U1000 referenced only by swaggo annotations
 
@@ -10,23 +7,22 @@ package handler
 
 import "time"
 
-// errorResponse は すべて の handler が 返す 共通 エラー JSON 形式。
-// OpenAPI spec で @Failure の レスポンス 型 と して 使う。
+// errorResponse は全 handler 共通のエラー JSON 形式。
 type errorResponse struct {
 	Error string `json:"error" example:"unauthorized"`
 }
 
-// successMessage は 単純 メッセージ のみ を 返す 成功 レスポンス (200 OK で 内容 が プロパティ 1 個 の とき)。
+// successMessage は success プロパティ 1 個の成功レスポンス。
 type successMessage struct {
 	Success string `json:"success" example:"プロフィールを更新しました"`
 }
 
-// messageResponse は ログアウト / ログイン 完了 等 の 一般 success メッセージ。
+// messageResponse は一般的な success メッセージ。
 type messageResponse struct {
 	Message string `json:"message" example:"ログインしました。"`
 }
 
-// meResponse は /auth/me の 戻り 値 形 (gin.H で 返して いる の を OpenAPI 用 に 型 化)。
+// meResponse は /auth/me の戻り値形（OpenAPI 用の型化）。
 type meResponse struct {
 	ID          uint64    `json:"id"          example:"42"`
 	CognitoSub  string    `json:"cognitoSub"  example:"abc-123-uuid"`
@@ -41,8 +37,7 @@ type meResponse struct {
 	Onboarded   bool      `json:"onboarded"   example:"true"`
 }
 
-// invitationValidateResponse は /invitations/accept/{token} (public) の 戻り 値 形。
-// email を 含め ない (= メタ 情報 漏洩 防止)。
+// invitationValidateResponse は /invitations/accept/{token} の戻り値形（email は含めない）。
 type invitationValidateResponse struct {
 	Role        string `json:"role"        example:"trainee"`
 	DisplayName string `json:"displayName" example:"山田 太郎"`

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -13,9 +13,7 @@ import (
 )
 
 // ProfileHandler は GET / PUT /profile/:userId(or "me") を提供する。
-//
-// 返却 DTO `domain.ProfileView` は users.display_name と profiles テーブルを合成したもの
-// （フロントは displayName / bio / avatarUrl / status を 1 つの object で扱う）。
+// 返却する domain.ProfileView は users.display_name と profiles を合成したもの。
 type ProfileHandler struct {
 	get    *usecase.GetProfileUseCase
 	update *usecase.UpdateProfileUseCase
@@ -35,10 +33,8 @@ var (
 	errProfileUnauthorized = errors.New("unauthorized")
 )
 
-// resolveUserID は path :userId を current user と突き合わせる。
-//   - "me" / 空文字 / 数字以外 → current user に解決（フロント /profile/me に対応）
-//   - 数字で current user と一致 → そのまま
-//   - 数字で current user 以外 → 403（IDOR 対策）
+// resolveUserID は "me" / 空文字 / 数字以外を current user に、数字一致はそのまま、
+// 数字で current user 以外は 403 にする（IDOR 対策）。
 func (h *ProfileHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	cur := middleware.CurrentUserIDOrZero(c)
 	if cur == 0 {
@@ -58,7 +54,7 @@ func (h *ProfileHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	return uid, nil
 }
 
-// Get は GET /profile/:userId (or "me") の ハンドラ。
+// Get は指定 user のプロフィールを返す。
 //
 //	@Summary      プロフィール 取得
 //	@Description  指定 user (or current user) の displayName / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。
@@ -86,17 +82,15 @@ func (h *ProfileHandler) Get(c *gin.Context) {
 }
 
 type updateProfileReq struct {
-	// `name` は旧フロント実装の互換のため受け付け、`displayName` を優先する。
 	DisplayName string `json:"displayName"`
-	Name        string `json:"name"`
+	Name        string `json:"name"` // 旧フロント互換。displayName を優先。
 	Bio         string `json:"bio"`
 	AvatarURL   string `json:"avatarUrl"`
-	// 旧フロント実装が `iconUrl` で送ってきた場合の互換。
-	IconURL string `json:"iconUrl"`
-	Status  string `json:"status"`
+	IconURL     string `json:"iconUrl"` // 旧フロント互換。avatarUrl を優先。
+	Status      string `json:"status"`
 }
 
-// Update は PUT /profile/:userId (or "me") の ハンドラ。
+// Update は current user のプロフィールを更新する。
 //
 //	@Summary      プロフィール 更新
 //	@Description  current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。
@@ -153,8 +147,7 @@ func (h *ProfileHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, view)
 }
 
-// buildView は users.display_name と profiles を合成して ProfileView を返す。
-// 未登録ユーザーでも UI が落ちないよう、欠損時は空文字フィールドで埋める。
+// buildView は users.display_name と profiles を合成して ProfileView を返す（欠損時は空文字で埋める）。
 func (h *ProfileHandler) buildView(c *gin.Context, uid uint64) (*domain.ProfileView, error) {
 	p, err := h.get.Execute(c.Request.Context(), uid)
 	if err != nil {

--- a/backend/internal/handler/profile_image_handler.go
+++ b/backend/internal/handler/profile_image_handler.go
@@ -11,7 +11,6 @@ import (
 )
 
 // ProfileImageHandler は profile アイコン用 S3 PUT 署名付き URL を発行する。
-// フロント ProfileRepository.getImagePresignedUrl が叩く /profile/:userId/image/presigned-url を提供する。
 type ProfileImageHandler struct {
 	issue *usecase.IssueProfileImageUploadURLUseCase
 }
@@ -50,8 +49,7 @@ func (h *ProfileImageHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	return uid, nil
 }
 
-// IssueUploadURL は POST /profile/:userId/image/presigned-url。
-// クライアントは { fileName, contentType } を送り、 { uploadUrl, imageUrl, key, expiresIn } を受け取る。
+// IssueUploadURL は { fileName, contentType } を受けて PUT 署名 URL 等を返す。
 //
 //	@Summary      プロフィール 画像 PUT 署名 URL
 //	@Description  プロフィール アイコン 用 の S3 PUT 署名 URL を 発行。 "me" / 数字 一致 のみ 許可 (IDOR 対策)。 body は 任意。

--- a/backend/internal/handler/public_invitation_handler.go
+++ b/backend/internal/handler/public_invitation_handler.go
@@ -7,9 +7,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// PublicInvitationHandler は招待マジックリンク受諾画面用の **認証不要** エンドポイントを提供する。
-// 通常 admin 系 (POST/GET/DELETE /admin/invitations) は AdminInvitationHandler が担当するが、
-// 受諾画面はログイン前のユーザーが踏むため、認証必須グループの外に切り出す。
+// PublicInvitationHandler は招待受諾画面用の認証不要エンドポイントを提供する
+// （ログイン前のユーザーが踏むため認証必須グループの外に置く）。
 type PublicInvitationHandler struct {
 	validate *usecase.ValidateInvitationTokenUseCase
 }
@@ -18,14 +17,8 @@ func NewPublicInvitationHandler(v *usecase.ValidateInvitationTokenUseCase) *Publ
 	return &PublicInvitationHandler{validate: v}
 }
 
-// Validate は GET /api/v2/invitations/accept/:token。
-//
-// 仕様:
-//   - 認証不要（招待リンクをまだログインしていないユーザーが踏むため）
-//   - token が空・該当なし・期限切れ・既受諾・canceled は **すべて 404** （メタ情報を漏らさない）
-//   - 成功時は role / displayName / companyId / companyName のみ返す（email は返さない）
-//
-// レート制限はミドルウェア層で別途実装する想定（現状は未実装）。
+// Validate は招待 token を検証する。無効・期限切れ・既受諾は全て 404（メタ情報を漏らさない）。
+// 成功時は role / displayName / companyId / companyName のみ返す（email は返さない）。
 //
 //	@Summary      招待 トークン 検証 (公開 / 認証 不要)
 //	@Description  招待 マジック リンク から 来た 未 ログイン user 用。 該当 / 期限 切れ / 既 受諾 等 は メタ 情報 を 漏らさず 全て 404。
@@ -40,7 +33,6 @@ func (h *PublicInvitationHandler) Validate(c *gin.Context) {
 	token := c.Param("token")
 	got, err := h.validate.Execute(c.Request.Context(), token)
 	if err != nil {
-		// 内部エラーは 500 だが、フロントには「招待が無効」とだけ伝えてメタ情報を出さない。
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		return
 	}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -58,10 +58,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 
 	v2 := r.Group("/api/v2")
 
-	// Swagger UI (/api/v2/swagger/index.html)。 ALB は /api/v2/* のみ backend に
-	// ルーティング する ので v2 group 内 で 配信 する。 認証 不要 (Cookie 認証 を 適用
-	// する authed group に は 入れない)。 docs/ は `make openapi` で 生成、
-	// cmd/server/main.go の blank import で 初期化。
+	// Swagger UI。ALB が /api/v2/* のみ backend に流すため v2 group 内で配信する（認証不要）。
 	v2.GET("/swagger/*any", ginswagger.WrapHandler(swaggerfiles.Handler))
 
 	registerHealthRoutes(v2, deps)
@@ -83,8 +80,6 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerLearningReportRoutes(authed, deps)
 	registerCourseRoutes(authed, deps)
 	registerTeachingMaterialRoutes(authed, deps)
-	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
-
 	return r
 }
 

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -10,17 +10,15 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerAdminRoutes は管理者向けの招待管理・シナリオ管理エンドポイントを登録する。
-// 認可（super_admin / company_admin のみ操作可能）は handler 層で実施する。
+// registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
+// 認可（super_admin / company_admin のみ）は handler 層で実施する。
 func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	// Company 一覧 (SuperAdmin 専用)
 	companyHandler := NewAdminCompanyHandler(
 		usecase.NewListCompaniesUseCase(persistence.NewCompanyRepository(deps.db)),
 	)
 	g.GET("/admin/companies", companyHandler.List)
 
-	// AdminInvitation — SES マジックリンク方式（Path B）。
-	// Cognito 事前作成は撤去し、ここでは UUID token を発行 + SES で独自メールを送る。
+	// AdminInvitation — SES マジックリンク方式（UUID token 発行 + SES でメール送信）。
 	adminInvRepo := persistence.NewAdminInvitationRepository(deps.db)
 
 	var sender usecase.MagicLinkSender
@@ -29,8 +27,7 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 
 	switch {
 	case deps.cfg.SES.FromAddress == "" || deps.cfg.AppBaseURL == "":
-		// SES 未設定 / APP_BASE_URL 未設定のローカル環境では送信をスキップしてフローを通すだけにする。
-		// 本番では必ず両方設定する前提（usecase 側でログにリンクを残す）。
+		// ローカルでは送信をスキップしてフローだけ通す（usecase 側でリンクをログに残す）。
 		log.Printf("WARN: SES_FROM_ADDRESS or APP_BASE_URL not set — invitation emails will NOT be sent (token will be logged instead)")
 	default:
 		sesClient, err := ses.NewClient(context.Background(), deps.cfg.SES.Region, deps.cfg.SES.FromAddress)
@@ -54,6 +51,4 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.GET("/admin/invitations", adminInvHandler.List)
 	g.POST("/admin/invitations", adminInvHandler.Create)
 	g.DELETE("/admin/invitations/:id", adminInvHandler.Cancel)
-
-	// AdminScenario は廃止 (PR-D, 2026-05-07)。練習モード一式の撤去に伴い、シナリオ管理 API も削除した。
 }

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -6,19 +6,15 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerAuthPublicRoutes は認証不要の Cognito 認証エンドポイント (logout / callback / refresh-token)
-// を登録し、後段の authed group で再利用するため AuthHandler を返す。
-//
-// callback / refresh-token は HttpOnly Cookie の発行・更新を行うため middleware.JWTAuth の対象外。
+// registerAuthPublicRoutes は認証不要の Cognito 認証エンドポイント（logout / callback / refresh-token）を
+// 登録し、authed group で再利用するため AuthHandler を返す。callback / refresh は Cookie を発行・更新するため JWTAuth 対象外。
 func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
 	invitations := persistence.NewAdminInvitationRepository(deps.db)
 	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito)
 
 	g.POST("/auth/cognito/logout", authHandler.Logout)
-	// callback は code を受け取って token に交換するので認証不要
 	g.POST("/auth/cognito/callback", authHandler.Callback)
-	// refresh-token は HttpOnly Cookie の refresh_token を読むため認証 middleware の対象外
 	g.POST("/auth/cognito/refresh-token", authHandler.Refresh)
 
 	return authHandler

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -12,7 +12,6 @@ import (
 )
 
 // registerChatRoutes は AI チャットセッションの REST + SSE エンドポイントを登録する。
-// WebSocket は registerWebSocketRoutes 側で別途登録する（SSE 移行完了まで並行運用）。
 func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	aiSessionRepo := persistence.NewAiChatSessionRepository(deps.db)
 	aiHandler := NewAiChatHandler(
@@ -30,19 +29,14 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.DELETE("/ai-chat/sessions/:id", aiHandler.DeleteSession)
 	g.GET("/ai-chat/sessions/:id/messages", aiHandler.GetMessages)
 
-	// 添付ファイル用 presigned PUT URL（PR-G1: 画像）。
-	// note image 系と同じく NOTE_IMAGES_BUCKET（= note-images バケット）を再利用し、
-	// `ai-chat/{userId}/{uuid}.{ext}` の prefix で運用する。bucket policy / IAM は
-	// 既存ノート画像と共有（runtime/iam.yml の `${NoteImagesBucketArn}/*` でカバー）。
+	// 添付用 presigned PUT URL。note image と同じバケットを ai-chat/ prefix で再利用する。
 	attachmentPresigner := newAiChatAttachmentPresignerOrFallback(deps)
 	attachmentHandler := NewAiChatAttachmentHandler(
 		usecase.NewIssueAiChatAttachmentUploadURLUseCase(attachmentPresigner),
 	)
 	g.POST("/ai-chat/attachments/upload-url", attachmentHandler.IssueUploadURL)
 
-	// SSE ストリーミング（汎用 AI チャットの token 単位送信）。
-	// Bedrock / DynamoDB の初期化に失敗していると bedrockClient / msgRepo は nil。
-	// nil sentinel は handler 側で 503 にする。
+	// SSE ストリーミング。Bedrock / DynamoDB 初期化失敗時は nil なので登録自体をスキップする。
 	if deps.bedrockClient != nil && deps.msgRepo != nil {
 		downloader := newAiChatAttachmentDownloaderOrNil(deps)
 		sseHandler := NewAiChatSseHandler(
@@ -52,8 +46,7 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	}
 }
 
-// newAiChatAttachmentPresignerOrFallback は本番経路では infra/s3.Presigner を、
-// dev / NOTE_IMAGES_BUCKET 未設定時は stub presigner を返す。Note 系と同じ fail open。
+// newAiChatAttachmentPresignerOrFallback は本番では S3 presigner、dev / 未設定時は stub を返す（fail open）。
 func newAiChatAttachmentPresignerOrFallback(deps *routeDeps) repository.AiChatAttachmentPresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {
@@ -68,14 +61,14 @@ func newAiChatAttachmentPresignerOrFallback(deps *routeDeps) repository.AiChatAt
 	return persistence.NewAiChatAttachmentPresigner(pre)
 }
 
-// newAiChatAttachmentDownloaderOrNil は本番では S3 GetObject downloader を返す。
-// bucket 未設定 / 初期化失敗時は nil を返し、SSE usecase 側で「添付なしと同じ振る舞い」にフォールバック。
+// newAiChatAttachmentDownloaderOrNil は本番では S3 downloader を返す。
+// bucket 未設定 / 失敗時は nil を返し、SSE usecase 側で添付なしと同じ振る舞いにフォールバックする。
 func newAiChatAttachmentDownloaderOrNil(deps *routeDeps) usecase.AttachmentDownloader {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {
 		return nil
 	}
-	// `ai-chat/` prefix のみ読み出し許可（他用途の S3 オブジェクト読み出しを防止）。
+	// ai-chat/ prefix のみ読み出し許可（他用途の読み出しを防止）。
 	dl, err := infraS3.NewDownloader(context.Background(), deps.cfg.S3.Region, bucket, "ai-chat/")
 	if err != nil {
 		log.Printf("[ai-chat-attachment] failed to init S3 downloader (%v) — attachments will be ignored", err)

--- a/backend/internal/handler/routes_courses.go
+++ b/backend/internal/handler/routes_courses.go
@@ -6,17 +6,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerCourseRoutes はコース API + コース配下教材一覧 API を登録する。
-//
-//	GET    /api/v2/courses                          一覧
-//	GET    /api/v2/courses/:id                      詳細
-//	POST   /api/v2/courses                          作成（company_admin / super_admin）
-//	PUT    /api/v2/courses/:id                      更新（同上）
-//	DELETE /api/v2/courses/:id                      削除（配下教材も cascade で削除）
-//	GET    /api/v2/courses/:courseId/materials      コース内教材一覧
-//
+// registerCourseRoutes はコース CRUD + コース配下教材一覧 API を登録する。
 // アクセス制御は usecase 層で actor の company_id / role を検証する。
-// trainee は同一 company の `is_published=true` コースのみ閲覧可。
 func registerCourseRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	courseRepo := persistence.NewCourseRepository(deps.db)
 	materialRepo := persistence.NewTeachingMaterialRepository(deps.db)

--- a/backend/internal/handler/routes_embed.go
+++ b/backend/internal/handler/routes_embed.go
@@ -5,8 +5,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/infra/embed"
 )
 
-// registerEmbedRoutes は外部 URL の OGP / oEmbed メタ情報取得エンドポイントを登録する。
-// Note エディタの埋め込みカード機能（Markdown 互換拡張 PR F）から利用される。
+// registerEmbedRoutes は外部 URL の OGP / oEmbed メタ取得エンドポイントを登録する。
 func registerEmbedRoutes(g *gin.RouterGroup) {
 	h := NewEmbedHandler(embed.NewFetcher())
 	g.GET("/embeds/oembed", h.Resolve)

--- a/backend/internal/handler/routes_exercises.go
+++ b/backend/internal/handler/routes_exercises.go
@@ -6,14 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerExerciseRoutes は運営マスタ演習問題の閲覧 + 提出 + 採点 API を登録する。
-//
-// 旧 `registerPhpRoutes` を「言語非依存」に汎用化したもの:
-//   - GET  /api/v2/exercises?language=php          一覧（current user 状態 + 全体集計を含む）
-//   - GET  /api/v2/exercises/:slug                 詳細（入出力例の配列を含む、 slug ベース URL）
-//   - POST /api/v2/exercises/:slug/submit          コードを提出して採点（履歴に保存）
-//   - GET  /api/v2/exercises/:slug/submissions     current user の履歴
-//   - POST /api/v2/code/execute                    コード実行（採点せず stdout だけ返す）
+// registerExerciseRoutes は運営マスタ演習問題の閲覧 + 提出 + 採点 + コード実行 API を登録する。
 func registerExerciseRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	exerciseRepo := persistence.NewMasterExerciseRepository(deps.db)
 	examplesRepo := persistence.NewMasterExerciseExampleRepository(deps.db)

--- a/backend/internal/handler/routes_invitation_public.go
+++ b/backend/internal/handler/routes_invitation_public.go
@@ -6,12 +6,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerInvitationPublicRoutes は招待マジックリンク受諾画面用の認証不要エンドポイントを登録する。
-//
-//	GET /api/v2/invitations/accept/:token  招待 token の検証 + 受諾画面用の最低限の情報返却
-//
-// 認可は無し（受諾前にユーザーが踏むため）。token が無効・期限切れの場合は 404 を返し、
-// 「招待が存在するかどうか」のメタ情報を漏らさない。
+// registerInvitationPublicRoutes は招待 token 検証の認証不要エンドポイントを登録する。
+// 無効・期限切れは 404 を返し、招待の存在有無を漏らさない。
 func registerInvitationPublicRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	invRepo := persistence.NewAdminInvitationRepository(deps.db)
 	companies := persistence.NewCompanyRepository(deps.db)

--- a/backend/internal/handler/routes_learning_report.go
+++ b/backend/internal/handler/routes_learning_report.go
@@ -7,12 +7,7 @@ import (
 )
 
 // registerLearningReportRoutes は月次学習レポートの取得 / 生成要求を登録する。
-//
-//	GET  /api/v2/learning-reports             current user のレポート一覧
-//	POST /api/v2/learning-reports/generate    `{year, month}` で月次レポート生成を要求
-//
-// 生成は SQS にキューする非同期ジョブで、 当面は stub enqueuer を使用する
-// （実 SQS 接続は別 PR / 別 infra で導入予定）。
+// 生成は SQS 非同期ジョブで、当面は stub enqueuer を使う。
 func registerLearningReportRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	repo := persistence.NewLearningReportRepository(deps.db)
 	queue := persistence.NewStubSqsEnqueuer()

--- a/backend/internal/handler/routes_note.go
+++ b/backend/internal/handler/routes_note.go
@@ -13,7 +13,6 @@ import (
 
 // registerNoteRoutes は Note CRUD・Note 画像 presigned URL・SessionNote のエンドポイントを登録する。
 func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	// Phase 10: Note CRUD
 	noteRepo := persistence.NewNoteRepository(deps.db)
 	noteHandler := NewNoteHandler(
 		usecase.NewListNotesByUserIDUseCase(noteRepo),
@@ -26,13 +25,13 @@ func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.PUT("/notes/:id", noteHandler.Update)
 	g.DELETE("/notes/:id", noteHandler.Delete)
 
-	// Phase 11: Note image (S3 presigned upload)
+	// Note 画像の S3 presigned upload。
 	noteImageHandler := NewNoteImageHandler(
 		usecase.NewIssueNoteImageUploadURLUseCase(newNoteImagePresignerOrFallback(deps)),
 	)
 	g.POST("/notes/images/upload-url", noteImageHandler.IssueUploadURL)
 
-	// Phase 12: SessionNote (セッション固有ノート)
+	// セッション固有ノート。
 	sessionNoteRepo := persistence.NewSessionNoteRepository(deps.db)
 	sessionNoteHandler := NewSessionNoteHandler(
 		usecase.NewGetSessionNoteUseCase(sessionNoteRepo),
@@ -42,9 +41,8 @@ func registerNoteRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.PUT("/sessions/:sessionId/note", sessionNoteHandler.Upsert)
 }
 
-// newNoteImagePresignerOrFallback は本番では infra/s3.Presigner で real な PUT presign を返し、
-// NOTE_IMAGES_BUCKET 未設定 (ローカル / dev) の場合だけ stub にフォールバックする。
-// presigner 失敗時も fail open で stub に降格 (Note image 機能だけ利用不可になる)。
+// newNoteImagePresignerOrFallback は本番では real な presigner、NOTE_IMAGES_BUCKET 未設定や
+// 初期化失敗時は stub にフォールバックする（fail open）。
 func newNoteImagePresignerOrFallback(deps *routeDeps) repository.NoteImagePresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {

--- a/backend/internal/handler/routes_profile.go
+++ b/backend/internal/handler/routes_profile.go
@@ -13,21 +13,18 @@ import (
 
 // registerProfileRoutes は profile / user-stats 関連の REST エンドポイントを登録する。
 func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	// Phase 5: プロフィール
 	profileRepo := persistence.NewProfileRepository(deps.db)
 	profileHandler := NewProfileHandler(
 		usecase.NewGetProfileUseCase(profileRepo),
 		usecase.NewUpdateProfileUseCase(profileRepo),
 		deps.userRepo,
 	)
-	// /profile/:userId は数字 / "me" の両方を受ける（handler.resolveUserID で current user 解決）。
-	// フロント互換のため /profile/:userId/update PUT / /profile/:userId/image/presigned-url POST も提供する。
+	// :userId は数字 / "me" の両方を受ける。/update はフロント互換の別 path。
 	g.GET("/profile/:userId", profileHandler.Get)
 	g.PUT("/profile/:userId", profileHandler.Update)
 	g.PUT("/profile/:userId/update", profileHandler.Update)
 
-	// Profile アイコン画像の S3 presigned-url。bucket / CDN は note image と同じインフラを共有する
-	// （prefix `profiles/` で分離）。
+	// Profile アイコン画像の S3 presigned-url（note image と同じバケットを profiles/ prefix で共有）。
 	profileImageHandler := NewProfileImageHandler(
 		usecase.NewIssueProfileImageUploadURLUseCase(
 			newProfileImagePresignerOrFallback(deps),
@@ -35,25 +32,20 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	)
 	g.POST("/profile/:userId/image/presigned-url", profileImageHandler.IssueUploadURL)
 
-	// Phase 6: ユーザー統計
+	// ユーザー統計。2 つの path は互換のため両方提供する。
 	statsHandler := NewUserStatsHandler(
 		usecase.NewGetUserStatsUseCase(persistence.NewUserStatsRepository(deps.db)),
 	)
-	// 旧 path /user-stats/:userId と Spring 風 /users/:userId/stats の両方を提供する。
 	g.GET("/user-stats/:userId", statsHandler.Get)
 	g.GET("/users/:userId/stats", statsHandler.Get)
 
-	// Welcome / オンボーディング完了通知。自分自身の users.onboarded_at を NOW() で更新。
-	// 詳細設計: frestyle-pdm docs/auth/auth-flow-screen-transitions.md
+	// オンボーディング完了（自分自身の users.onboarded_at を更新）。
 	onboardingHandler := NewOnboardingHandler(usecase.NewCompleteOnboardingUseCase(deps.userRepo))
 	g.POST("/profile/me/onboarding/complete", onboardingHandler.Complete)
 }
 
-// newProfileImagePresignerOrFallback は本番では infra/s3.Presigner で real な PUT presign を返し、
-// 環境変数 NOTE_IMAGES_BUCKET が未設定 (ローカル / dev) の場合だけ stub にフォールバックする。
-//
-// 配信 URL のベース (CDN) は config.S3.NoteImagesCDNBase を最優先で使う。
-// 未指定なら virtual-hosted-style (https://<bucket>.s3.<region>.amazonaws.com) で組み立てる。
+// newProfileImagePresignerOrFallback は本番では real な presigner、NOTE_IMAGES_BUCKET 未設定や
+// 初期化失敗時は stub にフォールバックする。CDN ベースは未指定時 virtual-hosted-style で組み立てる。
 func newProfileImagePresignerOrFallback(deps *routeDeps) repository.ProfileImagePresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {

--- a/backend/internal/handler/routes_teaching_materials.go
+++ b/backend/internal/handler/routes_teaching_materials.go
@@ -6,18 +6,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerTeachingMaterialRoutes は教材個別 API を登録する:
-//
-//	GET    /api/v2/teaching-materials/:id  詳細
-//	POST   /api/v2/teaching-materials      作成（company_admin / super_admin、 body の courseId 必須）
-//	PUT    /api/v2/teaching-materials/:id  更新（同上）
-//	DELETE /api/v2/teaching-materials/:id  削除（同上）
-//
-// コース配下の教材一覧 (`GET /api/v2/courses/:id/materials`) は
-// registerCourseRoutes 側で登録する（コース ACL の参照を簡潔にするため）。
-//
+// registerTeachingMaterialRoutes は教材個別 API（詳細 / 作成 / 更新 / 削除）を登録する。
+// コース配下の教材一覧は registerCourseRoutes 側で登録する。
 // アクセス制御は usecase 層で actor の company_id / role を検証する。
-// trainee は同一 company の `is_published=true` 教材かつ所属コースが published のときのみ閲覧可。
 func registerTeachingMaterialRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	courseRepo := persistence.NewCourseRepository(deps.db)
 	materialRepo := persistence.NewTeachingMaterialRepository(deps.db)

--- a/backend/internal/handler/session_note_handler.go
+++ b/backend/internal/handler/session_note_handler.go
@@ -18,7 +18,7 @@ func NewSessionNoteHandler(g *usecase.GetSessionNoteUseCase, u *usecase.UpsertSe
 	return &SessionNoteHandler{get: g, upsert: u}
 }
 
-// Get は AI チャット セッション に 紐づく ノート を 取得 する。
+// Get は AI チャットセッションに紐づくノートを取得する。
 //
 //	@Summary      セッション ノート 取得
 //	@Description  AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。
@@ -45,14 +45,12 @@ func (h *SessionNoteHandler) Get(c *gin.Context) {
 	c.JSON(http.StatusOK, n)
 }
 
-// sessionNoteUpsertReq は body 受け取り 形。 userId は **受け取らない** (current user
-// を middleware から 取って 強制 する)。 これ で 他人 名義 の 作成 / 更新 を 防ぐ
-// (CodeRabbit PR #1727 で 指摘 さ れた IDOR 修正)。
+// sessionNoteUpsertReq は body 受け取り形。userId は受け取らず current user に固定する（IDOR 対策）。
 type sessionNoteUpsertReq struct {
 	Content string `json:"content"`
 }
 
-// Upsert は セッション ノート を 作成 or 更新 する。
+// Upsert はセッションノートを作成 or 更新する。
 //
 //	@Summary      セッション ノート 作成 / 更新
 //	@Description  指定 セッション の ノート を upsert。 userId は body で 受け取らず current user 固定 (IDOR 対策)。

--- a/backend/internal/handler/teaching_material_handler.go
+++ b/backend/internal/handler/teaching_material_handler.go
@@ -11,13 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// TeachingMaterialHandler は教材 API を扱う。
-//
-//	GET    /api/v2/courses/:courseId/materials      コース内一覧（actor role で自動フィルタ）
-//	GET    /api/v2/teaching-materials/:id           詳細
-//	POST   /api/v2/teaching-materials               作成（company_admin / super_admin、 course_id 必須）
-//	PUT    /api/v2/teaching-materials/:id           更新（同上）
-//	DELETE /api/v2/teaching-materials/:id           削除（同上）
+// TeachingMaterialHandler は教材の CRUD + コース内一覧 API を扱う。
 type TeachingMaterialHandler struct {
 	uc *usecase.TeachingMaterialUseCase
 }
@@ -39,8 +33,7 @@ func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, 
 	return user.ID, companyID, user.Role, true
 }
 
-// List は backward-compat 用 GET /api/v2/teaching-materials 。 frontend がコース対応に
-// 切り替わったら削除予定。
+// List は company 内全教材を返す backward-compat 用（コース対応完了後に削除予定）。
 //
 //	@Summary      教材 全 件 一覧 (deprecated)
 //	@Description  backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。
@@ -65,8 +58,7 @@ func (h *TeachingMaterialHandler) List(c *gin.Context) {
 	c.JSON(http.StatusOK, rows)
 }
 
-// ListByCourse は GET /api/v2/courses/:id/materials 。 コース配下の教材を返す。
-// path param `:id` はコース ID（ルート競合を避けるため materials path 側で `:id` を流用）。
+// ListByCourse はコース配下の教材を返す（path の :id はコース ID）。
 //
 //	@Summary      コース内 教材 一覧
 //	@Description  指定 コース 配下 の 教材 を 返す。 trainee は published のみ。
@@ -126,7 +118,6 @@ func (h *TeachingMaterialHandler) Get(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "教材が見つかりません"})
 			return
 		}
-		// usecase が "forbidden" を返したら 403。
 		if err.Error() == "forbidden" {
 			c.JSON(http.StatusForbidden, gin.H{"error": "閲覧権限がありません"})
 			return

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -23,8 +23,7 @@ var (
 	errUserStatsUnauthorized = errors.New("unauthorized")
 )
 
-// resolveUserID は profile_handler と同じ規則で path :userId を解決する。
-// "me" / 空文字 → current user、数字は current user と一致した場合のみ通す（IDOR 対策）。
+// resolveUserID は "me" / 空文字を current user に、数字は current user 一致時のみ通す（IDOR 対策）。
 func (h *UserStatsHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	cur := middleware.CurrentUserIDOrZero(c)
 	if cur == 0 {

--- a/backend/internal/handler/ws_protocol.go
+++ b/backend/internal/handler/ws_protocol.go
@@ -5,9 +5,8 @@ import (
 	"time"
 )
 
-// ChatInbound はクライアントから WebSocket 経由で送られるメッセージの正規形。
-// senderId / roomId / id / createdAt はクライアント任意値を信用しないためサーバが埋める。
-// Spring Boot 時代の STOMP destination ベースから純 JSON ベースへ移行。
+// ChatInbound はクライアントから送られるメッセージの正規形。
+// senderId / roomId / id / createdAt はクライアント値を信用せずサーバが埋める。
 type ChatInbound struct {
 	Type    string `json:"type"` // "send" | "delete"
 	Content string `json:"content,omitempty"`
@@ -27,8 +26,7 @@ type ChatOutbound struct {
 	CreatedAt  string `json:"createdAt,omitempty"` // RFC3339
 }
 
-// BuildChatMessage は Inbound の "send" に対して Outbound の "message" を組み立てる。
-// 純粋関数化することでテストしやすい状態にする。
+// BuildChatMessage は Inbound の "send" から Outbound の "message" を組み立てる。
 func BuildChatMessage(in ChatInbound, roomID string, senderID uint64, senderName string, now time.Time) (ChatOutbound, bool) {
 	if in.Type != "send" || in.Content == "" {
 		return ChatOutbound{}, false

--- a/backend/internal/infra/bedrock/client.go
+++ b/backend/internal/infra/bedrock/client.go
@@ -71,21 +71,9 @@ type StreamEvent struct {
 	Err   error
 }
 
-// ConverseStream は ConverseStream API を呼び出して、token を逐次 channel に流す。
-//
-// 呼び出し側は返ってきた channel を range でループするだけで token を消費できる:
-//
-//	ch, err := bc.ConverseStream(ctx, prompt, history)
-//	if err != nil { ... }
-//	for ev := range ch {
-//	    if ev.Err != nil { ... break }
-//	    if ev.Done { break }
-//	    write(ev.Delta)
-//	}
-//
-// ctx が cancel されると channel は閉じられる。AWS SDK の EventStream は内部で
-// channel を持っているが、本ラッパでは「アプリケーションが扱いやすい形」に変換して提供する
-// ことで infra 詳細（brtypes の各 Member 型）を usecase 層に漏らさない。
+// ConverseStream は ConverseStream API の token を逐次 StreamEvent channel に流す。
+// SDK の EventStream を usecase が扱いやすい形に変換し、brtypes の詳細を漏らさない。
+// ctx が cancel されると channel は閉じる。
 func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan StreamEvent, error) {
 	messages := buildBedrockMessages(history)
 
@@ -146,17 +134,9 @@ func (c *Client) ConverseStream(ctx context.Context, systemPrompt string, histor
 }
 
 // buildBedrockMessages は domain.AiChatMessage を Bedrock Converse の Message 列に変換する。
-//
-// ユーザー発話に Attachments が付いていれば、各添付を image / document ContentBlock に
-// 展開して text の前に並べる（Bedrock の慣習: 画像 → テキストの順が推奨）。
-// BlobData が空の Attachment は無視する（usecase で S3 から取得済みであることが前提）。
-//
-// 空コンテンツ対応: Bedrock は user/assistant 役割の交互パターンを必須とする。空の
-// assistant 応答が DB に保存されているケースでも会話を成立させるため、空メッセージは
-// **skip しない** で、placeholder テキストを差し込んで Bedrock に渡す。
-// （旧実装で skip した結果、連続する user メッセージが発生して Bedrock が無言の
-// 空応答を返し、それがまた DB に空 assistant として保存されて負のループに陥る不具合
-// が判明したため）。
+// 添付は image / document ブロックとして text の前に並べ、BlobData が空のものは無視する。
+// Bedrock は user/assistant の交互を要求するため、空メッセージは skip せず placeholder を入れる
+// （skip すると連続 user → 空応答の負ループに陥るため）。
 func buildBedrockMessages(history []domain.AiChatMessage) []brtypes.Message {
 	messages := make([]brtypes.Message, 0, len(history))
 	for _, m := range history {

--- a/backend/internal/infra/cognito/token_exchanger.go
+++ b/backend/internal/infra/cognito/token_exchanger.go
@@ -40,12 +40,8 @@ type Config struct {
 	TokenURI     string
 }
 
-// TokenExchanger は Cognito User Pool の OAuth2 token endpoint を叩いて
+// TokenExchanger は Cognito の OAuth2 token endpoint を叩いて
 // authorization_code / refresh_token を access/id/refresh token に交換する。
-//
-// 旧実装は handler/auth_handler.go の Callback / Refresh に同じ HTTP 構築・
-// レスポンス処理が ~140 行重複していたが、grant_type だけ違う構造だったため
-// このパッケージに集約した。
 type TokenExchanger struct {
 	cfg        Config
 	httpClient *http.Client
@@ -100,7 +96,6 @@ func (e *TokenExchangeError) Error() string {
 func (e *TokenExchangeError) Unwrap() error { return ErrTokenExchangeFailed }
 
 // ExchangeAuthorizationCode は Cognito Hosted UI から戻った認可コードを token に交換する。
-// Spring Boot CognitoAuthController#callback と等価。
 func (t *TokenExchanger) ExchangeAuthorizationCode(ctx context.Context, code string) (*Token, error) {
 	form := url.Values{}
 	form.Set("grant_type", "authorization_code")
@@ -117,11 +112,9 @@ func (t *TokenExchanger) RefreshAccessToken(ctx context.Context, refreshToken st
 	return t.exchange(ctx, form)
 }
 
-// exchange は authorization_code / refresh_token grant の差を吸収した内部実装。
-//
-// Cognito の OAuth2 token endpoint には「Authorization Basic header 方式」と
-// 「body 方式 (client_id + client_secret を form に入れる)」があるが、両方送ると
-// invalid_client を返すケースがある。本実装では body 方式に統一する（AWS docs 推奨）。
+// exchange は grant 種別の差を吸収した内部実装。
+// 認証は body 方式（client_id + client_secret を form に入れる）に統一する
+// （Basic header と併用すると invalid_client を返すケースがあるため）。
 func (t *TokenExchanger) exchange(ctx context.Context, form url.Values) (*Token, error) {
 	if t.cfg.TokenURI == "" || t.cfg.ClientID == "" {
 		return nil, ErrNotConfigured
@@ -134,8 +127,6 @@ func (t *TokenExchanger) exchange(ctx context.Context, form url.Values) (*Token,
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.cfg.TokenURI, strings.NewReader(form.Encode()))
 	if err != nil {
-		// NewRequestWithContext は URL parse 不能などで失敗する。
-		// 設定不備に近いので handler 側で 500 にする想定。
 		return nil, fmt.Errorf("cognito: build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -9,13 +9,11 @@ type Config struct {
 	AppEnv     string
 	ServerPort string
 
-	// DatabaseURL は Supabase 等 の マネージド Postgres 用 の 完全 接続 文字 列。
-	// 例: "postgresql://postgres.xxxx:pwd@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true&sslmode=require"
-	// 環境 変数 DATABASE_URL がセットされていると こちらを 優先 し、 個別 の DB_HOST 等 は 無視 する。
-	// RDS から Supabase へ の 段階 移行 用 (= URL を 切り替える だけ で 接続 先 を 変えられる)。
+	// DatabaseURL は Supabase 等のマネージド Postgres の完全接続文字列。
+	// セットされていると DB_HOST 等より優先される。
 	DatabaseURL string
 
-	// 個別 接続 設定 (DATABASE_URL 未 セット 時 の フォールバック / ローカル 開発 用)
+	// 個別接続設定（DATABASE_URL 未設定時のフォールバック / ローカル開発用）。
 	DBHost     string
 	DBPort     string
 	DBUser     string
@@ -98,21 +96,9 @@ func Load() (*Config, error) {
 		},
 		Bedrock: BedrockConfig{
 			Region: getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
-			// Claude 4 系（haiku-4-5 / sonnet-4-x / opus-4-x）は on-demand throughput では呼べず、
-			// Inference Profile 経由必須。foundation-model ARN を直接指定すると ConverseStream が
-			// ValidationException で 400 を返す（2026-05-08 本番でユーザーから AI チャット返信なし
-			// の報告で発覚）。
-			//
-			// `jp.anthropic.claude-sonnet-4-5-20250929-v1:0` が ap-northeast-1 用の Japan inference
-			// profile（sonnet-4.5）。IAM 側 (frestyle-infrastructure: BedrockInvokeAccess) でも
-			// `arn:aws:bedrock:${region}:${account}:inference-profile/jp.anthropic.claude-sonnet-4-*`
-			// を許可しておく必要がある。
-			//
-			// モデル選定: 旧 default の haiku-4-5 から sonnet-4-5 にアップグレード。応答品質を優先し、
-			// チャット用途なら latency / コストとも実用範囲（ユーザー指示・2026-05-08）。
-			//
-			// 利用可能 inference profile 一覧:
-			//   aws bedrock list-inference-profiles --region ap-northeast-1
+			// Claude 4 系は on-demand では呼べず Inference Profile 経由必須
+			// （foundation-model ARN 直指定だと ConverseStream が ValidationException を返す）。
+			// IAM 側でも inference-profile ARN を許可しておくこと。
 			ModelID: getEnvOrDefault("BEDROCK_MODEL_ID", "jp.anthropic.claude-sonnet-4-5-20250929-v1:0"),
 		},
 		DynamoDB: DynamoDBConfig{
@@ -124,17 +110,15 @@ func Load() (*Config, error) {
 			FromAddress: os.Getenv("SES_FROM_ADDRESS"),
 		},
 	}
-	// DATABASE_URL がセットされていればそちら 優先 / DB_HOST フォールバック で
-	// 少なくとも どちら か は 設定 されて いる 必要 が ある。
+	// DATABASE_URL か DB_HOST の少なくとも一方は必須。
 	if cfg.DatabaseURL == "" && cfg.DBHost == "" {
 		return nil, fmt.Errorf("DATABASE_URL or DB_HOST is required")
 	}
 	return cfg, nil
 }
 
-// PostgresDSN は GORM に 渡す DSN を 返す。
-// DATABASE_URL (例: Supabase pooler の "postgresql://..." 形式) が あれば そのまま 返す。
-// 無ければ 旧 RDS 形式 の 個別 設定 から DSN を 組み立てる (= 後方 互換)。
+// PostgresDSN は GORM に渡す DSN を返す。DATABASE_URL があればそのまま、
+// 無ければ個別設定から key=value 形式の DSN を組み立てる。
 func (c *Config) PostgresDSN() string {
 	if c.DatabaseURL != "" {
 		return c.DatabaseURL

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -8,15 +8,8 @@ import (
 	"gorm.io/gorm"
 )
 
-// allDomainModels は全 domain 構造体のリスト。
-// AutoMigrate に渡してテーブル作成・列追加を一元管理する。
-// 新しい domain を追加したら必ずここにも追記する。
-//
-// 廃止済 (PR-D, 2026-05-07): PracticeScenario / ScenarioBookmark / SharedSession /
-//
-//	ScoreCard / ScoreGoal / ConversationTemplate / FavoritePhrase / ReminderSetting /
-//	DailyGoal / WeeklyChallenge / WeeklyChallengeProgress / SessionNote。
-//	既存テーブルは PR-E の DROP migration で物理削除予定。
+// allDomainModels は AutoMigrate に渡す全 domain 構造体のリスト。
+// 新しい domain を追加したらここにも追記する。
 func allDomainModels() []any {
 	return []any{
 		&domain.User{},
@@ -36,11 +29,8 @@ func allDomainModels() []any {
 	}
 }
 
-// Migrate は起動時のスキーマ整合チェック。
-//   - RESET_DB=true: DROP SCHEMA public CASCADE → CREATE SCHEMA public で完全 wipe してから AutoMigrate。
-//     リリース前に Go domain を「正」とする初期構築をしたいときの一回限り操作。
-//   - RESET_DB が未指定: AutoMigrate のみ走る（CREATE TABLE IF NOT EXISTS と ADD COLUMN は走るが、
-//     型変更・列削除は GORM の安全側仕様で実行されない）。
+// Migrate は起動時にスキーマを AutoMigrate する。
+// RESET_DB=true のときは public schema を完全 wipe してから再構築する（一回限りの初期構築用）。
 func Migrate(db *gorm.DB) error {
 	if os.Getenv("RESET_DB") == "true" {
 		log.Println("⚠️ RESET_DB=true: dropping public schema and recreating")

--- a/backend/internal/infra/database/postgres.go
+++ b/backend/internal/infra/database/postgres.go
@@ -11,13 +11,9 @@ import (
 	"gorm.io/gorm/logger"
 )
 
-// NewPostgres は GORM で PostgreSQL に 接続 する。
-//
-// DATABASE_URL が "pgbouncer=true" を 含む (= Supabase transaction pooler 接続) 場合 は
-// GORM の prepared statement キャッシュ を 無効 化 + driver 側 で simple query protocol を
-// 強制 する。 transaction-mode の pgbouncer は 接続 単位 の prepared statement を サポート
-// し ない ため、 デフォルト の まま だ と "prepared statement does not exist" エラー が
-// ランダム に 発生 する。
+// NewPostgres は GORM で PostgreSQL に接続する。
+// pgbouncer 経由（Supabase transaction pooler）の場合は prepared statement を無効化し
+// simple query protocol を強制する（"prepared statement does not exist" 対策）。
 func NewPostgres(cfg *config.Config) (*gorm.DB, error) {
 	gormCfg := &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
@@ -47,19 +43,14 @@ func NewPostgres(cfg *config.Config) (*gorm.DB, error) {
 	return db, nil
 }
 
-// isPgBouncerDSN は DSN が Supabase transaction pooler 等 の pgbouncer 経由 か を 判定 する。
-//
-// 判定 基準 (順 番 に):
-//  1. URL 形式 (postgres:// / postgresql://) なら net/url で parse し、 query string の
-//     pgbouncer=true / ホスト 名 が pooler.supabase.com を 含む かを 厳密 に 見る。
-//     これ により パスワード / path に 偶然 "pgbouncer=true" の 文字 列 が 含まれて も
-//     false positive に なら ない。
-//  2. key=value 形式 (host=... user=...) なら host= の 値 だけ を 切り 出して 判定。
+// isPgBouncerDSN は DSN が pgbouncer 経由かを判定する。
+// URL 形式は query の pgbouncer=true / host に pooler.supabase.com を厳密に見て
+// パスワードや path に紛れた文字列で false positive にならないようにする。
+// key=value 形式は host= の値だけを切り出して判定する。
 func isPgBouncerDSN(dsn string) bool {
 	trimmed := strings.TrimSpace(dsn)
 	lower := strings.ToLower(trimmed)
 
-	// 1. URL 形式
 	if strings.HasPrefix(lower, "postgres://") || strings.HasPrefix(lower, "postgresql://") {
 		u, err := url.Parse(trimmed)
 		if err != nil {
@@ -74,8 +65,7 @@ func isPgBouncerDSN(dsn string) bool {
 		return false
 	}
 
-	// 2. key=value 形式 (= 旧 RDS DSN フォールバック)
-	// "host=foo.pooler.supabase.com" を 検知 する ため、 host= キー だけ を 厳密 に 取る。
+	// key=value 形式は host= キーだけを厳密に取る。
 	for _, kv := range strings.Fields(trimmed) {
 		eq := strings.IndexByte(kv, '=')
 		if eq <= 0 {

--- a/backend/internal/infra/database/seed_master_exercises.go
+++ b/backend/internal/infra/database/seed_master_exercises.go
@@ -10,12 +10,8 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-// seedMasterExercises は master_exercises テーブルに初期演習データを投入する。
-// ON CONFLICT DO NOTHING で冪等。起動のたびに安全に呼び出せる。
-//
-// 旧 seedPhpExercises を MasterExercise 用に汎用化したもの。Language / Slug /
-// IsPublished / Difficulty の共通フィールドはデータ列挙の簡潔さを優先して
-// 末尾の補完ループで一括設定する（Slug は `php-{id}` の規則）。
+// seedMasterExercises は初期演習データを投入する（ON CONFLICT DO NOTHING で冪等）。
+// Language / Slug / IsPublished / Difficulty の共通値は末尾ループで一括設定する。
 func seedMasterExercises(db *gorm.DB) error {
 	now := time.Now()
 	exercises := []domain.MasterExercise{
@@ -165,8 +161,7 @@ func seedMasterExercises(db *gorm.DB) error {
 		},
 	}
 
-	// Language / Slug / Difficulty / IsPublished の共通フィールドを後付けで埋める。
-	// 各エントリに毎回書くと冗長なので、PHP 教材の defaults を一括設定する。
+	// PHP 教材の共通 defaults を一括設定する。
 	for i := range exercises {
 		exercises[i].Language = domain.ExerciseLanguagePhp
 		exercises[i].Slug = fmt.Sprintf("php-%d", exercises[i].ID)
@@ -188,12 +183,8 @@ func seedMasterExercises(db *gorm.DB) error {
 	return nil
 }
 
-// seedMasterExerciseExamples は既存の master_exercises.expected_output を
-// master_exercise_examples テーブルに「OrderIndex=1, InputText=空」の 1 行として
-// バックフィルする。既に同じ exercise_id の example が 1 件以上ある場合は skip。
-//
-// 複数 example の追加は将来的に運営側ツールで行う想定。当面の seed は 1 件のみで、
-// 採点ロジック (PR-W) も「example が 1 件のみのケース = 単一テスト」に対応する。
+// seedMasterExerciseExamples は各 exercise の expected_output を
+// 「OrderIndex=1, InputText=空」の 1 行として examples にバックフィルする（既存があれば skip）。
 func seedMasterExerciseExamples(db *gorm.DB, exercises []domain.MasterExercise) error {
 	now := time.Now()
 	inserted := 0

--- a/backend/internal/infra/embed/oembed_fetcher.go
+++ b/backend/internal/infra/embed/oembed_fetcher.go
@@ -1,11 +1,5 @@
-// Package embed は外部 URL の OGP / oEmbed メタ情報を取得して
-// フロントエンドの Embed カード描画に渡すためのユーティリティを提供する。
-//
-// 設計:
-//   - allow-list 方式（任意の URL を叩かせない）。SSRF / DNS rebinding 対策で
-//     scheme は https のみ許可、host は許可リストか明示的に「Web 一般」のみ
-//   - キャッシュは Note 編集中に同じ URL を何度も叩かれるのを避けるため In-Memory LRU で薄く保持
-//   - フロントは /api/v2/embeds/oembed?url=... で叩く（PR F の EmbedCardExtension が利用）
+// Package embed は外部 URL の OGP / oEmbed メタ情報を取得し、Embed カード描画用に返す。
+// SSRF 対策で https のみ許可、結果は In-Memory LRU で薄くキャッシュする。
 package embed
 
 import (
@@ -58,8 +52,7 @@ func NewFetcher() *Fetcher {
 	}
 }
 
-// NewFetcherWithClient はテスト時に http.Client を差し替える DI コンストラクタ。
-// 同時に allowLoopback=true にして httptest を踏めるようにする (test 限定の admit list)。
+// NewFetcherWithClient はテスト用。http.Client を差し替え、allowLoopback=true で httptest を許可する。
 func NewFetcherWithClient(c *http.Client) *Fetcher {
 	if c == nil {
 		c = &http.Client{Timeout: defaultHTTPTimeout}

--- a/backend/internal/infra/s3/downloader.go
+++ b/backend/internal/infra/s3/downloader.go
@@ -11,26 +11,18 @@ import (
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-// Downloader はサーバ側で S3 オブジェクトの実体を取得する。
-//
-// 用途: ユーザーが presigned PUT で S3 にアップロードした画像 / ドキュメントを
-// バックエンドが Bedrock Converse に渡す前に GetObject でバイト列として取り出す。
-// presigner.go と分けているのは「presigned URL は短期 / 一方通行（PUT）専用」と
-// 「server-side GetObject は IAM 権限経由 / 任意のサイズ」で責務が違うため。
+// Downloader はサーバ側で S3 オブジェクトの実体を GetObject で取得する
+// （presigned PUT 済みの添付を Bedrock に渡す前にバイト列で読む用途）。
 type Downloader struct {
 	client *awss3.Client
 	bucket string
-	// allowedKeyPrefix は読み出し許容 prefix。空のときは prefix チェックをスキップする。
-	// AI チャット添付では `ai-chat/` を渡して、誤って他用途の prefix を読まれないようにする。
+	// allowedKeyPrefix は読み出し許容 prefix（空ならチェックなし）。他用途の prefix 読み出しを防ぐ。
 	allowedKeyPrefix string
-	// maxBytes は 1 オブジェクトあたりの最大読み込みサイズ（バイト）。
-	// 任意 S3 オブジェクトを読まれた場合の OOM 防止用。
+	// maxBytes は 1 オブジェクトの最大読み込みサイズ（OOM 防止）。
 	maxBytes int64
 }
 
-// 既定の最大読み込みサイズ。Bedrock の image 上限 (5MB) と document 上限 (4.5MB) より
-// 余裕をもたせて 10MB を 1 オブジェクトの上限とする。実際のサイズ検証は usecase / handler 側で
-// 行うが、Downloader でも belt-and-suspenders として強制する。
+// defaultMaxDownloadBytes は 1 オブジェクトの上限（Bedrock 上限より余裕を持たせた 10MB）。
 const defaultMaxDownloadBytes int64 = 10 * 1024 * 1024
 
 // NewDownloader は本番用 (ECS Task Role 経由) で Downloader を組み立てる。
@@ -51,14 +43,8 @@ func NewDownloader(ctx context.Context, region, bucket, allowedKeyPrefix string)
 	}, nil
 }
 
-// Download は指定 key のオブジェクトをメモリに読み込んで返す。
-// Bedrock の image / document ブロックがバイト列を要求するため、ストリーミングではなく
-// 一括ロードで返す。
-//
-// 防御:
-//   - allowedKeyPrefix を持つ場合は prefix 不一致を error で弾く
-//   - maxBytes を超える object は error にしてメモリを使い切らない
-//     （io.LimitReader で +1 byte 余分に読んで超過判定する）
+// Download は指定 key のオブジェクトをメモリに一括ロードして返す。
+// prefix 不一致と maxBytes 超過は error で弾く（超過判定は +1 byte 読みで行う）。
 func (d *Downloader) Download(ctx context.Context, key string) ([]byte, error) {
 	if key == "" {
 		return nil, fmt.Errorf("s3: key is required")

--- a/backend/internal/infra/s3/presigner.go
+++ b/backend/internal/infra/s3/presigner.go
@@ -1,10 +1,5 @@
-// Package s3 は AWS S3 への PutObject presigned URL 発行を担当する Infra 層。
-//
-// 設計:
-//   - aws-sdk-go-v2 の s3.PresignClient を使う
-//   - 認証は default chain (ECS Task Role / EC2 Instance Role / 環境変数 / ~/.aws/credentials)
-//   - 期限は 10 分 (presigned URL は短期で十分)
-//   - bucket / region / 任意の CDN base URL は config から渡す
+// Package s3 は AWS S3 への PutObject presigned URL 発行と GetObject ダウンロードを担う Infra 層。
+// 認証は default chain、presigned URL の期限は 10 分。
 package s3
 
 import (
@@ -43,11 +38,7 @@ func NewPresigner(ctx context.Context, region, bucket string) (*Presigner, error
 }
 
 // PresignPut は指定 key への PutObject presigned URL を返す。
-// クライアント (フロントの axios) は HTTP PUT で同 URL に Content-Type ヘッダ付き
-// で body を送れば S3 が直接受け取る。
-//
-// contentType は presign に焼き込まれるため、PUT 時のヘッダと **完全一致** する必要がある
-// （食い違うと S3 が SignatureDoesNotMatch を返す）。
+// contentType は presign に焼き込まれるため PUT 時のヘッダと完全一致が必要（不一致だと SignatureDoesNotMatch）。
 func (p *Presigner) PresignPut(ctx context.Context, key, contentType string) (string, time.Duration, error) {
 	if key == "" {
 		return "", 0, fmt.Errorf("s3: key is required")

--- a/backend/internal/infra/ses/invitation_mail.go
+++ b/backend/internal/infra/ses/invitation_mail.go
@@ -8,18 +8,8 @@ import (
 )
 
 // BuildInvitationMail は招待メールの subject / HTML / text を返す。
-// magicLink には ?token=<UUID> 付きの URL をそのまま渡す（呼び出し側で組み立て）。
-//
-// HTML / text 双方を組み立てる理由:
-//   - SES の SendEmail で両方提供しておくと、HTML を許容しないクライアントでもテキスト本文が読める
-//   - 受信側のフィッシング誤判定を避けるため、URL は本文中に普通の文字列として明示的に提示する
-//
-// role は usecase 側のシグネチャ整合のため受け取るが本文には出さない。
-// 一般受信者には social role の生値（company_admin / trainee 等）が伝わらないため、
-// 本文では「招待が届いている」事実と会社名・表示名のみを示し、ログイン後の機能体験で
-// 暗黙的に役割を理解してもらう設計（受諾画面と一致）。
-//
-// displayName / companyName が空の場合は本文から該当行を省略する。
+// HTML 非対応クライアント向けに text 本文も用意する。role は本文には出さない（互換のため受け取るだけ）。
+// displayName / companyName が空なら該当行を省略する。
 func BuildInvitationMail(magicLink, displayName, companyName, _ string) (subject, htmlBody, textBody string) {
 	subject = "FreStyle へようこそ — 管理者からの招待"
 
@@ -49,9 +39,8 @@ func BuildInvitationMail(magicLink, displayName, companyName, _ string) (subject
 	return subject, htmlBody, textBody
 }
 
-// buildInvitationHTML は HTML 本文を組み立てる。受信者が入力した値はすべて html.EscapeString で
-// エスケープしてから埋め込み、HTML インジェクションを防ぐ。リンク URL は url.QueryEscape ではなく
-// HTML 属性向けに html.EscapeString で十分（URL 自体の組み立てはこの関数の責務外）。
+// buildInvitationHTML は HTML 本文を組み立てる。埋め込む値は html.EscapeString で
+// エスケープして HTML インジェクションを防ぐ。
 func buildInvitationHTML(magicLink, greeting, companyName string) string {
 	var sb strings.Builder
 	sb.WriteString(`<!DOCTYPE html><html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif; color: #1f2937; line-height: 1.7;">`)
@@ -76,9 +65,7 @@ func buildInvitationHTML(magicLink, greeting, companyName string) string {
 	return sb.String()
 }
 
-// MagicLinkURL は invitations の token から「フロント受諾画面」の絶対 URL を組み立てる。
-// baseURL は env APP_BASE_URL（例: https://normanblog.com）を渡す想定。
-// token は UUID なので URL エンコード不要だが、安全のため QueryEscape を通す。
+// MagicLinkURL は token からフロント受諾画面の絶対 URL を組み立てる（baseURL は APP_BASE_URL）。
 func MagicLinkURL(baseURL, token string) string {
 	base := strings.TrimRight(baseURL, "/")
 	return base + "/invitations/accept?token=" + url.QueryEscape(token)

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -12,8 +12,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// ListAdminInvitationsUseCase は 招待 一覧 を 取得 する Use Case。
-// 依存 port: [repository.AdminInvitationRepository] (一覧 取得 を 委譲)。
+// ListAdminInvitationsUseCase は招待一覧を取得する。
 type ListAdminInvitationsUseCase struct {
 	repo repository.AdminInvitationRepository
 }
@@ -22,8 +21,7 @@ func NewListAdminInvitationsUseCase(r repository.AdminInvitationRepository) *Lis
 	return &ListAdminInvitationsUseCase{repo: r}
 }
 
-// ListAll は全社横断で招待一覧を返す。SuperAdmin (運営側) からのみ呼ばれる想定。
-// 認可は handler 層で current user.role を見て行う。
+// ListAll は全社横断で招待一覧を返す（SuperAdmin 専用、認可は handler 層）。
 func (u *ListAdminInvitationsUseCase) ListAll(ctx context.Context) ([]domain.AdminInvitation, error) {
 	return u.repo.ListAll(ctx)
 }
@@ -36,36 +34,26 @@ func (u *ListAdminInvitationsUseCase) ListByCompanyID(ctx context.Context, compa
 	return u.repo.ListByCompanyID(ctx, companyID)
 }
 
-// MagicLinkSender は invitation メール送信を usecase 側から呼ぶための抽象。
-// infra/ses.Client が満たす想定。テストでは fake を差し込む。
-//
-// usecase 側に interface を置いている理由（DIP）:
-//   - usecase は infra を知らず、infra/ses が「usecase が要求する I/F」を満たす設計にする
-//   - 結果として infra/ses の API 変更が usecase に波及しない
-//
-// magicLink には ?token=<UUID> 付き受諾画面 URL を渡す。token 自体はメール本文には含めず、
-// 必ず magicLink 経由（URL の一部）でしか露出させない。
+// MagicLinkSender は invitation メール送信の抽象（infra/ses.Client が満たす）。
+// usecase 側に置くことで infra の API 変更を波及させない（DIP）。
 type MagicLinkSender interface {
 	SendInvitationEmail(ctx context.Context, to, subject, htmlBody, textBody string) error
 }
 
 // MailBuilder は招待メールの subject / HTML / text を組み立てる関数。
-// infra/ses.BuildInvitationMail を直接渡す（受諾画面 URL の組み立ても呼び出し側で済ませてから渡す）。
 type MailBuilder func(magicLink, displayName, companyName, role string) (subject, htmlBody, textBody string)
 
-// LinkBuilder は invitation の token から「受諾画面の絶対 URL」を組み立てる関数。
-// infra/ses.MagicLinkURL を直接渡す。
+// LinkBuilder は token から受諾画面の絶対 URL を組み立てる関数。
 type LinkBuilder func(token string) string
 
-// CreateAdminInvitationUseCase は 新規 招待 を 発行 + マジック リンク メール を 送る Use Case。
-// 依存 port: [repository.AdminInvitationRepository] (DB 永続化) + [MagicLinkSender] (SES 経由 の メール 送信)。
+// CreateAdminInvitationUseCase は新規招待を発行し、マジックリンクメールを送る。
 type CreateAdminInvitationUseCase struct {
 	repo        repository.AdminInvitationRepository
 	sender      MagicLinkSender
 	buildLink   LinkBuilder
 	buildMail   MailBuilder
 	expiresIn   time.Duration
-	companyName string // 任意。空なら本文から省略。会社マスタから引いて渡す未来用に拡張可能。
+	companyName string // 任意。空なら本文から省略。
 }
 
 // NewCreateAdminInvitationUseCase は SES マジックリンク方式の招待作成 usecase を組み立てる。
@@ -92,13 +80,8 @@ type CreateAdminInvitationInput struct {
 	DisplayName string
 }
 
-// Execute は招待を作成する。手順:
-//  1. UUID v4 トークンを発行
-//  2. invitations 行を pending + expires_at=今+7日 で保存
-//  3. SES で受諾画面マジックリンクメールを送信（sender が nil ならスキップ）
-//
-// メール送信失敗は invitation 自体の作成成功と切り離さず、エラーとして返す。
-// （部分的に成功してリンクが分からなくなる事故を避けるため、トランザクション境界はここで揃える）
+// Execute は token 発行 → invitations を pending で保存 → 受諾リンクメール送信、の順で招待を作る。
+// sender 未設定ならメール送信はスキップ。メール送信失敗はエラーとして返す。
 func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdminInvitationInput) (*domain.AdminInvitation, error) {
 	if in.CompanyID == 0 || in.Email == "" || in.Role == "" {
 		return nil, errors.New("companyID, email, role are required")
@@ -119,8 +102,7 @@ func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdm
 	}
 
 	if u.sender == nil || u.buildLink == nil || u.buildMail == nil {
-		// ローカル開発などで SES が無いときは、リンクをログ出力してフローを止めない。
-		// 本番では sender が必須なので、APP_BASE_URL / SES 設定がある前提で起動する。
+		// SES 未設定時はリンクをログ出力してフローを止めない（本番では sender 必須）。
 		log.Printf("admin_invitation: sender not configured — skipping email. token=%s email=%s", token, in.Email)
 		return inv, nil
 	}
@@ -128,14 +110,13 @@ func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdm
 	link := u.buildLink(token)
 	subject, htmlBody, textBody := u.buildMail(link, in.DisplayName, u.companyName, in.Role)
 	if err := u.sender.SendInvitationEmail(ctx, in.Email, subject, htmlBody, textBody); err != nil {
-		// 送信失敗は呼び出し側にエラーで返す。invitation 自体は DB に残るので、UI から再送信機能を作るときに使える。
+		// 送信失敗はエラーで返す（invitation は DB に残るので再送に使える）。
 		return nil, fmt.Errorf("send invitation email: %w", err)
 	}
 	return inv, nil
 }
 
-// CancelAdminInvitationUseCase は 既存 招待 の status を canceled に 更新 する Use Case。
-// 依存 port: [repository.AdminInvitationRepository]。
+// CancelAdminInvitationUseCase は既存招待の status を canceled に更新する。
 type CancelAdminInvitationUseCase struct {
 	repo repository.AdminInvitationRepository
 }

--- a/backend/internal/usecase/ai_chat_usecase.go
+++ b/backend/internal/usecase/ai_chat_usecase.go
@@ -9,7 +9,6 @@ import (
 )
 
 // GetAiChatSessionsByUserIDUseCase は指定ユーザーの AI チャットセッション一覧を返す。
-// 依存 port: [repository.AiChatSessionRepository]。
 type GetAiChatSessionsByUserIDUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -23,8 +22,6 @@ func (u *GetAiChatSessionsByUserIDUseCase) Execute(ctx context.Context, userID u
 }
 
 // CreateAiChatSessionUseCase は新規セッションを作成する。
-// 依存 port: [repository.AiChatSessionRepository]。 章 014 で 解説 する Clean Architecture
-// 手書き DI の 標準 例。
 type CreateAiChatSessionUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -60,7 +57,6 @@ func (u *CreateAiChatSessionUseCase) Execute(ctx context.Context, in CreateAiCha
 }
 
 // GetAiChatSessionUseCase は単一セッションを返す。
-// 依存 port: [repository.AiChatSessionRepository]。
 type GetAiChatSessionUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -74,7 +70,6 @@ func (u *GetAiChatSessionUseCase) Execute(ctx context.Context, id uint64) (*doma
 }
 
 // UpdateAiChatSessionTitleUseCase はセッションタイトルを更新する。
-// 依存 port: [repository.AiChatSessionRepository]。
 type UpdateAiChatSessionTitleUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -90,8 +85,7 @@ func (u *UpdateAiChatSessionTitleUseCase) Execute(ctx context.Context, id uint64
 	return u.sessions.UpdateTitle(ctx, id, title)
 }
 
-// DeleteAiChatSessionUseCase はセッションを削除する。
-// 依存 port: [repository.AiChatSessionRepository]。 削除 前 に FindByID で 所有者 検証。
+// DeleteAiChatSessionUseCase はセッションを削除する（FindByID で所有者検証してから）。
 type DeleteAiChatSessionUseCase struct {
 	sessions repository.AiChatSessionRepository
 }
@@ -112,7 +106,6 @@ func (u *DeleteAiChatSessionUseCase) Execute(ctx context.Context, id uint64, use
 }
 
 // GetAiChatMessagesUseCase は DynamoDB からセッションのメッセージ一覧を返す。
-// 依存 port: [repository.AiChatMessageRepository] (DynamoDB 実装)。
 type GetAiChatMessagesUseCase struct {
 	messages repository.AiChatMessageRepository
 }

--- a/backend/internal/usecase/company_usecase.go
+++ b/backend/internal/usecase/company_usecase.go
@@ -7,8 +7,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// ListCompaniesUseCase は 全 company を 返す Use Case。 SuperAdmin 専用 画面 用。
-// 依存 port: [repository.CompanyRepository]。
+// ListCompaniesUseCase は全 company を返す（SuperAdmin 専用）。
 type ListCompaniesUseCase struct {
 	repo repository.CompanyRepository
 }

--- a/backend/internal/usecase/complete_onboarding_usecase.go
+++ b/backend/internal/usecase/complete_onboarding_usecase.go
@@ -7,16 +7,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// CompleteOnboardingUseCase はユーザーが Welcome 画面の「はじめる」を押した時に
-// users.onboarded_at を NOW() で更新する。
-//
-// 仕様:
-//   - 既に値が入っているユーザーに対しても 200 を返す（冪等）。repo の MarkOnboarded が
-//     IS NULL ガード付きなので二度押しでも初回日時は保持される。
-//   - userID は handler で current user から渡す前提（API は自分自身しか変更不可）。
-//
-// CompleteOnboardingUseCase は Welcome 画面 押下 後 の onboarded_at 記録 を 行う。
-// 依存 port: [repository.UserRepository] (MarkOnboarded を 使用)。
+// CompleteOnboardingUseCase は Welcome 完了時に users.onboarded_at を更新する。
+// MarkOnboarded が IS NULL ガード付きなので二度押しでも初回日時は保持される（冪等）。
 type CompleteOnboardingUseCase struct {
 	users repository.UserRepository
 }

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -8,18 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// CourseUseCase はコース機能の操作（list / get / create / update / delete）を
-// 1 構造体で扱う。 内部ヘルパは teaching_material_usecase の canManage を共有する。
-//
-// アクセス制御:
-//   - List: 同一 company の company_admin / trainee / super_admin
-//     trainee は published のみ、 company_admin / super_admin は draft 含む全件
-//   - Get: 同一 company か super_admin（trainee は published のみ）
-//   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
-//   - Delete: コース内の教材も同時に削除する（cascade）
-//
-// 依存 port: [repository.CourseRepository] + [repository.TeachingMaterialRepository]
-// (削除 時 の cascade 用)。 章 002 §6 で 「単純 CRUD は 1 構造体 集約 OK」 の 例 と して 解説。
+// CourseUseCase はコースの list / get / create / update / delete を 1 構造体で扱う。
+// canManage は teaching_material_usecase と共有。trainee は published のみ閲覧、
+// 編集系は同一 company の company_admin または super_admin。Delete は配下教材も cascade 削除。
 type CourseUseCase struct {
 	courses   repository.CourseRepository
 	materials repository.TeachingMaterialRepository
@@ -123,8 +114,7 @@ func (uc *CourseUseCase) Update(ctx context.Context, in UpdateCourseInput) (*dom
 	return existing, nil
 }
 
-// Delete はコースとその配下の教材を同時に削除する。 教材は repository の
-// DeleteByCourse で一括削除（cascade 相当）。
+// Delete はコースと配下教材を同時に削除する（cascade 相当）。
 func (uc *CourseUseCase) Delete(ctx context.Context, id, actorCompanyID uint64, actorRole string) error {
 	existing, err := uc.courses.GetByID(ctx, id)
 	if err != nil {

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -16,11 +16,9 @@ import (
 
 const (
 	maxCodeBytes = 64 * 1024 // 64 KB
-	// execTimeout は PHP / bash の デフォルト 上限。 起動 + 実行が ~ms オーダー。
+	// execTimeout は PHP / bash の上限。
 	execTimeout = 8 * time.Second
-	// goExecTimeout は Go 専用。 `go run` は コンパイル + リンク + 実行 が走るため、
-	// ECS Fargate の ephemeral storage I/O 遅さも勘案して 余裕を持たせる。
-	// production の cold compile は ~6-8s の実測がある。
+	// goExecTimeout は Go 専用。go run はコンパイルも走るため余裕を持たせる（cold compile ~6-8s）。
 	goExecTimeout  = 15 * time.Second
 	maxOutputBytes = 64 * 1024 // 64 KB
 )
@@ -55,14 +53,8 @@ type ExecuteCodeOutput struct {
 	ExitCode int    `json:"exitCode"`
 }
 
-// ExecuteCodeUseCase はユーザーコードをサンドボックスで実行する。
-//
-// PHP / Go / bash の 3 言語サポート:
-//   - PHP: php CLI + disable_functions で危険関数を封じる
-//   - Go: go run で単一 main.go ファイルを実行。 build cache は共有して compile 時間短縮
-//   - bash: /bin/bash でシェルスクリプトを実行。 PATH を限定し HOME を temp dir に固定
-//
-// 共通制約: 8 秒 timeout / 64 KB code-size / 64 KB output-size。
+// ExecuteCodeUseCase は PHP / Go / bash のコードをサンドボックスで実行する。
+// 共通制約: timeout / 64 KB code-size / 64 KB output-size。
 type ExecuteCodeUseCase struct{}
 
 func NewExecuteCodeUseCase() *ExecuteCodeUseCase {
@@ -86,10 +78,7 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 }
 
 func (uc *ExecuteCodeUseCase) executePHP(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	// PHP CLI は `<?php` 開始タグが無いコードを「ただの HTML テキスト」として扱い、
-	// ソースコードをそのまま stdout に流して exit code 0 を返す。
-	// 別言語 (Java など) のコードを誤って貼り付けると「実行成功 + 出力 = 元コード」になり
-	// ユーザを混乱させるので、 ここで明示的に弾く。
+	// 開始タグが無いと PHP はソースをそのまま stdout に流すため、別言語の誤貼付けを明示的に弾く。
 	if !strings.Contains(input.Code, "<?php") && !strings.Contains(input.Code, "<?=") {
 		return &ExecuteCodeOutput{
 			Stdout:   "",
@@ -123,8 +112,7 @@ func (uc *ExecuteCodeUseCase) executePHP(ctx context.Context, input ExecuteCodeI
 }
 
 func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	// Go コードは `package main` + `func main()` を必須にする。
-	// 別言語のコードを「Go モード」 で投げて意味不明なコンパイルエラーになるのを避ける。
+	// 別言語コードが意味不明なコンパイルエラーになるのを避けるため package main を必須にする。
 	if !strings.Contains(input.Code, "package main") {
 		return &ExecuteCodeOutput{
 			Stdout:   "",
@@ -133,8 +121,7 @@ func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeIn
 		}, nil
 	}
 
-	// 各リクエストごとに独立した GOPATH 用ディレクトリを作る。
-	// build cache は共有 (/tmp/go-build-cache) で compile 時間短縮。
+	// リクエストごとに独立した HOME を作る。build cache は共有で compile 短縮。
 	tmpDir, err := os.MkdirTemp("", "go-exec-")
 	if err != nil {
 		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
@@ -146,12 +133,11 @@ func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeIn
 		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
 	}
 
-	// Go は コンパイル + 実行 が走るため timeout を 専用の 長めの値で取る。
 	ctx, cancel := context.WithTimeout(ctx, goExecTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "run", filename)
-	// GO111MODULE=off で単一ファイル実行（go.mod 不要）。 GOCACHE は環境共有で compile 高速化。
+	// GO111MODULE=off で go.mod 不要の単一ファイル実行。
 	cmd.Env = append(os.Environ(),
 		"GO111MODULE=off",
 		"HOME="+tmpDir,
@@ -161,9 +147,7 @@ func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeIn
 }
 
 func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	// 各リクエストごとに独立した一時ディレクトリを作る。
-	// 演習で `cat > /tmp/sample.txt` のような書き込みが起きても他リクエストに影響させないため
-	// HOME / PWD を temp dir に固定し、 副作用を temp に閉じる。
+	// リクエストごとに独立した temp dir を HOME / PWD に固定し、副作用を temp に閉じる。
 	tmpDir, err := os.MkdirTemp("", "bash-exec-")
 	if err != nil {
 		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
@@ -189,29 +173,25 @@ func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCode
 		"LC_ALL=C.UTF-8",
 	}
 
-	// bash はユーザが `sleep 30 &` のような バックグラウンド子プロセスを 起動しうる。
-	// timeout 時にそれら子孫プロセスを 確実に kill するため、 独立プロセスグループに置く。
+	// bash はバックグラウンド子プロセスを起動しうるので、独立プロセスグループに置いて一括 kill する。
 	configureProcessGroup(cmd)
 
 	return runCommand(cmd, input.Stdin)
 }
 
-// configureProcessGroup は cmd を独立した process group に置き、 ctx cancel 時に
-// グループ全体へ SIGKILL を送るよう設定する。 bash で バックグラウンド子孫が leak しないよう
-// に bash 実行のみで使う。 PHP / Go の `go run` は普通 子孫を起動しないため不要。
+// configureProcessGroup は cmd を独立 process group に置き、cancel 時にグループ全体へ SIGKILL を送る。
+// bash の子孫プロセス leak を防ぐ用途で、bash 実行時のみ使う。
 func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
 		}
-		// -pid を渡すと プロセスグループ全体に signal が飛ぶ (POSIX)。
-		// kill が失敗しても (既に終了済 / ESRCH) ExitError 上書きを防ぐため nil を返す。
+		// -pid でグループ全体に signal（POSIX）。失敗しても ExitError 上書き防止に nil を返す。
 		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 		return nil
 	}
-	// stdout / stderr のパイプが 残ったままの子孫がいても Wait が 無限に張り付かないよう、
-	// 小さい WaitDelay を付ける。 timeout 後 1 秒で 強制 close + kill。
+	// 残存子孫がいても Wait が張り付かないよう WaitDelay を付ける。
 	cmd.WaitDelay = 1 * time.Second
 }
 

--- a/backend/internal/usecase/get_current_user_usecase.go
+++ b/backend/internal/usecase/get_current_user_usecase.go
@@ -8,7 +8,6 @@ import (
 )
 
 // GetCurrentUserUseCase は Cognito sub から現在のユーザー情報を引く。
-// 依存 port: [repository.UserRepository] (FindByCognitoSub を 使用)。
 type GetCurrentUserUseCase struct {
 	users repository.UserRepository
 }

--- a/backend/internal/usecase/get_master_exercise_usecase.go
+++ b/backend/internal/usecase/get_master_exercise_usecase.go
@@ -9,22 +9,12 @@ import (
 )
 
 // GetMasterExerciseDetailOutput は詳細ページに渡す問題本体 + 入出力例セット。
-//
-// JSON 表現は handler でそのままシリアライズされる。フロントは `examples` 配列を
-// 入力例 1 / 入力例 2 / ... として全件描画し、提出時には同じ全件をテストケースとして
-// 順に実行して合否を判定する（採点ロジックは PR-W で追加）。
 type GetMasterExerciseDetailOutput struct {
 	Exercise *domain.MasterExercise         `json:"exercise"`
 	Examples []domain.MasterExerciseExample `json:"examples"`
 }
 
-// GetMasterExerciseUseCase は指定 slug の運営マスタ演習問題 + 入出力例を返す。
-//
-// 旧 API は `:id` ベースだったが、 人間可読な URL `/code-editor/php-1` を実現するため
-// 主導線を slug に切替える。 ID ベースの挙動も互換用に Execute / GetByID で残す。
-//
-// 依存 port: [repository.MasterExerciseRepository] (exercise 本体) +
-// [repository.MasterExerciseExampleRepository] (入出力例 セット)。
+// GetMasterExerciseUseCase は slug 指定で運営マスタ演習 + 入出力例を返す（ID 指定は Execute で互換維持）。
 type GetMasterExerciseUseCase struct {
 	repo     repository.MasterExerciseRepository
 	examples repository.MasterExerciseExampleRepository
@@ -42,11 +32,8 @@ func (uc *GetMasterExerciseUseCase) Execute(ctx context.Context, id uint64) (*do
 	return uc.repo.GetByID(ctx, id)
 }
 
-// ExecuteBySlug は slug ベースの詳細ページ向け。 examples を含めて 1 度に返す。
-//
-// `GetBySlug` が GORM の `gorm.ErrRecordNotFound` を返した場合は handler 側で 404 に分岐できるよう
-// そのまま伝搬する。 nil チェックは GORM が `(nil, nil)` を返さない前提だが、 リポジトリ実装の
-// バグや fake で `ex == nil` が起きたときの nil pointer panic を防ぐため defensive に弾いておく。
+// ExecuteBySlug は slug ベースの詳細ページ向けに examples を含めて返す。
+// NotFound は handler で 404 に分岐できるようそのまま伝搬し、ex == nil は defensive に弾く。
 func (uc *GetMasterExerciseUseCase) ExecuteBySlug(ctx context.Context, slug string) (*GetMasterExerciseDetailOutput, error) {
 	ex, err := uc.repo.GetBySlug(ctx, slug)
 	if err != nil {

--- a/backend/internal/usecase/health_usecase.go
+++ b/backend/internal/usecase/health_usecase.go
@@ -7,9 +7,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// CheckHealthUseCase はバックエンドの稼働状態を判定するユースケース。
-// DB 到達性を確認し、UP/DOWN を返す。
-// 依存 port: [repository.HealthRepository] (sql.DB.Ping を 内部 実行)。
+// CheckHealthUseCase は DB 到達性を確認し UP/DOWN を返す。
 type CheckHealthUseCase struct {
 	repo repository.HealthRepository
 }

--- a/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
+++ b/backend/internal/usecase/issue_ai_chat_attachment_upload_url_usecase.go
@@ -8,16 +8,7 @@ import (
 )
 
 // IssueAiChatAttachmentUploadURLUseCase は AI チャット添付の S3 PUT presigned URL を発行する。
-//
-// 入力検証:
-//   - userID 必須
-//   - contentType は事前に許容セット (image/png 等) であること
-//   - sizeBytes は Bedrock 上限 (5MB / image, 4.5MB / document) 以内であること
-//
-// 上限チェックを usecase 層で行うのは「presigned URL を発行する前に 413 を返す」ためで、
-// クライアント側の不正利用や typo を S3 アップロード前の早い段階で弾く目的。
-//
-// 依存 port: [repository.AiChatAttachmentPresigner] (S3 presigned URL 生成)。
+// contentType / sizeBytes を usecase 層で検証し、不正な添付は presigned URL 発行前に弾く。
 type IssueAiChatAttachmentUploadURLUseCase struct {
 	presigner repository.AiChatAttachmentPresigner
 }
@@ -39,8 +30,7 @@ const (
 	maxDocumentBytes int64 = 4_500_000 // Bedrock document upper bound
 )
 
-// AllowedAttachmentContentTypes は presigned URL 発行 OK / SSE 送信 OK な MIME 一覧。
-// PR-G1 では画像のみ。PR-G2 で application/pdf / text/csv を追加する想定。
+// AllowedAttachmentContentTypes は presigned URL 発行 / SSE 送信が許可される MIME 一覧。
 var AllowedAttachmentContentTypes = map[string]struct {
 	Kind   string // "image" | "document"
 	Format string // Bedrock format (png/jpeg/gif/webp/pdf/csv)
@@ -73,5 +63,5 @@ func (u *IssueAiChatAttachmentUploadURLUseCase) Execute(ctx context.Context, in 
 	return u.presigner.Generate(ctx, in.UserID, in.Filename, in.ContentType)
 }
 
-// _ = maxDocumentBytes は未使用警告抑止 + PR-G2 で利用予定の予約定数の宣言を残す目的。
+// maxDocumentBytes は document 対応で使う予約定数（未使用警告抑止）。
 var _ = maxDocumentBytes

--- a/backend/internal/usecase/learning_report_usecase.go
+++ b/backend/internal/usecase/learning_report_usecase.go
@@ -9,8 +9,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// ListLearningReportsUseCase は current user の レポート 一覧 を 返す。
-// 依存 port: [repository.LearningReportRepository]。
+// ListLearningReportsUseCase は current user のレポート一覧を返す。
 type ListLearningReportsUseCase struct {
 	repo repository.LearningReportRepository
 }
@@ -26,9 +25,7 @@ func (u *ListLearningReportsUseCase) Execute(ctx context.Context, userID uint64)
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-// RequestLearningReportUseCase は レポート 生成 ジョブ を 受け付けて DB に pending 行 を 作り、
-// SQS に enqueue する。 章 008 で 解説 する 「2 つ の port を 直列 に 呼ぶ」 例。
-// 依存 port: [repository.LearningReportRepository] (DB) + [repository.SqsEnqueuer] (キュー)。
+// RequestLearningReportUseCase はレポート生成ジョブを DB に pending 行で作り、SQS に enqueue する。
 type RequestLearningReportUseCase struct {
 	repo  repository.LearningReportRepository
 	queue repository.SqsEnqueuer

--- a/backend/internal/usecase/list_master_exercises_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_usecase.go
@@ -8,11 +8,6 @@ import (
 )
 
 // ListMasterExercisesUseCase は指定言語の運営マスタ演習問題一覧を返す。
-//
-// 旧 ListPhpExercisesUseCase の汎用版。言語固定の API（例: /php/exercises）を
-// 残しつつ、本 usecase は language を引数で受け取って多言語対応の準備をする。
-//
-// 依存 port: [repository.MasterExerciseRepository]。
 type ListMasterExercisesUseCase struct {
 	repo repository.MasterExerciseRepository
 }

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -7,14 +7,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// MasterExerciseWithStatus は一覧ページに渡す「問題 + 現在ユーザの状態 + 全体集計」のセット。
-//
-// Status の値:
-//   - "solved"      … current user が 1 度でも is_correct=true で解いた
-//   - "in_progress" … current user が提出はあるが正答していない
-//   - ""            … current user が未提出（未着手）
-//
-// Stats は全ユーザ合計の集計値。
+// MasterExerciseWithStatus は問題 + current user の状態（solved / in_progress / 未提出）+ 全体集計のセット。
 type MasterExerciseWithStatus struct {
 	domain.MasterExercise
 
@@ -23,11 +16,7 @@ type MasterExerciseWithStatus struct {
 }
 
 // ListMasterExercisesWithStatusUseCase は問題一覧 + 各問題の current user 状態 + 集計を返す。
-//
-// N+1 を避けるため、 user status と stats はそれぞれ batch クエリで取得する。
-//
-// 依存 port: [repository.MasterExerciseRepository] + [repository.ExerciseSubmissionRepository]
-// (BatchUserStatuses / ExerciseStatsBatch で N+1 回避)。
+// status と stats は batch クエリで取得して N+1 を避ける。
 type ListMasterExercisesWithStatusUseCase struct {
 	exercises   repository.MasterExerciseRepository
 	submissions repository.ExerciseSubmissionRepository

--- a/backend/internal/usecase/list_user_submissions_usecase.go
+++ b/backend/internal/usecase/list_user_submissions_usecase.go
@@ -15,8 +15,6 @@ type ListUserMasterSubmissionsInput struct {
 }
 
 // ListUserMasterSubmissionsUseCase は current user の指定問題に対する提出履歴を新しい順で返す。
-// 依存 port: [repository.MasterExerciseRepository] (slug 解決) +
-// [repository.ExerciseSubmissionRepository] (履歴 取得)。
 type ListUserMasterSubmissionsUseCase struct {
 	exercises   repository.MasterExerciseRepository
 	submissions repository.ExerciseSubmissionRepository

--- a/backend/internal/usecase/note_image_usecase.go
+++ b/backend/internal/usecase/note_image_usecase.go
@@ -8,8 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// IssueNoteImageUploadURLUseCase は ノート 画像 用 S3 PUT 署名付き URL を 発行 する。
-// 依存 port: [repository.NoteImagePresigner] (S3 presigned URL 生成)。
+// IssueNoteImageUploadURLUseCase はノート画像用 S3 PUT 署名付き URL を発行する。
 type IssueNoteImageUploadURLUseCase struct {
 	presigner repository.NoteImagePresigner
 }

--- a/backend/internal/usecase/note_usecase.go
+++ b/backend/internal/usecase/note_usecase.go
@@ -10,8 +10,7 @@ import (
 
 var ErrNoteForbidden = errors.New("forbidden")
 
-// ListNotesByUserIDUseCase は current user の ノート 一覧 を 返す。
-// 依存 port: [repository.NoteRepository]。
+// ListNotesByUserIDUseCase は current user のノート一覧を返す。
 type ListNotesByUserIDUseCase struct {
 	repo repository.NoteRepository
 }
@@ -27,8 +26,7 @@ func (u *ListNotesByUserIDUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-// CreateNoteUseCase は 新規 ノート を 作成 する。
-// 依存 port: [repository.NoteRepository]。
+// CreateNoteUseCase は新規ノートを作成する。
 type CreateNoteUseCase struct {
 	repo repository.NoteRepository
 }
@@ -65,8 +63,7 @@ func (u *CreateNoteUseCase) Execute(ctx context.Context, in CreateNoteInput) (*d
 	return n, nil
 }
 
-// UpdateNoteUseCase は ノート を 更新 する (所有者 検証 込み)。
-// 依存 port: [repository.NoteRepository] (FindByID で 所有者 検証 → Update)。
+// UpdateNoteUseCase はノートを更新する（所有者検証込み）。
 type UpdateNoteUseCase struct {
 	repo repository.NoteRepository
 }
@@ -84,8 +81,7 @@ type UpdateNoteInput struct {
 	IsPinned bool
 }
 
-// Execute は所有者検証込みで note を更新する。
-// 既存 note の UserID が input.UserID と一致しなければ ErrNoteForbidden を返す。
+// Execute は所有者でなければ ErrNoteForbidden を返し、そうでなければ note を更新する。
 func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*domain.Note, error) {
 	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
@@ -110,8 +106,7 @@ func (u *UpdateNoteUseCase) Execute(ctx context.Context, in UpdateNoteInput) (*d
 	return existing, nil
 }
 
-// DeleteNoteUseCase は ノート を 削除 する。 repo 側 で 所有者 検証 を 行う。
-// 依存 port: [repository.NoteRepository] (Delete に userID を 渡して WHERE 絞り込み)。
+// DeleteNoteUseCase はノートを削除する（repo 側で userID により所有者検証）。
 type DeleteNoteUseCase struct {
 	repo repository.NoteRepository
 }

--- a/backend/internal/usecase/notification_usecase.go
+++ b/backend/internal/usecase/notification_usecase.go
@@ -8,8 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// ListNotificationsUseCase は current user の 通知 一覧 を 返す。
-// 依存 port: [repository.NotificationRepository]。
+// ListNotificationsUseCase は current user の通知一覧を返す。
 type ListNotificationsUseCase struct {
 	repo repository.NotificationRepository
 }
@@ -25,8 +24,7 @@ func (u *ListNotificationsUseCase) Execute(ctx context.Context, userID uint64) (
 	return u.repo.ListByUserID(ctx, userID)
 }
 
-// MarkNotificationReadUseCase は 単一 通知 を 既読 化 する (所有者 検証 込み)。
-// 依存 port: [repository.NotificationRepository]。
+// MarkNotificationReadUseCase は単一通知を既読化する（所有者検証込み）。
 type MarkNotificationReadUseCase struct {
 	repo repository.NotificationRepository
 }
@@ -45,8 +43,7 @@ func (u *MarkNotificationReadUseCase) Execute(ctx context.Context, userID, id ui
 	return u.repo.MarkRead(ctx, userID, id)
 }
 
-// MarkAllNotificationsReadUseCase は current user の 全 通知 を 一括 既読 化 する。
-// 依存 port: [repository.NotificationRepository]。
+// MarkAllNotificationsReadUseCase は current user の全通知を一括既読化する。
 type MarkAllNotificationsReadUseCase struct {
 	repo repository.NotificationRepository
 }
@@ -62,8 +59,7 @@ func (u *MarkAllNotificationsReadUseCase) Execute(ctx context.Context, userID ui
 	return u.repo.MarkAllRead(ctx, userID)
 }
 
-// CountUnreadNotificationsUseCase は current user の 未読 通知 数 を 返す (バッジ 表示 用)。
-// 依存 port: [repository.NotificationRepository]。
+// CountUnreadNotificationsUseCase は current user の未読通知数を返す（バッジ表示用）。
 type CountUnreadNotificationsUseCase struct {
 	repo repository.NotificationRepository
 }

--- a/backend/internal/usecase/profile_image_usecase.go
+++ b/backend/internal/usecase/profile_image_usecase.go
@@ -8,9 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// IssueProfileImageUploadURLUseCase は profile アイコン 用 S3 PUT 署名 付き URL を 発行 する。
-// 章 009 で 解説 する Presigner port の 標準 例。
-// 依存 port: [repository.ProfileImagePresigner] (S3 presigned URL 生成)。
+// IssueProfileImageUploadURLUseCase は profile アイコン用 S3 PUT 署名付き URL を発行する。
 type IssueProfileImageUploadURLUseCase struct {
 	presigner repository.ProfileImagePresigner
 }
@@ -19,8 +17,6 @@ func NewIssueProfileImageUploadURLUseCase(p repository.ProfileImagePresigner) *I
 	return &IssueProfileImageUploadURLUseCase{presigner: p}
 }
 
-// Execute は current user の profile アイコン用 PUT 署名付き URL を発行する。
-// userID は handler 側で middleware 経由 (=current user) で渡す前提。
 func (u *IssueProfileImageUploadURLUseCase) Execute(ctx context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error) {
 	if userID == 0 {
 		return nil, errors.New("userID is required")

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -8,9 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// GetProfileUseCase は 指定 user の プロフィール を 返す。 章 002 §3.3 で 解説 する
-// DIP の 標準 例 (usecase は port だけ 知って GORM を 知ら ない)。
-// 依存 port: [repository.ProfileRepository] (FindByUserID)。
+// GetProfileUseCase は指定 user のプロフィールを返す。
 type GetProfileUseCase struct {
 	profiles repository.ProfileRepository
 }
@@ -26,8 +24,7 @@ func (u *GetProfileUseCase) Execute(ctx context.Context, userID uint64) (*domain
 	return u.profiles.FindByUserID(ctx, userID)
 }
 
-// UpdateProfileUseCase は プロフィール の 任意 フィールド を upsert する。
-// 依存 port: [repository.ProfileRepository] (Upsert)。
+// UpdateProfileUseCase はプロフィールの任意フィールドを upsert する。
 type UpdateProfileUseCase struct {
 	profiles repository.ProfileRepository
 }

--- a/backend/internal/usecase/repository/admin_invitation.go
+++ b/backend/internal/usecase/repository/admin_invitation.go
@@ -6,21 +6,15 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// AdminInvitationRepository は admin_invitations テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// adminInvitationRepository (GORM)。 招待 受諾 / pending 検索 / 監査 用 status 更新
-// の 一連 を 1 fat interface で 集約。
+// AdminInvitationRepository は invitations テーブルへのアクセスを提供する。
 type AdminInvitationRepository interface {
-	// ListAll は全社横断で招待を返す。SuperAdmin (運営) のダッシュボード用。
+	// ListAll は全社横断で招待を返す（SuperAdmin 用）。
 	ListAll(ctx context.Context) ([]domain.AdminInvitation, error)
-	// ListByCompanyID は CompanyAdmin が自社の招待のみを見るための query。
+	// ListByCompanyID は CompanyAdmin が自社の招待のみを見る用。
 	ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.AdminInvitation, error)
-	// FindPendingByEmail は招待受諾フローで「ログインしてきたユーザーが招待ユーザーか」
-	// を判定するために使う。同一 email で複数 pending があれば最新を返す。
+	// FindPendingByEmail は同一 email の pending 招待の最新を返す（受諾フロー判定用）。
 	FindPendingByEmail(ctx context.Context, email string) (*domain.AdminInvitation, error)
-	// FindPendingByToken はマジックリンク受諾フロー用。token 一致 & status=pending & expires_at 未経過のみ返す。
-	// 該当なしは (nil, nil) を返し、呼び出し側で「無効/期限切れ token」として扱う。
+	// FindPendingByToken は token 一致 & pending & 未期限切れのみ返す（該当なしは nil, nil）。
 	FindPendingByToken(ctx context.Context, token string) (*domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
 	UpdateStatus(ctx context.Context, id uint64, status string) error

--- a/backend/internal/usecase/repository/ai_chat_attachment.go
+++ b/backend/internal/usecase/repository/ai_chat_attachment.go
@@ -2,22 +2,13 @@ package repository
 
 import "context"
 
-// AiChatAttachmentPresigner は AI チャットの添付ファイル用 PUT presigned URL を発行する。
-//
-// note_image / profile_image と同様の責務だが、key prefix と content-type の許容範囲が違う。
-// 共通化せず別プレゼンタを切るのは、将来 PR-G2 で document (PDF/CSV) 対応をする際に
-// 「画像と document で別バケット / 別 lifecycle にしたい」可能性を残すため。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// aiChatAttachmentPresigner (S3 SDK)。
+// AiChatAttachmentPresigner は AI チャット添付用の PUT presigned URL を発行する。
 type AiChatAttachmentPresigner interface {
 	Generate(ctx context.Context, userID uint64, filename, contentType string) (*AiChatAttachmentUploadURL, error)
 }
 
 // AiChatAttachmentUploadURL は presigned URL 発行結果。
-//
-// Key は S3 オブジェクトキー。クライアントは UploadURL に PUT した後、
-// この Key を SSE 送信ペイロードの attachments[].key に詰めて返す。
+// クライアントは UploadURL に PUT 後、Key を SSE 送信ペイロードの attachments[].key に詰める。
 type AiChatAttachmentUploadURL struct {
 	UploadURL string `json:"uploadUrl"`
 	Key       string `json:"key"`

--- a/backend/internal/usecase/repository/ai_chat_message.go
+++ b/backend/internal/usecase/repository/ai_chat_message.go
@@ -6,11 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// AiChatMessageRepository は DynamoDB 上の AI チャットメッセージへのアクセスを提供する。
-// PK: sessionId (String)、SK: messageId (UUID String)
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// aiChatMessageRepository (DynamoDB SDK v2)。
+// AiChatMessageRepository は DynamoDB 上の AI チャットメッセージへのアクセスを提供する（PK: sessionId / SK: messageId）。
 type AiChatMessageRepository interface {
 	Save(ctx context.Context, msg *domain.AiChatMessage) error
 	ListBySessionID(ctx context.Context, sessionID uint64) ([]domain.AiChatMessage, error)

--- a/backend/internal/usecase/repository/ai_chat_session.go
+++ b/backend/internal/usecase/repository/ai_chat_session.go
@@ -7,9 +7,6 @@ import (
 )
 
 // AiChatSessionRepository は ai_chat_sessions テーブルへのアクセスを提供する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// aiChatSessionRepository (GORM)。
 type AiChatSessionRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.AiChatSession, error)
 	FindByID(ctx context.Context, id uint64) (*domain.AiChatSession, error)

--- a/backend/internal/usecase/repository/company.go
+++ b/backend/internal/usecase/repository/company.go
@@ -6,10 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// CompanyRepository は companies テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// companyRepository (GORM)。
+// CompanyRepository は companies テーブルへのアクセスを提供する。
 type CompanyRepository interface {
 	ListAll(ctx context.Context) ([]domain.Company, error)
 	FindByID(ctx context.Context, id uint64) (*domain.Company, error)

--- a/backend/internal/usecase/repository/course.go
+++ b/backend/internal/usecase/repository/course.go
@@ -6,13 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// CourseRepository はコースの永続化を担う。
-//
-// 教材と同様、 クエリは原則 company_id 指定で発行することで、 他社のコースが
-// アプリ層のバグで漏れる事故を予防する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// courseRepository (GORM)。
+// CourseRepository はコースの永続化を担う（クエリは company_id 指定で他社漏れを防ぐ）。
 type CourseRepository interface {
 	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.Course, error)
 	GetByID(ctx context.Context, id uint64) (*domain.Course, error)

--- a/backend/internal/usecase/repository/exercise_submission.go
+++ b/backend/internal/usecase/repository/exercise_submission.go
@@ -6,18 +6,8 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// ExerciseSubmissionRepository は演習提出履歴の永続化を担う。
-//
-// 履歴は append-only。ユーザ × 問題で複数行を許容し、合否や最新提出時刻を集計する。
-// 集計クエリ ( CountUsersSolved / CountTotal ) は exercise_id 単位で
-// 一覧ページの「正答者数」「提出数」表示に使う。
-//
-// 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// exerciseSubmissionRepository (GORM)。
+// ExerciseSubmissionRepository は演習提出履歴（append-only）の永続化と集計を担う。
 type ExerciseSubmissionRepository interface {
-	// Create は新しい提出を保存する。
 	Create(ctx context.Context, submission *domain.ExerciseSubmission) error
 
 	// ListByUserAndExercise は user × (kind, exercise_id) の履歴を新しい順に返す。
@@ -26,19 +16,16 @@ type ExerciseSubmissionRepository interface {
 	// HasSolved は user が exercise を 1 回でも is_correct=true で解いたかを返す。
 	HasSolved(ctx context.Context, userID, exerciseID uint64, kind string) (bool, error)
 
-	// HasAttempted は user が exercise に対して 1 回でも提出したかを返す。
+	// HasAttempted は user が exercise に 1 回でも提出したかを返す。
 	HasAttempted(ctx context.Context, userID, exerciseID uint64, kind string) (bool, error)
 
-	// BatchUserStatuses は user の (kind, exerciseIDs) について、
-	//   exercise_id -> "solved" / "in_progress"
-	// を返す。一覧ページの N+1 を避ける用途。
-	// 未提出は map に key が存在しないこと で 表す。
+	// BatchUserStatuses は exercise_id -> "solved" / "in_progress" を返す（未提出は key なし、N+1 回避）。
 	BatchUserStatuses(ctx context.Context, userID uint64, exerciseIDs []uint64, kind string) (map[uint64]string, error)
 
 	// ExerciseStats は exercise_id 単位の集計を返す。
 	ExerciseStats(ctx context.Context, exerciseID uint64, kind string) (ExerciseSubmissionStats, error)
 
-	// ExerciseStatsBatch は複数 exercise_id をまとめて集計する。一覧ページ用。
+	// ExerciseStatsBatch は複数 exercise_id をまとめて集計する。
 	ExerciseStatsBatch(ctx context.Context, exerciseIDs []uint64, kind string) (map[uint64]ExerciseSubmissionStats, error)
 }
 

--- a/backend/internal/usecase/repository/health.go
+++ b/backend/internal/usecase/repository/health.go
@@ -3,9 +3,6 @@ package repository
 import "context"
 
 // HealthRepository は DB の到達性を確認する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// healthRepository (GORM の sql.DB を Ping)。
 type HealthRepository interface {
 	PingDB(ctx context.Context) error
 }

--- a/backend/internal/usecase/repository/learning_report.go
+++ b/backend/internal/usecase/repository/learning_report.go
@@ -6,20 +6,13 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// LearningReportRepository は learning_reports テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// learningReportRepository (GORM)。
+// LearningReportRepository は learning_reports テーブルへのアクセスを提供する。
 type LearningReportRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.LearningReport, error)
 	Create(ctx context.Context, r *domain.LearningReport) error
 }
 
-// SqsEnqueuer はレポート生成ジョブを SQS にキューする interface。
-//
-// 単一 メソッド の port な ので Effective Go 流 の -er 命名 を 採用 (multi-method
-// の Repository とは ガイド ライン が 異なる)。 stub 実装 は
-// [github.com/norman6464/FreStyle/backend/internal/adapter/persistence].NewStubSqsEnqueuer。
+// SqsEnqueuer はレポート生成ジョブを SQS にキューする。
 type SqsEnqueuer interface {
 	Enqueue(ctx context.Context, reportID uint64) error
 }

--- a/backend/internal/usecase/repository/master_exercise.go
+++ b/backend/internal/usecase/repository/master_exercise.go
@@ -6,17 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// MasterExerciseRepository は運営マスタ演習問題（旧 php_exercises 由来）の永続化を担う。
-//
-// 旧 PhpExerciseRepository を language 引数を受け取れる形に汎用化したもの。
-// 言語フィルタは ListByLanguage で行い、PHP 専用 API は
-// usecase 層で `language="php"` を渡して既存挙動と互換を保つ。
-//
-// 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける
-// (キャンセル / タイムアウト / トレース ID 伝搬 の ため)。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// masterExerciseRepository (GORM)。
+// MasterExerciseRepository は運営マスタ演習問題の永続化を担う（言語フィルタは ListByLanguage）。
 type MasterExerciseRepository interface {
 	ListByLanguage(ctx context.Context, language string) ([]domain.MasterExercise, error)
 	GetByID(ctx context.Context, id uint64) (*domain.MasterExercise, error)

--- a/backend/internal/usecase/repository/master_exercise_example.go
+++ b/backend/internal/usecase/repository/master_exercise_example.go
@@ -7,15 +7,7 @@ import (
 )
 
 // MasterExerciseExampleRepository は MasterExercise に紐付く入出力例の永続化を担う。
-//
-// 一覧取得は `(exercise_id, order_index)` 複合インデックスで安定ソート。
-// 詳細画面では特定 exercise の全 example を表示し、採点 usecase では同じ全件を
-// テストケースとしてループ実行する。
-//
-// 全 メソッド は I/O 境界 として `ctx context.Context` を 第 1 引数 で 受ける。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// masterExerciseExampleRepository (GORM)。
+// 取得は (exercise_id, order_index) で安定ソートする。
 type MasterExerciseExampleRepository interface {
 	ListByExerciseID(ctx context.Context, exerciseID uint64) ([]domain.MasterExerciseExample, error)
 	ListByExerciseIDs(ctx context.Context, exerciseIDs []uint64) (map[uint64][]domain.MasterExerciseExample, error)

--- a/backend/internal/usecase/repository/note.go
+++ b/backend/internal/usecase/repository/note.go
@@ -6,16 +6,12 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// NoteRepository は notes テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// noteRepository (GORM)。
+// NoteRepository は notes テーブルへのアクセスを提供する。
 type NoteRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.Note, error)
 	FindByID(ctx context.Context, id uint64) (*domain.Note, error)
 	Create(ctx context.Context, n *domain.Note) error
 	Update(ctx context.Context, n *domain.Note) error
-	// Delete は所有者検証込みで note を削除する。
-	// WHERE で user_id を絞って他人の note を消せないようにする。
+	// Delete は WHERE で user_id を絞り、他人の note を消せないようにする。
 	Delete(ctx context.Context, userID, id uint64) error
 }

--- a/backend/internal/usecase/repository/note_image.go
+++ b/backend/internal/usecase/repository/note_image.go
@@ -7,10 +7,6 @@ import (
 )
 
 // NoteImagePresigner は S3 への PUT 用 presigned URL を発行する。
-//
-// 単一 メソッド の port な ので Effective Go 流 の -er 命名 を 採用。 実装 は
-// [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// noteImagePresigner (S3 SDK)。
 type NoteImagePresigner interface {
 	Generate(ctx context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error)
 }

--- a/backend/internal/usecase/repository/notification.go
+++ b/backend/internal/usecase/repository/notification.go
@@ -6,25 +6,16 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// NotificationRepository は notifications テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// notificationRepository (GORM)。
+// NotificationRepository は notifications テーブルへのアクセスを提供する。
 type NotificationRepository interface {
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error)
-	// MarkRead は所有者検証込みで is_read を立てる。
-	// 自分以外の通知を既読化できないように、必ず WHERE で user_id を絞る。
+	// MarkRead は WHERE で user_id を絞り、自分以外の通知を既読化できないようにする。
 	MarkRead(ctx context.Context, userID, id uint64) error
-	// MarkAllRead は current user の全通知を既読化する。
 	MarkAllRead(ctx context.Context, userID uint64) error
-	// CountUnread は current user の未読通知数を返す。
 	CountUnread(ctx context.Context, userID uint64) (int64, error)
 }
 
-// SnsPublisher は通知 push 用の interface（実装は AWS SDK 連携で別 PR）。
-//
-// 単一 メソッド の port な ので Effective Go 流 の -er 命名 を 採用。 stub 実装 は
-// [github.com/norman6464/FreStyle/backend/internal/adapter/persistence].NewStubSnsPublisher。
+// SnsPublisher は通知 push 用（実装は AWS SDK 連携で別 PR）。
 type SnsPublisher interface {
 	Publish(ctx context.Context, userID uint64, title, body string) error
 }

--- a/backend/internal/usecase/repository/profile.go
+++ b/backend/internal/usecase/repository/profile.go
@@ -6,10 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// ProfileRepository は profiles テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// profileRepository (GORM)。
+// ProfileRepository は profiles テーブルへのアクセスを提供する。
 type ProfileRepository interface {
 	FindByUserID(ctx context.Context, userID uint64) (*domain.Profile, error)
 	Upsert(ctx context.Context, p *domain.Profile) error

--- a/backend/internal/usecase/repository/profile_image.go
+++ b/backend/internal/usecase/repository/profile_image.go
@@ -7,10 +7,6 @@ import (
 )
 
 // ProfileImagePresigner は profile アイコン用 S3 PUT 署名付き URL を発行する。
-//
-// 単一 メソッド の port な ので Effective Go 流 の -er 命名 を 採用。 実装 は
-// [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// profileImagePresigner (S3 SDK)。
 type ProfileImagePresigner interface {
 	Generate(ctx context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error)
 }

--- a/backend/internal/usecase/repository/session_note.go
+++ b/backend/internal/usecase/repository/session_note.go
@@ -6,10 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// SessionNoteRepository は session_notes テーブル へ の アクセス を 提供 する。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// sessionNoteRepository (GORM)。
+// SessionNoteRepository は session_notes テーブルへのアクセスを提供する。
 type SessionNoteRepository interface {
 	FindBySessionID(ctx context.Context, sessionID uint64) (*domain.SessionNote, error)
 	Upsert(ctx context.Context, n *domain.SessionNote) error

--- a/backend/internal/usecase/repository/teaching_material.go
+++ b/backend/internal/usecase/repository/teaching_material.go
@@ -6,16 +6,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// TeachingMaterialRepository は教材の永続化を担う。
-//
-// クエリは原則 company_id 指定で発行することで、 他社の教材が
-// アプリ層のバグで漏れる事故を予防する（最後の防衛線として）。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// teachingMaterialRepository (GORM)。
+// TeachingMaterialRepository は教材の永続化を担う（クエリは company_id 指定で他社漏れを防ぐ）。
 type TeachingMaterialRepository interface {
-	// ListByCompany は backward-compat: 旧 GET /teaching-materials エンドポイント
-	// 用に company 内全教材を返す。 frontend がコース対応に切り替わったら削除予定。
+	// ListByCompany は company 内全教材を返す backward-compat 用（コース対応への移行後に削除予定）。
 	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
 	ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
 	GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error)

--- a/backend/internal/usecase/repository/user.go
+++ b/backend/internal/usecase/repository/user.go
@@ -1,12 +1,5 @@
-// Package repository は usecase 層 が 依存 する 永続化 境界 (port) を 定義 する。
-//
-// Clean Architecture の Use Case 層 が「自分 が 必要 と する 抽象」 を ここ で 宣言 し、
-// 実装 は [github.com/norman6464/FreStyle/backend/internal/adapter/persistence]
-// 配下 で 提供 さ れる (依存 方向: usecase ← persistence、 DIP)。
-//
-// 1 boundary = 1 fat interface の 方針 で 配置 する (Clean Architecture 通常 流儀)。
-// 単一 メソッド の port (例: Presigner / Enqueuer / Publisher) は Effective Go 流 の
-// -er 命名 で 別 ファイル に 配置 して 良い。
+// Package repository は usecase 層が依存する永続化境界（port）を定義する。
+// 実装は adapter/persistence 配下で提供される（依存方向: usecase ← persistence、DIP）。
 package repository
 
 import (
@@ -15,24 +8,17 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// UserRepository は users テーブル へ の アクセス を 提供 する。
-//
-// 旧 internal/repository/user_repository.go を Clean Architecture 構造 に 沿って
-// usecase 層 (port) と adapter 層 (実装) に 物理 分離 した うえ で、 interface 定義
-// を こちら に 移植 した もの。 メソッド 個別 の WHY は impl 側 (persistence.userRepository)
-// の メソッド コメント を 参照。
+// UserRepository は users テーブルへのアクセスを提供する。
 type UserRepository interface {
 	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
 	FindByID(ctx context.Context, id uint64) (*domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
-	// UpdateDisplayName は ProfilePage の「氏名」変更、 および OIDC ログイン時に
-	// 旧 displayName=email を id_token の name claim で自動補正するときに呼ばれる。
+	// UpdateDisplayName は氏名変更、および OIDC ログイン時の displayName 自動補正で呼ばれる。
 	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
 	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。
 	UpdateRole(ctx context.Context, userID uint64, role string) error
 	// UpdateCompanyID は既存ユーザーが招待を受けて company に紐付くときに呼ばれる。
 	UpdateCompanyID(ctx context.Context, userID uint64, companyID uint64) error
-	// MarkOnboarded は Welcome 画面の「はじめる」ボタン押下時に呼ばれ、
-	// onboarded_at = NOW() に更新する。冪等（既に値が入っていても上書きしない）。
+	// MarkOnboarded は onboarded_at = NOW() に更新する（冪等、既存値は上書きしない）。
 	MarkOnboarded(ctx context.Context, userID uint64) error
 }

--- a/backend/internal/usecase/repository/user_stats.go
+++ b/backend/internal/usecase/repository/user_stats.go
@@ -6,10 +6,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-// UserStatsRepository は user_stats を集計 して 返す。
-//
-// 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
-// userStatsRepository (GORM Raw SQL)。
+// UserStatsRepository は user_stats を集計して返す。
 type UserStatsRepository interface {
 	Compute(ctx context.Context, userID uint64) (*domain.UserStats, error)
 }

--- a/backend/internal/usecase/send_ai_message_stream_usecase.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase.go
@@ -19,35 +19,22 @@ type StreamingBedrockClient interface {
 	ConverseStream(ctx context.Context, systemPrompt string, history []domain.AiChatMessage) (<-chan bedrock.StreamEvent, error)
 }
 
-// AttachmentDownloader は S3 から attachment のバイト列を取得する抽象。
-// 本番では infra/s3.Downloader が満たす。usecase テストでは in-memory 実装を差し替える。
-//
-// nil でも動作する（その場合は添付なしと同等の振る舞い）。Bedrock / DynamoDB の初期化失敗
-// などで一時的に S3 利用不可になったときも、テキストだけは送れるよう優雅に degrade する。
+// AttachmentDownloader は S3 から attachment のバイト列を取得する抽象（infra/s3.Downloader が満たす）。
+// nil でも動作し、その場合は添付なしと同等にテキストだけ送る（優雅に degrade）。
 type AttachmentDownloader interface {
 	Download(ctx context.Context, key string) ([]byte, error)
 }
 
-// StreamEvent は handler に流すイベント。bedrock.StreamEvent と同形だが、
-// ここでは「session 作成済」「message 完成済」など usecase レベルの状態も合わせて返す。
+// StreamEvent は handler に流すイベント。token 配信に加え、session 作成 / message 完成などの状態も返す。
 type StreamEvent struct {
-	// Delta が non-empty なら token 追加（途中チャンク）
-	Delta string
-	// NewSession が non-nil なら新規セッションが作成されたことを示す（最初の 1 回のみ）
-	NewSession *domain.AiChatSession
-	// FinalMessage が non-nil ならアシスタント返答が完成して DB 保存済（末尾で 1 回のみ）
-	FinalMessage *domain.AiChatMessage
-	// Err が non-nil ならエラー終了
-	Err error
+	Delta        string                // 途中チャンク（token 追加）
+	NewSession   *domain.AiChatSession // 新規セッション作成時のみ（最初の 1 回）
+	FinalMessage *domain.AiChatMessage // アシスタント返答が完成し DB 保存済のとき（末尾で 1 回）
+	Err          error
 }
 
-// SendAiMessageStreamUseCase は WebSocket 版 (SendAiMessageUseCase) の streaming 版。
-// 互換のため両方を残し、フロントが対応した順から SSE に切り替える。 章 006 で SSE / Bedrock
-// streaming を 解説。
-//
-// 依存 port: [repository.AiChatSessionRepository] (RDB session 確認) +
-// [repository.AiChatMessageRepository] (DynamoDB メッセージ 永続化) +
-// [StreamingBedrockClient] (Bedrock token 配信) + [AttachmentDownloader] (S3 添付 取得、 nil OK)。
+// SendAiMessageStreamUseCase は AI チャットの SSE streaming 版。
+// session 確認 → メッセージ保存 → Bedrock streaming → 返答保存、をオーケストレーションする。
 type SendAiMessageStreamUseCase struct {
 	sessions      repository.AiChatSessionRepository
 	messages      repository.AiChatMessageRepository
@@ -69,15 +56,8 @@ func NewSendAiMessageStreamUseCase(
 	}
 }
 
-// Execute は handler 側でレスポンス書き込みに使う channel を返す。
-//
-// 流れ:
-//  1. sessionID == 0 なら新規セッション作成 → NewSession イベントを emit
-//  2. ユーザーメッセージを DB に保存 → 履歴を取得
-//  3. Bedrock ConverseStream を呼び、 token を Delta イベントで emit
-//  4. token を全て連結したアシスタント返答を DB に保存 → FinalMessage イベントを emit
-//  5. channel を close
-//
+// Execute は handler がレスポンス書き込みに使う StreamEvent channel を返す。
+// 新規セッション作成 → ユーザーメッセージ保存 → Bedrock streaming → 返答保存、を goroutine で進める。
 // ctx の cancel で全工程が中断される（クライアント切断時の goroutine リーク防止）。
 func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessageInput) (<-chan StreamEvent, error) {
 	out := make(chan StreamEvent, 16)
@@ -131,9 +111,7 @@ func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessa
 			return
 		}
 
-		// Bedrock 呼び出し直前に最新ユーザー発話の attachment 実体を S3 から取得して詰める。
-		// 過去履歴の画像は再送しない（料金 / latency / Bedrock 上限への配慮）。
-		// 取得失敗した attachment は除外して text だけで送る（部分劣化）。
+		// 最新ユーザー発話の attachment 実体だけを S3 から詰める（過去履歴の画像は再送しない）。
 		if u.attachments != nil && len(in.Attachments) > 0 {
 			if last := lastUserMessageIndex(history); last >= 0 {
 				history[last].Attachments = u.fetchAttachmentBlobs(ctx, in.Attachments)
@@ -162,9 +140,7 @@ func (u *SendAiMessageStreamUseCase) Execute(ctx context.Context, in SendAiMessa
 			}
 		}
 
-		// Bedrock が token を 1 つも emit しなかった場合は空のアシスタントメッセージに
-		// なる。これを DDB に保存すると将来の history 構築時に「連続 user → 空応答」の
-		// 負のループに陥るため、空応答は保存せずエラーとしてフロントに通知する。
+		// 空応答を保存すると history が「連続 user → 空応答」で壊れるため、保存せずエラー通知する。
 		if assistantBuf.Len() == 0 {
 			emit(ctx, out, StreamEvent{Err: fmt.Errorf("bedrock returned empty response")})
 			return
@@ -195,8 +171,7 @@ func emit(ctx context.Context, out chan<- StreamEvent, ev StreamEvent) {
 	}
 }
 
-// lastUserMessageIndex は history 末尾から最も近い user メッセージの index を返す。
-// 見つからなければ -1。最新ユーザー発話だけに今回のリクエスト由来 attachments を貼る用途。
+// lastUserMessageIndex は history 末尾から最も近い user メッセージの index を返す（無ければ -1）。
 func lastUserMessageIndex(history []domain.AiChatMessage) int {
 	for i := len(history) - 1; i >= 0; i-- {
 		if history[i].Role == domain.AiChatRoleUser {
@@ -206,11 +181,8 @@ func lastUserMessageIndex(history []domain.AiChatMessage) int {
 	return -1
 }
 
-// fetchAttachmentBlobs は in.Attachments それぞれを S3 から GetObject して BlobData を埋める。
-//
-// 取得失敗した attachment はスライスから落とす（その 1 枚だけ Bedrock に渡らない）。
-// すべて失敗したら空スライスを返し、Bedrock はテキストのみで応答する。
-// SizeBytes が 0 の attachment は metadata 不整合（フロント側のバグ）なのでスキップする。
+// fetchAttachmentBlobs は各 attachment を S3 から取得して BlobData を埋める。
+// 取得失敗した分は落とし、残りの添付 + テキストで送る（部分劣化）。
 func (u *SendAiMessageStreamUseCase) fetchAttachmentBlobs(ctx context.Context, in []domain.Attachment) []domain.Attachment {
 	out := make([]domain.Attachment, 0, len(in))
 	for _, a := range in {
@@ -219,7 +191,6 @@ func (u *SendAiMessageStreamUseCase) fetchAttachmentBlobs(ctx context.Context, i
 		}
 		data, err := u.attachments.Download(ctx, a.Key)
 		if err != nil {
-			// 1 件の失敗は致命でない。ログだけ残して続行（Bedrock には残りの添付＋テキストで送る）。
 			log.Printf("ai-chat attachment download failed: key=%s err=%v", a.Key, err)
 			continue
 		}

--- a/backend/internal/usecase/send_ai_message_usecase.go
+++ b/backend/internal/usecase/send_ai_message_usecase.go
@@ -2,22 +2,11 @@ package usecase
 
 import "github.com/norman6464/FreStyle/backend/internal/domain"
 
-// 旧 SendAiMessageUseCase（WebSocket 経由の同期呼び出し）は PR-D で撤去した。
-// SSE ストリーミング版（SendAiMessageStreamUseCase）が後継。
-//
-// 共通で使う型・ヘルパだけここに残す:
-//   - SendAiMessageInput: stream usecase の Execute 引数
-//   - truncateTitle:      新規セッション作成時のタイトル切り詰め
-//   - buildSystemPrompt:  Bedrock に渡す汎用 AI アシスタント用 system prompt
+// SendAiMessageStreamUseCase 用の共通型・ヘルパを置く。
 
 // SendAiMessageInput は AI チャット送信リクエスト。
-//
-// Scene / SessionType / ScenarioID は旧フロント仕様の互換のため残しているが、
-// 練習モード撤去（PR-A）以降はどれもプロンプトに反映しない。次のクリーンアップで削除予定。
-//
-// Attachments はユーザー発話に紐付く添付ファイル群（画像 / 将来の PDF / CSV）。
-// フロントは事前に S3 へ presigned PUT でアップロード済みで、ここには key と
-// メタデータだけが渡る。usecase が S3 から実体バイトを取得して Bedrock に渡す。
+// Scene / SessionType / ScenarioID は旧仕様の互換で残すが、プロンプトには反映しない。
+// Attachments は S3 へ presigned PUT 済みの key + メタで、usecase が実体を取得して Bedrock に渡す。
 type SendAiMessageInput struct {
 	UserID      uint64
 	SessionID   uint64
@@ -36,9 +25,7 @@ func truncateTitle(s string, max int) string {
 	return s
 }
 
-// buildSystemPrompt は汎用 AI チャットの system prompt を返す。
-//
-// 引数 sessionType / scene は旧シグネチャ互換で受けるが本文には反映しない。
+// buildSystemPrompt は汎用 AI チャットの system prompt を返す（引数は旧互換で未使用）。
 func buildSystemPrompt(_, _ string) string {
 	return "あなたは新卒 IT エンジニア向け学習プラットフォーム『FreStyle』に組み込まれた汎用 AI アシスタントです。" +
 		"ユーザーからの質問・要約依頼・コードレビュー・概念説明など、幅広いトピックに答えます。" +

--- a/backend/internal/usecase/session_note_usecase.go
+++ b/backend/internal/usecase/session_note_usecase.go
@@ -8,8 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// GetSessionNoteUseCase は AI チャット セッション 紐付き の ノート を 取得 する。
-// 依存 port: [repository.SessionNoteRepository]。
+// GetSessionNoteUseCase は AI チャットセッション紐付きのノートを取得する。
 type GetSessionNoteUseCase struct {
 	repo repository.SessionNoteRepository
 }
@@ -25,8 +24,7 @@ func (u *GetSessionNoteUseCase) Execute(ctx context.Context, sessionID uint64) (
 	return u.repo.FindBySessionID(ctx, sessionID)
 }
 
-// UpsertSessionNoteUseCase は セッション ノート を upsert する (新規 or 更新)。
-// 依存 port: [repository.SessionNoteRepository]。
+// UpsertSessionNoteUseCase はセッションノートを upsert する。
 type UpsertSessionNoteUseCase struct {
 	repo repository.SessionNoteRepository
 }

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -10,8 +10,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// CodeExecutor は ExecuteCodeUseCase を抽象化したインターフェイス。
-// usecase 層が usecase 同士に直接依存するのを避け、テストでは fake に差し替える。
+// CodeExecutor は ExecuteCodeUseCase を抽象化し、usecase 同士の直接依存を避ける。
 type CodeExecutor interface {
 	Execute(ctx context.Context, in ExecuteCodeInput) (*ExecuteCodeOutput, error)
 }
@@ -40,26 +39,15 @@ type SubmitMasterExerciseOutput struct {
 	Results      []TestCaseResult `json:"results"`
 }
 
-// SubmitMasterExerciseUseCase はユーザコードを slug の master_exercise に対して
-// 採点・提出履歴に保存する。
+// SubmitMasterExerciseUseCase はユーザコードを slug の master_exercise に対して採点し履歴に保存する。
 //
-// 採点ロジック:
-//   - mode='qa' の場合: コードを実行せず、 提出文字列と ExpectedOutput を trim 比較するだけ。
-//     docker / kubernetes など サンドボックス実行が困難な題材向け。
-//   - mode='execute' (default) の場合:
-//   - master_exercise_examples が登録されていれば 各 example の InputText を stdin に
-//     流して ExecuteCodeUseCase で実行し、 stdout を normalize して expected_output と比較
-//   - examples が無ければ exercise 自身の ExpectedOutput を 単一テストケースとして使う
-//     (linux / git / go 等の seed.py 経由で投入された演習向け)
-//     stdout を normalize（末尾改行 / CRLF を吸収）して expected_output と完全一致するか比較。
-//     全件 pass で isCorrect=true。1 件でも失敗・実行エラー（exit_code != 0）なら false。
-//     実行コスト削減のため、最初の不一致で打ち切らず全件実行（ユーザに「どこで落ちたか」を全部見せる方針）。
+// 採点は mode で分岐する:
+//   - qa: 実行せず提出文字列と ExpectedOutput を normalize 比較するだけ。
+//   - execute: examples（無ければ exercise 自身の ExpectedOutput を単一ケース化）を全件実行し、
+//     stdout を normalize 比較。全件 pass かつ exit_code 0 で isCorrect=true。
+//     どこで落ちたか全部見せるため最初の不一致で打ち切らず全件実行する。
 //
-// 履歴保存はテストケース個別ではなく、まとめて 1 行（最初に失敗した stdout / stderr / exit_code を採用）。
-//
-// 依存 port: [repository.MasterExerciseRepository] (slug → exercise) +
-// [repository.MasterExerciseExampleRepository] (入出力 例) +
-// [repository.ExerciseSubmissionRepository] (履歴 保存) + [CodeExecutor] (sandbox 実行)。
+// 履歴は 1 行にまとめて保存（失敗時は最初の失敗、成功時は最後の実行結果を採用）。
 type SubmitMasterExerciseUseCase struct {
 	exercises   repository.MasterExerciseRepository
 	examples    repository.MasterExerciseExampleRepository
@@ -100,7 +88,6 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 		return nil, fmt.Errorf("exercise not found: %s", in.Slug)
 	}
 
-	// QA モード: コード実行せず、 提出文字列と ExpectedOutput を直接比較する。
 	if ex.Mode == domain.ExerciseModeQA {
 		return uc.submitQA(ctx, in, ex)
 	}
@@ -109,9 +96,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 	if err != nil {
 		return nil, err
 	}
-	// examples が登録されていない演習 (seed.py 経由で投入された linux / git / go 等)
-	// は exercise 自身の ExpectedOutput を 単一の仮想テストケースとして使う。
-	// stdin は空、 OrderIndex=1 として扱う。
+	// examples が無い演習は exercise 自身の ExpectedOutput を単一の仮想テストケースとして使う。
 	if len(examples) == 0 {
 		examples = []domain.MasterExerciseExample{{
 			ExerciseID:     ex.ID,
@@ -123,7 +108,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 
 	results := make([]TestCaseResult, 0, len(examples))
 	allPassed := true
-	// 履歴保存用に「最初に失敗した実行結果」を保持。 全件 pass のときは最後の結果を使う。
+	// 履歴保存用の代表結果（失敗時は最初の失敗、全件 pass 時は最後の結果）。
 	var representativeStdout, representativeStderr string
 	var representativeExit int
 
@@ -149,17 +134,14 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 			Passed:         passed,
 		})
 		if !passed && allPassed {
-			// 最初の失敗を representative として記録し allPassed を false に倒す。
-			// 以降のループでは下の if も通らないため、 この値が representative として固定される。
+			// 最初の失敗を representative に固定する（以降は下の if も通らない）。
 			representativeStdout = out.Stdout
 			representativeStderr = out.Stderr
 			representativeExit = out.ExitCode
 			allPassed = false
 		}
 		if allPassed {
-			// 全件 pass し続けている経路。 ループのたびに最後の出力で上書きすることで、
-			// 最終的に representative が「最後に通ったテストケースの出力」になる。
-			// 1 件でも失敗したら上の if 文で allPassed=false に倒れ、 こちらは以降スキップされる。
+			// 全件 pass の間は最後の出力で上書きし続ける。
 			representativeStdout = out.Stdout
 			representativeStderr = out.Stderr
 			representativeExit = out.ExitCode
@@ -188,8 +170,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 	}, nil
 }
 
-// submitQA は QA モードの採点。 提出文字列と ExpectedOutput を normalize 比較するだけで
-// コード実行は行わない。 docker / kubernetes など サンドボックス実行が困難な題材向け。
+// submitQA は QA モードの採点。コード実行せず提出文字列と ExpectedOutput を normalize 比較する。
 func (uc *SubmitMasterExerciseUseCase) submitQA(ctx context.Context, in SubmitMasterExerciseInput, ex *domain.MasterExercise) (*SubmitMasterExerciseOutput, error) {
 	expected := normalizeOutput(ex.ExpectedOutput)
 	actual := normalizeOutput(in.Code)
@@ -224,12 +205,7 @@ func (uc *SubmitMasterExerciseUseCase) submitQA(ctx context.Context, in SubmitMa
 	}, nil
 }
 
-// normalizeOutput は stdout 比較時の表記揺れを吸収する。
-//   - CRLF / CR を LF に統一
-//   - 末尾の改行・空白をすべて除去（"42\n" と "42" を同一視）
-//
-// PHP の `echo` は末尾改行を付けない / 付けるが問題により混在するため、
-// 「末尾だけ揺れを許容」する方針で十分。 行内の空白は厳密一致。
+// normalizeOutput は CRLF/CR を LF に統一し末尾の改行・空白を除去する（行内の空白は厳密一致）。
 func normalizeOutput(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -8,21 +8,9 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// TeachingMaterialUseCase は教材機能の 5 操作（list / get / create / update / delete）を
-// まとめて 1 構造体で扱う。 各操作は独立した Execute メソッドではなく
-// 名前付きメソッドにすることで、 handler 側のディスパッチを単純化する。
-//
-// 教材は必ず Course に所属する前提のため、 list は Course 単位、 create は course_id 必須。
-//
-// アクセス制御:
-//   - List: 同一 company の company_admin / trainee / super_admin
-//     trainee は published のみ、 company_admin / super_admin は draft 含む全件
-//     trainee は所属コースが is_published=false の場合は閲覧不可
-//   - Get: 同一 company か super_admin、 trainee は published のみ閲覧可
-//   - Create / Update / Delete: 同一 company の company_admin、 または super_admin
-//
-// 依存 port: [repository.TeachingMaterialRepository] + [repository.CourseRepository]
-// (course との 整合性 検証 用)。 章 003 で 全 体 walk-through、 章 022 で 詳細 解説。
+// TeachingMaterialUseCase は教材の list / get / create / update / delete を 1 構造体で扱う。
+// 教材は必ず Course に所属するため list は Course 単位、create は course_id 必須。
+// trainee は published コース内の published 教材のみ閲覧、編集系は company_admin / super_admin。
 type TeachingMaterialUseCase struct {
 	repo    repository.TeachingMaterialRepository
 	courses repository.CourseRepository
@@ -37,8 +25,7 @@ func canManage(role string) bool {
 	return role == domain.RoleCompanyAdmin || role == domain.RoleSuperAdmin
 }
 
-// List は backward-compat 用。 既存 frontend が GET /teaching-materials を直接叩くため、
-// company 内の全教材を返す。 frontend がコース対応に切り替わったら削除予定。
+// List は company 内の全教材を返す backward-compat 用（コース対応への移行後に削除予定）。
 func (uc *TeachingMaterialUseCase) List(ctx context.Context, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
 	if actorCompanyID == 0 {
 		return []domain.TeachingMaterial{}, nil
@@ -47,8 +34,7 @@ func (uc *TeachingMaterialUseCase) List(ctx context.Context, actorCompanyID uint
 	return uc.repo.ListByCompany(ctx, actorCompanyID, includeUnpublished)
 }
 
-// ListByCourse は指定コース配下の教材を返す。 actor の role / company を検証してから
-// repository を呼ぶ。 trainee はコース自体が is_published=true の場合のみ閲覧可。
+// ListByCourse は指定コース配下の教材を返す（role / company を検証してから）。
 func (uc *TeachingMaterialUseCase) ListByCourse(ctx context.Context, courseID, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
 	course, err := uc.courses.GetByID(ctx, courseID)
 	if err != nil {
@@ -61,8 +47,7 @@ func (uc *TeachingMaterialUseCase) ListByCourse(ctx context.Context, courseID, a
 	return uc.repo.ListByCourse(ctx, courseID, includeUnpublished)
 }
 
-// Get は ID 指定で 1 件取得する。 actor の company と一致しないと 403 相当（nil）。
-// 所属コース自体が trainee に対して非公開なら閲覧不可。
+// Get は ID 指定で 1 件取得する（company 不一致 / 非公開コースは閲覧不可）。
 func (uc *TeachingMaterialUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.TeachingMaterial, error) {
 	m, err := uc.repo.GetByID(ctx, id)
 	if err != nil {
@@ -85,7 +70,7 @@ func canRead(m *domain.TeachingMaterial, course *domain.Course, actorCompanyID u
 	if m.CompanyID != actorCompanyID {
 		return false
 	}
-	// 所属コースも閲覧可能でないと教材も見せない（trainee は published コース内の published 教材のみ）。
+	// 所属コースが閲覧可能でなければ教材も見せない。
 	if !canReadCourse(course, actorCompanyID, actorRole) {
 		return false
 	}
@@ -95,7 +80,7 @@ func canRead(m *domain.TeachingMaterial, course *domain.Course, actorCompanyID u
 	return true
 }
 
-// CreateInput は POST 入力。 CourseID は必須（所属コース）。
+// CreateTeachingMaterialInput は POST 入力。CourseID は必須。
 type CreateTeachingMaterialInput struct {
 	ActorUserID    uint64
 	ActorCompanyID uint64
@@ -117,7 +102,6 @@ func (uc *TeachingMaterialUseCase) Create(ctx context.Context, in CreateTeaching
 	if in.CourseID == 0 {
 		return nil, fmt.Errorf("course_id is required")
 	}
-	// コースの存在 / company 一致を確認する。
 	course, err := uc.courses.GetByID(ctx, in.CourseID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/usecase/user_stats_usecase.go
+++ b/backend/internal/usecase/user_stats_usecase.go
@@ -8,8 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
-// GetUserStatsUseCase は user の マイページ 集計 (合計 セッション 数 / 平均 スコア 等) を 返す。
-// 依存 port: [repository.UserStatsRepository] (Raw SQL で 集計)。
+// GetUserStatsUseCase は user のマイページ集計（合計セッション数 / 平均スコア等）を返す。
 type GetUserStatsUseCase struct {
 	stats repository.UserStatsRepository
 }

--- a/backend/internal/usecase/validate_invitation_token_usecase.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase.go
@@ -8,17 +8,8 @@ import (
 )
 
 // ValidateInvitationTokenUseCase はマジックリンク受諾画面で token を検証する。
-//
-// 公開エンドポイント (GET /api/v2/invitations/accept/:token) から呼ばれる。
-// 該当なし / 期限切れ / 既受諾 / canceled はすべて (nil, nil) を返し、
-// 呼び出し側で 404 を返す（メタ情報を漏らさない設計）。
-//
-// 成功時は ValidatedInvitation (DTO) を返す。email は含めない:
-//   - 本人がメールから踏んでくる前提なので email は本人が知っている
-//   - 万一 token が漏れた場合の被害局所化（招待先 email を覗かれない）
-//
-// 依存 port: [repository.AdminInvitationRepository] (token 検証) +
-// [repository.CompanyRepository] (company 名 取得)。
+// 該当なし / 期限切れ / 既受諾 / canceled はすべて (nil, nil) を返す（メタ情報を漏らさない）。
+// 成功時の ValidatedInvitation に email は含めない（token 漏洩時の被害局所化）。
 type ValidateInvitationTokenUseCase struct {
 	invitations repository.AdminInvitationRepository
 	companies   repository.CompanyRepository
@@ -41,8 +32,6 @@ type ValidatedInvitation struct {
 
 func (u *ValidateInvitationTokenUseCase) Execute(ctx context.Context, token string) (*ValidatedInvitation, error) {
 	if token == "" {
-		// 空 token は repository でも nil 返却するが、handler が空文字を渡してきた場合の
-		// ガードを usecase 側にも置いて防御層を二重にする。
 		return nil, nil
 	}
 	inv, err := u.invitations.FindPendingByToken(ctx, token)
@@ -53,9 +42,7 @@ func (u *ValidateInvitationTokenUseCase) Execute(ctx context.Context, token stri
 		return nil, nil
 	}
 
-	// 招待の company を引いて name を返す。FindByID が err を返した場合は
-	// 招待そのものは有効なので company unknown でも 404 にせず、CompanyName を空で返す
-	// （フロントは「招待先を取得できませんでした」とフォールバック表示する想定）。
+	// company 取得に失敗しても招待自体は有効なので、CompanyName を空にして続行する。
 	companyName := ""
 	if u.companies != nil {
 		if c, err := u.companies.FindByID(ctx, inv.CompanyID); err == nil && c != nil {
@@ -71,8 +58,7 @@ func (u *ValidateInvitationTokenUseCase) Execute(ctx context.Context, token stri
 	}, nil
 }
 
-// normalizeInvitationRole は invitation の role を表示用に正規化する。
-// 想定外の値が入っていた場合は trainee にフォールバックして UI を壊さないようにする。
+// normalizeInvitationRole は invitation の role を表示用に正規化する（想定外は trainee にフォールバック）。
 func normalizeInvitationRole(role string) string {
 	switch role {
 	case domain.RoleCompanyAdmin, domain.RoleTrainee:


### PR DESCRIPTION
## 概要

`backend/` 配下の全 Go ソース（131 ファイル）を対象に、長いコメントの短縮とコードを読めば自明なコメントの削除を行いました。ロジック変更は一切なく、コメントのみの整理です（+441 / -1378 行）。

## 変更内容

- 全角スペース区切りの冗長コメント（`招待 一覧 を 取得 する Use Case` など）を通常の日本語に圧縮
- 構造体フィールドから自明な `// 依存 port: [...]` 記述を削除
- `章 XX で解説` / `PR-X` / `CodeRabbit PR #...` 等の履歴・教材参照を削除
- `Spring Boot の ... に相当` 等の移行元参照を削除
- handler の GoDoc にあったエンドポイント一覧表を 1 行サマリに集約
- 自明なコンストラクタ GoDoc（`NewXxx は GORM ベースの ... を返す`）を削除
- **保持したもの**: swaggo annotation（`@Summary` / `@Router` 等）、生成ファイル `docs/docs.go`、セキュリティ・設計判断の WHY コメント（招待ゲート / IDOR 対策 / pgbouncer 判定 / Bedrock inference profile 必須 等は短縮しつつ意図維持）
- テストファイルはテスト意図を説明する WHY コメントが中心のため現状維持

## テスト

- `gofmt -l ./internal/ ./cmd/` 差分なし
- `go vet ./...` 警告なし
- `go build ./...` 成功
- `go test ./...` 全パッケージ pass

## 関連 Issue

なし（コメント整理のリファクタ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 📋 リリースノート

* **New Features**
  * AI チャット添付ファイルアップロード用エンドポイントを追加
  * ユーザー統計とセッションノート取得機能を実装
  * マスタ演習問題一覧取得ユースケースを追加

* **Documentation**
  * コメントとドキュメント文言を全体的に整理・簡潔化
  * API 仕様と処理フローをより明確に記載
  * リポジトリインターフェースの説明を標準化

* **Refactor**
  * 複数のリポジトリ実装とコンストラクタを追加
  * ドメインモデルのコメント構造を統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->