### PR TITLE
chore(deps): AWS SDK の attributevalue / bedrockruntime を更新

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,8 +5,8 @@ go 1.26.1
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.21
-	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.43
-	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.2
+	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.47
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.4
@@ -28,7 +28,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 // indirect
-	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.19 // indirect
+	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.33.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.12.6 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -8,8 +8,8 @@ github.com/aws/aws-sdk-go-v2/config v1.32.21 h1:1i1v5jWn6iNPl7zkH4VwIXQOb+OMqMRF
 github.com/aws/aws-sdk-go-v2/config v1.32.21/go.mod h1:7NXDJjk0e4QOMv3Y3ppwALx3ifdSQHzCACFtRX5J1hI=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.20 h1:nIGz0+cQKwijxSsWNpggvPxjxFMtrAHNj16RYzGbu2Q=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.20/go.mod h1:/UQHYia3DSeilGdchXJDEVzJws15XuZSdnTlwbTBg0Q=
-github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.43 h1:UFil3tzIE+kjBoZ4YkmWac1cftiWS6IoXsIUSEWUShY=
-github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.43/go.mod h1:TULXfeWxj9ewBmRcGNkbfYUbJqOvCrG6NwA+3E+dBhE=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.47 h1:tbaPtkWtVJTSolMww/Mdl6EIeMgmMZR1Teb5p81IMRQ=
+github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.47/go.mod h1:2o+N6sj1PkLXPTkrafwcXl1bJYCPot3wEnLzfUUCiRk=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.26 h1:a1VPHz7eG7mVNHWHXUcCyC8rQDBEr4k+o4HJYbSoYZ0=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.26/go.mod h1:9G8LPblMwaodeQdS+IfDBgPqABDctJLpyZ/M6jflE6s=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 h1:f3vKqSo13fhTYb+JEcXwXefZQE26I1FB5eTSniU67ko=
@@ -18,12 +18,12 @@ github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 h1:RdwIf/CuUsvJX3RgJa
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29/go.mod h1:71wt8W2EgswdZy9Mf9KNnzxZ3TiZlv4caKghPktDOkA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaYzsyaPkCHGRRMAOhU=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
-github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.2 h1:CIQY7clOxy8tv0utQBHyvYgbCptZYw4+TZrFTvWDnoA=
-github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.2/go.mod h1:oP6137xfQ4DqDBKX/8GcvVT4tXDCoaQdrSggeoNvh5c=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5 h1:gWz8Ax1W8BXOoWe3obsIF4ueAY39u9A+NzsY4jppoIw=
+github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5/go.mod h1:8m0vIhh44Mmgb+x5o2WzTt0T5NKVtTBhO1j+t7AyvJI=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0 h1:S1qETDbdXKZMYVveuxACCKuRqnAt2NlnmYnlq5SeuMY=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0/go.mod h1:jLkDwIDBkCIpiENQhAOjAR2L9jwj56mZgVEvuro4gUE=
-github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.19 h1:xQwBDJVjbiFm+6zFz2u+uEUyDfWnMMYTyt1MJLP9Aoc=
-github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.19/go.mod h1:mSvotmAEuxK35P4Gmz6JnHXdr+N/QV0a7N8aGOccDbo=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.33.0 h1:3YaU3v3ybVnz+JRVJR19Y4EnEGebVHGKyo4rezXuGJo=
+github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.33.0/go.mod h1:Uk+gmBWz7i2hg5UeGT03758STndDVgEl5+siz9qwUP8=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 h1:ZD2+BSw9vFsNlKYIasSNt3uDbjqqXIBcM13UJv/Lx2k=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12/go.mod h1:Ms4zlcVBbXbiP7EVLhl+lgjvA/a7YphqQ3Ih3174EmI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 h1:V51LGlOq/1VsDsHUdoklAQi7rMmx4qQubvFYAlP2254=


### PR DESCRIPTION
## 概要

dependabot の #1871（`attributevalue` 1.20.43→1.20.47）/ #1873（`bedrockruntime` 1.53.2→1.53.5）が、互いに `go.sum` を干渉して rebase が堂々巡りになったため、ローカルで `go get` + `go mod tidy` してまとめて取り込む。

## 変更内容

- `attributevalue` 1.20.43 → 1.20.47
- `bedrockruntime` 1.53.2 → 1.53.5
- `dynamodbstreams`（transitive）1.32.19 → 1.33.0 を追従更新

## テスト

`go build ./...` 緑。CI（vet / test / build / 結合テスト）で確認。

## 関連 Issue

dependabot #1871 / #1873 の代替（クローズ）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * AWS SDKの依存関係をアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->