### PR TITLE
test(backend): 本物の PostgreSQL に対する repository 結合テストを追加

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -126,3 +126,39 @@ jobs:
 
       - name: Show binary size
         run: ls -lh /tmp/frestyle-backend
+
+  # repository(adapter/persistence) 層の結合テストを、本物の PostgreSQL に対して回す。
+  # docker-compose.integration.yml で postgres-integration-test を起動し、
+  # -tags=integration のテストだけを実行する（単体ジョブとは独立）。
+  integration:
+    name: integration tests (postgres)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: go mod download
+        run: go mod download
+
+      # 本物の PostgreSQL を起動し healthcheck が通るまで待つ（--wait）。
+      - name: Start PostgreSQL (docker compose)
+        run: docker compose -f docker-compose.integration.yml up -d --wait
+
+      # -run Integration で結合テスト（命名規約: テスト名に Integration を含む）だけを回す。
+      # 単体テストは test ジョブで実行済みで、TEST_DATABASE_URL を env に持つこのジョブで
+      # 再実行すると env 依存の単体テストが誤検知し得るため。
+      - name: Run integration tests (-tags=integration)
+        env:
+          TEST_DATABASE_URL: postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable
+        run: go test -tags=integration -run Integration ./...
+
+      - name: Stop PostgreSQL
+        if: always()
+        run: docker compose -f docker-compose.integration.yml down -v

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ npx tailwindcss init -p
 - **handler（結合, 9 ファイル）**: `gin.SetMode(gin.TestMode)` + `httptest.NewRecorder()` でルータに `ServeHTTP` し、ルーティング〜ステータス〜JSON を通しで検証する。例: `internal/handler/profile_handler_test.go`。
 - **middleware（単体, 4 ファイル）**: JWT 認証・CurrentUser 注入・レートリミットなど横断処理を個別に検証する。
 - **infra（単体 / 境界, 4 ファイル）**: 外部 I/O を境界で差し替える。Cognito トークン交換・JWKS 検証・oEmbed 取得・SES メールを `httptest` サーバや fake で検証する。例: `internal/infra/cognito/jwt_verifier_test.go`。
-- **repository（結合, 規約）**: 永続化ロジックを足すときは `*gorm.DB` を **sqlite in-memory** に差し替え、実 SQL でクエリを検証する。現状は persistence 層が薄く、データ操作の大半は usecase 単体テスト（mock）で覆っているため専用テストは未追加。
+- **repository（結合）**: `adapter/persistence` 層を **本物の PostgreSQL**（`docker-compose.integration.yml` の `postgres-integration-test`、本番と同系の 17.x）に対して検証する。`//go:build integration` で隔離し、`make test-integration`（compose 起動 → `go test -tags=integration -run Integration` → teardown）で実行する。通常の `go test ./...`（単体）からは独立。例: `internal/adapter/persistence/company_application_repository_integration_test.go`。
 - **自作 linter（単体 + 結合）**: `cmd/archlint` / `cmd/apispec-lint` / `cmd/naminglint` は、分類・ルール評価の純粋関数（単体）と、一時ディレクトリツリーを走査する `run` / CLI（結合）の両方を検証する（各カバレッジ 87〜89%）。
 
 ```bash

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -6,6 +6,7 @@
 #   make archlint     … クリーンアーキテクチャ依存方向ルール (CLAUDE.md §2) を 静的 検証
 #   make apispec-lint … Gin ルート ↔ swaggo @Router 注釈 の 整合 (CLAUDE.md §2.7) を 検証
 #   make naminglint   … usecase 命名・構造規約 (CLAUDE.md §2.3) を 検証
+#   make test-integration … docker-compose で PostgreSQL を起動し -tags=integration の結合テストを実行
 #   make run          … go run ./cmd/server で ローカル サーバ 起動
 #
 # swag CLI が PATH に なければ `go install github.com/swaggo/swag/cmd/swag@v1.16.4` を 自動 実行 する。
@@ -60,6 +61,17 @@ apispec-lint:
 naminglint:
 	@echo ">>> naminglint: usecase 命名規約チェック"
 	@go run ./cmd/naminglint .
+
+# 結合テスト: docker-compose で本物の PostgreSQL を起動し、-tags=integration のテストを回す。
+# 終了時は必ずコンテナを破棄する（テスト失敗でも teardown する）。
+INTEGRATION_DSN := postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable
+.PHONY: test-integration
+test-integration:
+	docker compose -f docker-compose.integration.yml up -d --wait
+	@TEST_DATABASE_URL='$(INTEGRATION_DSN)' go test -tags=integration -run Integration ./... ; \
+	  status=$$? ; \
+	  docker compose -f docker-compose.integration.yml down -v ; \
+	  exit $$status
 
 .PHONY: run
 run:

--- a/backend/README.md
+++ b/backend/README.md
@@ -125,12 +125,30 @@ docker build -t frestyle-backend:latest .
 
 ```bash
 go vet ./...
-go test ./...
+go test ./...        # 単体テスト（DB 不要）
 make archlint      # クリーンアーキテクチャ依存方向チェック
 make apispec-lint  # ルート ↔ swaggo @Router 注釈チェック（strict path 照合）
 make naminglint    # usecase 命名・構造規約チェック
 make verify        # gofmt / vet / build / test / 3 linter を一括実行
 ```
+
+### 結合テスト（本物の PostgreSQL）
+
+`adapter/persistence` 層は、GORM の実 SQL を **本物の PostgreSQL** に対して検証する結合テストを持つ。単体テスト（usecase の mock）とは独立し、`//go:build integration` タグで隔離しているため通常の `go test ./...` には含まれない。
+
+```bash
+make test-integration
+# = docker compose -f docker-compose.integration.yml up -d --wait
+#   → TEST_DATABASE_URL=... go test -tags=integration -run Integration ./...
+#   → docker compose ... down -v（テスト失敗でも teardown）
+```
+
+- **DB コンテナ**: `docker-compose.integration.yml` の `postgres-integration-test`（`postgres:17.6-alpine`、host 側 5433、`tmpfs` で毎回まっさら）。
+- **接続先**: `TEST_DATABASE_URL`（既定 `postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable`）。未設定 / 未起動なら結合テストは `t.Skip`。
+- **スキーマ**: `testsupport.OpenTestDB(t)` が `database.AutoMigrateAll(db)`（seed なしの全 domain AutoMigrate）でスキーマを構築。テスト間は `testsupport.TruncateAll(t, db, ...)` で独立性を確保。
+- **命名規約**: 結合テストの関数名には `Integration` を含める（CI / make は `-run Integration` で選別実行する。`TEST_DATABASE_URL` を env に持つこのジョブで env 依存の単体テストを巻き込まないため）。
+- **CI**: `ci-backend-go.yml` の `integration` ジョブが docker compose で Postgres を起動して実行する（単体 `test` ジョブとは別ジョブ）。
+- 新しい repository を足したら `internal/adapter/persistence/{entity}_repository_integration_test.go` を追加する。
 
 ## ログ方針（CloudWatch コスト対策）
 

--- a/backend/docker-compose.integration.yml
+++ b/backend/docker-compose.integration.yml
@@ -1,0 +1,31 @@
+# 結合テスト用 PostgreSQL コンテナ。
+#
+# 目的: repository(adapter/persistence) 層の結合テストを「本物の PostgreSQL」に対して回す。
+#   - 本番 Supabase は Postgres 17.x のため、同系統の公式イメージを使う。
+#   - 通常の `go test ./...`（単体）からは独立。`-tags=integration` のテストだけが接続する。
+#
+# 使い方:
+#   docker compose -f docker-compose.integration.yml up -d --wait
+#   TEST_DATABASE_URL='postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable' \
+#     go test -tags=integration ./...
+#   docker compose -f docker-compose.integration.yml down -v
+#
+# ローカル開発の 5432 と衝突しないよう host 側は 5433 に publish する。
+services:
+  postgres-integration-test:
+    image: postgres:17.6-alpine
+    container_name: frestyle-postgres-integration-test
+    environment:
+      POSTGRES_USER: frestyle
+      POSTGRES_PASSWORD: frestyle
+      POSTGRES_DB: frestyle_integration
+    ports:
+      - '5433:5432'
+    # tmpfs でデータを永続化しない（毎回まっさらな DB で結合テストを回す）。
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U frestyle -d frestyle_integration']
+      interval: 2s
+      timeout: 3s
+      retries: 30

--- a/backend/internal/adapter/persistence/company_application_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/company_application_repository_integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompanyApplicationRepository_Integration は本物の PostgreSQL に対して
+// CompanyApplicationRepository の Create / ListAll / UpdateStatus を検証する結合テスト。
+func TestCompanyApplicationRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	testsupport.TruncateAll(t, db, "company_applications")
+
+	repo := persistence.NewCompanyApplicationRepository(db)
+	ctx := context.Background()
+
+	t.Run("Create で保存し ListAll で取得できる", func(t *testing.T) {
+		app := &domain.CompanyApplication{
+			CompanyName:   "結合テスト株式会社",
+			ApplicantName: "山田 太郎",
+			Email:         "taro@example.com",
+			Message:       "利用したいです",
+			Status:        domain.CompanyApplicationStatusPending,
+		}
+		require.NoError(t, repo.Create(ctx, app))
+		require.NotZero(t, app.ID, "autoIncrement で ID が採番される")
+
+		rows, err := repo.ListAll(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, "結合テスト株式会社", rows[0].CompanyName)
+		require.Equal(t, domain.CompanyApplicationStatusPending, rows[0].Status)
+	})
+
+	t.Run("ListAll は created_at 降順で返す", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "company_applications")
+
+		older := &domain.CompanyApplication{
+			CompanyName: "古い申請", ApplicantName: "A", Email: "a@example.com",
+			Status: domain.CompanyApplicationStatusPending,
+			// 明示的に古い時刻を入れて並び順を確定させる。
+			CreatedAt: time.Now().Add(-time.Hour),
+		}
+		newer := &domain.CompanyApplication{
+			CompanyName: "新しい申請", ApplicantName: "B", Email: "b@example.com",
+			Status:    domain.CompanyApplicationStatusPending,
+			CreatedAt: time.Now(),
+		}
+		require.NoError(t, repo.Create(ctx, older))
+		require.NoError(t, repo.Create(ctx, newer))
+
+		rows, err := repo.ListAll(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 2)
+		require.Equal(t, "新しい申請", rows[0].CompanyName, "新しい順")
+		require.Equal(t, "古い申請", rows[1].CompanyName)
+	})
+
+	t.Run("UpdateStatus で status を更新できる", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "company_applications")
+
+		app := &domain.CompanyApplication{
+			CompanyName: "承認される会社", ApplicantName: "C", Email: "c@example.com",
+			Status: domain.CompanyApplicationStatusPending,
+		}
+		require.NoError(t, repo.Create(ctx, app))
+
+		require.NoError(t, repo.UpdateStatus(ctx, app.ID, domain.CompanyApplicationStatusApproved))
+
+		rows, err := repo.ListAll(ctx)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.Equal(t, domain.CompanyApplicationStatusApproved, rows[0].Status)
+	})
+}

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -30,6 +30,12 @@ func allDomainModels() []any {
 	}
 }
 
+// AutoMigrateAll は全 domain モデルを AutoMigrate する（seed なし）。
+// 起動時の Migrate と、結合テストのスキーマ初期化の両方から使う（モデル一覧の単一情報源）。
+func AutoMigrateAll(db *gorm.DB) error {
+	return db.AutoMigrate(allDomainModels()...)
+}
+
 // Migrate は起動時にスキーマを AutoMigrate する。
 // RESET_DB=true のときは public schema を完全 wipe してから再構築する（一回限りの初期構築用）。
 func Migrate(db *gorm.DB) error {
@@ -43,7 +49,7 @@ func Migrate(db *gorm.DB) error {
 		}
 	}
 	log.Println("migrate: AutoMigrate start")
-	if err := db.AutoMigrate(allDomainModels()...); err != nil {
+	if err := AutoMigrateAll(db); err != nil {
 		return err
 	}
 	log.Println("migrate: AutoMigrate done")

--- a/backend/internal/testsupport/integration_db.go
+++ b/backend/internal/testsupport/integration_db.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+// Package testsupport は結合テスト（-tags=integration）用のヘルパを提供する。
+// 本物の PostgreSQL（docker-compose.integration.yml）に接続し、スキーマ初期化と
+// テスト間のクリーンアップを行う。単体テストのビルドには含まれない（build tag で隔離）。
+//
+// 命名規約: 結合テストの関数名には "Integration" を含めること。
+// CI / make test-integration は `go test -tags=integration -run Integration ./...` で
+// 結合テストだけを選別して回す（env 依存の単体テストを巻き込まないため）。
+package testsupport
+
+import (
+	"os"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/infra/database"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// defaultTestDSN は TEST_DATABASE_URL 未設定時の既定接続先（docker-compose.integration.yml と一致）。
+const defaultTestDSN = "postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable"
+
+// OpenTestDB は結合テスト用 DB に接続し、全 domain モデルを AutoMigrate して返す。
+// TEST_DATABASE_URL が空 かつ 既定 DSN にも繋がらない場合は t.Skip する
+// （ローカルで docker を上げずに `-tags=integration` を流しても落ちないように）。
+func OpenTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = defaultTestDSN
+	}
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Skipf("結合テスト用 PostgreSQL に接続できません（docker compose -f docker-compose.integration.yml up -d 済か確認）: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("sql.DB 取得失敗: %v", err)
+	}
+	if err := sqlDB.Ping(); err != nil {
+		t.Skipf("結合テスト用 PostgreSQL に ping 失敗: %v", err)
+	}
+
+	if err := database.AutoMigrateAll(db); err != nil {
+		t.Fatalf("AutoMigrate 失敗: %v", err)
+	}
+	return db
+}
+
+// TruncateAll はテーブルを TRUNCATE して連番をリセットする。テスト間の独立性確保用。
+// 列挙したテーブルは結合テストが触る範囲に限定する（必要に応じて足す）。
+func TruncateAll(t *testing.T, db *gorm.DB, tables ...string) {
+	t.Helper()
+	for _, table := range tables {
+		if err := db.Exec("TRUNCATE TABLE " + table + " RESTART IDENTITY CASCADE").Error; err != nil {
+			t.Fatalf("TRUNCATE %s 失敗: %v", table, err)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

### 現状（バックエンドの結合テスト）

これまでバックエンドの「結合テスト」は **handler 層の httptest（ルータ〜JSON）** のみで、**`adapter/persistence`（repository）層には専用テストが無い**状態でした。データ操作のロジックは大半が usecase の mock 単体テストで覆われており、**GORM が実際に発行する SQL は検証されていません**でした（README で「sqlite 規約・未追加」としていた箇所）。

### 本 PR

`docker-compose.yml` で **本物の PostgreSQL** コンテナ（`postgres-integration-test`）を起動し、repository 層の結合テストを CI で回せるようにします。本番 Supabase と同系の Postgres 17.x に対して実 SQL を検証します。

## 変更内容

- **`backend/docker-compose.integration.yml`**: `postgres-integration-test` サービス（`postgres:17.6-alpine` / host 5433 / `tmpfs` で毎回まっさら / `healthcheck`）。
- **`internal/testsupport/integration_db.go`**（`//go:build integration`）: `OpenTestDB(t)`（接続 + `AutoMigrateAll`）/ `TruncateAll(t, db, ...)`。DB 未起動なら `t.Skip`。
- **`database.AutoMigrateAll`** を公開: seed なしの全 domain AutoMigrate。起動時 `Migrate` と結合テストでモデル一覧を単一情報源化。
- **`company_application_repository_integration_test.go`**: `Create` / `ListAll`（`created_at` 降順）/ `UpdateStatus` を実 Postgres で検証。
- **`make test-integration`**: `docker compose up -d --wait` → `go test -tags=integration -run Integration ./...` → `down -v`（失敗でも teardown）。
- **`ci-backend-go.yml`**: `integration` ジョブを追加（docker compose で Postgres 起動、単体 `test` ジョブとは独立）。
- **README**: 現状と実行方法を追記。

## 設計判断

- **build tag `integration` で隔離**: 通常の `go test ./...`（単体・DB 不要）には含まれない。結合は `-tags=integration` のときだけビルド/実行。
- **`-run Integration` で選別**: 結合ジョブは `TEST_DATABASE_URL` を env に持つため、`./...` 全実行だと env 依存の単体テスト（sandbox 環境変数フィルタ等）を巻き込む。命名規約「テスト名に `Integration` を含める」で結合テストだけ回す。
- **`tmpfs` + `TruncateAll`**: コンテナは毎回まっさら、テスト間も TRUNCATE で独立。

## テスト（ローカル実機確認済み）

```
make test-integration
# postgres-integration-test Healthy → 3 サブテスト PASS → コンテナ down
```

`go test ./...`（単体）/ gofmt / vet / 3 linter すべて green、結合テストは除外されることを確認。