### PR TITLE
perf(backend-java): 起動短縮のため lazy-initialization を有効化

### DIFF
--- a/backend-java/src/main/resources/application.properties
+++ b/backend-java/src/main/resources/application.properties
@@ -17,6 +17,9 @@ spring.flyway.baseline-on-migrate=true
 
 # ECS 0.25 vCPU / 0.5 GB を見据え、起動バナーを抑止。
 spring.main.banner-mode=off
+# 0.25 vCPU では cold start が遅い(~100s)。遅延初期化で起動を短縮する
+# (Bean は初回利用時に生成。毎晩 ECS を作り直す運用なので朝の復帰を速くする狙い)。
+spring.main.lazy-initialization=true
 
 # 認証: Cognito User Pool の JWKS で access_token(JWT)の署名を検証する。
 # 既定値は本番 Pool 2(ap-northeast-1_TkRen4lyD)。環境変数で上書きする。


### PR DESCRIPTION
## 概要

0.25 vCPU の Fargate では Spring Boot の cold start が遅い(~100s)。Bean の遅延初期化(`spring.main.lazy-initialization=true`)で起動を短縮する。毎晩 ECS を作り直す運用(夜間 \$0)のため朝の復帰を速くする狙い。

## 変更

- `application.properties`: `spring.main.lazy-initialization=true`

## テスト

- `./gradlew build` 成功(全テスト緑)。Spring Security のフィルタチェーンが遅延初期化でも正しく機能すること(未認証 401 / 偽造トークン 401 / admin 昇格)をテストで確認
- 本番デプロイ済み(grace period 300 と併用して Supabase 接続版が healthy 化)

## 補足

- 起動 ~100s の主因は Tomcat/JPA/Hikari 初期化で、lazy-init では大きく縮まらなかった。CDS/AOT 等の本格的な起動最適化は別途フォローアップ
- ECS の grace period 引き上げ(120→300)は infra リポ側 PR #86 で対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * リソース制約のある環境でアプリケーション起動時間を削減する最適化設定を有効化し、初期応答速度を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->