### PR TITLE
chore: Claude Code チーム設定（push/merge は ask + 個人例外）

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,36 @@
+# .claude — Claude Code チーム設定
+
+このディレクトリの **`settings.json` はリポジトリにコミットして共有する**チーム共通の Claude Code 設定です。
+個人ごとの上書きは **`settings.local.json`（`.gitignore` 済 / 共有されない）** に書きます。
+
+## 共有ポリシー（settings.json）
+
+人的ミス・暴走を防ぐため、`bypassPermissions`（全許可）は**共有設定では使いません**。allow / ask / deny で制御します。
+
+- **defaultMode: `acceptEdits`** — ファイル編集は自動承認（差分は PR でレビューする前提）。コマンドは下記に従う。
+- **allow（無確認で実行可）** — ビルド・テスト・lint・フォーマット・ローカル git（`status` / `diff` / `add` / `commit` / `checkout` 等）・`gh pr create/view/list/comment`・`gitleaks` / `trivy` など安全な開発操作。
+- **ask（毎回確認）** — **`git push` / `gh pr merge` / `gh pr review`**（リモート反映・マージ・承認）、`gh workflow run`（デプロイ起動）、`git rebase` / `git reset`。**既定では Claude に push / マージ させず、必ず人間が確認する**。
+- **deny（常に禁止・ローカルでも上書き不可）** — `gh repo delete` / `gh secret` / `rm -rf`、`.env` 系の読み取り。致命的・機密操作は誰の環境でも禁止。
+
+## 個人の例外（settings.local.json）
+
+`deny` はローカルでも上書きできない絶対ルールですが、**`ask` はローカル設定で上書きできます**。
+そのため、**リポジトリ管理者（norman6464）など信頼された個人は、自分の端末の `settings.local.json` で例外**にできます。
+
+例（norman6464 の端末・`settings.local.json` / 共有されない）:
+
+```json
+{
+  "permissions": { "defaultMode": "bypassPermissions" }
+}
+```
+
+- これにより**その端末の Claude Code だけ** push / マージ等の確認がスキップされる（norman6464 は実質ルール対象外）。
+- 一方で `rm -rf` / `.env` 読み取り等の **`deny` は維持**される（致命的操作は例外でも禁止）。
+- 他のメンバーは `settings.local.json` を持たないので、共有ポリシー（push / merge は `ask`）が適用される。
+
+## 運用
+
+- 既定では Claude Code は「ローカルで変更・コミット・PR 作成」までを行い、**push とマージは人間が確認**する。
+- ルールを変えたいときは `settings.json` を PR で変更する（チームで合意）。
+- サーバ側の本当の歯止めは **GitHub のブランチ保護**（承認必須）と **production Environment の承認ゲート**。`.claude` 設定はクライアント側の補助ガード。

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "defaultMode": "acceptEdits",
+    "allow": [
+      "Read",
+      "Grep",
+      "Glob",
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go run:*)",
+      "Bash(go mod:*)",
+      "Bash(gofmt:*)",
+      "Bash(staticcheck:*)",
+      "Bash(make:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git switch:*)",
+      "Bash(git branch:*)",
+      "Bash(git restore:*)",
+      "Bash(git stash:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pull:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh run:*)",
+      "Bash(gitleaks:*)",
+      "Bash(trivy:*)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git push)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr review:*)",
+      "Bash(gh workflow run:*)",
+      "Bash(git rebase:*)",
+      "Bash(git reset:*)"
+    ],
+    "deny": [
+      "Bash(gh repo delete:*)",
+      "Bash(gh secret:*)",
+      "Bash(rm -rf:*)",
+      "Read(./.env)",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.*.local)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env
-.claude/
+# Claude Code: チーム共有設定 (.claude/settings.json) はコミットする。
+# 個人用ローカル設定だけ除外する。
+.claude/settings.local.json
 CLAUDE.md
 
 infrastructure/


### PR DESCRIPTION
## 概要

Claude Code の権限を `bypassPermissions`（全許可）から、チームで安全に使える allow/ask/deny 方針へ。`.claude/settings.json` を共有し、個人用 `settings.local.json` のみ `.gitignore` する。

## 変更内容

- `.gitignore`: `.claude/` 全体除外 → **`.claude/settings.local.json` のみ除外**（共有 `settings.json` はコミット）
- `.claude/settings.json`（共有ポリシー）:
  - `ask`: **`git push` / `gh pr merge` / `gh pr review`** / `gh workflow run` / `git rebase` / `git reset`（既定では Claude に push/マージさせず人間が確認）
  - `deny`（ローカルでも上書き不可）: `gh repo delete` / `gh secret` / `rm -rf` / `.env` 読取
  - `allow`: ビルド・テスト・lint・ローカル git・`gh pr create/view` 等
  - `defaultMode`: `acceptEdits`
- `.claude/README.md`: 共有ポリシー + **個人 `settings.local.json` による例外**（norman6464 は自端末で bypass にして実質ルール対象外）を明文化

## 設計

- `deny` は絶対（致命的操作）。`ask` はローカルで上書き可能 → **信頼された個人だけ例外**にできる（Claude Code の仕様に沿った形）。
- サーバ側の本当の歯止めは **ブランチ保護（承認必須）** と **production Environment 承認ゲート**。`.claude` はクライアント側の補助ガード。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境設定ファイルを追加し、開発チームのツール設定と運用ポリシーを整備しました。個人用設定はバージョン管理から除外し、チーム共有設定のみを追跡対象としています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->