### PR TITLE
fix(ci): scheduled-start の monitoring で ErrorNotifyLambdaArn を渡す(#incident フィルタ維持)

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -207,10 +207,18 @@ jobs:
       #     その時は SNS topic を別の永続スタックに分離すること(現状は購読 0 件で無害)。
       - name: Deploy monitoring stack
         run: |
+          # 永続 chatbot スタックがあれば ERROR ログ整形 Lambda の ARN を取得し、
+          # ERROR サブスクリプションフィルタ(→Slack #incident)を毎朝張り直す。
+          NOTIFY_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-chatbot \
+            --query 'Stacks[0].Outputs[?OutputKey==`ErrorNotifyLambdaArn`].OutputValue' \
+            --output text 2>/dev/null || true)
+          [ "$NOTIFY_ARN" = "None" ] && NOTIFY_ARN=""
+          echo "ErrorNotifyLambdaArn=${NOTIFY_ARN:-(なし)}"
           aws cloudformation deploy --region $AWS_REGION \
             --stack-name $STACK_PFX-monitoring \
             --template-file iac/infrastructure/cloudformation/templates/monitoring/cloudwatch.yml \
-            --parameter-overrides Environment=prod AlbStackName=$STACK_PFX-alb \
+            --parameter-overrides Environment=prod AlbStackName=$STACK_PFX-alb ErrorNotifyLambdaArn="$NOTIFY_ARN" \
             --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
             --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
 


### PR DESCRIPTION
## 概要

毎朝の `scheduled-start` で monitoring スタックを再作成する際、永続 chatbot スタックの ERROR ログ整形 Lambda ARN を解決して `ErrorNotifyLambdaArn` で渡す。これにより ERROR サブスクリプションフィルタ（→ Slack #incident）が毎朝張り直る。

これが無いと、夜間 teardown → 朝 start のサイクルで #incident への **ERROR ログ通知だけ消える**（アラーム通知は SNS ARN 不変なので残るが、ログ内容通知が失われる）。

## 変更内容

- `.github/workflows/scheduled-start.yml` の monitoring デプロイステップで `frestyle-prod-chatbot` の `ErrorNotifyLambdaArn` を resolve し、`--parameter-overrides` に追加（無ければ空 = フィルタ無し）。

## テスト

- 手動で `make deploy-monitoring`（chatbot Lambda ARN 自動参照）→ `/ecs/frestyle-prod` に `?ERROR ?Exception` フィルタが張られることを確認済み。

## 関連

Related to #1854 / frestyle-infrastructure#89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 監視スタックのデプロイ時に、エラー通知設定がより正確に構成されるよう改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->