### PR TITLE
refactor(backend-java): 外部連携を infra/ パッケージに集約

### DIFF
--- a/backend-java/README.md
+++ b/backend-java/README.md
@@ -46,21 +46,25 @@ Spring Boot の標準的なレイヤ構成。
 ```
 com.normanblog.frestyle
 ├── FrestyleBackendApplication   起動クラス
-├── controller   HTTP エンドポイント (@RestController)
-├── service      ビジネスロジック (@Service)
+├── controller   HTTP エンドポイント (@RestController) ＝ inbound adapter
+├── service      ビジネスロジック (@Service)。外部連携は infra のポート interface に依存
 ├── repository   永続化 (Spring Data JPA, JpaRepository)
 ├── entity       JPA エンティティ (@Entity)
 ├── dto          リクエスト/レスポンスの転送オブジェクト (record)
-├── config       設定 (@ConfigurationProperties / @Configuration / Security)
-├── security     認証ヘルパー (CurrentUserProvider 等)
-├── cognito      Cognito token 交換クライアント
-├── s3           画像アップロードの S3 presigner (本番実装 + stub)
-├── sqs          学習レポート生成ジョブの enqueuer (現状 no-op stub)
-└── dynamo       AI チャットメッセージの DynamoDB reader (本番実装 + stub)
+├── config       設定 (@ConfigurationProperties / @Configuration / Security / 各 infra の bean 組み立て)
+├── security     認証ヘルパー (CurrentUserProvider 等。横断的関心事)
+└── infra        外部システムへの outbound adapter（ポート interface + 本番実装 + stub）
+    ├── cognito  Cognito token 交換クライアント
+    ├── s3       画像アップロードの S3 presigner
+    ├── sqs      学習レポート生成ジョブの enqueuer (現状 no-op stub)
+    └── dynamo   AI チャットメッセージの DynamoDB reader
 ```
 
 - `@Entity` は永続化専用とし、API には公開しない。レスポンスは `dto` の record（例: `NoteResponse`）に詰め替える
 - リクエストボディは `dto` の record に Bean Validation（`@NotBlank` 等）を付け、`controller` で `@Valid` 検証する
+- **外部システム連携（AWS SDK / 外部 HTTP）は `infra/<システム>` に集約**する。`service` はポート interface
+  （例: `ReportEnqueuer` / `ProfileImagePresigner` / `AiChatMessageReader`）にのみ依存し、実装は `infra` 側に置く
+  （依存性逆転）。資格情報の無い環境向けに各 infra は stub 実装を持ち、`config` が設定有無で実装を切り替える
 
 ## 認証（Cognito JWT）
 

--- a/backend-java/src/main/java/com/normanblog/frestyle/config/DynamoConfig.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/DynamoConfig.java
@@ -1,8 +1,8 @@
 package com.normanblog.frestyle.config;
 
-import com.normanblog.frestyle.dynamo.AiChatMessageReader;
-import com.normanblog.frestyle.dynamo.DynamoAiChatMessageReader;
-import com.normanblog.frestyle.dynamo.StubAiChatMessageReader;
+import com.normanblog.frestyle.infra.dynamo.AiChatMessageReader;
+import com.normanblog.frestyle.infra.dynamo.DynamoAiChatMessageReader;
+import com.normanblog.frestyle.infra.dynamo.StubAiChatMessageReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;

--- a/backend-java/src/main/java/com/normanblog/frestyle/config/S3Config.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/S3Config.java
@@ -1,11 +1,11 @@
 package com.normanblog.frestyle.config;
 
-import com.normanblog.frestyle.s3.AiChatAttachmentPresigner;
-import com.normanblog.frestyle.s3.ProfileImagePresigner;
-import com.normanblog.frestyle.s3.S3AiChatAttachmentPresigner;
-import com.normanblog.frestyle.s3.S3ProfileImagePresigner;
-import com.normanblog.frestyle.s3.StubAiChatAttachmentPresigner;
-import com.normanblog.frestyle.s3.StubProfileImagePresigner;
+import com.normanblog.frestyle.infra.s3.AiChatAttachmentPresigner;
+import com.normanblog.frestyle.infra.s3.ProfileImagePresigner;
+import com.normanblog.frestyle.infra.s3.S3AiChatAttachmentPresigner;
+import com.normanblog.frestyle.infra.s3.S3ProfileImagePresigner;
+import com.normanblog.frestyle.infra.s3.StubAiChatAttachmentPresigner;
+import com.normanblog.frestyle.infra.s3.StubProfileImagePresigner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;

--- a/backend-java/src/main/java/com/normanblog/frestyle/controller/AuthController.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.normanblog.frestyle.controller;
 
-import com.normanblog.frestyle.cognito.CognitoTokens;
-import com.normanblog.frestyle.cognito.TokenExchangeException;
+import com.normanblog.frestyle.infra.cognito.CognitoTokens;
+import com.normanblog.frestyle.infra.cognito.TokenExchangeException;
 import com.normanblog.frestyle.dto.CallbackRequest;
 import com.normanblog.frestyle.dto.MeResponse;
 import com.normanblog.frestyle.entity.User;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/CognitoTokenClient.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/CognitoTokenClient.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.cognito;
+package com.normanblog.frestyle.infra.cognito;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.normanblog.frestyle.config.CognitoProperties;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/CognitoTokens.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/CognitoTokens.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.cognito;
+package com.normanblog.frestyle.infra.cognito;
 
 /** Cognito の token endpoint レスポンス(必要項目のみ)。 */
 public record CognitoTokens(

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/IdTokenClaims.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/IdTokenClaims.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.cognito;
+package com.normanblog.frestyle.infra.cognito;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/TokenExchangeException.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/cognito/TokenExchangeException.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.cognito;
+package com.normanblog.frestyle.infra.cognito;
 
 /**
  * Cognito の token endpoint が non-2xx を返したときの例外。

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/dynamo/AiChatMessageReader.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/dynamo/AiChatMessageReader.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.dynamo;
+package com.normanblog.frestyle.infra.dynamo;
 
 import com.normanblog.frestyle.dto.AiChatMessageResponse;
 import java.util.List;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/dynamo/DynamoAiChatMessageReader.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/dynamo/DynamoAiChatMessageReader.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.dynamo;
+package com.normanblog.frestyle.infra.dynamo;
 
 import com.normanblog.frestyle.dto.AiChatAttachmentDto;
 import com.normanblog.frestyle.dto.AiChatMessageResponse;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/dynamo/StubAiChatMessageReader.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/dynamo/StubAiChatMessageReader.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.dynamo;
+package com.normanblog.frestyle.infra.dynamo;
 
 import com.normanblog.frestyle.dto.AiChatMessageResponse;
 import java.util.List;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/AiChatAttachmentPresigner.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/AiChatAttachmentPresigner.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import com.normanblog.frestyle.dto.AiChatAttachmentUploadUrl;
 

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/ImageKeys.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/ImageKeys.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import java.time.Instant;
 import java.util.UUID;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/ProfileImagePresigner.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/ProfileImagePresigner.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import com.normanblog.frestyle.dto.ProfileImageUploadUrl;
 

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/S3AiChatAttachmentPresigner.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/S3AiChatAttachmentPresigner.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import com.normanblog.frestyle.dto.AiChatAttachmentUploadUrl;
 import java.time.Duration;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/S3ProfileImagePresigner.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/S3ProfileImagePresigner.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import com.normanblog.frestyle.dto.ProfileImageUploadUrl;
 import java.time.Duration;

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/StubAiChatAttachmentPresigner.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/StubAiChatAttachmentPresigner.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import com.normanblog.frestyle.dto.AiChatAttachmentUploadUrl;
 

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/StubProfileImagePresigner.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/s3/StubProfileImagePresigner.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.s3;
+package com.normanblog.frestyle.infra.s3;
 
 import com.normanblog.frestyle.dto.ProfileImageUploadUrl;
 

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/sqs/ReportEnqueuer.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/sqs/ReportEnqueuer.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.sqs;
+package com.normanblog.frestyle.infra.sqs;
 
 /** 学習レポート生成ジョブを非同期キュー(SQS)に投入する境界。 */
 public interface ReportEnqueuer {

--- a/backend-java/src/main/java/com/normanblog/frestyle/infra/sqs/StubReportEnqueuer.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/infra/sqs/StubReportEnqueuer.java
@@ -1,4 +1,4 @@
-package com.normanblog.frestyle.sqs;
+package com.normanblog.frestyle.infra.sqs;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/AiChatAttachmentService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/AiChatAttachmentService.java
@@ -1,7 +1,7 @@
 package com.normanblog.frestyle.service;
 
 import com.normanblog.frestyle.dto.AiChatAttachmentUploadUrl;
-import com.normanblog.frestyle.s3.AiChatAttachmentPresigner;
+import com.normanblog.frestyle.infra.s3.AiChatAttachmentPresigner;
 import java.util.Map;
 import java.util.Set;
 import org.springframework.http.HttpStatus;

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/AiChatMessageService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/AiChatMessageService.java
@@ -1,7 +1,7 @@
 package com.normanblog.frestyle.service;
 
 import com.normanblog.frestyle.dto.AiChatMessageResponse;
-import com.normanblog.frestyle.dynamo.AiChatMessageReader;
+import com.normanblog.frestyle.infra.dynamo.AiChatMessageReader;
 import com.normanblog.frestyle.entity.User;
 import java.util.List;
 import org.springframework.stereotype.Service;

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/LearningReportService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/LearningReportService.java
@@ -3,7 +3,7 @@ package com.normanblog.frestyle.service;
 import com.normanblog.frestyle.entity.LearningReport;
 import com.normanblog.frestyle.entity.LearningReportStatus;
 import com.normanblog.frestyle.repository.LearningReportRepository;
-import com.normanblog.frestyle.sqs.ReportEnqueuer;
+import com.normanblog.frestyle.infra.sqs.ReportEnqueuer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/LoginService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/LoginService.java
@@ -1,8 +1,8 @@
 package com.normanblog.frestyle.service;
 
-import com.normanblog.frestyle.cognito.CognitoTokenClient;
-import com.normanblog.frestyle.cognito.CognitoTokens;
-import com.normanblog.frestyle.cognito.IdTokenClaims;
+import com.normanblog.frestyle.infra.cognito.CognitoTokenClient;
+import com.normanblog.frestyle.infra.cognito.CognitoTokens;
+import com.normanblog.frestyle.infra.cognito.IdTokenClaims;
 import org.springframework.stereotype.Service;
 
 /** ログインフロー(認可コード交換 / refresh)をオーケストレーションするサービス。 */

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/ProfileImageService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/ProfileImageService.java
@@ -1,7 +1,7 @@
 package com.normanblog.frestyle.service;
 
 import com.normanblog.frestyle.dto.ProfileImageUploadUrl;
-import com.normanblog.frestyle.s3.ProfileImagePresigner;
+import com.normanblog.frestyle.infra.s3.ProfileImagePresigner;
 import org.springframework.stereotype.Service;
 
 /** プロフィールアイコン用の S3 PUT 署名付き URL 発行を担うサービス。 */

--- a/backend-java/src/main/java/com/normanblog/frestyle/service/UserProvisioningService.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/service/UserProvisioningService.java
@@ -1,6 +1,6 @@
 package com.normanblog.frestyle.service;
 
-import com.normanblog.frestyle.cognito.IdTokenClaims;
+import com.normanblog.frestyle.infra.cognito.IdTokenClaims;
 import com.normanblog.frestyle.config.CognitoProperties;
 import com.normanblog.frestyle.entity.AdminInvitation;
 import com.normanblog.frestyle.entity.InvitationStatus;

--- a/backend-java/src/test/java/com/normanblog/frestyle/controller/AuthCognitoFlowControllerTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/controller/AuthCognitoFlowControllerTest.java
@@ -8,9 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.normanblog.frestyle.cognito.CognitoTokenClient;
-import com.normanblog.frestyle.cognito.CognitoTokens;
-import com.normanblog.frestyle.cognito.TokenExchangeException;
+import com.normanblog.frestyle.infra.cognito.CognitoTokenClient;
+import com.normanblog.frestyle.infra.cognito.CognitoTokens;
+import com.normanblog.frestyle.infra.cognito.TokenExchangeException;
 import com.normanblog.frestyle.entity.AdminInvitation;
 import com.normanblog.frestyle.entity.InvitationStatus;
 import com.normanblog.frestyle.entity.Role;

--- a/backend-java/src/test/java/com/normanblog/frestyle/service/UserProvisioningServiceTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/service/UserProvisioningServiceTest.java
@@ -2,7 +2,7 @@ package com.normanblog.frestyle.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.normanblog.frestyle.cognito.IdTokenClaims;
+import com.normanblog.frestyle.infra.cognito.IdTokenClaims;
 import com.normanblog.frestyle.entity.AdminInvitation;
 import com.normanblog.frestyle.entity.InvitationStatus;
 import com.normanblog.frestyle.entity.Role;


### PR DESCRIPTION
## 概要

`cognito` / `s3` / `sqs` / `dynamo` を controller/service/repository と同じトップ階層に並べていたのを、**外部システムへの outbound adapter として `infra/` 配下に集約**する。分類の軸（技術レイヤ × 外部連携）が混在していたのを解消。Closes #1837

## 変更内容

- `com.normanblog.frestyle.{cognito,s3,sqs,dynamo}` → `com.normanblog.frestyle.infra.{cognito,s3,sqs,dynamo}`
- 各 infra サブパッケージに **ポート interface + 本番実装 + stub** を同居（`service` はポートに依存＝依存性逆転は従来どおり）
- **ロジック変更なし**（package 宣言 + import のみ / git もリネームとして検出）
- README のパッケージ構成図を更新（`infra` の役割・DIP を明記）

## 設計判断

本プロジェクトは「実用的 Spring 標準レイヤ」を採用しており、フル Hexagonal 再編（domain/application/adapter）は過剰と判断。`controller`（inbound adapter）/ `repository`（Spring Data の慣習）はそのまま残し、AWS SDK・外部 HTTP を叩く 4 つだけ `infra/` に寄せる最小の整理とした。

## テスト

`./gradlew build` 緑（全テスト pass）。