### PR TITLE
feat(backend-go): courses / teaching-materials を Go に復元 (G3)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1047,6 +1047,341 @@ const docTemplate = `{
                 }
             }
         },
+        "/courses": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 CompanyAdmin は 自社 固定。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}/materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 コース 配下 の 教材 を 返す。 trainee は published のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "コース内 教材 一覧",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "course id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他社 コース",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/embeds/oembed": {
             "get": {
                 "security": [
@@ -2129,6 +2464,281 @@ const docTemplate = `{
                 }
             }
         },
+        "/teaching-materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 全 件 一覧 (deprecated)",
+                "deprecated": true,
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 courseId 必須。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/teaching-materials/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/{userId}/stats": {
             "get": {
                 "security": [
@@ -2326,6 +2936,38 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 },
                 "updatedAt": {
@@ -2600,6 +3242,42 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "description": "NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD COLUMN 対策）。",
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
             "type": "object",
             "properties": {
@@ -2840,6 +3518,23 @@ const docTemplate = `{
                 },
                 "invitationToken": {
                     "description": "InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.courseRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -3113,6 +3808,46 @@ const docTemplate = `{
             ],
             "properties": {
                 "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialCreateRequest": {
+            "type": "object",
+            "required": [
+                "courseId"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1040,6 +1040,341 @@
                 }
             }
         },
+        "/courses": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 CompanyAdmin は 自社 固定。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.courseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/courses/{id}/materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 コース 配下 の 教材 を 返す。 trainee は published のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "コース内 教材 一覧",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "course id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "他社 コース",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/embeds/oembed": {
             "get": {
                 "security": [
@@ -2122,6 +2457,281 @@
                 }
             }
         },
+        "/teaching-materials": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 全 件 一覧 (deprecated)",
+                "deprecated": true,
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "company_admin / super_admin の み。 courseId 必須。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 作成",
+                "parameters": [
+                    {
+                        "description": "作成 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/teaching-materials/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 詳細",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 更新 (company_admin / super_admin)。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 更新",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "更新 内容",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.teachingMaterialUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "指定 id の 教材 を 削除 (company_admin / super_admin)。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "教材 削除",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功 (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "操作 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "教材 が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/{userId}/stats": {
             "get": {
                 "security": [
@@ -2319,6 +2929,38 @@
                     "type": "string"
                 },
                 "status": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 },
                 "updatedAt": {
@@ -2593,6 +3235,42 @@
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial": {
+            "type": "object",
+            "properties": {
+                "companyId": {
+                    "type": "integer"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "description": "NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD COLUMN 対策）。",
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdByUserId": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
             "type": "object",
             "properties": {
@@ -2833,6 +3511,23 @@
                 },
                 "invitationToken": {
                     "description": "InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。",
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.courseRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "sortOrder": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 }
             }
@@ -3106,6 +3801,46 @@
             ],
             "properties": {
                 "code": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialCreateRequest": {
+            "type": "object",
+            "required": [
+                "courseId"
+            ],
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "courseId": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.teachingMaterialUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "orderInCourse": {
+                    "type": "integer"
+                },
+                "title": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -98,6 +98,27 @@ definitions:
       updatedAt:
         type: string
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.Course:
+    properties:
+      companyId:
+        type: integer
+      createdAt:
+        type: string
+      createdByUserId:
+        type: integer
+      description:
+        type: string
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      sortOrder:
+        type: integer
+      title:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.ExerciseSubmission:
     properties:
       exerciseId:
@@ -276,6 +297,31 @@ definitions:
       userId:
         type: integer
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial:
+    properties:
+      companyId:
+        type: integer
+      content:
+        type: string
+      courseId:
+        description: NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD
+          COLUMN 対策）。
+        type: integer
+      createdAt:
+        type: string
+      createdByUserId:
+        type: integer
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      orderInCourse:
+        type: integer
+      title:
+        type: string
+      updatedAt:
+        type: string
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.UserStats:
     properties:
       averageScore:
@@ -436,6 +482,17 @@ definitions:
         type: string
     required:
     - code
+    type: object
+  internal_handler.courseRequest:
+    properties:
+      description:
+        type: string
+      isPublished:
+        type: boolean
+      sortOrder:
+        type: integer
+      title:
+        type: string
     type: object
   internal_handler.createAdminInvReq:
     properties:
@@ -619,6 +676,32 @@ definitions:
         type: string
     required:
     - code
+    type: object
+  internal_handler.teachingMaterialCreateRequest:
+    properties:
+      content:
+        type: string
+      courseId:
+        type: integer
+      isPublished:
+        type: boolean
+      orderInCourse:
+        type: integer
+      title:
+        type: string
+    required:
+    - courseId
+    type: object
+  internal_handler.teachingMaterialUpdateRequest:
+    properties:
+      content:
+        type: string
+      isPublished:
+        type: boolean
+      orderInCourse:
+        type: integer
+      title:
+        type: string
     type: object
   internal_handler.updateCompanyApplicationStatusReq:
     properties:
@@ -1332,6 +1415,221 @@ paths:
       summary: 企業利用申請（公開 / 認証不要）
       tags:
       - company-applications
+  /courses:
+    get:
+      description: current user の role / company で 自動 フィルタ。 trainee は published のみ、
+        admin 系 は draft 含む。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 一覧
+      tags:
+      - courses
+    post:
+      consumes:
+      - application/json
+      description: company_admin / super_admin の み。 CompanyAdmin は 自社 固定。
+      parameters:
+      - description: 作成 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.courseRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 作成
+      tags:
+      - courses
+  /courses/{id}:
+    delete:
+      description: 指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功 (本文 なし)
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 削除
+      tags:
+      - courses
+    get:
+      description: 指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 詳細
+      tags:
+      - courses
+    put:
+      consumes:
+      - application/json
+      description: 指定 id を 更新 (company_admin / super_admin)。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 更新 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.courseRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Course'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース 更新
+      tags:
+      - courses
+  /courses/{id}/materials:
+    get:
+      description: 指定 コース 配下 の 教材 を 返す。 trainee は published のみ。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+            type: array
+        "400":
+          description: course id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 他社 コース
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース内 教材 一覧
+      tags:
+      - teaching-materials
   /embeds/oembed:
     get:
       description: ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list
@@ -2034,6 +2332,183 @@ paths:
       summary: セッション ノート 作成 / 更新
       tags:
       - session-notes
+  /teaching-materials:
+    get:
+      deprecated: true
+      description: backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後
+        に 削除 予定。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 全 件 一覧 (deprecated)
+      tags:
+      - teaching-materials
+    post:
+      consumes:
+      - application/json
+      description: company_admin / super_admin の み。 courseId 必須。
+      parameters:
+      - description: 作成 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.teachingMaterialCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 作成
+      tags:
+      - teaching-materials
+  /teaching-materials/{id}:
+    delete:
+      description: 指定 id の 教材 を 削除 (company_admin / super_admin)。
+      parameters:
+      - description: 教材 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: 成功 (本文 なし)
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 教材 が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 削除
+      tags:
+      - teaching-materials
+    get:
+      description: 指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。
+      parameters:
+      - description: 教材 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 教材 が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 詳細
+      tags:
+      - teaching-materials
+    put:
+      consumes:
+      - application/json
+      description: 指定 id の 教材 を 更新 (company_admin / super_admin)。
+      parameters:
+      - description: 教材 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: 更新 内容
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.teachingMaterialUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 操作 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 教材 が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 教材 更新
+      tags:
+      - teaching-materials
   /users/{userId}/stats:
     get:
       description: 指定 user (or 'me') の マイページ 集計 (合計 セッション / 平均 スコア)。 他 user 指定 は 403。

--- a/backend/internal/adapter/persistence/course_repository.go
+++ b/backend/internal/adapter/persistence/course_repository.go
@@ -1,0 +1,64 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// courseRepository は [repository.CourseRepository] の実装。
+// 読み取りは生 SQL 直書き(db.Raw)、書き込み(Create/Update/Delete)は採番 ID・autoTime の
+// 利便のため GORM を使う(ハイブリッド方針。docs/sqlc-data-access.md / testing-philosophy.md)。
+type courseRepository struct {
+	db *gorm.DB
+}
+
+func NewCourseRepository(db *gorm.DB) repository.CourseRepository {
+	return &courseRepository{db: db}
+}
+
+// ListByCompany は自社のコースを sort_order 昇順で返す。includeUnpublished=false なら公開のみ。
+func (r *courseRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.Course, error) {
+	const q = `
+SELECT * FROM courses
+WHERE company_id = ? AND (? OR is_published = TRUE)
+ORDER BY sort_order ASC, id ASC`
+	var rows []domain.Course
+	if err := r.db.WithContext(ctx).Raw(q, companyID, includeUnpublished).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// GetByID は単一コースを返す。未存在は gorm.ErrRecordNotFound（handler が 404 に分岐）。
+func (r *courseRepository) GetByID(ctx context.Context, id uint64) (*domain.Course, error) {
+	var c domain.Course
+	res := r.db.WithContext(ctx).Raw(`SELECT * FROM courses WHERE id = ?`, id).Scan(&c)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &c, nil
+}
+
+func (r *courseRepository) Create(ctx context.Context, c *domain.Course) error {
+	return r.db.WithContext(ctx).Create(c).Error
+}
+
+func (r *courseRepository) Update(ctx context.Context, c *domain.Course) error {
+	// CreatedBy / CompanyID は不変なので更新対象から外す。
+	return r.db.WithContext(ctx).Model(c).Updates(map[string]any{
+		"title":        c.Title,
+		"description":  c.Description,
+		"sort_order":   c.SortOrder,
+		"is_published": c.IsPublished,
+	}).Error
+}
+
+func (r *courseRepository) Delete(ctx context.Context, id uint64) error {
+	return r.db.WithContext(ctx).Delete(&domain.Course{}, id).Error
+}

--- a/backend/internal/adapter/persistence/course_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/course_repository_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCourseRepository_Integration は ListByCompany の company 絞り込み / published フィルタ /
+// 並び順を実 Postgres で検証する。
+func TestCourseRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewCourseRepository(db)
+	ctx := context.Background()
+
+	mk := func(companyID uint64, title string, published bool, sortOrder int) *domain.Course {
+		return &domain.Course{
+			CompanyID: companyID, CreatedByUserID: 1, Title: title,
+			IsPublished: published, SortOrder: sortOrder,
+		}
+	}
+
+	t.Run("ListByCompany は company で絞り published フィルタ + sort_order 昇順", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "courses")
+
+		require.NoError(t, repo.Create(ctx, mk(1, "published", true, 20)))
+		require.NoError(t, repo.Create(ctx, mk(1, "draft", false, 10)))
+		require.NoError(t, repo.Create(ctx, mk(2, "other-company", true, 5)))
+
+		// includeUnpublished=false → company 1 の published のみ。
+		pub, err := repo.ListByCompany(ctx, 1, false)
+		require.NoError(t, err)
+		require.Len(t, pub, 1)
+		require.Equal(t, "published", pub[0].Title)
+
+		// includeUnpublished=true → company 1 の全件を sort_order 昇順（draft=10, published=20）。
+		all, err := repo.ListByCompany(ctx, 1, true)
+		require.NoError(t, err)
+		require.Len(t, all, 2)
+		require.Equal(t, "draft", all[0].Title, "sort_order 昇順")
+		require.Equal(t, "published", all[1].Title)
+	})
+
+	t.Run("Create→GetByID→Update→Delete", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "courses")
+
+		c := mk(1, "lifecycle", true, 1)
+		require.NoError(t, repo.Create(ctx, c))
+		require.NotZero(t, c.ID)
+
+		got, err := repo.GetByID(ctx, c.ID)
+		require.NoError(t, err)
+		require.Equal(t, "lifecycle", got.Title)
+
+		got.Title = "updated"
+		require.NoError(t, repo.Update(ctx, got))
+		reread, err := repo.GetByID(ctx, c.ID)
+		require.NoError(t, err)
+		require.Equal(t, "updated", reread.Title)
+
+		require.NoError(t, repo.Delete(ctx, c.ID))
+		_, err = repo.GetByID(ctx, c.ID)
+		require.Error(t, err)
+	})
+}

--- a/backend/internal/adapter/persistence/teaching_material_repository.go
+++ b/backend/internal/adapter/persistence/teaching_material_repository.go
@@ -1,0 +1,81 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// teachingMaterialRepository は [repository.TeachingMaterialRepository] の実装。
+// 読み取りは生 SQL 直書き(db.Raw)、書き込みは GORM(採番 ID・autoTime の利便)のハイブリッド。
+type teachingMaterialRepository struct {
+	db *gorm.DB
+}
+
+func NewTeachingMaterialRepository(db *gorm.DB) repository.TeachingMaterialRepository {
+	return &teachingMaterialRepository{db: db}
+}
+
+// ListByCompany は backward-compat 用（コース対応完了後に削除予定）。
+func (r *teachingMaterialRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	const q = `
+SELECT * FROM teaching_materials
+WHERE company_id = ? AND (? OR is_published = TRUE)
+ORDER BY updated_at DESC, id DESC`
+	var rows []domain.TeachingMaterial
+	if err := r.db.WithContext(ctx).Raw(q, companyID, includeUnpublished).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// ListByCourse はコース内の教材を order_in_course 昇順で返す。
+func (r *teachingMaterialRepository) ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	const q = `
+SELECT * FROM teaching_materials
+WHERE course_id = ? AND (? OR is_published = TRUE)
+ORDER BY order_in_course ASC, id ASC`
+	var rows []domain.TeachingMaterial
+	if err := r.db.WithContext(ctx).Raw(q, courseID, includeUnpublished).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// GetByID は単一教材を返す。未存在は gorm.ErrRecordNotFound（handler が 404 に分岐）。
+func (r *teachingMaterialRepository) GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error) {
+	var m domain.TeachingMaterial
+	res := r.db.WithContext(ctx).Raw(`SELECT * FROM teaching_materials WHERE id = ?`, id).Scan(&m)
+	if res.Error != nil {
+		return nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, gorm.ErrRecordNotFound
+	}
+	return &m, nil
+}
+
+func (r *teachingMaterialRepository) Create(ctx context.Context, m *domain.TeachingMaterial) error {
+	return r.db.WithContext(ctx).Create(m).Error
+}
+
+func (r *teachingMaterialRepository) Update(ctx context.Context, m *domain.TeachingMaterial) error {
+	// CreatedBy / CompanyID / CourseID は不変なので更新対象から外す。
+	return r.db.WithContext(ctx).Model(m).Updates(map[string]any{
+		"title":           m.Title,
+		"content":         m.Content,
+		"order_in_course": m.OrderInCourse,
+		"is_published":    m.IsPublished,
+	}).Error
+}
+
+func (r *teachingMaterialRepository) Delete(ctx context.Context, id uint64) error {
+	return r.db.WithContext(ctx).Delete(&domain.TeachingMaterial{}, id).Error
+}
+
+// DeleteByCourse はコース削除時の cascade 用に配下教材を全削除する（FK に頼らず明示削除）。
+func (r *teachingMaterialRepository) DeleteByCourse(ctx context.Context, courseID uint64) error {
+	return r.db.WithContext(ctx).Where("course_id = ?", courseID).Delete(&domain.TeachingMaterial{}).Error
+}

--- a/backend/internal/domain/course.go
+++ b/backend/internal/domain/course.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// Course は教材を束ねるコース。階層は Company 1 ── * Course 1 ── * TeachingMaterial。
+// trainee は自社の is_published=true のみ閲覧可。並び順は SortOrder（同値時 ID 昇順）。
+type Course struct {
+	ID              uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyID       uint64    `gorm:"column:company_id;not null;index" json:"companyId"`
+	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
+	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
+	Description     string    `gorm:"column:description;type:text;not null;default:''" json:"description"`
+	SortOrder       int       `gorm:"column:sort_order;not null;default:100" json:"sortOrder"`
+	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
+	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt       time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (Course) TableName() string { return "courses" }

--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -1,0 +1,21 @@
+package domain
+
+import "time"
+
+// TeachingMaterial は company_admin が自社 trainee 向けに作る教材。必ず 1 つの Course に所属する。
+// 本文は raw Markdown 文字列。コース内の並び順は OrderInCourse（同値時 ID 昇順）。
+type TeachingMaterial struct {
+	ID        uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
+	CompanyID uint64 `gorm:"column:company_id;not null;index" json:"companyId"`
+	// NOT NULL は migration 0004 で確定するため GORM tag では指定しない（既存行への ADD COLUMN 対策）。
+	CourseID        uint64    `gorm:"column:course_id;index" json:"courseId"`
+	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
+	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
+	Content         string    `gorm:"column:content;type:text;not null;default:''" json:"content"`
+	OrderInCourse   int       `gorm:"column:order_in_course;not null;default:100" json:"orderInCourse"`
+	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
+	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt       time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (TeachingMaterial) TableName() string { return "teaching_materials" }

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -1,0 +1,217 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
+)
+
+// CourseHandler はコースの CRUD API を扱う。
+type CourseHandler struct {
+	uc *usecase.CourseUseCase
+}
+
+func NewCourseHandler(uc *usecase.CourseUseCase) *CourseHandler {
+	return &CourseHandler{uc: uc}
+}
+
+func (h *CourseHandler) actorContext(c *gin.Context) (uint64, uint64, string, bool) {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return 0, 0, "", false
+	}
+	companyID := uint64(0)
+	if user.CompanyID != nil {
+		companyID = *user.CompanyID
+	}
+	return user.ID, companyID, user.Role, true
+}
+
+// @Summary      コース 一覧
+// @Description  current user の role / company で 自動 フィルタ。 trainee は published のみ、 admin 系 は draft 含む。
+// @Tags         courses
+// @Produce      json
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /courses [get]
+// @Security     CookieAuth
+func (h *CourseHandler) List(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	rows, err := h.uc.List(c.Request.Context(), companyID, role)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "コースの取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// @Summary      コース 詳細
+// @Description  指定 id の コース を 返す。 他社 / 未 公開 (trainee 不可) は 403。
+// @Tags         courses
+// @Produce      json
+// @Param        id  path      int  true  "コース ID"
+// @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id} [get]
+// @Security     CookieAuth
+func (h *CourseHandler) Get(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	course, err := h.uc.Get(c.Request.Context(), id, companyID, role)
+	if err != nil {
+		respondCourseErr(c, err, "コースの取得に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, course)
+}
+
+type courseRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	SortOrder   int    `json:"sortOrder"`
+	IsPublished bool   `json:"isPublished"`
+}
+
+// @Summary      コース 作成
+// @Description  company_admin / super_admin の み。 CompanyAdmin は 自社 固定。
+// @Tags         courses
+// @Accept       json
+// @Produce      json
+// @Param        body  body      courseRequest  true  "作成 内容"
+// @Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Router       /courses [post]
+// @Security     CookieAuth
+func (h *CourseHandler) Create(c *gin.Context) {
+	uid, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	var req courseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	course, err := h.uc.Create(c.Request.Context(), usecase.CreateCourseInput{
+		ActorUserID:    uid,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Description:    req.Description,
+		SortOrder:      req.SortOrder,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondCourseErr(c, err, "コースの作成に失敗しました")
+		return
+	}
+	c.JSON(http.StatusCreated, course)
+}
+
+// @Summary      コース 更新
+// @Description  指定 id を 更新 (company_admin / super_admin)。
+// @Tags         courses
+// @Accept       json
+// @Produce      json
+// @Param        id    path      int            true  "コース ID"
+// @Param        body  body      courseRequest  true  "更新 内容"
+// @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.Course
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Failure      404   {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id} [put]
+// @Security     CookieAuth
+func (h *CourseHandler) Update(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var req courseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	course, err := h.uc.Update(c.Request.Context(), usecase.UpdateCourseInput{
+		ID:             id,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Description:    req.Description,
+		SortOrder:      req.SortOrder,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondCourseErr(c, err, "コースの更新に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, course)
+}
+
+// @Summary      コース 削除
+// @Description  指定 id を 削除 + 配下 教材 も cascade 削除 (company_admin / super_admin)。
+// @Tags         courses
+// @Produce      json
+// @Param        id  path  int  true  "コース ID"
+// @Success      204  "成功 (本文 なし)"
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id} [delete]
+// @Security     CookieAuth
+func (h *CourseHandler) Delete(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.uc.Delete(c.Request.Context(), id, companyID, role); err != nil {
+		respondCourseErr(c, err, "コースの削除に失敗しました")
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func respondCourseErr(c *gin.Context, err error, fallback string) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "コースが見つかりません"})
+		return
+	}
+	if err.Error() == "forbidden" || err.Error() == "forbidden: only company_admin or super_admin can create courses" || err.Error() == "actor must belong to a company" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
+}

--- a/backend/internal/handler/course_handler_test.go
+++ b/backend/internal/handler/course_handler_test.go
@@ -1,0 +1,158 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// fakeCourseRepo は repository.CourseRepository の最小 fake。
+type fakeCourseRepo struct {
+	rows     []domain.Course
+	one      *domain.Course
+	getErr   error
+	listErr  error
+	writeErr error
+}
+
+func (f *fakeCourseRepo) ListByCompany(context.Context, uint64, bool) ([]domain.Course, error) {
+	return f.rows, f.listErr
+}
+
+func (f *fakeCourseRepo) GetByID(context.Context, uint64) (*domain.Course, error) {
+	return f.one, f.getErr
+}
+
+func (f *fakeCourseRepo) Create(_ context.Context, c *domain.Course) error {
+	if f.writeErr == nil {
+		c.ID = 100
+	}
+	return f.writeErr
+}
+func (f *fakeCourseRepo) Update(context.Context, *domain.Course) error { return f.writeErr }
+func (f *fakeCourseRepo) Delete(context.Context, uint64) error         { return f.writeErr }
+
+// fakeMaterialRepo は repository.TeachingMaterialRepository の no-op fake（Delete cascade 用）。
+type fakeMaterialRepo struct{}
+
+func (fakeMaterialRepo) ListByCompany(context.Context, uint64, bool) ([]domain.TeachingMaterial, error) {
+	return nil, nil
+}
+
+func (fakeMaterialRepo) ListByCourse(context.Context, uint64, bool) ([]domain.TeachingMaterial, error) {
+	return nil, nil
+}
+
+func (fakeMaterialRepo) GetByID(context.Context, uint64) (*domain.TeachingMaterial, error) {
+	return nil, nil
+}
+func (fakeMaterialRepo) Create(context.Context, *domain.TeachingMaterial) error { return nil }
+func (fakeMaterialRepo) Update(context.Context, *domain.TeachingMaterial) error { return nil }
+func (fakeMaterialRepo) Delete(context.Context, uint64) error                   { return nil }
+func (fakeMaterialRepo) DeleteByCourse(context.Context, uint64) error           { return nil }
+
+func newCourseHandler(cr repository.CourseRepository) *CourseHandler {
+	return NewCourseHandler(usecase.NewCourseUseCase(cr, fakeMaterialRepo{}))
+}
+
+// superAdminCo は company_id 付きの super_admin（course handler の actorContext 用）。
+func superAdminCo() *domain.User {
+	cid := uint64(1)
+	return &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: &cid}
+}
+
+func TestCourseHandler_List(t *testing.T) {
+	t.Run("unauthorized", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", nil, nil)
+		newCourseHandler(&fakeCourseRepo{}).List(c)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d", w.Code)
+		}
+	})
+	t.Run("ok", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", nil, superAdminCo())
+		newCourseHandler(&fakeCourseRepo{rows: []domain.Course{{ID: 1, Title: "C"}}}).List(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", w.Code)
+		}
+	})
+	t.Run("repo error -> 500", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", nil, superAdminCo())
+		newCourseHandler(&fakeCourseRepo{listErr: context.DeadlineExceeded}).List(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d", w.Code)
+		}
+	})
+}
+
+func TestCourseHandler_Get(t *testing.T) {
+	t.Run("bad id -> 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Get(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("ok", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", idParam("5"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1, Title: "C"}}).Get(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestCourseHandler_Create(t *testing.T) {
+	t.Run("bad json -> 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodPost, `{`, nil, superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Create(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("ok -> 201", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodPost, `{"title":"New"}`, nil, superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Create(c)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("want 201, got %d", w.Code)
+		}
+	})
+}
+
+func TestCourseHandler_Update(t *testing.T) {
+	t.Run("bad id -> 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("abc"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Update(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("ok -> 200", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("5"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1}}).Update(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestCourseHandler_Delete(t *testing.T) {
+	t.Run("bad id -> 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodDelete, "", idParam("abc"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Delete(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("ok -> 204", func(t *testing.T) {
+		_, c := ctxJSON(http.MethodDelete, "", idParam("5"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1}}).Delete(c)
+		if c.Writer.Status() != http.StatusNoContent {
+			t.Fatalf("want 204, got %d", c.Writer.Status())
+		}
+	})
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -84,6 +84,8 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerAdminRoutes(authed, deps)
 	registerEmbedRoutes(authed)
 	registerExerciseRoutes(authed, deps)
+	registerCourseRoutes(authed, deps)
+	registerTeachingMaterialRoutes(authed, deps)
 	registerCompanyApplicationAdminRoutes(authed, companyAppHandler)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 	return r

--- a/backend/internal/handler/routes_courses.go
+++ b/backend/internal/handler/routes_courses.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerCourseRoutes はコース CRUD + コース配下教材一覧 API を登録する。
+// アクセス制御は usecase 層で actor の company_id / role を検証する。
+func registerCourseRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	courseRepo := persistence.NewCourseRepository(deps.db)
+	materialRepo := persistence.NewTeachingMaterialRepository(deps.db)
+
+	courseUC := usecase.NewCourseUseCase(courseRepo, materialRepo)
+	courseHandler := NewCourseHandler(courseUC)
+
+	materialUC := usecase.NewTeachingMaterialUseCase(materialRepo, courseRepo)
+	materialHandler := NewTeachingMaterialHandler(materialUC)
+
+	g.GET("/courses", courseHandler.List)
+	g.GET("/courses/:id", courseHandler.Get)
+	g.POST("/courses", courseHandler.Create)
+	g.PUT("/courses/:id", courseHandler.Update)
+	g.DELETE("/courses/:id", courseHandler.Delete)
+	g.GET("/courses/:id/materials", materialHandler.ListByCourse)
+}

--- a/backend/internal/handler/routes_teaching_materials.go
+++ b/backend/internal/handler/routes_teaching_materials.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerTeachingMaterialRoutes は教材個別 API（詳細 / 作成 / 更新 / 削除）を登録する。
+// コース配下の教材一覧は registerCourseRoutes 側で登録する。
+// アクセス制御は usecase 層で actor の company_id / role を検証する。
+func registerTeachingMaterialRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	courseRepo := persistence.NewCourseRepository(deps.db)
+	materialRepo := persistence.NewTeachingMaterialRepository(deps.db)
+	uc := usecase.NewTeachingMaterialUseCase(materialRepo, courseRepo)
+	h := NewTeachingMaterialHandler(uc)
+	g.GET("/teaching-materials", h.List) // backward-compat（frontend のコース対応後に削除予定）
+	g.GET("/teaching-materials/:id", h.Get)
+	g.POST("/teaching-materials", h.Create)
+	g.PUT("/teaching-materials/:id", h.Update)
+	g.DELETE("/teaching-materials/:id", h.Delete)
+}

--- a/backend/internal/handler/teaching_material_handler.go
+++ b/backend/internal/handler/teaching_material_handler.go
@@ -1,0 +1,269 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
+)
+
+// TeachingMaterialHandler は教材の CRUD + コース内一覧 API を扱う。
+type TeachingMaterialHandler struct {
+	uc *usecase.TeachingMaterialUseCase
+}
+
+func NewTeachingMaterialHandler(uc *usecase.TeachingMaterialUseCase) *TeachingMaterialHandler {
+	return &TeachingMaterialHandler{uc: uc}
+}
+
+func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, string, bool) {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return 0, 0, "", false
+	}
+	companyID := uint64(0)
+	if user.CompanyID != nil {
+		companyID = *user.CompanyID
+	}
+	return user.ID, companyID, user.Role, true
+}
+
+// List は company 内全教材を返す backward-compat 用（コース対応完了後に削除予定）。
+//
+//	@Summary      教材 全 件 一覧 (deprecated)
+//	@Description  backward-compat 用。 company 内 全 教材 を 返す。 frontend が コース 対応 完了 後 に 削除 予定。
+//	@Tags         teaching-materials
+//	@Produce      json
+//	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+//	@Failure      401  {object}  errorResponse  "未 認証"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /teaching-materials [get]
+//	@Security     CookieAuth
+//	@Deprecated
+func (h *TeachingMaterialHandler) List(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	rows, err := h.uc.List(c.Request.Context(), companyID, role)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "教材の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// ListByCourse はコース配下の教材を返す（path の :id はコース ID）。
+//
+//	@Summary      コース内 教材 一覧
+//	@Description  指定 コース 配下 の 教材 を 返す。 trainee は published のみ。
+//	@Tags         teaching-materials
+//	@Produce      json
+//	@Param        id  path      int  true  "コース ID"
+//	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+//	@Failure      400  {object}  errorResponse  "course id 不正"
+//	@Failure      401  {object}  errorResponse  "未 認証"
+//	@Failure      403  {object}  errorResponse  "他社 コース"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /courses/{id}/materials [get]
+//	@Security     CookieAuth
+func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	courseID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid course id"})
+		return
+	}
+	rows, err := h.uc.ListByCourse(c.Request.Context(), courseID, companyID, role)
+	if err != nil {
+		respondTeachingMaterialErr(c, err, "教材の取得に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// @Summary      教材 詳細
+// @Description  指定 id の 教材 を 返す。 他社 / 未 公開 (trainee) は 403。
+// @Tags         teaching-materials
+// @Produce      json
+// @Param        id  path      int  true  "教材 ID"
+// @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "教材 が ない"
+// @Router       /teaching-materials/{id} [get]
+// @Security     CookieAuth
+func (h *TeachingMaterialHandler) Get(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	m, err := h.uc.Get(c.Request.Context(), id, companyID, role)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "教材が見つかりません"})
+			return
+		}
+		if err.Error() == "forbidden" {
+			c.JSON(http.StatusForbidden, gin.H{"error": "閲覧権限がありません"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "教材の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, m)
+}
+
+type teachingMaterialCreateRequest struct {
+	CourseID      uint64 `json:"courseId" binding:"required"`
+	Title         string `json:"title"`
+	Content       string `json:"content"`
+	OrderInCourse int    `json:"orderInCourse"`
+	IsPublished   bool   `json:"isPublished"`
+}
+
+type teachingMaterialUpdateRequest struct {
+	Title         string `json:"title"`
+	Content       string `json:"content"`
+	OrderInCourse int    `json:"orderInCourse"`
+	IsPublished   bool   `json:"isPublished"`
+}
+
+// @Summary      教材 作成
+// @Description  company_admin / super_admin の み。 courseId 必須。
+// @Tags         teaching-materials
+// @Accept       json
+// @Produce      json
+// @Param        body  body      teachingMaterialCreateRequest  true  "作成 内容"
+// @Success      201   {object}  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Router       /teaching-materials [post]
+// @Security     CookieAuth
+func (h *TeachingMaterialHandler) Create(c *gin.Context) {
+	uid, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	var req teachingMaterialCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	m, err := h.uc.Create(c.Request.Context(), usecase.CreateTeachingMaterialInput{
+		ActorUserID:    uid,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		CourseID:       req.CourseID,
+		Title:          req.Title,
+		Content:        req.Content,
+		OrderInCourse:  req.OrderInCourse,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondTeachingMaterialErr(c, err, "教材の作成に失敗しました")
+		return
+	}
+	c.JSON(http.StatusCreated, m)
+}
+
+// @Summary      教材 更新
+// @Description  指定 id の 教材 を 更新 (company_admin / super_admin)。
+// @Tags         teaching-materials
+// @Accept       json
+// @Produce      json
+// @Param        id    path      int                            true  "教材 ID"
+// @Param        body  body      teachingMaterialUpdateRequest  true  "更新 内容"
+// @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.TeachingMaterial
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      403   {object}  errorResponse  "操作 権限 なし"
+// @Failure      404   {object}  errorResponse  "教材 が ない"
+// @Router       /teaching-materials/{id} [put]
+// @Security     CookieAuth
+func (h *TeachingMaterialHandler) Update(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var req teachingMaterialUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	m, err := h.uc.Update(c.Request.Context(), usecase.UpdateTeachingMaterialInput{
+		ID:             id,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		Title:          req.Title,
+		Content:        req.Content,
+		OrderInCourse:  req.OrderInCourse,
+		IsPublished:    req.IsPublished,
+	})
+	if err != nil {
+		respondTeachingMaterialErr(c, err, "教材の更新に失敗しました")
+		return
+	}
+	c.JSON(http.StatusOK, m)
+}
+
+// @Summary      教材 削除
+// @Description  指定 id の 教材 を 削除 (company_admin / super_admin)。
+// @Tags         teaching-materials
+// @Produce      json
+// @Param        id  path  int  true  "教材 ID"
+// @Success      204  "成功 (本文 なし)"
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "操作 権限 なし"
+// @Failure      404  {object}  errorResponse  "教材 が ない"
+// @Router       /teaching-materials/{id} [delete]
+// @Security     CookieAuth
+func (h *TeachingMaterialHandler) Delete(c *gin.Context) {
+	_, companyID, role, ok := h.actorContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.uc.Delete(c.Request.Context(), id, companyID, role); err != nil {
+		respondTeachingMaterialErr(c, err, "教材の削除に失敗しました")
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+func respondTeachingMaterialErr(c *gin.Context, err error, fallback string) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "教材が見つかりません"})
+		return
+	}
+	if err.Error() == "forbidden" || err.Error() == "forbidden: only company_admin or super_admin can create materials" || err.Error() == "actor must belong to a company" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
+}

--- a/backend/internal/handler/teaching_material_handler_test.go
+++ b/backend/internal/handler/teaching_material_handler_test.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// newTMHandler は no-op fake repo で組んだ TeachingMaterialHandler を返す。
+// 成功パスは List（materials.ListByCompany が空を返す）のみ、他は actorContext /
+// param / bind のガード分岐を検証する（usecase の深い分岐は結合テスト側）。
+func newTMHandler() *TeachingMaterialHandler {
+	return NewTeachingMaterialHandler(usecase.NewTeachingMaterialUseCase(fakeMaterialRepo{}, &fakeCourseRepo{}))
+}
+
+func TestTeachingMaterialHandler_List(t *testing.T) {
+	t.Run("unauthorized", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", nil, nil)
+		newTMHandler().List(c)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d", w.Code)
+		}
+	})
+	t.Run("ok", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", nil, superAdminCo())
+		newTMHandler().List(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestTeachingMaterialHandler_ListByCourse(t *testing.T) {
+	t.Run("unauthorized", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", idParam("1"), nil)
+		newTMHandler().ListByCourse(c)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d", w.Code)
+		}
+	})
+	t.Run("bad id -> 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
+		newTMHandler().ListByCourse(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+}
+
+func TestTeachingMaterialHandler_Get_BadID(t *testing.T) {
+	w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
+	newTMHandler().Get(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestTeachingMaterialHandler_Create_BadJSON(t *testing.T) {
+	w, c := ctxJSON(http.MethodPost, `{`, nil, superAdminCo())
+	newTMHandler().Create(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestTeachingMaterialHandler_Update_BadID(t *testing.T) {
+	w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("abc"), superAdminCo())
+	newTMHandler().Update(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestTeachingMaterialHandler_Delete_BadID(t *testing.T) {
+	w, c := ctxJSON(http.MethodDelete, "", idParam("abc"), superAdminCo())
+	newTMHandler().Delete(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -24,6 +24,8 @@ func allDomainModels() []any {
 		&domain.ExerciseSubmission{},
 		&domain.Company{},
 		&domain.CompanyApplication{},
+		&domain.Course{},
+		&domain.TeachingMaterial{},
 	}
 }
 

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -1,0 +1,135 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// CourseUseCase はコースの list / get / create / update / delete を 1 構造体で扱う。
+// canManage は teaching_material_usecase と共有。trainee は published のみ閲覧、
+// 編集系は同一 company の company_admin または super_admin。Delete は配下教材も cascade 削除。
+//
+//naminglint:allow 複数 CRUD を束ねる集約 usecase のため Execute 単一メソッドではなく List/Get/Create 等で公開する
+type CourseUseCase struct {
+	courses   repository.CourseRepository
+	materials repository.TeachingMaterialRepository
+}
+
+func NewCourseUseCase(courses repository.CourseRepository, materials repository.TeachingMaterialRepository) *CourseUseCase {
+	return &CourseUseCase{courses: courses, materials: materials}
+}
+
+func (uc *CourseUseCase) List(ctx context.Context, actorCompanyID uint64, actorRole string) ([]domain.Course, error) {
+	if actorCompanyID == 0 {
+		return []domain.Course{}, nil
+	}
+	includeUnpublished := canManage(actorRole)
+	return uc.courses.ListByCompany(ctx, actorCompanyID, includeUnpublished)
+}
+
+func (uc *CourseUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.Course, error) {
+	c, err := uc.courses.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if !canReadCourse(c, actorCompanyID, actorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	return c, nil
+}
+
+func canReadCourse(c *domain.Course, actorCompanyID uint64, actorRole string) bool {
+	if actorRole == domain.RoleSuperAdmin {
+		return true
+	}
+	if c.CompanyID != actorCompanyID {
+		return false
+	}
+	if !c.IsPublished && !canManage(actorRole) {
+		return false
+	}
+	return true
+}
+
+type CreateCourseInput struct {
+	ActorUserID    uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Description    string
+	SortOrder      int
+	IsPublished    bool
+}
+
+func (uc *CourseUseCase) Create(ctx context.Context, in CreateCourseInput) (*domain.Course, error) {
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden: only company_admin or super_admin can create courses")
+	}
+	if in.ActorCompanyID == 0 {
+		return nil, fmt.Errorf("actor must belong to a company")
+	}
+	c := &domain.Course{
+		CompanyID:       in.ActorCompanyID,
+		CreatedByUserID: in.ActorUserID,
+		Title:           in.Title,
+		Description:     in.Description,
+		SortOrder:       in.SortOrder,
+		IsPublished:     in.IsPublished,
+	}
+	if err := uc.courses.Create(ctx, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type UpdateCourseInput struct {
+	ID             uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Description    string
+	SortOrder      int
+	IsPublished    bool
+}
+
+func (uc *CourseUseCase) Update(ctx context.Context, in UpdateCourseInput) (*domain.Course, error) {
+	existing, err := uc.courses.GetByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	if in.ActorRole != domain.RoleSuperAdmin && existing.CompanyID != in.ActorCompanyID {
+		return nil, fmt.Errorf("forbidden")
+	}
+	existing.Title = in.Title
+	existing.Description = in.Description
+	existing.SortOrder = in.SortOrder
+	existing.IsPublished = in.IsPublished
+	if err := uc.courses.Update(ctx, existing); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+// Delete はコースと配下教材を同時に削除する（cascade 相当）。
+func (uc *CourseUseCase) Delete(ctx context.Context, id, actorCompanyID uint64, actorRole string) error {
+	existing, err := uc.courses.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canManage(actorRole) {
+		return fmt.Errorf("forbidden")
+	}
+	if actorRole != domain.RoleSuperAdmin && existing.CompanyID != actorCompanyID {
+		return fmt.Errorf("forbidden")
+	}
+	if err := uc.materials.DeleteByCourse(ctx, id); err != nil {
+		return err
+	}
+	return uc.courses.Delete(ctx, id)
+}

--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -1,0 +1,134 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCourseUseCase_List_TraineeOnlyPublished(t *testing.T) {
+	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.List(context.Background(), 10, domain.RoleTrainee)
+	require.NoError(t, err)
+}
+
+func TestCourseUseCase_List_NoCompanyReturnsEmpty(t *testing.T) {
+	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	out, err := uc.List(context.Background(), 0, domain.RoleSuperAdmin)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+}
+
+func TestCourseUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Get(context.Background(), 5, 10, domain.RoleTrainee)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestCourseUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Get(context.Background(), 5, 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), got.ID)
+}
+
+func TestCourseUseCase_Get_CrossCompanyForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Get(context.Background(), 5, 99, domain.RoleCompanyAdmin)
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Create_TraineeForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
+		Title: "Web 基礎",
+	})
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "Web 基礎", Description: "HTTP / REST", SortOrder: 10, IsPublished: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, crepo.created)
+	assert.Equal(t, uint64(7), crepo.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), crepo.created.CompanyID)
+	assert.Equal(t, "Web 基礎", got.Title)
+	assert.Equal(t, 10, got.SortOrder)
+}
+
+func TestCourseUseCase_Create_NoCompanyForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X",
+	})
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Update_CrossCompanyForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
+		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
+	})
+	require.Error(t, err)
+	assert.Nil(t, crepo.updated)
+}
+
+func TestCourseUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
+		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "new", Description: "X", SortOrder: 200, IsPublished: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Title)
+	assert.NotNil(t, crepo.updated)
+}
+
+func TestCourseUseCase_Delete_TraineeForbidden(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
+	require.Error(t, err)
+}
+
+func TestCourseUseCase_Delete_SameCompanyAdminCascadesMaterials(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), crepo.deleted)
+	assert.Equal(t, uint64(1), mrepo.deletedByCo, "コース配下の教材も cascade で削除される")
+}

--- a/backend/internal/usecase/repository/course.go
+++ b/backend/internal/usecase/repository/course.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// CourseRepository はコースの永続化を担う（クエリは company_id 指定で他社漏れを防ぐ）。
+type CourseRepository interface {
+	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.Course, error)
+	GetByID(ctx context.Context, id uint64) (*domain.Course, error)
+	Create(ctx context.Context, c *domain.Course) error
+	Update(ctx context.Context, c *domain.Course) error
+	Delete(ctx context.Context, id uint64) error
+}

--- a/backend/internal/usecase/repository/teaching_material.go
+++ b/backend/internal/usecase/repository/teaching_material.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// TeachingMaterialRepository は教材の永続化を担う（クエリは company_id 指定で他社漏れを防ぐ）。
+type TeachingMaterialRepository interface {
+	// ListByCompany は company 内全教材を返す backward-compat 用（コース対応への移行後に削除予定）。
+	ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
+	ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error)
+	GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error)
+	Create(ctx context.Context, m *domain.TeachingMaterial) error
+	Update(ctx context.Context, m *domain.TeachingMaterial) error
+	Delete(ctx context.Context, id uint64) error
+	DeleteByCourse(ctx context.Context, courseID uint64) error
+}

--- a/backend/internal/usecase/teaching_material_usecase.go
+++ b/backend/internal/usecase/teaching_material_usecase.go
@@ -1,0 +1,172 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// TeachingMaterialUseCase は教材の list / get / create / update / delete を 1 構造体で扱う。
+// 教材は必ず Course に所属するため list は Course 単位、create は course_id 必須。
+// trainee は published コース内の published 教材のみ閲覧、編集系は company_admin / super_admin。
+//
+//naminglint:allow 複数 CRUD を束ねる集約 usecase のため Execute 単一メソッドではなく List/Get/Create 等で公開する
+type TeachingMaterialUseCase struct {
+	repo    repository.TeachingMaterialRepository
+	courses repository.CourseRepository
+}
+
+func NewTeachingMaterialUseCase(repo repository.TeachingMaterialRepository, courses repository.CourseRepository) *TeachingMaterialUseCase {
+	return &TeachingMaterialUseCase{repo: repo, courses: courses}
+}
+
+// canManage は教材を作成 / 編集 / 削除できる role 判定。
+func canManage(role string) bool {
+	return role == domain.RoleCompanyAdmin || role == domain.RoleSuperAdmin
+}
+
+// List は company 内の全教材を返す backward-compat 用（コース対応への移行後に削除予定）。
+func (uc *TeachingMaterialUseCase) List(ctx context.Context, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
+	if actorCompanyID == 0 {
+		return []domain.TeachingMaterial{}, nil
+	}
+	includeUnpublished := canManage(actorRole)
+	return uc.repo.ListByCompany(ctx, actorCompanyID, includeUnpublished)
+}
+
+// ListByCourse は指定コース配下の教材を返す（role / company を検証してから）。
+func (uc *TeachingMaterialUseCase) ListByCourse(ctx context.Context, courseID, actorCompanyID uint64, actorRole string) ([]domain.TeachingMaterial, error) {
+	course, err := uc.courses.GetByID(ctx, courseID)
+	if err != nil {
+		return nil, err
+	}
+	if !canReadCourse(course, actorCompanyID, actorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	includeUnpublished := canManage(actorRole)
+	return uc.repo.ListByCourse(ctx, courseID, includeUnpublished)
+}
+
+// Get は ID 指定で 1 件取得する（company 不一致 / 非公開コースは閲覧不可）。
+func (uc *TeachingMaterialUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.TeachingMaterial, error) {
+	m, err := uc.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	course, err := uc.courses.GetByID(ctx, m.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if !canRead(m, course, actorCompanyID, actorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	return m, nil
+}
+
+func canRead(m *domain.TeachingMaterial, course *domain.Course, actorCompanyID uint64, actorRole string) bool {
+	if actorRole == domain.RoleSuperAdmin {
+		return true
+	}
+	if m.CompanyID != actorCompanyID {
+		return false
+	}
+	// 所属コースが閲覧可能でなければ教材も見せない。
+	if !canReadCourse(course, actorCompanyID, actorRole) {
+		return false
+	}
+	if !m.IsPublished && !canManage(actorRole) {
+		return false
+	}
+	return true
+}
+
+// CreateTeachingMaterialInput は POST 入力。CourseID は必須。
+type CreateTeachingMaterialInput struct {
+	ActorUserID    uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	CourseID       uint64
+	Title          string
+	Content        string
+	OrderInCourse  int
+	IsPublished    bool
+}
+
+func (uc *TeachingMaterialUseCase) Create(ctx context.Context, in CreateTeachingMaterialInput) (*domain.TeachingMaterial, error) {
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden: only company_admin or super_admin can create materials")
+	}
+	if in.ActorCompanyID == 0 {
+		return nil, fmt.Errorf("actor must belong to a company")
+	}
+	if in.CourseID == 0 {
+		return nil, fmt.Errorf("course_id is required")
+	}
+	course, err := uc.courses.GetByID(ctx, in.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if in.ActorRole != domain.RoleSuperAdmin && course.CompanyID != in.ActorCompanyID {
+		return nil, fmt.Errorf("forbidden")
+	}
+	m := &domain.TeachingMaterial{
+		CompanyID:       course.CompanyID,
+		CourseID:        in.CourseID,
+		CreatedByUserID: in.ActorUserID,
+		Title:           in.Title,
+		Content:         in.Content,
+		OrderInCourse:   in.OrderInCourse,
+		IsPublished:     in.IsPublished,
+	}
+	if err := uc.repo.Create(ctx, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+type UpdateTeachingMaterialInput struct {
+	ID             uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	Title          string
+	Content        string
+	OrderInCourse  int
+	IsPublished    bool
+}
+
+func (uc *TeachingMaterialUseCase) Update(ctx context.Context, in UpdateTeachingMaterialInput) (*domain.TeachingMaterial, error) {
+	existing, err := uc.repo.GetByID(ctx, in.ID)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage(in.ActorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	if in.ActorRole != domain.RoleSuperAdmin && existing.CompanyID != in.ActorCompanyID {
+		return nil, fmt.Errorf("forbidden")
+	}
+	existing.Title = in.Title
+	existing.Content = in.Content
+	existing.OrderInCourse = in.OrderInCourse
+	existing.IsPublished = in.IsPublished
+	if err := uc.repo.Update(ctx, existing); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+func (uc *TeachingMaterialUseCase) Delete(ctx context.Context, id, actorCompanyID uint64, actorRole string) error {
+	existing, err := uc.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if !canManage(actorRole) {
+		return fmt.Errorf("forbidden")
+	}
+	if actorRole != domain.RoleSuperAdmin && existing.CompanyID != actorCompanyID {
+		return fmt.Errorf("forbidden")
+	}
+	return uc.repo.Delete(ctx, id)
+}

--- a/backend/internal/usecase/teaching_material_usecase_test.go
+++ b/backend/internal/usecase/teaching_material_usecase_test.go
@@ -1,0 +1,283 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// fakeTeachingMaterialRepo は usecase テスト用フェイク。
+type fakeTeachingMaterialRepo struct {
+	rows           []domain.TeachingMaterial
+	getResp        *domain.TeachingMaterial
+	getErr         error
+	created        *domain.TeachingMaterial
+	updated        *domain.TeachingMaterial
+	deleted        uint64
+	deletedByCo    uint64
+	listCourseID   uint64
+	listIncludeAll bool
+}
+
+func (r *fakeTeachingMaterialRepo) ListByCompany(_ context.Context, _ uint64, _ bool) ([]domain.TeachingMaterial, error) {
+	return r.rows, nil
+}
+
+func (r *fakeTeachingMaterialRepo) ListByCourse(_ context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	r.listCourseID, r.listIncludeAll = courseID, includeUnpublished
+	return r.rows, nil
+}
+
+func (r *fakeTeachingMaterialRepo) GetByID(_ context.Context, _ uint64) (*domain.TeachingMaterial, error) {
+	return r.getResp, r.getErr
+}
+
+func (r *fakeTeachingMaterialRepo) Create(_ context.Context, m *domain.TeachingMaterial) error {
+	m.ID = 99
+	r.created = m
+	return nil
+}
+
+func (r *fakeTeachingMaterialRepo) Update(_ context.Context, m *domain.TeachingMaterial) error {
+	r.updated = m
+	return nil
+}
+
+func (r *fakeTeachingMaterialRepo) Delete(_ context.Context, id uint64) error {
+	r.deleted = id
+	return nil
+}
+
+func (r *fakeTeachingMaterialRepo) DeleteByCourse(_ context.Context, courseID uint64) error {
+	r.deletedByCo = courseID
+	return nil
+}
+
+// fakeCourseRepo は course 依存をスタブ化する。
+type fakeCourseRepo struct {
+	rows    []domain.Course
+	getResp *domain.Course
+	getErr  error
+	created *domain.Course
+	updated *domain.Course
+	deleted uint64
+}
+
+func (r *fakeCourseRepo) ListByCompany(_ context.Context, _ uint64, _ bool) ([]domain.Course, error) {
+	return r.rows, nil
+}
+
+func (r *fakeCourseRepo) GetByID(_ context.Context, _ uint64) (*domain.Course, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	return r.getResp, nil
+}
+
+func (r *fakeCourseRepo) Create(_ context.Context, c *domain.Course) error {
+	c.ID = 88
+	r.created = c
+	return nil
+}
+
+func (r *fakeCourseRepo) Update(_ context.Context, c *domain.Course) error {
+	r.updated = c
+	return nil
+}
+
+func (r *fakeCourseRepo) Delete(_ context.Context, id uint64) error {
+	r.deleted = id
+	return nil
+}
+
+func TestTeachingMaterialUseCase_ListByCourse_TraineeOnlyPublished(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), mrepo.listCourseID)
+	assert.False(t, mrepo.listIncludeAll, "trainee は draft を含まない")
+}
+
+func TestTeachingMaterialUseCase_ListByCourse_TraineeCannotSeeUnpublishedCourse(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleTrainee)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_ListByCourse_CompanyAdminIncludesDraft(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.True(t, mrepo.listIncludeAll)
+}
+
+func TestTeachingMaterialUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	got, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), got.ID)
+}
+
+func TestTeachingMaterialUseCase_Get_CrossCompanyForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Get(context.Background(), 1, 99, domain.RoleCompanyAdmin)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_Get_SuperAdminCrossCompanyAllowed(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	got, err := uc.Get(context.Background(), 1, 99, domain.RoleSuperAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), got.ID)
+}
+
+func TestTeachingMaterialUseCase_Create_TraineeForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
+		CourseID: 5, Title: "X", Content: "Y", IsPublished: true,
+	})
+	require.Error(t, err)
+}
+
+func TestTeachingMaterialUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	got, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		CourseID: 5, Title: "Spring 入門", Content: "# Spring", IsPublished: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mrepo.created)
+	assert.Equal(t, uint64(7), mrepo.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), mrepo.created.CompanyID)
+	assert.Equal(t, uint64(5), mrepo.created.CourseID)
+	assert.Equal(t, "Spring 入門", got.Title)
+}
+
+func TestTeachingMaterialUseCase_Create_MissingCourseIDForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "course_id")
+}
+
+func TestTeachingMaterialUseCase_Create_CrossCompanyCourseForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 99}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		CourseID: 5, Title: "X",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func TestTeachingMaterialUseCase_Create_NoCompanyForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{}
+	crepo := &fakeCourseRepo{}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
+		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
+		CourseID: 5, Title: "X",
+	})
+	require.Error(t, err)
+}
+
+func TestTeachingMaterialUseCase_Update_CrossCompanyForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	_, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
+		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
+	})
+	require.Error(t, err)
+	assert.Nil(t, mrepo.updated)
+}
+
+func TestTeachingMaterialUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	got, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
+		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "new", Content: "X", OrderInCourse: 200, IsPublished: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "new", got.Title)
+	assert.Equal(t, 200, got.OrderInCourse)
+	assert.NotNil(t, mrepo.updated)
+}
+
+func TestTeachingMaterialUseCase_Delete_TraineeForbidden(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5,
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
+	require.Error(t, err)
+}
+
+func TestTeachingMaterialUseCase_Delete_SameCompanyAdminSucceeds(t *testing.T) {
+	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+		ID: 1, CompanyID: 10, CourseID: 5,
+	}}
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
+	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), mrepo.deleted)
+}
+
+// 念のため: gorm 依存を import で残すための no-op（一部 import path 揃え用）。
+var _ = gorm.ErrRecordNotFound


### PR DESCRIPTION
## 概要

Java→Go 差し戻し（設計書 `docs/design/2026年/0002` の **G3**）。#1831 で Go から削除した **course / teaching-material**（コース・教材の閲覧 + CRUD）を git 履歴（削除直前）から復元し、現 main に再配線する。**本 PR は非破壊**（本番 ECS は Java 稼働中で Go は未デプロイ）。

## 変更内容

- **復元（17 ファイル）**: `domain`(Course / TeachingMaterial) / usecase port + 実装 + テスト / `adapter/persistence` / handler + routes + ハンドラテスト
- `router.go` に `registerCourseRoutes` / `registerTeachingMaterialRoutes` を再登録
- `migrate.go` の AutoMigrate に `Course` / `TeachingMaterial` を再追加
- **repository の読み取り**（`ListByCompany` / `ListByCourse` / `GetByID`）を **`db.Raw` の生 SQL 直書き**に書き換え（`GetByID` は `RowsAffected==0` で `gorm.ErrRecordNotFound` を返し **404 挙動を維持**）。書き込み（Create/Update/Delete）は採番 ID・autoTime の利便のため **GORM 維持**（ハイブリッド方針）
- `make openapi` で `/courses` `/courses/{id}` `/courses/{id}/materials` `/teaching-materials/{id}` を spec に復活

## API / アクセス制御

`GET /courses`（company/role フィルタ）/ `GET /courses/{id}` / `GET /courses/{id}/materials` / `GET・PUT・DELETE /teaching-materials/{id}` ほか。trainee=自社 published のみ / 管理者=draft 含む / 他社・未存在は 403 / 404。

## テスト

- 復元した usecase / handler テスト + 結合テスト（`//go:build integration` 実 Postgres）
- `go build` / `go vet` / `archlint` / `gofumpt -l`(0) / 全テスト PASS

## 関連 Issue

Refs: 設計書 `docs/design/2026年/0002` の G3