### PR TITLE
chore(frontend): OpenAPI 生成型を backend spec と再同期

### DIFF
--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -52,6 +52,153 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/company-applications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 企業申請一覧（super_admin）
+         * @description 受け付けた企業申請を新しい順で返す。super_admin 専用。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"][];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description super_admin 以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/company-applications/{id}/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 企業申請の status 更新（super_admin）
+         * @description 申請を approved / rejected / pending に更新する。super_admin 専用。
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 申請 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description status */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.updateCompanyApplicationStatusReq"];
+                };
+            };
+            responses: {
+                /** @description 成功（本文なし） */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description id / status 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description super_admin 以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 更新失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/admin/invitations": {
         parameters: {
             query?: never;
@@ -816,6 +963,17 @@ export interface paths {
                         "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
+                /** @description レート制限超過 */
+                429: {
+                    headers: {
+                        /** @description 再試行までの秒数 (例: 60) */
+                        "Retry-After"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
                 /** @description Cognito 未 設定 等 の 内部 エラー */
                 500: {
                     headers: {
@@ -915,6 +1073,17 @@ export interface paths {
                 /** @description refresh_token 欠落 / 無効 */
                 401: {
                     headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description レート制限超過 */
+                429: {
+                    headers: {
+                        /** @description 再試行までの秒数 (例: 60) */
+                        "Retry-After"?: string;
                         [name: string]: unknown;
                     };
                     content: {
@@ -1051,6 +1220,79 @@ export interface paths {
                 };
                 /** @description 未 認証 */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/company-applications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 企業利用申請（公開 / 認証不要）
+         * @description ログイン前のユーザーが会社名 / 氏名 / メール / 任意メッセージで利用申請を送る。受理時に super_admin へ通知する。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description 申請内容 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.createCompanyApplicationReq"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"];
+                    };
+                };
+                /** @description バリデーションエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description レート制限超過 */
+                429: {
+                    headers: {
+                        /** @description 再試行までの秒数 (例: 60) */
+                        "Retry-After"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部エラー */
+                500: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -1918,6 +2160,17 @@ export interface paths {
                         "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
+                /** @description レート制限超過 */
+                429: {
+                    headers: {
+                        /** @description 再試行までの秒数 (例: 60) */
+                        "Retry-After"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
                 /** @description 内部 エラー */
                 500: {
                     headers: {
@@ -2159,7 +2412,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/notes/image-upload-url": {
+    "/notes/images/upload-url": {
         parameters: {
             query?: never;
             header?: never;
@@ -2820,75 +3073,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/profile/{userId}/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * ユーザー 統計 取得
-         * @description 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description 数字 ID または 'me' */
-                    userId: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserStats"];
-                    };
-                };
-                /** @description DB 失敗 */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.errorResponse"];
-                    };
-                };
-                /** @description 未 認証 */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.errorResponse"];
-                    };
-                };
-                /** @description 他 user 指定 */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.errorResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/sessions/{sessionId}/note": {
         parameters: {
             query?: never;
@@ -3325,6 +3509,75 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/{userId}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ユーザー 統計 取得
+         * @description 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 数字 ID または 'me' */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserStats"];
+                    };
+                };
+                /** @description DB 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 他 user 指定 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3370,6 +3623,16 @@ export interface components {
             name?: string;
             updatedAt?: string;
         };
+        "github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication": {
+            applicantName?: string;
+            companyName?: string;
+            createdAt?: string;
+            email?: string;
+            id?: number;
+            message?: string;
+            status?: string;
+            updatedAt?: string;
+        };
         "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
             companyId?: number;
             createdAt?: string;
@@ -3413,20 +3676,13 @@ export interface components {
             description?: string;
             difficulty?: number;
             expectedOutput?: string;
-            /**
-             * @description Explanation は QA モードで 正解後に表示される markdown 解説。
-             *     execute モードでは未使用 (空文字)。
-             */
+            /** @description Explanation は qa モードで正解後に表示する markdown 解説。 */
             explanation?: string;
             hintText?: string;
             id?: number;
             isPublished?: boolean;
             language?: string;
-            /**
-             * @description Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
-             *     'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
-             *     docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
-             */
+            /** @description Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。 */
             mode?: string;
             orderIndex?: number;
             slug?: string;
@@ -3436,18 +3692,12 @@ export interface components {
         };
         "github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample": {
             createdAt?: string;
-            /**
-             * @description (exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で
-             *     OrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。
-             */
+            /** @description (exercise_id, order_index) の UNIQUE で同一問題内の OrderIndex 衝突を DB レベルで弾く。 */
             exerciseId?: number;
             expectedOutput?: string;
             id?: number;
             inputText?: string;
-            /**
-             * @description OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。
-             *     （default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）
-             */
+            /** @description DEFAULT を持たせない（default:0 だと未指定 INSERT が 0 で衝突するため）。 */
             orderIndex?: number;
             updatedAt?: string;
         };
@@ -3485,10 +3735,6 @@ export interface components {
             avatarUrl?: string;
             bio?: string;
             displayName?: string;
-            /**
-             * @description Email は users.email を そのまま返す。 frontend の sidebar ユーザーメニューで
-             *     「ログイン中のメールアドレスを 表示する」 用途で参照する。
-             */
             email?: string;
             status?: string;
             updatedAt?: string;
@@ -3505,10 +3751,7 @@ export interface components {
         "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
             companyId?: number;
             content?: string;
-            /**
-             * @description course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を
-             *     AutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。
-             */
+            /** @description NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD COLUMN 対策）。 */
             courseId?: number;
             createdAt?: string;
             createdByUserId?: number;
@@ -3550,20 +3793,13 @@ export interface components {
             description?: string;
             difficulty?: number;
             expectedOutput?: string;
-            /**
-             * @description Explanation は QA モードで 正解後に表示される markdown 解説。
-             *     execute モードでは未使用 (空文字)。
-             */
+            /** @description Explanation は qa モードで正解後に表示する markdown 解説。 */
             explanation?: string;
             hintText?: string;
             id?: number;
             isPublished?: boolean;
             language?: string;
-            /**
-             * @description Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、
-             *     'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。
-             *     docker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。
-             */
+            /** @description Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。 */
             mode?: string;
             orderIndex?: number;
             slug?: string;
@@ -3606,11 +3842,7 @@ export interface components {
         };
         "internal_handler.cognitoCallbackReq": {
             code: string;
-            /**
-             * @description InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で
-             *     受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より
-             *     優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。
-             */
+            /** @description InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。 */
             invitationToken?: string;
         };
         "internal_handler.courseRequest": {
@@ -3624,6 +3856,12 @@ export interface components {
             displayName?: string;
             email: string;
             role: string;
+        };
+        "internal_handler.createCompanyApplicationReq": {
+            applicantName: string;
+            companyName: string;
+            email: string;
+            message?: string;
         };
         "internal_handler.createSessionReq": {
             scenarioId?: number;
@@ -3730,13 +3968,16 @@ export interface components {
             orderInCourse?: number;
             title?: string;
         };
+        "internal_handler.updateCompanyApplicationStatusReq": {
+            status: string;
+        };
         "internal_handler.updateProfileReq": {
             avatarUrl?: string;
             bio?: string;
-            /** @description `name` は旧フロント実装の互換のため受け付け、`displayName` を優先する。 */
             displayName?: string;
-            /** @description 旧フロント実装が `iconUrl` で送ってきた場合の互換。 */
+            /** @description 旧フロント互換。avatarUrl を優先。 */
             iconUrl?: string;
+            /** @description 旧フロント互換。displayName を優先。 */
             name?: string;
             status?: string;
         };

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -50,6 +50,146 @@
                 }
             }
         },
+        "/admin/company-applications": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "受け付けた企業申請を新しい順で返す。super_admin 専用。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "企業申請一覧（super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/company-applications/{id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "申請を approved / rejected / pending に更新する。super_admin 専用。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "企業申請の status 更新（super_admin）",
+                "parameters": [
+                    {
+                        "description": "申請 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.updateCompanyApplicationStatusReq"
+                            }
+                        }
+                    },
+                    "description": "status",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "成功（本文なし）"
+                    },
+                    "400": {
+                        "description": "id / status 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 更新失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/invitations": {
             "get": {
                 "security": [
@@ -832,6 +972,24 @@
                             }
                         }
                     },
+                    "429": {
+                        "description": "レート制限超過",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "再試行までの秒数 (例: 60)",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "Cognito 未 設定 等 の 内部 エラー",
                         "content": {
@@ -896,6 +1054,24 @@
                     },
                     "401": {
                         "description": "refresh_token 欠落 / 無効",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "再試行までの秒数 (例: 60)",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1019,6 +1195,76 @@
                     },
                     "401": {
                         "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/company-applications": {
+            "post": {
+                "description": "ログイン前のユーザーが会社名 / 氏名 / メール / 任意メッセージで利用申請を送る。受理時に super_admin へ通知する。",
+                "tags": [
+                    "company-applications"
+                ],
+                "summary": "企業利用申請（公開 / 認証不要）",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.createCompanyApplicationReq"
+                            }
+                        }
+                    },
+                    "description": "申請内容",
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーションエラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "再試行までの秒数 (例: 60)",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1896,6 +2142,24 @@
                             }
                         }
                     },
+                    "429": {
+                        "description": "レート制限超過",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "再試行までの秒数 (例: 60)",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
                     "500": {
                         "description": "内部 エラー",
                         "content": {
@@ -2119,7 +2383,7 @@
                 }
             }
         },
-        "/notes/image-upload-url": {
+        "/notes/images/upload-url": {
             "post": {
                 "security": [
                     {
@@ -2744,73 +3008,6 @@
                 }
             }
         },
-        "/profile/{userId}/stats": {
-            "get": {
-                "security": [
-                    {
-                        "CookieAuth": []
-                    }
-                ],
-                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
-                "tags": [
-                    "profile"
-                ],
-                "summary": "ユーザー 統計 取得",
-                "parameters": [
-                    {
-                        "description": "数字 ID または 'me'",
-                        "name": "userId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "DB 失敗",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "未 認証",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "他 user 指定",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/sessions/{sessionId}/note": {
             "get": {
                 "security": [
@@ -3289,6 +3486,73 @@
                     }
                 }
             }
+        },
+        "/users/{userId}/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。",
+                "tags": [
+                    "profile"
+                ],
+                "summary": "ユーザー 統計 取得",
+                "parameters": [
+                    {
+                        "description": "数字 ID または 'me'",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserStats"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "他 user 指定",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "servers": [
@@ -3427,6 +3691,35 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_domain.CompanyApplication": {
+                "type": "object",
+                "properties": {
+                    "applicantName": {
+                        "type": "string"
+                    },
+                    "companyName": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string"
+                    },
+                    "updatedAt": {
+                        "type": "string"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
                 "type": "object",
                 "properties": {
@@ -3553,7 +3846,7 @@
                         "type": "string"
                     },
                     "explanation": {
-                        "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                        "description": "Explanation は qa モードで正解後に表示する markdown 解説。",
                         "type": "string"
                     },
                     "hintText": {
@@ -3569,7 +3862,7 @@
                         "type": "string"
                     },
                     "mode": {
-                        "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。",
+                        "description": "Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。",
                         "type": "string"
                     },
                     "orderIndex": {
@@ -3596,7 +3889,7 @@
                         "type": "string"
                     },
                     "exerciseId": {
-                        "description": "(exercise_id, order_index) で UNIQUE 制約を張ることで、同じ問題内で\nOrderIndex が衝突する行を DB レベルで弾く（UI 上「入力例 1」が 2 つ並ぶ事故防止）。",
+                        "description": "(exercise_id, order_index) の UNIQUE で同一問題内の OrderIndex 衝突を DB レベルで弾く。",
                         "type": "integer"
                     },
                     "expectedOutput": {
@@ -3609,7 +3902,7 @@
                         "type": "string"
                     },
                     "orderIndex": {
-                        "description": "OrderIndex は seed / 運営入力時に必ず明示する想定で DB DEFAULT を持たせない。\n（default:0 を残すと order_index 未指定の INSERT が黙って 0 を採用して衝突を起こすため）",
+                        "description": "DEFAULT を持たせない（default:0 だと未指定 INSERT が 0 で衝突するため）。",
                         "type": "integer"
                     },
                     "updatedAt": {
@@ -3716,7 +4009,6 @@
                         "type": "string"
                     },
                     "email": {
-                        "description": "Email は users.email を そのまま返す。 frontend の sidebar ユーザーメニューで\n「ログイン中のメールアドレスを 表示する」 用途で参照する。",
                         "type": "string"
                     },
                     "status": {
@@ -3763,7 +4055,7 @@
                         "type": "string"
                     },
                     "courseId": {
-                        "description": "course_id の NOT NULL 制約は migration 0004 で確定する（既存行への ADD COLUMN を\nAutoMigrate で安全に通すため、 GORM tag では not null を指定しない）。",
+                        "description": "NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD COLUMN 対策）。",
                         "type": "integer"
                     },
                     "createdAt": {
@@ -3883,7 +4175,7 @@
                         "type": "string"
                     },
                     "explanation": {
-                        "description": "Explanation は QA モードで 正解後に表示される markdown 解説。\nexecute モードでは未使用 (空文字)。",
+                        "description": "Explanation は qa モードで正解後に表示する markdown 解説。",
                         "type": "string"
                     },
                     "hintText": {
@@ -3899,7 +4191,7 @@
                         "type": "string"
                     },
                     "mode": {
-                        "description": "Mode は採点モード。 'execute' (default) は コードを実行して stdout を比較、\n'qa' は コード実行をせず提出文字列と ExpectedOutput を直接 trim 比較する。\ndocker / kubernetes など サンドボックス実行が困難な題材を Q&A 形式で扱うために導入。",
+                        "description": "Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。",
                         "type": "string"
                     },
                     "orderIndex": {
@@ -4028,7 +4320,7 @@
                         "type": "string"
                     },
                     "invitationToken": {
-                        "description": "InvitationToken はフロントが sessionStorage から復元してくる、招待マジックリンク経由で\n受領した UUID トークン。任意。指定がある場合は upsert 時に email ベースの招待検索より\n優先して照合に使う（同じ email に複数 pending invitation がある異常系での誤一致を防ぐ）。",
+                        "description": "InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。",
                         "type": "string"
                     }
                 }
@@ -4068,6 +4360,28 @@
                         "type": "string"
                     },
                     "role": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.createCompanyApplicationReq": {
+                "type": "object",
+                "required": [
+                    "applicantName",
+                    "companyName",
+                    "email"
+                ],
+                "properties": {
+                    "applicantName": {
+                        "type": "string"
+                    },
+                    "companyName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "message": {
                         "type": "string"
                     }
                 }
@@ -4360,6 +4674,17 @@
                     }
                 }
             },
+            "internal_handler.updateCompanyApplicationStatusReq": {
+                "type": "object",
+                "required": [
+                    "status"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string"
+                    }
+                }
+            },
             "internal_handler.updateProfileReq": {
                 "type": "object",
                 "properties": {
@@ -4370,14 +4695,14 @@
                         "type": "string"
                     },
                     "displayName": {
-                        "description": "`name` は旧フロント実装の互換のため受け付け、`displayName` を優先する。",
                         "type": "string"
                     },
                     "iconUrl": {
-                        "description": "旧フロント実装が `iconUrl` で送ってきた場合の互換。",
+                        "description": "旧フロント互換。avatarUrl を優先。",
                         "type": "string"
                     },
                     "name": {
+                        "description": "旧フロント互換。displayName を優先。",
                         "type": "string"
                     },
                     "status": {


### PR DESCRIPTION
## 概要

apispec-lint strict 化（#1746）で修正した swaggo 注釈 path が、フロントの OpenAPI 生成型（`src/generated/api.ts` / `openapi.json`）に未反映だったため `npm run openapi:generate` で再生成しました。

## 変更内容

`swagger2openapi ../backend/docs/swagger.json` → `openapi-typescript` で再生成。主な差分:

- `/notes/image-upload-url` → **`/notes/images/upload-url`**（実ルートに修正済みの注釈を反映）
- `/profile/{userId}/stats` → **`/users/{userId}/stats`**（同上）
- stale だった `company-applications` 系エンドポイントの型を追加同期

## 影響範囲

- `src/generated/api.ts` は現状アプリコードから import されていない**同期用アーティファクト**のため runtime 影響なし。
- `tsc --noEmit` / ESLint(max-warnings=0) / build / Vitest（186 ファイル・1491 テスト）すべて green。

## 関連

- apispec-lint strict 化 #1746 / infra docs frestyle-infrastructure#63