### PR TITLE
feat(observability): 構造化ログ(slog/JSON) + リクエストログ middleware

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -20,20 +20,33 @@
 package main
 
 import (
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/gin-gonic/gin"
 	_ "github.com/norman6464/FreStyle/backend/docs" // swag init で生成される OpenAPI spec
 	"github.com/norman6464/FreStyle/backend/internal/handler"
 	"github.com/norman6464/FreStyle/backend/internal/infra/config"
 	"github.com/norman6464/FreStyle/backend/internal/infra/database"
+	"github.com/norman6464/FreStyle/backend/internal/infra/logging"
 )
+
+// fatal は致命的エラーを構造化ログで出して終了する（log.Fatalf の slog 版）。
+func fatal(msg string, err error) {
+	slog.Error(msg, slog.Any("error", err))
+	os.Exit(1)
+}
 
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
-		log.Fatalf("config load failed: %v", err)
+		// logging.Setup 前なので env は分からない。既定(Info/JSON)で出す。
+		logging.Setup("")
+		fatal("config load failed", err)
 	}
+
+	// 構造化ログ(slog/JSON)を初期化する。以降は request middleware 含め JSON で出力する。
+	logging.Setup(cfg.AppEnv)
 
 	// 本番は gin を release モードにする。debug モードのルート登録ログ ([GIN-debug] ...) や
 	// 起動時 warning を抑止して CloudWatch のログ量を減らす。ローカルは debug のまま。
@@ -43,18 +56,18 @@ func main() {
 
 	db, err := database.NewPostgres(cfg)
 	if err != nil {
-		log.Fatalf("database connect failed: %v", err)
+		fatal("database connect failed", err)
 	}
 
 	// Go domain を「正」とする AutoMigrate。
 	if err := database.Migrate(db); err != nil {
-		log.Fatalf("migrate failed: %v", err)
+		fatal("migrate failed", err)
 	}
 
 	r := handler.NewRouter(db, cfg)
 	addr := ":" + cfg.ServerPort
-	log.Printf("FreStyle Go backend listening on %s (env=%s)", addr, cfg.AppEnv)
+	slog.Info("FreStyle Go backend listening", slog.String("addr", addr), slog.String("env", cfg.AppEnv))
 	if err := r.Run(addr); err != nil {
-		log.Fatalf("server stopped: %v", err)
+		fatal("server stopped", err)
 	}
 }

--- a/backend/internal/handler/middleware/request_logger.go
+++ b/backend/internal/handler/middleware/request_logger.go
@@ -1,0 +1,67 @@
+package middleware
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+// RequestIDHeader は採番したリクエスト ID を載せるレスポンスヘッダ名。
+// 障害調査時にユーザーから受け取ったこの ID でログを一意に追える。
+const RequestIDHeader = "X-Request-ID"
+
+// ContextKeyRequestID は c.Get で request_id を取り出すキー。
+const ContextKeyRequestID = "requestID"
+
+// RequestLogger は 1 リクエストごとに request_id を採番し、完了時に
+// method / path / status / latency_ms / client_ip / user_id を構造化ログ(slog)で出力する。
+// status に応じてレベルを変える(5xx=Error / 4xx=Warn / それ以外=Info)ので、
+// アラートやダッシュボードでエラー率を拾いやすい。
+//
+// skipPaths はアクセスログを出さないルートパターン(ヘルスチェック等のノイズ抑制)。
+// gin の c.FullPath()(例: /api/v2/health)で一致判定する。
+func RequestLogger(skipPaths ...string) gin.HandlerFunc {
+	skip := make(map[string]struct{}, len(skipPaths))
+	for _, p := range skipPaths {
+		skip[p] = struct{}{}
+	}
+	return func(c *gin.Context) {
+		// 既存の X-Request-ID を尊重し(フロント/プロキシ採番)、無ければ生成する。
+		rid := c.GetHeader(RequestIDHeader)
+		if rid == "" {
+			rid = uuid.NewString()
+		}
+		c.Set(ContextKeyRequestID, rid)
+		c.Header(RequestIDHeader, rid)
+
+		start := time.Now()
+		c.Next()
+
+		if _, ok := skip[c.FullPath()]; ok {
+			return
+		}
+
+		attrs := []any{
+			slog.String("request_id", rid),
+			slog.String("method", c.Request.Method),
+			slog.String("path", c.FullPath()),
+			slog.Int("status", c.Writer.Status()),
+			slog.Int64("latency_ms", time.Since(start).Milliseconds()),
+			slog.String("client_ip", c.ClientIP()),
+		}
+		if uid := CurrentUserIDOrZero(c); uid != 0 {
+			attrs = append(attrs, slog.Uint64("user_id", uid))
+		}
+
+		switch status := c.Writer.Status(); {
+		case status >= 500:
+			slog.Error("request", attrs...)
+		case status >= 400:
+			slog.Warn("request", attrs...)
+		default:
+			slog.Info("request", attrs...)
+		}
+	}
+}

--- a/backend/internal/handler/middleware/request_logger_test.go
+++ b/backend/internal/handler/middleware/request_logger_test.go
@@ -1,0 +1,116 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// captureLogs は RequestLogger の出力(slog/JSON)を buffer に差し替えて回収する。
+func captureLogs(t *testing.T, run func(r *gin.Engine)) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	defer slog.SetDefault(prev)
+
+	r := gin.New()
+	run(r)
+
+	var out []map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			t.Fatalf("ログが JSON でない: %v (%s)", err, line)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestRequestLogger_EmitsStructuredFields(t *testing.T) {
+	logs := captureLogs(t, func(r *gin.Engine) {
+		r.Use(RequestLogger())
+		r.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		// レスポンスに request_id ヘッダが付与される。
+		if w.Header().Get(RequestIDHeader) == "" {
+			t.Fatalf("%s ヘッダが無い", RequestIDHeader)
+		}
+	})
+
+	if len(logs) != 1 {
+		t.Fatalf("ログは 1 件のはず, got %d", len(logs))
+	}
+	got := logs[0]
+	if got["msg"] != "request" {
+		t.Errorf("msg=request のはず, got %v", got["msg"])
+	}
+	if got["method"] != http.MethodGet || got["path"] != "/ping" {
+		t.Errorf("method/path が不正: %v %v", got["method"], got["path"])
+	}
+	if got["status"] != float64(http.StatusOK) {
+		t.Errorf("status=200 のはず, got %v", got["status"])
+	}
+	if _, ok := got["request_id"]; !ok {
+		t.Errorf("request_id フィールドが無い")
+	}
+	if _, ok := got["latency_ms"]; !ok {
+		t.Errorf("latency_ms フィールドが無い")
+	}
+}
+
+func TestRequestLogger_SkipPaths(t *testing.T) {
+	logs := captureLogs(t, func(r *gin.Engine) {
+		r.Use(RequestLogger("/api/v2/health"))
+		r.GET("/api/v2/health", func(c *gin.Context) { c.Status(http.StatusOK) })
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/health", nil)
+		r.ServeHTTP(httptest.NewRecorder(), req)
+	})
+	if len(logs) != 0 {
+		t.Fatalf("skip 対象はログを出さないはず, got %d", len(logs))
+	}
+}
+
+func TestRequestLogger_5xxIsErrorLevel(t *testing.T) {
+	logs := captureLogs(t, func(r *gin.Engine) {
+		r.Use(RequestLogger())
+		r.GET("/boom", func(c *gin.Context) { c.Status(http.StatusInternalServerError) })
+		req := httptest.NewRequest(http.MethodGet, "/boom", nil)
+		r.ServeHTTP(httptest.NewRecorder(), req)
+	})
+	if len(logs) != 1 || logs[0]["level"] != "ERROR" {
+		t.Fatalf("5xx は ERROR レベルのはず, got %v", logs)
+	}
+}
+
+func TestRequestLogger_HonorsIncomingRequestID(t *testing.T) {
+	const incoming = "abc-123"
+	logs := captureLogs(t, func(r *gin.Engine) {
+		r.Use(RequestLogger())
+		r.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		req.Header.Set(RequestIDHeader, incoming)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Header().Get(RequestIDHeader) != incoming {
+			t.Fatalf("既存の request_id を引き継ぐはず, got %s", w.Header().Get(RequestIDHeader))
+		}
+	})
+	if logs[0]["request_id"] != incoming {
+		t.Fatalf("ログの request_id が引き継がれていない: %v", logs[0]["request_id"])
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -31,11 +31,10 @@ type routeDeps struct {
 func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
+	// 構造化アクセスログ(slog/JSON)。request_id 採番 + status 別レベルで出力する。
 	// ヘルスチェック (ALB が 30 秒間隔で叩く /api/v2/health) と root の access log は出さない。
 	// 大量の health ログが CloudWatch の取り込み課金を押し上げるのを防ぐ。
-	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
-		SkipPaths: []string{"/api/v2/health", "/"},
-	}))
+	r.Use(middleware.RequestLogger("/api/v2/health", "/"))
 	r.Use(middleware.CORS())
 
 	r.GET("/", func(c *gin.Context) {

--- a/backend/internal/infra/logging/logger.go
+++ b/backend/internal/infra/logging/logger.go
@@ -1,0 +1,20 @@
+// Package logging はアプリ全体の構造化ログ(slog / JSON)を初期化する。
+// JSON 出力にすることで CloudWatch Logs Insights や将来の APM(NewRelic 等)で
+// フィールド(request_id / status / latency_ms / user_id 等)を集計・検索できる。
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Setup はアプリ全体の slog を JSON ハンドラで初期化し、slog.Default に設定する。
+// レベルは本番(production / prod)は Info、それ以外は Debug。
+func Setup(env string) {
+	level := slog.LevelInfo
+	if env != "production" && env != "prod" {
+		level = slog.LevelDebug
+	}
+	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	slog.SetDefault(slog.New(handler))
+}


### PR DESCRIPTION
## 概要

可観測性の第一歩。アクセスログを **JSON 構造化（slog）** し、障害調査・エラー率集計・将来の APM（NewRelic 等）連携の土台にする。Blue/Green でデプロイノイズを抑えた次の「シグナルを良くする」施策。

## 変更内容

- **internal/infra/logging** — slog を JSON ハンドラで初期化（本番 Info / それ以外 Debug）。`slog.SetDefault`
- **middleware.RequestLogger** — 1 リクエストごとに **request_id を採番**し、完了時に `method / path / status / latency_ms / client_ip / user_id` を構造化出力
  - **status 別レベル**（5xx=Error / 4xx=Warn / その他=Info）でエラー率・アラートを拾いやすく
  - `X-Request-ID` は既存値（フロント/プロキシ採番）を尊重し、無ければ生成。レスポンスにも返す → ユーザーから受け取った ID でログを一意に追える
- **router** — gin の text access log を `RequestLogger` に置換（`/api/v2/health` と `/` は従来どおり skip でノイズ抑制）
- **main** — slog 初期化 + 起動/致命ログを構造化（`log.Fatalf` → `slog.Error` + `os.Exit`）

## テスト

- `request_logger_test.go`: 構造化フィールド出力 / skipPaths / 5xx=Error レベル / 既存 request_id 引き継ぎ を検証
- `go test ./... / go vet / go build` green、`golangci-lint` 0 件、`gofmt` 差分なし

## 補足（将来）

- 構造化済みなので CloudWatch Logs Insights で `status>=500` のエラー率や p95 latency を即集計できる
- NewRelic を入れる際は OTel ハンドラを slog に足す or ログ転送するだけで、この request_id/属性がそのまま活きる

## 関連

品質向上の可観測性軸（第一歩）。APM 本体・メトリクス/アラームは後続。