### PR TITLE
feat(deploy): CodeBuild/CodeDeploy 用の buildspec/appspec を追加 (Blue/Green)

### DIFF
--- a/appspec.yaml
+++ b/appspec.yaml
@@ -1,0 +1,14 @@
+# CodeDeploy（ECS Blue/Green）の appspec。
+#
+# CodeBuild が artifact として出力し（backend/buildspec.yml）、CodePipeline の Deploy ステージ
+# （CodeDeployToECS）が使う。<TASK_DEFINITION> は CodeDeploy が登録した新タスク定義の ARN に
+# 置換される。ContainerName / ContainerPort は frestyle-infrastructure の ecs.yml と一致させる。
+version: 0.0
+Resources:
+  - TargetService:
+      Type: AWS::ECS::Service
+      Properties:
+        TaskDefinition: "<TASK_DEFINITION>"
+        LoadBalancerInfo:
+          ContainerName: "fre-style"
+          ContainerPort: 8080

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -1,0 +1,43 @@
+# CodeBuild ビルド定義（ECS Blue/Green デプロイ用）。
+#
+# CodePipeline の Build ステージから呼ばれる。backend を docker build して ECR に push し、
+# CodeDeploy(ECS Blue/Green) が使う taskdef.json / appspec.yaml / imageDetail.json を
+# artifact として出力する。
+#
+# 環境変数は frestyle-infrastructure の cicd/codepipeline.yml の CodeBuild Project が渡す:
+#   AWS_ACCOUNT_ID / AWS_REGION / ECR_REPOSITORY / CONTAINER_NAME
+#
+# 注: CodeBuild の作業ディレクトリはリポジトリのルート（appspec.yaml と同じ階層）。
+
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - REPO_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPOSITORY
+      # コミット SHA をタグにする（imageDetail.json 経由で CodeDeploy が taskdef に焼き込む）。
+      - IMAGE_TAG=${CODEBUILD_RESOLVED_SOURCE_VERSION:-latest}
+      - aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+  build:
+    commands:
+      - docker build --platform linux/amd64 -t "$REPO_URI:$IMAGE_TAG" backend
+      - docker tag "$REPO_URI:$IMAGE_TAG" "$REPO_URI:latest"
+  post_build:
+    commands:
+      - docker push "$REPO_URI:$IMAGE_TAG"
+      - docker push "$REPO_URI:latest"
+      # 現行の本番タスク定義を取得し、image だけ CodeDeploy 用プレースホルダに差し替える。
+      # env / secrets / roles は現行定義をそのまま引き継ぐ（image 以外は ecs.yml が管理）。
+      - aws ecs describe-task-definition --task-definition frestyle-prod-task --query taskDefinition > taskdef-full.json
+      - >-
+        jq 'del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .compatibilities, .registeredAt, .registeredBy)
+            | .containerDefinitions[0].image = "<IMAGE1_NAME>"' taskdef-full.json > taskdef.json
+      # CodeDeploy が <IMAGE1_NAME> をこの ImageURI で置換する。
+      - printf '{"ImageURI":"%s"}' "$REPO_URI:$IMAGE_TAG" > imageDetail.json
+
+artifacts:
+  files:
+    - taskdef.json
+    - appspec.yaml
+    - imageDetail.json
+  discard-paths: yes

--- a/backend/buildspec.yml
+++ b/backend/buildspec.yml
@@ -5,7 +5,9 @@
 # artifact として出力する。
 #
 # 環境変数は frestyle-infrastructure の cicd/codepipeline.yml の CodeBuild Project が渡す:
-#   AWS_ACCOUNT_ID / AWS_REGION / ECR_REPOSITORY / CONTAINER_NAME
+#   AWS_ACCOUNT_ID / AWS_REGION / ECR_REPOSITORY
+# コンテナ名は appspec.yaml で固定（fre-style）。taskdef も現行定義の name を引き継ぐため
+# buildspec では扱わない。
 #
 # 注: CodeBuild の作業ディレクトリはリポジトリのルート（appspec.yaml と同じ階層）。
 


### PR DESCRIPTION
## 概要

ECS Blue/Green デプロイ（frestyle-infrastructure#76）で **CodeBuild / CodeDeploy が使う設定ファイル**を本体リポに追加する。

## 変更内容

- **backend/buildspec.yml**（CodeBuild）
  - docker build → ECR push `:sha`
  - `aws ecs describe-task-definition` で現行 taskdef を取得し、**image だけ `<IMAGE1_NAME>` プレースホルダに差し替え**て `taskdef.json` を生成（env / secrets / roles は現行を引き継ぐ＝二重管理を避ける）
  - `appspec.yaml` / `imageDetail.json` も artifact 出力
- **appspec.yaml**（CodeDeploy ECS）
  - `TargetService` の `<TASK_DEFINITION>` は CodeDeploy が置換。`ContainerName=fre-style` / `ContainerPort=8080`（`ecs.yml` と一致）

## テスト

- buildspec / appspec の YAML 構文 OK
- taskdef 生成の jq フィルタを検証（不要フィールド除去 + image プレースホルダ化）

## 補足

- 既存 `cd-backend.yml`（GitHub Actions ローリング）は緊急フォールバックとして併存
- 実 deploy の順序・運用は frestyle-infrastructure `docs/30-blue-green-deploy-runbook.md`

## 関連
- frestyle-infrastructure#76（Blue/Green 基盤 Phase 1）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 本番環境へのデプロイメント自動化設定を追加しました。Docker イメージのビルド、レジストリへのプッシュ、ECS Blue/Green デプロイメント機能が自動実行されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->