### PR TITLE
feat: naminglint 追加 + apispec-lint を strict path 照合に強化

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -70,9 +70,14 @@ jobs:
         run: go run ./cmd/archlint .
 
       # Gin ルートと swaggo @Router 注釈の整合（CLAUDE.md §2.7）を検証する自作 linter。
-      # ルートを生やしたのに OpenAPI 注釈を書き忘れた endpoint を CI で弾く。
+      # ルート（HTTP method + path）と @Router 宣言の不一致・注釈漏れを CI で弾く。
       - name: apispec-lint (route ↔ swaggo annotation)
         run: go run ./cmd/apispec-lint .
+
+      # usecase の命名・構造規約（CLAUDE.md §2.3）を検証する自作 linter。
+      # XxxUseCase に NewXxxUseCase コンストラクタと Execute メソッドがあるかを CI で検査する。
+      - name: naminglint (usecase naming)
+        run: go run ./cmd/naminglint .
 
       # govulncheck は Go 公式の脆弱性スキャナ。実際に呼んでいるコードパスに該当する
       # 既知 CVE だけを報告する。stdlib の CVE は Go パッチ追随次第で頻出するため、

--- a/README.md
+++ b/README.md
@@ -157,40 +157,68 @@ npx tailwindcss init -p
 - **request / response 型は handler 内 local 定義**: DTO / Mapper 層は持たず、機密フィールドは domain 構造体側で `json:"-"` で隠す
 - **テスト必須**: 新規追加コードには必ず単体テストを付ける
 
-### テスト
+### テスト戦略（単体 / 結合 / E2E の定義）
 
-#### バックエンド (Go)
+このアプリでの各テスト種別の定義・対象・ツール・配置は次のとおり。
+
+| 種別 | このアプリでの定義 | 主な対象 | ツール / 実行 |
+|---|---|---|---|
+| **単体テスト (unit)** | 1 つの関数・構造体を依存から隔離して検証する。依存は interface 経由で mock / fake / stub に差し替え、DB / HTTP / AWS への実 I/O を行わない | backend: usecase・middleware・infra クライアント・自作 linter / frontend: component・hook・repository | `go test` (testify) / Vitest |
+| **結合テスト (integration)** | 複数層を実際に繋いで 1 プロセス内で検証する。外部サービスはテスト用実体（sqlite / httptest）に差し替える | backend: handler（router〜JSON）・repository（GORM × sqlite）・linter の走査 run | `go test` |
+| **E2E テスト** | 実ブラウザ（Chromium）で本番 URL に対しユーザー導線を端から端まで検証する | デプロイ済み本番のスモーク（SPA ロード / セキュリティヘッダー / 認証境界） | Playwright |
+
+#### バックエンド (Go) — `go test ./...`
+
+標準 `testing` + `github.com/stretchr/testify`。
+
+- **usecase（単体, 22 ファイル）**: 依存する repository / infra を `testify/mock` の `mock.Mock` で差し替え、ビジネスロジックだけを隔離検証する。例: `internal/usecase/*_test.go`。
+- **handler（結合, 9 ファイル）**: `gin.SetMode(gin.TestMode)` + `httptest.NewRecorder()` でルータに `ServeHTTP` し、ルーティング〜ステータス〜JSON を通しで検証する。例: `internal/handler/profile_handler_test.go`。
+- **middleware（単体, 4 ファイル）**: JWT 認証・CurrentUser 注入・レートリミットなど横断処理を個別に検証する。
+- **infra（単体 / 境界, 4 ファイル）**: 外部 I/O を境界で差し替える。Cognito トークン交換・JWKS 検証・oEmbed 取得・SES メールを `httptest` サーバや fake で検証する。例: `internal/infra/cognito/jwt_verifier_test.go`。
+- **repository（結合, 規約）**: 永続化ロジックを足すときは `*gorm.DB` を **sqlite in-memory** に差し替え、実 SQL でクエリを検証する。現状は persistence 層が薄く、データ操作の大半は usecase 単体テスト（mock）で覆っているため専用テストは未追加。
+- **自作 linter（単体 + 結合）**: `cmd/archlint` / `cmd/apispec-lint` / `cmd/naminglint` は、分類・ルール評価の純粋関数（単体）と、一時ディレクトリツリーを走査する `run` / CLI（結合）の両方を検証する（各カバレッジ 87〜89%）。
 
 ```bash
 cd backend
-go vet ./...
-go test ./...
+go test ./...                                   # 全テスト
+go test -race -covermode=atomic ./...           # CI と同条件（競合検出 + カバレッジ）
+go test ./internal/usecase/...                  # 層を絞って実行
 ```
 
-- 標準 `testing` パッケージ + `github.com/stretchr/testify`（順次導入）
-- usecase: 依存をインターフェイスとしてモック化した単体テスト
-- repository: テスト用 PostgreSQL コンテナまたは sqlite による統合テスト
-- handler: `httptest.NewRecorder` + `gin.New()` でルータごと検証
+#### フロントエンド (Vitest + React Testing Library) — `npm test`
 
-#### フロントエンド
+セットアップは `frontend/src/test/setup.ts`。
+
+- **component（単体）**: `render` + `screen.getByRole` でアクセシビリティ込みに描画検証、`fireEvent` でイベント発火。`localStorage` 等は `vi.stubGlobal` でスタブ。
+- **hook（単体）**: `renderHook` で状態遷移・副作用を検証。例: `src/hooks/__tests__/*.test.ts`。
+- **repository（単体）**: axios を `vi.mock` で差し替え、API 呼び出しの URL / payload / レスポンス整形を検証。例: `src/repositories/__tests__/AuthRepository.test.ts`。
 
 ```bash
 cd frontend
-npm test
+npm test                 # watch
+npm run test:run         # 1 回実行（CI と同じ）
+npm run test:run -- --coverage
 ```
 
-- Vitest + React Testing Library
-- 慣習: `vi.stubGlobal('localStorage', createMockStorage())` で localStorage をスタブ、`fireEvent` でイベント発火
+#### E2E (Playwright) — `frontend/e2e/smoke.spec.ts`
 
-#### E2E (Playwright)
+デプロイ済み本番（既定 `https://normanblog.com`）に対する **未認証スモーク 6 ケース**: ① SPA ロード + ロゴ / ログイン誘導表示 ② CloudFront セキュリティヘッダー配信 ③ `index.html` の CSP meta ④ `GET /api/v2/health` が 200 ⑤ 認証必須エンドポイントが Cookie 無で 401 ⑥ 廃止済み SockJS フォールバック路が 404 / 401。設定は `frontend/playwright.config.ts`。
 
 ```bash
 cd frontend
-npm run e2e:install   # 初回のみ（Chromium + OS deps）
-npm run e2e            # 本番に対してスモーク 6 ケース
-npm run e2e:ui         # UI モードでデバッグ
-PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run e2e   # ローカル dev server 経由
+npm run e2e:install                                       # 初回のみ（Chromium + OS deps）
+npm run e2e                                                # 本番に対してスモーク
+npm run e2e:ui                                             # UI モードでデバッグ
+PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run e2e      # ローカル dev server 経由
 ```
+
+#### CI でのテスト実行
+
+| ワークフロー | 実行内容 |
+|---|---|
+| `ci-backend-go.yml` | `go test -race` + カバレッジ / 3 linter（archlint・apispec-lint・naminglint）/ OpenAPI drift |
+| `ci-frontend.yml` | `tsc` / ESLint / Vitest + カバレッジ / build |
+| `e2e.yml` | Playwright スモーク（Chromium） |
 
 ---
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,9 +2,10 @@
 #
 # 主要 target:
 #   make openapi      … swag init で OpenAPI spec を 再 生成 (docs/swagger.{json,yaml})
-#   make verify       … gofmt / vet / build / test / archlint / apispec-lint を 一括 実行
+#   make verify       … gofmt / vet / build / test / archlint / apispec-lint / naminglint を 一括 実行
 #   make archlint     … クリーンアーキテクチャ依存方向ルール (CLAUDE.md §2) を 静的 検証
 #   make apispec-lint … Gin ルート ↔ swaggo @Router 注釈 の 整合 (CLAUDE.md §2.7) を 検証
+#   make naminglint   … usecase 命名・構造規約 (CLAUDE.md §2.3) を 検証
 #   make run          … go run ./cmd/server で ローカル サーバ 起動
 #
 # swag CLI が PATH に なければ `go install github.com/swaggo/swag/cmd/swag@v1.16.4` を 自動 実行 する。
@@ -40,6 +41,7 @@ verify:
 	go test ./...
 	$(MAKE) archlint
 	$(MAKE) apispec-lint
+	$(MAKE) naminglint
 
 # クリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を静的に検証する。
 .PHONY: archlint
@@ -52,6 +54,12 @@ archlint:
 apispec-lint:
 	@echo ">>> apispec-lint: ルート ↔ swaggo 注釈チェック"
 	@go run ./cmd/apispec-lint .
+
+# usecase 命名・構造規約（CLAUDE.md §2.3: struct + コンストラクタ + Execute）を検証する。
+.PHONY: naminglint
+naminglint:
+	@echo ">>> naminglint: usecase 命名規約チェック"
+	@go run ./cmd/naminglint .
 
 .PHONY: run
 run:

--- a/backend/README.md
+++ b/backend/README.md
@@ -55,19 +55,31 @@ make archlint        # = go run ./cmd/archlint .
 - 意図的に例外を通したいときは、import 行末に `//archlint:allow <理由>`、ファイル全体なら先頭コメントに `//archlint:ignore-file <理由>` を付ける。
 - ルールを追加・変更したら `cmd/archlint/main.go` の `rules` を編集し、`cmd/archlint/main_test.go` にケースを足す。
 
-### apispec-lint — ルート ↔ swaggo 注釈の整合検証
+### apispec-lint — ルート ↔ swaggo 注釈の整合検証（strict path 照合）
 
-CLAUDE.md §2.7「新しい HTTP endpoint には handler メソッドの直前に swaggo annotation を必ず書く」を機械化した自作 linter（`go/ast` のみ）。ルートを生やしたのに `@Router` 注釈を書き忘れた endpoint を CI で弾く。
+CLAUDE.md §2.7「新しい HTTP endpoint には handler メソッドの直前に swaggo annotation を必ず書く」を機械化した自作 linter（`go/ast` のみ）。ルートと `@Router` 宣言の **HTTP method + path を完全一致で照合**し、注釈漏れ・path 相違・method 相違を CI で弾く。
 
 ```bash
 make apispec-lint    # = go run ./cmd/apispec-lint .
 ```
 
-- `internal/handler` の `g.GET("/path", ..., h.Method)` 形式のルート登録を AST で抽出し、最後の引数（handler メソッド）を特定する。
-- レシーバ付き func の doc コメントに `@Router` を含むメソッド名を「注釈あり」として収集し、ルートが指すメソッドに注釈が無ければ違反として `path:line` で報告し exit 1。
-- SSE / WebSocket / multipart など OpenAPI で表現しない endpoint は、ルート登録行の行末に `//apispec:allow <理由>`、ファイル全体なら先頭コメントに `//apispec:ignore-file <理由>` で抑制する。
+- `internal/handler` の `g.GET("/path", ..., h.Method)` 形式のルート登録を AST で抽出する（最後の引数が handler）。
+- レシーバ付き func の doc コメントの `@Router /path [method]` 宣言を `(method, path)` として全ファイル横断で収集する（1 メソッドが複数 `@Router` を持つ場合は複数宣言）。
+- gin の `:id` / `*filepath` を swaggo の `{id}` / `{filepath}` に正規化し、ルートと一致する `@Router` 宣言が無ければ `path:line` で報告し exit 1。
+- SSE / WebSocket / multipart など OpenAPI で表現しない endpoint や、フロント互換の別 path / 別 method エイリアスは、ルート登録行の行末に `//apispec:allow <理由>`、ファイル全体なら先頭コメントに `//apispec:ignore-file <理由>` で抑制する。
 
-> 注釈の path 文字列まで照合する厳密版ではなく「注釈の有無」を見る軽量ガードレール。書き忘れの一次検知が目的で、生成された spec の正しさは `make openapi` の drift check（CI）が担う。
+> 生成 spec そのものの正しさ（schema 等）は `make openapi` の drift check（CI）が担い、apispec-lint は「ルートに対応する @Router 宣言が正しい method/path で存在するか」を担う。両者は補完関係。
+
+### naminglint — usecase 命名・構造規約の検証
+
+CLAUDE.md §2.3「1 usecase = struct + コンストラクタ + Execute メソッド」を機械化した自作 linter（`go/ast` のみ）。対象は `internal/usecase` 直下（`repository` サブパッケージは除外）。
+
+```bash
+make naminglint    # = go run ./cmd/naminglint .
+```
+
+- 公開 struct `XxxUseCase` に対し、コンストラクタ `NewXxxUseCase` と メソッド `Execute` の存在を検査し、欠けていれば `path:line` で報告し exit 1。
+- 複数 CRUD を束ねる集約 usecase（`CourseUseCase` / `TeachingMaterialUseCase` / `ListAdminInvitationsUseCase`）など `Execute` 単一メソッドにしない正当な例外は、struct の doc コメントに `//naminglint:allow <理由>` を付けて Execute 必須を免除する。ファイル全体は先頭コメントに `//naminglint:ignore-file <理由>`。
 
 ## ローカル開発
 
@@ -115,8 +127,9 @@ docker build -t frestyle-backend:latest .
 go vet ./...
 go test ./...
 make archlint      # クリーンアーキテクチャ依存方向チェック
-make apispec-lint  # ルート ↔ swaggo @Router 注釈チェック
-make verify        # gofmt / vet / build / test / archlint / apispec-lint を一括実行
+make apispec-lint  # ルート ↔ swaggo @Router 注釈チェック（strict path 照合）
+make naminglint    # usecase 命名・構造規約チェック
+make verify        # gofmt / vet / build / test / 3 linter を一括実行
 ```
 
 ## ログ方針（CloudWatch コスト対策）

--- a/backend/cmd/apispec-lint/main.go
+++ b/backend/cmd/apispec-lint/main.go
@@ -2,11 +2,12 @@
 // CLAUDE.md §2.7「handler メソッドの直前に swaggo annotation を必ず書く」を機械化し、
 // ルートを生やしたのに @Router 注釈を書き忘れた endpoint を CI で弾く。
 //
-// 仕組み:
+// 仕組み（strict path 照合）:
 //   - internal/handler の全 .go を go/ast で解析
-//   - `g.GET("/path", ..., h.Method)` 形式のルート登録から (HTTP method, path, handler メソッド名) を抽出
-//   - レシーバ付き func の doc コメントに @Router を含むメソッド名を「注釈あり」として収集
-//   - ルートが指す handler メソッド名に @Router が一つも無ければ違反として報告
+//   - `g.GET("/path", ..., h.Method)` 形式のルート登録から (HTTP method, path) を抽出
+//   - レシーバ付き func の doc コメントの @Router 宣言を (HTTP method, path) として収集
+//   - gin の `:id` / `*p` を swaggo の `{id}` / `{p}` に正規化し、ルートと完全一致する
+//     @Router 宣言が無ければ違反として報告（注釈漏れ・path 相違・method 相違を検出）
 //
 // 使い方:
 //
@@ -115,8 +116,8 @@ func run(handlerRoot string) ([]violation, error) {
 		if perr != nil {
 			return fmt.Errorf("%s: %w", path, perr)
 		}
-		for _, m := range extractAnnotatedMethods(f) {
-			annotated[m] = true
+		for _, k := range extractRouterKeys(f) {
+			annotated[k] = true
 		}
 		files = append(files, parsedFile{path: path, file: f, ignore: hasIgnoreFile(f)})
 		return nil
@@ -131,32 +132,81 @@ func run(handlerRoot string) ([]violation, error) {
 			continue
 		}
 		for _, r := range extractRoutes(fset, pf.file) {
-			if r.handler == "" || r.suppressed || annotated[r.handler] {
+			// handler が selector/ident でないもの（swagger UI 等）は検査対象外。
+			if r.handler == "" || r.suppressed {
+				continue
+			}
+			key := routerKey(r.method, normalizeGinPath(r.path))
+			if annotated[key] {
 				continue
 			}
 			out = append(out, violation{
 				file: pf.path,
 				line: r.line,
-				msg:  fmt.Sprintf("%s %s → %s に swaggo @Router 注釈がありません（CLAUDE.md §2.7）", r.method, r.path, r.handler),
+				msg: fmt.Sprintf("%s %s → 対応する swaggo @Router（%s %s）がありません（CLAUDE.md §2.7）",
+					r.method, r.path, strings.ToUpper(r.method), normalizeGinPath(r.path)),
 			})
 		}
 	}
 	return out, nil
 }
 
-// extractAnnotatedMethods は doc コメントに @Router を含むレシーバ付きメソッド名を返す。
-func extractAnnotatedMethods(f *ast.File) []string {
-	var names []string
+// extractRouterKeys は doc コメントの @Router 宣言を「METHOD 正規化済みpath」キーに変換して返す。
+// 1 メソッドが複数の @Router を持つ場合は複数キーを返す。
+func extractRouterKeys(f *ast.File) []string {
+	var keys []string
 	for _, decl := range f.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Recv == nil || fn.Doc == nil {
 			continue
 		}
-		if commentContains(fn.Doc, "@Router") {
-			names = append(names, fn.Name.Name)
+		for _, c := range fn.Doc.List {
+			if method, path, ok := parseRouterLine(c.Text); ok {
+				keys = append(keys, routerKey(method, path))
+			}
 		}
 	}
-	return names
+	return keys
+}
+
+// parseRouterLine は `// @Router /path/{id} [get]` 形式の 1 行から (method, path) を取り出す。
+func parseRouterLine(text string) (method, path string, ok bool) {
+	idx := strings.Index(text, "@Router")
+	if idx < 0 {
+		return "", "", false
+	}
+	fields := strings.Fields(text[idx+len("@Router"):])
+	if len(fields) < 2 {
+		return "", "", false
+	}
+	path = fields[0]
+	// 末尾の `[get]` から method を取り出す。
+	m := fields[len(fields)-1]
+	if !strings.HasPrefix(m, "[") || !strings.HasSuffix(m, "]") {
+		return "", "", false
+	}
+	method = strings.ToLower(strings.TrimSuffix(strings.TrimPrefix(m, "["), "]"))
+	if path == "" || method == "" || !strings.HasPrefix(path, "/") {
+		return "", "", false
+	}
+	return method, path, true
+}
+
+// normalizeGinPath は gin のパスパラメータ表記を swaggo の {param} 表記に揃える。
+// `:id` → `{id}` / `*filepath` → `{filepath}`。
+func normalizeGinPath(p string) string {
+	segs := strings.Split(p, "/")
+	for i, s := range segs {
+		if strings.HasPrefix(s, ":") || strings.HasPrefix(s, "*") {
+			segs[i] = "{" + s[1:] + "}"
+		}
+	}
+	return strings.Join(segs, "/")
+}
+
+// routerKey は照合用のキー「method path」を作る（method は小文字）。
+func routerKey(method, path string) string {
+	return strings.ToLower(method) + " " + path
 }
 
 // extractRoutes は Gin のルート登録呼び出しを抽出する。

--- a/backend/cmd/apispec-lint/main_test.go
+++ b/backend/cmd/apispec-lint/main_test.go
@@ -23,26 +23,67 @@ func parseSrc(t *testing.T, src string) (*token.FileSet, *ast.File) {
 	return fset, f
 }
 
-func TestExtractAnnotatedMethods(t *testing.T) {
+func TestExtractRouterKeys(t *testing.T) {
 	_, f := parseSrc(t, `package handler
 
-// Create は申請を作る。
+// Create は作る。
 //
 //	@Router /company-applications [post]
 func (h *H) Create(c *gin.Context) {}
 
-// List はドキュメント無しのメソッド。
-func (h *H) List(c *gin.Context) {}
-
-// freeFunc は @Router を持つがレシーバ無し（メソッドではない）。
+// MarkRead は既読化（PATCH 正規 + PUT 互換の 2 宣言）。
 //
-//	@Router /x [get]
-func freeFunc() {}
+//	@Router /notifications/{id}/read [patch]
+//	@Router /notifications/{id}/read [put]
+func (h *H) MarkRead(c *gin.Context) {}
+
+// List は注釈無し。
+func (h *H) List(c *gin.Context) {}
 `)
-	got := extractAnnotatedMethods(f)
+	got := extractRouterKeys(f)
 	sort.Strings(got)
-	if len(got) != 1 || got[0] != "Create" {
-		t.Fatalf("extractAnnotatedMethods = %v, want [Create]", got)
+	want := []string{
+		"patch /notifications/{id}/read",
+		"post /company-applications",
+		"put /notifications/{id}/read",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("extractRouterKeys = %v, want %v", got, want)
+	}
+}
+
+func TestParseRouterLine(t *testing.T) {
+	cases := []struct {
+		text         string
+		method, path string
+		ok           bool
+	}{
+		{"//\t@Router /a/{id} [get]", "get", "/a/{id}", true},
+		{"// @Router   /b   [POST]", "post", "/b", true},
+		{"// just a comment", "", "", false},
+		{"// @Router /c", "", "", false},             // method 欠落
+		{"// @Router relative [get]", "", "", false}, // / 始まりでない
+	}
+	for _, c := range cases {
+		m, p, ok := parseRouterLine(c.text)
+		if ok != c.ok || m != c.method || p != c.path {
+			t.Errorf("parseRouterLine(%q) = (%q,%q,%v), want (%q,%q,%v)", c.text, m, p, ok, c.method, c.path, c.ok)
+		}
+	}
+}
+
+func TestNormalizeGinPath(t *testing.T) {
+	cases := map[string]string{
+		"/profile/:userId":        "/profile/{userId}",
+		"/a/:id/b/:slug":          "/a/{id}/b/{slug}",
+		"/files/*filepath":        "/files/{filepath}",
+		"/no/params":              "/no/params",
+		"/notifications/read-all": "/notifications/read-all",
+	}
+	for in, want := range cases {
+		if got := normalizeGinPath(in); got != want {
+			t.Errorf("normalizeGinPath(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 
@@ -157,8 +198,46 @@ func reg(g *gin.RouterGroup, h *H) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(vs) != 1 || !strings.Contains(vs[0].msg, "Destroy") {
-			t.Fatalf("want 1 violation for Destroy, got %+v", vs)
+		if len(vs) != 1 || !strings.Contains(vs[0].msg, "/things/:id") {
+			t.Fatalf("want 1 violation for DELETE /things/:id, got %+v", vs)
+		}
+	})
+
+	t.Run("path mismatch is a violation", func(t *testing.T) {
+		// 注釈は /things/{id} だが実ルートは /items/{id} → 不一致。
+		handlerRoot := mkHandlerTree(t, map[string]string{
+			"h.go": annotatedHandler,
+			"routes.go": `package handler
+func reg(g *gin.RouterGroup, h *H) {
+	g.GET("/items/:id", h.Get)
+}
+`,
+		})
+		vs, err := run(handlerRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 1 || !strings.Contains(vs[0].msg, "/items/:id") {
+			t.Fatalf("want 1 path-mismatch violation, got %+v", vs)
+		}
+	})
+
+	t.Run("method mismatch is a violation", func(t *testing.T) {
+		// 注釈は [get] だが実ルートは PUT → 不一致。
+		handlerRoot := mkHandlerTree(t, map[string]string{
+			"h.go": annotatedHandler,
+			"routes.go": `package handler
+func reg(g *gin.RouterGroup, h *H) {
+	g.PUT("/things/:id", h.Get)
+}
+`,
+		})
+		vs, err := run(handlerRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 1 {
+			t.Fatalf("want 1 method-mismatch violation, got %+v", vs)
 		}
 	})
 
@@ -248,8 +327,8 @@ func TestRunCLI(t *testing.T) {
 		if code := runCLI([]string{root}, &out, &errBuf); code != 1 {
 			t.Fatalf("want 1, got %d", code)
 		}
-		if !strings.Contains(out.String(), "Destroy") {
-			t.Errorf("want Destroy in output, got %q", out.String())
+		if !strings.Contains(out.String(), "/things/:id") {
+			t.Errorf("want /things/:id in output, got %q", out.String())
 		}
 	})
 }

--- a/backend/cmd/naminglint/main.go
+++ b/backend/cmd/naminglint/main.go
@@ -1,0 +1,226 @@
+// Command naminglint は usecase 層の命名・構造規約（CLAUDE.md §2.3 / §3.2）を検証する。
+// 「1 usecase = struct + コンストラクタ + Execute メソッド」を機械化し、規約から外れた
+// usecase を CI で弾く。archlint / apispec-lint と同じ枠組み（go/ast のみ・外部依存なし）。
+//
+// 検査対象は internal/usecase 直下（repository サブパッケージは対象外）。
+//
+// ルール:
+//   - 公開 struct `XxxUseCase` には コンストラクタ `NewXxxUseCase` が必要
+//   - 公開 struct `XxxUseCase` には メソッド `Execute` が必要
+//
+// 使い方:
+//
+//	go run ./cmd/naminglint            # backend/ 直下で実行
+//	go run ./cmd/naminglint <root>     # 別ディレクトリを指定
+//
+// 違反は `path:line: メッセージ` 形式で出力し exit 1。
+//
+// 抑制（集約 read usecase など Execute を持たない正当な例外用）:
+//   - struct の doc / 行末コメントに `//naminglint:allow <理由>`
+//   - ファイル先頭コメントに `//naminglint:ignore-file <理由>`
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ucStruct は 1 つの `XxxUseCase` struct 宣言。
+type ucStruct struct {
+	name       string
+	file       string
+	line       int
+	suppressed bool // //naminglint:allow が付いていれば Execute 必須を免除
+}
+
+// violation は 1 件の規約違反。
+type violation struct {
+	file string
+	line int
+	msg  string
+}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// runCLI は CLI 本体。exit code を返す（0=OK / 1=違反あり / 2=実行エラー）。
+func runCLI(args []string, stdout, stderr io.Writer) int {
+	root := "."
+	if len(args) > 0 {
+		root = args[0]
+	}
+	usecaseRoot := filepath.Join(root, "internal", "usecase")
+
+	violations, err := run(usecaseRoot)
+	if err != nil {
+		fmt.Fprintf(stderr, "naminglint: %v\n", err)
+		return 2
+	}
+
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "naminglint: OK — usecase 命名規約違反なし")
+		return 0
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].file != violations[j].file {
+			return violations[i].file < violations[j].file
+		}
+		return violations[i].line < violations[j].line
+	})
+	for _, v := range violations {
+		fmt.Fprintf(stdout, "%s:%d: %s\n", v.file, v.line, v.msg)
+	}
+	fmt.Fprintf(stderr, "\nnaminglint: %d 件の命名規約違反が見つかりました\n", len(violations))
+	return 1
+}
+
+// run は usecaseRoot 直下の .go を解析し、UseCase 規約違反を集める。
+func run(usecaseRoot string) ([]violation, error) {
+	fset := token.NewFileSet()
+
+	var structs []ucStruct
+	constructors := map[string]bool{} // "NewXxxUseCase"
+	executeRecv := map[string]bool{}  // Execute メソッドを持つレシーバ型名
+
+	err := filepath.WalkDir(usecaseRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// repository サブパッケージ等、usecase 直下以外は対象外。
+			if path != usecaseRoot {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			return fmt.Errorf("%s: %w", path, perr)
+		}
+		if hasIgnoreFile(f) {
+			return nil
+		}
+		s, ctors, execs := analyzeFile(fset, f, path)
+		structs = append(structs, s...)
+		for _, c := range ctors {
+			constructors[c] = true
+		}
+		for _, e := range execs {
+			executeRecv[e] = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var out []violation
+	for _, s := range structs {
+		if !constructors["New"+s.name] {
+			out = append(out, violation{s.file, s.line,
+				fmt.Sprintf("%s にはコンストラクタ New%s がありません（CLAUDE.md §2.3）", s.name, s.name)})
+		}
+		if !s.suppressed && !executeRecv[s.name] {
+			out = append(out, violation{s.file, s.line,
+				fmt.Sprintf("%s には Execute メソッドがありません（CLAUDE.md §2.3。集約 usecase 等の例外は //naminglint:allow）", s.name)})
+		}
+	}
+	return out, nil
+}
+
+// analyzeFile は 1 ファイルから UseCase struct / New コンストラクタ / Execute レシーバを抽出する。
+func analyzeFile(fset *token.FileSet, f *ast.File, path string) (structs []ucStruct, constructors, executeRecv []string) {
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.GenDecl:
+			if d.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range d.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !strings.HasSuffix(ts.Name.Name, "UseCase") {
+					continue
+				}
+				if _, ok := ts.Type.(*ast.StructType); !ok {
+					continue
+				}
+				structs = append(structs, ucStruct{
+					name:       ts.Name.Name,
+					file:       path,
+					line:       fset.Position(ts.Pos()).Line,
+					suppressed: commentContains(d.Doc, "naminglint:allow") || commentContains(ts.Doc, "naminglint:allow") || commentContains(ts.Comment, "naminglint:allow"),
+				})
+			}
+		case *ast.FuncDecl:
+			if d.Recv == nil {
+				// 関数: New コンストラクタを集める。
+				if strings.HasPrefix(d.Name.Name, "New") {
+					constructors = append(constructors, d.Name.Name)
+				}
+				continue
+			}
+			// メソッド: Execute を持つレシーバ型名を集める。
+			if d.Name.Name == "Execute" {
+				if name := receiverTypeName(d.Recv); name != "" {
+					executeRecv = append(executeRecv, name)
+				}
+			}
+		}
+	}
+	return structs, constructors, executeRecv
+}
+
+// receiverTypeName はレシーバ（*T または T）から型名 T を取り出す。
+func receiverTypeName(recv *ast.FieldList) string {
+	if recv == nil || len(recv.List) == 0 {
+		return ""
+	}
+	switch e := recv.List[0].Type.(type) {
+	case *ast.StarExpr:
+		if id, ok := e.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.Ident:
+		return e.Name
+	}
+	return ""
+}
+
+// hasIgnoreFile はファイル先頭（package 宣言より前）に //naminglint:ignore-file があるかを返す。
+func hasIgnoreFile(f *ast.File) bool {
+	for _, cg := range f.Comments {
+		if cg.End() > f.Package {
+			break
+		}
+		if commentContains(cg, "naminglint:ignore-file") {
+			return true
+		}
+	}
+	return false
+}
+
+// commentContains はコメント群の生テキストに needle が含まれるかを返す。
+// //naminglint:xxx は go ディレクティブ扱いで Text() に出ないため List を直接走査する。
+func commentContains(cg *ast.CommentGroup, needle string) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if strings.Contains(c.Text, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/cmd/naminglint/main.go
+++ b/backend/cmd/naminglint/main.go
@@ -150,7 +150,8 @@ func analyzeFile(fset *token.FileSet, f *ast.File, path string) (structs []ucStr
 			}
 			for _, spec := range d.Specs {
 				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || !strings.HasSuffix(ts.Name.Name, "UseCase") {
+				// 公開 struct `XxxUseCase` のみを対象にする（非公開の補助型は除外）。
+				if !ok || !ast.IsExported(ts.Name.Name) || !strings.HasSuffix(ts.Name.Name, "UseCase") {
 					continue
 				}
 				if _, ok := ts.Type.(*ast.StructType); !ok {

--- a/backend/cmd/naminglint/main_test.go
+++ b/backend/cmd/naminglint/main_test.go
@@ -33,6 +33,9 @@ func (u *CourseUseCase) List() {}
 
 // notAUseCase は対象外。
 type Helper struct{}
+
+// privateUseCase は非公開なので対象外。
+type privateUseCase struct{}
 `, parser.ParseComments)
 	if err != nil {
 		t.Fatal(err)
@@ -55,6 +58,9 @@ type Helper struct{}
 	}
 	if _, ok := byName["Helper"]; ok {
 		t.Error("Helper (not *UseCase) should be ignored")
+	}
+	if _, ok := byName["privateUseCase"]; ok {
+		t.Error("non-exported privateUseCase should be ignored")
 	}
 
 	ctorSet := toSet(ctors)

--- a/backend/cmd/naminglint/main_test.go
+++ b/backend/cmd/naminglint/main_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAnalyzeFile(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", `package usecase
+
+// CreateThingUseCase は作る。
+type CreateThingUseCase struct{ r int }
+
+func NewCreateThingUseCase(r int) *CreateThingUseCase { return &CreateThingUseCase{r} }
+
+func (u *CreateThingUseCase) Execute() {}
+
+// CourseUseCase は集約。
+//
+//naminglint:allow 集約
+type CourseUseCase struct{ r int }
+
+func NewCourseUseCase(r int) *CourseUseCase { return &CourseUseCase{r} }
+
+func (u *CourseUseCase) List() {}
+
+// notAUseCase は対象外。
+type Helper struct{}
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	structs, ctors, execs := analyzeFile(fset, f, "x.go")
+
+	if len(structs) != 2 {
+		t.Fatalf("want 2 UseCase structs, got %d", len(structs))
+	}
+	byName := map[string]ucStruct{}
+	for _, s := range structs {
+		byName[s.name] = s
+	}
+	if s := byName["CreateThingUseCase"]; s.suppressed {
+		t.Error("CreateThingUseCase should not be suppressed")
+	}
+	if s, ok := byName["CourseUseCase"]; !ok || !s.suppressed {
+		t.Errorf("CourseUseCase should be suppressed: %+v ok=%v", s, ok)
+	}
+	if _, ok := byName["Helper"]; ok {
+		t.Error("Helper (not *UseCase) should be ignored")
+	}
+
+	ctorSet := toSet(ctors)
+	if !ctorSet["NewCreateThingUseCase"] || !ctorSet["NewCourseUseCase"] {
+		t.Errorf("constructors missing: %v", ctors)
+	}
+	execSet := toSet(execs)
+	if !execSet["CreateThingUseCase"] {
+		t.Errorf("Execute recv missing CreateThingUseCase: %v", execs)
+	}
+	if execSet["CourseUseCase"] {
+		t.Error("CourseUseCase has no Execute, should not be in execs")
+	}
+}
+
+func toSet(ss []string) map[string]bool {
+	m := map[string]bool{}
+	for _, s := range ss {
+		m[s] = true
+	}
+	return m
+}
+
+func TestReceiverTypeName(t *testing.T) {
+	fset := token.NewFileSet()
+	f, _ := parser.ParseFile(fset, "x.go", `package p
+type T struct{}
+func (u *T) A() {}
+func (u T) B() {}
+func Free() {}
+`, parser.ParseComments)
+
+	var got []string
+	for _, d := range f.Decls {
+		if fn, ok := d.(*ast.FuncDecl); ok && fn.Recv != nil {
+			got = append(got, receiverTypeName(fn.Recv))
+		}
+	}
+	if len(got) != 2 || got[0] != "T" || got[1] != "T" {
+		t.Fatalf("receiverTypeName results = %v, want [T T]", got)
+	}
+	if receiverTypeName(nil) != "" {
+		t.Error("nil receiver should return empty")
+	}
+}
+
+// mkUsecaseTree は tmp/internal/usecase 配下にファイルを作り usecaseRoot を返す。
+func mkUsecaseTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	usecaseRoot := filepath.Join(root, "internal", "usecase")
+	if err := os.MkdirAll(filepath.Join(usecaseRoot, "repository"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		full := filepath.Join(usecaseRoot, name)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return usecaseRoot
+}
+
+func TestRunIntegration(t *testing.T) {
+	t.Run("missing Execute is a violation", func(t *testing.T) {
+		usecaseRoot := mkUsecaseTree(t, map[string]string{
+			"a.go": `package usecase
+type FooUseCase struct{}
+func NewFooUseCase() *FooUseCase { return &FooUseCase{} }
+`,
+		})
+		vs, err := run(usecaseRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 1 || !strings.Contains(vs[0].msg, "Execute") {
+			t.Fatalf("want 1 Execute violation, got %+v", vs)
+		}
+	})
+
+	t.Run("missing constructor is a violation", func(t *testing.T) {
+		usecaseRoot := mkUsecaseTree(t, map[string]string{
+			"a.go": `package usecase
+type FooUseCase struct{}
+func (u *FooUseCase) Execute() {}
+`,
+		})
+		vs, err := run(usecaseRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 1 || !strings.Contains(vs[0].msg, "NewFooUseCase") {
+			t.Fatalf("want 1 constructor violation, got %+v", vs)
+		}
+	})
+
+	t.Run("compliant usecase passes", func(t *testing.T) {
+		usecaseRoot := mkUsecaseTree(t, map[string]string{
+			"a.go": `package usecase
+type FooUseCase struct{}
+func NewFooUseCase() *FooUseCase { return &FooUseCase{} }
+func (u *FooUseCase) Execute() {}
+`,
+		})
+		vs, err := run(usecaseRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("want 0 violation, got %+v", vs)
+		}
+	})
+
+	t.Run("//naminglint:allow suppresses Execute requirement", func(t *testing.T) {
+		usecaseRoot := mkUsecaseTree(t, map[string]string{
+			"a.go": `package usecase
+
+//naminglint:allow 集約
+type FooUseCase struct{}
+func NewFooUseCase() *FooUseCase { return &FooUseCase{} }
+func (u *FooUseCase) List() {}
+`,
+		})
+		vs, err := run(usecaseRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("allow should suppress Execute requirement, got %+v", vs)
+		}
+	})
+
+	t.Run("repository subpackage is ignored", func(t *testing.T) {
+		usecaseRoot := mkUsecaseTree(t, map[string]string{
+			"a.go": `package usecase
+type FooUseCase struct{}
+func NewFooUseCase() *FooUseCase { return &FooUseCase{} }
+func (u *FooUseCase) Execute() {}
+`,
+			"repository/bad.go": `package repository
+type BrokenUseCase struct{}
+`,
+		})
+		vs, err := run(usecaseRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("repository subdir should be skipped, got %+v", vs)
+		}
+	})
+
+	t.Run("//naminglint:ignore-file skips file", func(t *testing.T) {
+		usecaseRoot := mkUsecaseTree(t, map[string]string{
+			"a.go": `//naminglint:ignore-file レガシー
+package usecase
+type FooUseCase struct{}
+`,
+		})
+		vs, err := run(usecaseRoot)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(vs) != 0 {
+			t.Fatalf("ignore-file should skip, got %+v", vs)
+		}
+	})
+}
+
+func TestRunCLI(t *testing.T) {
+	good := mkUsecaseTree(t, map[string]string{
+		"a.go": `package usecase
+type FooUseCase struct{}
+func NewFooUseCase() *FooUseCase { return &FooUseCase{} }
+func (u *FooUseCase) Execute() {}
+`,
+	})
+	root := filepath.Dir(filepath.Dir(good))
+	var out, errBuf bytes.Buffer
+	if code := runCLI([]string{root}, &out, &errBuf); code != 0 {
+		t.Fatalf("want 0, got %d (%s)", code, errBuf.String())
+	}
+	if !strings.Contains(out.String(), "OK") {
+		t.Errorf("want OK, got %q", out.String())
+	}
+
+	bad := mkUsecaseTree(t, map[string]string{
+		"a.go": `package usecase
+type FooUseCase struct{}
+`,
+	})
+	out.Reset()
+	errBuf.Reset()
+	if code := runCLI([]string{filepath.Dir(filepath.Dir(bad))}, &out, &errBuf); code != 1 {
+		t.Fatalf("want 1, got %d", code)
+	}
+}

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1930,7 +1930,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/notes/image-upload-url": {
+        "/notes/images/upload-url": {
             "post": {
                 "security": [
                     {
@@ -2447,58 +2447,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/profile/{userId}/stats": {
-            "get": {
-                "security": [
-                    {
-                        "CookieAuth": []
-                    }
-                ],
-                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "profile"
-                ],
-                "summary": "ユーザー 統計 取得",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "数字 ID または 'me'",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
-                        }
-                    },
-                    "400": {
-                        "description": "DB 失敗",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "未 認証",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "他 user 指定",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/sessions/{sessionId}/note": {
             "get": {
                 "security": [
@@ -2875,6 +2823,58 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{userId}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "ユーザー 統計 取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1923,7 +1923,7 @@
                 }
             }
         },
-        "/notes/image-upload-url": {
+        "/notes/images/upload-url": {
             "post": {
                 "security": [
                     {
@@ -2440,58 +2440,6 @@
                 }
             }
         },
-        "/profile/{userId}/stats": {
-            "get": {
-                "security": [
-                    {
-                        "CookieAuth": []
-                    }
-                ],
-                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "profile"
-                ],
-                "summary": "ユーザー 統計 取得",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "数字 ID または 'me'",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
-                        }
-                    },
-                    "400": {
-                        "description": "DB 失敗",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "未 認証",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "他 user 指定",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/sessions/{sessionId}/note": {
             "get": {
                 "security": [
@@ -2868,6 +2816,58 @@
                     },
                     "404": {
                         "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{userId}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "profile"
+                ],
+                "summary": "ユーザー 統計 取得",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2084,7 +2084,7 @@ paths:
       summary: ノート 更新
       tags:
       - notes
-  /notes/image-upload-url:
+  /notes/images/upload-url:
     post:
       consumes:
       - application/json
@@ -2328,39 +2328,6 @@ paths:
       security:
       - CookieAuth: []
       summary: プロフィール 画像 PUT 署名 URL
-      tags:
-      - profile
-  /profile/{userId}/stats:
-    get:
-      description: 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
-      parameters:
-      - description: 数字 ID または 'me'
-        in: path
-        name: userId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats'
-        "400":
-          description: DB 失敗
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
-        "401":
-          description: 未 認証
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
-        "403":
-          description: 他 user 指定
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
-      security:
-      - CookieAuth: []
-      summary: ユーザー 統計 取得
       tags:
       - profile
   /profile/me/onboarding/complete:
@@ -2631,6 +2598,39 @@ paths:
       summary: 教材 更新
       tags:
       - teaching-materials
+  /users/{userId}/stats:
+    get:
+      description: 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
+      parameters:
+      - description: 数字 ID または 'me'
+        in: path
+        name: userId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserStats'
+        "400":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 他 user 指定
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: ユーザー 統計 取得
+      tags:
+      - profile
 securityDefinitions:
   CookieAuth:
     description: Cognito 由来 の JWT を HttpOnly Cookie で 送る。 ログイン 後 自動 付与。

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -32,7 +32,7 @@ type issueUploadURLReq struct {
 // @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL
 // @Failure      400   {object}  errorResponse  "発行 失敗"
 // @Failure      401   {object}  errorResponse  "未 認証"
-// @Router       /notes/image-upload-url [post]
+// @Router       /notes/images/upload-url [post]
 // @Security     CookieAuth
 func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
 	uid := middleware.CurrentUserIDOrZero(c)

--- a/backend/internal/handler/routes_profile.go
+++ b/backend/internal/handler/routes_profile.go
@@ -22,7 +22,7 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	// :userId は数字 / "me" の両方を受ける。/update はフロント互換の別 path。
 	g.GET("/profile/:userId", profileHandler.Get)
 	g.PUT("/profile/:userId", profileHandler.Update)
-	g.PUT("/profile/:userId/update", profileHandler.Update)
+	g.PUT("/profile/:userId/update", profileHandler.Update) //apispec:allow フロント互換の別 path（正規は PUT /profile/:userId）
 
 	// Profile アイコン画像の S3 presigned-url（note image と同じバケットを profiles/ prefix で共有）。
 	profileImageHandler := NewProfileImageHandler(
@@ -36,7 +36,7 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	statsHandler := NewUserStatsHandler(
 		usecase.NewGetUserStatsUseCase(persistence.NewUserStatsRepository(deps.db)),
 	)
-	g.GET("/user-stats/:userId", statsHandler.Get)
+	g.GET("/user-stats/:userId", statsHandler.Get) //apispec:allow 互換用エイリアス（正規は GET /users/:userId/stats）
 	g.GET("/users/:userId/stats", statsHandler.Get)
 
 	// オンボーディング完了（自分自身の users.onboarded_at を更新）。

--- a/backend/internal/handler/routes_social.go
+++ b/backend/internal/handler/routes_social.go
@@ -19,7 +19,7 @@ func registerSocialRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.GET("/notifications", notificationHandler.List)
 	g.GET("/notifications/unread-count", notificationHandler.UnreadCount)
 	g.PATCH("/notifications/:id/read", notificationHandler.MarkRead)
-	g.PUT("/notifications/:id/read", notificationHandler.MarkRead)
+	g.PUT("/notifications/:id/read", notificationHandler.MarkRead) //apispec:allow フロント互換の別 method（正規は PATCH）
 	g.PATCH("/notifications/read-all", notificationHandler.MarkAllRead)
-	g.PUT("/notifications/read-all", notificationHandler.MarkAllRead)
+	g.PUT("/notifications/read-all", notificationHandler.MarkAllRead) //apispec:allow フロント互換の別 method（正規は PATCH）
 }

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -52,7 +52,7 @@ func (h *UserStatsHandler) resolveUserID(c *gin.Context) (uint64, error) {
 // @Failure      401     {object}  errorResponse  "未 認証"
 // @Failure      403     {object}  errorResponse  "他 user 指定"
 // @Failure      400     {object}  errorResponse  "DB 失敗"
-// @Router       /profile/{userId}/stats [get]
+// @Router       /users/{userId}/stats [get]
 // @Security     CookieAuth
 func (h *UserStatsHandler) Get(c *gin.Context) {
 	uid, err := h.resolveUserID(c)

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -13,6 +13,8 @@ import (
 )
 
 // ListAdminInvitationsUseCase は招待一覧を取得する。
+//
+//naminglint:allow 全社横断 ListAll と自社 ListByCompanyID の 2 系統を公開する集約 read usecase
 type ListAdminInvitationsUseCase struct {
 	repo repository.AdminInvitationRepository
 }

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -11,6 +11,8 @@ import (
 // CourseUseCase はコースの list / get / create / update / delete を 1 構造体で扱う。
 // canManage は teaching_material_usecase と共有。trainee は published のみ閲覧、
 // 編集系は同一 company の company_admin または super_admin。Delete は配下教材も cascade 削除。
+//
+//naminglint:allow 複数 CRUD を束ねる集約 usecase のため Execute 単一メソッドではなく List/Get/Create 等で公開する
 type CourseUseCase struct {
 	courses   repository.CourseRepository
 	materials repository.TeachingMaterialRepository

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -11,6 +11,8 @@ import (
 // TeachingMaterialUseCase は教材の list / get / create / update / delete を 1 構造体で扱う。
 // 教材は必ず Course に所属するため list は Course 単位、create は course_id 必須。
 // trainee は published コース内の published 教材のみ閲覧、編集系は company_admin / super_admin。
+//
+//naminglint:allow 複数 CRUD を束ねる集約 usecase のため Execute 単一メソッドではなく List/Get/Create 等で公開する
 type TeachingMaterialUseCase struct {
 	repo    repository.TeachingMaterialRepository
 	courses repository.CourseRepository


### PR DESCRIPTION
## 概要

規約検証 linter を 2 本整備しました。archlint(#1744) / apispec-lint(#1745) と同じ枠組み（`go/ast` のみ・`//tool:allow` 抑制）です。技術ドキュメントは frestyle-infrastructure#63（`docs/24`）に集約済み。

## naminglint（新規）

CLAUDE.md §2.3「1 usecase = struct + コンストラクタ + Execute」を機械化。

- `internal/usecase` 直下の `XxxUseCase` に `NewXxxUseCase` と `Execute` の存在を検査
- 集約系 3 件（`CourseUseCase` / `TeachingMaterialUseCase` / `ListAdminInvitationsUseCase`）は `//naminglint:allow` で Execute 必須を免除
- 単体 + 統合 + CLI テスト（カバレッジ 88%）

## apispec-lint（strict 化）

「注釈の有無」から「ルート ↔ `@Router` の **method + path 完全一致**」へ強化（gin `:id` → swaggo `{id}` 正規化込み）。

- **strict 化の初回実行で実在の OpenAPI ドリフトを 6 件検出**:
  - **注釈 path の誤り 2 件**を実ルートに修正 → `make openapi` で spec 再生成
    - `@Router /notes/image-upload-url` → 実ルート `/notes/images/upload-url`
    - `@Router /profile/{userId}/stats` → 実ルート `/users/{userId}/stats`
  - **フロント互換エイリアス 4 件**を `//apispec:allow` で明示（`/profile/:userId/update`、`/user-stats/:userId`、`/notifications/{id}/read` と `/notifications/read-all` の PUT 別名＝正規は PATCH）

> ⚠️ 注釈 path 修正により OpenAPI spec のパスが変わります（誤った path → 実際に served される path への修正）。フロントは `openapi-typescript` で型を再生成すると正しいパスになります。

## 組み込み・ドキュメント

- `make naminglint` / `make verify` / CI(`ci-backend-go.yml`) に追加
- `backend/README.md` に 3 linter の節（archlint / apispec-lint strict / naminglint）
- トップ `README.md` に**テスト種別（単体 / 結合 / E2E）の具体的な定義**を追記（各層の対象・ツール・配置・CI マッピング）

## テスト

```
make verify   # gofmt/vet/build/test/archlint/apispec-lint/naminglint すべて green
go test ./cmd/naminglint/ -cover     # 88.0%
go test ./cmd/apispec-lint/ -cover   # 89.6%
```

現状コードは 3 linter とも違反ゼロ（基準線）。

## 関連

- archlint #1744 / apispec-lint #1745 / CI 品質ゲート #1743 / infra docs frestyle-infrastructure#63