### PR TITLE
fix(security): ユーザコード実行から AWS 認証情報・シークレットを遮断

### DIFF
--- a/backend/internal/usecase/execute_code_sandbox_test.go
+++ b/backend/internal/usecase/execute_code_sandbox_test.go
@@ -1,0 +1,65 @@
+package usecase
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestIsSensitiveEnvKey(t *testing.T) {
+	sensitive := []string{
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"DATABASE_URL",
+		"DB_PASSWORD",
+		"COGNITO_CLIENT_SECRET",
+		"SES_FROM_ADDRESS",
+		"BEDROCK_MODEL_ID",
+		"SOME_API_TOKEN",
+		"MY_PRIVATE_KEY",
+	}
+	for _, k := range sensitive {
+		if !isSensitiveEnvKey(k) {
+			t.Errorf("%q should be treated as sensitive", k)
+		}
+	}
+	benign := []string{"PATH", "HOME", "LANG", "GOCACHE", "GOROOT", "GO111MODULE", "TERM"}
+	for _, k := range benign {
+		if isSensitiveEnvKey(k) {
+			t.Errorf("%q should NOT be treated as sensitive", k)
+		}
+	}
+}
+
+func TestSandboxEnv_StripsSecretsKeepsBenign(t *testing.T) {
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/abc")
+	t.Setenv("DATABASE_URL", "postgresql://user:pw@host/db")
+	t.Setenv("COGNITO_CLIENT_SECRET", "super-secret")
+	t.Setenv("SANDBOX_TEST_BENIGN", "ok")
+
+	env := sandboxEnv("EXTRA=1")
+	joined := strings.Join(env, "\n")
+
+	for _, leaked := range []string{
+		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+		"DATABASE_URL",
+		"COGNITO_CLIENT_SECRET",
+		"super-secret",
+	} {
+		if strings.Contains(joined, leaked) {
+			t.Errorf("sandbox env must not contain %q", leaked)
+		}
+	}
+	if !strings.Contains(joined, "SANDBOX_TEST_BENIGN=ok") {
+		t.Error("benign var should be preserved")
+	}
+	if !strings.Contains(joined, "EXTRA=1") {
+		t.Error("extra var should be appended")
+	}
+	// PATH のような go/php 実行に必要な env は残ること。
+	if os.Getenv("PATH") != "" && !strings.Contains(joined, "PATH=") {
+		t.Error("PATH should be preserved for the interpreter/toolchain")
+	}
+}

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -116,8 +116,12 @@ func (uc *ExecuteCodeUseCase) executePHP(ctx context.Context, input ExecuteCodeI
 		"-d", "open_basedir="+tmpDir,
 		"-d", "display_errors=stderr",
 		"-d", "log_errors=0",
+		// variables_order から E を外し $_ENV を空にする（disable_functions=getenv の抜け穴を塞ぐ）。
+		"-d", "variables_order=GPCS",
 		filename,
 	)
+	// AWS 認証情報・注入シークレットを子プロセスに渡さない。
+	cmd.Env = sandboxEnv()
 
 	return runCommand(cmd, input.Stdin)
 }
@@ -151,8 +155,9 @@ func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeIn
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "go", "run", filename)
-	// GO111MODULE=off で単一ファイル実行（go.mod 不要）。 GOCACHE は環境共有で compile 高速化。
-	cmd.Env = append(os.Environ(),
+	// GO111MODULE=off で単一ファイル実行（go.mod 不要）。GOCACHE 等の go 動作に必要な env は
+	// sandboxEnv が残すが、AWS 認証情報・注入シークレットは除外する。
+	cmd.Env = sandboxEnv(
 		"GO111MODULE=off",
 		"HOME="+tmpDir,
 	)
@@ -237,6 +242,42 @@ func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
 		}
 	}
 	return out, nil
+}
+
+// sandboxEnv は os.Environ() から認証情報・秘密の env を除いて返す（末尾に extra を足す）。
+// 特に AWS_CONTAINER_CREDENTIALS_* を落とすことで、ユーザコードが ECS Task Role の
+// 一時クレデンシャル取得エンドポイントへ到達する経路を塞ぐ。DATABASE_URL や
+// COGNITO_CLIENT_SECRET 等の注入シークレットも読めないようにする。
+func sandboxEnv(extra ...string) []string {
+	base := os.Environ()
+	out := make([]string, 0, len(base)+len(extra))
+	for _, kv := range base {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		if isSensitiveEnvKey(kv[:eq]) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, extra...)
+}
+
+// isSensitiveEnvKey はユーザコードに渡してはいけない env 名かを判定する。
+func isSensitiveEnvKey(key string) bool {
+	k := strings.ToUpper(key)
+	for _, p := range []string{"AWS_", "COGNITO_", "DB_", "DATABASE", "SES_", "DYNAMODB_", "NOTE_IMAGES", "BEDROCK_"} {
+		if strings.HasPrefix(k, p) {
+			return true
+		}
+	}
+	for _, s := range []string{"SECRET", "PASSWORD", "TOKEN", "CREDENTIAL", "_KEY"} {
+		if strings.Contains(k, s) {
+			return true
+		}
+	}
+	return false
 }
 
 func truncate(s string, max int) string {


### PR DESCRIPTION
## 概要

🔴 **Critical（緩和策）**: `execute_code` の **php は env 未設定で親プロセスの env を全継承**し、**go は `os.Environ()` を全継承**していた。ECS タスクには Secrets Manager 由来の `DATABASE_URL` / `COGNITO_CLIENT_SECRET` が env 注入され、さらに `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`（Task Role の一時クレデンシャル取得用）も存在するため、**ユーザコードがこれらを読み出して DB 接続文字列や Task Role 権限を奪取できた**（bash は既に最小 env で対策済み）。

本 PR で php / go の実行プロセスからも秘密の env を遮断する。

## 変更内容

- `sandboxEnv()` を追加：`os.Environ()` から `AWS_` / `COGNITO_` / `DB_` / `DATABASE` / `SES_` / `DYNAMODB_` / `BEDROCK_` 系、および `SECRET` / `PASSWORD` / `TOKEN` / `CREDENTIAL` / `_KEY` を含む env を除外。go 実行に必要な `PATH` / `GO*` 等は残す
- **php**: `cmd.Env = sandboxEnv()` ＋ `-d variables_order=GPCS` で `$_ENV` を空にし、`disable_functions=getenv` の抜け穴（`$_ENV` 経由の参照）も塞ぐ
- **go**: `cmd.Env = append(os.Environ(), ...)` → `sandboxEnv("GO111MODULE=off", "HOME=...")`
- `sandboxEnv` / `isSensitiveEnvKey` の単体テストを追加（漏洩防止と benign 保持を検証）

## 効果と限界

- `AWS_CONTAINER_CREDENTIALS_*` を落とすことで、ユーザコードから ECS Task Role の一時クレデンシャル取得経路を遮断（path id が env からしか得られないため事実上ブロック）
- これは**同一コンテナ内実行のクレデンシャル奪取を塞ぐ緩和策**。実行環境の完全分離（権限最小の専用サービス / ネットワーク隔離 / gVisor 等）は別 PR で扱う

## テスト

- `go build ./...` / `go test ./internal/usecase/` / `go vet` pass

## 関連
Critical 2件のうち2つ目。1つ目（JWT 署名検証）は #1738。