### PR TITLE
feat(security): 公開エンドポイントにレートリミットを適用

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -90,6 +90,21 @@ go test ./...
 - ロググループ `/ecs/frestyle-prod` は CFn 側で retention 14 日。Container Insights は
   コスト削減のため無効（詳細は frestyle-infrastructure の `docs/06-maintenance-cookbook.md` §15）。
 
+## レートリミット（公開エンドポイント）
+
+`middleware.RateLimitPerMinute(perMinute, burst)`（per-IP トークンバケット）を公開ルートに適用する。
+
+| エンドポイント | 制限 | 目的 |
+|---|---|---|
+| `POST /company-applications` | 5/分・burst 5 | 公開フォームのスパム対策 |
+| `GET /invitations/accept/:token` | 30/分・burst 10 | 招待 token の総当たり緩和 |
+| `POST /auth/cognito/callback` | 30/分・burst 10 | コールバック総当たり緩和 |
+| `POST /auth/cognito/refresh-token` | 60/分・burst 30 | 正規利用は高頻度なので緩め（NAT 共有 IP 考慮） |
+
+- 超過時は `429 Too Many Requests` + `Retry-After: 60`。
+- **単一 ECS タスク前提の in-memory 実装**。スケールアウト時はインスタンスごとに別カウントになるため共有ストア（Redis 等）が必要。
+- キーは `c.ClientIP()`（ALB / CloudFront の X-Forwarded-For 由来）。詐称を完全には防げないため、軽い総当たり / スパムの緩和が目的。
+
 ## デプロイ方針（後続 Phase で確立）
 
 - ALB の path-based routing で `/api/v2/*` を Go ECS Service に振り、

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -804,6 +804,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
+                    "429": {
+                        "description": "レート制限超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Cognito 未 設定 等 の 内部 エラー",
                         "schema": {
@@ -858,6 +864,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "refresh_token 欠落 / 無効",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -998,6 +1010,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "バリデーションエラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -1689,6 +1707,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "招待 が 無効 / 期限 切れ",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -808,6 +808,12 @@ const docTemplate = `{
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "500": {
@@ -872,6 +878,12 @@ const docTemplate = `{
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "502": {
@@ -1018,6 +1030,12 @@ const docTemplate = `{
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "500": {
@@ -1715,6 +1733,12 @@ const docTemplate = `{
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "500": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -797,6 +797,12 @@
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
+                    "429": {
+                        "description": "レート制限超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Cognito 未 設定 等 の 内部 エラー",
                         "schema": {
@@ -851,6 +857,12 @@
                     },
                     "401": {
                         "description": "refresh_token 欠落 / 無効",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -991,6 +1003,12 @@
                     },
                     "400": {
                         "description": "バリデーションエラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -1682,6 +1700,12 @@
                     },
                     "404": {
                         "description": "招待 が 無効 / 期限 切れ",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -801,6 +801,12 @@
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "500": {
@@ -865,6 +871,12 @@
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "502": {
@@ -1011,6 +1023,12 @@
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "500": {
@@ -1708,6 +1726,12 @@
                         "description": "レート制限超過",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
                         }
                     },
                     "500": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1304,6 +1304,10 @@ paths:
             $ref: '#/definitions/internal_handler.errorResponse'
         "429":
           description: レート制限超過
+          headers:
+            Retry-After:
+              description: '再試行までの秒数 (例: 60)'
+              type: string
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":
@@ -1348,6 +1352,10 @@ paths:
             $ref: '#/definitions/internal_handler.errorResponse'
         "429":
           description: レート制限超過
+          headers:
+            Retry-After:
+              description: '再試行までの秒数 (例: 60)'
+              type: string
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "502":
@@ -1443,6 +1451,10 @@ paths:
             $ref: '#/definitions/internal_handler.errorResponse'
         "429":
           description: レート制限超過
+          headers:
+            Retry-After:
+              description: '再試行までの秒数 (例: 60)'
+              type: string
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":
@@ -1894,6 +1906,10 @@ paths:
             $ref: '#/definitions/internal_handler.errorResponse'
         "429":
           description: レート制限超過
+          headers:
+            Retry-After:
+              description: '再試行までの秒数 (例: 60)'
+              type: string
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1302,6 +1302,10 @@ paths:
           description: 招待 なし の 新規 user
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
+        "429":
+          description: レート制限超過
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
         "500":
           description: Cognito 未 設定 等 の 内部 エラー
           schema:
@@ -1340,6 +1344,10 @@ paths:
             $ref: '#/definitions/internal_handler.messageResponse'
         "401":
           description: refresh_token 欠落 / 無効
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "429":
+          description: レート制限超過
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "502":
@@ -1431,6 +1439,10 @@ paths:
             $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication'
         "400":
           description: バリデーションエラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "429":
+          description: レート制限超過
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":
@@ -1878,6 +1890,10 @@ paths:
             $ref: '#/definitions/internal_handler.invitationValidateResponse'
         "404":
           description: 招待 が 無効 / 期限 切れ
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "429":
+          description: レート制限超過
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -149,6 +149,7 @@ type cognitoCallbackReq struct {
 //	@Failure      403   {object}  errorResponse  "招待 なし の 新規 user"
 //	@Failure      500   {object}  errorResponse  "Cognito 未 設定 等 の 内部 エラー"
 //	@Failure      502   {object}  errorResponse  "Cognito 到達 不可"
+//	@Failure      429   {object}  errorResponse  "レート制限超過"
 //	@Router       /auth/cognito/callback [post]
 func (h *AuthHandler) Callback(c *gin.Context) {
 	var req cognitoCallbackReq
@@ -193,6 +194,7 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 //	@Success      200  {object}  messageResponse
 //	@Failure      401  {object}  errorResponse  "refresh_token 欠落 / 無効"
 //	@Failure      502  {object}  errorResponse  "Cognito 到達 不可"
+//	@Failure      429   {object}  errorResponse  "レート制限超過"
 //	@Router       /auth/cognito/refresh-token [post]
 func (h *AuthHandler) Refresh(c *gin.Context) {
 	rt, err := c.Cookie(middleware.CookieRefreshToken)

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -150,6 +150,7 @@ type cognitoCallbackReq struct {
 //	@Failure      500   {object}  errorResponse  "Cognito 未 設定 等 の 内部 エラー"
 //	@Failure      502   {object}  errorResponse  "Cognito 到達 不可"
 //	@Failure      429   {object}  errorResponse  "レート制限超過"
+//	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
 //	@Router       /auth/cognito/callback [post]
 func (h *AuthHandler) Callback(c *gin.Context) {
 	var req cognitoCallbackReq
@@ -195,6 +196,7 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 //	@Failure      401  {object}  errorResponse  "refresh_token 欠落 / 無効"
 //	@Failure      502  {object}  errorResponse  "Cognito 到達 不可"
 //	@Failure      429   {object}  errorResponse  "レート制限超過"
+//	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
 //	@Router       /auth/cognito/refresh-token [post]
 func (h *AuthHandler) Refresh(c *gin.Context) {
 	rt, err := c.Cookie(middleware.CookieRefreshToken)

--- a/backend/internal/handler/company_application_handler.go
+++ b/backend/internal/handler/company_application_handler.go
@@ -43,6 +43,7 @@ type createCompanyApplicationReq struct {
 //	@Param        body  body      createCompanyApplicationReq  true  "申請内容"
 //	@Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication
 //	@Failure      400   {object}  errorResponse  "バリデーションエラー"
+//	@Failure      429   {object}  errorResponse  "レート制限超過"
 //	@Failure      500   {object}  errorResponse  "内部エラー"
 //	@Router       /company-applications [post]
 func (h *CompanyApplicationHandler) Create(c *gin.Context) {

--- a/backend/internal/handler/company_application_handler.go
+++ b/backend/internal/handler/company_application_handler.go
@@ -44,6 +44,7 @@ type createCompanyApplicationReq struct {
 //	@Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication
 //	@Failure      400   {object}  errorResponse  "バリデーションエラー"
 //	@Failure      429   {object}  errorResponse  "レート制限超過"
+//	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
 //	@Failure      500   {object}  errorResponse  "内部エラー"
 //	@Router       /company-applications [post]
 func (h *CompanyApplicationHandler) Create(c *gin.Context) {

--- a/backend/internal/handler/middleware/rate_limit.go
+++ b/backend/internal/handler/middleware/rate_limit.go
@@ -1,0 +1,98 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// rlBucket は 1 クライアント分のトークンバケット状態。
+type rlBucket struct {
+	tokens float64
+	last   time.Time
+}
+
+// ipRateLimiter は IP ごとのトークンバケットで流量を制限する。
+//
+// 単一 ECS タスク (desiredCount=1) 前提の in-memory 実装。スケールアウトしたら
+// インスタンスごとに別カウントになるため、その際は共有ストア (Redis 等) が必要。
+// キーは gin の ClientIP()。ALB / CloudFront 経由の X-Forwarded-For を信用するため
+// 厳密な詐称防止にはならない（フォームスパムや軽い総当たりの緩和が目的）。
+type ipRateLimiter struct {
+	mu          sync.Mutex
+	buckets     map[string]*rlBucket
+	rate        float64 // 毎秒の補充トークン数
+	burst       float64 // バケット上限
+	idleTTL     time.Duration
+	lastCleanup time.Time
+	now         func() time.Time // テスト差し替え用
+}
+
+func newIPRateLimiter(perMinute float64, burst int) *ipRateLimiter {
+	return &ipRateLimiter{
+		buckets:     map[string]*rlBucket{},
+		rate:        perMinute / 60.0,
+		burst:       float64(burst),
+		idleTTL:     10 * time.Minute,
+		lastCleanup: time.Now(),
+		now:         time.Now,
+	}
+}
+
+// allow は key の 1 リクエスト分のトークンを消費できれば true を返す。
+func (l *ipRateLimiter) allow(key string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	l.cleanupLocked(now)
+
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &rlBucket{tokens: l.burst, last: now}
+		l.buckets[key] = b
+	}
+	// 経過時間ぶんトークンを補充する。
+	b.tokens += now.Sub(b.last).Seconds() * l.rate
+	if b.tokens > l.burst {
+		b.tokens = l.burst
+	}
+	b.last = now
+
+	if b.tokens >= 1 {
+		b.tokens--
+		return true
+	}
+	return false
+}
+
+// cleanupLocked は idleTTL を超えて使われていないバケットを掃除する（メモリ肥大化防止）。
+func (l *ipRateLimiter) cleanupLocked(now time.Time) {
+	if now.Sub(l.lastCleanup) < l.idleTTL {
+		return
+	}
+	for k, b := range l.buckets {
+		if now.Sub(b.last) > l.idleTTL {
+			delete(l.buckets, k)
+		}
+	}
+	l.lastCleanup = now
+}
+
+// RateLimitPerMinute は IP あたり perMinute 回（短期 burst まで許容）に制限する middleware を返す。
+// 超過時は 429 + Retry-After を返す。各呼び出しが独立した limiter を持つ。
+func RateLimitPerMinute(perMinute float64, burst int) gin.HandlerFunc {
+	limiter := newIPRateLimiter(perMinute, burst)
+	return func(c *gin.Context) {
+		if !limiter.allow(c.ClientIP()) {
+			c.Header("Retry-After", "60")
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error":   "rate_limited",
+				"message": "リクエストが多すぎます。しばらく時間をおいて再度お試しください。",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/handler/middleware/rate_limit_test.go
+++ b/backend/internal/handler/middleware/rate_limit_test.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestIPRateLimiter_BurstThenDeny(t *testing.T) {
+	l := newIPRateLimiter(60, 3) // 3 burst
+	for i := 0; i < 3; i++ {
+		if !l.allow("1.2.3.4") {
+			t.Fatalf("request %d should be allowed within burst", i+1)
+		}
+	}
+	if l.allow("1.2.3.4") {
+		t.Fatal("4th request should be denied after burst is exhausted")
+	}
+}
+
+func TestIPRateLimiter_PerKeyIndependent(t *testing.T) {
+	l := newIPRateLimiter(60, 1)
+	if !l.allow("a") || !l.allow("b") {
+		t.Fatal("different IPs should have independent buckets")
+	}
+	if l.allow("a") {
+		t.Fatal("same IP should be limited after its own burst")
+	}
+}
+
+func TestIPRateLimiter_RefillsOverTime(t *testing.T) {
+	cur := time.Now()
+	l := newIPRateLimiter(60, 1) // 1 token/sec
+	l.now = func() time.Time { return cur }
+
+	if !l.allow("ip") {
+		t.Fatal("first request should pass")
+	}
+	if l.allow("ip") {
+		t.Fatal("immediate second request should be denied")
+	}
+	// 1 秒経過させると 1 トークン補充される。
+	cur = cur.Add(1100 * time.Millisecond)
+	if !l.allow("ip") {
+		t.Fatal("request after refill window should pass")
+	}
+}
+
+func TestRateLimitPerMinute_Returns429(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/x", RateLimitPerMinute(60, 2), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	codes := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/x", nil)
+		req.RemoteAddr = "9.9.9.9:1234"
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		codes = append(codes, w.Code)
+	}
+	if codes[0] != http.StatusOK || codes[1] != http.StatusOK {
+		t.Fatalf("first 2 should be 200, got %v", codes)
+	}
+	if codes[2] != http.StatusTooManyRequests {
+		t.Fatalf("3rd should be 429, got %d", codes[2])
+	}
+}

--- a/backend/internal/handler/public_invitation_handler.go
+++ b/backend/internal/handler/public_invitation_handler.go
@@ -35,6 +35,7 @@ func NewPublicInvitationHandler(v *usecase.ValidateInvitationTokenUseCase) *Publ
 //	@Success      200    {object}  invitationValidateResponse
 //	@Failure      404    {object}  errorResponse  "招待 が 無効 / 期限 切れ"
 //	@Failure      500    {object}  errorResponse  "内部 エラー"
+//	@Failure      429    {object}  errorResponse  "レート制限超過"
 //	@Router       /invitations/accept/{token} [get]
 func (h *PublicInvitationHandler) Validate(c *gin.Context) {
 	token := c.Param("token")

--- a/backend/internal/handler/public_invitation_handler.go
+++ b/backend/internal/handler/public_invitation_handler.go
@@ -36,6 +36,7 @@ func NewPublicInvitationHandler(v *usecase.ValidateInvitationTokenUseCase) *Publ
 //	@Failure      404    {object}  errorResponse  "招待 が 無効 / 期限 切れ"
 //	@Failure      500    {object}  errorResponse  "内部 エラー"
 //	@Failure      429    {object}  errorResponse  "レート制限超過"
+//	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
 //	@Router       /invitations/accept/{token} [get]
 func (h *PublicInvitationHandler) Validate(c *gin.Context) {
 	token := c.Param("token")

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -16,10 +17,10 @@ func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler 
 	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito)
 
 	g.POST("/auth/cognito/logout", authHandler.Logout)
-	// callback は code を受け取って token に交換するので認証不要
-	g.POST("/auth/cognito/callback", authHandler.Callback)
-	// refresh-token は HttpOnly Cookie の refresh_token を読むため認証 middleware の対象外
-	g.POST("/auth/cognito/refresh-token", authHandler.Refresh)
+	// callback は code を受け取って token に交換するので認証不要。総当たり緩和に per-IP 制限を掛ける。
+	g.POST("/auth/cognito/callback", middleware.RateLimitPerMinute(30, 10), authHandler.Callback)
+	// refresh-token は正規ユーザーが定期的に叩くため、NAT 共有 IP を考慮して緩めに設定する。
+	g.POST("/auth/cognito/refresh-token", middleware.RateLimitPerMinute(60, 30), authHandler.Refresh)
 
 	return authHandler
 }

--- a/backend/internal/handler/routes_company_application.go
+++ b/backend/internal/handler/routes_company_application.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -18,8 +19,9 @@ func newCompanyApplicationHandler(deps *routeDeps) *CompanyApplicationHandler {
 }
 
 // registerCompanyApplicationPublicRoutes は認証不要の企業申請作成を登録する。
+// 公開フォームのスパム対策として per-IP レートリミット（5 回/分、burst 5）を掛ける。
 func registerCompanyApplicationPublicRoutes(g *gin.RouterGroup, h *CompanyApplicationHandler) {
-	g.POST("/company-applications", h.Create)
+	g.POST("/company-applications", middleware.RateLimitPerMinute(5, 5), h.Create)
 }
 
 // registerCompanyApplicationAdminRoutes は super_admin 用の一覧 / status 更新を登録する（認可は handler 層）。

--- a/backend/internal/handler/routes_invitation_public.go
+++ b/backend/internal/handler/routes_invitation_public.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -16,5 +17,6 @@ func registerInvitationPublicRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	invRepo := persistence.NewAdminInvitationRepository(deps.db)
 	companies := persistence.NewCompanyRepository(deps.db)
 	h := NewPublicInvitationHandler(usecase.NewValidateInvitationTokenUseCase(invRepo, companies))
-	g.GET("/invitations/accept/:token", h.Validate)
+	// token 総当たり（招待 token の列挙）を緩和するため per-IP レートリミットを掛ける。
+	g.GET("/invitations/accept/:token", middleware.RateLimitPerMinute(30, 10), h.Validate)
 }


### PR DESCRIPTION
## 概要

本番懸念の High 項目だった「公開エンドポイントにレートリミットが無い」を解消する。per-IP トークンバケットの middleware を追加し、認証不要の公開ルートに適用する。

## 変更内容（コミット単位）

1. **middleware 追加**: `RateLimitPerMinute(perMinute, burst)`（per-IP トークンバケット、in-memory、idleTTL でバケット掃除、超過時 429 + Retry-After）+ 単体テスト（burst→拒否 / IP 独立 / 時間補充 / middleware 429）
2. **公開ルートへ適用** + swaggo 429 追記 + README:

| エンドポイント | 制限 | 目的 |
|---|---|---|
| `POST /company-applications` | 5/分・burst 5 | フォームスパム |
| `GET /invitations/accept/:token` | 30/分・burst 10 | 招待 token 総当たり |
| `POST /auth/cognito/callback` | 30/分・burst 10 | コールバック総当たり |
| `POST /auth/cognito/refresh-token` | 60/分・burst 30 | 正規利用は高頻度なので緩め（NAT 共有 IP 考慮） |

## 設計と限界

- **単一 ECS タスク（desiredCount=1）前提の in-memory 実装**。スケールアウト時はインスタンス毎カウントになるため共有ストア（Redis 等）が必要 → README に明記
- キーは `c.ClientIP()`（ALB / CloudFront の X-Forwarded-For 由来）。詐称を完全には防げず、軽い総当たり / スパムの緩和が目的
- `refresh-token` は正規ユーザーが定期的に叩くため、NAT 共有 IP を考慮して緩めに設定（ロックアウト回避）
- health（ALB が 30 秒毎に叩く）には**適用しない**

## テスト

- `go build ./...` / `go test ./...` / `go vet ./...` pass / `make openapi` 再生成

## フォローアップ
- 認証必須だが高コストな `POST /code/execute` の per-user 制限（別 PR 候補）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - 公開APIエンドポイントにレート制限を導入。Cognito認証フロー、企業申請作成、招待受諾エンドポイントに対してクライアントIPベースの制限を適用し、過度なリクエストに対しHTTP 429レスポンスを返すように対応しました。

* **ドキュメント**
  - APIドキュメント（README、Swagger/OpenAPI仕様）をレート制限ポリシーおよびレスポンス定義に対応。

* **テスト**
  - レート制限機能の動作検証テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->