### PR TITLE
feat(backend-java): プロフィール(取得・更新・onboarding)を移植

### DIFF
--- a/backend-java/README.md
+++ b/backend-java/README.md
@@ -101,6 +101,12 @@ Cognito の **access_token(JWT)を HttpOnly Cookie で受け取り、Cognito の
 | `POST /api/v2/company-applications` | 企業の利用申請（公開フォーム） | 不要 |
 | `GET /api/v2/admin/company-applications` | 申請一覧（新しい順） | super_admin |
 | `PATCH /api/v2/admin/company-applications/{id}/status` | 申請 status 更新（approved/rejected/pending） | super_admin |
+| `GET /api/v2/profile/{userId}` | プロフィール取得（`me` か自分の id のみ。他者 403） | 必須 |
+| `PUT /api/v2/profile/{userId}`（+ `/update` 別名） | プロフィール更新（displayName / bio / avatarUrl / status） | 必須 |
+| `POST /api/v2/profile/me/onboarding/complete` | Welcome 完了（`onboarded_at` を冪等にセット） | 必須 |
+
+プロフィールは自分のみ操作可（IDOR 対策）。displayName は `users`、bio/avatar/status は `profiles` に保存。
+更新は省略フィールドの既存値を保持。画像アップロード（presigned URL）は S3 連携で別 PR。
 
 コース/教材の権限: 閲覧は trainee=自社の published のみ / 管理者(company_admin・super_admin)=draft 含む、
 super_admin は会社跨ぎ可。編集系は管理者かつ(super_admin または同一会社)。アクセス制御は

--- a/backend-java/src/main/java/com/normanblog/frestyle/controller/ProfileController.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/controller/ProfileController.java
@@ -1,0 +1,76 @@
+package com.normanblog.frestyle.controller;
+
+import com.normanblog.frestyle.dto.ProfileResponse;
+import com.normanblog.frestyle.dto.ProfileUpdateRequest;
+import com.normanblog.frestyle.entity.User;
+import com.normanblog.frestyle.security.CurrentUserProvider;
+import com.normanblog.frestyle.service.ProfileService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * プロフィール API。自分のプロフィールのみ操作できる(IDOR 対策で他ユーザーは 403)。
+ *
+ * <p>userId は "me" または自分の数値 id。
+ */
+@RestController
+@RequestMapping("/api/v2/profile")
+public class ProfileController {
+
+  private final ProfileService profileService;
+  private final CurrentUserProvider currentUser;
+
+  public ProfileController(ProfileService profileService, CurrentUserProvider currentUser) {
+    this.profileService = profileService;
+    this.currentUser = currentUser;
+  }
+
+  @GetMapping("/{userId}")
+  public ProfileResponse get(@PathVariable String userId) {
+    return profileService.view(requireSelf(userId));
+  }
+
+  @PutMapping("/{userId}")
+  public ProfileResponse update(
+      @PathVariable String userId, @RequestBody ProfileUpdateRequest request) {
+    return profileService.update(requireSelf(userId), request);
+  }
+
+  // 旧フロント互換の別パス(正規は PUT /profile/{userId})。
+  @PutMapping("/{userId}/update")
+  public ProfileResponse updateAlias(
+      @PathVariable String userId, @RequestBody ProfileUpdateRequest request) {
+    return profileService.update(requireSelf(userId), request);
+  }
+
+  @PostMapping("/me/onboarding/complete")
+  public ResponseEntity<Void> completeOnboarding() {
+    profileService.completeOnboarding(currentUser.require());
+
+    return ResponseEntity.noContent().build();
+  }
+
+  // userId が "me" か自分の id のときだけ許可。他人の id は 403(IDOR 対策)。
+  private User requireSelf(String userId) {
+    User actor = currentUser.require();
+    if ("me".equals(userId)) {
+      return actor;
+    }
+    try {
+      if (actor.getId().equals(Long.valueOf(userId))) {
+        return actor;
+      }
+    } catch (NumberFormatException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid_user_id");
+    }
+    throw new ResponseStatusException(HttpStatus.FORBIDDEN, "forbidden");
+  }
+}

--- a/backend-java/src/main/java/com/normanblog/frestyle/dto/ProfileResponse.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/dto/ProfileResponse.java
@@ -1,0 +1,28 @@
+package com.normanblog.frestyle.dto;
+
+import com.normanblog.frestyle.entity.Profile;
+import com.normanblog.frestyle.entity.User;
+import java.time.Instant;
+
+/** プロフィール表示用。users(displayName / email) と profiles(bio / avatar / status)の合成。 */
+public record ProfileResponse(
+    Long userId,
+    String displayName,
+    String email,
+    String bio,
+    String avatarUrl,
+    String status,
+    Instant updatedAt) {
+
+  /** profile が未作成(null)でも空の値で組み立てる。 */
+  public static ProfileResponse of(User user, Profile profile) {
+    return new ProfileResponse(
+        user.getId(),
+        user.getDisplayName(),
+        user.getEmail(),
+        profile != null ? profile.getBio() : null,
+        profile != null ? profile.getAvatarUrl() : null,
+        profile != null ? profile.getStatus() : "",
+        profile != null ? profile.getUpdatedAt() : null);
+  }
+}

--- a/backend-java/src/main/java/com/normanblog/frestyle/dto/ProfileUpdateRequest.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/dto/ProfileUpdateRequest.java
@@ -1,0 +1,21 @@
+package com.normanblog.frestyle.dto;
+
+/**
+ * プロフィール更新のリクエストボディ。
+ *
+ * <p>name / iconUrl は旧フロント互換の別名。それぞれ displayName / avatarUrl を優先する。
+ * 省略(null)されたフィールドは既存値を保持する(誤って空にしないため)。
+ */
+public record ProfileUpdateRequest(
+    String displayName, String name, String bio, String avatarUrl, String iconUrl, String status) {
+
+  /** displayName 優先、無ければ name。 */
+  public String resolvedDisplayName() {
+    return displayName != null && !displayName.isBlank() ? displayName : name;
+  }
+
+  /** avatarUrl 優先、無ければ iconUrl。 */
+  public String resolvedAvatarUrl() {
+    return avatarUrl != null ? avatarUrl : iconUrl;
+  }
+}

--- a/backend-java/src/main/java/com/normanblog/frestyle/entity/Profile.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/entity/Profile.java
@@ -1,0 +1,44 @@
+package com.normanblog.frestyle.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * users とは別管理のプロフィール拡張情報。主キーは users.id と一致する user_id(1:1)。
+ *
+ * <p>displayName / email は users 側に持つため、ここには bio / avatar / status だけを持つ。
+ */
+@Entity
+@Table(name = "profiles")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Profile {
+
+  // users.id と同値。自動採番せず、ユーザーの id を明示的に入れる。
+  @Id
+  @Column(name = "user_id")
+  private Long userId;
+
+  @Column(columnDefinition = "text")
+  private String bio;
+
+  @Column(name = "avatar_url", columnDefinition = "text")
+  private String avatarUrl;
+
+  @Column(columnDefinition = "text")
+  private String status;
+
+  @Column(name = "updated_at")
+  private Instant updatedAt;
+}

--- a/backend-java/src/main/java/com/normanblog/frestyle/repository/ProfileRepository.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/repository/ProfileRepository.java
@@ -1,0 +1,7 @@
+package com.normanblog.frestyle.repository;
+
+import com.normanblog.frestyle.entity.Profile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** profiles テーブルへのアクセス。主キーは user_id。 */
+public interface ProfileRepository extends JpaRepository<Profile, Long> {}

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/ProfileService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/ProfileService.java
@@ -1,0 +1,78 @@
+package com.normanblog.frestyle.service;
+
+import com.normanblog.frestyle.dto.ProfileResponse;
+import com.normanblog.frestyle.dto.ProfileUpdateRequest;
+import com.normanblog.frestyle.entity.Profile;
+import com.normanblog.frestyle.entity.User;
+import com.normanblog.frestyle.repository.ProfileRepository;
+import com.normanblog.frestyle.repository.UserRepository;
+import java.time.Instant;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** 認証ユーザー自身のプロフィール(displayName + bio/avatar/status)と onboarding を担う。 */
+@Service
+public class ProfileService {
+
+  private final ProfileRepository profiles;
+  private final UserRepository users;
+
+  public ProfileService(ProfileRepository profiles, UserRepository users) {
+    this.profiles = profiles;
+    this.users = users;
+  }
+
+  /** プロフィール表示。profile 行が無ければ空の値で返す。 */
+  public ProfileResponse view(User actor) {
+    Profile profile = profiles.findById(actor.getId()).orElse(null);
+
+    return ProfileResponse.of(actor, profile);
+  }
+
+  /**
+   * プロフィールを更新する。displayName は users、bio/avatar/status は profiles に保存する。
+   * 省略(null)されたフィールドは既存値を保持する。
+   */
+  @Transactional
+  public ProfileResponse update(User actor, ProfileUpdateRequest request) {
+    String displayName = request.resolvedDisplayName();
+    if (displayName != null && !displayName.isBlank()) {
+      actor.setDisplayName(displayName);
+      actor.setUpdatedAt(Instant.now());
+      users.save(actor);
+    }
+
+    Profile profile = profiles.findById(actor.getId()).orElseGet(() -> newProfile(actor.getId()));
+    if (request.bio() != null) {
+      profile.setBio(request.bio());
+    }
+    String avatarUrl = request.resolvedAvatarUrl();
+    if (avatarUrl != null) {
+      profile.setAvatarUrl(avatarUrl);
+    }
+    if (request.status() != null) {
+      profile.setStatus(request.status());
+    }
+    profile.setUpdatedAt(Instant.now());
+    profiles.save(profile);
+
+    return ProfileResponse.of(actor, profile);
+  }
+
+  /**
+   * Welcome 完了時に users.onboarded_at をセットする。
+   *
+   * <p>すでに値があれば何もしない(冪等。再押下でも初回日時を保持する)。
+   */
+  @Transactional
+  public void completeOnboarding(User actor) {
+    if (actor.getOnboardedAt() == null) {
+      actor.setOnboardedAt(Instant.now());
+      users.save(actor);
+    }
+  }
+
+  private Profile newProfile(Long userId) {
+    return Profile.builder().userId(userId).status("").build();
+  }
+}

--- a/backend-java/src/main/resources/db/migration/V6__create_profiles.sql
+++ b/backend-java/src/main/resources/db/migration/V6__create_profiles.sql
@@ -1,0 +1,9 @@
+-- profiles: users と 1:1 のプロフィール拡張(user_id が PK = users.id)。Profile エンティティに対応。
+-- 型は H2(PostgreSQL モード) と PostgreSQL の双方で通る書き方。本番は既存(GORM 製)のため no-op。
+CREATE TABLE IF NOT EXISTS profiles (
+    user_id    BIGINT PRIMARY KEY,
+    bio        VARCHAR,
+    avatar_url VARCHAR,
+    status     VARCHAR DEFAULT '',
+    updated_at TIMESTAMP
+);

--- a/backend-java/src/test/java/com/normanblog/frestyle/MigrationTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/MigrationTest.java
@@ -20,7 +20,7 @@ class MigrationTest {
         java.util.Arrays.stream(flyway.info().applied())
             .map(m -> m.getVersion().getVersion())
             .toList();
-    assertThat(applied).contains("1", "2", "3", "4", "5");
-    assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("5");
+    assertThat(applied).contains("1", "2", "3", "4", "5", "6");
+    assertThat(flyway.info().current().getVersion().getVersion()).isEqualTo("6");
   }
 }

--- a/backend-java/src/test/java/com/normanblog/frestyle/controller/ProfileControllerTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/controller/ProfileControllerTest.java
@@ -1,0 +1,111 @@
+package com.normanblog.frestyle.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.normanblog.frestyle.entity.Role;
+import com.normanblog.frestyle.entity.User;
+import com.normanblog.frestyle.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/** プロフィール API の自己参照(IDOR)・更新・onboarding を検証する。 */
+@SpringBootTest
+class ProfileControllerTest {
+
+  private static final String SUB = "prof-sub";
+
+  @Autowired private WebApplicationContext context;
+  @Autowired private UserRepository users;
+
+  private MockMvc mvc;
+  private Long myId;
+
+  @BeforeEach
+  void setUp() {
+    users.deleteAll();
+    User me =
+        users.save(
+            User.builder()
+                .cognitoSub(SUB)
+                .email("me@example.com")
+                .displayName("Me")
+                .role(Role.TRAINEE)
+                .build());
+    myId = me.getId();
+    mvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void get_withoutAuth_returns401() throws Exception {
+    mvc.perform(get("/api/v2/profile/me")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void get_me_returnsOwnProfile() throws Exception {
+    mvc.perform(get("/api/v2/profile/me").with(jwt().jwt(j -> j.subject(SUB))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.userId").value(myId))
+        .andExpect(jsonPath("$.displayName").value("Me"))
+        .andExpect(jsonPath("$.email").value("me@example.com"));
+  }
+
+  @Test
+  void get_otherUserId_returns403() throws Exception {
+    mvc.perform(get("/api/v2/profile/" + (myId + 999)).with(jwt().jwt(j -> j.subject(SUB))))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void update_savesDisplayNameAndProfileFields() throws Exception {
+    mvc.perform(
+            put("/api/v2/profile/me")
+                .with(jwt().jwt(j -> j.subject(SUB)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"displayName\":\"新しい名前\",\"bio\":\"自己紹介\",\"status\":\"学習中\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("新しい名前"))
+        .andExpect(jsonPath("$.bio").value("自己紹介"))
+        .andExpect(jsonPath("$.status").value("学習中"));
+
+    assertThat(users.findById(myId).orElseThrow().getDisplayName()).isEqualTo("新しい名前");
+  }
+
+  @Test
+  void update_omittedDisplayName_isPreserved() throws Exception {
+    // displayName を省略 → 既存の "Me" を保持し、bio だけ更新する。
+    mvc.perform(
+            put("/api/v2/profile/me/update")
+                .with(jwt().jwt(j -> j.subject(SUB)))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"bio\":\"bioのみ\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.displayName").value("Me"))
+        .andExpect(jsonPath("$.bio").value("bioのみ"));
+  }
+
+  @Test
+  void onboarding_setsOnboardedAt_idempotent() throws Exception {
+    mvc.perform(post("/api/v2/profile/me/onboarding/complete").with(jwt().jwt(j -> j.subject(SUB))))
+        .andExpect(status().isNoContent());
+    assertThat(users.findById(myId).orElseThrow().getOnboardedAt()).isNotNull();
+
+    var first = users.findById(myId).orElseThrow().getOnboardedAt();
+    mvc.perform(post("/api/v2/profile/me/onboarding/complete").with(jwt().jwt(j -> j.subject(SUB))))
+        .andExpect(status().isNoContent());
+    // 二度押しでも初回日時を保持する(冪等)。
+    assertThat(users.findById(myId).orElseThrow().getOnboardedAt()).isEqualTo(first);
+  }
+}


### PR DESCRIPTION
## 概要

ログインユーザー自身のプロフィールを Java へ移植。アバター画像アップロード(S3 presigned URL)は S3 連携が要るため別 PR。

## エンドポイント

| メソッド | パス | 認証 |
|---|---|---|
| GET | `/api/v2/profile/{userId}` | 必須(自分のみ) |
| PUT | `/api/v2/profile/{userId}`（+ `/update` 別名） | 必須(自分のみ) |
| POST | `/api/v2/profile/me/onboarding/complete` | 必須 |

## 仕様

- **IDOR 対策**: `userId` は `me` か自分の数値 id のみ。他者の id は **403**
- displayName は `users`、bio / avatarUrl / status は `profiles`(user_id PK の 1:1)に保存
- **更新は省略(null)フィールドの既存値を保持**(誤って空にしない)
- `name` / `iconUrl` は旧フロント互換の別名(`displayName` / `avatarUrl` を優先)
- onboarding は `onboarded_at` を**冪等**にセット(二度押しでも初回日時を保持)、成功は 204

## 変更内容

- `Profile` entity + `V6__create_profiles.sql`(IF NOT EXISTS で本番既存テーブルに no-op)
- `ProfileResponse`(users + profiles の合成)/ `ProfileUpdateRequest`(record)
- `ProfileService`(view / update / completeOnboarding)/ `ProfileController`

## テスト

- `./gradlew build` 緑。`ProfileControllerTest`: 未認証401 / me 取得 / 他者403 / 更新で displayName と profile 保存 / 省略 displayName 保持 / onboarding 冪等
- 実機: profile は未認証 401、Flyway V1-V6 適用を確認