### PR TITLE
feat: ログイン画面に企業利用申請ボタン + 申請フォーム（フロント）

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ const ConfirmPage = lazyWithReload(() => import('./pages/ConfirmPage'), 'Confirm
 const ForgotPasswordPage = lazyWithReload(() => import('./pages/ForgotPasswordPage'), 'ForgotPasswordPage');
 const ConfirmForgotPasswordPage = lazyWithReload(() => import('./pages/ConfirmForgotPasswordPage'), 'ConfirmForgotPasswordPage');
 const AcceptInvitationPage = lazyWithReload(() => import('./pages/AcceptInvitationPage'), 'AcceptInvitationPage');
+const CompanyApplicationPage = lazyWithReload(() => import('./pages/CompanyApplicationPage'), 'CompanyApplicationPage');
 
 // 認証必要ページ
 const MenuPage = lazyWithReload(() => import('./pages/MenuPage'), 'MenuPage');
@@ -86,6 +87,7 @@ export default function App() {
       />
       {/* 招待マジックリンクの受諾画面（認証不要・SES メールから踏まれる） */}
       <Route path="/invitations/accept" element={<AcceptInvitationPage />} />
+      <Route path="/company-application" element={<CompanyApplicationPage />} />
 
       {/* 認証が必要（AppShell レイアウト内） */}
       <Route

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -182,4 +182,15 @@ export const TEACHING_MATERIALS = {
   create: `${API_V2}/teaching-materials`,
 } as const;
 
+/** 企業利用申請（公開フォーム → super_admin 通知）*/
+export const COMPANY_APPLICATIONS = {
+  /** POST /api/v2/company-applications — 認証不要の申請作成 */
+  create: `${API_V2}/company-applications`,
+  /** GET /api/v2/admin/company-applications — super_admin 専用一覧 */
+  adminList: `${API_V2}/admin/company-applications`,
+  /** PATCH /api/v2/admin/company-applications/:id/status — status 更新 */
+  adminUpdateStatus: (id: number | string) =>
+    `${API_V2}/admin/company-applications/${id}/status`,
+} as const;
+
 // WebSocket は SSE (AI_CHAT.stream) への置換で廃止 (PR-D, 2026-05-07)。

--- a/frontend/src/hooks/useCompanyApplication.ts
+++ b/frontend/src/hooks/useCompanyApplication.ts
@@ -1,0 +1,48 @@
+import { ChangeEvent, FormEvent, useState } from 'react';
+import {
+  CompanyApplicationForm,
+  CompanyApplicationRepository,
+} from '../repositories/CompanyApplicationRepository';
+
+const EMPTY: CompanyApplicationForm = {
+  companyName: '',
+  applicantName: '',
+  email: '',
+  message: '',
+};
+
+/** useCompanyApplication は企業利用申請フォームの状態と送信を扱う。 */
+export function useCompanyApplication() {
+  const [form, setForm] = useState<CompanyApplicationForm>(EMPTY);
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!form.companyName.trim() || !form.applicantName.trim() || !form.email.trim()) {
+      setError('会社名・お名前・メールアドレスは必須です。');
+      return;
+    }
+    setLoading(true);
+    try {
+      await CompanyApplicationRepository.apply(form);
+      setSubmitted(true);
+      setForm(EMPTY);
+    } catch {
+      setError('送信に失敗しました。時間をおいて再度お試しください。');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { form, loading, submitted, error, handleChange, handleSubmit };
+}

--- a/frontend/src/hooks/useCompanyApplication.ts
+++ b/frontend/src/hooks/useCompanyApplication.ts
@@ -1,8 +1,20 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
+import axios from 'axios';
 import {
   CompanyApplicationForm,
   CompanyApplicationRepository,
 } from '../repositories/CompanyApplicationRepository';
+
+const GENERIC_ERROR = '送信に失敗しました。時間をおいて再度お試しください。';
+
+// serverErrorMessage は axios エラーから backend の {error} メッセージを取り出す（無ければ汎用文言）。
+function serverErrorMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data as { error?: string; message?: string } | undefined;
+    return data?.message || data?.error || GENERIC_ERROR;
+  }
+  return GENERIC_ERROR;
+}
 
 const EMPTY: CompanyApplicationForm = {
   companyName: '',
@@ -37,8 +49,8 @@ export function useCompanyApplication() {
       await CompanyApplicationRepository.apply(form);
       setSubmitted(true);
       setForm(EMPTY);
-    } catch {
-      setError('送信に失敗しました。時間をおいて再度お試しください。');
+    } catch (err) {
+      setError(serverErrorMessage(err));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/CompanyApplicationPage.tsx
+++ b/frontend/src/pages/CompanyApplicationPage.tsx
@@ -1,0 +1,93 @@
+import AuthLayout from '../components/AuthLayout';
+import InputField from '../components/InputField';
+import TextareaField from '../components/TextareaField';
+import PrimaryButton from '../components/PrimaryButton';
+import LinkText from '../components/LinkText';
+import { useCompanyApplication } from '../hooks/useCompanyApplication';
+import { XCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+
+/** CompanyApplicationPage は未登録の企業担当者がログイン前に出す利用申請フォーム。 */
+export default function CompanyApplicationPage() {
+  const { form, loading, submitted, error, handleChange, handleSubmit } =
+    useCompanyApplication();
+
+  return (
+    <AuthLayout
+      title="企業の利用申請"
+      footer={
+        <p className="text-sm text-[var(--color-text-muted)]">
+          すでにアカウントをお持ちの方{' '}
+          <LinkText to="/login">ログイン</LinkText>
+        </p>
+      }
+    >
+      {submitted ? (
+        <p
+          role="status"
+          className="flex items-center justify-center gap-1 text-emerald-400 text-center p-4 bg-emerald-900/30 rounded-lg font-medium"
+        >
+          <CheckCircleIcon className="w-5 h-5" aria-hidden="true" />
+          申請を受け付けました。担当者より追ってご連絡いたします。
+        </p>
+      ) : (
+        <>
+          <p className="text-sm text-[var(--color-text-muted)] mb-4">
+            FreStyle の導入をご検討の企業さまはこちらからお申し込みください。運営が内容を確認し、ご登録手続きのご案内をいたします。
+          </p>
+
+          {error && (
+            <p
+              role="alert"
+              className="flex items-center justify-center gap-1 text-rose-400 text-center mb-4 p-3 bg-rose-900/30 rounded-lg font-medium"
+            >
+              <XCircleIcon className="w-4 h-4" aria-hidden="true" />
+              {error}
+            </p>
+          )}
+
+          <form onSubmit={handleSubmit} aria-label="企業利用申請フォーム">
+            <InputField
+              label="会社名"
+              name="companyName"
+              value={form.companyName}
+              onChange={handleChange}
+              disabled={loading}
+              maxLength={200}
+            />
+            <InputField
+              label="お名前（ご担当者）"
+              name="applicantName"
+              value={form.applicantName}
+              onChange={handleChange}
+              disabled={loading}
+              maxLength={120}
+            />
+            <InputField
+              label="メールアドレス"
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={handleChange}
+              disabled={loading}
+              maxLength={255}
+            />
+            <div className="mb-4">
+              <TextareaField
+                label="メッセージ（任意）"
+                name="message"
+                value={form.message}
+                onChange={handleChange}
+                rows={4}
+                maxLength={2000}
+                placeholder="ご利用人数や導入時期など、ご要望があればご記入ください。"
+              />
+            </div>
+            <PrimaryButton type="submit" loading={loading}>
+              {loading ? '送信中...' : '申請する'}
+            </PrimaryButton>
+          </form>
+        </>
+      )}
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,7 +5,8 @@ import SNSSignInButton from '../components/SNSSignInButton';
 import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
 import { useLoginPage } from '../hooks/useLoginPage';
-import { XCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+import { Link } from 'react-router-dom';
+import { XCircleIcon, CheckCircleIcon, BuildingOffice2Icon } from '@heroicons/react/24/outline';
 
 export default function LoginPage() {
   const { form, loginMessage, flashMessage, loading, handleLogin, handleChange } = useLoginPage();
@@ -20,6 +21,15 @@ export default function LoginPage() {
         </p>
       }
     >
+      {/* 企業の利用申請（未登録の企業担当者向け） */}
+      <Link
+        to="/company-application"
+        className="flex items-center justify-center gap-2 mb-5 px-4 py-2.5 rounded-lg border border-surface-3 text-sm font-medium text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors"
+      >
+        <BuildingOffice2Icon className="w-4 h-4" aria-hidden="true" />
+        企業の方はこちら（利用申請）
+      </Link>
+
       {/* フラッシュメッセージ（成功） */}
       {flashMessage && (
         <p

--- a/frontend/src/pages/__tests__/CompanyApplicationPage.test.tsx
+++ b/frontend/src/pages/__tests__/CompanyApplicationPage.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CompanyApplicationPage from '../CompanyApplicationPage';
+
+const mockApply = vi.fn();
+
+vi.mock('../../repositories/CompanyApplicationRepository', () => ({
+  CompanyApplicationRepository: {
+    apply: (form: unknown) => mockApply(form),
+  },
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CompanyApplicationPage />
+    </MemoryRouter>,
+  );
+}
+
+function fillRequired() {
+  fireEvent.change(screen.getByLabelText('会社名'), {
+    target: { value: 'Example Corp' },
+  });
+  fireEvent.change(screen.getByLabelText('お名前（ご担当者）'), {
+    target: { value: '山田太郎' },
+  });
+  fireEvent.change(screen.getByLabelText('メールアドレス'), {
+    target: { value: 'yamada@example.com' },
+  });
+}
+
+describe('CompanyApplicationPage', () => {
+  beforeEach(() => {
+    mockApply.mockReset();
+  });
+
+  it('フォーム項目が表示される', () => {
+    renderPage();
+    expect(screen.getByLabelText('会社名')).toBeInTheDocument();
+    expect(screen.getByLabelText('お名前（ご担当者）')).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '申請する' })).toBeInTheDocument();
+  });
+
+  it('必須項目を入力して送信すると repository.apply が呼ばれ、成功表示になる', async () => {
+    mockApply.mockResolvedValueOnce(undefined);
+    renderPage();
+    fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: '申請する' }));
+
+    await waitFor(() => {
+      expect(mockApply).toHaveBeenCalledWith({
+        companyName: 'Example Corp',
+        applicantName: '山田太郎',
+        email: 'yamada@example.com',
+        message: '',
+      });
+    });
+    expect(
+      await screen.findByText(/申請を受け付けました/),
+    ).toBeInTheDocument();
+  });
+
+  it('必須が空のまま送信するとバリデーションエラーを出し、送信しない', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '申請する' }));
+    expect(
+      await screen.findByText(/会社名・お名前・メールアドレスは必須です/),
+    ).toBeInTheDocument();
+    expect(mockApply).not.toHaveBeenCalled();
+  });
+
+  it('送信が失敗するとエラーメッセージを表示する', async () => {
+    mockApply.mockRejectedValueOnce(new Error('network'));
+    renderPage();
+    fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: '申請する' }));
+    expect(await screen.findByText(/送信に失敗しました/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/CompanyApplicationPage.test.tsx
+++ b/frontend/src/pages/__tests__/CompanyApplicationPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { AxiosError } from 'axios';
 import CompanyApplicationPage from '../CompanyApplicationPage';
 
 const mockApply = vi.fn();
@@ -72,11 +73,29 @@ describe('CompanyApplicationPage', () => {
     expect(mockApply).not.toHaveBeenCalled();
   });
 
-  it('送信が失敗するとエラーメッセージを表示する', async () => {
+  it('送信が失敗すると汎用エラーメッセージを表示する', async () => {
     mockApply.mockRejectedValueOnce(new Error('network'));
     renderPage();
     fillRequired();
     fireEvent.click(screen.getByRole('button', { name: '申請する' }));
     expect(await screen.findByText(/送信に失敗しました/)).toBeInTheDocument();
+  });
+
+  it('サーバーがエラーメッセージを返したらそれを表示する', async () => {
+    mockApply.mockRejectedValueOnce(
+      new AxiosError(
+        'Too Many Requests',
+        '429',
+        undefined,
+        undefined,
+        { data: { error: 'リクエストが多すぎます。しばらくお待ちください。' } } as never,
+      ),
+    );
+    renderPage();
+    fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: '申請する' }));
+    expect(
+      await screen.findByText(/リクエストが多すぎます/),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/repositories/CompanyApplicationRepository.ts
+++ b/frontend/src/repositories/CompanyApplicationRepository.ts
@@ -1,0 +1,17 @@
+import apiClient from '../lib/axios';
+import { COMPANY_APPLICATIONS } from '../constants/apiRoutes';
+
+/** 企業利用申請フォームの送信内容（公開・認証不要）。 */
+export interface CompanyApplicationForm {
+  companyName: string;
+  applicantName: string;
+  email: string;
+  message: string;
+}
+
+export const CompanyApplicationRepository = {
+  /** 企業利用申請を送信する。認証不要。 */
+  async apply(form: CompanyApplicationForm): Promise<void> {
+    await apiClient.post(COMPANY_APPLICATIONS.create, form);
+  },
+};


### PR DESCRIPTION
## 概要

未登録の企業担当者がログイン画面から**利用申請**を出せるようにする。ログイン画面の上部に「企業の方はこちら（利用申請）」ボタンを追加し、公開の申請フォーム画面を新設する。バックエンドは #1740。

申請が送信されると backend が super_admin に通知を作成し、super_admin は既存の通知 UI / 一覧で確認できる。

## 変更内容（コミット単位）

1. **データ層**: `apiRoutes` に `COMPANY_APPLICATIONS` / `CompanyApplicationRepository.apply`（認証不要 POST）/ `useCompanyApplication`（フォーム状態・必須検証・送信）
2. **UI**: ログイン画面に申請ボタン / `CompanyApplicationPage`（会社名・お名前・メール・任意メッセージ）/ 公開ルート `/company-application` / vitest テスト

## 画面

- `/login`: 上部に「企業の方はこちら（利用申請）」ボタン（新規登録・パスワード忘れに加えて）
- `/company-application`: 公開フォーム。送信成功で「申請を受け付けました。担当者より追ってご連絡いたします。」を表示

## テスト

- `tsc --noEmit` / `vitest run`（CompanyApplicationPage 4 + LoginPage 4）/ `eslint --max-warnings 0` / `npm run build` すべて pass

## 関連
- バックエンド: #1740（公開 POST + super_admin 通知 + 一覧）
- デプロイ順: backend(#1740) を先にデプロイしてからフロントを反映