### PR TITLE
test(e2e): 本番スモークの networkidle 依存を排除し flake を低減

### DIFF
--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -16,13 +16,15 @@ const API_BASE = 'https://api.normanblog.com';
 
 test.describe('FreStyle smoke', () => {
   test('SPA がロードされ FreStyle ロゴ / ログイン誘導が見える', async ({ page }) => {
-    await page.goto('/');
+    // networkidle は SPA のヘルスポーリング等で「無通信」に到達せず timeout して flake るため使わない。
+    // domcontentloaded で遷移し、描画要素（ログインフォーム）の出現を明示的に待つ。
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(page).toHaveTitle(/FreStyle/);
-    // SPA の root が描画されるまで待つ
-    await page.waitForLoadState('networkidle');
-    // ログイン前は LoginPage か Landing が出る。'fre' / 'login' のどちらかが見える前提
-    const visibleText = (await page.locator('body').innerText()).toLowerCase();
-    expect(visibleText.length).toBeGreaterThan(0);
+    // 未認証アクセスは /login にリダイレクトされ、ログインフォームが描画される。
+    // 本番のコールドロード + 認証チェックを見込んで余裕を持った timeout で待つ。
+    await expect(
+      page.getByRole('form', { name: 'ログインフォーム' })
+    ).toBeVisible({ timeout: 20_000 });
   });
 
   test('CloudFront セキュリティヘッダーが配信される', async ({ request }) => {


### PR DESCRIPTION
## 概要

本番外形スモーク（`e2e/smoke.spec.ts`）の SPA ロード判定が `page.waitForLoadState('networkidle')` に依存しており、**本番 SPA はヘルスチェック等の定期ポーリングで「無通信」状態に到達せず 30s timeout して flake** していました（直近 PR #1758 の CI で再現）。

## 変更内容

- `goto` を `{ waitUntil: 'domcontentloaded' }` にし、`networkidle` 待ちを撤去。
- 代わりに**描画要素の出現を明示的に待つ**: 未認証アクセスは `/login` にリダイレクトされるため、ログインフォーム（`getByRole('form', { name: 'ログインフォーム' })`）の表示を `toBeVisible({ timeout: 20s })` で待つ（`expect` の auto-retry + 余裕ある timeout で本番コールドロードにも耐える）。

## なぜ堅牢になるか

`networkidle` は「500ms 無通信」を待つため、`useBackendHealth` の定期ポーリングや keep-alive がある SPA では**永遠に settle せず timeout**しやすい。明示的な要素待ちは「実際にユーザーに見える状態」を判定するため、本番のレイテンシ揺らぎに強い。

## テスト（本番に対しローカル実機確認済み）

```
npx playwright test e2e/smoke.spec.ts --project=chromium
# 6 passed（2.3s）。変更したテストは連続実行でも安定 pass（従来 30s timeout → 約 2s）
tsc --noEmit / eslint  # clean
```

## 関連

- flake が出た PR #1758 / E2E 基盤 #1748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * スモークテストの待機ロジックを改善し、ページロード検証の信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->