### PR TITLE
feat(frontend): 演習の言語選択に Java を追加

### DIFF
--- a/frontend/src/hooks/useExerciseList.ts
+++ b/frontend/src/hooks/useExerciseList.ts
@@ -7,7 +7,7 @@ import { MasterExerciseWithStatus } from '../types';
 const LANGUAGE_STORAGE_KEY = 'frestyle:exercise-list:language';
 
 // localStorage が許す言語コード集合 (許容されない値は default に戻す)。
-const VALID_LANGUAGES = new Set(['', 'php', 'go', 'bash', 'docker']);
+const VALID_LANGUAGES = new Set(['', 'java', 'php', 'go', 'bash', 'docker']);
 
 function loadStoredLanguage(fallback: string): string {
   if (typeof window === 'undefined') return fallback;

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -38,6 +38,7 @@ export default function ExerciseListPage() {
           className="px-2 py-1 rounded-md bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] focus:outline-none focus:border-primary-500"
         >
           <option value="">すべて</option>
+          <option value="java">Java</option>
           <option value="php">PHP</option>
           <option value="go">Go</option>
           <option value="bash">Bash / Linux</option>


### PR DESCRIPTION
## 概要

バックエンドのコード実行が **java** に対応した（#1842）ため、演習の言語選択 UI に Java を追加する。

## 変更内容
- `ExerciseListPage`: 言語ドロップダウンに `Java` オプションを追加（すべて の直後＝Java を前面に）
- `useExerciseList`: `VALID_LANGUAGES` に `'java'` を追加（localStorage 復元の許容セット）
- Monaco エディタは `java` を標準サポートするためシンタックスハイライトはそのまま効く

## テスト
`tsc --noEmit` OK / 演習関連テスト緑。

## 補足（フォローアップ）
演習一覧/詳細/提出の**バックエンド（`/api/v2/exercises`）は現状 Java バックエンドに未移植**で、これは別 PR で移植する（移植時に master 演習の language=java を許可）。本 PR は UI の言語選択肢の先行追加。