### PR TITLE
fix(ci): 夜間 $0 のため scheduled-stop/start で monitoring も teardown/recreate

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -200,6 +200,20 @@ jobs:
             --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
             --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
 
+      # 監視スタックは scheduled-stop で毎晩消えるため、ここで作り直す。
+      # alb の Export を ImportValue し、ecs が作る LogGroup(/ecs/frestyle-prod)に
+      # メトリクスフィルタを張るので、alb・ecs より後に deploy する。
+      # 注: SNS 購読(メール通知)を将来足す場合、毎晩 topic が作り直されると購読が消える。
+      #     その時は SNS topic を別の永続スタックに分離すること(現状は購読 0 件で無害)。
+      - name: Deploy monitoring stack
+        run: |
+          aws cloudformation deploy --region $AWS_REGION \
+            --stack-name $STACK_PFX-monitoring \
+            --template-file iac/infrastructure/cloudformation/templates/monitoring/cloudwatch.yml \
+            --parameter-overrides Environment=prod AlbStackName=$STACK_PFX-alb \
+            --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
+            --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
+
       - name: Upsert Route 53 Alias record (api.normanblog.com → ALB)
         env:
           ALB_DNS: ${{ steps.deps.outputs.alb_dns }}

--- a/.github/workflows/scheduled-stop.yml
+++ b/.github/workflows/scheduled-stop.yml
@@ -68,6 +68,20 @@ jobs:
           role-session-name: frestyle-scheduled-stop
           aws-region: ${{ env.AWS_REGION }}
 
+      # 監視スタックは alb の Export(LoadBalancerFullName / TargetGroupFullName)を
+      # ImportValue しているため、alb より先に消さないと alb 削除が「Export 使用中」で
+      # 失敗する。日中の監視は scheduled-start が朝に作り直す。
+      - name: Destroy monitoring stack
+        run: |
+          if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $STACK_PFX-monitoring >/dev/null 2>&1; then
+            echo "Deleting $STACK_PFX-monitoring ..."
+            aws cloudformation delete-stack --region $AWS_REGION --stack-name $STACK_PFX-monitoring
+            aws cloudformation wait stack-delete-complete --region $AWS_REGION --stack-name $STACK_PFX-monitoring
+            echo "✅ monitoring deleted"
+          else
+            echo "monitoring stack already absent, skip"
+          fi
+
       - name: Destroy ECS stack
         run: |
           if aws cloudformation describe-stacks --region $AWS_REGION --stack-name $STACK_PFX-ecs >/dev/null 2>&1; then


### PR DESCRIPTION
## 概要

ALB+ECS を夜間削除して **\$0** にするユーザー絶対条件を満たすための修正。monitoring スタックが alb の Export を ImportValue しているため、**monitoring を消さないと alb を削除できず**（CFn の「Export 使用中」制約）、実際に scheduled-stop が ALB を消せずに失敗していた。

## 変更内容

- `scheduled-stop.yml`: monitoring を ecs/alb より**先に**削除（`monitoring → ecs → alb`）
- `scheduled-start.yml`: ecs の**後に** monitoring を再作成（`alb → ecs → monitoring`）
  - monitoring は alb の Export と、ecs が作る LogGroup `/ecs/frestyle-prod` に依存するため最後
- SNS 購読を将来足す場合の注意（毎晩 topic 再作成で購読が消える→永続スタック分離が必要）をコメント明記

## 前提

- GitHub Actions OIDC ロールへの CloudWatch/SNS/MetricFilter 権限追加は **infra リポ側 PR #85** で対応済み（deploy 反映済み）
- マージ後、`workflow_dispatch` で stop→start の全サイクルを実地検証する（OIDC trust は main のみ許可のため）

## テスト

- マージ後に手動 dispatch で「stop で ALB+ECS+monitoring 全削除（\$0）→ start で全復旧」を確認予定
- 既に clean 構成(ローリング)で start 単体成功は確認済み

## 関連 Issue

なし（本番コスト最適化 / 夜間 \$0 の徹底）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* スケジュール実行ワークフローを改善し、モニタリングスタックのデプロイ・削除処理を最適化。リソース削除の失敗を防ぎ、ライフサイクル管理の信頼性を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->