### PR TITLE
feat(backend-java): コース・教材の CRUD を移植(管理者向け)

### DIFF
--- a/backend-java/README.md
+++ b/backend-java/README.md
@@ -91,17 +91,24 @@ Cognito の **access_token(JWT)を HttpOnly Cookie で受け取り、Cognito の
 | `GET /api/v2/courses` | コース一覧（company/role でフィルタ） | 必須 |
 | `GET /api/v2/courses/{id}` | コース詳細 | 必須 |
 | `GET /api/v2/courses/{id}/materials` | コース内教材一覧 | 必須 |
+| `POST /api/v2/courses` | コース作成 | 管理者 |
+| `PUT /api/v2/courses/{id}` | コース更新 | 管理者 |
+| `DELETE /api/v2/courses/{id}` | コース削除（配下教材も cascade） | 管理者 |
 | `GET /api/v2/teaching-materials/{id}` | 教材詳細 | 必須 |
+| `POST /api/v2/teaching-materials` | 教材作成（`courseId` 必須） | 管理者 |
+| `PUT /api/v2/teaching-materials/{id}` | 教材更新 | 管理者 |
+| `DELETE /api/v2/teaching-materials/{id}` | 教材削除 | 管理者 |
 | `POST /api/v2/company-applications` | 企業の利用申請（公開フォーム） | 不要 |
 | `GET /api/v2/admin/company-applications` | 申請一覧（新しい順） | super_admin |
 | `PATCH /api/v2/admin/company-applications/{id}/status` | 申請 status 更新（approved/rejected/pending） | super_admin |
 
-コース/教材の閲覧権: trainee は自社の published のみ、company_admin / super_admin は draft 含む。
-super_admin は会社を跨いで閲覧可。アクセス制御は `CourseService` で actor の company/role を見て判定。
+コース/教材の権限: 閲覧は trainee=自社の published のみ / 管理者(company_admin・super_admin)=draft 含む、
+super_admin は会社跨ぎ可。編集系は管理者かつ(super_admin または同一会社)。アクセス制御は
+`CourseService` / `TeachingMaterialService` に集約。
 
 ### 今後追加する機能（1 機能 = 1 PR）
 
-企業申請受理時の super_admin 通知 / コース/教材の CRUD(company_admin) / AI チャット(Bedrock SSE) / 演習(サンドボックス実行) /
+企業申請受理時の super_admin 通知 / AI チャット(Bedrock SSE) / 演習(サンドボックス実行) /
 通知 / レポート(SQS) + S3 / DynamoDB / SES 連携。CSRF 対策。
 
 ## メモリ実測（ECS スペック検証）

--- a/backend-java/src/main/java/com/normanblog/frestyle/controller/CourseController.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/controller/CourseController.java
@@ -1,13 +1,19 @@
 package com.normanblog.frestyle.controller;
 
+import com.normanblog.frestyle.dto.CourseRequest;
 import com.normanblog.frestyle.dto.CourseResponse;
 import com.normanblog.frestyle.dto.TeachingMaterialResponse;
 import com.normanblog.frestyle.entity.User;
 import com.normanblog.frestyle.security.CurrentUserProvider;
 import com.normanblog.frestyle.service.CourseService;
 import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,5 +51,27 @@ public class CourseController {
     return courseService.listMaterials(id, actor).stream()
         .map(TeachingMaterialResponse::from)
         .toList();
+  }
+
+  @PostMapping
+  public CourseResponse create(@RequestBody CourseRequest request) {
+    User actor = currentUser.require();
+
+    return CourseResponse.from(courseService.create(actor, request));
+  }
+
+  @PutMapping("/{id}")
+  public CourseResponse update(@PathVariable Long id, @RequestBody CourseRequest request) {
+    User actor = currentUser.require();
+
+    return CourseResponse.from(courseService.update(id, actor, request));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    User actor = currentUser.require();
+    courseService.delete(id, actor);
+
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend-java/src/main/java/com/normanblog/frestyle/controller/TeachingMaterialController.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/controller/TeachingMaterialController.java
@@ -1,15 +1,21 @@
 package com.normanblog.frestyle.controller;
 
+import com.normanblog.frestyle.dto.TeachingMaterialRequest;
 import com.normanblog.frestyle.dto.TeachingMaterialResponse;
 import com.normanblog.frestyle.entity.User;
 import com.normanblog.frestyle.security.CurrentUserProvider;
 import com.normanblog.frestyle.service.TeachingMaterialService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** 教材単体の閲覧 API。 */
+/** 教材の閲覧・作成・更新・削除 API。作成/編集/削除は所属コースの管理者のみ。 */
 @RestController
 @RequestMapping("/api/v2/teaching-materials")
 public class TeachingMaterialController {
@@ -28,5 +34,28 @@ public class TeachingMaterialController {
     User actor = currentUser.require();
 
     return TeachingMaterialResponse.from(materialService.get(id, actor));
+  }
+
+  @PostMapping
+  public TeachingMaterialResponse create(@RequestBody TeachingMaterialRequest request) {
+    User actor = currentUser.require();
+
+    return TeachingMaterialResponse.from(materialService.create(actor, request));
+  }
+
+  @PutMapping("/{id}")
+  public TeachingMaterialResponse update(
+      @PathVariable Long id, @RequestBody TeachingMaterialRequest request) {
+    User actor = currentUser.require();
+
+    return TeachingMaterialResponse.from(materialService.update(id, actor, request));
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<Void> delete(@PathVariable Long id) {
+    User actor = currentUser.require();
+    materialService.delete(id, actor);
+
+    return ResponseEntity.noContent().build();
   }
 }

--- a/backend-java/src/main/java/com/normanblog/frestyle/dto/CourseRequest.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/dto/CourseRequest.java
@@ -1,0 +1,10 @@
+package com.normanblog.frestyle.dto;
+
+/**
+ * コース作成・更新のリクエストボディ。
+ *
+ * <p>companyId / createdByUserId はリクエストからは受け取らず、認証ユーザーから決める。
+ * sortOrder / isPublished は未指定なら既定(100 / false)を service 側で補う。
+ */
+public record CourseRequest(
+    String title, String description, Integer sortOrder, Boolean isPublished) {}

--- a/backend-java/src/main/java/com/normanblog/frestyle/dto/TeachingMaterialRequest.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/dto/TeachingMaterialRequest.java
@@ -1,0 +1,10 @@
+package com.normanblog.frestyle.dto;
+
+/**
+ * 教材作成・更新のリクエストボディ。
+ *
+ * <p>作成時は courseId 必須(service で検証)。更新時は courseId を無視する(所属コースは変えない)。
+ * companyId / createdByUserId は所属コース・認証ユーザーから決める。
+ */
+public record TeachingMaterialRequest(
+    Long courseId, String title, String content, Integer orderInCourse, Boolean isPublished) {}

--- a/backend-java/src/main/java/com/normanblog/frestyle/repository/TeachingMaterialRepository.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/repository/TeachingMaterialRepository.java
@@ -10,4 +10,7 @@ public interface TeachingMaterialRepository extends JpaRepository<TeachingMateri
   List<TeachingMaterial> findByCourseIdOrderByOrderInCourseAscIdAsc(Long courseId);
 
   List<TeachingMaterial> findByCourseIdAndIsPublishedTrueOrderByOrderInCourseAscIdAsc(Long courseId);
+
+  // コース削除時の cascade 用(呼び出し側を @Transactional にする)。
+  void deleteByCourseId(Long courseId);
 }

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/CourseService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/CourseService.java
@@ -94,12 +94,20 @@ public class CourseService {
     Course course = findOrThrow(id);
     requireManage(course, actor);
 
-    course.setTitle(request.title());
-    course.setDescription(request.description());
+    // 省略(null)されたフィールドは既存値を保持する(誤って空にしないため)。
+    // 明示的な空文字でクリアは可能。
+    if (request.title() != null) {
+      course.setTitle(request.title());
+    }
+    if (request.description() != null) {
+      course.setDescription(request.description());
+    }
     if (request.sortOrder() != null) {
       course.setSortOrder(request.sortOrder());
     }
-    course.setPublished(Boolean.TRUE.equals(request.isPublished()));
+    if (request.isPublished() != null) {
+      course.setPublished(request.isPublished());
+    }
     course.setUpdatedAt(Instant.now());
 
     return courses.save(course);

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/CourseService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/CourseService.java
@@ -1,14 +1,17 @@
 package com.normanblog.frestyle.service;
 
+import com.normanblog.frestyle.dto.CourseRequest;
 import com.normanblog.frestyle.entity.Course;
 import com.normanblog.frestyle.entity.Role;
 import com.normanblog.frestyle.entity.TeachingMaterial;
 import com.normanblog.frestyle.entity.User;
 import com.normanblog.frestyle.repository.CourseRepository;
 import com.normanblog.frestyle.repository.TeachingMaterialRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -19,6 +22,8 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @Service
 public class CourseService {
+
+  private static final int DEFAULT_SORT_ORDER = 100;
 
   private final CourseRepository courses;
   private final TeachingMaterialRepository materials;
@@ -62,6 +67,54 @@ public class CourseService {
     return materials.findByCourseIdAndIsPublishedTrueOrderByOrderInCourseAscIdAsc(courseId);
   }
 
+  /** コースを作成する。管理者(company_admin / super_admin)かつ会社所属が必要。 */
+  @Transactional
+  public Course create(User actor, CourseRequest request) {
+    requireManagerWithCompany(actor);
+
+    Instant now = Instant.now();
+    Course course =
+        Course.builder()
+            .companyId(actor.getCompanyId())
+            .createdByUserId(actor.getId())
+            .title(request.title())
+            .description(request.description())
+            .sortOrder(request.sortOrder() != null ? request.sortOrder() : DEFAULT_SORT_ORDER)
+            .isPublished(Boolean.TRUE.equals(request.isPublished()))
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+
+    return courses.save(course);
+  }
+
+  /** コースを更新する。管理権が無ければ 403、未存在は 404。 */
+  @Transactional
+  public Course update(Long id, User actor, CourseRequest request) {
+    Course course = findOrThrow(id);
+    requireManage(course, actor);
+
+    course.setTitle(request.title());
+    course.setDescription(request.description());
+    if (request.sortOrder() != null) {
+      course.setSortOrder(request.sortOrder());
+    }
+    course.setPublished(Boolean.TRUE.equals(request.isPublished()));
+    course.setUpdatedAt(Instant.now());
+
+    return courses.save(course);
+  }
+
+  /** コースと配下教材を削除する(cascade 相当)。管理権が無ければ 403、未存在は 404。 */
+  @Transactional
+  public void delete(Long id, User actor) {
+    Course course = findOrThrow(id);
+    requireManage(course, actor);
+
+    materials.deleteByCourseId(id);
+    courses.delete(course);
+  }
+
   private Course findOrThrow(Long id) {
     return courses
         .findById(id)
@@ -71,6 +124,27 @@ public class CourseService {
   void requireReadable(Course course, User actor) {
     if (!canRead(course, actor)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+  }
+
+  // 編集権: 管理者であり、super_admin か同一会社であること。
+  void requireManage(Course course, User actor) {
+    if (!isManager(actor.getRole())) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+    if (!Role.SUPER_ADMIN.equals(actor.getRole())
+        && !course.getCompanyId().equals(actor.getCompanyId())) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+  }
+
+  // 作成権: 管理者であり、会社に所属していること(作成物の会社を決められるため)。
+  void requireManagerWithCompany(User actor) {
+    if (!isManager(actor.getRole())) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+    }
+    if (actor.getCompanyId() == null) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "actor_must_belong_to_company");
     }
   }
 

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/TeachingMaterialService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/TeachingMaterialService.java
@@ -1,17 +1,22 @@
 package com.normanblog.frestyle.service;
 
+import com.normanblog.frestyle.dto.TeachingMaterialRequest;
 import com.normanblog.frestyle.entity.Course;
 import com.normanblog.frestyle.entity.TeachingMaterial;
 import com.normanblog.frestyle.entity.User;
 import com.normanblog.frestyle.repository.CourseRepository;
 import com.normanblog.frestyle.repository.TeachingMaterialRepository;
+import java.time.Instant;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-/** 教材単体の閲覧を担うサービス。所属コースの閲覧権 + 教材自身の公開状態で判定する。 */
+/** 教材の閲覧・作成・更新・削除を担うサービス。所属コースの権限で認可する。 */
 @Service
 public class TeachingMaterialService {
+
+  private static final int DEFAULT_ORDER = 100;
 
   private final TeachingMaterialRepository materials;
   private final CourseRepository courses;
@@ -26,16 +31,8 @@ public class TeachingMaterialService {
 
   /** 教材詳細。所属コースが閲覧可能で、かつ公開済み(または管理者)でなければ 403。存在しなければ 404。 */
   public TeachingMaterial get(Long id, User actor) {
-    TeachingMaterial material =
-        materials
-            .findById(id)
-            .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "material_not_found"));
-    Course course =
-        courses
-            .findById(material.getCourseId())
-            .orElseThrow(
-                () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "course_not_found"));
+    TeachingMaterial material = findOrThrow(id);
+    Course course = findCourseOrThrow(material.getCourseId());
 
     courseService.requireReadable(course, actor);
     if (!material.isPublished() && !CourseService.isManager(actor.getRole())) {
@@ -43,5 +40,73 @@ public class TeachingMaterialService {
     }
 
     return material;
+  }
+
+  /** 教材を作成する。courseId 必須。所属コースの編集権が必要。 */
+  @Transactional
+  public TeachingMaterial create(User actor, TeachingMaterialRequest request) {
+    courseService.requireManagerWithCompany(actor);
+    if (request.courseId() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "course_id is required");
+    }
+
+    Course course = findCourseOrThrow(request.courseId());
+    courseService.requireManage(course, actor);
+
+    Instant now = Instant.now();
+    TeachingMaterial material =
+        TeachingMaterial.builder()
+            .companyId(course.getCompanyId())
+            .courseId(course.getId())
+            .createdByUserId(actor.getId())
+            .title(request.title())
+            .content(request.content())
+            .orderInCourse(request.orderInCourse() != null ? request.orderInCourse() : DEFAULT_ORDER)
+            .isPublished(Boolean.TRUE.equals(request.isPublished()))
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+
+    return materials.save(material);
+  }
+
+  /** 教材を更新する。所属コースは変えない。編集権が無ければ 403、未存在は 404。 */
+  @Transactional
+  public TeachingMaterial update(Long id, User actor, TeachingMaterialRequest request) {
+    TeachingMaterial material = findOrThrow(id);
+    Course course = findCourseOrThrow(material.getCourseId());
+    courseService.requireManage(course, actor);
+
+    material.setTitle(request.title());
+    material.setContent(request.content());
+    if (request.orderInCourse() != null) {
+      material.setOrderInCourse(request.orderInCourse());
+    }
+    material.setPublished(Boolean.TRUE.equals(request.isPublished()));
+    material.setUpdatedAt(Instant.now());
+
+    return materials.save(material);
+  }
+
+  /** 教材を削除する。編集権が無ければ 403、未存在は 404。 */
+  @Transactional
+  public void delete(Long id, User actor) {
+    TeachingMaterial material = findOrThrow(id);
+    Course course = findCourseOrThrow(material.getCourseId());
+    courseService.requireManage(course, actor);
+
+    materials.delete(material);
+  }
+
+  private TeachingMaterial findOrThrow(Long id) {
+    return materials
+        .findById(id)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "material_not_found"));
+  }
+
+  private Course findCourseOrThrow(Long courseId) {
+    return courses
+        .findById(courseId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "course_not_found"));
   }
 }

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/TeachingMaterialService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/TeachingMaterialService.java
@@ -77,12 +77,19 @@ public class TeachingMaterialService {
     Course course = findCourseOrThrow(material.getCourseId());
     courseService.requireManage(course, actor);
 
-    material.setTitle(request.title());
-    material.setContent(request.content());
+    // 省略(null)されたフィールドは既存値を保持する(誤って空にしないため)。
+    if (request.title() != null) {
+      material.setTitle(request.title());
+    }
+    if (request.content() != null) {
+      material.setContent(request.content());
+    }
     if (request.orderInCourse() != null) {
       material.setOrderInCourse(request.orderInCourse());
     }
-    material.setPublished(Boolean.TRUE.equals(request.isPublished()));
+    if (request.isPublished() != null) {
+      material.setPublished(request.isPublished());
+    }
     material.setUpdatedAt(Instant.now());
 
     return materials.save(material);

--- a/backend-java/src/test/java/com/normanblog/frestyle/controller/CourseCrudControllerTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/controller/CourseCrudControllerTest.java
@@ -1,0 +1,144 @@
+package com.normanblog.frestyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.normanblog.frestyle.entity.Course;
+import com.normanblog.frestyle.entity.Role;
+import com.normanblog.frestyle.entity.TeachingMaterial;
+import com.normanblog.frestyle.entity.User;
+import com.normanblog.frestyle.repository.CourseRepository;
+import com.normanblog.frestyle.repository.TeachingMaterialRepository;
+import com.normanblog.frestyle.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/** コース・教材 CRUD の認可とロジックを検証する。 */
+@SpringBootTest
+class CourseCrudControllerTest {
+
+  @Autowired private WebApplicationContext context;
+  @Autowired private UserRepository users;
+  @Autowired private CourseRepository courses;
+  @Autowired private TeachingMaterialRepository materials;
+
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    users.deleteAll();
+    courses.deleteAll();
+    materials.deleteAll();
+    mvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  private void seedUser(String sub, Long companyId, String role) {
+    users.save(User.builder().cognitoSub(sub).companyId(companyId).role(role).build());
+  }
+
+  private Long seedCourse(Long companyId) {
+    return courses
+        .save(Course.builder().companyId(companyId).createdByUserId(1L).title("c").build())
+        .getId();
+  }
+
+  @Test
+  void create_asTrainee_returns403() throws Exception {
+    seedUser("t1", 1L, Role.TRAINEE);
+
+    mvc.perform(
+            post("/api/v2/courses")
+                .with(jwt().jwt(j -> j.subject("t1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"新コース\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void create_asCompanyAdmin_succeedsAndSetsCompany() throws Exception {
+    seedUser("a1", 5L, Role.COMPANY_ADMIN);
+
+    mvc.perform(
+            post("/api/v2/courses")
+                .with(jwt().jwt(j -> j.subject("a1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"新コース\",\"isPublished\":true}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("新コース"))
+        .andExpect(jsonPath("$.companyId").value(5))
+        .andExpect(jsonPath("$.isPublished").value(true))
+        .andExpect(jsonPath("$.sortOrder").value(100));
+  }
+
+  @Test
+  void update_otherCompanyCourse_asCompanyAdmin_returns403() throws Exception {
+    seedUser("a1", 1L, Role.COMPANY_ADMIN);
+    Long otherCourse = seedCourse(2L);
+
+    mvc.perform(
+            put("/api/v2/courses/" + otherCourse)
+                .with(jwt().jwt(j -> j.subject("a1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"乗っ取り\"}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void delete_cascadesMaterials() throws Exception {
+    seedUser("a1", 1L, Role.COMPANY_ADMIN);
+    Long courseId = seedCourse(1L);
+    materials.save(
+        TeachingMaterial.builder()
+            .companyId(1L)
+            .courseId(courseId)
+            .createdByUserId(1L)
+            .title("m")
+            .build());
+
+    mvc.perform(delete("/api/v2/courses/" + courseId).with(jwt().jwt(j -> j.subject("a1"))))
+        .andExpect(status().isNoContent());
+
+    assertThat(courses.findById(courseId)).isEmpty();
+    assertThat(materials.findByCourseIdOrderByOrderInCourseAscIdAsc(courseId)).isEmpty();
+  }
+
+  @Test
+  void createMaterial_withoutCourseId_returns400() throws Exception {
+    seedUser("a1", 1L, Role.COMPANY_ADMIN);
+
+    mvc.perform(
+            post("/api/v2/teaching-materials")
+                .with(jwt().jwt(j -> j.subject("a1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"教材\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void createMaterial_inOwnCourse_succeeds() throws Exception {
+    seedUser("a1", 1L, Role.COMPANY_ADMIN);
+    Long courseId = seedCourse(1L);
+
+    mvc.perform(
+            post("/api/v2/teaching-materials")
+                .with(jwt().jwt(j -> j.subject("a1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"courseId\":" + courseId + ",\"title\":\"教材1\",\"content\":\"本文\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("教材1"))
+        .andExpect(jsonPath("$.courseId").value(courseId))
+        .andExpect(jsonPath("$.companyId").value(1));
+  }
+}

--- a/backend-java/src/test/java/com/normanblog/frestyle/controller/CourseCrudControllerTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/controller/CourseCrudControllerTest.java
@@ -115,6 +115,33 @@ class CourseCrudControllerTest {
   }
 
   @Test
+  void update_omittedFields_arePreserved() throws Exception {
+    seedUser("a1", 1L, Role.COMPANY_ADMIN);
+    Long courseId =
+        courses
+            .save(
+                Course.builder()
+                    .companyId(1L)
+                    .createdByUserId(1L)
+                    .title("元タイトル")
+                    .description("元説明")
+                    .isPublished(true)
+                    .build())
+            .getId();
+
+    // title だけ更新。description / isPublished は省略 → 既存値を保持する。
+    mvc.perform(
+            put("/api/v2/courses/" + courseId)
+                .with(jwt().jwt(j -> j.subject("a1")))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"title\":\"新タイトル\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.title").value("新タイトル"))
+        .andExpect(jsonPath("$.description").value("元説明"))
+        .andExpect(jsonPath("$.isPublished").value(true));
+  }
+
+  @Test
   void createMaterial_withoutCourseId_returns400() throws Exception {
     seedUser("a1", 1L, Role.COMPANY_ADMIN);
 


### PR DESCRIPTION
## 概要

閲覧 API(PR #1813)の対として、company_admin が学習コンテンツ(コース・教材)を**作成・編集・削除**できるようにする。これでコース/教材機能が一通り揃う。

## エンドポイント（すべて管理者のみ）

| メソッド | パス |
|---|---|
| POST | `/api/v2/courses` |
| PUT | `/api/v2/courses/{id}` |
| DELETE | `/api/v2/courses/{id}`（配下教材も cascade 削除） |
| POST | `/api/v2/teaching-materials`（`courseId` 必須） |
| PUT | `/api/v2/teaching-materials/{id}` |
| DELETE | `/api/v2/teaching-materials/{id}` |

## アクセス制御

- **編集権** `requireManage`: 管理者(company_admin / super_admin)かつ super_admin または同一会社
- **作成権** `requireManagerWithCompany`: 管理者かつ会社所属(作成物の会社を決めるため)
- `companyId` / `createdByUserId` はリクエストから受けず、認証ユーザー・所属コースから決める(なりすまし防止)

## 変更内容

- `CourseService` に create / update / delete(cascade)、`TeachingMaterialService` に create / update / delete
- `CourseRequest` / `TeachingMaterialRequest`(record)。sort_order / order_in_course 未指定は 100
- `TeachingMaterialRepository.deleteByCourseId`(cascade 用、呼び元 `@Transactional`)
- 削除は 204 No Content

## テスト

- `./gradlew build` 緑。`CourseCrudControllerTest`: trainee 作成403 / company_admin 作成で company 自動設定 + sortOrder 既定100 / 他社更新403 / 削除で教材 cascade / 教材 courseId 無し400 / 自社コースに教材作成成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コースの作成・更新・削除機能を追加
  * 教材の作成・更新・削除機能を追加
  * アクセス権限チェック機能を実装

* **ドキュメント**
  * API エンドポイント一覧とアクセス権限仕様を更新

* **テスト**
  * CRUD 操作と権限チェックのテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->