### PR TITLE
feat: ルート↔swaggo 注釈の整合 linter (apispec-lint) を追加

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -69,6 +69,11 @@ jobs:
       - name: archlint (clean architecture deps)
         run: go run ./cmd/archlint .
 
+      # Gin ルートと swaggo @Router 注釈の整合（CLAUDE.md §2.7）を検証する自作 linter。
+      # ルートを生やしたのに OpenAPI 注釈を書き忘れた endpoint を CI で弾く。
+      - name: apispec-lint (route ↔ swaggo annotation)
+        run: go run ./cmd/apispec-lint .
+
       # govulncheck は Go 公式の脆弱性スキャナ。実際に呼んでいるコードパスに該当する
       # 既知 CVE だけを報告する。stdlib の CVE は Go パッチ追随次第で頻出するため、
       # CI を止めずに「可視化」目的の非ブロッキング（continue-on-error）にする。

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,8 +2,9 @@
 #
 # 主要 target:
 #   make openapi      … swag init で OpenAPI spec を 再 生成 (docs/swagger.{json,yaml})
-#   make verify       … gofmt / vet / build / test / archlint を 一括 実行
+#   make verify       … gofmt / vet / build / test / archlint / apispec-lint を 一括 実行
 #   make archlint     … クリーンアーキテクチャ依存方向ルール (CLAUDE.md §2) を 静的 検証
+#   make apispec-lint … Gin ルート ↔ swaggo @Router 注釈 の 整合 (CLAUDE.md §2.7) を 検証
 #   make run          … go run ./cmd/server で ローカル サーバ 起動
 #
 # swag CLI が PATH に なければ `go install github.com/swaggo/swag/cmd/swag@v1.16.4` を 自動 実行 する。
@@ -38,12 +39,19 @@ verify:
 	go build ./...
 	go test ./...
 	$(MAKE) archlint
+	$(MAKE) apispec-lint
 
 # クリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を静的に検証する。
 .PHONY: archlint
 archlint:
 	@echo ">>> archlint: クリーンアーキテクチャ依存方向チェック"
 	@go run ./cmd/archlint .
+
+# Gin ルート ↔ swaggo @Router 注釈の整合（CLAUDE.md §2.7）を検証する。
+.PHONY: apispec-lint
+apispec-lint:
+	@echo ">>> apispec-lint: ルート ↔ swaggo 注釈チェック"
+	@go run ./cmd/apispec-lint .
 
 .PHONY: run
 run:

--- a/backend/README.md
+++ b/backend/README.md
@@ -55,6 +55,20 @@ make archlint        # = go run ./cmd/archlint .
 - 意図的に例外を通したいときは、import 行末に `//archlint:allow <理由>`、ファイル全体なら先頭コメントに `//archlint:ignore-file <理由>` を付ける。
 - ルールを追加・変更したら `cmd/archlint/main.go` の `rules` を編集し、`cmd/archlint/main_test.go` にケースを足す。
 
+### apispec-lint — ルート ↔ swaggo 注釈の整合検証
+
+CLAUDE.md §2.7「新しい HTTP endpoint には handler メソッドの直前に swaggo annotation を必ず書く」を機械化した自作 linter（`go/ast` のみ）。ルートを生やしたのに `@Router` 注釈を書き忘れた endpoint を CI で弾く。
+
+```bash
+make apispec-lint    # = go run ./cmd/apispec-lint .
+```
+
+- `internal/handler` の `g.GET("/path", ..., h.Method)` 形式のルート登録を AST で抽出し、最後の引数（handler メソッド）を特定する。
+- レシーバ付き func の doc コメントに `@Router` を含むメソッド名を「注釈あり」として収集し、ルートが指すメソッドに注釈が無ければ違反として `path:line` で報告し exit 1。
+- SSE / WebSocket / multipart など OpenAPI で表現しない endpoint は、ルート登録行の行末に `//apispec:allow <理由>`、ファイル全体なら先頭コメントに `//apispec:ignore-file <理由>` で抑制する。
+
+> 注釈の path 文字列まで照合する厳密版ではなく「注釈の有無」を見る軽量ガードレール。書き忘れの一次検知が目的で、生成された spec の正しさは `make openapi` の drift check（CI）が担う。
+
 ## ローカル開発
 
 ```bash
@@ -100,8 +114,9 @@ docker build -t frestyle-backend:latest .
 ```bash
 go vet ./...
 go test ./...
-make archlint   # クリーンアーキテクチャ依存方向チェック
-make verify     # gofmt / vet / build / test / archlint を一括実行
+make archlint      # クリーンアーキテクチャ依存方向チェック
+make apispec-lint  # ルート ↔ swaggo @Router 注釈チェック
+make verify        # gofmt / vet / build / test / archlint / apispec-lint を一括実行
 ```
 
 ## ログ方針（CloudWatch コスト対策）

--- a/backend/cmd/apispec-lint/main.go
+++ b/backend/cmd/apispec-lint/main.go
@@ -1,0 +1,260 @@
+// Command apispec-lint は Gin に登録されたルートと swaggo 注釈の整合を検証する。
+// CLAUDE.md §2.7「handler メソッドの直前に swaggo annotation を必ず書く」を機械化し、
+// ルートを生やしたのに @Router 注釈を書き忘れた endpoint を CI で弾く。
+//
+// 仕組み:
+//   - internal/handler の全 .go を go/ast で解析
+//   - `g.GET("/path", ..., h.Method)` 形式のルート登録から (HTTP method, path, handler メソッド名) を抽出
+//   - レシーバ付き func の doc コメントに @Router を含むメソッド名を「注釈あり」として収集
+//   - ルートが指す handler メソッド名に @Router が一つも無ければ違反として報告
+//
+// 使い方:
+//
+//	go run ./cmd/apispec-lint           # backend/ 直下で実行
+//	go run ./cmd/apispec-lint <root>    # 別ディレクトリを指定
+//
+// 違反は `path:line: メッセージ` 形式で出力し exit 1。
+//
+// 抑制（SSE / WebSocket / multipart など OpenAPI で表現しない endpoint 用）:
+//   - ルート登録行の行末に `//apispec:allow <理由>`
+//   - ファイル先頭コメントに `//apispec:ignore-file <理由>` でファイル全体
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// httpMethods は Gin のルート登録メソッド名。
+var httpMethods = map[string]bool{
+	"GET": true, "POST": true, "PUT": true, "PATCH": true,
+	"DELETE": true, "HEAD": true, "OPTIONS": true,
+}
+
+// route は 1 件のルート登録。
+type route struct {
+	method     string // GET / POST ...
+	path       string // "/company-applications"
+	handler    string // ルートが指す handler メソッド名（"Create" 等）
+	line       int
+	suppressed bool // //apispec:allow が付いていれば true
+}
+
+// violation は 1 件の注釈漏れ。
+type violation struct {
+	file string
+	line int
+	msg  string
+}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// runCLI は CLI 本体。exit code を返す（0=OK / 1=違反あり / 2=実行エラー）。
+func runCLI(args []string, stdout, stderr io.Writer) int {
+	root := "."
+	if len(args) > 0 {
+		root = args[0]
+	}
+	handlerRoot := filepath.Join(root, "internal", "handler")
+
+	violations, err := run(handlerRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "apispec-lint: %v\n", err)
+		return 2
+	}
+
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "apispec-lint: OK — 全ルートに swaggo @Router 注釈があります")
+		return 0
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].file != violations[j].file {
+			return violations[i].file < violations[j].file
+		}
+		return violations[i].line < violations[j].line
+	})
+	for _, v := range violations {
+		fmt.Fprintf(stdout, "%s:%d: %s\n", v.file, v.line, v.msg)
+	}
+	fmt.Fprintf(stderr, "\napispec-lint: %d 件の @Router 注釈漏れが見つかりました\n", len(violations))
+	return 1
+}
+
+// run は handlerRoot 配下を 2 パスで解析する。
+// 1 パス目で注釈ありメソッド名を全ファイル横断で集め、2 パス目でルートと突き合わせる。
+func run(handlerRoot string) ([]violation, error) {
+	fset := token.NewFileSet()
+
+	type parsedFile struct {
+		path   string
+		file   *ast.File
+		ignore bool
+	}
+	var files []parsedFile
+	annotated := map[string]bool{}
+
+	err := filepath.WalkDir(handlerRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			return fmt.Errorf("%s: %w", path, perr)
+		}
+		for _, m := range extractAnnotatedMethods(f) {
+			annotated[m] = true
+		}
+		files = append(files, parsedFile{path: path, file: f, ignore: hasIgnoreFile(f)})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var out []violation
+	for _, pf := range files {
+		if pf.ignore {
+			continue
+		}
+		for _, r := range extractRoutes(fset, pf.file) {
+			if r.handler == "" || r.suppressed || annotated[r.handler] {
+				continue
+			}
+			out = append(out, violation{
+				file: pf.path,
+				line: r.line,
+				msg:  fmt.Sprintf("%s %s → %s に swaggo @Router 注釈がありません（CLAUDE.md §2.7）", r.method, r.path, r.handler),
+			})
+		}
+	}
+	return out, nil
+}
+
+// extractAnnotatedMethods は doc コメントに @Router を含むレシーバ付きメソッド名を返す。
+func extractAnnotatedMethods(f *ast.File) []string {
+	var names []string
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv == nil || fn.Doc == nil {
+			continue
+		}
+		if commentContains(fn.Doc, "@Router") {
+			names = append(names, fn.Name.Name)
+		}
+	}
+	return names
+}
+
+// extractRoutes は Gin のルート登録呼び出しを抽出する。
+func extractRoutes(fset *token.FileSet, f *ast.File) []route {
+	allowLines := collectDirectiveLines(fset, f, "apispec:allow")
+
+	var routes []route
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !httpMethods[sel.Sel.Name] || len(call.Args) < 2 {
+			return true
+		}
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		path, err := strconv.Unquote(lit.Value)
+		if err != nil || !strings.HasPrefix(path, "/") {
+			return true
+		}
+
+		start := fset.Position(call.Pos()).Line
+		end := fset.Position(call.End()).Line
+		routes = append(routes, route{
+			method:     sel.Sel.Name,
+			path:       path,
+			handler:    handlerName(call.Args[len(call.Args)-1]),
+			line:       start,
+			suppressed: lineInRange(allowLines, start, end),
+		})
+		return true
+	})
+	return routes
+}
+
+// handlerName はルート最終引数（handler）からメソッド名を取り出す。
+// `h.Create` のような selector を主に想定。inline func 等は "" を返して検査対象外にする。
+func handlerName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	case *ast.Ident:
+		return e.Name
+	default:
+		return ""
+	}
+}
+
+// hasIgnoreFile はファイル先頭（package 宣言より前）に //apispec:ignore-file があるかを返す。
+func hasIgnoreFile(f *ast.File) bool {
+	for _, cg := range f.Comments {
+		if cg.End() > f.Package {
+			break
+		}
+		if commentContains(cg, "apispec:ignore-file") {
+			return true
+		}
+	}
+	return false
+}
+
+// collectDirectiveLines は needle を含むコメントが存在する行番号の集合を返す。
+// //apispec:xxx は go ディレクティブ形式で CommentGroup.Text() に出ないため生テキストを走査する。
+func collectDirectiveLines(fset *token.FileSet, f *ast.File, needle string) map[int]bool {
+	lines := map[int]bool{}
+	for _, cg := range f.Comments {
+		for _, c := range cg.List {
+			if strings.Contains(c.Text, needle) {
+				lines[fset.Position(c.Slash).Line] = true
+			}
+		}
+	}
+	return lines
+}
+
+// lineInRange は [start,end] のいずれかの行が set に含まれるかを返す。
+func lineInRange(set map[int]bool, start, end int) bool {
+	for l := start; l <= end; l++ {
+		if set[l] {
+			return true
+		}
+	}
+	return false
+}
+
+// commentContains はコメント群の生テキストに needle が含まれるかを返す。
+func commentContains(cg *ast.CommentGroup, needle string) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if strings.Contains(c.Text, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/cmd/apispec-lint/main_test.go
+++ b/backend/cmd/apispec-lint/main_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// parseSrc は Go ソース文字列を *ast.File に解析する小道具。
+func parseSrc(t *testing.T, src string) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return fset, f
+}
+
+func TestExtractAnnotatedMethods(t *testing.T) {
+	_, f := parseSrc(t, `package handler
+
+// Create は申請を作る。
+//
+//	@Router /company-applications [post]
+func (h *H) Create(c *gin.Context) {}
+
+// List はドキュメント無しのメソッド。
+func (h *H) List(c *gin.Context) {}
+
+// freeFunc は @Router を持つがレシーバ無し（メソッドではない）。
+//
+//	@Router /x [get]
+func freeFunc() {}
+`)
+	got := extractAnnotatedMethods(f)
+	sort.Strings(got)
+	if len(got) != 1 || got[0] != "Create" {
+		t.Fatalf("extractAnnotatedMethods = %v, want [Create]", got)
+	}
+}
+
+func TestExtractRoutes(t *testing.T) {
+	fset, f := parseSrc(t, `package handler
+
+func reg(g *gin.RouterGroup, h *H) {
+	g.GET("/exercises", h.List)
+	g.POST("/company-applications", middleware.RateLimitPerMinute(5, 5), h.Create)
+	g.GET("/stream/:id", h.Stream) //apispec:allow SSE
+	foo.Bar("/not-a-route", h.Nope)
+	g.GET(pathVar, h.Dynamic)
+}
+`)
+	routes := extractRoutes(fset, f)
+
+	byHandler := map[string]route{}
+	for _, r := range routes {
+		byHandler[r.handler] = r
+	}
+
+	if r, ok := byHandler["List"]; !ok || r.method != "GET" || r.path != "/exercises" || r.suppressed {
+		t.Errorf("List route wrong: %+v ok=%v", r, ok)
+	}
+	// ミドルウェア引数があっても handler は最後の引数（Create）。
+	if r, ok := byHandler["Create"]; !ok || r.method != "POST" || r.suppressed {
+		t.Errorf("Create route wrong: %+v ok=%v", r, ok)
+	}
+	// 行末 //apispec:allow で suppressed。
+	if r, ok := byHandler["Stream"]; !ok || !r.suppressed {
+		t.Errorf("Stream route should be suppressed: %+v ok=%v", r, ok)
+	}
+	// HTTP メソッドでない foo.Bar は拾わない。
+	if _, ok := byHandler["Nope"]; ok {
+		t.Error("foo.Bar should not be treated as a route")
+	}
+	// 第 1 引数が文字列リテラルでない（pathVar）ものは拾わない。
+	if _, ok := byHandler["Dynamic"]; ok {
+		t.Error("non-literal path should be skipped")
+	}
+}
+
+func TestHandlerName(t *testing.T) {
+	mustExpr := func(src string) ast.Expr {
+		_, f := parseSrc(t, "package p\nvar _ = "+src+"\n")
+		return f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Values[0]
+	}
+	if got := handlerName(mustExpr("h.Create")); got != "Create" {
+		t.Errorf("selector handlerName = %q, want Create", got)
+	}
+	if got := handlerName(mustExpr("BareFunc")); got != "BareFunc" {
+		t.Errorf("ident handlerName = %q, want BareFunc", got)
+	}
+	if got := handlerName(mustExpr("func() {}")); got != "" {
+		t.Errorf("funcLit handlerName = %q, want empty", got)
+	}
+}
+
+func TestHasIgnoreFile(t *testing.T) {
+	_, lead := parseSrc(t, "//apispec:ignore-file 生成物\npackage handler\n")
+	if !hasIgnoreFile(lead) {
+		t.Error("leading //apispec:ignore-file should be detected")
+	}
+
+	_, mid := parseSrc(t, "package handler\n\n//apispec:ignore-file ここでは効かない\nvar x = 1\n")
+	if hasIgnoreFile(mid) {
+		t.Error("non-leading ignore-file must NOT apply")
+	}
+}
+
+// mkHandlerTree は tmp/internal/handler 配下にファイルを作り handlerRoot を返す。
+func mkHandlerTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	handlerRoot := filepath.Join(root, "internal", "handler")
+	if err := os.MkdirAll(handlerRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(handlerRoot, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return handlerRoot
+}
+
+func TestRunIntegration(t *testing.T) {
+	const annotatedHandler = `package handler
+
+// Create は作る。
+//
+//	@Router /things [post]
+func (h *H) Create(c *gin.Context) {}
+
+// Get は取る。
+//
+//	@Router /things/{id} [get]
+func (h *H) Get(c *gin.Context) {}
+`
+
+	t.Run("missing annotation is a violation", func(t *testing.T) {
+		handlerRoot := mkHandlerTree(t, map[string]string{
+			"h.go": annotatedHandler,
+			"routes.go": `package handler
+func reg(g *gin.RouterGroup, h *H) {
+	g.POST("/things", h.Create)
+	g.DELETE("/things/:id", h.Destroy)
+}
+`,
+		})
+		vs, err := run(handlerRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 1 || !strings.Contains(vs[0].msg, "Destroy") {
+			t.Fatalf("want 1 violation for Destroy, got %+v", vs)
+		}
+	})
+
+	t.Run("all annotated -> no violation", func(t *testing.T) {
+		handlerRoot := mkHandlerTree(t, map[string]string{
+			"h.go": annotatedHandler,
+			"routes.go": `package handler
+func reg(g *gin.RouterGroup, h *H) {
+	g.POST("/things", h.Create)
+	g.GET("/things/:id", h.Get)
+}
+`,
+		})
+		vs, err := run(handlerRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("want 0 violation, got %+v", vs)
+		}
+	})
+
+	t.Run("//apispec:allow suppresses", func(t *testing.T) {
+		handlerRoot := mkHandlerTree(t, map[string]string{
+			"h.go": annotatedHandler,
+			"routes.go": `package handler
+func reg(g *gin.RouterGroup, h *H) {
+	g.GET("/stream/:id", h.Stream) //apispec:allow SSE は OpenAPI 対象外
+}
+`,
+		})
+		vs, err := run(handlerRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("allow should suppress, got %+v", vs)
+		}
+	})
+
+	t.Run("//apispec:ignore-file skips file", func(t *testing.T) {
+		handlerRoot := mkHandlerTree(t, map[string]string{
+			"h.go": annotatedHandler,
+			"routes.go": `//apispec:ignore-file レガシー
+package handler
+func reg(g *gin.RouterGroup, h *H) {
+	g.DELETE("/things/:id", h.Destroy)
+}
+`,
+		})
+		vs, err := run(handlerRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("ignore-file should skip, got %+v", vs)
+		}
+	})
+}
+
+func TestRunCLI(t *testing.T) {
+	handlerRoot := func(t *testing.T, violating bool) string {
+		routes := "g.POST(\"/things\", h.Create)"
+		if violating {
+			routes += "\n\tg.DELETE(\"/things/:id\", h.Destroy)"
+		}
+		return mkHandlerTree(t, map[string]string{
+			"h.go":      "package handler\n\n// Create は作る。\n//\n//\t@Router /things [post]\nfunc (h *H) Create(c *gin.Context) {}\n",
+			"routes.go": "package handler\nfunc reg(g *gin.RouterGroup, h *H) {\n\t" + routes + "\n}\n",
+		})
+	}
+
+	t.Run("clean returns 0", func(t *testing.T) {
+		root := filepath.Dir(filepath.Dir(handlerRoot(t, false))) // root that contains internal/handler
+		var out, errBuf bytes.Buffer
+		if code := runCLI([]string{root}, &out, &errBuf); code != 0 {
+			t.Fatalf("want 0, got %d (%s)", code, errBuf.String())
+		}
+		if !strings.Contains(out.String(), "OK") {
+			t.Errorf("want OK, got %q", out.String())
+		}
+	})
+
+	t.Run("violation returns 1", func(t *testing.T) {
+		root := filepath.Dir(filepath.Dir(handlerRoot(t, true)))
+		var out, errBuf bytes.Buffer
+		if code := runCLI([]string{root}, &out, &errBuf); code != 1 {
+			t.Fatalf("want 1, got %d", code)
+		}
+		if !strings.Contains(out.String(), "Destroy") {
+			t.Errorf("want Destroy in output, got %q", out.String())
+		}
+	})
+}


### PR DESCRIPTION
## 概要

CLAUDE.md §2.7「新しい HTTP endpoint には handler メソッドの直前に swaggo annotation を必ず書く」を機械化する自作 linter `cmd/apispec-lint` を追加します。**Gin に登録したルートが指す handler メソッドに `@Router` 注釈が無い**＝書き忘れを CI で弾きます。先日の archlint(#1744) と同じ枠組み（`go/ast` のみ・外部依存なし）です。

**現状の全ルートは注釈あり**で、今後の書き忘れを防ぐ基準線になります。

## 変更内容

- **`backend/cmd/apispec-lint/main.go`**:
  - `internal/handler` の `g.GET("/path", ..., h.Method)` 形式のルート登録を AST で抽出（最後の引数 = handler メソッド。途中のミドルウェア引数は無視）
  - レシーバ付き func の doc コメントに `@Router` を含むメソッド名を「注釈あり」として全ファイル横断で収集
  - ルートが指すメソッド名に注釈が一つも無ければ `path:line: METHOD /path → Method に @Router 注釈がありません` を出力し exit 1
  - 抑制: ルート登録行末に `//apispec:allow <理由>`（SSE/WebSocket/multipart 用）、ファイル全体は先頭コメントに `//apispec:ignore-file <理由>`
- **`backend/cmd/apispec-lint/main_test.go`**: 抽出/注釈収集/抑制/統合/CLI のテスト。**カバレッジ 89.1%**。
- **`backend/Makefile`**: `make apispec-lint` 追加、`make verify` に組み込み。
- **`.github/workflows/ci-backend-go.yml`**: archlint の後に検証ステップ追加。
- **`backend/README.md`**: 仕組み・使い方・抑制方法を記載。

## 設計メモ

- 注釈の **path 文字列までは照合しない**軽量ガードレール（gin `:id` vs swaggo `{id}` の表記差で誤検知しないため）。「注釈の有無」の一次検知が目的で、生成 spec の正しさは既存の `make openapi` drift check（CI）が担う。
- handler メソッド名で突き合わせる方式（型解決は行わず stdlib のみ）。§2.7 が「全 endpoint に注釈」を要求するため、名前衝突による取りこぼしは実運用上ほぼ起きない。

## テスト

```
make apispec-lint                      # OK — 全ルートに注釈あり
go test ./cmd/apispec-lint/ -cover     # ok  coverage: 89.1%
make verify                            # gofmt/vet/build/test/archlint/apispec-lint すべて green
```

- 負例スモーク実施: 注釈の無いメソッドへのルートを一時追加 → `exit 1` で検出 → 除去後 OK。

## 関連

- archlint(依存方向 linter) #1744 の姉妹ツール。CI 品質ゲート強化 #1743 の延長。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * API スペック検証機能を追加。Gin ルートに対応する OpenAPI アノテーションが必須になりました。
  * `make apispec-lint` で検証を実行可能、CI で自動実行されます。
  * `//apispec:allow` または `//apispec:ignore-file` コメントで検証をスキップできます。

* **Documentation**
  * API スペック検証の使用方法と抑止方法をドキュメントに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->