### PR TITLE
ci: CI の path フィルタ撤去（必須チェック化の前提）

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -1,15 +1,12 @@
 name: CI - Backend (Go)
 
+# path フィルタは付けない: 必須ステータスチェック（branch protection）として使うため、
+# 対象外パスの PR でも必ず report されるよう全 PR / main push で走らせる。
 on:
   push:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - '.github/workflows/ci-backend-go.yml'
   pull_request:
-    paths:
-      - 'backend/**'
-      - '.github/workflows/ci-backend-go.yml'
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -3,17 +3,13 @@ name: CI - Frontend (Vite + Vitest)
 # 目的: PR / push のたびにフロントエンドのテストとビルド検証だけを行う。
 # 本ワークフローは S3 / CloudFront に一切触らない。デプロイは cd-frontend.yml で別途。
 
+# path フィルタは付けない: 必須ステータスチェック（branch protection）として使うため、
+# 対象外パスの PR でも必ず report されるよう全 PR / main push で走らせる。
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/ci-frontend.yml'
   push:
     branches: [main]
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/ci-frontend.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
backend/frontend CI を branch protection の必須ステータスチェックにするための前提。path フィルタがあると対象外パスの PR で check が report されず永久にブロックされるため、全 PR で必ず走るよう撤去する。

マージ後に branch protection の required_status_checks へ `vet / test / build`・`Vitest + Build`・`gitleaks`・`trivy` を追加（CodeQL は既に必須）。