### PR TITLE
feat: クリーンアーキテクチャ依存方向 linter (archlint) を追加

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -64,6 +64,11 @@ jobs:
           go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
           staticcheck ./...
 
+      # クリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を検証する自作 linter。
+      # handler→usecase→repository/infra→domain の矢印に反する import を CI で弾く。
+      - name: archlint (clean architecture deps)
+        run: go run ./cmd/archlint .
+
       # govulncheck は Go 公式の脆弱性スキャナ。実際に呼んでいるコードパスに該当する
       # 既知 CVE だけを報告する。stdlib の CVE は Go パッチ追随次第で頻出するため、
       # CI を止めずに「可視化」目的の非ブロッキング（continue-on-error）にする。

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,7 +2,8 @@
 #
 # 主要 target:
 #   make openapi      … swag init で OpenAPI spec を 再 生成 (docs/swagger.{json,yaml})
-#   make verify       … go build / vet / test を 一括 実行
+#   make verify       … gofmt / vet / build / test / archlint を 一括 実行
+#   make archlint     … クリーンアーキテクチャ依存方向ルール (CLAUDE.md §2) を 静的 検証
 #   make run          … go run ./cmd/server で ローカル サーバ 起動
 #
 # swag CLI が PATH に なければ `go install github.com/swaggo/swag/cmd/swag@v1.16.4` を 自動 実行 する。
@@ -36,6 +37,13 @@ verify:
 	go vet ./...
 	go build ./...
 	go test ./...
+	$(MAKE) archlint
+
+# クリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を静的に検証する。
+.PHONY: archlint
+archlint:
+	@echo ">>> archlint: クリーンアーキテクチャ依存方向チェック"
+	@go run ./cmd/archlint .
 
 .PHONY: run
 run:

--- a/backend/README.md
+++ b/backend/README.md
@@ -32,6 +32,29 @@ handler  →  usecase  →  repository  →  domain
 - repository は usecase のことを知らない
 - domain は他のどの層にも依存しない
 
+### archlint — 依存方向の静的検証
+
+上記ルールを人手のレビューだけに頼らず CI で機械的に弾くため、自作 linter `cmd/archlint` を用意している（`go/ast` のみ・外部依存なし）。
+
+```bash
+make archlint        # = go run ./cmd/archlint .
+```
+
+各 `.go`（`_test.go` は除外）の import を解析し、層をまたぐ禁止依存を検出する。違反は `path:line: メッセージ` 形式で出力し exit 1。
+
+| ソース層 | 禁止する import |
+|---|---|
+| `domain` | 他の内部層すべて / `gin` / `net/http`（標準ライブラリ + GORM tag のみ） |
+| `usecase/repository`（port） | `domain` 以外の内部層 / `gin` / `net/http` |
+| `usecase` | `handler` / `adapter/persistence`（DIP: port に依存）/ `gin` / `net/http` |
+| `adapter/persistence` | `handler` / `usecase` 本体（依存先は port のみ）/ `gin` |
+| `infra` | `handler` / `usecase` / `usecase/repository` / `adapter/persistence` / `gin` |
+| `handler` | `adapter/persistence` の直接 import（**wiring の `router.go` / `routes_*.go` は例外**） |
+
+- `usecase → infra`、`infra → net/http`（HTTP クライアント用途）、`handler → infra`（auth / embed の pragmatic 例外）は **許容**。
+- 意図的に例外を通したいときは、import 行末に `//archlint:allow <理由>`、ファイル全体なら先頭コメントに `//archlint:ignore-file <理由>` を付ける。
+- ルールを追加・変更したら `cmd/archlint/main.go` の `rules` を編集し、`cmd/archlint/main_test.go` にケースを足す。
+
 ## ローカル開発
 
 ```bash
@@ -77,6 +100,8 @@ docker build -t frestyle-backend:latest .
 ```bash
 go vet ./...
 go test ./...
+make archlint   # クリーンアーキテクチャ依存方向チェック
+make verify     # gofmt / vet / build / test / archlint を一括実行
 ```
 
 ## ログ方針（CloudWatch コスト対策）

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,13 +34,13 @@ handler  →  usecase  →  repository  →  domain
 
 ### archlint — 依存方向の静的検証
 
-上記ルールを人手のレビューだけに頼らず CI で機械的に弾くため、自作 linter `cmd/archlint` を用意している（`go/ast` のみ・外部依存なし）。
+上記ルールを人手のレビューだけに頼らず CI で機械的に弾くため、自作 linter `cmd/archlint` を用意している（Go 標準の `go/parser` / `go/ast` のみ・外部依存なし）。
 
 ```bash
 make archlint        # = go run ./cmd/archlint .
 ```
 
-各 `.go`（`_test.go` は除外）の import を解析し、層をまたぐ禁止依存を検出する。違反は `path:line: メッセージ` 形式で出力し exit 1。
+`internal/` 配下の `.go`（`_test.go` は除外）の import を解析し、層をまたぐ禁止依存を検出する。違反は `path:line: メッセージ` 形式で出力し exit 1。
 
 | ソース層 | 禁止する import |
 |---|---|

--- a/backend/cmd/archlint/main.go
+++ b/backend/cmd/archlint/main.go
@@ -1,0 +1,312 @@
+// Command archlint は FreStyle のクリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を
+// 静的に検証する。go/parser で各ファイルの import を解析し、層をまたぐ禁止依存を検出する。
+//
+// 依存方向: handler → usecase → repository(port) / infra → domain
+// （実装は adapter/persistence、port は usecase/repository に分離）
+//
+// 使い方:
+//
+//	go run ./cmd/archlint           # backend/ 直下で実行（カレントを module root とみなす）
+//	go run ./cmd/archlint <root>    # 別ディレクトリを指定
+//
+// 違反があれば `path:line: メッセージ` 形式で出力し exit code 1 を返す。CI の品質ゲートに組み込む。
+//
+// 抑制:
+//   - import 行末に `//archlint:allow` を付けるとその 1 行を無視する
+//   - ファイル先頭コメントに `//archlint:ignore-file` を含めるとそのファイル全体を無視する
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// 層・依存先の分類キー。import path / ファイルパスの両方をこの値に正規化して照合する。
+const (
+	layerDomain      = "domain"
+	layerUsecase     = "usecase"
+	layerUsecaseRepo = "usecase/repository"
+	layerHandler     = "handler"
+	layerPersistence = "adapter/persistence"
+	layerInfra       = "infra"
+
+	targetGin     = "gin"
+	targetNetHTTP = "net/http"
+)
+
+// rules は「ソース層 → 禁止する依存先 → 違反メッセージ」。ここに無い組み合わせは許容。
+// handler→persistence だけは wiring ファイル（router.go / routes_*.go）で例外扱いする（§2.6）。
+var rules = map[string]map[string]string{
+	layerDomain: {
+		layerHandler:     "domain は handler を import できません（domain は他層に依存しない）",
+		layerUsecase:     "domain は usecase を import できません（domain は他層に依存しない）",
+		layerUsecaseRepo: "domain は usecase/repository を import できません（domain は他層に依存しない）",
+		layerPersistence: "domain は adapter/persistence を import できません（domain は他層に依存しない）",
+		layerInfra:       "domain は infra を import できません（domain は他層に依存しない）",
+		targetGin:        "domain は gin を import できません（domain は標準ライブラリ + GORM tag のみ）",
+		targetNetHTTP:    "domain は net/http を import できません（domain は標準ライブラリ + GORM tag のみ）",
+	},
+	layerUsecaseRepo: {
+		layerHandler:     "usecase/repository(port) は handler を import できません",
+		layerUsecase:     "usecase/repository(port) は usecase 本体を import できません（port は domain のみに依存）",
+		layerPersistence: "usecase/repository(port) は adapter/persistence を import できません（DIP 違反）",
+		layerInfra:       "usecase/repository(port) は infra を import できません",
+		targetGin:        "usecase/repository(port) は gin を import できません",
+		targetNetHTTP:    "usecase/repository(port) は net/http を import できません",
+	},
+	layerUsecase: {
+		layerHandler:     "usecase は handler を import できません（依存方向違反）",
+		layerPersistence: "usecase は adapter/persistence を import できません（repository interface に依存すること: DIP）",
+		targetGin:        "usecase は gin を import できません（*gin.Context など HTTP 層の型を参照しない）",
+		targetNetHTTP:    "usecase は net/http を import できません（HTTP 層の型を参照しない）",
+	},
+	layerPersistence: {
+		layerHandler: "adapter/persistence は handler を import できません",
+		layerUsecase: "adapter/persistence は usecase 本体を import できません（依存先は port = usecase/repository だけ）",
+		targetGin:    "adapter/persistence は gin を import できません",
+	},
+	layerInfra: {
+		layerHandler:     "infra は handler を import できません（infra は usecase / handler を参照しない）",
+		layerUsecase:     "infra は usecase を import できません（infra は usecase / handler を参照しない）",
+		layerUsecaseRepo: "infra は usecase/repository を import できません",
+		layerPersistence: "infra は adapter/persistence を import できません",
+		targetGin:        "infra は gin を import できません",
+	},
+	layerHandler: {
+		layerPersistence: "handler は adapter/persistence を直接 import できません（usecase 経由にする。wiring は router.go / routes_*.go に限定）",
+	},
+}
+
+// violation は 1 件の依存方向違反。
+type violation struct {
+	file string
+	line int
+	imp  string
+	msg  string
+}
+
+// importRef は解析済みの 1 つの import。
+type importRef struct {
+	path       string
+	line       int
+	target     string // 分類済みの依存先キー（rules の照合に使う）
+	suppressed bool   // //archlint:allow が付いていれば true
+}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// runCLI は CLI 本体。exit code を返す（0=OK / 1=違反あり / 2=実行エラー）。
+// os.Exit を呼ばないことで end-to-end テストを可能にする。
+func runCLI(args []string, stdout, stderr io.Writer) int {
+	root := "."
+	if len(args) > 0 {
+		root = args[0]
+	}
+
+	modulePath, err := readModulePath(filepath.Join(root, "go.mod"))
+	if err != nil {
+		fmt.Fprintf(stderr, "archlint: go.mod を読めません: %v\n", err)
+		return 2
+	}
+	internalPrefix := modulePath + "/internal/"
+	internalRoot := filepath.Join(root, "internal")
+
+	violations, err := run(internalRoot, internalPrefix)
+	if err != nil {
+		fmt.Fprintf(stderr, "archlint: %v\n", err)
+		return 2
+	}
+
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "archlint: OK — クリーンアーキテクチャ依存方向ルール違反なし")
+		return 0
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].file != violations[j].file {
+			return violations[i].file < violations[j].file
+		}
+		return violations[i].line < violations[j].line
+	})
+	for _, v := range violations {
+		fmt.Fprintf(stdout, "%s:%d: %s（import %q）\n", v.file, v.line, v.msg, v.imp)
+	}
+	fmt.Fprintf(stderr, "\narchlint: %d 件の依存方向違反が見つかりました\n", len(violations))
+	return 1
+}
+
+// run は internalRoot 配下の本番 .go を走査し、依存方向違反を集める。
+func run(internalRoot, internalPrefix string) ([]violation, error) {
+	var out []violation
+	err := filepath.WalkDir(internalRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		relDir, err := filepath.Rel(internalRoot, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		src := classifyRel(filepath.ToSlash(relDir))
+		if _, ok := rules[src]; !ok {
+			return nil // ルール対象外の層（cmd 等）はスキップ
+		}
+
+		imports, ignoreFile, err := parseImports(path, internalPrefix)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		if ignoreFile {
+			return nil
+		}
+		out = append(out, violationsFor(src, filepath.Base(path), path, imports)...)
+		return nil
+	})
+	return out, err
+}
+
+// violationsFor は 1 ファイル分の import 列からルール違反を抽出する（純粋関数: テスト容易）。
+func violationsFor(src, filename, fullpath string, imports []importRef) []violation {
+	forbidden := rules[src]
+	wiring := isWiringFile(filename)
+	var vs []violation
+	for _, imp := range imports {
+		if imp.suppressed || imp.target == "" {
+			continue
+		}
+		// handler→persistence は wiring ファイルでのみ許容。
+		if src == layerHandler && imp.target == layerPersistence && wiring {
+			continue
+		}
+		if msg, bad := forbidden[imp.target]; bad {
+			vs = append(vs, violation{file: fullpath, line: imp.line, imp: imp.path, msg: msg})
+		}
+	}
+	return vs
+}
+
+// parseImports は import 文だけを解析し、各 import を分類して返す。
+// ファイル先頭コメントに archlint:ignore-file があれば ignoreFile=true。
+func parseImports(path, internalPrefix string) (imports []importRef, ignoreFile bool, err error) {
+	fset := token.NewFileSet()
+	// ImportsOnly は import の trailing コメント関連付けを欠落させるため使わない（抑制判定に必要）。
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		return nil, false, err
+	}
+
+	for _, cg := range f.Comments {
+		if commentContains(cg, "archlint:ignore-file") {
+			return nil, true, nil
+		}
+	}
+
+	for _, spec := range f.Imports {
+		p := strings.Trim(spec.Path.Value, `"`)
+		ref := importRef{
+			path:   p,
+			line:   fset.Position(spec.Path.Pos()).Line,
+			target: classifyImport(p, internalPrefix),
+		}
+		if commentHasAllow(spec.Comment) || commentHasAllow(spec.Doc) {
+			ref.suppressed = true
+		}
+		imports = append(imports, ref)
+	}
+	return imports, false, nil
+}
+
+// commentHasAllow は import に付いた抑制コメント //archlint:allow の有無を返す。
+func commentHasAllow(cg *ast.CommentGroup) bool {
+	return commentContains(cg, "archlint:allow")
+}
+
+// commentContains はコメント群の「生テキスト」に needle が含まれるかを返す。
+// CommentGroup.Text() は //archlint:xxx を go ディレクティブ扱いで除去するため、
+// 各 Comment.Text（// を含む生文字列）を直接走査する。
+func commentContains(cg *ast.CommentGroup, needle string) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if strings.Contains(c.Text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyImport は import path を rules 照合用キーに正規化する。対象外は "" を返す。
+func classifyImport(importPath, internalPrefix string) string {
+	if importPath == targetNetHTTP {
+		return targetNetHTTP
+	}
+	if importPath == "github.com/gin-gonic/gin" || strings.HasPrefix(importPath, "github.com/gin-gonic/gin/") {
+		return targetGin
+	}
+	if strings.HasPrefix(importPath, internalPrefix) {
+		return classifyRel(strings.TrimPrefix(importPath, internalPrefix))
+	}
+	return ""
+}
+
+// classifyRel は internal/ からの相対パス（import / ファイル共通）を層キーに分類する。
+func classifyRel(rel string) string {
+	switch {
+	case rel == layerDomain || strings.HasPrefix(rel, layerDomain+"/"):
+		return layerDomain
+	case rel == layerUsecaseRepo || strings.HasPrefix(rel, layerUsecaseRepo+"/"):
+		return layerUsecaseRepo
+	case rel == layerUsecase || strings.HasPrefix(rel, layerUsecase+"/"):
+		return layerUsecase
+	case rel == layerHandler || strings.HasPrefix(rel, layerHandler+"/"):
+		return layerHandler
+	case rel == layerPersistence || strings.HasPrefix(rel, layerPersistence+"/"):
+		return layerPersistence
+	case rel == "adapter" || strings.HasPrefix(rel, "adapter/"):
+		return layerPersistence
+	case rel == layerInfra || strings.HasPrefix(rel, layerInfra+"/"):
+		return layerInfra
+	default:
+		return ""
+	}
+}
+
+// isWiringFile は handler の組み立て担当ファイル（router.go / routes_*.go）かを判定する。
+func isWiringFile(filename string) bool {
+	return filename == "router.go" ||
+		(strings.HasPrefix(filename, "routes_") && strings.HasSuffix(filename, ".go"))
+}
+
+// readModulePath は go.mod の先頭 module 行から module path を取り出す。
+func readModulePath(goModPath string) (string, error) {
+	f, err := os.Open(goModPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("module 行が見つかりません")
+}

--- a/backend/cmd/archlint/main.go
+++ b/backend/cmd/archlint/main.go
@@ -171,16 +171,19 @@ func run(internalRoot, internalPrefix string) ([]violation, error) {
 		if ignoreFile {
 			return nil
 		}
-		out = append(out, violationsFor(src, filepath.Base(path), path, imports)...)
+		out = append(out, violationsFor(src, filepath.ToSlash(relDir), filepath.Base(path), path, imports)...)
 		return nil
 	})
 	return out, err
 }
 
 // violationsFor は 1 ファイル分の import 列からルール違反を抽出する（純粋関数: テスト容易）。
-func violationsFor(src, filename, fullpath string, imports []importRef) []violation {
+// relDir は internal/ からの相対ディレクトリ（slash 区切り）。wiring 例外の厳密判定に使う。
+func violationsFor(src, relDir, filename, fullpath string, imports []importRef) []violation {
 	forbidden := rules[src]
-	wiring := isWiringFile(filename)
+	// wiring 例外は handler 直下の router.go / routes_*.go のみに限定する。
+	// handler/middleware など別ディレクトリの同名ファイルでは例外を効かせない。
+	wiring := relDir == layerHandler && isWiringFile(filename)
 	var vs []violation
 	for _, imp := range imports {
 		if imp.suppressed || imp.target == "" {
@@ -207,7 +210,12 @@ func parseImports(path, internalPrefix string) (imports []importRef, ignoreFile 
 		return nil, false, err
 	}
 
+	// ignore-file は「ファイル先頭（package 宣言より前）」のコメントだけを対象にする。
+	// 途中コメントでルールを回避できないようにするため。
 	for _, cg := range f.Comments {
+		if cg.End() > f.Package {
+			break // f.Comments は位置順。package 宣言以降は対象外。
+		}
 		if commentContains(cg, "archlint:ignore-file") {
 			return nil, true, nil
 		}
@@ -300,9 +308,10 @@ func readModulePath(goModPath string) (string, error) {
 
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
-		line := strings.TrimSpace(sc.Text())
-		if strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module ")), nil
+		// タブ区切り・複数スペースでも読めるよう Fields でトークン化する。
+		fields := strings.Fields(sc.Text())
+		if len(fields) >= 2 && fields[0] == "module" {
+			return fields[1], nil
 		}
 	}
 	if err := sc.Err(); err != nil {

--- a/backend/cmd/archlint/main_test.go
+++ b/backend/cmd/archlint/main_test.go
@@ -77,70 +77,78 @@ func TestViolationsFor(t *testing.T) {
 	imp := func(target string) importRef { return importRef{path: "p", line: 1, target: target} }
 
 	t.Run("domain importing usecase is a violation", func(t *testing.T) {
-		vs := violationsFor(layerDomain, "user.go", "internal/domain/user.go", []importRef{imp(layerUsecase)})
+		vs := violationsFor(layerDomain, "domain", "user.go", "internal/domain/user.go", []importRef{imp(layerUsecase)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("usecase importing persistence is a violation (DIP)", func(t *testing.T) {
-		vs := violationsFor(layerUsecase, "foo_usecase.go", "p", []importRef{imp(layerPersistence)})
+		vs := violationsFor(layerUsecase, "usecase", "foo_usecase.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("usecase importing infra is allowed", func(t *testing.T) {
-		vs := violationsFor(layerUsecase, "foo_usecase.go", "p", []importRef{imp(layerInfra)})
+		vs := violationsFor(layerUsecase, "usecase", "foo_usecase.go", "p", []importRef{imp(layerInfra)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("usecase importing gin is a violation", func(t *testing.T) {
-		vs := violationsFor(layerUsecase, "foo_usecase.go", "p", []importRef{imp(targetGin)})
+		vs := violationsFor(layerUsecase, "usecase", "foo_usecase.go", "p", []importRef{imp(targetGin)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("handler importing persistence in wiring file is allowed", func(t *testing.T) {
-		vs := violationsFor(layerHandler, "router.go", "p", []importRef{imp(layerPersistence)})
+		vs := violationsFor(layerHandler, "handler", "router.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 0 {
 			t.Fatalf("wiring file should be exempt, got %d", len(vs))
 		}
 	})
 
 	t.Run("handler importing persistence in non-wiring file is a violation", func(t *testing.T) {
-		vs := violationsFor(layerHandler, "foo_handler.go", "p", []importRef{imp(layerPersistence)})
+		vs := violationsFor(layerHandler, "handler", "foo_handler.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
+	t.Run("wiring-named file in handler subdir is NOT exempt", func(t *testing.T) {
+		// handler/middleware/routes_x.go のような別ディレクトリでは wiring 例外を効かせない。
+		vs := violationsFor(layerHandler, "handler/middleware", "routes_x.go", "p", []importRef{imp(layerPersistence)})
+		if len(vs) != 1 {
+			t.Fatalf("subdir wiring-named file should NOT be exempt, got %d", len(vs))
+		}
+	})
+
 	t.Run("handler importing infra is allowed (pragmatic exception)", func(t *testing.T) {
-		vs := violationsFor(layerHandler, "auth_handler.go", "p", []importRef{imp(layerInfra)})
+		vs := violationsFor(layerHandler, "handler", "auth_handler.go", "p", []importRef{imp(layerInfra)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("infra importing net/http is allowed (client use)", func(t *testing.T) {
-		vs := violationsFor(layerInfra, "fetcher.go", "p", []importRef{imp(targetNetHTTP)})
+		vs := violationsFor(layerInfra, "infra/embed", "fetcher.go", "p", []importRef{imp(targetNetHTTP)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("persistence importing usecase business is a violation", func(t *testing.T) {
-		vs := violationsFor(layerPersistence, "user_repository.go", "p", []importRef{imp(layerUsecase)})
+		vs := violationsFor(layerPersistence, "adapter/persistence", "user_repository.go", "p", []importRef{imp(layerUsecase)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
 	t.Run("persistence importing port is allowed", func(t *testing.T) {
-		vs := violationsFor(layerPersistence, "user_repository.go", "p", []importRef{imp(layerUsecaseRepo)})
+		vs := violationsFor(layerPersistence, "adapter/persistence", "user_repository.go", "p", []importRef{imp(layerUsecaseRepo)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
@@ -148,7 +156,7 @@ func TestViolationsFor(t *testing.T) {
 
 	t.Run("suppressed import is skipped", func(t *testing.T) {
 		ref := importRef{path: "p", line: 1, target: layerUsecase, suppressed: true}
-		vs := violationsFor(layerDomain, "user.go", "p", []importRef{ref})
+		vs := violationsFor(layerDomain, "domain", "user.go", "p", []importRef{ref})
 		if len(vs) != 0 {
 			t.Fatalf("suppressed import should be skipped, got %d", len(vs))
 		}
@@ -205,7 +213,7 @@ var _ = context.Background
 		}
 	})
 
-	t.Run("file-level ignore", func(t *testing.T) {
+	t.Run("file-level ignore (先頭コメント)", func(t *testing.T) {
 		p := write("b.go", `//archlint:ignore-file 生成ファイルのため除外
 package x
 
@@ -217,6 +225,22 @@ import _ "`+testPrefix+`adapter/persistence"
 		}
 		if !ignore {
 			t.Fatal("ignoreFile should be true")
+		}
+	})
+
+	t.Run("mid-file ignore-file は無効", func(t *testing.T) {
+		// package 宣言より後のコメントでは抑制できない（回避防止）。
+		p := write("c.go", `package x
+
+// archlint:ignore-file ここでは効かないはず
+import _ "`+testPrefix+`adapter/persistence"
+`)
+		_, ignore, err := parseImports(p, testPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ignore {
+			t.Fatal("ignoreFile should be false for non-leading comment")
 		}
 	})
 }
@@ -313,6 +337,15 @@ func TestReadModulePath(t *testing.T) {
 	}
 	if got != "example.com/foo/bar" {
 		t.Errorf("readModulePath = %q, want example.com/foo/bar", got)
+	}
+
+	// タブ区切り・複数スペースでも読めること。
+	tabbed := filepath.Join(dir, "tab.mod")
+	if err := os.WriteFile(tabbed, []byte("module\texample.com/tab\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := readModulePath(tabbed); err != nil || got != "example.com/tab" {
+		t.Errorf("readModulePath(tab) = %q, %v; want example.com/tab", got, err)
 	}
 
 	if _, err := readModulePath(filepath.Join(dir, "missing.go.mod")); err == nil {

--- a/backend/cmd/archlint/main_test.go
+++ b/backend/cmd/archlint/main_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testPrefix = "github.com/norman6464/FreStyle/backend/internal/"
+
+func TestClassifyRel(t *testing.T) {
+	cases := map[string]string{
+		"domain":                       layerDomain,
+		"domain/sub":                   layerDomain,
+		"usecase":                      layerUsecase,
+		"usecase/foo":                  layerUsecase,
+		"usecase/repository":           layerUsecaseRepo,
+		"usecase/repository/sub":       layerUsecaseRepo,
+		"handler":                      layerHandler,
+		"handler/middleware":           layerHandler,
+		"adapter/persistence":          layerPersistence,
+		"adapter/persistence/whatever": layerPersistence,
+		"adapter":                      layerPersistence,
+		"infra":                        layerInfra,
+		"infra/cognito":                layerInfra,
+		"cmd/server":                   "",
+		"":                             "",
+	}
+	for rel, want := range cases {
+		if got := classifyRel(rel); got != want {
+			t.Errorf("classifyRel(%q) = %q, want %q", rel, got, want)
+		}
+	}
+}
+
+func TestClassifyImport(t *testing.T) {
+	cases := map[string]string{
+		"net/http":                         targetNetHTTP,
+		"github.com/gin-gonic/gin":         targetGin,
+		"github.com/gin-gonic/gin/binding": targetGin,
+		testPrefix + "domain":              layerDomain,
+		testPrefix + "usecase":             layerUsecase,
+		testPrefix + "usecase/repository":  layerUsecaseRepo,
+		testPrefix + "handler/middleware":  layerHandler,
+		testPrefix + "adapter/persistence": layerPersistence,
+		testPrefix + "infra/s3":            layerInfra,
+		"github.com/stretchr/testify/mock": "",
+		"context":                          "",
+		"github.com/gin-gonic/ginkgo":      "", // gin で始まるが別物
+	}
+	for path, want := range cases {
+		if got := classifyImport(path, testPrefix); got != want {
+			t.Errorf("classifyImport(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func TestIsWiringFile(t *testing.T) {
+	cases := map[string]bool{
+		"router.go":                     true,
+		"routes_auth.go":                true,
+		"routes_company_application.go": true,
+		"auth_handler.go":               false,
+		"handler.go":                    false,
+		"routes.go":                     false, // routes_ プレフィックスではない
+	}
+	for name, want := range cases {
+		if got := isWiringFile(name); got != want {
+			t.Errorf("isWiringFile(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestViolationsFor(t *testing.T) {
+	imp := func(target string) importRef { return importRef{path: "p", line: 1, target: target} }
+
+	t.Run("domain importing usecase is a violation", func(t *testing.T) {
+		vs := violationsFor(layerDomain, "user.go", "internal/domain/user.go", []importRef{imp(layerUsecase)})
+		if len(vs) != 1 {
+			t.Fatalf("want 1 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("usecase importing persistence is a violation (DIP)", func(t *testing.T) {
+		vs := violationsFor(layerUsecase, "foo_usecase.go", "p", []importRef{imp(layerPersistence)})
+		if len(vs) != 1 {
+			t.Fatalf("want 1 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("usecase importing infra is allowed", func(t *testing.T) {
+		vs := violationsFor(layerUsecase, "foo_usecase.go", "p", []importRef{imp(layerInfra)})
+		if len(vs) != 0 {
+			t.Fatalf("want 0 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("usecase importing gin is a violation", func(t *testing.T) {
+		vs := violationsFor(layerUsecase, "foo_usecase.go", "p", []importRef{imp(targetGin)})
+		if len(vs) != 1 {
+			t.Fatalf("want 1 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("handler importing persistence in wiring file is allowed", func(t *testing.T) {
+		vs := violationsFor(layerHandler, "router.go", "p", []importRef{imp(layerPersistence)})
+		if len(vs) != 0 {
+			t.Fatalf("wiring file should be exempt, got %d", len(vs))
+		}
+	})
+
+	t.Run("handler importing persistence in non-wiring file is a violation", func(t *testing.T) {
+		vs := violationsFor(layerHandler, "foo_handler.go", "p", []importRef{imp(layerPersistence)})
+		if len(vs) != 1 {
+			t.Fatalf("want 1 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("handler importing infra is allowed (pragmatic exception)", func(t *testing.T) {
+		vs := violationsFor(layerHandler, "auth_handler.go", "p", []importRef{imp(layerInfra)})
+		if len(vs) != 0 {
+			t.Fatalf("want 0 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("infra importing net/http is allowed (client use)", func(t *testing.T) {
+		vs := violationsFor(layerInfra, "fetcher.go", "p", []importRef{imp(targetNetHTTP)})
+		if len(vs) != 0 {
+			t.Fatalf("want 0 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("persistence importing usecase business is a violation", func(t *testing.T) {
+		vs := violationsFor(layerPersistence, "user_repository.go", "p", []importRef{imp(layerUsecase)})
+		if len(vs) != 1 {
+			t.Fatalf("want 1 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("persistence importing port is allowed", func(t *testing.T) {
+		vs := violationsFor(layerPersistence, "user_repository.go", "p", []importRef{imp(layerUsecaseRepo)})
+		if len(vs) != 0 {
+			t.Fatalf("want 0 violation, got %d", len(vs))
+		}
+	})
+
+	t.Run("suppressed import is skipped", func(t *testing.T) {
+		ref := importRef{path: "p", line: 1, target: layerUsecase, suppressed: true}
+		vs := violationsFor(layerDomain, "user.go", "p", []importRef{ref})
+		if len(vs) != 0 {
+			t.Fatalf("suppressed import should be skipped, got %d", len(vs))
+		}
+	})
+}
+
+// TestParseImports は実ファイルを書き出して import 解析と抑制を検証する。
+func TestParseImports(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, content string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("classifies and detects suppression", func(t *testing.T) {
+		p := write("a.go", `package x
+
+import (
+	"context"
+	"net/http" //archlint:allow テスト用
+	usecase "`+testPrefix+`usecase"
+)
+
+var _ = context.Background
+`)
+		imports, ignore, err := parseImports(p, testPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ignore {
+			t.Fatal("ignoreFile should be false")
+		}
+		var sawNetHTTP, sawUsecase bool
+		for _, imp := range imports {
+			switch imp.target {
+			case targetNetHTTP:
+				sawNetHTTP = true
+				if !imp.suppressed {
+					t.Error("net/http should be suppressed by //archlint:allow")
+				}
+			case layerUsecase:
+				sawUsecase = true
+				if imp.suppressed {
+					t.Error("usecase import should not be suppressed")
+				}
+			}
+		}
+		if !sawNetHTTP || !sawUsecase {
+			t.Errorf("expected both imports parsed, netHTTP=%v usecase=%v", sawNetHTTP, sawUsecase)
+		}
+	})
+
+	t.Run("file-level ignore", func(t *testing.T) {
+		p := write("b.go", `//archlint:ignore-file 生成ファイルのため除外
+package x
+
+import _ "`+testPrefix+`adapter/persistence"
+`)
+		_, ignore, err := parseImports(p, testPrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ignore {
+			t.Fatal("ignoreFile should be true")
+		}
+	})
+}
+
+// buildTree は層ディレクトリを模した一時ツリーを作り、root を返す。
+func buildTree(t *testing.T, withViolation bool) string {
+	t.Helper()
+	root := t.TempDir()
+	internal := filepath.Join(root, "internal")
+
+	if err := os.WriteFile(filepath.Join(root, "go.mod"),
+		[]byte("module github.com/norman6464/FreStyle/backend\n\ngo 1.26\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mk := func(rel, content string) {
+		p := filepath.Join(internal, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 正常: usecase が repository(port) を import
+	mk("usecase/ok.go", "package usecase\nimport _ \""+testPrefix+"usecase/repository\"\n")
+	// 正常: wiring ファイルなので handler→persistence は許容
+	mk("handler/router.go", "package handler\nimport _ \""+testPrefix+"adapter/persistence\"\n")
+	// テストファイルは無視される（違反 import を入れても拾わない）
+	mk("domain/bad_test.go", "package domain\nimport _ \""+testPrefix+"handler\"\n")
+
+	if withViolation {
+		// 違反: domain が usecase を import
+		mk("domain/bad.go", "package domain\nimport _ \""+testPrefix+"usecase\"\n")
+	}
+	return root
+}
+
+// TestRunIntegration は run の違反検出（とテストファイル無視・wiring 例外）を確認する。
+func TestRunIntegration(t *testing.T) {
+	root := buildTree(t, true)
+	vs, err := run(filepath.Join(root, "internal"), testPrefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 1 {
+		t.Fatalf("want exactly 1 violation (domain→usecase), got %d: %+v", len(vs), vs)
+	}
+	if filepath.Base(vs[0].file) != "bad.go" {
+		t.Errorf("violation should be in bad.go, got %s", vs[0].file)
+	}
+}
+
+func TestRunCLI(t *testing.T) {
+	t.Run("clean tree returns 0", func(t *testing.T) {
+		root := buildTree(t, false)
+		var out, errBuf bytes.Buffer
+		if code := runCLI([]string{root}, &out, &errBuf); code != 0 {
+			t.Fatalf("want exit 0, got %d (stderr=%s)", code, errBuf.String())
+		}
+		if !strings.Contains(out.String(), "OK") {
+			t.Errorf("stdout should report OK, got %q", out.String())
+		}
+	})
+
+	t.Run("violating tree returns 1", func(t *testing.T) {
+		root := buildTree(t, true)
+		var out, errBuf bytes.Buffer
+		if code := runCLI([]string{root}, &out, &errBuf); code != 1 {
+			t.Fatalf("want exit 1, got %d", code)
+		}
+		if !strings.Contains(out.String(), "bad.go") {
+			t.Errorf("stdout should name the offending file, got %q", out.String())
+		}
+	})
+
+	t.Run("missing go.mod returns 2", func(t *testing.T) {
+		var out, errBuf bytes.Buffer
+		if code := runCLI([]string{t.TempDir()}, &out, &errBuf); code != 2 {
+			t.Fatalf("want exit 2, got %d", code)
+		}
+	})
+}
+
+func TestReadModulePath(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(good, []byte("// comment\nmodule example.com/foo/bar\n\ngo 1.26\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readModulePath(good)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "example.com/foo/bar" {
+		t.Errorf("readModulePath = %q, want example.com/foo/bar", got)
+	}
+
+	if _, err := readModulePath(filepath.Join(dir, "missing.go.mod")); err == nil {
+		t.Error("want error for missing go.mod")
+	}
+
+	noModule := filepath.Join(dir, "no-module.mod")
+	if err := os.WriteFile(noModule, []byte("go 1.26\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readModulePath(noModule); err == nil {
+		t.Error("want error when module line is absent")
+	}
+}


### PR DESCRIPTION
## 概要

CLAUDE.md §2 のクリーンアーキテクチャ依存方向ルール（`handler → usecase → repository/infra → domain`）を、人手のレビューだけに頼らず **CI で機械的に検証する自作 linter** `cmd/archlint` を追加します。Go 標準の `go/ast` / `go/parser` のみ使用で外部依存はありません。

先日強化した CI 品質ゲート（#1743）の延長として、アーキテクチャ規約の自動ガードレールを追加するものです。**現状の全コードは違反ゼロ**で、今後の回帰を防ぐ基準線になります。

## 変更内容

- **`backend/cmd/archlint/main.go`**: 各 `.go`（`_test.go` 除外）の import を解析し、層をまたぐ禁止依存を検出。違反は `path:line: メッセージ` 形式で出力し exit 1。
  - `domain` → 他の内部層・`gin`・`net/http` 不可（domain の純粋性）
  - `usecase/repository`(port) → `domain` 以外の内部層・`gin`・`net/http` 不可
  - `usecase` → `handler`・`adapter/persistence`（DIP: port に依存）・`gin`・`net/http` 不可
  - `adapter/persistence` → `handler`・`usecase` 本体・`gin` 不可（依存先は port のみ）
  - `infra` → `handler`・`usecase`・`usecase/repository`・`adapter/persistence`・`gin` 不可
  - `handler` → `adapter/persistence` の直 import 不可（**wiring の `router.go` / `routes_*.go` は例外**, §2.6）
  - 許容: `usecase → infra` / `infra → net/http`（HTTP クライアント）/ `handler → infra`（auth・embed の pragmatic 例外）
  - 抑制機構: 行末 `//archlint:allow <理由>` / ファイル先頭 `//archlint:ignore-file <理由>`
- **`backend/cmd/archlint/main_test.go`**: 単体（分類・ルール評価・抑制）＋統合（一時ツリー走査）＋CLI end-to-end テスト。**カバレッジ 87.7%**。
- **`backend/Makefile`**: `make archlint` 追加、`make verify` に組み込み。
- **`.github/workflows/ci-backend-go.yml`**: staticcheck の後に `archlint` 検証ステップを追加。
- **`backend/README.md`**: ルール表・使い方・抑制方法を記載。

## テスト

```
make archlint   # OK — 違反なし
go test ./cmd/archlint/ -cover   # ok  coverage: 87.7%
gofmt -l . / go vet ./... / staticcheck ./... / go test ./...   # すべて green
```

- 負例の手動スモークも実施: domain に `gin` import を一時注入 → `exit 1` で `domain は gin を import できません` を検出 → 除去後 OK を確認。

## 関連

- CI 品質ゲート強化 #1743 / 運用ドキュメント frestyle-infrastructure#62 の延長

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 変更内容

* **New Features**
  * クリーンアーキテクチャの依存方向ルール（handler→usecase→repository→domain）を自動検証する静的解析ツールを実装しました。

* **Documentation**
  * アーキテクチャ検証手順とルール定義をドキュメントに追加しました。

* **Tests**
  * 検証ツールの包括的なテストスイートを追加しました。

* **Chores**
  * CI/CDパイプラインに自動検証ステップを統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->