### PR TITLE
feat(backend-java): 本番 Supabase(PostgreSQL)接続を追加(DATABASE_URL)

### DIFF
--- a/backend-java/src/main/java/com/normanblog/frestyle/config/DataSourceConfig.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/DataSourceConfig.java
@@ -1,0 +1,39 @@
+package com.normanblog.frestyle.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 本番(Supabase)用の DataSource 設定。
+ *
+ * <p>環境変数 {@code DATABASE_URL} がセットされているとき**だけ** Postgres の DataSource を
+ * 構築し、Spring Boot の H2 自動設定を上書きする。未設定(ローカル / テスト)では本 Bean は
+ * 生成されず、application.properties の H2 がそのまま使われる。これにより本番では DATABASE_URL を
+ * inject するだけで Postgres に切り替わる(既存 Go バックエンドと同じ運用)。
+ */
+@Configuration
+public class DataSourceConfig {
+
+  @Bean
+  @ConditionalOnExpression("'${DATABASE_URL:}' != ''")
+  DataSource dataSource(@Value("${DATABASE_URL}") String databaseUrl) {
+    SupabaseUrl parsed = SupabaseUrl.parse(databaseUrl);
+    HikariDataSource ds =
+        DataSourceBuilder.create()
+            .type(HikariDataSource.class)
+            .driverClassName("org.postgresql.Driver")
+            .url(parsed.jdbcUrl())
+            .username(parsed.username())
+            .password(parsed.password())
+            .build();
+    // Supabase Free の pooler は同時接続数が小さいため控えめに。
+    ds.setMaximumPoolSize(5);
+    ds.setPoolName("frestyle-supabase");
+    return ds;
+  }
+}

--- a/backend-java/src/main/java/com/normanblog/frestyle/config/SupabaseUrl.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/SupabaseUrl.java
@@ -14,6 +14,13 @@ import java.nio.charset.StandardCharsets;
  */
 public record SupabaseUrl(String jdbcUrl, String username, String password) {
 
+  // record の自動生成 toString は password を平文で出すため、ログ/スタックトレース漏洩を防ぐよう
+  // マスクして上書きする(jdbcUrl には password を含めていないのでそのまま出してよい)。
+  @Override
+  public String toString() {
+    return "SupabaseUrl[jdbcUrl=" + jdbcUrl + ", username=" + username + ", password=***]";
+  }
+
   /** libpq 形式の DATABASE_URL を解析する。host 名で pgbouncer を判定し prepared statement を無効化する。 */
   public static SupabaseUrl parse(String databaseUrl) {
     URI uri = URI.create(databaseUrl.trim());

--- a/backend-java/src/main/java/com/normanblog/frestyle/config/SupabaseUrl.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/SupabaseUrl.java
@@ -1,0 +1,52 @@
+package com.normanblog.frestyle.config;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Supabase / マネージド Postgres の libpq 形式 URL を JDBC 接続情報に変換する。
+ *
+ * <p>環境変数 {@code DATABASE_URL} は
+ * {@code postgresql://user:password@host:6543/postgres?sslmode=require} という libpq 形式で
+ * 渡ってくる(既存 Go バックエンドと同じ secret を共有)。JDBC ドライバはこの形式をそのまま
+ * 受け取れないため、host/port/db と user/password に分解し JDBC URL を組み立てる。
+ */
+public record SupabaseUrl(String jdbcUrl, String username, String password) {
+
+  /** libpq 形式の DATABASE_URL を解析する。host 名で pgbouncer を判定し prepared statement を無効化する。 */
+  public static SupabaseUrl parse(String databaseUrl) {
+    URI uri = URI.create(databaseUrl.trim());
+
+    String host = uri.getHost();
+    if (host == null) {
+      throw new IllegalArgumentException("DATABASE_URL に host がありません");
+    }
+    int port = uri.getPort() == -1 ? 5432 : uri.getPort();
+    String db = uri.getPath() == null || uri.getPath().isBlank() ? "/postgres" : uri.getPath();
+
+    String userInfo = uri.getUserInfo();
+    if (userInfo == null || !userInfo.contains(":")) {
+      throw new IllegalArgumentException("DATABASE_URL に user:password がありません");
+    }
+    int sep = userInfo.indexOf(':');
+    String username = decode(userInfo.substring(0, sep));
+    String password = decode(userInfo.substring(sep + 1));
+
+    // pgbouncer(Supabase Transaction pooler)はサーバ側 prepared statement を保持できないため、
+    // host 名にプール識別子が含まれるときは prepareThreshold=0 で named statement を使わせない。
+    boolean pooled = host.contains("pooler.supabase.com") || host.contains("pgbouncer");
+    StringBuilder jdbc = new StringBuilder("jdbc:postgresql://").append(host).append(':').append(port).append(db);
+    String query = uri.getQuery();
+    jdbc.append('?').append(query == null || query.isBlank() ? "sslmode=require" : query);
+    if (pooled) {
+      jdbc.append("&prepareThreshold=0");
+    }
+
+    return new SupabaseUrl(jdbc.toString(), username, password);
+  }
+
+  private static String decode(String s) {
+    return URLDecoder.decode(s, StandardCharsets.UTF_8);
+  }
+}

--- a/backend-java/src/test/java/com/normanblog/frestyle/config/SupabaseUrlTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/config/SupabaseUrlTest.java
@@ -37,6 +37,12 @@ class SupabaseUrlTest {
   }
 
   @Test
+  void toString_masksPassword() {
+    SupabaseUrl r = SupabaseUrl.parse("postgresql://user:topsecret@db.example.com:5432/postgres");
+    assertThat(r.toString()).doesNotContain("topsecret").contains("password=***");
+  }
+
+  @Test
   void parse_missingCredentials_throws() {
     assertThatThrownBy(() -> SupabaseUrl.parse("postgresql://db.example.com:5432/postgres"))
         .isInstanceOf(IllegalArgumentException.class);

--- a/backend-java/src/test/java/com/normanblog/frestyle/config/SupabaseUrlTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/config/SupabaseUrlTest.java
@@ -1,0 +1,44 @@
+package com.normanblog.frestyle.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** libpq 形式 DATABASE_URL → JDBC 変換の検証。 */
+class SupabaseUrlTest {
+
+  @Test
+  void parse_supabasePooler_disablesPreparedStatements() {
+    SupabaseUrl r =
+        SupabaseUrl.parse(
+            "postgresql://postgres.abcdef:s3cret@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?sslmode=require");
+
+    assertThat(r.jdbcUrl())
+        .isEqualTo(
+            "jdbc:postgresql://aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres?sslmode=require&prepareThreshold=0");
+    assertThat(r.username()).isEqualTo("postgres.abcdef");
+    assertThat(r.password()).isEqualTo("s3cret");
+  }
+
+  @Test
+  void parse_nonPooled_keepsPreparedStatements() {
+    SupabaseUrl r = SupabaseUrl.parse("postgresql://user:pw@db.example.com:5432/postgres?sslmode=require");
+
+    assertThat(r.jdbcUrl()).doesNotContain("prepareThreshold");
+    assertThat(r.jdbcUrl()).isEqualTo("jdbc:postgresql://db.example.com:5432/postgres?sslmode=require");
+  }
+
+  @Test
+  void parse_urlEncodedPassword_isDecoded() {
+    // パスワードに記号が含まれ %-エンコードされている場合はデコードする。
+    SupabaseUrl r = SupabaseUrl.parse("postgresql://user:p%40ss%2Fword@db.example.com:5432/postgres");
+    assertThat(r.password()).isEqualTo("p@ss/word");
+  }
+
+  @Test
+  void parse_missingCredentials_throws() {
+    assertThatThrownBy(() -> SupabaseUrl.parse("postgresql://db.example.com:5432/postgres"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}


### PR DESCRIPTION
## 概要

本番 ECS の Java を H2(インメモリ)から **Supabase(PostgreSQL)** に接続できるようにする。`DATABASE_URL` がセットされているとき**だけ** Postgres に切り替わり、未設定(ローカル/テスト)では H2 のまま。

本番 ECS task は既に Go 用に `DATABASE_URL`(Secrets)を注入しており Java コンテナにも渡るため、**infra 変更は不要**。

## 変更内容

- `SupabaseUrl`: libpq 形式 URL(`postgresql://user:pw@host:6543/db?sslmode=require`)を JDBC URL + user + password に分解。host に `pooler.supabase.com` を含むとき `prepareThreshold=0` を付与（pgbouncer transaction mode は named prepared statement を保持できないため）
- `DataSourceConfig`: `@ConditionalOnExpression("'${DATABASE_URL:}' != ''")` で Postgres DataSource(Hikari, maxPoolSize=5)を構築。未設定なら Bean を作らず H2 自動設定にフォールバック
- `ddl-auto=none` + Flyway `baseline-on-migrate` で既存スキーマ(GORM 製)に追従（migration は IF NOT EXISTS で冪等＝既存テーブルには no-op）

## テスト

- `./gradlew build` 成功（Java 21、全テスト緑、H2 経路は不変）
- `SupabaseUrlTest`: pooler の prepareThreshold 付与 / 非 pooler / %-エンコード PW 復号 / 認証情報欠落で例外
- 本番接続の実検証はマージ後デプロイで実施（アプリ起動＝Flyway が Supabase 接続成功。失敗時は ECS 循環ブレーカーが現行タスクへ自動ロールバック）

## 関連

- 次 PR: ログインフロー(認可コード→token 交換 / Cookie 発行 / logout / refresh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Supabase データベースへの接続に対応しました。環境変数 `DATABASE_URL` を設定すると、自動的に接続が確立され、Supabase Free プランに最適化された構成で動作します。環境変数が未設定の場合は従来の H2 データベースが使用されます。

* **テスト**
  * Supabase データベース接続機能のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->