### PR TITLE
fix(backend-java): 本番 CORS 不備を修正(別オリジンのフロントを許可)

### DIFF
--- a/backend-java/src/main/java/com/normanblog/frestyle/config/SecurityConfig.java
+++ b/backend-java/src/main/java/com/normanblog/frestyle/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.normanblog.frestyle.config;
 
 import com.normanblog.frestyle.security.CognitoCookieBearerTokenResolver;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
@@ -10,16 +13,30 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /** Cognito の access_token(JWT)を JWKS 検証する Spring Security 設定。 */
 @Configuration
 public class SecurityConfig {
+
+  // CORS 許可オリジン(Go 版 CorsMiddleware と同じ allowlist)。env FRESTYLE_CORS_ALLOWED_ORIGINS で上書き可。
+  // 末尾スラッシュ無しの完全一致。credentials を返すため "*" は使わない。
+  @Value(
+      "${frestyle.cors.allowed-origins:"
+          + "https://normanblog.com,http://normanblog.com,http://localhost:5173,"
+          + "https://dcd3m6lwt0z8u.cloudfront.net,"
+          + "http://fre-style-bucket.s3-website-ap-northeast-1.amazonaws.com}")
+  private String allowedOrigins;
 
   // ヘルスチェックは LB が認証なしで叩くため誰でも通す。それ以外は JWT 必須。
   @Bean
   SecurityFilterChain securityFilterChain(HttpSecurity http, BearerTokenResolver bearerTokenResolver)
       throws Exception {
     http
+        // フロント(normanblog.com)と API(api.normanblog.com)は別オリジンのため CORS を有効化する。
+        .cors(Customizer.withDefaults())
         // JWT を Cookie で運ぶステートレス API のため、セッションは持たない。
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         // TODO(認証フォローアップ): Cookie 認証向けの CSRF 対策(Go の CsrfMiddleware 相当)を追加する。
@@ -50,5 +67,24 @@ public class SecurityConfig {
   @Bean
   BearerTokenResolver cognitoCookieBearerTokenResolver() {
     return new CognitoCookieBearerTokenResolver();
+  }
+
+  /**
+   * CORS 設定。フロント(別オリジン)から Cookie 付き(credentials)で API を叩くため、許可オリジンは
+   * allowlist の完全一致にし、ワイルドカードは使わない(credentials と "*" は併用不可)。
+   */
+  @Bean
+  CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowedOrigins(
+        Arrays.stream(allowedOrigins.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList());
+    config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    config.setAllowedHeaders(List.of("Content-Type", "Authorization", "X-Requested-With"));
+    config.setAllowCredentials(true);
+    config.setMaxAge(3600L);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return source;
   }
 }

--- a/backend-java/src/test/java/com/normanblog/frestyle/config/CorsConfigTest.java
+++ b/backend-java/src/test/java/com/normanblog/frestyle/config/CorsConfigTest.java
@@ -1,0 +1,63 @@
+package com.normanblog.frestyle.config;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * フロント(normanblog.com)と API(api.normanblog.com)が別オリジンのため、許可オリジンには
+ * CORS ヘッダ(credentials 付き)を返すことを検証する。これが無いとブラウザが全 API を遮断し
+ * メンテナンス画面になる(本番障害の再発防止)。
+ */
+@SpringBootTest
+class CorsConfigTest {
+
+  private static final String PROD_ORIGIN = "https://normanblog.com";
+
+  @Autowired private WebApplicationContext context;
+  private MockMvc mvc;
+
+  @BeforeEach
+  void setUp() {
+    mvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @Test
+  void preflight_fromAllowedOrigin_returnsCorsHeaders() throws Exception {
+    mvc.perform(
+            options("/api/v2/health")
+                .header(HttpHeaders.ORIGIN, PROD_ORIGIN)
+                .header("Access-Control-Request-Method", "GET"))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", PROD_ORIGIN))
+        .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+  }
+
+  @Test
+  void simpleGet_fromAllowedOrigin_echoesAllowOrigin() throws Exception {
+    mvc.perform(get("/api/v2/health").header(HttpHeaders.ORIGIN, PROD_ORIGIN))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Access-Control-Allow-Origin", PROD_ORIGIN))
+        .andExpect(header().string("Access-Control-Allow-Credentials", "true"));
+  }
+
+  @Test
+  void preflight_fromDisallowedOrigin_hasNoAllowOrigin() throws Exception {
+    mvc.perform(
+            options("/api/v2/health")
+                .header(HttpHeaders.ORIGIN, "https://evil.example.com")
+                .header("Access-Control-Request-Method", "GET"))
+        .andExpect(header().doesNotExist("Access-Control-Allow-Origin"));
+  }
+}


### PR DESCRIPTION
## 概要

本番で `https://normanblog.com` → `https://api.normanblog.com` への全 API リクエストが CORS でブロックされ、メンテナンス画面化する障害を修正する。原因は **backend-java(現在の本番バックエンド)に CORS 設定が無い**こと（Go 版 `CorsMiddleware` の移植漏れ）。

## 変更内容

- `SecurityConfig`: Spring Security に `.cors(Customizer.withDefaults())` を有効化し、`CorsConfigurationSource` Bean を追加
  - 許可オリジン allowlist（`https://normanblog.com` / `http://normanblog.com` / `http://localhost:5173` / CloudFront / S3）。`frestyle.cors.allowed-origins`（env `FRESTYLE_CORS_ALLOWED_ORIGINS`）で上書き可
  - `Allow-Credentials: true`（Cookie 認証のため）/ methods `GET,POST,PUT,PATCH,DELETE,OPTIONS` / headers `Content-Type, Authorization, X-Requested-With` / max-age 3600
  - credentials を返すため `*` は使わず完全一致 allowlist（Go 版と parity）
- `CorsConfigTest`（新規）: 許可オリジンの preflight / simple GET で `Access-Control-Allow-Origin` + `Allow-Credentials` が返り、未許可オリジンには返らないことを検証

## テスト

- `./gradlew test` 全 green（`CorsConfigTest` 追加、回帰防止）

## 関連 Issue

Closes #1849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CORS対応を実装。複数のオリジンからのアクセスと、認証情報を含むクロスオリジンリクエストをサポートするようになりました。

* **テスト**
  * CORS設定の動作を検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->