### PR TITLE
fix(ci): backend CD を Supabase の DATABASE_URL inject に修正（RDS 参照を撤去）

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -160,8 +160,10 @@ jobs:
             --query 'Stacks[0].Outputs[?OutputKey==`TaskRoleArn`].OutputValue' --output text)
           # Supabase 接続 URL の Secret ARN (Transaction pooler / port 6543)。
           # RDS 撤去後は DATABASE_URL を Secrets Manager から inject する。
+          # `|| true`: set -e 下で secret 不在時に AWS CLI の非ゼロ終了で step が落ちると
+          # 下の親切な ::error:: が出ないため、ここでは握りつぶして空判定に委ねる。
           DB_URL_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
-            --secret-id "$DATABASE_URL_SECRET_NAME" --query 'ARN' --output text 2>/dev/null)
+            --secret-id "$DATABASE_URL_SECRET_NAME" --query 'ARN' --output text 2>/dev/null || true)
           if [ -z "$DB_URL_ARN" ] || [ "$DB_URL_ARN" = "None" ]; then
             echo "::error::DATABASE_URL_SECRET_NAME=$DATABASE_URL_SECRET_NAME を Secrets Manager で見つけられませんでした"
             exit 1

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -43,6 +43,9 @@ env:
   STACK_PFX: frestyle-prod
   IAC_REPO: norman6464/frestyle-infrastructure
   AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
+  # DATABASE_URL は Supabase の Transaction pooler URL を Secrets Manager から inject する
+  # (2026-05 の RDS 撤去後の構成。scheduled-start.yml / infra Makefile と同じ secret 名)。
+  DATABASE_URL_SECRET_NAME: frestyle-prod/database-url
 
 permissions:
   id-token: write
@@ -143,16 +146,6 @@ jobs:
           TG_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
             --stack-name $STACK_PFX-alb \
             --query 'Stacks[0].Outputs[?OutputKey==`TargetGroupArn`].OutputValue' --output text)
-          # PostgreSQL に切替済 (frestyle-prod-rds-postgres)
-          DB_HOST=$(aws cloudformation describe-stacks --region $AWS_REGION \
-            --stack-name $STACK_PFX-rds-postgres \
-            --query 'Stacks[0].Outputs[?OutputKey==`DBEndpoint`].OutputValue' --output text)
-          DB_PORT=$(aws cloudformation describe-stacks --region $AWS_REGION \
-            --stack-name $STACK_PFX-rds-postgres \
-            --query 'Stacks[0].Outputs[?OutputKey==`DBPort`].OutputValue' --output text)
-          DB_NAME=$(aws cloudformation describe-stacks --region $AWS_REGION \
-            --stack-name $STACK_PFX-rds-postgres \
-            --query 'Stacks[0].Outputs[?OutputKey==`DBName`].OutputValue' --output text)
           S3_BUCKET=$(aws cloudformation describe-stacks --region $AWS_REGION \
             --stack-name $STACK_PFX-s3 \
             --query 'Stacks[0].Outputs[?OutputKey==`NoteImagesBucketName`].OutputValue' --output text)
@@ -165,64 +158,39 @@ jobs:
           TASK_ROLE=$(aws cloudformation describe-stacks --region $AWS_REGION \
             --stack-name $STACK_PFX-iam \
             --query 'Stacks[0].Outputs[?OutputKey==`TaskRoleArn`].OutputValue' --output text)
-          # PostgreSQL master password の Secret ARN を解決する。
-          # scheduled-start.yml と同じロジック:
-          # 1) RDS スタック Output `MasterUserSecretArn`
-          # 2) `aws rds describe-db-instances` の MasterUserSecret.SecretArn
-          #    (modify-db-instance --manage-master-user-password で後付け管理化された場合)
-          # 3) 旧 manual Secret `frestyle-prod/pg-master-password`
-          # AWS managed secret は JSON 形式なので :password:: jsonField suffix を付ける。
-          MANAGED_SECRET_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
-            --stack-name $STACK_PFX-rds-postgres \
-            --query 'Stacks[0].Outputs[?OutputKey==`MasterUserSecretArn`].OutputValue' --output text 2>/dev/null || true)
-          if [ -z "$MANAGED_SECRET_ARN" ] || [ "$MANAGED_SECRET_ARN" = "None" ]; then
-            DB_INSTANCE_ID=$(aws cloudformation list-stack-resources --region $AWS_REGION \
-              --stack-name $STACK_PFX-rds-postgres \
-              --query "StackResourceSummaries[?ResourceType=='AWS::RDS::DBInstance'].PhysicalResourceId | [0]" \
-              --output text 2>/dev/null || true)
-            if [ -n "$DB_INSTANCE_ID" ] && [ "$DB_INSTANCE_ID" != "None" ]; then
-              MANAGED_SECRET_ARN=$(aws rds describe-db-instances --region $AWS_REGION \
-                --db-instance-identifier "$DB_INSTANCE_ID" \
-                --query 'DBInstances[0].MasterUserSecret.SecretArn' --output text 2>/dev/null || true)
-            fi
-          fi
-          if [ -n "$MANAGED_SECRET_ARN" ] && [ "$MANAGED_SECRET_ARN" != "None" ]; then
-            echo "Using AWS-managed master user secret: $MANAGED_SECRET_ARN"
-            DB_PWD_ARN="${MANAGED_SECRET_ARN}:password::"
-          else
-            echo "Managed secret not found — fallback to manual Secret pg-master-password"
-            DB_PWD_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
-              --secret-id $STACK_PFX/pg-master-password --query 'ARN' --output text)
+          # Supabase 接続 URL の Secret ARN (Transaction pooler / port 6543)。
+          # RDS 撤去後は DATABASE_URL を Secrets Manager から inject する。
+          DB_URL_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
+            --secret-id "$DATABASE_URL_SECRET_NAME" --query 'ARN' --output text 2>/dev/null)
+          if [ -z "$DB_URL_ARN" ] || [ "$DB_URL_ARN" = "None" ]; then
+            echo "::error::DATABASE_URL_SECRET_NAME=$DATABASE_URL_SECRET_NAME を Secrets Manager で見つけられませんでした"
+            exit 1
           fi
           COG_SEC_ARN=$(aws secretsmanager describe-secret --region $AWS_REGION \
             --secret-id $STACK_PFX/cognito-client-secret --query 'ARN' --output text)
 
           echo "ecs_sg=$ECS_SG" >> "$GITHUB_OUTPUT"
           echo "tg_arn=$TG_ARN" >> "$GITHUB_OUTPUT"
-          echo "db_host=$DB_HOST" >> "$GITHUB_OUTPUT"
-          echo "db_port=$DB_PORT" >> "$GITHUB_OUTPUT"
-          echo "db_name=$DB_NAME" >> "$GITHUB_OUTPUT"
+          echo "db_url_arn=$DB_URL_ARN" >> "$GITHUB_OUTPUT"
           echo "s3_bucket=$S3_BUCKET" >> "$GITHUB_OUTPUT"
           echo "sqs_url=$SQS_URL" >> "$GITHUB_OUTPUT"
           echo "exec_role=$EXEC_ROLE" >> "$GITHUB_OUTPUT"
           echo "task_role=$TASK_ROLE" >> "$GITHUB_OUTPUT"
-          echo "db_pwd_arn=$DB_PWD_ARN" >> "$GITHUB_OUTPUT"
           echo "cog_sec_arn=$COG_SEC_ARN" >> "$GITHUB_OUTPUT"
 
       - name: Deploy ECS stack
         env:
           ECS_SG: ${{ steps.deps.outputs.ecs_sg }}
           TG_ARN: ${{ steps.deps.outputs.tg_arn }}
-          DB_HOST: ${{ steps.deps.outputs.db_host }}
-          DB_PORT: ${{ steps.deps.outputs.db_port }}
-          DB_NAME: ${{ steps.deps.outputs.db_name }}
+          DB_URL_ARN: ${{ steps.deps.outputs.db_url_arn }}
           S3_BUCKET: ${{ steps.deps.outputs.s3_bucket }}
           SQS_URL: ${{ steps.deps.outputs.sqs_url }}
           EXEC_ROLE: ${{ steps.deps.outputs.exec_role }}
           TASK_ROLE: ${{ steps.deps.outputs.task_role }}
-          DB_PWD_ARN: ${{ steps.deps.outputs.db_pwd_arn }}
           COG_SEC_ARN: ${{ steps.deps.outputs.cog_sec_arn }}
         run: |
+          # DBHost / DBPasswordSecretArn は Supabase 運用では空文字で明示的に渡す
+          # (CFn の前回値 retain を回避するため)。DATABASE_URL は DatabaseUrlSecretArn で inject。
           aws cloudformation deploy --region $AWS_REGION \
             --stack-name $STACK_PFX-ecs \
             --template-file iac/infrastructure/cloudformation/templates/runtime/ecs.yml \
@@ -230,11 +198,9 @@ jobs:
               Environment=$ENV \
               EcsServiceSecurityGroupId="$ECS_SG" \
               TargetGroupArn="$TG_ARN" \
-              DBHost="$DB_HOST" \
-              DBPort="$DB_PORT" \
-              DBName="$DB_NAME" \
-              DBUser=postgres \
-              DBPasswordSecretArn="$DB_PWD_ARN" \
+              DatabaseUrlSecretArn="$DB_URL_ARN" \
+              DBHost= \
+              DBPasswordSecretArn= \
               CognitoClientId="${{ secrets.COGNITO_CLIENT_ID }}" \
               CognitoClientSecretArn="$COG_SEC_ARN" \
               CognitoRedirectUri="${{ secrets.COGNITO_REDIRECT_URI }}" \


### PR DESCRIPTION
## 概要

`CD - Backend Deploy to ECS`（`cd-backend.yml`）が **廃止済みの RDS スタック `frestyle-prod-rds-postgres`** の Output を解決しようとして失敗し、**backend デプロイがずっと壊れていた**。2026-05 の Supabase 移行で RDS は撤去済みのため、`Resolve dependent stack outputs` ステップが `Stack with id frestyle-prod-rds-postgres does not exist`（exit 254）で落ちていた。

> 実際に CloudWatch コスト削減（health ログ除外 PR #1735）の反映でこのワークフローを起動した際に発覚。

## 変更内容

`scheduled-start.yml` / infra repo の `make deploy-ecs` と同じ Supabase 方式に統一:

- `DATABASE_URL` を Secrets Manager（`frestyle-prod/database-url`）の ARN で `DatabaseUrlSecretArn` として inject
- `DBHost` / `DBPasswordSecretArn` は空文字で明示的に渡す（CFn の前回値 retain を回避）
- 廃止 RDS スタックへの `describe-stacks`（DBEndpoint / DBPort / DBName / MasterUserSecretArn）と `pg-master-password` フォールバックを全削除
- env に `DATABASE_URL_SECRET_NAME: frestyle-prod/database-url` を追加

## テスト

- 残存する RDS / 旧 DB 参照が 0 件であることを grep で確認
- YAML 構文 OK
- マージ後に `workflow_dispatch` で再デプロイして緑を確認予定

## 関連

- CloudWatch コスト削減: FreStyle #1735（health ログ除外、マージ済）/ frestyle-infrastructure #61（Container Insights 無効化、反映済）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Chores**
  * デプロイメントパイプラインの内部インフラストラクチャを更新しました。本更新はシステムの安定性と保守性の向上を目的としたものであり、エンドユーザーに対する直接的な機能変更や改善はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->