### PR TITLE
perf: 本番で gin を release モードにして起動ログを抑止

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -85,7 +85,7 @@ go test ./...
   `/api/v2/health`（ALB が 30 秒間隔で叩くヘルスチェック）と `/` を指定して**除外**する。
   大量の health ログが CloudWatch の取り込み課金を押し上げるのを防ぐため。
 - 認証・業務ロジックの WARN / ERROR は `log.Printf` で従来どおり出力する。
-- 本番（`APP_ENV != local`）は gin を **release モード**にして、起動時の
+- 本番（`APP_ENV` が `"local"` 以外）は gin を **release モード**にして、起動時の
   `[GIN-debug]` ルート登録ログ・warning を抑止する（ローカルは debug のまま）。
 - ロググループ `/ecs/frestyle-prod` は CFn 側で retention 14 日。Container Insights は
   コスト削減のため無効（詳細は frestyle-infrastructure の `docs/06-maintenance-cookbook.md` §15）。

--- a/backend/README.md
+++ b/backend/README.md
@@ -85,6 +85,8 @@ go test ./...
   `/api/v2/health`（ALB が 30 秒間隔で叩くヘルスチェック）と `/` を指定して**除外**する。
   大量の health ログが CloudWatch の取り込み課金を押し上げるのを防ぐため。
 - 認証・業務ロジックの WARN / ERROR は `log.Printf` で従来どおり出力する。
+- 本番（`APP_ENV != local`）は gin を **release モード**にして、起動時の
+  `[GIN-debug]` ルート登録ログ・warning を抑止する（ローカルは debug のまま）。
 - ロググループ `/ecs/frestyle-prod` は CFn 側で retention 14 日。Container Insights は
   コスト削減のため無効（詳細は frestyle-infrastructure の `docs/06-maintenance-cookbook.md` §15）。
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -24,6 +24,7 @@ package main
 import (
 	"log"
 
+	"github.com/gin-gonic/gin"
 	_ "github.com/norman6464/FreStyle/backend/docs" // swag init で 生成 さ れる OpenAPI spec
 	"github.com/norman6464/FreStyle/backend/internal/handler"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
@@ -34,6 +35,12 @@ func main() {
 	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("config load failed: %v", err)
+	}
+
+	// 本番は gin を release モードにする。debug モードのルート登録ログ ([GIN-debug] ...) や
+	// 起動時 warning を抑止して CloudWatch のログ量を減らす。ローカルは debug のまま。
+	if cfg.AppEnv != "local" {
+		gin.SetMode(gin.ReleaseMode)
 	}
 
 	db, err := database.NewPostgres(cfg)


### PR DESCRIPTION
## 概要

CloudWatch ログ削減の追加施策。debug モードの gin は起動時に `[GIN-debug]` のルート登録ログや warning を出力する。本番（`APP_ENV != local`）で `gin.SetMode(gin.ReleaseMode)` を設定してこれらを抑止する。

## 変更内容

- `cmd/server/main.go`: config ロード後、`cfg.AppEnv != "local"` のとき release モードに設定
- `backend/README.md`: ログ方針に追記

## 影響と安全性

- ローカル開発（`APP_ENV=local`）は debug のまま（デバッグしやすさ優先）
- アクセスログ自体は `gin.LoggerWithConfig`（#1735）で従来どおり出力。release モードは debug 専用の起動ログのみ抑止
- テストは各自 `gin.SetMode(gin.TestMode)` を設定しており main を経由しないため無影響

## テスト

- `gofmt` / `go build ./...` / `go vet ./cmd/...` pass

## 関連

- CloudWatch コスト削減シリーズ: #1735（health ログ除外）/ #1736（CD 修正）/ frestyle-infrastructure#61（Container Insights 無効化）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **ドキュメント**
  * バックエンドのログ管理ポリシーの説明を更新しました。本番環境でのシステム出力を抑制する際の具体的な運用方針について、より詳しく記載しています。

* **保守**
  * 本番環境においてシステムのログ出力を環境に応じて自動制御する機能を実装しました。本番環境でのログ出力が抑制される設定となります。ローカル環境では従来通りのログ出力が行われます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->