### PR TITLE
fix(exercise): 実行プレビューのステータスを正誤と誤解されない文言に修正

### DIFF
--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -9,11 +9,15 @@ interface Props {
 
 /**
  * 提出前 動作 確認 (= 単発 実行) の 結果 を テーブル 形式 で 表示。
- * stdout / stderr / 期待 出力 を 並列 で 見せて、 末尾 で 「期待値 一致 / 不一致」 を バナー 表示。
+ * stdout / stderr / 期待 出力 を 並列 で 見せる。 採点 (正誤) は 行わ ず、 末尾 で
+ * 「ここ は 実行 プレビュー」 と 明示 する (正誤 は サーバ 側 採点)。
  *
- * 「実行 ステータス」 は exit code に 応じて 色 + アイコン を 付ける:
- *   - exit 0 → 緑 + ✓ (Success) で 「コンパイル / 実行 は 通った」 を 視覚 化
- *   - exit != 0 → 赤 + ✗ (Failure) で 「コンパイル or 実行 で 失敗 した」 を 強調
+ * 「実行 ステータス」 は exit code に 応じた 「実行 が 通った / エラー」 を 表す だけ で、
+ * 「答え が 正しい か どうか」 とは 無関係 (= ここ を 正誤 と 誤解 され ない 文言 に する):
+ *   - exit 0 → 緑 + ✓ 「実行 成功 (エラー なし)」
+ *   - exit != 0 → 赤 + ✗ 「実行 エラー (exit N)」
+ * さらに exit 0 でも stdout が 空 の とき は 「まだ 出力 が ない」 ヒント を 出し、
+ * 「出力 ゼロ なのに Success」 で 正解 と 誤解 され る の を 防ぐ。
  */
 export default function ExecutionResultTable({ result, expected, submitError }: Props) {
   if (submitError) {
@@ -26,6 +30,7 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
   if (!result) return null;
 
   const isSuccess = result.exitCode === 0;
+  const hasNoOutput = isSuccess && !result.stdout;
 
   return (
     <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
@@ -39,12 +44,12 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
               {isSuccess ? (
                 <span className="inline-flex items-center gap-1 font-semibold text-green-400">
                   <CheckCircleIcon className="w-4 h-4" />
-                  Success
+                  実行成功（エラーなし）
                 </span>
               ) : (
                 <span className="inline-flex items-center gap-1 font-semibold text-red-400">
                   <XCircleIcon className="w-4 h-4" />
-                  Failure (exit {result.exitCode})
+                  実行エラー（exit {result.exitCode}）
                 </span>
               )}
             </td>
@@ -62,6 +67,11 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
                   {result.stderr}
                 </pre>
               )}
+              {hasNoOutput && (
+                <p className="mt-2 text-amber-500">
+                  まだ出力がありません。<code>echo</code> や <code>print</code> などで結果を出力すると、ここに表示されます。
+                </p>
+              )}
             </td>
           </tr>
           <tr className="border-b border-surface-3">
@@ -76,7 +86,7 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
       </table>
       {/* 採点はサーバ側で行う(フロントでローカル判定しない)。ここは実行結果のプレビューのみ。 */}
       <div className="px-4 py-2 text-xs text-[var(--color-text-muted)] border-t border-surface-3">
-        ここは実行プレビューです。正誤は「提出する」でサーバ側採点されます。
+        「実行成功」はコードがエラーなく動いたという意味で、正誤の判定ではありません。正誤は「提出する」で複数のテストケースによりサーバ側採点されます。
       </div>
     </div>
   );

--- a/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
+++ b/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ExecutionResultTable from '../ExecutionResultTable';
+import { CodeExecutionResult } from '../../../types';
+
+const expected = '{"id":1}';
+
+function result(over: Partial<CodeExecutionResult>): CodeExecutionResult {
+  return { stdout: '', stderr: '', exitCode: 0, ...over };
+}
+
+describe('ExecutionResultTable', () => {
+  it('result が null なら何も描画しない', () => {
+    const { container } = render(
+      <ExecutionResultTable result={null} expected={expected} submitError={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('submitError があればエラーメッセージを表示する', () => {
+    render(
+      <ExecutionResultTable result={null} expected={expected} submitError="実行に失敗しました" />,
+    );
+    expect(screen.getByText('実行に失敗しました')).toBeInTheDocument();
+  });
+
+  it('exit 0 は「実行成功（エラーなし）」と表示し、正誤ではないことを明記する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '{"id":1}', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByText('実行成功（エラーなし）')).toBeInTheDocument();
+    // 「Success」単独で正誤と誤解させる旧文言は使わない
+    expect(screen.queryByText('Success')).not.toBeInTheDocument();
+    expect(screen.getByText(/正誤の判定ではありません/)).toBeInTheDocument();
+  });
+
+  it('exit が 0 以外なら「実行エラー（exit N）」を表示する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stderr: 'Parse error', exitCode: 255 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByText('実行エラー（exit 255）')).toBeInTheDocument();
+    expect(screen.getByText('Parse error')).toBeInTheDocument();
+  });
+
+  it('エラーなしでも出力が空なら「まだ出力がありません」ヒントを出す（空っぽで成功＝正解と誤解させない）', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByText(/まだ出力がありません/)).toBeInTheDocument();
+  });
+
+  it('出力があるときは「まだ出力がありません」ヒントを出さない', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '{"id":1}', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.queryByText(/まだ出力がありません/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

演習の実行プレビューで「実行結果ステータス: Success」が「答えが正しい」と誤解される問題を修正する。`Success` / `Failure` は exit code に基づく「コードがエラーなく動いたか」の表示でしかなく、正誤とは無関係。`echo` を書かず出力ゼロのまま実行しても `Success`（=エラーなし）になり、正解と取り違えられていた。

## 変更内容

- ステータス文言を明確化: `Success` → **「実行成功（エラーなし）」** / `Failure (exit N)` → **「実行エラー（exit N）」**
- exit 0 でも stdout が空のときは中立ヒント「**まだ出力がありません。`echo`/`print` で…**」を表示（出力ゼロを正解と誤解させない）
- フッタ文言を「**実行成功は正誤の判定ではない／正誤は『提出する』で複数テストケースによりサーバ採点**」と明記
- 採点ロジックはフロントに復活させない（従来どおりサーバ側採点のみ）

## テスト

- `ExecutionResultTable.test.tsx` を新規追加（6 ケース）: null/submitError 描画、実行成功/実行エラーの文言、出力ゼロ時のヒント有無 — 全グリーン
- `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` 成功

## 関連 Issue

なし（UI 文言の誤解修正）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 実行ステータスと採点結果の表示が明確に区別されました。
  * エラー時のメッセージがより詳細に表示されるようになりました。
  * 出力がない場合にヒント文が表示されるようになりました。

* **テスト**
  * 実行結果表示の動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->