### PR TITLE
feat(backend-go): コード実行サンドボックスに Java を追加(G1)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,12 +15,13 @@ ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
 
 # --- Runtime stage ---
-# サンドボックスでユーザコードを実行するため、 PHP CLI と Go ツールチェインを同居させる。
+# サンドボックスでユーザコードを実行するため、 PHP CLI / Go ツールチェイン / JDK を同居させる。
 # golang:1.26-bookworm をそのまま runtime に使い、 必要なパッケージのみ apt-install。
+# Java は単一ファイルソースランチャ (`java Main.java`) を使うため javac 入りの JDK が要る。
 FROM golang:1.26-bookworm
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends php-cli ca-certificates && \
+    apt-get install -y --no-install-recommends php-cli default-jdk-headless ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -945,7 +945,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。",
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / java。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -938,7 +938,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。",
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / java。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1266,7 +1266,7 @@ paths:
       consumes:
       - application/json
       description: trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode
-        を 返す。 language は php / go 等。
+        を 返す。 language は php / go / bash / java。
       parameters:
       - description: コード + 言語
         in: body

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -22,7 +22,7 @@ type codeExecuteRequest struct {
 }
 
 // @Summary      コード サンドボックス 実行
-// @Description  trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。
+// @Description  trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / java。
 // @Tags         code-execution
 // @Accept       json
 // @Produce      json

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -20,8 +20,10 @@ const (
 	// execTimeout は PHP / bash の上限。
 	execTimeout = 8 * time.Second
 	// goExecTimeout は Go 専用。go run はコンパイルも走るため余裕を持たせる（cold compile ~6-8s）。
-	goExecTimeout  = 15 * time.Second
-	maxOutputBytes = 64 * 1024 // 64 KB
+	goExecTimeout = 15 * time.Second
+	// javaExecTimeout は Java 専用。`java Main.java` は in-memory コンパイル + JVM 起動を含むため長め。
+	javaExecTimeout = 20 * time.Second
+	maxOutputBytes  = 64 * 1024 // 64 KB
 )
 
 // 実行を禁止する PHP 関数。ファイル操作・OS 操作・ネットワーク通信などを封じる。
@@ -42,7 +44,7 @@ var disableFunctions = strings.Join([]string{
 // ExecuteCodeInput はコード実行の入力。
 type ExecuteCodeInput struct {
 	Code     string
-	Language string // "php" / "go" / "bash"
+	Language string // "php" / "go" / "bash" / "java"
 	// Stdin は実行時に標準入力として流す内容（テストケース採点で使う）。
 	Stdin string
 }
@@ -54,7 +56,7 @@ type ExecuteCodeOutput struct {
 	ExitCode int    `json:"exitCode"`
 }
 
-// ExecuteCodeUseCase は PHP / Go / bash のコードをサンドボックスで実行する。
+// ExecuteCodeUseCase は PHP / Go / bash / Java のコードをサンドボックスで実行する。
 // 共通制約: timeout / 64 KB code-size / 64 KB output-size。
 type ExecuteCodeUseCase struct{}
 
@@ -73,6 +75,8 @@ func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInpu
 		return uc.executeGo(ctx, input)
 	case "bash":
 		return uc.executeBash(ctx, input)
+	case "java":
+		return uc.executeJava(ctx, input)
 	default:
 		return nil, fmt.Errorf("未対応の言語: %s", input.Language)
 	}
@@ -185,8 +189,54 @@ func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCode
 	return runCommand(cmd, input.Stdin)
 }
 
+func (uc *ExecuteCodeUseCase) executeJava(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
+	// 単一ファイル実行 `java Main.java` はソース内に Main クラスが要る。別言語の誤貼付けも弾く。
+	if !strings.Contains(input.Code, "class Main") {
+		return &ExecuteCodeOutput{
+			Stdout:   "",
+			Stderr:   "Java コードには `public class Main` が必要です。",
+			ExitCode: 1,
+		}, nil
+	}
+
+	// リクエストごとに独立した temp dir を作り、ソース / in-memory コンパイル産物を閉じ込める。
+	tmpDir, err := os.MkdirTemp("", "java-exec-")
+	if err != nil {
+		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// 単一ファイルソースランチャ（Java 11+）は `java Main.java` でコンパイル+実行する。
+	// ファイル名はクラス名に合わせて Main.java とする。
+	filename := filepath.Join(tmpDir, "Main.java")
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, javaExecTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
+		"java",
+		// 短命プログラム向けに起動を速くする（C1 のみ / SerialGC）+ ヒープと stack を制限。
+		"-XX:+UseSerialGC",
+		"-XX:TieredStopAtLevel=1",
+		"-Xss16m",
+		"-Xmx256m",
+		filename,
+	)
+	cmd.Dir = tmpDir
+	// AWS 認証情報・注入シークレットを子プロセスに渡さない。HOME は temp に固定。
+	cmd.Env = sandboxEnv("HOME=" + tmpDir)
+
+	// 学習者コードが Runtime.exec 等で子プロセスを作っても道連れに kill できるようにする。
+	configureProcessGroup(cmd)
+
+	return runCommand(cmd, input.Stdin)
+}
+
 // configureProcessGroup は cmd を独立 process group に置き、cancel 時にグループ全体へ SIGKILL を送る。
-// bash の子孫プロセス leak を防ぐ用途で、bash 実行時のみ使う。
+// bash / Java など、子孫プロセスを起動しうる言語の leak を防ぐ用途で使う。
 func configureProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -8,12 +8,17 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// javaMainClassRe は `public class Main` を検出する。Java は class と識別子の間に
+// 空白・タブ・改行を許すため、固定文字列一致ではなく \s+ で柔軟に判定する。
+var javaMainClassRe = regexp.MustCompile(`\bclass\s+Main\b`)
 
 const (
 	maxCodeBytes = 64 * 1024 // 64 KB
@@ -191,7 +196,8 @@ func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCode
 
 func (uc *ExecuteCodeUseCase) executeJava(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
 	// 単一ファイル実行 `java Main.java` はソース内に Main クラスが要る。別言語の誤貼付けも弾く。
-	if !strings.Contains(input.Code, "class Main") {
+	// class と Main の間の空白/タブ/改行を許容するため正規表現で判定する。
+	if !javaMainClassRe.MatchString(input.Code) {
 		return &ExecuteCodeOutput{
 			Stdout:   "",
 			Stderr:   "Java コードには `public class Main` が必要です。",

--- a/backend/internal/usecase/execute_code_usecase_test.go
+++ b/backend/internal/usecase/execute_code_usecase_test.go
@@ -292,3 +292,102 @@ sleep 30
 	// 修正前: 30 秒 ブロック / 修正後: timeout 1s + WaitDelay 1s で 数秒以内に return。
 	assert.Less(t, elapsed, 5*time.Second, "should NOT wait for orphan sleep child to exit")
 }
+
+// --- Java ---
+
+func TestExecuteCodeUseCase_Java_HelloWorld(t *testing.T) {
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("java not found in PATH, skipping integration test")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `public class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello, World!");
+    }
+}
+`,
+		Language: "java",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestExecuteCodeUseCase_Java_RejectsMissingMainClass(t *testing.T) {
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code:     `System.out.println("hi");`,
+		Language: "java",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.Stdout)
+	assert.NotEqual(t, 0, out.ExitCode)
+	assert.Contains(t, out.Stderr, "class Main")
+}
+
+func TestExecuteCodeUseCase_Java_CompileError(t *testing.T) {
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("java not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `public class Main {
+    public static void main(String[] args) {
+        undefinedMethod();
+    }
+}
+`,
+		Language: "java",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, out.ExitCode)
+	// コンパイルエラーは stderr に出る
+	assert.NotEmpty(t, out.Stderr)
+}
+
+func TestExecuteCodeUseCase_Java_ReadsStdin(t *testing.T) {
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("java not found in PATH")
+	}
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `import java.util.Scanner;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        String line = sc.nextLine();
+        System.out.println("got: " + line);
+    }
+}
+`,
+		Language: "java",
+		Stdin:    "hello\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "got: hello\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
+func TestExecuteCodeUseCase_Java_DropsParentEnv(t *testing.T) {
+	if _, err := exec.LookPath("java"); err != nil {
+		t.Skip("java not found in PATH")
+	}
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "must-not-leak")
+	uc := usecase.NewExecuteCodeUseCase()
+	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
+		Code: `public class Main {
+    public static void main(String[] args) {
+        String v = System.getenv("AWS_SECRET_ACCESS_KEY");
+        System.out.println("value=" + (v == null ? "missing" : v));
+    }
+}
+`,
+		Language: "java",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value=missing\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}


### PR DESCRIPTION
## 概要

バックエンドを Java から **Go へ差し戻す**方針（設計書 `docs/design/2026年/0002-backend-java-to-go-revert.md`、PR #1860）の Phase A・**G1**。

Go の演習コード実行ランナーは `php / go / bash` のみ対応で **Java 未対応**だったため、教材の Java 演習（java-1〜8 等）が Go バックエンドでは動かなかった。これを解消し、演習が Go 上でも実行できるようにする。**本 PR は非破壊**（本番 ECS は Java 稼働中で Go は未デプロイ。Go の機能パリティを先に揃える段）。

## 変更内容

- `ExecuteCodeUseCase` に `executeJava` を追加。単一ファイルソースランチャ `java Main.java`（Java 11+）で in-memory コンパイル + 実行。`class Main` を必須にして別言語の誤貼付けを弾く（空白許容の正規表現 `\bclass\s+Main\b` で判定）
- セキュリティは既存 php/go/bash と同等: `sandboxEnv` でシークレット env を除去 / リクエストごとの専用 temp dir / `context` timeout（20s）/ 出力 64KB 上限 / `configureProcessGroup` で timeout 時に子孫プロセスごと SIGKILL
- JVM 短命起動の高速化: `-XX:+UseSerialGC -XX:TieredStopAtLevel=1 -Xss16m -Xmx256m`
- `backend/Dockerfile` runtime に `default-jdk-headless` を追加（`javac` 入り JDK が必要）
- handler の `@Description` と OpenAPI spec を `php / go / bash / java` に更新

## テスト

`go test ./internal/usecase/`（java が PATH にあれば実行 / 無ければ Skip）: Hello World / `class Main` 欠落の拒否 / コンパイルエラー / stdin 読み取り / 親プロセスの `AWS_SECRET_ACCESS_KEY` が子に継承されないこと。全 PASS。`archlint` / `go vet` / `go build` 緑。

## 関連 Issue

Refs: 設計書 `docs/design/2026年/0002-backend-java-to-go-revert.md`（PR #1860）の G1