### PR TITLE
feat: 企業利用申請フロー（公開申請→super_admin 通知）バックエンド

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -53,6 +53,113 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/company-applications": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "受け付けた企業申請を新しい順で返す。super_admin 専用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "企業申請一覧（super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/company-applications/{id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "申請を approved / rejected / pending に更新する。super_admin 専用。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "企業申請の status 更新（super_admin）",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "申請 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "status",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateCompanyApplicationStatusReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功（本文なし）"
+                    },
+                    "400": {
+                        "description": "status 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/invitations": {
             "get": {
                 "security": [
@@ -845,6 +952,52 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/company-applications": {
+            "post": {
+                "description": "ログイン前のユーザーが会社名 / 氏名 / メール / 任意メッセージで利用申請を送る。受理時に super_admin へ通知する。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company-applications"
+                ],
+                "summary": "企業利用申請（公開 / 認証不要）",
+                "parameters": [
+                    {
+                        "description": "申請内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.createCompanyApplicationReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーションエラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -2798,6 +2951,35 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication": {
+            "type": "object",
+            "properties": {
+                "applicantName": {
+                    "type": "string"
+                },
+                "companyName": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
             "type": "object",
             "properties": {
@@ -3443,6 +3625,28 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_handler.createCompanyApplicationReq": {
+            "type": "object",
+            "required": [
+                "applicantName",
+                "companyName",
+                "email"
+            ],
+            "properties": {
+                "applicantName": {
+                    "type": "string"
+                },
+                "companyName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.createSessionReq": {
             "type": "object",
             "required": [
@@ -3727,6 +3931,17 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.updateCompanyApplicationStatusReq": {
+            "type": "object",
+            "required": [
+                "status"
+            ],
+            "properties": {
+                "status": {
                     "type": "string"
                 }
             }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -140,7 +140,7 @@ const docTemplate = `{
                         "description": "成功（本文なし）"
                     },
                     "400": {
-                        "description": "status 不正",
+                        "description": "id / status 不正",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -153,6 +153,12 @@ const docTemplate = `{
                     },
                     "403": {
                         "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 更新失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -133,7 +133,7 @@
                         "description": "成功（本文なし）"
                     },
                     "400": {
-                        "description": "status 不正",
+                        "description": "id / status 不正",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -146,6 +146,12 @@
                     },
                     "403": {
                         "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 更新失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -46,6 +46,113 @@
                 }
             }
         },
+        "/admin/company-applications": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "受け付けた企業申請を新しい順で返す。super_admin 専用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "企業申請一覧（super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/company-applications/{id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "申請を approved / rejected / pending に更新する。super_admin 専用。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "企業申請の status 更新（super_admin）",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "申請 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "status",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateCompanyApplicationStatusReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功（本文なし）"
+                    },
+                    "400": {
+                        "description": "status 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/invitations": {
             "get": {
                 "security": [
@@ -838,6 +945,52 @@
                     },
                     "401": {
                         "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/company-applications": {
+            "post": {
+                "description": "ログイン前のユーザーが会社名 / 氏名 / メール / 任意メッセージで利用申請を送る。受理時に super_admin へ通知する。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company-applications"
+                ],
+                "summary": "企業利用申請（公開 / 認証不要）",
+                "parameters": [
+                    {
+                        "description": "申請内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.createCompanyApplicationReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーションエラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -2791,6 +2944,35 @@
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication": {
+            "type": "object",
+            "properties": {
+                "applicantName": {
+                    "type": "string"
+                },
+                "companyName": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
             "type": "object",
             "properties": {
@@ -3436,6 +3618,28 @@
                 }
             }
         },
+        "internal_handler.createCompanyApplicationReq": {
+            "type": "object",
+            "required": [
+                "applicantName",
+                "companyName",
+                "email"
+            ],
+            "properties": {
+                "applicantName": {
+                    "type": "string"
+                },
+                "companyName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.createSessionReq": {
             "type": "object",
             "required": [
@@ -3720,6 +3924,17 @@
                     "type": "integer"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.updateCompanyApplicationStatusReq": {
+            "type": "object",
+            "required": [
+                "status"
+            ],
+            "properties": {
+                "status": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -79,6 +79,25 @@ definitions:
       updatedAt:
         type: string
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication:
+    properties:
+      applicantName:
+        type: string
+      companyName:
+        type: string
+      createdAt:
+        type: string
+      email:
+        type: string
+      id:
+        type: integer
+      message:
+        type: string
+      status:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Course:
     properties:
       companyId:
@@ -525,6 +544,21 @@ definitions:
     - email
     - role
     type: object
+  internal_handler.createCompanyApplicationReq:
+    properties:
+      applicantName:
+        type: string
+      companyName:
+        type: string
+      email:
+        type: string
+      message:
+        type: string
+    required:
+    - applicantName
+    - companyName
+    - email
+    type: object
   internal_handler.createSessionReq:
     properties:
       scenarioId:
@@ -718,6 +752,13 @@ definitions:
       title:
         type: string
     type: object
+  internal_handler.updateCompanyApplicationStatusReq:
+    properties:
+      status:
+        type: string
+    required:
+    - status
+    type: object
   internal_handler.updateProfileReq:
     properties:
       avatarUrl:
@@ -772,6 +813,74 @@ paths:
       security:
       - CookieAuth: []
       summary: 会社 一覧 (SuperAdmin)
+      tags:
+      - admin
+  /admin/company-applications:
+    get:
+      description: 受け付けた企業申請を新しい順で返す。super_admin 専用。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication'
+            type: array
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 企業申請一覧（super_admin）
+      tags:
+      - admin
+  /admin/company-applications/{id}/status:
+    patch:
+      consumes:
+      - application/json
+      description: 申請を approved / rejected / pending に更新する。super_admin 専用。
+      parameters:
+      - description: 申請 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: status
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.updateCompanyApplicationStatusReq'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功（本文なし）
+        "400":
+          description: status 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 企業申請の status 更新（super_admin）
       tags:
       - admin
   /admin/invitations:
@@ -1297,6 +1406,36 @@ paths:
       summary: コード サンドボックス 実行
       tags:
       - code-execution
+  /company-applications:
+    post:
+      consumes:
+      - application/json
+      description: ログイン前のユーザーが会社名 / 氏名 / メール / 任意メッセージで利用申請を送る。受理時に super_admin へ通知する。
+      parameters:
+      - description: 申請内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.createCompanyApplicationReq'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication'
+        "400":
+          description: バリデーションエラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 内部エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      summary: 企業利用申請（公開 / 認証不要）
+      tags:
+      - company-applications
   /courses:
     get:
       description: current user の role / company で 自動 フィルタ。 trainee は published のみ、

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -867,7 +867,7 @@ paths:
         "204":
           description: 成功（本文なし）
         "400":
-          description: status 不正
+          description: id / status 不正
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "401":
@@ -876,6 +876,10 @@ paths:
             $ref: '#/definitions/internal_handler.errorResponse'
         "403":
           description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 更新失敗
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:

--- a/backend/internal/adapter/persistence/company_application_repository.go
+++ b/backend/internal/adapter/persistence/company_application_repository.go
@@ -1,0 +1,33 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// companyApplicationRepository は [repository.CompanyApplicationRepository] の GORM 実装。
+type companyApplicationRepository struct{ db *gorm.DB }
+
+func NewCompanyApplicationRepository(db *gorm.DB) repository.CompanyApplicationRepository {
+	return &companyApplicationRepository{db: db}
+}
+
+func (r *companyApplicationRepository) Create(ctx context.Context, app *domain.CompanyApplication) error {
+	return r.db.WithContext(ctx).Create(app).Error
+}
+
+func (r *companyApplicationRepository) ListAll(ctx context.Context) ([]domain.CompanyApplication, error) {
+	var rows []domain.CompanyApplication
+	err := r.db.WithContext(ctx).Order("created_at DESC").Find(&rows).Error
+	return rows, err
+}
+
+func (r *companyApplicationRepository) UpdateStatus(ctx context.Context, id uint64, status string) error {
+	return r.db.WithContext(ctx).
+		Model(&domain.CompanyApplication{}).
+		Where("id = ?", id).
+		Update("status", status).Error
+}

--- a/backend/internal/adapter/persistence/notification_repository.go
+++ b/backend/internal/adapter/persistence/notification_repository.go
@@ -16,6 +16,10 @@ func NewNotificationRepository(db *gorm.DB) repository.NotificationRepository {
 	return &notificationRepository{db: db}
 }
 
+func (r *notificationRepository) Create(ctx context.Context, n *domain.Notification) error {
+	return r.db.WithContext(ctx).Create(n).Error
+}
+
 func (r *notificationRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error) {
 	var rows []domain.Notification
 	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Order("created_at DESC").Find(&rows).Error

--- a/backend/internal/adapter/persistence/user_repository.go
+++ b/backend/internal/adapter/persistence/user_repository.go
@@ -50,6 +50,14 @@ func (r *userRepository) FindByID(ctx context.Context, id uint64) (*domain.User,
 	return &u, nil
 }
 
+func (r *userRepository) ListByRole(ctx context.Context, role string) ([]domain.User, error) {
+	var rows []domain.User
+	err := r.db.WithContext(ctx).
+		Where("role = ? AND deleted_at IS NULL", role).
+		Find(&rows).Error
+	return rows, err
+}
+
 func (r *userRepository) Create(ctx context.Context, user *domain.User) error {
 	return r.db.WithContext(ctx).Create(user).Error
 }

--- a/backend/internal/domain/company_application.go
+++ b/backend/internal/domain/company_application.go
@@ -1,0 +1,27 @@
+package domain
+
+import "time"
+
+// CompanyApplication は未登録の企業担当者がログイン前の公開フォームから出す「利用申請」。
+// super_admin が一覧で確認し、問題なければ既存の招待フローで company_admin を招待する。
+type CompanyApplication struct {
+	ID            uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyName   string    `gorm:"size:200;not null" json:"companyName"`
+	ApplicantName string    `gorm:"size:120;not null" json:"applicantName"`
+	Email         string    `gorm:"size:255;not null;index" json:"email"`
+	Message       string    `gorm:"type:text" json:"message"`
+	Status        string    `gorm:"size:16;not null;default:'pending';index" json:"status"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
+func (CompanyApplication) TableName() string { return "company_applications" }
+
+const (
+	CompanyApplicationStatusPending  = "pending"
+	CompanyApplicationStatusApproved = "approved"
+	CompanyApplicationStatusRejected = "rejected"
+)
+
+// NotificationTypeCompanyApplication は企業申請が届いたことを super_admin に知らせる通知の Type。
+const NotificationTypeCompanyApplication = "company_application"

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -33,6 +33,9 @@ func (r *fakeUserRepo) FindByCognitoSub(_ context.Context, sub string) (*domain.
 func (r *fakeUserRepo) FindByID(_ context.Context, _ uint64) (*domain.User, error) {
 	return nil, nil
 }
+func (r *fakeUserRepo) ListByRole(_ context.Context, _ string) ([]domain.User, error) {
+	return nil, nil
+}
 func (r *fakeUserRepo) Create(_ context.Context, u *domain.User) error {
 	if r.createErr != nil {
 		return r.createErr

--- a/backend/internal/handler/company_application_handler.go
+++ b/backend/internal/handler/company_application_handler.go
@@ -106,27 +106,33 @@ type updateCompanyApplicationStatusReq struct {
 //	@Param        id    path      int                                 true  "申請 ID"
 //	@Param        body  body      updateCompanyApplicationStatusReq   true  "status"
 //	@Success      204   "成功（本文なし）"
-//	@Failure      400   {object}  errorResponse  "status 不正"
+//	@Failure      400   {object}  errorResponse  "id / status 不正"
 //	@Failure      401   {object}  errorResponse  "未認証"
 //	@Failure      403   {object}  errorResponse  "super_admin 以外"
+//	@Failure      500   {object}  errorResponse  "DB 更新失敗"
 //	@Router       /admin/company-applications/{id}/status [patch]
 //	@Security     CookieAuth
 func (h *CompanyApplicationHandler) UpdateStatus(c *gin.Context) {
 	if !h.requireSuperAdmin(c) {
 		return
 	}
-	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
 	var req updateCompanyApplicationStatusReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	if err := h.updateStatus.Execute(c.Request.Context(), id, req.Status); err != nil {
+		// status 不正のみ 400。DB 更新失敗等の内部エラーは詳細を漏らさず 500。
 		if errors.Is(err, usecase.ErrCompanyApplicationBadStatus) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/backend/internal/handler/company_application_handler.go
+++ b/backend/internal/handler/company_application_handler.go
@@ -1,0 +1,147 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// CompanyApplicationHandler は企業利用申請の作成（公開）と一覧 / status 更新（super_admin）を扱う。
+type CompanyApplicationHandler struct {
+	create       *usecase.CreateCompanyApplicationUseCase
+	list         *usecase.ListCompanyApplicationsUseCase
+	updateStatus *usecase.UpdateCompanyApplicationStatusUseCase
+}
+
+func NewCompanyApplicationHandler(
+	create *usecase.CreateCompanyApplicationUseCase,
+	list *usecase.ListCompanyApplicationsUseCase,
+	updateStatus *usecase.UpdateCompanyApplicationStatusUseCase,
+) *CompanyApplicationHandler {
+	return &CompanyApplicationHandler{create: create, list: list, updateStatus: updateStatus}
+}
+
+type createCompanyApplicationReq struct {
+	CompanyName   string `json:"companyName" binding:"required"`
+	ApplicantName string `json:"applicantName" binding:"required"`
+	Email         string `json:"email" binding:"required"`
+	Message       string `json:"message"`
+}
+
+// Create は未登録ユーザーが出す企業申請を受け付ける（認証不要）。
+//
+//	@Summary      企業利用申請（公開 / 認証不要）
+//	@Description  ログイン前のユーザーが会社名 / 氏名 / メール / 任意メッセージで利用申請を送る。受理時に super_admin へ通知する。
+//	@Tags         company-applications
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body      createCompanyApplicationReq  true  "申請内容"
+//	@Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication
+//	@Failure      400   {object}  errorResponse  "バリデーションエラー"
+//	@Failure      500   {object}  errorResponse  "内部エラー"
+//	@Router       /company-applications [post]
+func (h *CompanyApplicationHandler) Create(c *gin.Context) {
+	var req createCompanyApplicationReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	app, err := h.create.Execute(c.Request.Context(), usecase.CreateCompanyApplicationInput{
+		CompanyName:   req.CompanyName,
+		ApplicantName: req.ApplicantName,
+		Email:         req.Email,
+		Message:       req.Message,
+	})
+	if err != nil {
+		if errors.Is(err, usecase.ErrCompanyApplicationInvalid) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusCreated, app)
+}
+
+// List は全企業申請を返す（super_admin 専用）。
+//
+//	@Summary      企業申請一覧（super_admin）
+//	@Description  受け付けた企業申請を新しい順で返す。super_admin 専用。
+//	@Tags         admin
+//	@Produce      json
+//	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "super_admin 以外"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /admin/company-applications [get]
+//	@Security     CookieAuth
+func (h *CompanyApplicationHandler) List(c *gin.Context) {
+	if !h.requireSuperAdmin(c) {
+		return
+	}
+	rows, err := h.list.Execute(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+type updateCompanyApplicationStatusReq struct {
+	Status string `json:"status" binding:"required"`
+}
+
+// UpdateStatus は申請の status を更新する（super_admin 専用）。
+//
+//	@Summary      企業申請の status 更新（super_admin）
+//	@Description  申請を approved / rejected / pending に更新する。super_admin 専用。
+//	@Tags         admin
+//	@Accept       json
+//	@Produce      json
+//	@Param        id    path      int                                 true  "申請 ID"
+//	@Param        body  body      updateCompanyApplicationStatusReq   true  "status"
+//	@Success      204   "成功（本文なし）"
+//	@Failure      400   {object}  errorResponse  "status 不正"
+//	@Failure      401   {object}  errorResponse  "未認証"
+//	@Failure      403   {object}  errorResponse  "super_admin 以外"
+//	@Router       /admin/company-applications/{id}/status [patch]
+//	@Security     CookieAuth
+func (h *CompanyApplicationHandler) UpdateStatus(c *gin.Context) {
+	if !h.requireSuperAdmin(c) {
+		return
+	}
+	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
+	var req updateCompanyApplicationStatusReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.updateStatus.Execute(c.Request.Context(), id, req.Status); err != nil {
+		if errors.Is(err, usecase.ErrCompanyApplicationBadStatus) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// requireSuperAdmin は current user が super_admin でなければ 401/403 を返して false を返す。
+func (h *CompanyApplicationHandler) requireSuperAdmin(c *gin.Context) bool {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return false
+	}
+	if user.Role != domain.RoleSuperAdmin {
+		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return false
+	}
+	return true
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -70,6 +70,8 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 
 	registerHealthRoutes(v2, deps)
 	registerInvitationPublicRoutes(v2, deps)
+	companyAppHandler := newCompanyApplicationHandler(deps)
+	registerCompanyApplicationPublicRoutes(v2, companyAppHandler)
 	authHandler := registerAuthPublicRoutes(v2, deps)
 
 	authed := v2.Group("")
@@ -87,6 +89,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerLearningReportRoutes(authed, deps)
 	registerCourseRoutes(authed, deps)
 	registerTeachingMaterialRoutes(authed, deps)
+	registerCompanyApplicationAdminRoutes(authed, companyAppHandler)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 
 	return r

--- a/backend/internal/handler/routes_company_application.go
+++ b/backend/internal/handler/routes_company_application.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// newCompanyApplicationHandler は申請の usecase 一式を組み立てて handler を返す。
+func newCompanyApplicationHandler(deps *routeDeps) *CompanyApplicationHandler {
+	appRepo := persistence.NewCompanyApplicationRepository(deps.db)
+	notifRepo := persistence.NewNotificationRepository(deps.db)
+	return NewCompanyApplicationHandler(
+		usecase.NewCreateCompanyApplicationUseCase(appRepo, deps.userRepo, notifRepo),
+		usecase.NewListCompanyApplicationsUseCase(appRepo),
+		usecase.NewUpdateCompanyApplicationStatusUseCase(appRepo),
+	)
+}
+
+// registerCompanyApplicationPublicRoutes は認証不要の企業申請作成を登録する。
+func registerCompanyApplicationPublicRoutes(g *gin.RouterGroup, h *CompanyApplicationHandler) {
+	g.POST("/company-applications", h.Create)
+}
+
+// registerCompanyApplicationAdminRoutes は super_admin 用の一覧 / status 更新を登録する（認可は handler 層）。
+func registerCompanyApplicationAdminRoutes(g *gin.RouterGroup, h *CompanyApplicationHandler) {
+	g.GET("/admin/company-applications", h.List)
+	g.PATCH("/admin/company-applications/:id/status", h.UpdateStatus)
+}

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -33,6 +33,7 @@ func allDomainModels() []any {
 		&domain.Company{},
 		&domain.Course{},
 		&domain.TeachingMaterial{},
+		&domain.CompanyApplication{},
 	}
 }
 

--- a/backend/internal/usecase/create_company_application_usecase.go
+++ b/backend/internal/usecase/create_company_application_usecase.go
@@ -1,0 +1,103 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// CreateCompanyApplicationUseCase は公開フォームから来た企業申請を保存し、
+// 全 super_admin に「申請が届いた」通知を作成する。
+type CreateCompanyApplicationUseCase struct {
+	apps          repository.CompanyApplicationRepository
+	users         repository.UserRepository
+	notifications repository.NotificationRepository
+}
+
+func NewCreateCompanyApplicationUseCase(
+	apps repository.CompanyApplicationRepository,
+	users repository.UserRepository,
+	notifications repository.NotificationRepository,
+) *CreateCompanyApplicationUseCase {
+	return &CreateCompanyApplicationUseCase{apps: apps, users: users, notifications: notifications}
+}
+
+type CreateCompanyApplicationInput struct {
+	CompanyName   string
+	ApplicantName string
+	Email         string
+	Message       string
+}
+
+// ErrCompanyApplicationInvalid は必須項目欠落 / 形式不正のとき返る。
+var ErrCompanyApplicationInvalid = errors.New("company application: invalid input")
+
+// 入力長の上限（DB カラム長 + スパム肥大化対策）。
+const (
+	maxCompanyNameLen   = 200
+	maxApplicantNameLen = 120
+	maxEmailLen         = 255
+	maxMessageLen       = 2000
+)
+
+func (u *CreateCompanyApplicationUseCase) Execute(ctx context.Context, in CreateCompanyApplicationInput) (*domain.CompanyApplication, error) {
+	company := strings.TrimSpace(in.CompanyName)
+	name := strings.TrimSpace(in.ApplicantName)
+	email := strings.TrimSpace(in.Email)
+	message := strings.TrimSpace(in.Message)
+
+	if company == "" || name == "" || email == "" {
+		return nil, fmt.Errorf("%w: companyName, applicantName, email are required", ErrCompanyApplicationInvalid)
+	}
+	if !strings.Contains(email, "@") || strings.Contains(email, " ") {
+		return nil, fmt.Errorf("%w: invalid email", ErrCompanyApplicationInvalid)
+	}
+	if len(company) > maxCompanyNameLen || len(name) > maxApplicantNameLen ||
+		len(email) > maxEmailLen || len(message) > maxMessageLen {
+		return nil, fmt.Errorf("%w: field too long", ErrCompanyApplicationInvalid)
+	}
+
+	app := &domain.CompanyApplication{
+		CompanyName:   company,
+		ApplicantName: name,
+		Email:         email,
+		Message:       message,
+		Status:        domain.CompanyApplicationStatusPending,
+	}
+	if err := u.apps.Create(ctx, app); err != nil {
+		return nil, fmt.Errorf("create company application: %w", err)
+	}
+
+	// 申請保存は成功扱いとし、通知作成失敗はログのみ（best-effort）。
+	u.notifySuperAdmins(ctx, app)
+	return app, nil
+}
+
+func (u *CreateCompanyApplicationUseCase) notifySuperAdmins(ctx context.Context, app *domain.CompanyApplication) {
+	if u.users == nil || u.notifications == nil {
+		return
+	}
+	admins, err := u.users.ListByRole(ctx, domain.RoleSuperAdmin)
+	if err != nil {
+		log.Printf("company-application: list super_admins failed: %v", err)
+		return
+	}
+	title := "新しい企業申請が届きました"
+	body := fmt.Sprintf("%s（%s / %s）から利用申請がありました。", app.CompanyName, app.ApplicantName, app.Email)
+	for _, admin := range admins {
+		n := &domain.Notification{
+			UserID: admin.ID,
+			Type:   domain.NotificationTypeCompanyApplication,
+			Title:  title,
+			Body:   body,
+		}
+		if err := u.notifications.Create(ctx, n); err != nil {
+			log.Printf("company-application: notify super_admin %d failed: %v", admin.ID, err)
+		}
+	}
+}

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -1,0 +1,122 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type fakeAppRepo struct {
+	created *domain.CompanyApplication
+	err     error
+}
+
+func (r *fakeAppRepo) Create(_ context.Context, app *domain.CompanyApplication) error {
+	if r.err != nil {
+		return r.err
+	}
+	app.ID = 1
+	r.created = app
+	return nil
+}
+func (r *fakeAppRepo) ListAll(context.Context) ([]domain.CompanyApplication, error) { return nil, nil }
+func (r *fakeAppRepo) UpdateStatus(context.Context, uint64, string) error           { return nil }
+
+// fakeUsersForApp は ListByRole で super_admin を返す最小 UserRepository。
+type fakeUsersForApp struct{ admins []domain.User }
+
+func (f *fakeUsersForApp) FindByCognitoSub(context.Context, string) (*domain.User, error) {
+	return nil, nil
+}
+func (f *fakeUsersForApp) FindByID(context.Context, uint64) (*domain.User, error) { return nil, nil }
+func (f *fakeUsersForApp) ListByRole(_ context.Context, role string) ([]domain.User, error) {
+	if role == domain.RoleSuperAdmin {
+		return f.admins, nil
+	}
+	return nil, nil
+}
+func (f *fakeUsersForApp) Create(context.Context, *domain.User) error              { return nil }
+func (f *fakeUsersForApp) UpdateDisplayName(context.Context, uint64, string) error { return nil }
+func (f *fakeUsersForApp) UpdateRole(context.Context, uint64, string) error        { return nil }
+func (f *fakeUsersForApp) UpdateCompanyID(context.Context, uint64, uint64) error   { return nil }
+func (f *fakeUsersForApp) MarkOnboarded(context.Context, uint64) error             { return nil }
+
+type recordingNotifRepo struct{ created []domain.Notification }
+
+func (r *recordingNotifRepo) Create(_ context.Context, n *domain.Notification) error {
+	r.created = append(r.created, *n)
+	return nil
+}
+func (r *recordingNotifRepo) ListByUserID(context.Context, uint64) ([]domain.Notification, error) {
+	return nil, nil
+}
+func (r *recordingNotifRepo) MarkRead(context.Context, uint64, uint64) error { return nil }
+func (r *recordingNotifRepo) MarkAllRead(context.Context, uint64) error      { return nil }
+func (r *recordingNotifRepo) CountUnread(context.Context, uint64) (int64, error) {
+	return 0, nil
+}
+
+func TestCreateCompanyApplication_NotifiesSuperAdmins(t *testing.T) {
+	apps := &fakeAppRepo{}
+	users := &fakeUsersForApp{admins: []domain.User{{ID: 10}, {ID: 11}}}
+	notifs := &recordingNotifRepo{}
+	uc := usecase.NewCreateCompanyApplicationUseCase(apps, users, notifs)
+
+	app, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
+		CompanyName:   "Example Corp",
+		ApplicantName: "山田太郎",
+		Email:         "yamada@example.com",
+		Message:       "利用を検討しています",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app.Status != domain.CompanyApplicationStatusPending {
+		t.Fatalf("status should be pending, got %q", app.Status)
+	}
+	if len(notifs.created) != 2 {
+		t.Fatalf("expected 2 super_admin notifications, got %d", len(notifs.created))
+	}
+	if notifs.created[0].Type != domain.NotificationTypeCompanyApplication {
+		t.Fatalf("notification type mismatch: %q", notifs.created[0].Type)
+	}
+}
+
+func TestCreateCompanyApplication_Validation(t *testing.T) {
+	uc := usecase.NewCreateCompanyApplicationUseCase(&fakeAppRepo{}, &fakeUsersForApp{}, &recordingNotifRepo{})
+	cases := []usecase.CreateCompanyApplicationInput{
+		{CompanyName: "", ApplicantName: "a", Email: "a@b.com"},     // company 欠落
+		{CompanyName: "c", ApplicantName: "", Email: "a@b.com"},     // name 欠落
+		{CompanyName: "c", ApplicantName: "a", Email: ""},           // email 欠落
+		{CompanyName: "c", ApplicantName: "a", Email: "no-at-sign"}, // email 形式不正
+	}
+	for i, in := range cases {
+		if _, err := uc.Execute(context.Background(), in); !errors.Is(err, usecase.ErrCompanyApplicationInvalid) {
+			t.Errorf("case %d: expected ErrCompanyApplicationInvalid, got %v", i, err)
+		}
+	}
+}
+
+func TestCreateCompanyApplication_SavesEvenIfNotifyFails(t *testing.T) {
+	// 通知作成に失敗しても申請保存は成功扱い（best-effort）。
+	apps := &fakeAppRepo{}
+	users := &fakeUsersForApp{admins: []domain.User{{ID: 10}}}
+	uc := usecase.NewCreateCompanyApplicationUseCase(apps, users, &failingNotifRepo{})
+	if _, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
+		CompanyName: "c", ApplicantName: "a", Email: "a@b.com",
+	}); err != nil {
+		t.Fatalf("application should be created despite notify failure, got %v", err)
+	}
+	if apps.created == nil {
+		t.Fatal("application was not saved")
+	}
+}
+
+type failingNotifRepo struct{ recordingNotifRepo }
+
+func (r *failingNotifRepo) Create(context.Context, *domain.Notification) error {
+	return errors.New("boom")
+}

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -19,6 +19,9 @@ func (s *stubUserRepo) FindByCognitoSub(_ context.Context, _ string) (*domain.Us
 func (s *stubUserRepo) FindByID(_ context.Context, _ uint64) (*domain.User, error) {
 	return s.user, s.err
 }
+func (s *stubUserRepo) ListByRole(_ context.Context, _ string) ([]domain.User, error) {
+	return nil, s.err
+}
 func (s *stubUserRepo) Create(_ context.Context, _ *domain.User) error { return s.err }
 func (s *stubUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error {
 	return s.err

--- a/backend/internal/usecase/list_company_applications_usecase.go
+++ b/backend/internal/usecase/list_company_applications_usecase.go
@@ -1,0 +1,21 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// ListCompanyApplicationsUseCase は全企業申請を新しい順で返す（super_admin 専用）。
+type ListCompanyApplicationsUseCase struct {
+	apps repository.CompanyApplicationRepository
+}
+
+func NewListCompanyApplicationsUseCase(apps repository.CompanyApplicationRepository) *ListCompanyApplicationsUseCase {
+	return &ListCompanyApplicationsUseCase{apps: apps}
+}
+
+func (u *ListCompanyApplicationsUseCase) Execute(ctx context.Context) ([]domain.CompanyApplication, error) {
+	return u.apps.ListAll(ctx)
+}

--- a/backend/internal/usecase/notification_usecase_test.go
+++ b/backend/internal/usecase/notification_usecase_test.go
@@ -12,6 +12,9 @@ type stubNotificationRepo struct {
 	err  error
 }
 
+func (s *stubNotificationRepo) Create(_ context.Context, _ *domain.Notification) error {
+	return s.err
+}
 func (s *stubNotificationRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.Notification, error) {
 	return s.rows, s.err
 }

--- a/backend/internal/usecase/repository/company_application.go
+++ b/backend/internal/usecase/repository/company_application.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// CompanyApplicationRepository は company_applications テーブルへのアクセスを提供する。
+type CompanyApplicationRepository interface {
+	Create(ctx context.Context, app *domain.CompanyApplication) error
+	// ListAll は全申請を新しい順で返す（super_admin の一覧用）。
+	ListAll(ctx context.Context) ([]domain.CompanyApplication, error)
+	UpdateStatus(ctx context.Context, id uint64, status string) error
+}

--- a/backend/internal/usecase/repository/notification.go
+++ b/backend/internal/usecase/repository/notification.go
@@ -11,6 +11,8 @@ import (
 // 実装: [github.com/norman6464/FreStyle/backend/internal/adapter/persistence] の
 // notificationRepository (GORM)。
 type NotificationRepository interface {
+	// Create は通知を 1 件作成する（システムが super_admin 等に通知を出す用途）。
+	Create(ctx context.Context, n *domain.Notification) error
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error)
 	// MarkRead は所有者検証込みで is_read を立てる。
 	// 自分以外の通知を既読化できないように、必ず WHERE で user_id を絞る。

--- a/backend/internal/usecase/repository/user.go
+++ b/backend/internal/usecase/repository/user.go
@@ -24,6 +24,8 @@ import (
 type UserRepository interface {
 	FindByCognitoSub(ctx context.Context, sub string) (*domain.User, error)
 	FindByID(ctx context.Context, id uint64) (*domain.User, error)
+	// ListByRole は指定 role のユーザー一覧を返す（super_admin への一斉通知などに使う）。
+	ListByRole(ctx context.Context, role string) ([]domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
 	// UpdateDisplayName は ProfilePage の「氏名」変更、 および OIDC ログイン時に
 	// 旧 displayName=email を id_token の name claim で自動補正するときに呼ばれる。

--- a/backend/internal/usecase/update_company_application_status_usecase.go
+++ b/backend/internal/usecase/update_company_application_status_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
@@ -24,12 +25,14 @@ func (u *UpdateCompanyApplicationStatusUseCase) Execute(ctx context.Context, id 
 	if id == 0 {
 		return errors.New("id is required")
 	}
-	switch status {
+	// 前後空白・大文字混在を正規化してから検証する。
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch normalized {
 	case domain.CompanyApplicationStatusPending,
 		domain.CompanyApplicationStatusApproved,
 		domain.CompanyApplicationStatusRejected:
 	default:
 		return ErrCompanyApplicationBadStatus
 	}
-	return u.apps.UpdateStatus(ctx, id, status)
+	return u.apps.UpdateStatus(ctx, id, normalized)
 }

--- a/backend/internal/usecase/update_company_application_status_usecase.go
+++ b/backend/internal/usecase/update_company_application_status_usecase.go
@@ -1,0 +1,35 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// UpdateCompanyApplicationStatusUseCase は申請の status を更新する（super_admin 専用）。
+type UpdateCompanyApplicationStatusUseCase struct {
+	apps repository.CompanyApplicationRepository
+}
+
+func NewUpdateCompanyApplicationStatusUseCase(apps repository.CompanyApplicationRepository) *UpdateCompanyApplicationStatusUseCase {
+	return &UpdateCompanyApplicationStatusUseCase{apps: apps}
+}
+
+// ErrCompanyApplicationBadStatus は許容外の status が渡されたとき返る。
+var ErrCompanyApplicationBadStatus = errors.New("company application: invalid status")
+
+func (u *UpdateCompanyApplicationStatusUseCase) Execute(ctx context.Context, id uint64, status string) error {
+	if id == 0 {
+		return errors.New("id is required")
+	}
+	switch status {
+	case domain.CompanyApplicationStatusPending,
+		domain.CompanyApplicationStatusApproved,
+		domain.CompanyApplicationStatusRejected:
+	default:
+		return ErrCompanyApplicationBadStatus
+	}
+	return u.apps.UpdateStatus(ctx, id, status)
+}

--- a/backend/internal/usecase/update_company_application_status_usecase_test.go
+++ b/backend/internal/usecase/update_company_application_status_usecase_test.go
@@ -1,0 +1,57 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// statusRepo は UpdateStatus に渡された値を記録する fake。
+type statusRepo struct {
+	gotID     uint64
+	gotStatus string
+	err       error
+}
+
+func (r *statusRepo) Create(context.Context, *domain.CompanyApplication) error     { return nil }
+func (r *statusRepo) ListAll(context.Context) ([]domain.CompanyApplication, error) { return nil, nil }
+func (r *statusRepo) UpdateStatus(_ context.Context, id uint64, status string) error {
+	r.gotID, r.gotStatus = id, status
+	return r.err
+}
+
+func TestUpdateCompanyApplicationStatus_NormalizesAndUpdates(t *testing.T) {
+	repo := &statusRepo{}
+	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(repo)
+	if err := uc.Execute(context.Background(), 5, "  Approved "); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.gotID != 5 || repo.gotStatus != domain.CompanyApplicationStatusApproved {
+		t.Fatalf("expected (5, approved), got (%d, %q)", repo.gotID, repo.gotStatus)
+	}
+}
+
+func TestUpdateCompanyApplicationStatus_RejectsBadStatus(t *testing.T) {
+	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(&statusRepo{})
+	if err := uc.Execute(context.Background(), 5, "banana"); !errors.Is(err, usecase.ErrCompanyApplicationBadStatus) {
+		t.Fatalf("expected ErrCompanyApplicationBadStatus, got %v", err)
+	}
+}
+
+func TestUpdateCompanyApplicationStatus_RequiresID(t *testing.T) {
+	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(&statusRepo{})
+	if err := uc.Execute(context.Background(), 0, "approved"); err == nil {
+		t.Fatal("expected error when id == 0")
+	}
+}
+
+func TestUpdateCompanyApplicationStatus_PropagatesRepoError(t *testing.T) {
+	repo := &statusRepo{err: errors.New("db down")}
+	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(repo)
+	if err := uc.Execute(context.Background(), 5, "rejected"); err == nil {
+		t.Fatal("expected repo error to propagate")
+	}
+}


### PR DESCRIPTION
## 概要

未登録の企業担当者（将来の company_admin）が**ログイン前の公開フォームから利用申請**を出し、**super_admin に「申請が届いた」通知**が届く機能のバックエンドを追加する。フロント（ログイン画面の申請ボタン + 申請フォーム）は別 PR。

申請の確認は **既存の通知 UI**（NotificationPage / ベル）で行える（v1 スコープ）。承認時の自動招待は行わず、super_admin は一覧を見て**既存の招待フロー**で company_admin を招待する。

## 変更内容（コミット単位）

1. **domain / 永続化**: `CompanyApplication`（会社名/氏名/メール/メッセージ/status）+ status・通知 Type 定数 / `CompanyApplicationRepository`(port+GORM) / `NotificationRepository.Create` / `UserRepository.ListByRole` / AutoMigrate 登録
2. **usecase**: `Create`（検証→保存→全 super_admin に通知作成、通知失敗は best-effort）/ `List` / `UpdateStatus` ＋ 単体テスト
3. **handler / routes / OpenAPI**: 公開 `POST /company-applications` と super_admin 専用 `GET/PATCH /admin/company-applications`、swaggo 付与 + `make openapi` 再生成

## エンドポイント

| Method | Path | 認証 | 説明 |
|---|---|---|---|
| POST | `/api/v2/company-applications` | 不要 | 申請を作成し super_admin に通知 |
| GET | `/api/v2/admin/company-applications` | super_admin | 申請一覧（新しい順） |
| PATCH | `/api/v2/admin/company-applications/{id}/status` | super_admin | status を approved/rejected/pending に更新 |

## テスト

- `go build ./...` / `go test ./...` / `go vet ./...` pass
- usecase テスト: super_admin 通知作成 / 入力検証 / 通知失敗でも申請保存

## 既知の制約 / フォローアップ
- 公開エンドポイントの**レートリミット未実装**（スパム対策は別 PR）。最小限の必須・形式・長さ検証は実施
- フロントエンド（ログイン画面の申請ボタン + 申請フォーム）は別 PR