### PR TITLE
refactor(exercise): フロントのプレビュー用 normalizeOutput 重複を撤去

### DIFF
--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -1,6 +1,5 @@
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { CodeExecutionResult } from '../../types';
-import { normalizeOutput } from '../../utils/exerciseFormat';
 
 interface Props {
   result: CodeExecutionResult | null;
@@ -27,7 +26,6 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
   if (!result) return null;
 
   const isSuccess = result.exitCode === 0;
-  const matched = isSuccess && normalizeOutput(result.stdout) === normalizeOutput(expected);
 
   return (
     <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
@@ -76,14 +74,9 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
           </tr>
         </tbody>
       </table>
-      <div
-        className={`px-4 py-2 text-xs font-semibold ${
-          matched
-            ? 'bg-green-500/15 text-green-400 border-t border-green-500/30'
-            : 'bg-red-500/15 text-red-400 border-t border-red-500/30'
-        }`}
-      >
-        コード実行結果: {matched ? '◎ 期待出力と一致' : '✗ 期待出力と不一致'}
+      {/* 採点はサーバ側で行う(フロントでローカル判定しない)。ここは実行結果のプレビューのみ。 */}
+      <div className="px-4 py-2 text-xs text-[var(--color-text-muted)] border-t border-surface-3">
+        ここは実行プレビューです。正誤は「提出する」でサーバ側採点されます。
       </div>
     </div>
   );

--- a/frontend/src/utils/exerciseFormat.ts
+++ b/frontend/src/utils/exerciseFormat.ts
@@ -22,14 +22,6 @@ export function monacoLanguageOf(lang: string): string {
 }
 
 /**
- * バックエンドの normalizeOutput と同等の正規化（提出前確認の「期待値と一致」表示用）。
- * 末尾の改行 / 空白を吸収して厳密一致判定する。
- */
-export function normalizeOutput(s: string): string {
-  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/[\s]+$/, '');
-}
-
-/**
  * 数値 を 最小 2 桁 の 0 埋め 文字列 に する。 日時 表示 用。
  * 例: `pad(3)` → `"03"`、 `pad(12)` → `"12"`、 `pad(123)` → `"123"` (3 桁 以上 は そのまま)。
  */


### PR DESCRIPTION
## 概要

採点ロジックはサーバ側（`ExerciseGrading`、PR #1845）に一本化済み。フロントの提出前プレビューが `normalizeOutput` を**再実装してローカルで一致判定**していた重複を撤去し、採点の正本をサーバに統一する。

## 変更内容

- `utils/exerciseFormat.ts`: `normalizeOutput` を削除（`monacoLanguageOf` / `pad` は残す）
- `components/exercise/ExecutionResultTable.tsx`: ローカル一致判定（`matched`）と「◎期待出力と一致 / ✗不一致」バナーを撤去。プレビューは実行結果（stdout/stderr/期待出力）の表示のみにし、**正誤は「提出する」のサーバ採点に委ねる**旨の案内に置換

## テスト

- 残 `normalizeOutput` 参照なし / `tsc --noEmit` clean / `eslint --max-warnings 0` clean

## 関連

Related to #1856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 実行結果の採点プロセスをサーバー側に移行しました。フロントエンドは実行結果の表示のみを行うようになります。
  * 実行結果画面に、採点がサーバー側で実施されることを明記する注記を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->