### PR TITLE
feat(backend-go): company settings(trainee への AI トグル)を Go に移植 (G5)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1047,6 +1047,110 @@ const docTemplate = `{
                 }
             }
         },
+        "/company/settings": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の trainee への AI チャット有効化フラグを返す。company_admin / super_admin のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "会社設定 取得 (AI 有効化)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.companySettingsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "会社未所属",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "会社が存在しない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の trainee への AI チャット有効化フラグを更新する。company_admin / super_admin のみ。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "会社設定 更新 (AI 有効化)",
+                "parameters": [
+                    {
+                        "description": "aiChatEnabledForTrainees",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateCompanySettingsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.companySettingsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション / 会社未所属",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/courses": {
             "get": {
                 "security": [
@@ -2991,6 +3095,10 @@ const docTemplate = `{
         "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
             "type": "object",
             "properties": {
+                "aiChatEnabledForTrainees": {
+                    "description": "AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。\ncompany_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。",
+                    "type": "boolean"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -3639,6 +3747,14 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_handler.companySettingsResponse": {
+            "type": "object",
+            "properties": {
+                "aiChatEnabledForTrainees": {
+                    "type": "boolean"
+                }
+            }
+        },
         "internal_handler.courseRequest": {
             "type": "object",
             "properties": {
@@ -3996,6 +4112,18 @@ const docTemplate = `{
             "properties": {
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.updateCompanySettingsRequest": {
+            "type": "object",
+            "required": [
+                "aiChatEnabledForTrainees"
+            ],
+            "properties": {
+                "aiChatEnabledForTrainees": {
+                    "description": "bool の必須を binding:\"required\" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。",
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1040,6 +1040,110 @@
                 }
             }
         },
+        "/company/settings": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の trainee への AI チャット有効化フラグを返す。company_admin / super_admin のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "会社設定 取得 (AI 有効化)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.companySettingsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "会社未所属",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "会社が存在しない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の trainee への AI チャット有効化フラグを更新する。company_admin / super_admin のみ。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "company"
+                ],
+                "summary": "会社設定 更新 (AI 有効化)",
+                "parameters": [
+                    {
+                        "description": "aiChatEnabledForTrainees",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateCompanySettingsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.companySettingsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション / 会社未所属",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/courses": {
             "get": {
                 "security": [
@@ -2984,6 +3088,10 @@
         "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
             "type": "object",
             "properties": {
+                "aiChatEnabledForTrainees": {
+                    "description": "AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。\ncompany_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。",
+                    "type": "boolean"
+                },
                 "createdAt": {
                     "type": "string"
                 },
@@ -3632,6 +3740,14 @@
                 }
             }
         },
+        "internal_handler.companySettingsResponse": {
+            "type": "object",
+            "properties": {
+                "aiChatEnabledForTrainees": {
+                    "type": "boolean"
+                }
+            }
+        },
         "internal_handler.courseRequest": {
             "type": "object",
             "properties": {
@@ -3989,6 +4105,18 @@
             "properties": {
                 "status": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.updateCompanySettingsRequest": {
+            "type": "object",
+            "required": [
+                "aiChatEnabledForTrainees"
+            ],
+            "properties": {
+                "aiChatEnabledForTrainees": {
+                    "description": "bool の必須を binding:\"required\" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。",
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -70,6 +70,11 @@ definitions:
     type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Company:
     properties:
+      aiChatEnabledForTrainees:
+        description: |-
+          AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。
+          company_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。
+        type: boolean
       createdAt:
         type: string
       id:
@@ -500,6 +505,11 @@ definitions:
     required:
     - code
     type: object
+  internal_handler.companySettingsResponse:
+    properties:
+      aiChatEnabledForTrainees:
+        type: boolean
+    type: object
   internal_handler.courseRequest:
     properties:
       description:
@@ -740,6 +750,14 @@ definitions:
         type: string
     required:
     - status
+    type: object
+  internal_handler.updateCompanySettingsRequest:
+    properties:
+      aiChatEnabledForTrainees:
+        description: bool の必須を binding:"required" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。
+        type: boolean
+    required:
+    - aiChatEnabledForTrainees
     type: object
   internal_handler.updateProfileReq:
     properties:
@@ -1446,6 +1464,72 @@ paths:
       summary: 企業利用申請（公開 / 認証不要）
       tags:
       - company-applications
+  /company/settings:
+    get:
+      description: 自社の trainee への AI チャット有効化フラグを返す。company_admin / super_admin のみ。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.companySettingsResponse'
+        "400":
+          description: 会社未所属
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 会社が存在しない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 会社設定 取得 (AI 有効化)
+      tags:
+      - company
+    put:
+      consumes:
+      - application/json
+      description: 自社の trainee への AI チャット有効化フラグを更新する。company_admin / super_admin のみ。
+      parameters:
+      - description: aiChatEnabledForTrainees
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.updateCompanySettingsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.companySettingsResponse'
+        "400":
+          description: バリデーション / 会社未所属
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 会社設定 更新 (AI 有効化)
+      tags:
+      - company
   /courses:
     get:
       description: current user の role / company で 自動 フィルタ。 trainee は published のみ、

--- a/backend/internal/adapter/persistence/company_repository.go
+++ b/backend/internal/adapter/persistence/company_repository.go
@@ -28,3 +28,9 @@ func (r *companyRepository) FindByID(ctx context.Context, id uint64) (*domain.Co
 	}
 	return &c, nil
 }
+
+// UpdateAiChatEnabled は ai_chat_enabled_for_trainees を更新する（生 SQL 直書き / updated_at も更新）。
+func (r *companyRepository) UpdateAiChatEnabled(ctx context.Context, companyID uint64, enabled bool) error {
+	const q = `UPDATE companies SET ai_chat_enabled_for_trainees = ?, updated_at = NOW() WHERE id = ?`
+	return r.db.WithContext(ctx).Exec(q, enabled, companyID).Error
+}

--- a/backend/internal/domain/company.go
+++ b/backend/internal/domain/company.go
@@ -3,10 +3,13 @@ package domain
 import "time"
 
 type Company struct {
-	ID        uint64    `gorm:"primaryKey" json:"id"`
-	Name      string    `gorm:"column:name;not null" json:"name"`
-	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
-	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
+	ID   uint64 `gorm:"primaryKey" json:"id"`
+	Name string `gorm:"column:name;not null" json:"name"`
+	// AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。
+	// company_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。
+	AiChatEnabledForTrainees bool      `gorm:"column:ai_chat_enabled_for_trainees;not null;default:true" json:"aiChatEnabledForTrainees"`
+	CreatedAt                time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt                time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
 func (Company) TableName() string { return "companies" }

--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -23,6 +23,8 @@ func (f *fakeCompanyRepo) FindByID(context.Context, uint64) (*domain.Company, er
 	return nil, f.err
 }
 
+func (f *fakeCompanyRepo) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
+
 func newAdminCompanyHandler(repo *fakeCompanyRepo) *AdminCompanyHandler {
 	return NewAdminCompanyHandler(usecase.NewListCompaniesUseCase(repo))
 }

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -22,21 +22,25 @@ type AuthHandler struct {
 	invitations    repository.AdminInvitationRepository
 	cognitoCfg     *config.CognitoConfig
 	tokens         *cognito.TokenExchanger
+	aiChatAccess   *usecase.AiChatEnabledForUserUseCase
 }
 
 // NewAuthHandler は本番用に http.Client + 10s timeout の TokenExchanger を組み立てて DI する。
 // invitations は招待受諾フロー（初回ログイン時に invitations から role/companyId を反映）に使う。nil 可。
+// aiChatAccess は /auth/me で aiChatEnabledForTrainees を算出するのに使う。nil 可（その場合は既定 true）。
 func NewAuthHandler(
 	getCurrentUser *usecase.GetCurrentUserUseCase,
 	users repository.UserRepository,
 	invitations repository.AdminInvitationRepository,
 	cognitoCfg *config.CognitoConfig,
+	aiChatAccess *usecase.AiChatEnabledForUserUseCase,
 ) *AuthHandler {
 	return &AuthHandler{
 		getCurrentUser: getCurrentUser,
 		users:          users,
 		invitations:    invitations,
 		cognitoCfg:     cognitoCfg,
+		aiChatAccess:   aiChatAccess,
 		tokens: cognito.NewTokenExchanger(cognito.Config{
 			ClientID:     cognitoCfg.ClientID,
 			ClientSecret: cognitoCfg.ClientSecret,
@@ -84,6 +88,13 @@ func (h *AuthHandler) Me(c *gin.Context) {
 			_ = h.users.UpdateRole(c.Request.Context(), user.ID, domain.RoleSuperAdmin)
 		}
 	}
+	// trainee への AI チャット表示判定。会社設定が無効なら false。算出失敗・未配線時は既定 true。
+	aiEnabled := true
+	if h.aiChatAccess != nil {
+		if ok, err := h.aiChatAccess.Execute(c.Request.Context(), user); err == nil {
+			aiEnabled = ok
+		}
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"id":          user.ID,
 		"cognitoSub":  user.CognitoSub,
@@ -97,6 +108,8 @@ func (h *AuthHandler) Me(c *gin.Context) {
 		"isAdmin":     isAdmin,
 		// onboarded: フロントの /welcome リダイレクト判定に使う。
 		"onboarded": user.OnboardedAt != nil,
+		// aiChatEnabledForTrainees: フロントのサイドバー AI 表示判定に使う。
+		"aiChatEnabledForTrainees": aiEnabled,
 	})
 }
 

--- a/backend/internal/handler/company_settings_handler.go
+++ b/backend/internal/handler/company_settings_handler.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// CompanySettingsHandler は会社単位の設定（trainee への AI 有効化）の取得・更新を扱う。
+type CompanySettingsHandler struct {
+	get    *usecase.GetCompanyAiChatSettingUseCase
+	update *usecase.UpdateCompanyAiChatSettingUseCase
+}
+
+func NewCompanySettingsHandler(
+	get *usecase.GetCompanyAiChatSettingUseCase,
+	update *usecase.UpdateCompanyAiChatSettingUseCase,
+) *CompanySettingsHandler {
+	return &CompanySettingsHandler{get: get, update: update}
+}
+
+type companySettingsResponse struct {
+	AiChatEnabledForTrainees bool `json:"aiChatEnabledForTrainees"`
+}
+
+type updateCompanySettingsRequest struct {
+	// bool の必須を binding:"required" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。
+	AiChatEnabledForTrainees *bool `json:"aiChatEnabledForTrainees" binding:"required"`
+}
+
+// Get は自社の AI 有効化フラグを返す。
+//
+//	@Summary      会社設定 取得 (AI 有効化)
+//	@Description  自社の trainee への AI チャット有効化フラグを返す。company_admin / super_admin のみ。
+//	@Tags         company
+//	@Produce      json
+//	@Success      200  {object}  companySettingsResponse
+//	@Failure      400  {object}  errorResponse  "会社未所属"
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "管理者以外"
+//	@Failure      404  {object}  errorResponse  "会社が存在しない"
+//	@Router       /company/settings [get]
+//	@Security     CookieAuth
+func (h *CompanySettingsHandler) Get(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	enabled, err := h.get.Execute(c.Request.Context(), actor)
+	if err != nil {
+		h.writeErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, companySettingsResponse{AiChatEnabledForTrainees: enabled})
+}
+
+// Update は自社の AI 有効化フラグを更新する。
+//
+//	@Summary      会社設定 更新 (AI 有効化)
+//	@Description  自社の trainee への AI チャット有効化フラグを更新する。company_admin / super_admin のみ。
+//	@Tags         company
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body      updateCompanySettingsRequest  true  "aiChatEnabledForTrainees"
+//	@Success      200   {object}  companySettingsResponse
+//	@Failure      400   {object}  errorResponse  "バリデーション / 会社未所属"
+//	@Failure      401   {object}  errorResponse  "未認証"
+//	@Failure      403   {object}  errorResponse  "管理者以外"
+//	@Router       /company/settings [put]
+//	@Security     CookieAuth
+func (h *CompanySettingsHandler) Update(c *gin.Context) {
+	var req updateCompanySettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	actor := middleware.CurrentUserFromContext(c)
+	enabled, err := h.update.Execute(c.Request.Context(), actor, *req.AiChatEnabledForTrainees)
+	if err != nil {
+		h.writeErr(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, companySettingsResponse{AiChatEnabledForTrainees: enabled})
+}
+
+func (h *CompanySettingsHandler) writeErr(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, usecase.ErrCompanySettingsForbidden):
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	case errors.Is(err, usecase.ErrCompanySettingsNoCompany):
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no_company"})
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": "company_not_found"})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+	}
+}

--- a/backend/internal/handler/company_settings_handler_test.go
+++ b/backend/internal/handler/company_settings_handler_test.go
@@ -1,0 +1,118 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// settingsCompanyRepo は CompanyRepository の最小スタブ。
+type settingsCompanyRepo struct {
+	company *domain.Company
+	updated *bool
+}
+
+func (s *settingsCompanyRepo) ListAll(_ context.Context) ([]domain.Company, error) { return nil, nil }
+
+func (s *settingsCompanyRepo) FindByID(_ context.Context, _ uint64) (*domain.Company, error) {
+	return s.company, nil
+}
+
+func (s *settingsCompanyRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, enabled bool) error {
+	s.updated = &enabled
+	return nil
+}
+
+// newCompanySettingsTestRouter は context に actor を注入してから company settings ルートを通す。
+func newCompanySettingsTestRouter(repo *settingsCompanyRepo, actor *domain.User) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	h := NewCompanySettingsHandler(
+		usecase.NewGetCompanyAiChatSettingUseCase(repo),
+		usecase.NewUpdateCompanyAiChatSettingUseCase(repo),
+	)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if actor != nil {
+			c.Set(middleware.ContextKeyCurrentUser, actor)
+		}
+		c.Next()
+	})
+	r.GET("/company/settings", h.Get)
+	r.PUT("/company/settings", h.Update)
+	return r
+}
+
+func TestCompanySettingsHandler_Get_Admin(t *testing.T) {
+	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1, AiChatEnabledForTrainees: false}}
+	actor := &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(1)}
+	r := newCompanySettingsTestRouter(repo, actor)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/company/settings", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body map[string]bool
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["aiChatEnabledForTrainees"] != false {
+		t.Errorf("aiChatEnabledForTrainees = %v, want false", body["aiChatEnabledForTrainees"])
+	}
+}
+
+func TestCompanySettingsHandler_Get_TraineeForbidden(t *testing.T) {
+	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1}}
+	actor := &domain.User{Role: domain.RoleTrainee, CompanyID: u64ptr(1)}
+	r := newCompanySettingsTestRouter(repo, actor)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/company/settings", nil))
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestCompanySettingsHandler_Update_Admin(t *testing.T) {
+	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1, AiChatEnabledForTrainees: true}}
+	actor := &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(1)}
+	r := newCompanySettingsTestRouter(repo, actor)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/company/settings", strings.NewReader(`{"aiChatEnabledForTrainees":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if repo.updated == nil || *repo.updated != false {
+		t.Errorf("UpdateAiChatEnabled が false で呼ばれていない: %v", repo.updated)
+	}
+}
+
+func TestCompanySettingsHandler_Update_MissingBody(t *testing.T) {
+	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1}}
+	actor := &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(1)}
+	r := newCompanySettingsTestRouter(repo, actor)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/company/settings", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func u64ptr(v uint64) *uint64 { return &v }

--- a/backend/internal/handler/middleware/ai_chat_access.go
+++ b/backend/internal/handler/middleware/ai_chat_access.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// RequireAiChatEnabled は ai-chat 系エンドポイントの入口で、会社設定により trainee の AI 利用が
+// 無効化されていれば 403 で弾く横断ゲート。管理者・会社未所属は常に通す（判定は usecase に委譲）。
+// 認可の前提として、先に CurrentUser ミドルウェアが *domain.User を context に入れている必要がある。
+func RequireAiChatEnabled(checker *usecase.AiChatEnabledForUserUseCase) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		user, _ := c.Get(ContextKeyCurrentUser)
+		u, _ := user.(*domain.User)
+		allowed, err := checker.Execute(c.Request.Context(), u)
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+			return
+		}
+		if !allowed {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "ai_chat_disabled_for_company"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -87,6 +87,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerCourseRoutes(authed, deps)
 	registerTeachingMaterialRoutes(authed, deps)
 	registerLearningReportRoutes(authed, deps)
+	registerCompanySettingsRoutes(authed, deps)
 	registerCompanyApplicationAdminRoutes(authed, companyAppHandler)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 	return r

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -13,7 +13,8 @@ import (
 func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
 	invitations := persistence.NewAdminInvitationRepository(deps.db)
-	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito)
+	aiAccess := usecase.NewAiChatEnabledForUserUseCase(persistence.NewCompanyRepository(deps.db))
+	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito, aiAccess)
 
 	g.POST("/auth/logout", authHandler.Logout)
 	// login（認可コード→token 交換）は認証不要のため、総当たり緩和に per-IP 制限を掛ける。

--- a/backend/internal/handler/routes_chat.go
+++ b/backend/internal/handler/routes_chat.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	infraS3 "github.com/norman6464/FreStyle/backend/internal/infra/s3"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 // registerChatRoutes は AI チャットセッションの REST + SSE エンドポイントを登録する。
+// 会社設定で trainee の AI 利用が無効化されている場合は RequireAiChatEnabled ゲートで 403。
 func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	aiSessionRepo := persistence.NewAiChatSessionRepository(deps.db)
 	aiHandler := NewAiChatHandler(
@@ -22,19 +24,25 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 		usecase.NewDeleteAiChatSessionUseCase(aiSessionRepo),
 		usecase.NewGetAiChatMessagesUseCase(deps.msgRepo),
 	)
-	g.GET("/ai-chat/sessions", aiHandler.GetSessions)
-	g.POST("/ai-chat/sessions", aiHandler.CreateSession)
-	g.GET("/ai-chat/sessions/:id", aiHandler.GetSession)
-	g.PUT("/ai-chat/sessions/:id", aiHandler.UpdateSessionTitle)
-	g.DELETE("/ai-chat/sessions/:id", aiHandler.DeleteSession)
-	g.GET("/ai-chat/sessions/:id/messages", aiHandler.GetMessages)
+
+	// ai-chat 配下は会社の AI 有効化ゲートを通す（管理者・会社未所属は常に通過）。
+	gate := usecase.NewAiChatEnabledForUserUseCase(persistence.NewCompanyRepository(deps.db))
+	chat := g.Group("")
+	chat.Use(middleware.RequireAiChatEnabled(gate))
+
+	chat.GET("/ai-chat/sessions", aiHandler.GetSessions)
+	chat.POST("/ai-chat/sessions", aiHandler.CreateSession)
+	chat.GET("/ai-chat/sessions/:id", aiHandler.GetSession)
+	chat.PUT("/ai-chat/sessions/:id", aiHandler.UpdateSessionTitle)
+	chat.DELETE("/ai-chat/sessions/:id", aiHandler.DeleteSession)
+	chat.GET("/ai-chat/sessions/:id/messages", aiHandler.GetMessages)
 
 	// 添付用 presigned PUT URL。note image と同じバケットを ai-chat/ prefix で再利用する。
 	attachmentPresigner := newAiChatAttachmentPresignerOrFallback(deps)
 	attachmentHandler := NewAiChatAttachmentHandler(
 		usecase.NewIssueAiChatAttachmentUploadURLUseCase(attachmentPresigner),
 	)
-	g.POST("/ai-chat/attachments/upload-url", attachmentHandler.IssueUploadURL)
+	chat.POST("/ai-chat/attachments/upload-url", attachmentHandler.IssueUploadURL)
 
 	// SSE ストリーミング。Bedrock / DynamoDB 初期化失敗時は nil なので登録自体をスキップする。
 	if deps.bedrockClient != nil && deps.msgRepo != nil {
@@ -42,7 +50,7 @@ func registerChatRoutes(g *gin.RouterGroup, deps *routeDeps) {
 		sseHandler := NewAiChatSseHandler(
 			usecase.NewSendAiMessageStreamUseCase(aiSessionRepo, deps.msgRepo, deps.bedrockClient, downloader),
 		)
-		g.POST("/ai-chat/stream", sseHandler.Handle)
+		chat.POST("/ai-chat/stream", sseHandler.Handle)
 	}
 }
 

--- a/backend/internal/handler/routes_company_settings.go
+++ b/backend/internal/handler/routes_company_settings.go
@@ -1,0 +1,19 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerCompanySettingsRoutes は会社設定（trainee への AI 有効化）の取得・更新を登録する。
+func registerCompanySettingsRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	companies := persistence.NewCompanyRepository(deps.db)
+	h := NewCompanySettingsHandler(
+		usecase.NewGetCompanyAiChatSettingUseCase(companies),
+		usecase.NewUpdateCompanyAiChatSettingUseCase(companies),
+	)
+	g.GET("/company/settings", h.Get)
+	g.PUT("/company/settings", h.Update)
+}

--- a/backend/internal/usecase/ai_chat_access_usecase.go
+++ b/backend/internal/usecase/ai_chat_access_usecase.go
@@ -1,0 +1,46 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// AiChatEnabledForUserUseCase は「この user が AI チャットを使ってよいか」を判定する認可ポリシー。
+// /auth/me の表示判定と、ai-chat 系エンドポイントの入口ゲート(middleware)の両方で使う。
+//
+// ルール: company_admin / super_admin は会社設定に関わらず常に true（自社設定確認のため自分で使う）。
+// 会社未所属(company_id=null)も true。それ以外は自社の ai_chat_enabled_for_trainees に従う
+// （会社行が見つからないときは安全側に倒さず既定 true）。
+type AiChatEnabledForUserUseCase struct {
+	companies repository.CompanyRepository
+}
+
+func NewAiChatEnabledForUserUseCase(c repository.CompanyRepository) *AiChatEnabledForUserUseCase {
+	return &AiChatEnabledForUserUseCase{companies: c}
+}
+
+// Execute は user が AI チャットを使えるかを返す。actor は middleware が context に入れた *domain.User。
+func (uc *AiChatEnabledForUserUseCase) Execute(ctx context.Context, user *domain.User) (bool, error) {
+	if user == nil {
+		return false, nil
+	}
+	if isCompanyAdminRole(user.Role) {
+		return true, nil
+	}
+	if user.CompanyID == nil {
+		return true, nil
+	}
+	company, err := uc.companies.FindByID(ctx, *user.CompanyID)
+	if err != nil {
+		// 会社行が無い場合は既定 true（後方互換）。それ以外の DB エラーは伝搬する。
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return true, nil
+		}
+		return false, err
+	}
+	return company.AiChatEnabledForTrainees, nil
+}

--- a/backend/internal/usecase/company_settings_usecase.go
+++ b/backend/internal/usecase/company_settings_usecase.go
@@ -1,0 +1,68 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// 会社設定（trainee への AI 有効化）の操作で返すセンチネルエラー。handler が HTTP ステータスに分岐する。
+var (
+	// ErrCompanySettingsForbidden は company_admin / super_admin 以外が操作したとき。403。
+	ErrCompanySettingsForbidden = errors.New("forbidden")
+	// ErrCompanySettingsNoCompany は actor が会社未所属（company_id=null）のとき。400。
+	ErrCompanySettingsNoCompany = errors.New("no_company")
+)
+
+func isCompanyAdminRole(role string) bool {
+	return role == domain.RoleCompanyAdmin || role == domain.RoleSuperAdmin
+}
+
+// GetCompanyAiChatSettingUseCase は自社の AI 有効化フラグを取得する（company_admin / super_admin のみ）。
+type GetCompanyAiChatSettingUseCase struct {
+	companies repository.CompanyRepository
+}
+
+func NewGetCompanyAiChatSettingUseCase(c repository.CompanyRepository) *GetCompanyAiChatSettingUseCase {
+	return &GetCompanyAiChatSettingUseCase{companies: c}
+}
+
+// Execute は actor の自社設定を返す。actor は middleware が context に入れた *domain.User。
+func (uc *GetCompanyAiChatSettingUseCase) Execute(ctx context.Context, actor *domain.User) (bool, error) {
+	if actor == nil || !isCompanyAdminRole(actor.Role) {
+		return false, ErrCompanySettingsForbidden
+	}
+	if actor.CompanyID == nil {
+		return false, ErrCompanySettingsNoCompany
+	}
+	company, err := uc.companies.FindByID(ctx, *actor.CompanyID)
+	if err != nil {
+		return false, err
+	}
+	return company.AiChatEnabledForTrainees, nil
+}
+
+// UpdateCompanyAiChatSettingUseCase は自社の AI 有効化フラグを更新する（company_admin / super_admin のみ）。
+type UpdateCompanyAiChatSettingUseCase struct {
+	companies repository.CompanyRepository
+}
+
+func NewUpdateCompanyAiChatSettingUseCase(c repository.CompanyRepository) *UpdateCompanyAiChatSettingUseCase {
+	return &UpdateCompanyAiChatSettingUseCase{companies: c}
+}
+
+// Execute は actor の自社フラグを enabled に更新し、更新後の値を返す。
+func (uc *UpdateCompanyAiChatSettingUseCase) Execute(ctx context.Context, actor *domain.User, enabled bool) (bool, error) {
+	if actor == nil || !isCompanyAdminRole(actor.Role) {
+		return false, ErrCompanySettingsForbidden
+	}
+	if actor.CompanyID == nil {
+		return false, ErrCompanySettingsNoCompany
+	}
+	if err := uc.companies.UpdateAiChatEnabled(ctx, *actor.CompanyID, enabled); err != nil {
+		return false, err
+	}
+	return enabled, nil
+}

--- a/backend/internal/usecase/company_settings_usecase_test.go
+++ b/backend/internal/usecase/company_settings_usecase_test.go
@@ -1,0 +1,105 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// settingsCompanyRepo は CompanyRepository の最小スタブ（state 検証・古典派）。
+type settingsCompanyRepo struct {
+	company    *domain.Company
+	findErr    error
+	lastEnable *bool
+}
+
+func (s *settingsCompanyRepo) ListAll(context.Context) ([]domain.Company, error) { return nil, nil }
+func (s *settingsCompanyRepo) FindByID(context.Context, uint64) (*domain.Company, error) {
+	return s.company, s.findErr
+}
+
+func (s *settingsCompanyRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, enabled bool) error {
+	s.lastEnable = &enabled
+	return nil
+}
+
+func u64p(v uint64) *uint64 { return &v }
+
+func TestGetCompanyAiChatSetting(t *testing.T) {
+	t.Run("trainee は forbidden", func(t *testing.T) {
+		uc := usecase.NewGetCompanyAiChatSettingUseCase(&settingsCompanyRepo{})
+		_, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1)})
+		require.ErrorIs(t, err, usecase.ErrCompanySettingsForbidden)
+	})
+
+	t.Run("会社未所属の admin は no_company", func(t *testing.T) {
+		uc := usecase.NewGetCompanyAiChatSettingUseCase(&settingsCompanyRepo{})
+		_, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: nil})
+		require.ErrorIs(t, err, usecase.ErrCompanySettingsNoCompany)
+	})
+
+	t.Run("admin は自社フラグを取得", func(t *testing.T) {
+		repo := &settingsCompanyRepo{company: &domain.Company{ID: 1, AiChatEnabledForTrainees: false}}
+		uc := usecase.NewGetCompanyAiChatSettingUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64p(1)})
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+}
+
+func TestUpdateCompanyAiChatSetting(t *testing.T) {
+	t.Run("非 admin は forbidden", func(t *testing.T) {
+		uc := usecase.NewUpdateCompanyAiChatSettingUseCase(&settingsCompanyRepo{})
+		_, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1)}, false)
+		require.ErrorIs(t, err, usecase.ErrCompanySettingsForbidden)
+	})
+
+	t.Run("admin はフラグを更新する", func(t *testing.T) {
+		repo := &settingsCompanyRepo{}
+		uc := usecase.NewUpdateCompanyAiChatSettingUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleSuperAdmin, CompanyID: u64p(7)}, false)
+		require.NoError(t, err)
+		assert.False(t, got)
+		require.NotNil(t, repo.lastEnable)
+		assert.False(t, *repo.lastEnable)
+	})
+}
+
+func TestAiChatEnabledForUser(t *testing.T) {
+	t.Run("admin は会社設定に関わらず常に true", func(t *testing.T) {
+		repo := &settingsCompanyRepo{company: &domain.Company{AiChatEnabledForTrainees: false}}
+		uc := usecase.NewAiChatEnabledForUserUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64p(1)})
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("会社未所属の trainee は true", func(t *testing.T) {
+		uc := usecase.NewAiChatEnabledForUserUseCase(&settingsCompanyRepo{})
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: nil})
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("trainee は自社フラグに従う(false)", func(t *testing.T) {
+		repo := &settingsCompanyRepo{company: &domain.Company{AiChatEnabledForTrainees: false}}
+		uc := usecase.NewAiChatEnabledForUserUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1)})
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("会社行が無い(RecordNotFound)なら既定 true", func(t *testing.T) {
+		repo := &settingsCompanyRepo{findErr: gorm.ErrRecordNotFound}
+		uc := usecase.NewAiChatEnabledForUserUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(99)})
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+}

--- a/backend/internal/usecase/repository/company.go
+++ b/backend/internal/usecase/repository/company.go
@@ -10,4 +10,6 @@ import (
 type CompanyRepository interface {
 	ListAll(ctx context.Context) ([]domain.Company, error)
 	FindByID(ctx context.Context, id uint64) (*domain.Company, error)
+	// UpdateAiChatEnabled は trainee への AI チャット許可フラグを更新する。
+	UpdateAiChatEnabled(ctx context.Context, companyID uint64, enabled bool) error
 }

--- a/backend/internal/usecase/validate_invitation_token_usecase_test.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase_test.go
@@ -13,7 +13,8 @@ type stubCompanies struct {
 	err  error
 }
 
-func (s *stubCompanies) ListAll(_ context.Context) ([]domain.Company, error) { return nil, s.err }
+func (s *stubCompanies) ListAll(_ context.Context) ([]domain.Company, error)     { return nil, s.err }
+func (s *stubCompanies) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
 func (s *stubCompanies) FindByID(_ context.Context, id uint64) (*domain.Company, error) {
 	if s.err != nil {
 		return nil, s.err


### PR DESCRIPTION
## 概要

Java→Go 差し戻し（設計書 `docs/design/2026年/0002` の **G5**）。Java 専用だった**会社単位の AI 有効化トグル**（#1851）を Go に新規実装する（Go には無かったため git 復元ではなく移植）。**本 PR は非破壊**（Go 未デプロイ）。

## 変更内容

- `domain.Company` に `ai_chat_enabled_for_trainees`（既定 true）を追加。AutoMigrate が列を追加
- `CompanyRepository` に `UpdateAiChatEnabled`（生 SQL UPDATE）を追加
- **usecase**:
  - `GetCompanyAiChatSetting` / `UpdateCompanyAiChatSetting`（company_admin・super_admin のみ。trainee は 403 / 会社未所属は 400）
  - `AiChatEnabledForUser`（認可ポリシー: 管理者・会社未所属は常に true、それ以外は会社フラグ。会社行が無ければ既定 true）
- **handler**: `CompanySettingsHandler` `GET`/`PUT` `/company/settings`
- `middleware.RequireAiChatEnabled` を **ai-chat 配下に適用**（会社で無効なら 403 `ai_chat_disabled_for_company`）
- **`/auth/me` に `aiChatEnabledForTrainees` を露出**（フロントのサイドバー AI 表示判定）
- `make openapi` で `/company/settings` を spec に追加

## frontend 整合

frontend は #1851 で UI / authSlice 実装済のため、本 API（`/company/settings`）と `/auth/me` の `aiChatEnabledForTrainees` で整合する。

## テスト

古典派スタイル（usecase は state 検証の手書き fake、handler は `httptest` + context に actor 注入）で usecase / handler テストを追加。`go build` / `go vet` / `archlint` / `gofumpt -l`(0) / 全テスト PASS。

## 関連 Issue

Refs: 設計書 `docs/design/2026年/0002` の G5