### PR TITLE
test(backend): 結合テストが本番 Supabase を指したら落とす安全弁を追加

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -144,7 +144,8 @@ make test-integration
 ```
 
 - **DB コンテナ**: `docker-compose.integration.yml` の `postgres-integration-test`（`postgres:17.6-alpine`、host 側 5433、`tmpfs` で毎回まっさら）。
-- **接続先**: `TEST_DATABASE_URL`（既定 `postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable`）。未設定 / 未起動なら結合テストは `t.Skip`。
+- **接続先**: `TEST_DATABASE_URL`（既定 `postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable`）。未設定 / 未起動なら結合テストは `t.Skip`。本番が使う `DATABASE_URL` とは**別の env**で、Supabase / 本番には**接続しない**。
+- **安全弁（本番 Supabase 保護）**: `OpenTestDB` は接続先が `supabase.com` / `pooler.supabase` を含む場合、接続前に `t.Fatal` で**必ず落とす**。結合テストは `TruncateAll`（`TRUNCATE ... CASCADE`）でテーブルを破壊するため、誤って `TEST_DATABASE_URL` に本番を入れてもデータを消さない。
 - **スキーマ**: `testsupport.OpenTestDB(t)` が `database.AutoMigrateAll(db)`（seed なしの全 domain AutoMigrate）でスキーマを構築。テスト間は `testsupport.TruncateAll(t, db, ...)` で独立性を確保。
 - **命名規約**: 結合テストの関数名には `Integration` を含める（CI / make は `-run Integration` で選別実行する。`TEST_DATABASE_URL` を env に持つこのジョブで env 依存の単体テストを巻き込まないため）。
 - **CI**: `ci-backend-go.yml` の `integration` ジョブが docker compose で Postgres を起動して実行する（単体 `test` ジョブとは別ジョブ）。

--- a/backend/internal/testsupport/integration_db.go
+++ b/backend/internal/testsupport/integration_db.go
@@ -11,6 +11,7 @@ package testsupport
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/infra/database"
@@ -33,6 +34,14 @@ func OpenTestDB(t *testing.T) *gorm.DB {
 		dsn = defaultTestDSN
 	}
 
+	// 安全弁: 接続先が Supabase / 本番 pooler の場合は接続前に必ず落とす。
+	// 結合テストは TruncateAll（TRUNCATE ... CASCADE）でテーブルを破壊するため、
+	// 誤って TEST_DATABASE_URL に本番 DATABASE_URL を入れた事故で本番データを消さないようにする。
+	if looksLikeSupabase(dsn) {
+		t.Fatal("結合テストの接続先が Supabase / 本番 pooler を指しています。" +
+			"TEST_DATABASE_URL を解除し、ローカルの postgres-integration-test（make test-integration）を使ってください。")
+	}
+
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
@@ -51,6 +60,12 @@ func OpenTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("AutoMigrate 失敗: %v", err)
 	}
 	return db
+}
+
+// looksLikeSupabase は DSN が Supabase / 本番 pooler を指しているかを返す（安全弁用）。
+func looksLikeSupabase(dsn string) bool {
+	l := strings.ToLower(dsn)
+	return strings.Contains(l, "supabase.com") || strings.Contains(l, "pooler.supabase")
 }
 
 // TruncateAll はテーブルを TRUNCATE して連番をリセットする。テスト間の独立性確保用。

--- a/backend/internal/testsupport/integration_db_test.go
+++ b/backend/internal/testsupport/integration_db_test.go
@@ -1,0 +1,30 @@
+//go:build integration
+
+package testsupport
+
+import "testing"
+
+// TestLooksLikeSupabase_Integration は安全弁 looksLikeSupabase の判定を検証する（DB 不要）。
+func TestLooksLikeSupabase_Integration(t *testing.T) {
+	blocked := []string{
+		"postgres://postgres.ref:pw@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres",
+		"postgresql://x:y@db.abcd.supabase.com:5432/postgres?sslmode=require",
+		"host=aws-0-ap-northeast-1.POOLER.SUPABASE.com user=postgres",
+	}
+	for _, dsn := range blocked {
+		if !looksLikeSupabase(dsn) {
+			t.Errorf("Supabase と判定されるべき: %q", dsn)
+		}
+	}
+
+	allowed := []string{
+		"postgres://frestyle:frestyle@localhost:5433/frestyle_integration?sslmode=disable",
+		"host=127.0.0.1 port=5433 user=frestyle dbname=frestyle_integration",
+		"postgres://u:p@postgres-integration-test:5432/frestyle_integration",
+	}
+	for _, dsn := range allowed {
+		if looksLikeSupabase(dsn) {
+			t.Errorf("ローカルは許可されるべき: %q", dsn)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

結合テスト（#1749）は**ローカル docker の `postgres-integration-test` 専用**で、本番 Supabase は使いません（本番が使う `DATABASE_URL` とは別の `TEST_DATABASE_URL` を見ます）。

それを**コードで担保**するため、誤って `TEST_DATABASE_URL` に本番（Supabase）を入れても接続させない安全弁を追加します。結合テストは `TruncateAll`（`TRUNCATE ... CASCADE`）でテーブルを破壊するため、本番を指した場合の**データ消失事故**を物理的に防ぎます。

## 変更内容

- `OpenTestDB`: 接続先の DSN が `supabase.com` / `pooler.supabase` を含む場合、**接続前に `t.Fatal`** で必ず落とす（`looksLikeSupabase` 判定）。
- `looksLikeSupabase` のユニットテスト追加（DB 不要 / `Integration` 命名で `-run Integration` に乗る）。
- `README`: 安全弁と「`TEST_DATABASE_URL` は `DATABASE_URL` と別 env / Supabase には接続しない」旨を明記。

## テスト（ローカル実機確認済み）

- 安全弁テスト: Supabase 系 DSN 3 種 → ブロック判定 / ローカル DSN 3 種 → 許可、すべて PASS（DB 不要）。
- `make test-integration`: ローカル `localhost:5433` は安全弁を通過し、従来どおり 3 サブテスト PASS → コンテナ teardown。

## 関連

- repository 結合テスト基盤 #1749