### PR TITLE
test(e2e): ノート作成（POST /notes モック）の導線を追加

### DIFF
--- a/frontend/e2e/local/authenticated.spec.ts
+++ b/frontend/e2e/local/authenticated.spec.ts
@@ -128,3 +128,63 @@ test.describe('認証済み導線（super_admin）', () => {
     await expect(page).toHaveURL(/\/admin\/companies/);
   });
 });
+
+test.describe('ノート作成導線（POST モック）', () => {
+  test('「新しいノート」で POST /notes が呼ばれ一覧に追加される', async ({ page }) => {
+    await mockAuthenticated(page);
+
+    let postCalled = false;
+    // GET /notes（既存 1 件で空状態を回避）と POST /notes（作成）を method で出し分ける。
+    // mockAuthenticated の後に登録するため /notes ではこの handler が優先される。
+    await page.route('**/api/v2/notes', (route) => {
+      if (route.request().method() === 'POST') {
+        postCalled = true;
+        return route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 999,
+            userId: 7,
+            title: '無題',
+            content: '',
+            isPublic: false,
+            isPinned: false,
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            id: 1,
+            userId: 7,
+            title: '既存ノート',
+            content: '',
+            isPublic: false,
+            isPinned: false,
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ]),
+      });
+    });
+
+    await page.goto('/notes');
+    await expect(page).toHaveURL(/\/notes/);
+    // 既存ノートが一覧に出ている（GET モックが効いている）。
+    await expect(page.getByText('既存ノート').filter({ visible: true }).first()).toBeVisible();
+
+    await page
+      .getByRole('button', { name: '新しいノート' })
+      .filter({ visible: true })
+      .first()
+      .click();
+
+    // POST が呼ばれ、作成された「無題」ノートが一覧に追加される。
+    await expect(page.getByText('無題').filter({ visible: true }).first()).toBeVisible();
+    expect(postCalled).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

ローカルビルド + API モックの E2E に「**ノート作成**」のユーザー導線を追加します。これまでの「画面が描画される」検証から一歩進んで、**ボタン押下 → POST → 一覧反映**の操作導線を検証します。

## テスト内容

- `GET /notes` と `POST /notes` は**同一 path のため route handler 内で method を判定**して出し分け（GET = 既存 1 件、POST = 作成された無題ノートを返し、呼ばれたことを記録）。
- `/notes` で「**新しいノート**」ボタンを押下 → `POST /notes` が呼ばれ、`useNotes` が `setNotes([note, ...prev])` で一覧に追加した**無題ノートが表示される**ことを検証。

## ハマりどころ

レスポンシブ UI で list 要素がモバイル/デスクトップの両パネルに重複し、`.first()` が**非表示（モバイル）要素**を掴んで失敗した。`filter({ visible: true })` で**可視要素に絞る**ことで解消。

## 検証（ローカル実機確認済み）

```
VITE_API_BASE_URL= npm run build && npm run e2e:local
# → 9 passed（既存 8 + 新規 1）
tsc --noEmit / eslint  # clean
```

## 関連

- 認証導線 E2E #1758 / スモーク堅牢化 #1759 / E2E 基盤 #1748