### PR TITLE
feat(staging): frontend を nginx 配信コンテナ化（Lightsail ステージング用）

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+.vite
+coverage
+playwright-report
+test-results
+.env
+.env.*
+*.log

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+#
+# ステージング(Lightsail)用に frontend を nginx 静的配信コンテナ化する Dockerfile。
+# 本番は S3 + CloudFront 配信のためこの Dockerfile は使わない（ステージング検証専用）。
+#
+# VITE_* はビルド時にバンドルへ焼き込まれるため build-arg で受け取る。
+# サブドメインごとに redirect_uri（Cognito callback）が変わるため、deploy 時に
+# VITE_REDIRECT_URI をそのサブドメインの値で渡してビルドする。
+# API は同一ホストの /api/* を Caddy が backend に振るので VITE_API_BASE_URL は
+# 空（相対パス）でよい。
+
+# --- Build stage ---
+FROM node:20-bookworm-slim AS builder
+WORKDIR /app
+
+# 依存だけ先に入れてレイヤキャッシュを効かせる。
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+# Vite に焼き込む公開設定（すべて build-arg 経由）。
+ARG VITE_API_BASE_URL=""
+ARG VITE_COGNITO_DOMAIN=""
+ARG VITE_CLIENT_ID=""
+ARG VITE_REDIRECT_URI=""
+ARG VITE_RESPONSE_TYPE="code"
+ARG VITE_SCOPE="openid"
+ARG VITE_WEB_SOCKET_URL_AI_CHAT=""
+ARG VITE_WEB_SOCKET_URL_CHAT=""
+
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL \
+    VITE_COGNITO_DOMAIN=$VITE_COGNITO_DOMAIN \
+    VITE_CLIENT_ID=$VITE_CLIENT_ID \
+    VITE_REDIRECT_URI=$VITE_REDIRECT_URI \
+    VITE_RESPONSE_TYPE=$VITE_RESPONSE_TYPE \
+    VITE_SCOPE=$VITE_SCOPE \
+    VITE_WEB_SOCKET_URL_AI_CHAT=$VITE_WEB_SOCKET_URL_AI_CHAT \
+    VITE_WEB_SOCKET_URL_CHAT=$VITE_WEB_SOCKET_URL_CHAT
+
+RUN npm run build
+
+# --- Runtime stage ---
+FROM nginx:1.27-alpine
+COPY nginx.staging.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/frontend/nginx.staging.conf
+++ b/frontend/nginx.staging.conf
@@ -1,0 +1,28 @@
+# ステージング(Lightsail)で frontend を配信する nginx 設定。
+# SPA なので存在しないパスは index.html にフォールバックする（React Router 用）。
+# TLS / サブドメイン振り分け / /api のプロキシは前段の Caddy が担うため、
+# ここでは静的ファイル配信と SPA フォールバックだけに専念する。
+
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # gzip で転送量を削減（検証時の体感速度向上）。
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    # ハッシュ付きアセットは長期キャッシュ可。
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # SPA フォールバック: 実ファイルが無ければ index.html を返す。
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## 概要

Lightsail 上のステージング環境で frontend をコンテナ配信するための Dockerfile を追加する。本番は引き続き S3 + CloudFront 配信で、この Dockerfile は**ステージング検証専用**。

infra リポ（frestyle-infrastructure）側に deploy 機構・Caddy・docker-compose・手順書を用意する一連の作業の一部。

## 変更内容

- **frontend/Dockerfile**（node ビルド → nginx 配信のマルチステージ）
  - `VITE_*` はビルド時にバンドルへ焼き込まれるため build-arg で受け取る
  - サブドメインごとに `VITE_REDIRECT_URI`（Cognito callback）が変わるため deploy 時に注入
  - API は同一ホストの `/api/*` を前段 Caddy が backend に振るので `VITE_API_BASE_URL` は空（相対パス）でよい
- **frontend/nginx.staging.conf** — SPA フォールバック + アセット長期キャッシュのみ。TLS / サブドメイン振り分け / `/api` プロキシは前段 Caddy が担当
- **frontend/.dockerignore** — node_modules / dist / .env を除外

## テスト

- `docker build` がローカルで成功（vite build 13.9s → nginx イメージ生成を確認）
- 既存ロジックの変更なし（配信構成の追加のみ）

## 関連

- ステージング全体設計は infra リポ `docs/28-lightsail-staging-runbook.md`（別 PR）にまとめる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * フロントエンドのDockerコンテナ化対応を追加しました。Nginxによる静的ファイル配信環境を構築し、ステージング環境での検証が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->