### PR TITLE
feat(ci): golangci-lint(v2) 導入 + errorlint/gosec 指摘を解消

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -53,13 +53,16 @@ jobs:
       - name: go vet
         run: go vet ./...
 
-      # staticcheck は Go 公式 Tools チームが推奨する高品質 linter。
-      # honnef.co/go/tools/cmd/staticcheck でしか拾えない bug pattern (SA*** 系)
-      # を CI で検知する。go vet との重複は避けつつ深いバグを拾える。
-      - name: staticcheck
-        run: |
-          go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
-          staticcheck ./...
+      # golangci-lint(v2) で複数 linter を一括実行する。default の
+      # staticcheck / errcheck / govet / ineffassign / unused に加え、
+      # errorlint(errors.Is/As・%w 強制) / bodyclose(HTTP body リーク) /
+      # gosec(セキュリティ) / misspell / unconvert を有効化。設定は backend/.golangci.yml。
+      # 従来の単体 staticcheck step を置き換える(staticcheck は golangci に内包)。
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12.2
+          working-directory: backend
 
       # クリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を検証する自作 linter。
       # handler→usecase→repository/infra→domain の矢印に反する import を CI で弾く。

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,51 @@
+# golangci-lint v2 設定。
+# 既存 CI の staticcheck / govet / govulncheck を補完し、以下を追加で強制する:
+#   - errorlint : errors.Is/As と %w ラップを強制（エラーの文脈喪失を防ぐ）
+#   - bodyclose : HTTP response body の Close 漏れ（リーク）検出
+#   - gosec     : セキュリティ静的解析（誤検知は下で正当に除外）
+#   - misspell  : コメント/識別子のスペルミス
+#   - unconvert : 不要な型変換
+# default で errcheck / govet / ineffassign / staticcheck / unused も走る。
+
+version: "2"
+
+linters:
+  enable:
+    - errorlint
+    - bodyclose
+    - gosec
+    - misspell
+    - unconvert
+  settings:
+    gosec:
+      excludes:
+        # G204: サンドボックス(execute_code_usecase)はユーザコードを意図的に exec する。
+        # 引数(filename/tmpDir)は内部生成で外部入力をそのまま渡していない。
+        - G204
+  exclusions:
+    rules:
+      # 自作 lint ツール(archlint/apispec-lint/naminglint)は自分のソースツリーを
+      # WalkDir / os.Open するため Path traversal(G304/G703)は誤検知。
+      - path: cmd/(archlint|apispec-lint|naminglint)/
+        linters:
+          - gosec
+      # テストのディレクトリ権限(G301) / Cookie 属性(G124) / ダミー認証情報(G101)は
+      # 検証用途であり実害がないため除外。
+      - path: _test\.go
+        linters:
+          - gosec
+      # defer Close() / os.Remove() / CLI の fmt.Fprint は慣例的に戻り値を無視する。
+      - linters:
+          - errcheck
+        source: 'defer .*\.Close\(\)'
+      - linters:
+          - errcheck
+        source: 'defer os\.Remove'
+      - linters:
+          - errcheck
+        source: 'fmt\.Fprint'
+
+# 同種・同 linter の指摘を省略せず全件報告する（CI で取りこぼさないため）。
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -16,14 +16,15 @@ linters:
     - gosec
     - misspell
     - unconvert
-  settings:
-    gosec:
-      excludes:
-        # G204: サンドボックス(execute_code_usecase)はユーザコードを意図的に exec する。
-        # 引数(filename/tmpDir)は内部生成で外部入力をそのまま渡していない。
-        - G204
   exclusions:
     rules:
+      # サンドボックス(execute_code_usecase)はユーザコードを意図的に exec する。
+      # 引数(filename/tmpDir)は内部生成で外部入力をそのまま渡していない。G204 は
+      # このファイルに限定して除外し、他箇所の危険な exec は検出を維持する。
+      - path: internal/usecase/execute_code_usecase\.go
+        linters:
+          - gosec
+        text: 'G204'
       # 自作 lint ツール(archlint/apispec-lint/naminglint)は自分のソースツリーを
       # WalkDir / os.Open するため Path traversal(G304/G703)は誤検知。
       - path: cmd/(archlint|apispec-lint|naminglint)/

--- a/backend/internal/handler/ai_chat_sse_handler.go
+++ b/backend/internal/handler/ai_chat_sse_handler.go
@@ -28,7 +28,7 @@ func NewAiChatSseHandler(sendStream *usecase.SendAiMessageStreamUseCase) *AiChat
 }
 
 type sseRequestBody struct {
-	SessionID   int64                  `json:"sessionId"`
+	SessionID   uint64                 `json:"sessionId"`
 	Content     string                 `json:"content"`
 	Scene       string                 `json:"scene"`
 	SessionType string                 `json:"sessionType"`
@@ -103,7 +103,7 @@ func (h *AiChatSseHandler) Handle(c *gin.Context) {
 
 	stream, err := h.sendStream.Execute(ctx, usecase.SendAiMessageInput{
 		UserID:      uid,
-		SessionID:   uint64(body.SessionID),
+		SessionID:   body.SessionID,
 		Content:     body.Content,
 		Scene:       body.Scene,
 		SessionType: body.SessionType,

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -169,10 +169,10 @@ func (h *ProfileHandler) buildView(c *gin.Context, uid uint64) (*domain.ProfileV
 }
 
 func writeProfileError(c *gin.Context, err error) {
-	switch err {
-	case errProfileUnauthorized:
+	switch {
+	case errors.Is(err, errProfileUnauthorized):
 		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-	case errProfileForbidden:
+	case errors.Is(err, errProfileForbidden):
 		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 	default:
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/profile_handler_test.go
+++ b/backend/internal/handler/profile_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -49,14 +50,14 @@ func TestProfileResolveUserID_MatchingNumeric(t *testing.T) {
 
 func TestProfileResolveUserID_MismatchNumericIsForbidden(t *testing.T) {
 	h := &ProfileHandler{}
-	if _, err := h.resolveUserID(makeCtx(7, "99")); err != errProfileForbidden {
+	if _, err := h.resolveUserID(makeCtx(7, "99")); !errors.Is(err, errProfileForbidden) {
 		t.Fatalf("mismatch numeric should be forbidden; got %v", err)
 	}
 }
 
 func TestProfileResolveUserID_NoCurrentUserIsUnauthorized(t *testing.T) {
 	h := &ProfileHandler{}
-	if _, err := h.resolveUserID(makeCtx(0, "me")); err != errProfileUnauthorized {
+	if _, err := h.resolveUserID(makeCtx(0, "me")); !errors.Is(err, errProfileUnauthorized) {
 		t.Fatalf("no current user should be unauthorized; got %v", err)
 	}
 }

--- a/backend/internal/handler/profile_image_handler.go
+++ b/backend/internal/handler/profile_image_handler.go
@@ -67,10 +67,10 @@ func (h *ProfileImageHandler) resolveUserID(c *gin.Context) (uint64, error) {
 func (h *ProfileImageHandler) IssueUploadURL(c *gin.Context) {
 	uid, err := h.resolveUserID(c)
 	if err != nil {
-		switch err {
-		case errProfileImageUnauthorized:
+		switch {
+		case errors.Is(err, errProfileImageUnauthorized):
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		case errProfileImageForbidden:
+		case errors.Is(err, errProfileImageForbidden):
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		default:
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -57,10 +57,10 @@ func (h *UserStatsHandler) resolveUserID(c *gin.Context) (uint64, error) {
 func (h *UserStatsHandler) Get(c *gin.Context) {
 	uid, err := h.resolveUserID(c)
 	if err != nil {
-		switch err {
-		case errUserStatsUnauthorized:
+		switch {
+		case errors.Is(err, errUserStatsUnauthorized):
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		case errUserStatsForbidden:
+		case errors.Is(err, errUserStatsForbidden):
 			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 		default:
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/backend/internal/handler/user_stats_handler_test.go
+++ b/backend/internal/handler/user_stats_handler_test.go
@@ -1,6 +1,9 @@
 package handler
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestUserStatsResolveUserID_MeKeyword(t *testing.T) {
 	h := &UserStatsHandler{}
@@ -12,14 +15,14 @@ func TestUserStatsResolveUserID_MeKeyword(t *testing.T) {
 
 func TestUserStatsResolveUserID_MismatchNumericIsForbidden(t *testing.T) {
 	h := &UserStatsHandler{}
-	if _, err := h.resolveUserID(makeCtx(7, "99")); err != errUserStatsForbidden {
+	if _, err := h.resolveUserID(makeCtx(7, "99")); !errors.Is(err, errUserStatsForbidden) {
 		t.Fatalf("mismatch numeric should be forbidden; got %v", err)
 	}
 }
 
 func TestUserStatsResolveUserID_NoCurrentUserIsUnauthorized(t *testing.T) {
 	h := &UserStatsHandler{}
-	if _, err := h.resolveUserID(makeCtx(0, "me")); err != errUserStatsUnauthorized {
+	if _, err := h.resolveUserID(makeCtx(0, "me")); !errors.Is(err, errUserStatsUnauthorized) {
 		t.Fatalf("no current user should be unauthorized; got %v", err)
 	}
 }

--- a/backend/internal/infra/cognito/jwt_verifier.go
+++ b/backend/internal/infra/cognito/jwt_verifier.go
@@ -184,11 +184,11 @@ type jwk struct {
 func (v *Verifier) refresh(ctx context.Context) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.jwksURI, nil)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrJWKSUnavailable, err)
+		return fmt.Errorf("%w: %w", ErrJWKSUnavailable, err)
 	}
 	resp, err := v.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("%w: %v", ErrJWKSUnavailable, err)
+		return fmt.Errorf("%w: %w", ErrJWKSUnavailable, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -198,7 +198,7 @@ func (v *Verifier) refresh(ctx context.Context) error {
 		Keys []jwk `json:"keys"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-		return fmt.Errorf("%w: %v", ErrJWKSUnavailable, err)
+		return fmt.Errorf("%w: %w", ErrJWKSUnavailable, err)
 	}
 	keys := make(map[string]*rsa.PublicKey, len(doc.Keys))
 	for _, k := range doc.Keys {

--- a/backend/internal/infra/cognito/token_exchanger.go
+++ b/backend/internal/infra/cognito/token_exchanger.go
@@ -133,7 +133,7 @@ func (t *TokenExchanger) exchange(ctx context.Context, form url.Values) (*Token,
 
 	resp, err := t.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrUnreachable, err)
+		return nil, fmt.Errorf("%w: %w", ErrUnreachable, err)
 	}
 	defer resp.Body.Close()
 
@@ -145,7 +145,7 @@ func (t *TokenExchanger) exchange(ctx context.Context, form url.Values) (*Token,
 
 	var tok Token
 	if err := json.Unmarshal(body, &tok); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidResponse, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
 	}
 	return &tok, nil
 }

--- a/backend/internal/infra/embed/oembed_fetcher.go
+++ b/backend/internal/infra/embed/oembed_fetcher.go
@@ -92,7 +92,7 @@ func (f *Fetcher) Resolve(ctx context.Context, raw string) (*Card, error) {
 func (f *Fetcher) validateURL(raw string) (*url.URL, error) {
 	u, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 	if u.Scheme != "https" {
 		return nil, fmt.Errorf("%w: scheme must be https", ErrInvalidURL)
@@ -138,14 +138,14 @@ func isPrivateOrLocalHost(host string) bool {
 func (f *Fetcher) resolveOGP(ctx context.Context, u *url.URL) (*Card, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrInvalidURL, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidURL, err)
 	}
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Accept", "text/html,application/xhtml+xml")
 
 	resp, err := f.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrUnreachable, err)
+		return nil, fmt.Errorf("%w: %w", ErrUnreachable, err)
 	}
 	defer resp.Body.Close()
 

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -215,7 +216,8 @@ func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
 		Stderr: truncate(stderr.String(), maxOutputBytes),
 	}
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
 			out.ExitCode = exitErr.ExitCode()
 		} else {
 			out.ExitCode = 1


### PR DESCRIPTION
## 概要

品質向上の第 1 弾（静的解析の深化）。`golangci-lint`(v2) を CI に導入し、エラーハンドリングの一貫性とセキュリティ静的解析を機械的に担保する。あわせて既存コードの指摘をすべて解消した。

## 変更内容

- **backend/.golangci.yml**（新規）
  - default の staticcheck / errcheck / govet / ineffassign / unused に加え、**errorlint**(errors.Is/As・%w 強制)/ **bodyclose**(HTTP body リーク検出)/ **gosec** / **misspell** / **unconvert** を有効化
  - gosec の誤検知は**理由付きで除外**：自作 lint ツールの WalkDir(G703/G304)、テストの dir 権限・Cookie 属性・ダミー認証情報、サンドボックスの意図的 exec(G204)
  - errcheck の慣例的無視(defer Close / CLI の fmt.Fprint)を source ルールで除外
  - `max-issues-per-linter: 0` / `max-same-issues: 0` で取りこぼし防止
- **ci-backend-go.yml** — 単体 staticcheck step を `golangci-lint-action@v8`(v2.12.2)に置換（staticcheck は golangci に内包）
- **errorlint 指摘の解消**
  - handler の `switch err` / テストの `!= err` → `errors.Is`
  - `fmt.Errorf("%w: %v", ...)` → `"%w: %w"`（原因 error もラップして文脈を保持）
  - `exec.ExitError` の type assertion → `errors.As`
- **gosec G115 の解消** — AI チャット SSE の `sessionId` を `int64`→`uint64` にし `uint64(...)` 変換を除去（負値は bind 時に弾かれ、整数オーバーフロー変換が消える）

## テスト

- `golangci-lint run ./...` 指摘 **0 件**
- `go test ./...` **green**（race 付き含む）
- `gofmt -l` 差分なし / `go build ./...` OK

## ドキュメント

CI 品質ゲートの一次情報である frestyle-infrastructure `docs/23-ci-quality-gates.md` を別 PR で更新します（本体リポに CI docs を持たない構成のため）。

## 関連

品質向上 3 軸（静的解析 / 可観測性 / E2E）の 1 つ目。残り 2 つは後続 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * CI/Linting パイプラインを強化し、コード品質チェックの精度を向上。
  * エラーハンドリングロジックを改善し、より堅牢なエラー判定機構を実装。
  * テスト体系の更新により、エラーケースのカバレッジを拡大。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->