### PR TITLE
test(e2e): ローカルビルド + API モックの認証付き E2E を CI に追加

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,3 +82,63 @@ jobs:
           name: playwright-test-results
           path: frontend/test-results/
           retention-days: 7
+
+  # ローカルビルド + API モックによる「認証付き導線・主要画面」E2E。
+  # 本番 Cognito / DB に触れず、/api/v2/** を Playwright route でモックして検証する。
+  local-mocked:
+    name: Playwright Local (mocked API)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # VITE_API_BASE_URL='' で同一オリジン相対 (/api/v2/*) にする。これにより index.html の
+      # CSP connect-src 'self' に収まり、Playwright route がモックを差し込める（cross-origin の
+      # ダミーホストは CSP でブロックされ route に到達しないため）。
+      - name: Build (same-origin / API モック前提)
+        env:
+          VITE_API_BASE_URL: ''
+          VITE_WEB_SOCKET_URL_AI_CHAT: wss://example.invalid
+          VITE_WEB_SOCKET_URL_CHAT: wss://example.invalid
+          VITE_COGNITO_DOMAIN: https://example.invalid
+          VITE_CLIENT_ID: ci-dummy
+          VITE_REDIRECT_URI: https://example.invalid/callback
+          VITE_RESPONSE_TYPE: code
+          VITE_SCOPE: openid
+        run: npm run build
+
+      - name: Run local mocked E2E
+        run: npm run e2e:local
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-local
+          path: frontend/playwright-report/
+          retention-days: 7
+
+      - name: Upload trace / screenshots / video on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results-local
+          path: frontend/test-results/
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -200,17 +200,26 @@ npm run test:run         # 1 回実行（CI と同じ）
 npm run test:run -- --coverage
 ```
 
-#### E2E (Playwright) — `frontend/e2e/smoke.spec.ts`
+E2E は **2 系統**に分かれる。
 
-デプロイ済み本番（既定 `https://normanblog.com`）に対する **未認証スモーク 6 ケース**: ① SPA ロード + ロゴ / ログイン誘導表示 ② CloudFront セキュリティヘッダー配信 ③ `index.html` の CSP meta ④ `GET /api/v2/health` が 200 ⑤ 認証必須エンドポイントが Cookie 無で 401 ⑥ 廃止済み SockJS フォールバック路が 404 / 401。設定は `frontend/playwright.config.ts`。
+**(a) 本番スモーク（外形監視）** — `frontend/e2e/smoke.spec.ts` / 設定 `playwright.config.ts`
+
+デプロイ済み本番（既定 `https://normanblog.com`）に対する **未認証スモーク 6 ケース**: ① SPA ロード + ロゴ / ログイン誘導表示 ② CloudFront セキュリティヘッダー配信 ③ `index.html` の CSP meta ④ `GET /api/v2/health` が 200 ⑤ 認証必須エンドポイントが Cookie 無で 401 ⑥ 廃止済み SockJS フォールバック路が 404 / 401。
+
+**(b) ローカルビルド + API モック（認証付き導線）** — `frontend/e2e/local/*.spec.ts` / 設定 `playwright.local.config.ts`
+
+`vite preview` で配信したビルド済み SPA に対し、Playwright の `page.route` で `/api/v2/**` をモックして認証付きの主要画面を検証する。`GET /auth/me` のレスポンスで認証状態を制御する（401→未認証で `/login` リダイレクト、200+`role`→認証済みで AppShell 描画）。**本番 Cognito / DB に一切触れない**ため CI で毎回安全に回せる。ビルドは `VITE_API_BASE_URL=''`（同一オリジン相対）で行い、`index.html` の CSP `connect-src 'self'` に収めてモックを差し込める状態にするのが要点。
 
 ```bash
 cd frontend
 npm run e2e:install                                       # 初回のみ（Chromium + OS deps）
-npm run e2e                                                # 本番に対してスモーク
+npm run e2e                                                # (a) 本番スモーク
+npm run e2e:local                                         # (b) ローカルビルド + API モック（要 build）
 npm run e2e:ui                                             # UI モードでデバッグ
-PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run e2e      # ローカル dev server 経由
+PLAYWRIGHT_BASE_URL=http://localhost:5173 npm run e2e      # (a) をローカル dev server に向ける
 ```
+
+CI（`e2e.yml`）は **smoke（本番）** と **local-mocked（ローカル + モック）** の 2 ジョブで実行する。
 
 #### CI でのテスト実行
 

--- a/frontend/e2e/local/authenticated.spec.ts
+++ b/frontend/e2e/local/authenticated.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * ローカルビルド + API モックによる「認証付き導線・主要画面」E2E。
+ *
+ * 本番 Cognito / DB に触れず、`/api/v2/**` を Playwright route でモックして
+ * 認証ガード (AuthInitializer → Protected) と主要画面の描画を検証する。
+ *
+ * 認証は `GET /auth/me` のレスポンスで制御する:
+ *   - 401 を返す → 未認証扱い → /login へリダイレクト
+ *   - 200 + { role } を返す → 認証済み → AppShell + ページ描画
+ */
+
+// 認証済みユーザー（trainee）として /api/v2/** をモックする。
+// 個別エンドポイントを上書きできるよう overrides を受け取る。
+async function mockAuthenticated(
+  page: Page,
+  overrides: Record<string, unknown> = {}
+) {
+  // 既定: 未指定の API は空配列で 200（リスト/オブジェクトどちらの消費側も undefined 安全）。
+  await page.route('**/api/v2/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  // 認証確認: trainee として認証済みにする。
+  await page.route('**/api/v2/auth/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ isAdmin: false, role: 'trainee' }),
+    })
+  );
+  for (const [pattern, body] of Object.entries(overrides)) {
+    await page.route(pattern, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      })
+    );
+  }
+}
+
+test.describe('認証ガード', () => {
+  test('未認証で保護ルートを開くと /login にリダイレクトされる', async ({ page }) => {
+    // すべての API を 401 にする → getCurrentUser 401 → refresh 401 → /login。
+    await page.route('**/api/v2/**', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: '{"error":"unauthorized"}',
+      })
+    );
+
+    await page.goto('/courses');
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('認証済みなら保護ルートはログインに飛ばされない', async ({ page }) => {
+    await mockAuthenticated(page);
+
+    await page.goto('/');
+
+    await expect(page).not.toHaveURL(/\/login/);
+  });
+});
+
+test.describe('主要画面（認証済み）', () => {
+  test('コース一覧でモックしたコースが描画される', async ({ page }) => {
+    const course = {
+      id: 1,
+      companyId: 1,
+      createdByUserId: 1,
+      title: 'E2E モックコース',
+      description: 'Playwright によるモックコース',
+      sortOrder: 10,
+      isPublished: true,
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    await mockAuthenticated(page, { '**/api/v2/courses': [course] });
+
+    await page.goto('/courses');
+
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page.getByText('E2E モックコース')).toBeVisible();
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "test:run": "vitest run",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
+    "e2e:local": "playwright test --config=playwright.local.config.ts",
     "e2e:install": "playwright install --with-deps chromium",
     "tailwind:init": "tailwindcss init -p",
     "openapi:generate": "swagger2openapi ../backend/docs/swagger.json --outfile src/generated/openapi.json && openapi-typescript src/generated/openapi.json --output src/generated/api.ts"

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -15,6 +15,8 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './e2e',
+  // ローカルビルド + API モック用の e2e/local は別 config (playwright.local.config.ts) で回す。
+  testIgnore: ['**/local/**'],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/frontend/playwright.local.config.ts
+++ b/frontend/playwright.local.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E config（ローカルビルド + API モック）
+ *
+ * 本番 (playwright.config.ts) とは別系統。`vite preview` で配信したビルド済み SPA に対し、
+ * Playwright の route 機能で `/api/v2/**` をモックして「認証付き導線・主要画面」を検証する。
+ * 本番 Cognito / 本番 DB に一切触れないため、CI で安全に毎回回せる。
+ *
+ * 重要: ビルドは VITE_API_BASE_URL='' （同一オリジン相対 /api/v2/*）で行う。index.html の
+ * CSP connect-src 'self' に収め、Playwright route がモックを差し込めるようにするため。
+ * cross-origin のダミーホストにすると CSP でブロックされ route に到達しない。
+ *
+ *   npm run e2e:local            # build 済み前提（CI は build → preview → test）
+ */
+export default defineConfig({
+  testDir: './e2e/local',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [['html', { open: 'never' }], ['github']]
+    : [['list']],
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  // ビルド済み dist/ を vite preview で配信する（SPA history fallback 込み）。
+  webServer: {
+    command: 'npm run preview -- --port 4173 --strictPort',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
## 概要

E2E を CI で拡充しました。これまでの **本番外形スモーク（未認証 6 ケース）** に加え、**認証付き導線・主要画面**を検証する E2E 層を追加します。本番 Cognito / DB に一切触れず、`vite preview` のビルド済み SPA に対し Playwright の `page.route` で `/api/v2/**` をモックするため、CI で毎回安全に回せます。

## 追加した E2E（`frontend/e2e/local/authenticated.spec.ts`）

`GET /auth/me` のレスポンスで認証状態を制御（AuthInitializer → Protected の挙動を検証）:

1. **未認証**（`/auth/me` 401）→ 保護ルート `/courses` で `/login` にリダイレクト
2. **認証済み**（`/auth/me` 200 + `role`）→ 保護ルートで `/login` に飛ばされない
3. **認証済み + `/courses` モック** → コース一覧にモックしたコースが描画される

## 構成

- `playwright.local.config.ts`（新規）: `baseURL=http://localhost:4173` + `webServer`（`vite preview`）。本番 config とは別系統。
- `playwright.config.ts`: `testIgnore: [**/local/**]` で本番スモークから `e2e/local` を除外。
- `package.json`: `e2e:local` スクリプト追加。
- `.github/workflows/e2e.yml`: `local-mocked` ジョブ追加（build → preview → test）。
- `README.md`: E2E 2 系統（本番スモーク / ローカル + モック）の定義を追記。

## ハマりどころ（重要）

ビルドを `VITE_API_BASE_URL=`（同一オリジン相対 `/api/v2/*`）で行うのが要点です。`index.html` の CSP `connect-src self https://api.normanblog.com ...` により、**cross-origin のダミーホストは Playwright の route に到達する前に CSP でブロック**されます。同一オリジンにすることで `self` に収まり、route モックが差し込めます。

## テスト

```
cd frontend
npm run build   # VITE_API_BASE_URL= （同一オリジン）
npm run e2e:local
# → 3 passed

npx playwright test --list   # 本番 config は smoke 6 件のみ（local は除外）
tsc --noEmit / eslint / vitest すべて green
```

## 関連

- 既存 E2E スモーク（`e2e.yml` smoke ジョブ）/ テスト定義 README #1746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * ローカル環境でのE2Eテストが新たに追加されました。認証機能と主要画面の動作を検証できます。
  * CI/CDで本番環境テストに加えてローカル環境テストも実行されるようになりました。

* **ドキュメント**
  * E2Eテストの実行方法と設定が更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->