### PR TITLE
test(integration): Note / Course repository の結合テストを横展開

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ npx tailwindcss init -p
 - **handler（結合, 9 ファイル）**: `gin.SetMode(gin.TestMode)` + `httptest.NewRecorder()` でルータに `ServeHTTP` し、ルーティング〜ステータス〜JSON を通しで検証する。例: `internal/handler/profile_handler_test.go`。
 - **middleware（単体, 4 ファイル）**: JWT 認証・CurrentUser 注入・レートリミットなど横断処理を個別に検証する。
 - **infra（単体 / 境界, 4 ファイル）**: 外部 I/O を境界で差し替える。Cognito トークン交換・JWKS 検証・oEmbed 取得・SES メールを `httptest` サーバや fake で検証する。例: `internal/infra/cognito/jwt_verifier_test.go`。
-- **repository（結合）**: `adapter/persistence` 層を **本物の PostgreSQL**（`docker-compose.integration.yml` の `postgres-integration-test`、本番と同系の 17.x）に対して検証する。`//go:build integration` で隔離し、`make test-integration`（compose 起動 → `go test -tags=integration -run Integration` → teardown）で実行する。通常の `go test ./...`（単体）からは独立。例: `internal/adapter/persistence/company_application_repository_integration_test.go`。
+- **repository（結合）**: `adapter/persistence` 層を **本物の PostgreSQL**（`docker-compose.integration.yml` の `postgres-integration-test`、本番と同系の 17.x）に対して検証する。`//go:build integration` で隔離し、`make test-integration`（compose 起動 → `go test -tags=integration -run Integration` → teardown）で実行する。通常の `go test ./...`（単体）からは独立。対象例: `company_application`（Create / ListAll 降順 / UpdateStatus）/ `note`（`WHERE user_id` 所有権スコープ・`updated_at DESC`）/ `course`（company 絞り・`is_published` フィルタ・`sort_order` 昇順）の各 `*_repository_integration_test.go`。実 SQL の WHERE / ORDER / 制約を本物の Postgres で検証する。
 - **自作 linter（単体 + 結合）**: `cmd/archlint` / `cmd/apispec-lint` / `cmd/naminglint` は、分類・ルール評価の純粋関数（単体）と、一時ディレクトリツリーを走査する `run` / CLI（結合）の両方を検証する（各カバレッジ 87〜89%）。
 
 ```bash

--- a/backend/internal/adapter/persistence/course_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/course_repository_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCourseRepository_Integration は ListByCompany の company 絞り込み / published フィルタ /
+// 並び順を実 Postgres で検証する。
+func TestCourseRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewCourseRepository(db)
+	ctx := context.Background()
+
+	mk := func(companyID uint64, title string, published bool, sortOrder int) *domain.Course {
+		return &domain.Course{
+			CompanyID: companyID, CreatedByUserID: 1, Title: title,
+			IsPublished: published, SortOrder: sortOrder,
+		}
+	}
+
+	t.Run("ListByCompany は company で絞り published フィルタ + sort_order 昇順", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "courses")
+
+		require.NoError(t, repo.Create(ctx, mk(1, "published", true, 20)))
+		require.NoError(t, repo.Create(ctx, mk(1, "draft", false, 10)))
+		require.NoError(t, repo.Create(ctx, mk(2, "other-company", true, 5)))
+
+		// includeUnpublished=false → company 1 の published のみ。
+		pub, err := repo.ListByCompany(ctx, 1, false)
+		require.NoError(t, err)
+		require.Len(t, pub, 1)
+		require.Equal(t, "published", pub[0].Title)
+
+		// includeUnpublished=true → company 1 の全件を sort_order 昇順（draft=10, published=20）。
+		all, err := repo.ListByCompany(ctx, 1, true)
+		require.NoError(t, err)
+		require.Len(t, all, 2)
+		require.Equal(t, "draft", all[0].Title, "sort_order 昇順")
+		require.Equal(t, "published", all[1].Title)
+	})
+
+	t.Run("Create→GetByID→Update→Delete", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "courses")
+
+		c := mk(1, "lifecycle", true, 1)
+		require.NoError(t, repo.Create(ctx, c))
+		require.NotZero(t, c.ID)
+
+		got, err := repo.GetByID(ctx, c.ID)
+		require.NoError(t, err)
+		require.Equal(t, "lifecycle", got.Title)
+
+		got.Title = "updated"
+		require.NoError(t, repo.Update(ctx, got))
+		reread, err := repo.GetByID(ctx, c.ID)
+		require.NoError(t, err)
+		require.Equal(t, "updated", reread.Title)
+
+		require.NoError(t, repo.Delete(ctx, c.ID))
+		_, err = repo.GetByID(ctx, c.ID)
+		require.Error(t, err)
+	})
+}

--- a/backend/internal/adapter/persistence/note_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/note_repository_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoteRepository_Integration は NoteRepository の所有権スコープと並び順を実 Postgres で検証する。
+func TestNoteRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewNoteRepository(db)
+	ctx := context.Background()
+
+	t.Run("ListByUserID は自分の note だけを updated_at DESC で返す", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "notes")
+
+		older := &domain.Note{UserID: 7, Title: "older", UpdatedAt: time.Now().Add(-time.Hour)}
+		newer := &domain.Note{UserID: 7, Title: "newer", UpdatedAt: time.Now()}
+		other := &domain.Note{UserID: 8, Title: "someone-else"}
+		require.NoError(t, repo.Create(ctx, older))
+		require.NoError(t, repo.Create(ctx, newer))
+		require.NoError(t, repo.Create(ctx, other))
+
+		rows, err := repo.ListByUserID(ctx, 7)
+		require.NoError(t, err)
+		require.Len(t, rows, 2, "user 8 の note は WHERE user_id で除外される")
+		require.Equal(t, "newer", rows[0].Title, "updated_at DESC で新しい順")
+		require.Equal(t, "older", rows[1].Title)
+	})
+
+	t.Run("Delete は user_id スコープで他人の note を消さない", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "notes")
+
+		mine := &domain.Note{UserID: 7, Title: "mine"}
+		theirs := &domain.Note{UserID: 8, Title: "theirs"}
+		require.NoError(t, repo.Create(ctx, mine))
+		require.NoError(t, repo.Create(ctx, theirs))
+
+		// user 7 が user 8 の note を消そうとしても WHERE user_id=7 で no-op。
+		require.NoError(t, repo.Delete(ctx, 7, theirs.ID))
+		got, err := repo.FindByID(ctx, theirs.ID)
+		require.NoError(t, err, "他人の note は残る")
+		require.Equal(t, "theirs", got.Title)
+
+		// 自分の note は消せる。
+		require.NoError(t, repo.Delete(ctx, 7, mine.ID))
+		_, err = repo.FindByID(ctx, mine.ID)
+		require.Error(t, err, "自分の note は削除済み")
+	})
+
+	t.Run("Update は内容を保存する", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "notes")
+
+		n := &domain.Note{UserID: 7, Title: "before", Content: "x"}
+		require.NoError(t, repo.Create(ctx, n))
+		n.Title = "after"
+		require.NoError(t, repo.Update(ctx, n))
+
+		got, err := repo.FindByID(ctx, n.ID)
+		require.NoError(t, err)
+		require.Equal(t, "after", got.Title)
+	})
+}


### PR DESCRIPTION
## 概要

先に構築した結合テスト基盤（本物の PostgreSQL / docker-compose / `//go:build integration`）を **Note / Course repository** に横展開します。mock では検証できない **実 SQL の WHERE / ORDER / 所有権スコープ** を本物の Postgres で検証します。

## 追加したテスト

| repository | 検証内容 |
|---|---|
| note | `ListByUserID` の `WHERE user_id` 所有権スコープ + `updated_at DESC` 並び順 / `Delete` の `WHERE id AND user_id`（他人の note を消さない）/ `Update` |
| course | `ListByCompany` の company 絞り + `is_published` フィルタ + `sort_order` 昇順 / Create→GetByID→Update→Delete ライフサイクル |

CompanyApplication（既存）に続き **3 repository** を実 Postgres で検証。

## 設計

- `//go:build integration` で単体から隔離（`go test ./...` には含まれない）。
- `testsupport.OpenTestDB` / `TruncateAll` を再利用。テスト名に `Integration` を含め `-run Integration` で選別。
- CI の `integration` ジョブ（ECR Public ミラーの Postgres）で実行。

## テスト（ローカル実機確認済み）

```
make test-integration
# CompanyApplication / Course / Note の全結合テスト PASS（実 Postgres）
go test ./...（単体）/ go vet -tags=integration / gofmt  # clean、単体からは除外
```

> 結合テストは単体カバレッジ floor の計測対象外（別ジョブ・`-run Integration`）のため floor 変更なし。永続化の実 SQL に対する信頼性が上がる。

## 関連

- 結合テスト基盤 #1749 / 安全弁 #1750 / ECR ミラー #1754