### PR TITLE
feat(backend-go): learning-reports を Go に復元 (G4)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1750,6 +1750,97 @@ const docTemplate = `{
                 }
             }
         },
+        "/learning-reports": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "学習 レポート 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports/generate": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "月次 学習 レポート 生成 要求",
+                "parameters": [
+                    {
+                        "description": "year + month",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.requestReportReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/notes": {
             "get": {
                 "security": [
@@ -3021,6 +3112,32 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.LearningReport": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "periodFrom": {
+                    "type": "string"
+                },
+                "periodTo": {
+                    "type": "string"
+                },
+                "s3Key": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise": {
             "type": "object",
             "properties": {
@@ -3747,6 +3864,25 @@ const docTemplate = `{
                 },
                 "title": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.requestReportReq": {
+            "type": "object",
+            "required": [
+                "month",
+                "year"
+            ],
+            "properties": {
+                "month": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1
+                },
+                "year": {
+                    "type": "integer",
+                    "maximum": 2100,
+                    "minimum": 2000
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1743,6 +1743,97 @@
                 }
             }
         },
+        "/learning-reports": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "学習 レポート 一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/learning-reports/generate": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "learning-reports"
+                ],
+                "summary": "月次 学習 レポート 生成 要求",
+                "parameters": [
+                    {
+                        "description": "year + month",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.requestReportReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/notes": {
             "get": {
                 "security": [
@@ -3014,6 +3105,32 @@
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.LearningReport": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "periodFrom": {
+                    "type": "string"
+                },
+                "periodTo": {
+                    "type": "string"
+                },
+                "s3Key": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "userId": {
+                    "type": "integer"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise": {
             "type": "object",
             "properties": {
@@ -3740,6 +3857,25 @@
                 },
                 "title": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.requestReportReq": {
+            "type": "object",
+            "required": [
+                "month",
+                "year"
+            ],
+            "properties": {
+                "month": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1
+                },
+                "year": {
+                    "type": "integer",
+                    "maximum": 2100,
+                    "minimum": 2000
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -149,6 +149,23 @@ definitions:
       status:
         type: string
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.LearningReport:
+    properties:
+      createdAt:
+        type: string
+      id:
+        type: integer
+      periodFrom:
+        type: string
+      periodTo:
+        type: string
+      s3Key:
+        type: string
+      status:
+        type: string
+      userId:
+        type: integer
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise:
     properties:
       category:
@@ -636,6 +653,20 @@ definitions:
         type: string
     required:
     - title
+    type: object
+  internal_handler.requestReportReq:
+    properties:
+      month:
+        maximum: 12
+        minimum: 1
+        type: integer
+      year:
+        maximum: 2100
+        minimum: 2000
+        type: integer
+    required:
+    - month
+    - year
     type: object
   internal_handler.sessionNoteUpsertReq:
     properties:
@@ -1870,6 +1901,64 @@ paths:
       summary: 招待 トークン 検証 (公開 / 認証 不要)
       tags:
       - invitations
+  /learning-reports:
+    get:
+      description: current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport'
+            type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 学習 レポート 一覧
+      tags:
+      - learning-reports
+  /learning-reports/generate:
+    post:
+      consumes:
+      - application/json
+      description: current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。
+        202 Accepted を 返す。
+      parameters:
+      - description: year + month
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.requestReportReq'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.LearningReport'
+        "400":
+          description: バリデーション
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 月次 学習 レポート 生成 要求
+      tags:
+      - learning-reports
   /notes:
     get:
       description: current user の note を 更新 日 降順 で 返す。 IDOR 対策 で userId は 受け取らない。

--- a/backend/internal/adapter/persistence/learning_report_repository.go
+++ b/backend/internal/adapter/persistence/learning_report_repository.go
@@ -1,0 +1,38 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// learningReportRepository は [repository.LearningReportRepository] の実装。
+// 読み取りは生 SQL 直書き(db.Raw)、書き込み(Create)は採番 ID・autoTime の利便のため GORM。
+type learningReportRepository struct{ db *gorm.DB }
+
+func NewLearningReportRepository(db *gorm.DB) repository.LearningReportRepository {
+	return &learningReportRepository{db: db}
+}
+
+// ListByUserID は自分のレポートを期間末(period_to)降順で返す。
+func (r *learningReportRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.LearningReport, error) {
+	const q = `SELECT * FROM learning_reports WHERE user_id = ? ORDER BY period_to DESC`
+	var rows []domain.LearningReport
+	if err := r.db.WithContext(ctx).Raw(q, userID).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+func (r *learningReportRepository) Create(ctx context.Context, lr *domain.LearningReport) error {
+	return r.db.WithContext(ctx).Create(lr).Error
+}
+
+// stubEnqueuer は [repository.SqsEnqueuer] の no-op 実装（本番の SQS 実装は別 PR）。
+type stubEnqueuer struct{}
+
+func NewStubSqsEnqueuer() repository.SqsEnqueuer { return &stubEnqueuer{} }
+
+func (e *stubEnqueuer) Enqueue(_ context.Context, _ uint64) error { return nil }

--- a/backend/internal/domain/learning_report.go
+++ b/backend/internal/domain/learning_report.go
@@ -1,0 +1,22 @@
+package domain
+
+import "time"
+
+// LearningReport はユーザーの学習レポート (週次・月次集計を非同期で生成)。
+type LearningReport struct {
+	ID         uint64    `gorm:"primaryKey" json:"id"`
+	UserID     uint64    `gorm:"column:user_id;index" json:"userId"`
+	PeriodFrom time.Time `gorm:"column:period_from" json:"periodFrom"`
+	PeriodTo   time.Time `gorm:"column:period_to" json:"periodTo"`
+	Status     string    `gorm:"column:status" json:"status"`
+	S3Key      string    `gorm:"column:s3_key" json:"s3Key,omitempty"`
+	CreatedAt  time.Time `gorm:"column:created_at" json:"createdAt"`
+}
+
+func (LearningReport) TableName() string { return "learning_reports" }
+
+const (
+	LearningReportStatusPending = "pending"
+	LearningReportStatusReady   = "ready"
+	LearningReportStatusFailed  = "failed"
+)

--- a/backend/internal/handler/learning_report_handler.go
+++ b/backend/internal/handler/learning_report_handler.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+type LearningReportHandler struct {
+	list    *usecase.ListLearningReportsUseCase
+	request *usecase.RequestLearningReportUseCase
+}
+
+func NewLearningReportHandler(l *usecase.ListLearningReportsUseCase, r *usecase.RequestLearningReportUseCase) *LearningReportHandler {
+	return &LearningReportHandler{list: l, request: r}
+}
+
+// @Summary      学習 レポート 一覧
+// @Description  current user の レポート を 期間 降順 で 返す。 userId は IDOR 対策 で 受け取らない。
+// @Tags         learning-reports
+// @Produce      json
+// @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.LearningReport
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      500  {object}  errorResponse  "DB 失敗"
+// @Router       /learning-reports [get]
+// @Security     CookieAuth
+func (h *LearningReportHandler) List(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	rows, err := h.list.Execute(c.Request.Context(), uid)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}
+
+// requestReportReq は月次レポート生成 body。year + month から月初〜翌月初の period を組み立てる。
+type requestReportReq struct {
+	Year  int `json:"year"  binding:"required,min=2000,max=2100"`
+	Month int `json:"month" binding:"required,min=1,max=12"`
+}
+
+// @Summary      月次 学習 レポート 生成 要求
+// @Description  current user で 指定 月 の レポート 生成 ジョブ を 受け付け、 SQS に enqueue (現状 stub)。 202 Accepted を 返す。
+// @Tags         learning-reports
+// @Accept       json
+// @Produce      json
+// @Param        body  body      requestReportReq  true  "year + month"
+// @Success      202   {object}  github_com_norman6464_FreStyle_backend_internal_domain.LearningReport
+// @Failure      400   {object}  errorResponse  "バリデーション"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Router       /learning-reports/generate [post]
+// @Security     CookieAuth
+func (h *LearningReportHandler) Request(c *gin.Context) {
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	var req requestReportReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	// year + month を月初〜翌月初の半開区間 [PeriodFrom, PeriodTo) に変換する。
+	from := time.Date(req.Year, time.Month(req.Month), 1, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 1, 0)
+	got, err := h.request.Execute(c.Request.Context(), usecase.RequestLearningReportInput{
+		UserID: uid, PeriodFrom: from, PeriodTo: to,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusAccepted, got)
+}

--- a/backend/internal/handler/learning_report_handler_test.go
+++ b/backend/internal/handler/learning_report_handler_test.go
@@ -1,0 +1,30 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestLearningReportHandler_List_Unauthorized(t *testing.T) {
+	w, c := noteCtx(http.MethodGet, "", 0, "")
+	(&LearningReportHandler{}).List(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", w.Code)
+	}
+}
+
+func TestLearningReportHandler_Request_Unauthorized(t *testing.T) {
+	w, c := noteCtx(http.MethodPost, `{}`, 0, "")
+	(&LearningReportHandler{}).Request(c)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", w.Code)
+	}
+}
+
+func TestLearningReportHandler_Request_BadJSON(t *testing.T) {
+	w, c := noteCtx(http.MethodPost, `not-json`, 7, "")
+	(&LearningReportHandler{}).Request(c)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -86,6 +86,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerExerciseRoutes(authed, deps)
 	registerCourseRoutes(authed, deps)
 	registerTeachingMaterialRoutes(authed, deps)
+	registerLearningReportRoutes(authed, deps)
 	registerCompanyApplicationAdminRoutes(authed, companyAppHandler)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 	return r

--- a/backend/internal/handler/routes_learning_report.go
+++ b/backend/internal/handler/routes_learning_report.go
@@ -1,0 +1,20 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerLearningReportRoutes は月次学習レポートの取得 / 生成要求を登録する。
+// 生成は SQS 非同期ジョブで、当面は stub enqueuer を使う。
+func registerLearningReportRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	repo := persistence.NewLearningReportRepository(deps.db)
+	queue := persistence.NewStubSqsEnqueuer()
+	h := NewLearningReportHandler(
+		usecase.NewListLearningReportsUseCase(repo),
+		usecase.NewRequestLearningReportUseCase(repo, queue),
+	)
+	g.GET("/learning-reports", h.List)
+	g.POST("/learning-reports/generate", h.Request)
+}

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -26,6 +26,7 @@ func allDomainModels() []any {
 		&domain.CompanyApplication{},
 		&domain.Course{},
 		&domain.TeachingMaterial{},
+		&domain.LearningReport{},
 	}
 }
 

--- a/backend/internal/usecase/learning_report_usecase.go
+++ b/backend/internal/usecase/learning_report_usecase.go
@@ -1,0 +1,62 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// ListLearningReportsUseCase は current user のレポート一覧を返す。
+type ListLearningReportsUseCase struct {
+	repo repository.LearningReportRepository
+}
+
+func NewListLearningReportsUseCase(r repository.LearningReportRepository) *ListLearningReportsUseCase {
+	return &ListLearningReportsUseCase{repo: r}
+}
+
+func (u *ListLearningReportsUseCase) Execute(ctx context.Context, userID uint64) ([]domain.LearningReport, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	return u.repo.ListByUserID(ctx, userID)
+}
+
+// RequestLearningReportUseCase はレポート生成ジョブを DB に pending 行で作り、SQS に enqueue する。
+type RequestLearningReportUseCase struct {
+	repo  repository.LearningReportRepository
+	queue repository.SqsEnqueuer
+}
+
+func NewRequestLearningReportUseCase(r repository.LearningReportRepository, q repository.SqsEnqueuer) *RequestLearningReportUseCase {
+	return &RequestLearningReportUseCase{repo: r, queue: q}
+}
+
+type RequestLearningReportInput struct {
+	UserID     uint64
+	PeriodFrom time.Time
+	PeriodTo   time.Time
+}
+
+func (u *RequestLearningReportUseCase) Execute(ctx context.Context, in RequestLearningReportInput) (*domain.LearningReport, error) {
+	if in.UserID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	if !in.PeriodTo.After(in.PeriodFrom) {
+		return nil, errors.New("periodTo must be after periodFrom")
+	}
+	r := &domain.LearningReport{
+		UserID: in.UserID, PeriodFrom: in.PeriodFrom, PeriodTo: in.PeriodTo,
+		Status: domain.LearningReportStatusPending,
+	}
+	if err := u.repo.Create(ctx, r); err != nil {
+		return nil, err
+	}
+	if err := u.queue.Enqueue(ctx, r.ID); err != nil {
+		return nil, err
+	}
+	return r, nil
+}

--- a/backend/internal/usecase/learning_report_usecase_test.go
+++ b/backend/internal/usecase/learning_report_usecase_test.go
@@ -1,0 +1,67 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type stubLearningReportRepo struct {
+	rows []domain.LearningReport
+	err  error
+}
+
+func (s *stubLearningReportRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.LearningReport, error) {
+	return s.rows, s.err
+}
+
+func (s *stubLearningReportRepo) Create(_ context.Context, r *domain.LearningReport) error {
+	if s.err != nil {
+		return s.err
+	}
+	r.ID = 51
+	return nil
+}
+
+type stubEnqueuer struct{ err error }
+
+func (s *stubEnqueuer) Enqueue(_ context.Context, _ uint64) error { return s.err }
+
+func TestListLearningReports_RequiresUserID(t *testing.T) {
+	uc := NewListLearningReportsUseCase(&stubLearningReportRepo{})
+	if _, err := uc.Execute(context.Background(), 0); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestRequestLearningReport_Validates(t *testing.T) {
+	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{})
+	now := time.Now()
+	if _, err := uc.Execute(context.Background(), RequestLearningReportInput{UserID: 1, PeriodFrom: now, PeriodTo: now}); err == nil {
+		t.Fatal("expected error for equal periods")
+	}
+}
+
+func TestRequestLearningReport_OK(t *testing.T) {
+	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{})
+	now := time.Now()
+	got, err := uc.Execute(context.Background(), RequestLearningReportInput{
+		UserID: 1, PeriodFrom: now.Add(-24 * time.Hour), PeriodTo: now,
+	})
+	if err != nil || got.Status != domain.LearningReportStatusPending {
+		t.Fatalf("unexpected: %+v err=%v", got, err)
+	}
+}
+
+func TestRequestLearningReport_EnqueueError(t *testing.T) {
+	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{err: errors.New("sqs")})
+	now := time.Now()
+	if _, err := uc.Execute(context.Background(), RequestLearningReportInput{
+		UserID: 1, PeriodFrom: now.Add(-24 * time.Hour), PeriodTo: now,
+	}); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/backend/internal/usecase/repository/learning_report.go
+++ b/backend/internal/usecase/repository/learning_report.go
@@ -1,0 +1,18 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// LearningReportRepository は learning_reports テーブルへのアクセスを提供する。
+type LearningReportRepository interface {
+	ListByUserID(ctx context.Context, userID uint64) ([]domain.LearningReport, error)
+	Create(ctx context.Context, r *domain.LearningReport) error
+}
+
+// SqsEnqueuer はレポート生成ジョブを SQS にキューする。
+type SqsEnqueuer interface {
+	Enqueue(ctx context.Context, reportID uint64) error
+}


### PR DESCRIPTION
## 概要

Java→Go 差し戻し（設計書 `docs/design/2026年/0002` の **G4**）。#1833 で Go から削除した**学習レポート**（一覧 / 月次生成要求）を git 履歴から復元し再配線する。**本 PR は非破壊**（Go 未デプロイ）。

## 変更内容

- **復元（8 ファイル）**: `domain`(LearningReport) / usecase port(`LearningReportRepository` + `SqsEnqueuer`) + 実装 + テスト / `adapter/persistence`（repo + `StubSqsEnqueuer` no-op）/ handler + routes + ハンドラテスト
- `router.go` に `registerLearningReportRoutes` を再登録 / `migrate.go` に `LearningReport` を追加
- repository の読み取り（`ListByUserID`）を **`db.Raw` の生 SQL 直書き**に（`Create` は GORM 維持・ハイブリッド）
- `make openapi` で `/learning-reports` `/learning-reports/generate` を spec に復活

## API

- `GET /learning-reports`（自分のみ・`period_to` 降順）
- `POST /learning-reports/generate`（year+month → `[月初, 翌月初)` で pending 行作成 → SQS enqueue）。現状 enqueuer は **no-op stub**、本番 SQS 実装は別 PR

## テスト

復元した usecase / handler テスト全 PASS。`go build` / `go vet` / `archlint` / `gofumpt -l`(0)。

## 関連 Issue

Refs: 設計書 `docs/design/2026年/0002` の G4