### PR TITLE
perf: health check のアクセスログを除外して CloudWatch 取り込みを削減

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -79,6 +79,15 @@ go vet ./...
 go test ./...
 ```
 
+## ログ方針（CloudWatch コスト対策）
+
+- アクセスログは `gin.LoggerWithConfig` で出力し、`SkipPaths` に
+  `/api/v2/health`（ALB が 30 秒間隔で叩くヘルスチェック）と `/` を指定して**除外**する。
+  大量の health ログが CloudWatch の取り込み課金を押し上げるのを防ぐため。
+- 認証・業務ロジックの WARN / ERROR は `log.Printf` で従来どおり出力する。
+- ロググループ `/ecs/frestyle-prod` は CFn 側で retention 14 日。Container Insights は
+  コスト削減のため無効（詳細は frestyle-infrastructure の `docs/06-maintenance-cookbook.md` §15）。
+
 ## デプロイ方針（後続 Phase で確立）
 
 - ALB の path-based routing で `/api/v2/*` を Go ECS Service に振り、

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -29,7 +29,11 @@ type routeDeps struct {
 func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
-	r.Use(gin.Logger())
+	// ヘルスチェック (ALB が 30 秒間隔で叩く /api/v2/health) と root の access log は出さない。
+	// 大量の health ログが CloudWatch の取り込み課金を押し上げるのを防ぐ。
+	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+		SkipPaths: []string{"/api/v2/health", "/"},
+	}))
 	r.Use(middleware.CORS())
 
 	r.GET("/", func(c *gin.Context) {


### PR DESCRIPTION
## 概要

CloudWatch のログ代対策の一環。ALB のヘルスチェック（`/api/v2/health`、30 秒間隔）と root（`/`）のアクセスログは情報量が乏しい割に大量に出力されるため、gin のアクセスログから除外して CloudWatch Logs の取り込み課金（ingestion）を抑える。

## 変更内容

- `internal/handler/router.go`: `gin.Logger()` → `gin.LoggerWithConfig(SkipPaths: ["/api/v2/health", "/"])`
- `backend/README.md`: 「ログ方針（CloudWatch コスト対策）」セクションを追記

## 影響と安全性

- 認証・業務ロジックの WARN / ERROR は `log.Printf` で従来どおり出力されるため、障害調査への影響はない
- スキップ対象は health チェックと root のみ。業務 API のアクセスログは従来どおり

## テスト

- `gofmt` / `go build ./...` / `go test ./internal/handler/` pass

## 関連 Issue

なし（コスト最適化。infra 側の Container Insights 無効化は frestyle-infrastructure#61）