### PR TITLE
fix(exercise): Monaco の言語マッピングに java を追加(ハイライト復活)

### DIFF
--- a/frontend/src/utils/exerciseFormat.ts
+++ b/frontend/src/utils/exerciseFormat.ts
@@ -5,16 +5,25 @@
 
 /**
  * master_exercises.language → Monaco のシンタックスハイライト言語ID へのマッピング。
- * Monaco は `php` / `go` / `shell` を組み込みでサポート。
- * 該当しない言語は plaintext に fallback する。
+ * Monaco は java / php / go / python / javascript / typescript / shell などを組み込みでサポートする。
+ * 未対応の言語(docker など)は plaintext に fallback する。
  */
 export function monacoLanguageOf(lang: string): string {
   switch (lang) {
+    case 'java':
+      return 'java';
     case 'php':
       return 'php';
     case 'go':
       return 'go';
+    case 'python':
+      return 'python';
+    case 'javascript':
+      return 'javascript';
+    case 'typescript':
+      return 'typescript';
     case 'bash':
+    case 'sh':
       return 'shell';
     default:
       return 'plaintext';


### PR DESCRIPTION
## 概要

演習コードエディタで **Java が無色**（シンタックスハイライトが効かない）問題を修正する。

## 原因

`utils/exerciseFormat.ts` の `monacoLanguageOf` が `php` / `go` / `bash` しか対応しておらず、`java` を含むそれ以外は `plaintext` にフォールバックしていた。`monaco-editor` は `editor.main`（全 basic-languages 同梱）なので Java の Monarch は登録済みで、**マッピングを足すだけ**で解決する。

## 変更内容
- `monacoLanguageOf`: `java` → `java`（加えて `python` / `javascript` / `typescript` / `sh` も追加）

## テスト
- `tsc --noEmit` / `eslint` clean。`CodeEditor` は `language` prop を `setModelLanguage` で適用済み。

## 補足
プレビューの赤い「✗ 期待出力と不一致」バナーは PR #1857（マージ済）で中立表示に撤去済み。本 PR と一緒に frontend をデプロイすれば、その表示変更も本番反映される。

## 関連
Related to #1856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Java、PHP、Go、Python、JavaScript、TypeScript、Bash を含む複数のプログラミング言語に対応しました。対応外の言語はプレーンテキストで表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->