### PR TITLE
docs: 開発タスク用 issue template + config を追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+# 空 Issue を禁止し、必ずテンプレートから起票させる。
+blank_issues_enabled: false
+
+contact_links:
+  - name: backend-java の構成・コーディング規約
+    url: https://github.com/norman6464/FreStyle/blob/main/backend-java/README.md
+    about: Java バックエンドのレイヤ構成・空行ルール・移植状況はこちら
+  - name: Markdown 記法ヘルプ
+    url: https://normanblog.com/notes/markdown-help
+    about: 教材・ノートの Markdown レンダラ仕様

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,36 @@
+---
+name: 開発タスク / 機能移植
+about: 機能追加・Java 移行などの開発タスクを起票する（1 タスク = 1 PR）
+title: 'feat: '
+labels: task
+---
+
+## 目的・背景
+
+<!-- なぜこれをやるか。解決したい課題・狙い -->
+
+## 完了条件（Definition of Done）
+
+<!-- これが満たされたら完了、という条件を箇条書きで -->
+
+- [ ]
+- [ ]
+
+## 想定する変更
+
+<!-- 触る範囲: backend-java(controller / service / repository / entity / dto) / frontend / infra / docs -->
+<!-- 追加・変更する API パス、画面、マイグレーション(V{n}) など -->
+
+## 進行（カンバンのステータスに対応）
+
+<!-- ボードの「ステータス」を進めつつ、ここもチェックしていく -->
+
+- [ ] **開発中**: 実装 + テスト（`./gradlew build` / `vitest`）
+- [ ] **レビュー**: PR 作成 → CodeRabbit 対応 → squash merge
+- [ ] **ステージング検証**: ローカル / ステージングで動作確認
+- [ ] **リリース**: 本番デプロイ（backend = ECS force-new-deployment / frontend = CD）
+- [ ] **リリース検証**: 本番で health + 当該エンドポイント・画面を確認
+
+## 補足
+
+<!-- 設計メモ・代替案・関連 Issue / PR / docs -->


### PR DESCRIPTION
## 概要

Java 移行・開発タスクを起票するための issue template を追加。カンバン（GitHub Projects）の **6 ステージ（開発中 → レビュー → ステージング検証 → リリース → リリース検証）** に対応した進行チェックリストを持たせ、ボードのステータスと連動して進められるようにする。

## 変更内容

- `task.md`: 開発タスク / 機能移植テンプレ（目的・背景 / 完了条件(DoD) / 想定する変更 / 進行チェックリスト）
- `config.yml`: 空 Issue を禁止 + `backend-java/README.md`・Markdown ヘルプへの導線

既存の `bug_report.md` / `feature_request.md` はそのまま。

## 補足

- カンバン（Projects v2）のステータス列はボード側で管理。本テンプレはその進行を Issue 本文でも追えるようにするもの。