### PR TITLE
feat(backend-go): 認証パスを REST 化(/auth/login|logout|refresh) (G2)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -755,7 +755,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/auth/cognito/callback": {
+        "/auth/login": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
                 "consumes": [
@@ -767,7 +767,7 @@ const docTemplate = `{
                 "tags": [
                     "auth"
                 ],
-                "summary": "Cognito callback (認可 コード → token 交換)",
+                "summary": "ログイン (認可 コード → token 交換)",
                 "parameters": [
                     {
                         "description": "Cognito callback (code 必須、 invitationToken 任意)",
@@ -831,7 +831,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/auth/cognito/logout": {
+        "/auth/logout": {
             "post": {
                 "description": "HttpOnly Cookie の access / refresh token を 消去 する。 Cognito 側 の セッション は 別途 hosted UI で 切る。",
                 "produces": [
@@ -846,50 +846,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.messageResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/cognito/refresh-token": {
-            "post": {
-                "description": "refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "アクセス トークン リフレッシュ",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.messageResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "refresh_token 欠落 / 無効",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    },
-                    "429": {
-                        "description": "レート制限超過",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        },
-                        "headers": {
-                            "Retry-After": {
-                                "type": "string",
-                                "description": "再試行までの秒数 (例: 60)"
-                            }
-                        }
-                    },
-                    "502": {
-                        "description": "Cognito 到達 不可",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     }
                 }
@@ -931,6 +887,50 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "DB / repository 取得 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/refresh": {
+            "post": {
+                "description": "refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "アクセス トークン リフレッシュ",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.messageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "refresh_token 欠落 / 無効",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Cognito 到達 不可",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -748,7 +748,7 @@
                 }
             }
         },
-        "/auth/cognito/callback": {
+        "/auth/login": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
                 "consumes": [
@@ -760,7 +760,7 @@
                 "tags": [
                     "auth"
                 ],
-                "summary": "Cognito callback (認可 コード → token 交換)",
+                "summary": "ログイン (認可 コード → token 交換)",
                 "parameters": [
                     {
                         "description": "Cognito callback (code 必須、 invitationToken 任意)",
@@ -824,7 +824,7 @@
                 }
             }
         },
-        "/auth/cognito/logout": {
+        "/auth/logout": {
             "post": {
                 "description": "HttpOnly Cookie の access / refresh token を 消去 する。 Cognito 側 の セッション は 別途 hosted UI で 切る。",
                 "produces": [
@@ -839,50 +839,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.messageResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/cognito/refresh-token": {
-            "post": {
-                "description": "refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "アクセス トークン リフレッシュ",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.messageResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "refresh_token 欠落 / 無効",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        }
-                    },
-                    "429": {
-                        "description": "レート制限超過",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
-                        },
-                        "headers": {
-                            "Retry-After": {
-                                "type": "string",
-                                "description": "再試行までの秒数 (例: 60)"
-                            }
-                        }
-                    },
-                    "502": {
-                        "description": "Cognito 到達 不可",
-                        "schema": {
-                            "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     }
                 }
@@ -924,6 +880,50 @@
                     },
                     "500": {
                         "description": "DB / repository 取得 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/refresh": {
+            "post": {
+                "description": "refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "アクセス トークン リフレッシュ",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.messageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "refresh_token 欠落 / 無効",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Cognito 到達 不可",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1137,7 +1137,7 @@ paths:
       summary: AI チャット SSE ストリーミング
       tags:
       - ai-chat
-  /auth/cognito/callback:
+  /auth/login:
     post:
       consumes:
       - application/json
@@ -1186,10 +1186,10 @@ paths:
           description: Cognito 到達 不可
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
-      summary: Cognito callback (認可 コード → token 交換)
+      summary: ログイン (認可 コード → token 交換)
       tags:
       - auth
-  /auth/cognito/logout:
+  /auth/logout:
     post:
       description: HttpOnly Cookie の access / refresh token を 消去 する。 Cognito 側 の セッション
         は 別途 hosted UI で 切る。
@@ -1201,36 +1201,6 @@ paths:
           schema:
             $ref: '#/definitions/internal_handler.messageResponse'
       summary: ログアウト
-      tags:
-      - auth
-  /auth/cognito/refresh-token:
-    post:
-      description: refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に
-        セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/internal_handler.messageResponse'
-        "401":
-          description: refresh_token 欠落 / 無効
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
-        "429":
-          description: レート制限超過
-          headers:
-            Retry-After:
-              description: '再試行までの秒数 (例: 60)'
-              type: string
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
-        "502":
-          description: Cognito 到達 不可
-          schema:
-            $ref: '#/definitions/internal_handler.errorResponse'
-      summary: アクセス トークン リフレッシュ
       tags:
       - auth
   /auth/me:
@@ -1259,6 +1229,36 @@ paths:
       security:
       - CookieAuth: []
       summary: current user 情報 取得
+      tags:
+      - auth
+  /auth/refresh:
+    post:
+      description: refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に
+        セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.messageResponse'
+        "401":
+          description: refresh_token 欠落 / 無効
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "429":
+          description: レート制限超過
+          headers:
+            Retry-After:
+              description: '再試行までの秒数 (例: 60)'
+              type: string
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "502":
+          description: Cognito 到達 不可
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      summary: アクセス トークン リフレッシュ
       tags:
       - auth
   /code/execute:

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -107,7 +107,7 @@ func (h *AuthHandler) Me(c *gin.Context) {
 //	@Tags         auth
 //	@Produce      json
 //	@Success      200  {object}  messageResponse
-//	@Router       /auth/cognito/logout [post]
+//	@Router       /auth/logout [post]
 func (h *AuthHandler) Logout(c *gin.Context) {
 	middleware.ClearAuthCookies(c)
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました。"})
@@ -122,7 +122,7 @@ type cognitoCallbackReq struct {
 // Callback は認可コードを token に交換して HttpOnly Cookie に格納する。
 // 招待ゲート: 新規ユーザーは Cognito group admin か pending invitation 受信者でなければ 403 で拒否する。
 //
-//	@Summary      Cognito callback (認可 コード → token 交換)
+//	@Summary      ログイン (認可 コード → token 交換)
 //	@Description  Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。
 //	@Tags         auth
 //	@Accept       json
@@ -136,7 +136,7 @@ type cognitoCallbackReq struct {
 //	@Failure      502   {object}  errorResponse  "Cognito 到達 不可"
 //	@Failure      429   {object}  errorResponse  "レート制限超過"
 //	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
-//	@Router       /auth/cognito/callback [post]
+//	@Router       /auth/login [post]
 func (h *AuthHandler) Callback(c *gin.Context) {
 	var req cognitoCallbackReq
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -178,7 +178,7 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 //	@Failure      502  {object}  errorResponse  "Cognito 到達 不可"
 //	@Failure      429   {object}  errorResponse  "レート制限超過"
 //	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
-//	@Router       /auth/cognito/refresh-token [post]
+//	@Router       /auth/refresh [post]
 func (h *AuthHandler) Refresh(c *gin.Context) {
 	rt, err := c.Cookie(middleware.CookieRefreshToken)
 	if err != nil || rt == "" {

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -7,18 +7,19 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerAuthPublicRoutes は認証不要の Cognito 認証エンドポイント（logout / callback / refresh-token）を
-// 登録し、authed group で再利用するため AuthHandler を返す。callback / refresh は Cookie を発行・更新するため JWTAuth 対象外。
+// registerAuthPublicRoutes は認証不要の認証エンドポイント（login / logout / refresh）を
+// 登録し、authed group で再利用するため AuthHandler を返す。login / refresh は Cookie を発行・更新するため JWTAuth 対象外。
+// パスは provider 非依存の REST 形（/auth/login = 認可コード→token 交換 / /auth/logout / /auth/refresh）で、frontend の apiRoutes と一致させる。
 func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
 	invitations := persistence.NewAdminInvitationRepository(deps.db)
 	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito)
 
-	g.POST("/auth/cognito/logout", authHandler.Logout)
-	// callback は認証不要のため、総当たり緩和に per-IP 制限を掛ける。
-	g.POST("/auth/cognito/callback", middleware.RateLimitPerMinute(30, 10), authHandler.Callback)
-	// refresh-token は正規ユーザーが定期的に叩くため、NAT 共有 IP を考慮して緩めに設定する。
-	g.POST("/auth/cognito/refresh-token", middleware.RateLimitPerMinute(60, 30), authHandler.Refresh)
+	g.POST("/auth/logout", authHandler.Logout)
+	// login（認可コード→token 交換）は認証不要のため、総当たり緩和に per-IP 制限を掛ける。
+	g.POST("/auth/login", middleware.RateLimitPerMinute(30, 10), authHandler.Callback)
+	// refresh は正規ユーザーが定期的に叩くため、NAT 共有 IP を考慮して緩めに設定する。
+	g.POST("/auth/refresh", middleware.RateLimitPerMinute(60, 30), authHandler.Refresh)
 
 	return authHandler
 }


### PR DESCRIPTION
## 概要

Java→Go 差し戻し（Design Doc `docs/design/2026年/0002` の **G2**）。Go の認証ルートが旧 `/auth/cognito/*` のままで、frontend（`apiRoutes.ts`）が実際に呼ぶ REST パスと**不一致**だった。Go へ切り替えるとログインが 404 で壊れるため、パスを揃える。

frontend の実呼び出し: `/auth/login`（認可コード→token 交換）・`/auth/logout`・`/auth/refresh`・`/auth/me`。

## 変更内容

- `routes_auth.go`: `/auth/cognito/logout`→`/auth/logout`、`/auth/cognito/callback`→`/auth/login`、`/auth/cognito/refresh-token`→`/auth/refresh`（**ハンドラ本体・レート制限・招待ゲートは不変**、パスのみ）
- `auth_handler.go` の `@Router` / `@Summary` を REST パスに更新（provider 非依存表現）
- `/auth/me` は不変。public group と authed(JWTAuth) group が分離済みのため公開パス allowlist 等の追加変更は不要
- `make openapi` で spec 再生成（`/auth/cognito/*` が消え `/auth/login` 等に）

## 非破壊

本番 ECS は Java 稼働中で Go は未デプロイ。frontend の generated 型は Go の新 spec から `openapi-typescript` で再生成すれば同期する（runtime は `apiRoutes` 経由で既に新パスと一致）。

## テスト

`go build` / `go vet` / `archlint` / handler・usecase テスト回帰なし。旧パスを参照する Go コード/テストは無し。

## 関連
Design Doc `docs/design/2026年/0002` の G2。