### PR TITLE
feat(auth): 認証 API パスを REST 化 + ログイン導線を整理(単一 Hosted UI + 公開ヘッダー)

### DIFF
--- a/backend-java/src/main/java/com/normanblog/frestyle/config/SecurityConfig.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/SecurityConfig.java
@@ -27,9 +27,9 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/api/v2/health")
                     .permitAll()
-                    // ログインフロー(callback/logout/refresh)は Cookie を発行・破棄する側なので
+                    // ログインフロー(login/logout/refresh)は Cookie を発行・破棄する側なので
                     // JWT 検証の前段。認証不要で通す。
-                    .requestMatchers("/api/v2/auth/cognito/**")
+                    .requestMatchers("/api/v2/auth/login", "/api/v2/auth/logout", "/api/v2/auth/refresh")
                     .permitAll()
                     // 例外発生時に Spring Boot が /error へフォワードする。ここが認証必須だと
                     // バリデーション 400 等が 401 に化けるため公開する(本来の status を返させる)。

--- a/backend-java/src/main/java/com/normanblog/frestyle/controller/AuthController.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/controller/AuthController.java
@@ -56,8 +56,8 @@ public class AuthController {
   }
 
   /** 認可コードを token に交換し、HttpOnly Cookie を発行する。招待が無い新規ユーザーは 403。 */
-  @PostMapping("/cognito/callback")
-  public ResponseEntity<Map<String, String>> callback(
+  @PostMapping("/login")
+  public ResponseEntity<Map<String, String>> login(
       @Valid @RequestBody CallbackRequest request, HttpServletResponse response) {
     LoginService.LoginResult result;
     try {
@@ -78,7 +78,7 @@ public class AuthController {
                   "error",
                   "invitation_required",
                   "message",
-                  "FreStyle のご利用には管理者からの招待が必要です。招待メールに記載されたリンクからログインしてください。"));
+                  "ご利用には企業申請、または所属企業からの招待が必要です。招待メールに記載されたリンクからログインしてください。"));
     }
 
     CognitoTokens tokens = result.tokens();
@@ -88,14 +88,14 @@ public class AuthController {
   }
 
   /** access/refresh Cookie を破棄する。 */
-  @PostMapping("/cognito/logout")
+  @PostMapping("/logout")
   public ResponseEntity<Map<String, String>> logout(HttpServletResponse response) {
     cookies.clear(response);
     return ResponseEntity.ok(Map.of("message", "ログアウトしました。"));
   }
 
   /** refresh_token Cookie で access_token を再発行する。失効していれば Cookie を破棄して 401。 */
-  @PostMapping("/cognito/refresh-token")
+  @PostMapping("/refresh")
   public ResponseEntity<Map<String, String>> refresh(
       @CookieValue(name = "refresh_token", required = false) String refreshToken,
       HttpServletResponse response) {

--- a/backend-java/src/main/java/com/normanblog/frestyle/security/CognitoCookieBearerTokenResolver.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/security/CognitoCookieBearerTokenResolver.java
@@ -2,6 +2,7 @@ package com.normanblog.frestyle.security;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Set;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 
 /**
@@ -15,8 +16,22 @@ public class CognitoCookieBearerTokenResolver implements BearerTokenResolver {
 
   private static final String COOKIE_NAME = "access_token";
 
+  // 公開エンドポイントでは Bearer 解決をしない(= JWT 検証を走らせない)。
+  // とくに /refresh は access_token が期限切れの状態で叩かれるため、ここでトークンを返すと
+  // 期限切れ JWT の検証が先に走って 401 になり、refresh 本来の役割(再発行)が壊れる。
+  private static final Set<String> PUBLIC_PATHS =
+      Set.of(
+          "/api/v2/health",
+          "/api/v2/auth/login",
+          "/api/v2/auth/logout",
+          "/api/v2/auth/refresh");
+
   @Override
   public String resolve(HttpServletRequest request) {
+    if (PUBLIC_PATHS.contains(request.getRequestURI())) {
+      return null;
+    }
+
     Cookie[] cookies = request.getCookies();
     if (cookies == null) {
       return null;

--- a/backend-java/src/test/java/com/normanblog/frestyle/controller/AuthCognitoFlowControllerTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/controller/AuthCognitoFlowControllerTest.java
@@ -140,4 +140,19 @@ class AuthCognitoFlowControllerTest {
   void refresh_withoutCookie_returns401() throws Exception {
     mvc.perform(post("/api/v2/auth/refresh")).andExpect(status().isUnauthorized());
   }
+
+  @Test
+  void refresh_withExpiredAccessTokenCookie_stillReachesController() throws Exception {
+    // refresh は access_token が期限切れの状態で叩かれる。壊れた access_token Cookie が
+    // 付いていても JWT 検証で 401 にならず、controller に到達して再発行できること。
+    when(tokenClient.refreshAccessToken(any()))
+        .thenReturn(new CognitoTokens("new-access", "", "", 3600));
+
+    mvc.perform(
+            post("/api/v2/auth/refresh")
+                .cookie(new Cookie("refresh_token", "rt"))
+                .cookie(new Cookie("access_token", "expired-or-garbage")))
+        .andExpect(status().isOk())
+        .andExpect(cookie().value("access_token", "new-access"));
+  }
 }

--- a/backend-java/src/test/java/com/normanblog/frestyle/controller/AuthCognitoFlowControllerTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/controller/AuthCognitoFlowControllerTest.java
@@ -81,7 +81,7 @@ class AuthCognitoFlowControllerTest {
             new CognitoTokens("access-jwt", fakeIdToken("sub1", "inv@x.com", List.of()), "refresh-jwt", 3600));
 
     mvc.perform(
-            post("/api/v2/auth/cognito/callback")
+            post("/api/v2/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"code\":\"abc\"}"))
         .andExpect(status().isOk())
@@ -98,7 +98,7 @@ class AuthCognitoFlowControllerTest {
             new CognitoTokens("access-jwt", fakeIdToken("sub2", "nobody@x.com", List.of()), "refresh-jwt", 3600));
 
     mvc.perform(
-            post("/api/v2/auth/cognito/callback")
+            post("/api/v2/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"code\":\"abc\"}"))
         .andExpect(status().isForbidden())
@@ -112,7 +112,7 @@ class AuthCognitoFlowControllerTest {
         .thenThrow(new TokenExchangeException(400, "invalid_grant"));
 
     mvc.perform(
-            post("/api/v2/auth/cognito/callback")
+            post("/api/v2/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"code\":\"bad\"}"))
         .andExpect(status().isUnauthorized());
@@ -120,7 +120,7 @@ class AuthCognitoFlowControllerTest {
 
   @Test
   void logout_clearsCookies() throws Exception {
-    mvc.perform(post("/api/v2/auth/cognito/logout"))
+    mvc.perform(post("/api/v2/auth/logout"))
         .andExpect(status().isOk())
         .andExpect(cookie().maxAge("access_token", 0))
         .andExpect(cookie().maxAge("refresh_token", 0));
@@ -131,13 +131,13 @@ class AuthCognitoFlowControllerTest {
     when(tokenClient.refreshAccessToken(any()))
         .thenReturn(new CognitoTokens("new-access", "", "", 3600));
 
-    mvc.perform(post("/api/v2/auth/cognito/refresh-token").cookie(new Cookie("refresh_token", "rt")))
+    mvc.perform(post("/api/v2/auth/refresh").cookie(new Cookie("refresh_token", "rt")))
         .andExpect(status().isOk())
         .andExpect(cookie().value("access_token", "new-access"));
   }
 
   @Test
   void refresh_withoutCookie_returns401() throws Exception {
-    mvc.perform(post("/api/v2/auth/cognito/refresh-token")).andExpect(status().isUnauthorized());
+    mvc.perform(post("/api/v2/auth/refresh")).andExpect(status().isUnauthorized());
   }
 }

--- a/frontend/src/components/AuthLayout.tsx
+++ b/frontend/src/components/AuthLayout.tsx
@@ -4,32 +4,40 @@ interface AuthLayoutProps {
   children: ReactNode;
   title?: string;
   footer?: ReactNode;
+  /** ページ上部に固定するヘッダー(公開ページの導線など)。省略時は従来どおり中央寄せのみ。 */
+  header?: ReactNode;
 }
 
-export default function AuthLayout({ children, title, footer }: AuthLayoutProps) {
+export default function AuthLayout({ children, title, footer, header }: AuthLayoutProps) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-surface px-4 py-12">
-      <div className="mb-6 flex flex-col items-center">
-        <img
-          src="/favicon.svg"
-          alt=""
-          aria-hidden="true"
-          className="w-12 h-12 mb-3"
-        />
-        {title && (
-          <h1 className="text-2xl font-bold text-[var(--color-text-primary)] tracking-tight">
-            {title}
-          </h1>
+    <div className="min-h-screen flex flex-col bg-surface">
+      {header}
+
+      <div className="flex flex-1 flex-col items-center justify-center px-4 py-12">
+        <div className="mb-6 flex flex-col items-center">
+          <img
+            src="/favicon.svg"
+            alt=""
+            aria-hidden="true"
+            className="w-12 h-12 mb-3"
+          />
+          {title && (
+            <h1 className="text-2xl font-bold text-[var(--color-text-primary)] tracking-tight">
+              {title}
+            </h1>
+          )}
+        </div>
+
+        <div className="w-full max-w-sm bg-surface-1 rounded-xl border border-surface-3 p-6">
+          {children}
+        </div>
+
+        {footer && (
+          <div className="w-full max-w-sm bg-surface-1 rounded-xl border border-surface-3 p-4 text-center mt-4">
+            {footer}
+          </div>
         )}
       </div>
-      <div className="w-full max-w-sm bg-surface-1 rounded-xl border border-surface-3 p-6">
-        {children}
-      </div>
-      {footer && (
-        <div className="w-full max-w-sm bg-surface-1 rounded-xl border border-surface-3 p-4 text-center mt-4">
-          {footer}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/PublicHeader.tsx
+++ b/frontend/src/components/PublicHeader.tsx
@@ -1,0 +1,39 @@
+import { Link } from 'react-router-dom';
+import { BuildingOffice2Icon } from '@heroicons/react/24/outline';
+
+/**
+ * 公開ページ(ログイン / 企業利用申請)共通のヘッダー。
+ *
+ * 既存ユーザーの「ログイン」と、見込み企業の「利用申請」の 2 導線を提供する。
+ * ログインは role を問わず 1 つに統一し、ログイン後にダッシュボードを出し分ける方針。
+ */
+export default function PublicHeader() {
+  return (
+    <header className="w-full border-b border-surface-3 bg-surface-1">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+        <Link to="/login" className="flex items-center gap-2" aria-label="FreStyle ホーム">
+          <img src="/favicon.svg" alt="" aria-hidden="true" className="h-7 w-7" />
+          <span className="text-lg font-bold tracking-tight text-[var(--color-text-primary)]">
+            FreStyle
+          </span>
+        </Link>
+
+        <nav className="flex items-center gap-2">
+          <Link
+            to="/company-application"
+            className="flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-surface-2"
+          >
+            <BuildingOffice2Icon className="h-4 w-4" aria-hidden="true" />
+            企業の利用申請
+          </Link>
+          <Link
+            to="/login"
+            className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-600"
+          >
+            ログイン
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/components/__tests__/AuthLayout.test.tsx
@@ -30,10 +30,11 @@ describe('AuthLayout', () => {
 
   it('中央寄せレイアウトが適用される', () => {
     const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
-    const wrapper = container.firstElementChild as HTMLElement;
-    expect(wrapper.className).toContain('flex');
-    expect(wrapper.className).toContain('items-center');
-    expect(wrapper.className).toContain('justify-center');
+    // 外枠は min-h-screen の縦並び、内側に中央寄せの領域を持つ(header スロット追加に伴う構造)。
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('min-h-screen');
+    const centered = container.querySelector('.items-center.justify-center') as HTMLElement;
+    expect(centered).not.toBeNull();
   });
 
   it('カードに角丸が適用される', () => {

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -24,11 +24,13 @@ export const AUTH = {
   login: `${API_V2}/auth/cognito/login`,
   signup: `${API_V2}/auth/cognito/signup`,
   confirm: `${API_V2}/auth/cognito/confirm`,
-  callback: `${API_V2}/auth/cognito/callback`,
+  // OAuth Hosted UI ログイン(認可コード→token 交換)/ logout / refresh は
+  // provider 非依存の REST パスに統一(/auth/login, /auth/logout, /auth/refresh)。
+  callback: `${API_V2}/auth/login`,
   forgotPassword: `${API_V2}/auth/cognito/forgot-password`,
   confirmForgotPassword: `${API_V2}/auth/cognito/confirm-forgot-password`,
-  logout: `${API_V2}/auth/cognito/logout`,
-  refreshToken: `${API_V2}/auth/cognito/refresh-token`,
+  logout: `${API_V2}/auth/logout`,
+  refreshToken: `${API_V2}/auth/refresh`,
   me: `${API_V2}/auth/me`,
 } as const;
 

--- a/frontend/src/hooks/__tests__/useLoginPage.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginPage.test.ts
@@ -1,161 +1,29 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { useLoginPage } from '../useLoginPage';
 
-const mockLogin = vi.fn();
-const mockNavigate = vi.fn();
 const mockLocationState = { message: '' };
 
 vi.mock('react-router-dom', () => ({
   useLocation: () => ({ state: mockLocationState }),
-  useNavigate: () => mockNavigate,
-}));
-
-vi.mock('../useAuth', () => ({
-  useAuth: () => ({ login: mockLogin }),
 }));
 
 describe('useLoginPage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
     mockLocationState.message = '';
   });
 
-  it('初期状態でformが空文字列である', () => {
-    const { result } = renderHook(() => useLoginPage());
-    expect(result.current.form).toEqual({ email: '', password: '' });
-  });
-
-  it('初期状態でloginMessageがnullである', () => {
-    const { result } = renderHook(() => useLoginPage());
-    expect(result.current.loginMessage).toBeNull();
-  });
-
-  it('handleChangeでフォーム値が更新される', () => {
-    const { result } = renderHook(() => useLoginPage());
-    act(() => {
-      result.current.handleChange({
-        target: { name: 'email', value: 'test@example.com' },
-      } as React.ChangeEvent<HTMLInputElement>);
-    });
-    expect(result.current.form.email).toBe('test@example.com');
-  });
-
-  it('handleChangeでパスワードが更新される', () => {
-    const { result } = renderHook(() => useLoginPage());
-    act(() => {
-      result.current.handleChange({
-        target: { name: 'password', value: 'secret123' },
-      } as React.ChangeEvent<HTMLInputElement>);
-    });
-    expect(result.current.form.password).toBe('secret123');
-  });
-
-  it('ログイン成功時にナビゲートされる', async () => {
-    mockLogin.mockResolvedValue(true);
-    const { result } = renderHook(() => useLoginPage());
-
-    await act(async () => {
-      await result.current.handleLogin({
-        preventDefault: vi.fn(),
-      } as unknown as React.FormEvent<HTMLFormElement>);
-    });
-
-    expect(mockLogin).toHaveBeenCalledWith({ email: '', password: '' });
-    expect(mockNavigate).toHaveBeenCalledWith('/');
-  });
-
-  it('ログイン失敗時にエラーメッセージが設定される', async () => {
-    mockLogin.mockResolvedValue(false);
-    const { result } = renderHook(() => useLoginPage());
-
-    await act(async () => {
-      await result.current.handleLogin({
-        preventDefault: vi.fn(),
-      } as unknown as React.FormEvent<HTMLFormElement>);
-    });
-
-    expect(result.current.loginMessage).toEqual({
-      type: 'error',
-      text: 'ログインに失敗しました。',
-    });
-    expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('handleLoginでpreventDefaultが呼ばれる', async () => {
-    mockLogin.mockResolvedValue(true);
-    const { result } = renderHook(() => useLoginPage());
-    const preventDefault = vi.fn();
-
-    await act(async () => {
-      await result.current.handleLogin({
-        preventDefault,
-      } as unknown as React.FormEvent<HTMLFormElement>);
-    });
-
-    expect(preventDefault).toHaveBeenCalled();
-  });
-
-  it('locationStateのメッセージが取得される', () => {
+  it('locationState のメッセージを取得する', () => {
     mockLocationState.message = '確認メールを送信しました';
+
     const { result } = renderHook(() => useLoginPage());
+
     expect(result.current.flashMessage).toBe('確認メールを送信しました');
   });
 
-  it('locationStateにメッセージがない場合はundefined', () => {
-    mockLocationState.message = '';
+  it('メッセージが無い場合は空文字を返す', () => {
     const { result } = renderHook(() => useLoginPage());
+
     expect(result.current.flashMessage).toBe('');
-  });
-
-  it('ログイン時にフォームの値が送信される', async () => {
-    mockLogin.mockResolvedValue(true);
-    const { result } = renderHook(() => useLoginPage());
-
-    act(() => {
-      result.current.handleChange({
-        target: { name: 'email', value: 'user@test.com' },
-      } as React.ChangeEvent<HTMLInputElement>);
-    });
-    act(() => {
-      result.current.handleChange({
-        target: { name: 'password', value: 'pass123' },
-      } as React.ChangeEvent<HTMLInputElement>);
-    });
-
-    await act(async () => {
-      await result.current.handleLogin({
-        preventDefault: vi.fn(),
-      } as unknown as React.FormEvent<HTMLFormElement>);
-    });
-
-    expect(mockLogin).toHaveBeenCalledWith({ email: 'user@test.com', password: 'pass123' });
-  });
-
-  it('初期状態でloadingがfalseである', () => {
-    const { result } = renderHook(() => useLoginPage());
-    expect(result.current.loading).toBe(false);
-  });
-
-  it('handleLogin実行中にloadingがtrueになる', async () => {
-    let resolveLogin: (value: boolean) => void;
-    mockLogin.mockReturnValue(new Promise<boolean>((resolve) => { resolveLogin = resolve; }));
-    const { result } = renderHook(() => useLoginPage());
-
-    let loginPromise: Promise<void>;
-    act(() => {
-      loginPromise = result.current.handleLogin({
-        preventDefault: vi.fn(),
-      } as unknown as React.FormEvent<HTMLFormElement>);
-    });
-
-    expect(result.current.loading).toBe(true);
-
-    await act(async () => {
-      resolveLogin!(true);
-      await loginPromise;
-    });
-
-    expect(result.current.loading).toBe(false);
   });
 });

--- a/frontend/src/hooks/useLoginPage.ts
+++ b/frontend/src/hooks/useLoginPage.ts
@@ -1,59 +1,14 @@
-import { useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useAuth } from './useAuth';
-import { useFormField } from './useFormField';
-
-interface LoginMessage {
-  type: 'success' | 'error';
-  text: string;
-}
+import { useLocation } from 'react-router-dom';
 
 /**
- * LoginPageフック
+ * LoginPage 用フック。
  *
- * <p>役割:</p>
- * <ul>
- *   <li>LoginPageのフォーム管理・バリデーション</li>
- *   <li>ログイン処理のロジック</li>
- * </ul>
+ * ログインは Cognito Hosted UI に一本化したため、フォーム状態は持たない。
+ * ログアウト後や招待受諾後などに遷移元から渡されるフラッシュメッセージだけを取り出す。
  */
 export function useLoginPage() {
-  const { form, handleChange } = useFormField({ email: '', password: '' });
-  const [loginMessage, setLoginMessage] = useState<LoginMessage | null>(null);
-  const [loading, setLoading] = useState(false);
-
   const location = useLocation();
-  const navigate = useNavigate();
-  const { login } = useAuth();
-
   const flashMessage = (location.state as { message?: string })?.message || '';
 
-  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setLoading(true);
-
-    try {
-      const success = await login({ email: form.email, password: form.password });
-
-      if (success) {
-        navigate('/');
-      } else {
-        setLoginMessage({
-          type: 'error',
-          text: 'ログインに失敗しました。',
-        });
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  return {
-    form,
-    loginMessage,
-    flashMessage,
-    loading,
-    handleLogin,
-    handleChange,
-  };
+  return { flashMessage };
 }

--- a/frontend/src/lib/invitationToken.ts
+++ b/frontend/src/lib/invitationToken.ts
@@ -5,7 +5,7 @@
  *   1. /invitations/accept?token=<UUID> を踏むと AcceptInvitationPage が saveInvitationToken
  *   2. ユーザーが「ログインへ進む」ボタンで /login → Cognito Hosted UI へリダイレクト
  *   3. /login/callback (LoginCallback) が consumeInvitationToken で取り出して
- *      POST /auth/cognito/callback の body に invitationToken として含めて送る
+ *      POST /auth/login の body に invitationToken として含めて送る
  *
  * sessionStorage を選んだ理由:
  *   - localStorage だと別タブの誤読込みリスクがある

--- a/frontend/src/pages/CompanyApplicationPage.tsx
+++ b/frontend/src/pages/CompanyApplicationPage.tsx
@@ -1,4 +1,5 @@
 import AuthLayout from '../components/AuthLayout';
+import PublicHeader from '../components/PublicHeader';
 import InputField from '../components/InputField';
 import TextareaField from '../components/TextareaField';
 import PrimaryButton from '../components/PrimaryButton';
@@ -14,6 +15,7 @@ export default function CompanyApplicationPage() {
   return (
     <AuthLayout
       title="企業の利用申請"
+      header={<PublicHeader />}
       footer={
         <p className="text-sm text-[var(--color-text-muted)]">
           すでにアカウントをお持ちの方{' '}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -50,7 +50,7 @@ export default function LoginPage() {
       />
 
       <p className="mt-5 text-center text-sm text-[var(--color-text-muted)]">
-        ログインには所属企業からの招待が必要です。
+        招待された方は招待メールのリンクからログインしてください。
         <br />
         企業の方は <LinkText to="/company-application">利用申請</LinkText> から。
       </p>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,58 +1,47 @@
 import AuthLayout from '../components/AuthLayout';
-import InputField from '../components/InputField';
-import PrimaryButton from '../components/PrimaryButton';
+import PublicHeader from '../components/PublicHeader';
 import SNSSignInButton from '../components/SNSSignInButton';
 import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
 import { useLoginPage } from '../hooks/useLoginPage';
-import { Link } from 'react-router-dom';
-import { XCircleIcon, CheckCircleIcon, BuildingOffice2Icon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/outline';
 
 export default function LoginPage() {
-  const { form, loginMessage, flashMessage, loading, handleLogin, handleChange } = useLoginPage();
+  const { flashMessage } = useLoginPage();
 
   return (
-    <AuthLayout
-      title="ログイン"
-      footer={
-        <p className="text-sm text-[var(--color-text-muted)]">
-          アカウントをお持ちでない方{' '}
-          <LinkText to="/signup">新規登録</LinkText>
-        </p>
-      }
-    >
-      {/* 企業の利用申請（未登録の企業担当者向け） */}
-      <Link
-        to="/company-application"
-        className="flex items-center justify-center gap-2 mb-5 px-4 py-2.5 rounded-lg border border-surface-3 text-sm font-medium text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors"
-      >
-        <BuildingOffice2Icon className="w-4 h-4" aria-hidden="true" />
-        企業の方はこちら（利用申請）
-      </Link>
-
-      {/* フラッシュメッセージ（成功） */}
+    <AuthLayout title="ログイン" header={<PublicHeader />}>
       {flashMessage && (
         <p
           role="status"
-          className="flex items-center justify-center gap-1 text-emerald-400 text-center mb-4 p-3 bg-emerald-900/30 rounded-lg font-medium"
+          className="mb-4 flex items-center justify-center gap-1 rounded-lg bg-emerald-900/30 p-3 text-center font-medium text-emerald-400"
         >
-          <CheckCircleIcon className="w-4 h-4" aria-hidden="true" />
+          <CheckCircleIcon className="h-4 w-4" aria-hidden="true" />
           {flashMessage}
         </p>
       )}
 
-      {/* エラーメッセージ */}
-      {loginMessage?.type === 'error' && (
-        <p
-          role="alert"
-          className="flex items-center justify-center gap-1 text-rose-400 text-center mb-4 p-3 bg-rose-900/30 rounded-lg font-medium"
-        >
-          <XCircleIcon className="w-4 h-4" aria-hidden="true" />
-          {loginMessage.text}
-        </p>
-      )}
+      {/* ログインは Cognito Hosted UI に一本化(メール/パスワード + ソーシャルを Hosted UI 側で選択)。 */}
+      <button
+        type="button"
+        onClick={() => {
+          window.location.href = getCognitoAuthUrl();
+        }}
+        className="w-full rounded-lg bg-primary-500 py-2.5 font-medium text-white transition-colors duration-150 hover:bg-primary-600 active:bg-primary-700"
+      >
+        ログイン / 新規登録
+      </button>
 
-      {/* Google ログイン */}
+      <div className="relative my-5">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-surface-3"></div>
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="bg-surface-1 px-2 text-[var(--color-text-muted)]">または</span>
+        </div>
+      </div>
+
+      {/* Google で直接ログイン */}
       <SNSSignInButton
         provider="google"
         onClick={() => {
@@ -60,43 +49,11 @@ export default function LoginPage() {
         }}
       />
 
-      {/* 区切り線 */}
-      <div className="relative my-5">
-        <div className="absolute inset-0 flex items-center">
-          <div className="w-full border-t border-surface-3"></div>
-        </div>
-        <div className="relative flex justify-center text-sm">
-          <span className="px-2 bg-surface-1 text-[var(--color-text-muted)]">または</span>
-        </div>
-      </div>
-
-      {/* メール・パスワードフォーム */}
-      <form onSubmit={handleLogin} aria-label="ログインフォーム">
-        <InputField
-          label="メールアドレス"
-          name="email"
-          type="email"
-          value={form.email}
-          onChange={handleChange}
-          disabled={loading}
-        />
-        <InputField
-          label="パスワード"
-          name="password"
-          type="password"
-          value={form.password}
-          onChange={handleChange}
-          disabled={loading}
-        />
-        <PrimaryButton type="submit" loading={loading}>
-          {loading ? 'ログイン中...' : 'ログイン'}
-        </PrimaryButton>
-      </form>
-
-      {/* パスワードリセットリンク */}
-      <div className="mt-4 text-center">
-        <LinkText to="/forgot-password">パスワードを忘れた方</LinkText>
-      </div>
+      <p className="mt-5 text-center text-sm text-[var(--color-text-muted)]">
+        ログインには所属企業からの招待が必要です。
+        <br />
+        企業の方は <LinkText to="/company-application">利用申請</LinkText> から。
+      </p>
     </AuthLayout>
   );
 }

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,89 +1,51 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import { configureStore } from '@reduxjs/toolkit';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import LoginPage from '../LoginPage';
-import authReducer from '../../store/authSlice';
 
-const mockLogin = vi.fn();
-const mockNavigate = vi.fn();
+// Hosted UI への遷移は window.location.href への代入で行うため、副作用を検証できるようにする。
+const hrefSetter = vi.fn();
 
-vi.mock('../../hooks/useAuth', () => ({
-  useAuth: () => ({
-    login: mockLogin,
-    loading: false,
-    error: null,
-    isAuthenticated: false,
-  }),
-}));
-
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
-  return {
-    ...actual,
-    useNavigate: () => mockNavigate,
-  };
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(window, 'location', {
+    value: { set href(v: string) { hrefSetter(v); } },
+    writable: true,
+  });
 });
 
 function renderLoginPage() {
-  const store = configureStore({ reducer: { auth: authReducer } });
   return render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <LoginPage />
-      </MemoryRouter>
-    </Provider>
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>
   );
 }
 
 describe('LoginPage', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('ログインフォームが表示される', () => {
+  it('Hosted UI ログインへの導線と公開ヘッダーが表示される', () => {
     renderLoginPage();
 
     expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
-    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
-    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'ログイン / 新規登録' })).toBeInTheDocument();
+    // SRP のメール/パスワードフォームは廃止されている。
+    expect(screen.queryByLabelText('メールアドレス')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('パスワード')).not.toBeInTheDocument();
   });
 
-  it('リンクテキストが表示される', () => {
+  it('利用申請への導線がある', () => {
     renderLoginPage();
 
-    expect(screen.getByText('パスワードを忘れた方')).toBeInTheDocument();
-    expect(screen.getByText('新規登録')).toBeInTheDocument();
+    // ヘッダーと本文の双方に企業利用申請への導線がある。
+    const applyLinks = screen.getAllByRole('link', { name: /利用申請/ });
+    expect(applyLinks.length).toBeGreaterThan(0);
   });
 
-  it('ログイン成功時にホームに遷移する', async () => {
-    mockLogin.mockResolvedValue(true);
+  it('ログインボタンで Cognito Hosted UI へ遷移する', () => {
     renderLoginPage();
 
-    fireEvent.change(screen.getByLabelText('メールアドレス'), { target: { value: 'test@example.com', name: 'email' } });
-    fireEvent.change(screen.getByLabelText('パスワード'), { target: { value: 'password123', name: 'password' } });
-
-    const loginButtons = screen.getAllByText('ログイン');
-    const submitButton = loginButtons.find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit');
-    fireEvent.click(submitButton!);
-
-    await waitFor(() => {
-      expect(mockLogin).toHaveBeenCalledWith({ email: 'test@example.com', password: 'password123' });
-      expect(mockNavigate).toHaveBeenCalledWith('/');
-    });
-  });
-
-  it('ログイン失敗時にエラーメッセージが表示される', async () => {
-    mockLogin.mockResolvedValue(false);
-    renderLoginPage();
-
-    const loginButtons = screen.getAllByText('ログイン');
-    const submitButton = loginButtons.find(el => el.tagName === 'BUTTON' && el.getAttribute('type') === 'submit');
-    fireEvent.click(submitButton!);
-
-    await waitFor(() => {
-      expect(screen.getByText(/ログインに失敗しました/)).toBeInTheDocument();
-    });
+    screen.getByRole('button', { name: 'ログイン / 新規登録' }).click();
+    expect(hrefSetter).toHaveBeenCalledTimes(1);
+    expect(hrefSetter.mock.calls[0][0]).toContain('/oauth2/authorize');
   });
 });

--- a/frontend/src/repositories/__tests__/AuthRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AuthRepository.test.ts
@@ -44,7 +44,7 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.callback('auth-code-123');
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/callback', { code: 'auth-code-123' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/login', { code: 'auth-code-123' });
     expect(result).toEqual(mockData);
   });
 
@@ -79,7 +79,7 @@ describe('AuthRepository', () => {
 
     await authRepository.logout();
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/logout');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/logout');
   });
 
   it('getCurrentUser: 現在のユーザー情報を取得できる', async () => {
@@ -97,6 +97,6 @@ describe('AuthRepository', () => {
 
     await authRepository.refreshToken();
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/refresh-token');
+    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/refresh');
   });
 });

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -1,4 +1,10 @@
-export function getCognitoAuthUrl(provider: string): string {
+/**
+ * Cognito Hosted UI の認可 URL を組み立てる。
+ *
+ * provider を渡すと特定の IdP(例: Google)へ直行する。省略すると identity_provider を付けず、
+ * Cognito Hosted UI のログイン画面(メール/パスワード + ソーシャルを選べる)へ遷移する。
+ */
+export function getCognitoAuthUrl(provider?: string): string {
   const url = new URL(
     `https://${import.meta.env.VITE_COGNITO_DOMAIN}/oauth2/authorize`
   );
@@ -8,7 +14,9 @@ export function getCognitoAuthUrl(provider: string): string {
   url.searchParams.append('response_type', import.meta.env.VITE_RESPONSE_TYPE);
   url.searchParams.append('scope', import.meta.env.VITE_SCOPE);
   url.searchParams.append('state', generateRandomState());
-  url.searchParams.append('identity_provider', provider);
+  if (provider) {
+    url.searchParams.append('identity_provider', provider);
+  }
 
   return url.toString();
 }


### PR DESCRIPTION
## 概要

2 点をまとめて対応:
1. 認証 API の URL から実装詳細(provider 名 `cognito`)を除去し、REST ベストプラクティスの**アクション型パス**に統一
2. B2B SaaS の定石に沿って**ログイン導線を整理**(role を問わず単一の Hosted UI ログイン + 公開ヘッダーに「ログイン / 企業の利用申請」の 2 導線)

## API パス変更(backend + frontend)

| 旧 | 新 |
|---|---|
| `POST /api/v2/auth/cognito/callback` | `POST /api/v2/auth/login` |
| `POST /api/v2/auth/cognito/logout` | `POST /api/v2/auth/logout` |
| `POST /api/v2/auth/cognito/refresh-token` | `POST /api/v2/auth/refresh` |

- backend-java: `AuthController` / `SecurityConfig` 更新。403 文言を「ご利用には企業申請、または所属企業からの招待が必要です。…」に変更
- frontend: `apiRoutes`(callback/logout/refreshToken)を新パスへ

## ログイン導線の整理(frontend)

- `PublicHeader` を新設(「ログイン」/「企業の利用申請」)。`AuthLayout` に header スロット追加
- `LoginPage`: レガシーの SRP メール/パスワードフォーム(Java 未実装で不動作)を撤去し、**Hosted UI 単一ログイン**(「ログイン / 新規登録」+ Google)に整理。招待が必要な旨を明示
- `CompanyApplicationPage` に `PublicHeader` 追加
- `getCognitoAuthUrl` の provider を任意化(省略時 Hosted UI ログイン画面へ)
- `useLoginPage` を flashMessage のみに簡素化
- **方針**: trainee / company_admin でログイン画面は分けない(同一認証 + ログイン後の role で出し分け)

## テスト

- backend `./gradlew build` 緑
- frontend `tsc` / `eslint --max-warnings=0` / `vitest`(**1480 件**) / `build` すべて緑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 公開ページ向け共通ヘッダーを追加
  * Cognito Hosted UI を活用した新しいログインフロー

* **改善**
  * 認証エンドポイントをシンプルに統一
  * 認証ページのレイアウト構造を最適化

* **バグ修正**
  * 企業招待時のエラーメッセージを改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->