### PR TITLE
fix(security): JWT の JWKS 署名検証を必須化（偽造トークン対策）

### DIFF
--- a/backend/internal/handler/middleware/jwt.go
+++ b/backend/internal/handler/middleware/jwt.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -10,6 +11,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
+
+// VerifyFunc は access_token を検証して claims を返す関数。
+// 本番は infra/cognito.Verifier.Verify（JWKS 署名検証）を注入する。
+type VerifyFunc func(ctx context.Context, token string) (map[string]any, error)
 
 const (
 	ContextKeyCognitoSub    = "cognitoSub"
@@ -24,17 +29,17 @@ const (
 // 既存 group `admin` (小文字) を Spring Boot 時代から踏襲している。
 const AdminGroupName = "admin"
 
-// JWTAuth は HttpOnly Cookie の access_token を検証する Gin middleware。
-// 現状は payload (claims) の base64 デコードのみで、署名 (JWKS) 検証は別 issue で実装する。
-// ハンドラから c.Get(ContextKeyCognitoSub) で本物の Cognito sub を取れる。
-func JWTAuth() gin.HandlerFunc {
+// JWTAuth は HttpOnly Cookie の access_token を verify で検証する Gin middleware。
+// verify は JWKS 署名検証を行う関数を注入する（偽造トークンを弾く）。
+// ハンドラから c.Get(ContextKeyCognitoSub) で検証済みの Cognito sub を取れる。
+func JWTAuth(verify VerifyFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		token, err := c.Cookie(CookieAccessToken)
 		if err != nil || token == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
-		claims, err := DecodeClaims(token)
+		claims, err := verify(c.Request.Context(), token)
 		if err != nil {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid_token"})
 			return

--- a/backend/internal/handler/middleware/jwt_test.go
+++ b/backend/internal/handler/middleware/jwt_test.go
@@ -1,11 +1,16 @@
 package middleware
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 // makeJWT は header.payload.signature 形式のダミー JWT を組み立てる。
@@ -101,5 +106,65 @@ func TestToStringSliceFromClaim(t *testing.T) {
 	}
 	if ToStringSliceFromClaim("not-an-array") != nil {
 		t.Fatal("non-array should return nil")
+	}
+}
+
+// runJWTAuth は JWTAuth を 1 リクエスト分実行し、status と context にセットされた sub を返す。
+func runJWTAuth(t *testing.T, verify VerifyFunc, cookie string) (int, string) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	var gotSub string
+	r.GET("/x", JWTAuth(verify), func(c *gin.Context) {
+		if v, ok := c.Get(ContextKeyCognitoSub); ok {
+			gotSub, _ = v.(string)
+		}
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	if cookie != "" {
+		req.AddCookie(&http.Cookie{Name: CookieAccessToken, Value: cookie})
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code, gotSub
+}
+
+func TestJWTAuth_NoCookie(t *testing.T) {
+	verify := func(context.Context, string) (map[string]any, error) { return nil, nil }
+	if code, _ := runJWTAuth(t, verify, ""); code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", code)
+	}
+}
+
+func TestJWTAuth_VerifyFails(t *testing.T) {
+	// 偽造トークン相当: verify がエラーを返したら 401 で弾く。
+	verify := func(context.Context, string) (map[string]any, error) {
+		return nil, errors.New("bad signature")
+	}
+	if code, _ := runJWTAuth(t, verify, "forged"); code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 on verify failure, got %d", code)
+	}
+}
+
+func TestJWTAuth_VerifySucceeds(t *testing.T) {
+	verify := func(context.Context, string) (map[string]any, error) {
+		return map[string]any{"sub": "user-9"}, nil
+	}
+	code, sub := runJWTAuth(t, verify, "good")
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", code)
+	}
+	if sub != "user-9" {
+		t.Fatalf("expected sub user-9, got %q", sub)
+	}
+}
+
+func TestJWTAuth_MissingSub(t *testing.T) {
+	verify := func(context.Context, string) (map[string]any, error) {
+		return map[string]any{"email": "u@example.com"}, nil
+	}
+	if code, _ := runJWTAuth(t, verify, "good"); code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 when sub missing, got %d", code)
 	}
 }

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -2,12 +2,14 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/bedrock"
+	"github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
@@ -73,7 +75,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	authHandler := registerAuthPublicRoutes(v2, deps)
 
 	authed := v2.Group("")
-	authed.Use(middleware.JWTAuth())
+	authed.Use(middleware.JWTAuth(buildJWTVerify(cfg)))
 	authed.Use(middleware.CurrentUser(deps.userRepo))
 
 	registerAuthAuthedRoutes(authed, authHandler)
@@ -90,6 +92,27 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 
 	return r
+}
+
+// buildJWTVerify は JWTAuth に渡す access_token 検証関数を組み立てる。
+//   - JWKS URI 設定あり: cognito.Verifier で JWKS 署名検証する（本番の正規経路）
+//   - JWKS 未設定 & local: 署名未検証の decode にフォールバック（Cognito 無しのローカル開発用）
+//   - JWKS 未設定 & 非 local: fail closed（全リクエストを拒否し、未検証で本番が動くのを防ぐ）
+func buildJWTVerify(cfg *config.Config) middleware.VerifyFunc {
+	if cfg.Cognito.JwkSetURI != "" {
+		v := cognito.NewVerifier(cfg.Cognito.JwkSetURI)
+		return v.Verify
+	}
+	if cfg.AppEnv == "local" {
+		log.Printf("WARN: COGNITO_JWK_SET_URI 未設定 — ローカル開発のため JWT 署名検証をスキップします（本番では設定必須）")
+		return func(_ context.Context, token string) (map[string]any, error) {
+			return middleware.DecodeClaims(token)
+		}
+	}
+	log.Printf("ERROR: COGNITO_JWK_SET_URI 未設定 — 署名検証できないため認証付きリクエストを全拒否します")
+	return func(_ context.Context, _ string) (map[string]any, error) {
+		return nil, errors.New("jwt verifier not configured")
+	}
 }
 
 // registerHealthRoutes は認証不要のヘルスチェック (/api/v2/health) を登録する。

--- a/backend/internal/infra/cognito/jwt_verifier.go
+++ b/backend/internal/infra/cognito/jwt_verifier.go
@@ -1,0 +1,258 @@
+package cognito
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Verifier は Cognito が発行した JWT (access_token / id_token) の署名と
+// 標準クレームを検証する。JWKS を取得して kid ごとの RSA 公開鍵で RS256 署名を検証し、
+// exp（有効期限）と iss（発行者）も確認する。
+//
+// 署名未検証の base64 デコードだけでは sub / cognito:groups を偽造できてしまうため、
+// 保護ルートの認可前に必ずこの Verify を通す。
+type Verifier struct {
+	jwksURI    string
+	issuer     string
+	httpClient *http.Client
+
+	mu        sync.RWMutex
+	keys      map[string]*rsa.PublicKey
+	fetchedAt time.Time
+	// refreshCooldown は未知 kid によるリフェッチ連打 (DoS) を防ぐ最小間隔。
+	refreshCooldown time.Duration
+	// leeway は時計ずれを吸収する exp の許容誤差。
+	leeway time.Duration
+}
+
+// 検証失敗の sentinel エラー。呼び出し側は errors.Is で分岐できる。
+var (
+	ErrJWTMalformed     = errors.New("cognito: malformed jwt")
+	ErrJWTBadAlg        = errors.New("cognito: unexpected signing alg")
+	ErrJWTUnknownKey    = errors.New("cognito: signing key not found")
+	ErrJWTBadSignature  = errors.New("cognito: signature verification failed")
+	ErrJWTExpired       = errors.New("cognito: token expired")
+	ErrJWTBadIssuer     = errors.New("cognito: unexpected issuer")
+	ErrJWKSUnavailable  = errors.New("cognito: jwks fetch failed")
+	ErrVerifierDisabled = errors.New("cognito: verifier not configured (empty jwks uri)")
+)
+
+// NewVerifier は JWKS URI から Verifier を組み立てる。
+// issuer は JWKS URI から `/.well-known/jwks.json` を除いて導出する
+// (Cognito の iss = https://cognito-idp.<region>.amazonaws.com/<userPoolId>)。
+func NewVerifier(jwksURI string) *Verifier {
+	issuer := strings.TrimSuffix(jwksURI, "/.well-known/jwks.json")
+	return &Verifier{
+		jwksURI:         jwksURI,
+		issuer:          issuer,
+		httpClient:      &http.Client{Timeout: 5 * time.Second},
+		keys:            map[string]*rsa.PublicKey{},
+		refreshCooldown: 1 * time.Minute,
+		leeway:          60 * time.Second,
+	}
+}
+
+// NewVerifierWithClient はテスト用に http.Client / issuer を差し替えるコンストラクタ。
+func NewVerifierWithClient(jwksURI, issuer string, client *http.Client) *Verifier {
+	v := NewVerifier(jwksURI)
+	v.issuer = issuer
+	if client != nil {
+		v.httpClient = client
+	}
+	return v
+}
+
+// Verify は token の署名・exp・iss を検証し、検証済みの claims を返す。
+func (v *Verifier) Verify(ctx context.Context, token string) (map[string]any, error) {
+	if v.jwksURI == "" {
+		return nil, ErrVerifierDisabled
+	}
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, ErrJWTMalformed
+	}
+
+	header, err := decodeJSONSegment(parts[0])
+	if err != nil {
+		return nil, ErrJWTMalformed
+	}
+	// alg confusion 攻撃 (none / HS256 で公開鍵を秘密鍵扱い) を防ぐため RS256 を強制。
+	if alg, _ := header["alg"].(string); alg != "RS256" {
+		return nil, ErrJWTBadAlg
+	}
+	kid, _ := header["kid"].(string)
+	if kid == "" {
+		return nil, ErrJWTMalformed
+	}
+
+	key, err := v.keyForKid(ctx, kid)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := verifyRS256(parts[0]+"."+parts[1], parts[2], key); err != nil {
+		return nil, err
+	}
+
+	claims, err := decodeJSONSegment(parts[1])
+	if err != nil {
+		return nil, ErrJWTMalformed
+	}
+	if err := v.verifyClaims(claims); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// verifyClaims は exp と iss を検証する。
+func (v *Verifier) verifyClaims(claims map[string]any) error {
+	if exp, ok := claims["exp"].(float64); ok {
+		if time.Now().After(time.Unix(int64(exp), 0).Add(v.leeway)) {
+			return ErrJWTExpired
+		}
+	} else {
+		return ErrJWTMalformed
+	}
+	if v.issuer != "" {
+		if iss, _ := claims["iss"].(string); iss != v.issuer {
+			return ErrJWTBadIssuer
+		}
+	}
+	return nil
+}
+
+// keyForKid は kid に対応する RSA 公開鍵を返す。キャッシュに無ければ JWKS を再取得する。
+func (v *Verifier) keyForKid(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	v.mu.RLock()
+	key, ok := v.keys[kid]
+	stale := time.Since(v.fetchedAt) > v.refreshCooldown
+	v.mu.RUnlock()
+	if ok {
+		return key, nil
+	}
+	// 未知 kid。cooldown を超えていれば 1 度だけ再取得する (キー rotation 追従)。
+	if !stale {
+		return nil, ErrJWTUnknownKey
+	}
+	if err := v.refresh(ctx); err != nil {
+		return nil, err
+	}
+	v.mu.RLock()
+	key, ok = v.keys[kid]
+	v.mu.RUnlock()
+	if !ok {
+		return nil, ErrJWTUnknownKey
+	}
+	return key, nil
+}
+
+// jwk は JWKS 内の 1 鍵 (RSA) を表す。
+type jwk struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// refresh は JWKS を取得してキャッシュを差し替える。
+func (v *Verifier) refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURI, nil)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrJWKSUnavailable, err)
+	}
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrJWKSUnavailable, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: status %d", ErrJWKSUnavailable, resp.StatusCode)
+	}
+	var doc struct {
+		Keys []jwk `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return fmt.Errorf("%w: %v", ErrJWKSUnavailable, err)
+	}
+	keys := make(map[string]*rsa.PublicKey, len(doc.Keys))
+	for _, k := range doc.Keys {
+		if k.Kty != "RSA" || k.Kid == "" {
+			continue
+		}
+		pub, err := k.toRSAPublicKey()
+		if err != nil {
+			continue
+		}
+		keys[k.Kid] = pub
+	}
+	v.mu.Lock()
+	v.keys = keys
+	v.fetchedAt = time.Now()
+	v.mu.Unlock()
+	return nil
+}
+
+// toRSAPublicKey は JWK の n / e (base64url) から rsa.PublicKey を組み立てる。
+func (k jwk) toRSAPublicKey() (*rsa.PublicKey, error) {
+	nBytes, err := base64URLDecode(k.N)
+	if err != nil {
+		return nil, err
+	}
+	eBytes, err := base64URLDecode(k.E)
+	if err != nil {
+		return nil, err
+	}
+	e := new(big.Int).SetBytes(eBytes).Int64()
+	if e == 0 {
+		return nil, errors.New("cognito: invalid jwk exponent")
+	}
+	return &rsa.PublicKey{
+		N: new(big.Int).SetBytes(nBytes),
+		E: int(e),
+	}, nil
+}
+
+// verifyRS256 は signingInput (header.payload) の RS256 署名を公開鍵で検証する。
+func verifyRS256(signingInput, sigSegment string, key *rsa.PublicKey) error {
+	sig, err := base64URLDecode(sigSegment)
+	if err != nil {
+		return ErrJWTMalformed
+	}
+	hashed := sha256.Sum256([]byte(signingInput))
+	if err := rsa.VerifyPKCS1v15(key, crypto.SHA256, hashed[:], sig); err != nil {
+		return ErrJWTBadSignature
+	}
+	return nil
+}
+
+// decodeJSONSegment は base64url セグメントを JSON object にデコードする。
+func decodeJSONSegment(seg string) (map[string]any, error) {
+	raw, err := base64URLDecode(seg)
+	if err != nil {
+		return nil, err
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// base64URLDecode は JWT の URL-safe base64 (パディング省略可) をデコードする。
+func base64URLDecode(s string) ([]byte, error) {
+	if b, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return b, nil
+	}
+	return base64.URLEncoding.DecodeString(s)
+}

--- a/backend/internal/infra/cognito/jwt_verifier.go
+++ b/backend/internal/infra/cognito/jwt_verifier.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net/http"
 	"strings"
@@ -30,6 +31,8 @@ type Verifier struct {
 	mu        sync.RWMutex
 	keys      map[string]*rsa.PublicKey
 	fetchedAt time.Time
+	// refreshMu は JWKS 再取得を 1 本に直列化し、未知 kid 同時多発時のスパイクを防ぐ。
+	refreshMu sync.Mutex
 	// refreshCooldown は未知 kid によるリフェッチ連打 (DoS) を防ぐ最小間隔。
 	refreshCooldown time.Duration
 	// leeway は時計ずれを吸収する exp の許容誤差。
@@ -134,27 +137,39 @@ func (v *Verifier) verifyClaims(claims map[string]any) error {
 
 // keyForKid は kid に対応する RSA 公開鍵を返す。キャッシュに無ければ JWKS を再取得する。
 func (v *Verifier) keyForKid(ctx context.Context, kid string) (*rsa.PublicKey, error) {
-	v.mu.RLock()
-	key, ok := v.keys[kid]
-	stale := time.Since(v.fetchedAt) > v.refreshCooldown
-	v.mu.RUnlock()
-	if ok {
+	if key, ok := v.lookup(kid); ok {
 		return key, nil
 	}
-	// 未知 kid。cooldown を超えていれば 1 度だけ再取得する (キー rotation 追従)。
+
+	// 未知 kid。refresh を 1 本に直列化し、待機中に他 goroutine が更新済みか / cooldown 内かを再確認する。
+	v.refreshMu.Lock()
+	defer v.refreshMu.Unlock()
+
+	if key, ok := v.lookup(kid); ok {
+		return key, nil
+	}
+	v.mu.RLock()
+	stale := time.Since(v.fetchedAt) > v.refreshCooldown
+	v.mu.RUnlock()
 	if !stale {
+		// 直前に別 goroutine が refresh 済み（かつ kid は依然見つからない）。連打せず未知扱い。
 		return nil, ErrJWTUnknownKey
 	}
 	if err := v.refresh(ctx); err != nil {
 		return nil, err
 	}
-	v.mu.RLock()
-	key, ok = v.keys[kid]
-	v.mu.RUnlock()
-	if !ok {
-		return nil, ErrJWTUnknownKey
+	if key, ok := v.lookup(kid); ok {
+		return key, nil
 	}
-	return key, nil
+	return nil, ErrJWTUnknownKey
+}
+
+// lookup は kid に対応する鍵をキャッシュから返す。
+func (v *Verifier) lookup(kid string) (*rsa.PublicKey, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	key, ok := v.keys[kid]
+	return key, ok
 }
 
 // jwk は JWKS 内の 1 鍵 (RSA) を表す。
@@ -196,6 +211,10 @@ func (v *Verifier) refresh(ctx context.Context) error {
 		}
 		keys[k.Kid] = pub
 	}
+	// 空 / 壊れた JWKS で既存の有効キャッシュを潰さない（認証全断の回避）。
+	if len(keys) == 0 {
+		return fmt.Errorf("%w: no usable rsa keys", ErrJWKSUnavailable)
+	}
 	v.mu.Lock()
 	v.keys = keys
 	v.fetchedAt = time.Now()
@@ -213,8 +232,13 @@ func (k jwk) toRSAPublicKey() (*rsa.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	e := new(big.Int).SetBytes(eBytes).Int64()
-	if e == 0 {
+	// 外部入力なので exponent の範囲を検証する（int 変換のオーバーフロー / 異常値を弾く）。
+	eBig := new(big.Int).SetBytes(eBytes)
+	if !eBig.IsInt64() {
+		return nil, errors.New("cognito: jwk exponent too large")
+	}
+	e := eBig.Int64()
+	if e <= 0 || e > math.MaxInt32 {
 		return nil, errors.New("cognito: invalid jwk exponent")
 	}
 	return &rsa.PublicKey{

--- a/backend/internal/infra/cognito/jwt_verifier_test.go
+++ b/backend/internal/infra/cognito/jwt_verifier_test.go
@@ -1,0 +1,165 @@
+package cognito
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// testSigner は RSA 鍵と JWKS を提供するテスト用 IdP。
+type testSigner struct {
+	key *rsa.PrivateKey
+	kid string
+}
+
+func newTestSigner(t *testing.T) *testSigner {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	return &testSigner{key: key, kid: "test-kid-1"}
+}
+
+// jwksJSON は signer の公開鍵を JWKS 形式で返す。
+func (s *testSigner) jwksJSON() []byte {
+	n := base64.RawURLEncoding.EncodeToString(s.key.N.Bytes())
+	e := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(s.key.E)).Bytes())
+	doc := map[string]any{"keys": []map[string]any{
+		{"kid": s.kid, "kty": "RSA", "alg": "RS256", "use": "sig", "n": n, "e": e},
+	}}
+	b, _ := json.Marshal(doc)
+	return b
+}
+
+// sign は claims を RS256 で署名した JWT を返す。kid / alg は引数で差し替え可能。
+func (s *testSigner) sign(t *testing.T, claims map[string]any, alg, kid string) string {
+	t.Helper()
+	header := map[string]any{"alg": alg, "typ": "JWT", "kid": kid}
+	seg := func(v any) string {
+		b, _ := json.Marshal(v)
+		return base64.RawURLEncoding.EncodeToString(b)
+	}
+	signingInput := seg(header) + "." + seg(claims)
+	hashed := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, s.key, crypto.SHA256, hashed[:])
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+const testIssuer = "https://cognito-idp.ap-northeast-1.amazonaws.com/pool"
+
+// newVerifier は JWKS を返す httptest サーバに紐づく Verifier を作る。
+func newVerifier(t *testing.T, s *testSigner) *Verifier {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(s.jwksJSON())
+	}))
+	t.Cleanup(srv.Close)
+	return NewVerifierWithClient(srv.URL, testIssuer, srv.Client())
+}
+
+func validClaims() map[string]any {
+	return map[string]any{
+		"sub":            "user-1",
+		"iss":            testIssuer,
+		"exp":            float64(time.Now().Add(time.Hour).Unix()),
+		"cognito:groups": []any{"admin"},
+	}
+}
+
+func TestVerify_Success(t *testing.T) {
+	s := newTestSigner(t)
+	v := newVerifier(t, s)
+	tok := s.sign(t, validClaims(), "RS256", s.kid)
+	claims, err := v.Verify(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if claims["sub"] != "user-1" {
+		t.Fatalf("sub mismatch: %v", claims["sub"])
+	}
+}
+
+func TestVerify_TamperedSignature(t *testing.T) {
+	s := newTestSigner(t)
+	v := newVerifier(t, s)
+	tok := s.sign(t, validClaims(), "RS256", s.kid)
+	// 署名を別の鍵で作り直す（payload はそのまま）→ 検証は失敗するべき。
+	other := newTestSigner(t)
+	other.kid = s.kid
+	forged := other.sign(t, validClaims(), "RS256", s.kid)
+	if _, err := v.Verify(context.Background(), forged); !errors.Is(err, ErrJWTBadSignature) {
+		t.Fatalf("expected ErrJWTBadSignature, got %v", err)
+	}
+	// 正規トークンは通る（前段の偽造でキャッシュが壊れていないこと）。
+	if _, err := v.Verify(context.Background(), tok); err != nil {
+		t.Fatalf("valid token should pass, got %v", err)
+	}
+}
+
+func TestVerify_Expired(t *testing.T) {
+	s := newTestSigner(t)
+	v := newVerifier(t, s)
+	c := validClaims()
+	c["exp"] = float64(time.Now().Add(-2 * time.Hour).Unix())
+	tok := s.sign(t, c, "RS256", s.kid)
+	if _, err := v.Verify(context.Background(), tok); !errors.Is(err, ErrJWTExpired) {
+		t.Fatalf("expected ErrJWTExpired, got %v", err)
+	}
+}
+
+func TestVerify_BadIssuer(t *testing.T) {
+	s := newTestSigner(t)
+	v := newVerifier(t, s)
+	c := validClaims()
+	c["iss"] = "https://evil.example.com"
+	tok := s.sign(t, c, "RS256", s.kid)
+	if _, err := v.Verify(context.Background(), tok); !errors.Is(err, ErrJWTBadIssuer) {
+		t.Fatalf("expected ErrJWTBadIssuer, got %v", err)
+	}
+}
+
+func TestVerify_RejectNonRS256(t *testing.T) {
+	s := newTestSigner(t)
+	v := newVerifier(t, s)
+	tok := s.sign(t, validClaims(), "none", s.kid)
+	if _, err := v.Verify(context.Background(), tok); !errors.Is(err, ErrJWTBadAlg) {
+		t.Fatalf("expected ErrJWTBadAlg, got %v", err)
+	}
+}
+
+func TestVerify_UnknownKid(t *testing.T) {
+	s := newTestSigner(t)
+	v := newVerifier(t, s)
+	tok := s.sign(t, validClaims(), "RS256", "some-other-kid")
+	if _, err := v.Verify(context.Background(), tok); !errors.Is(err, ErrJWTUnknownKey) {
+		t.Fatalf("expected ErrJWTUnknownKey, got %v", err)
+	}
+}
+
+func TestVerify_Malformed(t *testing.T) {
+	v := newVerifier(t, newTestSigner(t))
+	if _, err := v.Verify(context.Background(), "not-a-jwt"); !errors.Is(err, ErrJWTMalformed) {
+		t.Fatalf("expected ErrJWTMalformed, got %v", err)
+	}
+}
+
+func TestVerify_DisabledWhenNoJWKS(t *testing.T) {
+	v := NewVerifier("")
+	if _, err := v.Verify(context.Background(), "a.b.c"); !errors.Is(err, ErrVerifierDisabled) {
+		t.Fatalf("expected ErrVerifierDisabled, got %v", err)
+	}
+}

--- a/backend/internal/infra/cognito/jwt_verifier_test.go
+++ b/backend/internal/infra/cognito/jwt_verifier_test.go
@@ -163,3 +163,36 @@ func TestVerify_DisabledWhenNoJWKS(t *testing.T) {
 		t.Fatalf("expected ErrVerifierDisabled, got %v", err)
 	}
 }
+
+// TestVerify_EmptyJWKSDoesNotWipeCache は空 JWKS が来ても既存の有効キャッシュを保持し、
+// 既知トークンが通り続けることを確認する。
+func TestVerify_EmptyJWKSDoesNotWipeCache(t *testing.T) {
+	s := newTestSigner(t)
+	empty := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if empty {
+			_, _ = w.Write([]byte(`{"keys":[]}`))
+			return
+		}
+		_, _ = w.Write(s.jwksJSON())
+	}))
+	t.Cleanup(srv.Close)
+	v := NewVerifierWithClient(srv.URL, testIssuer, srv.Client())
+	v.refreshCooldown = 0 // 毎回 refresh を許可
+
+	tok := s.sign(t, validClaims(), "RS256", s.kid)
+	if _, err := v.Verify(context.Background(), tok); err != nil {
+		t.Fatalf("first verify should pass: %v", err)
+	}
+
+	// JWKS が空を返す状態に切替。未知 kid を引くと refresh は ErrJWKSUnavailable で失敗するが、
+	// 既存キャッシュは空に潰されない。
+	empty = true
+	if _, err := v.Verify(context.Background(), s.sign(t, validClaims(), "RS256", "unknown")); !errors.Is(err, ErrJWKSUnavailable) {
+		t.Fatalf("unknown kid with empty jwks should be ErrJWKSUnavailable, got %v", err)
+	}
+	// 既存 kid のトークンは引き続き通る（キャッシュが空に潰されていない）。
+	if _, err := v.Verify(context.Background(), tok); err != nil {
+		t.Fatalf("known token should still pass after empty jwks: %v", err)
+	}
+}


### PR DESCRIPTION
## 概要

🔴 **Critical**: これまで `middleware/jwt.go` の `JWTAuth` は access_token の **payload を base64 デコードするだけで署名を検証していなかった**。署名されていない偽造トークンでも `sub` / `cognito:groups` を任意に差し替えられ、**認証・管理者判定を丸ごと回避可能**だった（保護ルート全体が実質ノーガード）。

本 PR で **JWKS による RS256 署名検証 + exp / iss 検証**を必須化する。

## 変更内容（コミット単位）

1. **`feat(security)`** `infra/cognito/jwt_verifier.go` を新設（stdlib のみ・新規依存なし）
   - JWKS を取得し kid ごとの RSA 公開鍵で RS256 署名を検証（`alg` は RS256 強制 → alg confusion 対策）
   - `exp`（時計ずれ 60s 許容）と `iss`（発行者）を検証
   - 鍵は kid キャッシュ + cooldown 付き再取得で rotation 追従 / 連打防止
   - 単体テスト: 正常 / 署名改ざん / 期限切れ / iss 不正 / 非 RS256 / 未知 kid / 不正形式
2. **`fix(security)`** `JWTAuth(verify VerifyFunc)` に変更し検証関数を注入
   - `buildJWTVerify`: JWKS 設定あり→検証 / 未設定&local→decode フォールバック / 未設定&非local→**fail closed**
   - JWTAuth のハンドラテスト（cookie 無し / 検証失敗 / 成功 / sub 欠落）を追加

## 互換性・安全性

- 本番（`COGNITO_JWK_SET_URI` は task def で設定済）は正規の JWKS 検証経路に乗る
- ローカル開発（`APP_ENV=local` かつ JWKS 未設定）のみ従来どおり decode で動く（警告ログ付き）
- `DecodeClaims` は Cognito から TLS で直取得する id_token 用に残置（auth_handler）

## テスト

- `go test ./internal/infra/cognito/ ./internal/handler/...` pass / `go vet ./...` クリーン

## フォローアップ（別 PR 想定）
- `token_use=access` / `client_id` の追加検証（多層防御）
- ユーザーコード実行の隔離（もう一つの Critical）

## 関連 Issue
CodeRabbit が #1734 でも指摘していた JWT 署名未検証への対応。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * JWT署名検証の堅牢性が向上しました。RSA公開鍵による署名検証、トークン有効期限の確認、発行者の検証を実装しました。

* **改善**
  * 環境に応じた認証検証方式の切り替えに対応しました。

* **テスト**
  * 認証検証の各ケース（署名検証、期限切れ、発行者不一致など）をカバーするテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->