### PR TITLE
feat(auth): メール/パスワードログインを Go で実装 + ログイン画面を従来フォームへ復元

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -817,7 +817,7 @@ const docTemplate = `{
                         }
                     },
                     "500": {
-                        "description": "Cognito 未 設定",
+                        "description": "内部 エラー (Cognito 未 設定 / DB 失敗 等)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -4067,7 +4067,8 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "email"
                 },
                 "password": {
                     "type": "string"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -755,6 +755,82 @@ const docTemplate = `{
                 }
             }
         },
+        "/auth/cognito/login": {
+            "post": {
+                "description": "email / password を Cognito の USER_PASSWORD_AUTH で 検証 し、 access / refresh token を HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "ログイン (メール / パスワード)",
+                "parameters": [
+                    {
+                        "description": "メール / パスワード",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.passwordLoginReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.messageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "入力 不正 (email 形式 / password 欠落)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "資格 情報 誤り",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "招待 なし の 新規 user",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Cognito 未 設定",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Cognito 到達 不可",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/login": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
@@ -3979,6 +4055,21 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.passwordLoginReq": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -810,7 +810,7 @@
                         }
                     },
                     "500": {
-                        "description": "Cognito 未 設定",
+                        "description": "内部 エラー (Cognito 未 設定 / DB 失敗 等)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -4060,7 +4060,8 @@
             ],
             "properties": {
                 "email": {
-                    "type": "string"
+                    "type": "string",
+                    "format": "email"
                 },
                 "password": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -748,6 +748,82 @@
                 }
             }
         },
+        "/auth/cognito/login": {
+            "post": {
+                "description": "email / password を Cognito の USER_PASSWORD_AUTH で 検証 し、 access / refresh token を HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "ログイン (メール / パスワード)",
+                "parameters": [
+                    {
+                        "description": "メール / パスワード",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.passwordLoginReq"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.messageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "入力 不正 (email 形式 / password 欠落)",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "資格 情報 誤り",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "招待 なし の 新規 user",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        },
+                        "headers": {
+                            "Retry-After": {
+                                "type": "string",
+                                "description": "再試行までの秒数 (例: 60)"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Cognito 未 設定",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Cognito 到達 不可",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/login": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
@@ -3972,6 +4048,21 @@
                     "type": "boolean"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.passwordLoginReq": {
+            "type": "object",
+            "required": [
+                "email",
+                "password"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -667,6 +667,7 @@ definitions:
   internal_handler.passwordLoginReq:
     properties:
       email:
+        format: email
         type: string
       password:
         type: string
@@ -1321,7 +1322,7 @@ paths:
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":
-          description: Cognito 未 設定
+          description: 内部 エラー (Cognito 未 設定 / DB 失敗 等)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "502":

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -664,6 +664,16 @@ definitions:
     required:
     - title
     type: object
+  internal_handler.passwordLoginReq:
+    properties:
+      email:
+        type: string
+      password:
+        type: string
+    required:
+    - email
+    - password
+    type: object
   internal_handler.requestReportReq:
     properties:
       month:
@@ -1269,6 +1279,58 @@ paths:
       summary: AI チャット SSE ストリーミング
       tags:
       - ai-chat
+  /auth/cognito/login:
+    post:
+      consumes:
+      - application/json
+      description: email / password を Cognito の USER_PASSWORD_AUTH で 検証 し、 access
+        / refresh token を HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group
+        必須。
+      parameters:
+      - description: メール / パスワード
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.passwordLoginReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.messageResponse'
+        "400":
+          description: 入力 不正 (email 形式 / password 欠落)
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 資格 情報 誤り
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 招待 なし の 新規 user
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "429":
+          description: レート制限超過
+          headers:
+            Retry-After:
+              description: '再試行までの秒数 (例: 60)'
+              type: string
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: Cognito 未 設定
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "502":
+          description: Cognito 到達 不可
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      summary: ログイン (メール / パスワード)
+      tags:
+      - auth
   /auth/login:
     post:
       consumes:

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.21
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.47
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.61.4
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.103.3
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.4

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 h1:VTGy885W5DKBxWRUJbym9hytNaY
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30/go.mod h1:AS0HycUvJRFvTt613AYDOgO2jzw+00cVSMny8XB3yMY=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5 h1:gWz8Ax1W8BXOoWe3obsIF4ueAY39u9A+NzsY4jppoIw=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.53.5/go.mod h1:8m0vIhh44Mmgb+x5o2WzTt0T5NKVtTBhO1j+t7AyvJI=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.61.4 h1:KDPcknxnbdpcAU04wq+9wfDW4Yoo9h0tsO8Uv+oES4c=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.61.4/go.mod h1:fhiInRlq2MkbUqzDYoWLF+dE/NdEg24s9TML5FcSwhA=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0 h1:S1qETDbdXKZMYVveuxACCKuRqnAt2NlnmYnlq5SeuMY=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.0/go.mod h1:jLkDwIDBkCIpiENQhAOjAR2L9jwj56mZgVEvuro4gUE=
 github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.33.0 h1:3YaU3v3ybVnz+JRVJR19Y4EnEGebVHGKyo4rezXuGJo=

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 
@@ -137,7 +138,7 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 }
 
 type passwordLoginReq struct {
-	Email    string `json:"email" binding:"required,email"`
+	Email    string `json:"email" binding:"required,email" format:"email"`
 	Password string `json:"password" binding:"required"`
 }
 
@@ -154,7 +155,7 @@ type passwordLoginReq struct {
 //	@Failure      400   {object}  errorResponse  "入力 不正 (email 形式 / password 欠落)"
 //	@Failure      401   {object}  errorResponse  "資格 情報 誤り"
 //	@Failure      403   {object}  errorResponse  "招待 なし の 新規 user"
-//	@Failure      500   {object}  errorResponse  "Cognito 未 設定"
+//	@Failure      500   {object}  errorResponse  "内部 エラー (Cognito 未 設定 / DB 失敗 等)"
 //	@Failure      502   {object}  errorResponse  "Cognito 到達 不可"
 //	@Failure      429   {object}  errorResponse  "レート制限超過"
 //	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
@@ -187,8 +188,15 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
 	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
-	// Callback と同じ招待ゲート。拒否された新規ユーザーは Cookie をクリアしてセッションを残さない。
-	if allowed := h.upsertUserFromIDToken(c, tok.IDToken, ""); !allowed {
+	// Callback と同じ招待ゲート。内部エラー(DB/decode)は 500、招待拒否は 403 に切り分ける。
+	allowed, upErr := h.upsertUserFromIDToken(c, tok.IDToken, "")
+	if upErr != nil {
+		log.Printf("cognito password login: upsert failed: %v", upErr)
+		middleware.ClearAuthCookies(c)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	if !allowed {
 		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "invitation_required",
@@ -241,8 +249,15 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
 	// 初回ログインで users 行が無いと /auth/me が 404 になるため upsert する。
-	// 拒否された新規ユーザーは Cookie をクリアしてセッションを残さない。
-	if allowed := h.upsertUserFromIDToken(c, tok.IDToken, req.InvitationToken); !allowed {
+	// 内部エラー(DB/decode)は 500、招待拒否は 403。拒否時は Cookie をクリアしてセッションを残さない。
+	allowed, upErr := h.upsertUserFromIDToken(c, tok.IDToken, req.InvitationToken)
+	if upErr != nil {
+		log.Printf("cognito callback: upsert failed: %v", upErr)
+		middleware.ClearAuthCookies(c)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	if !allowed {
 		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "invitation_required",
@@ -292,7 +307,8 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	// id_token があれば DB role を同期する。無ければ access_token の claims から昇格を試みる
 	// （federated ユーザーは id_token に groups が無いことがある）。refresh は既存ユーザー前提。
 	if tok.IDToken != "" {
-		_ = h.upsertUserFromIDToken(c, tok.IDToken, "")
+		// refresh は既存ユーザー前提。role 同期の best-effort なので結果は無視する。
+		_, _ = h.upsertUserFromIDToken(c, tok.IDToken, "")
 	} else {
 		h.syncRoleFromAccessToken(c, tok.AccessToken)
 	}
@@ -352,17 +368,22 @@ func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (in
 }
 
 // upsertUserFromIDToken は id_token の claim から users 行を新規作成 / role 更新する。
-// allowed=false は「招待なし & Cognito admin でもない」新規ユーザー（ログイン拒否）または create 失敗。
+// 戻り値は (allowed, err)。allowed=false かつ err=nil は「招待なし & Cognito admin でもない」新規
+// ユーザーの **ログイン拒否（403）** を表す。err!=nil は decode 失敗 / DB 失敗等の **内部エラー（500）**で、
+// 招待拒否と切り分けて呼び元がレスポンスを出し分けられるようにする。
 // invitationToken 指定時は email より優先して照合する（同 email 複数 pending での誤一致防止）。
 // 招待ゲートを handler 層に置くのは、Cookie 発行 / 401-403 を返す認可境界が HTTP 層だから。
-func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationToken string) (allowed bool) {
-	claims, err := middleware.DecodeClaims(idToken)
-	if err != nil || h.users == nil {
-		return false
+func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationToken string) (allowed bool, err error) {
+	claims, derr := middleware.DecodeClaims(idToken)
+	if derr != nil {
+		return false, fmt.Errorf("decode id_token: %w", derr)
+	}
+	if h.users == nil {
+		return false, errors.New("user repository not configured")
 	}
 	sub, _ := claims["sub"].(string)
 	if sub == "" {
-		return false
+		return false, errors.New("id_token missing sub")
 	}
 	email, _ := claims["email"].(string)
 	// OIDC 経由は id_token に name を含む（Cognito SRP では無いこともあるので空許容）。
@@ -413,13 +434,13 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 			// 招待を accepted にマーク（再利用防止 + 監査）。
 			_ = h.invitations.UpdateStatus(c.Request.Context(), inv.ID, domain.InvitationStatusAccepted)
 		}
-		return true
+		return true, nil
 	}
 
-	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否。
+	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否（403、内部エラーではない）。
 	if !isCognitoAdmin && inv == nil {
 		log.Printf("upsertUserFromIDToken: signup blocked — no invitation and not Cognito admin sub=%s email=%s token_provided=%t", sub, email, invitationToken != "")
-		return false
+		return false, nil
 	}
 
 	role := domain.RoleTrainee
@@ -454,11 +475,11 @@ func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationT
 		CompanyID:   companyID,
 	}); err != nil {
 		log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
-		return false
+		return false, fmt.Errorf("create user: %w", err)
 	}
 	// 招待を accepted にマーク（履歴・監査）。
 	if h.invitations != nil && acceptedInvID != 0 {
 		_ = h.invitations.UpdateStatus(c.Request.Context(), acceptedInvID, domain.InvitationStatusAccepted)
 	}
-	return true
+	return true, nil
 }

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
@@ -14,6 +15,12 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
+// passwordAuthenticator は email / password を Cognito で検証して token を返す境界。
+// infra/cognito.PasswordAuthenticator が実装し、テストでは fake を注入する。
+type passwordAuthenticator interface {
+	Authenticate(ctx context.Context, email, password string) (*cognito.Token, error)
+}
+
 // AuthHandler は Cognito 関連の認証エンドポイントを提供する。
 // OAuth2 通信は infra/cognito.TokenExchanger に切り出し、ここは HTTP 境界と user upsert だけを持つ。
 type AuthHandler struct {
@@ -22,6 +29,7 @@ type AuthHandler struct {
 	invitations    repository.AdminInvitationRepository
 	cognitoCfg     *config.CognitoConfig
 	tokens         *cognito.TokenExchanger
+	passwordAuth   passwordAuthenticator
 	aiChatAccess   *usecase.AiChatEnabledForUserUseCase
 }
 
@@ -33,6 +41,7 @@ func NewAuthHandler(
 	users repository.UserRepository,
 	invitations repository.AdminInvitationRepository,
 	cognitoCfg *config.CognitoConfig,
+	passwordAuth passwordAuthenticator,
 	aiChatAccess *usecase.AiChatEnabledForUserUseCase,
 ) *AuthHandler {
 	return &AuthHandler{
@@ -40,6 +49,7 @@ func NewAuthHandler(
 		users:          users,
 		invitations:    invitations,
 		cognitoCfg:     cognitoCfg,
+		passwordAuth:   passwordAuth,
 		aiChatAccess:   aiChatAccess,
 		tokens: cognito.NewTokenExchanger(cognito.Config{
 			ClientID:     cognitoCfg.ClientID,
@@ -124,6 +134,70 @@ func (h *AuthHandler) Me(c *gin.Context) {
 func (h *AuthHandler) Logout(c *gin.Context) {
 	middleware.ClearAuthCookies(c)
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウトしました。"})
+}
+
+type passwordLoginReq struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required"`
+}
+
+// Login は email / password を Cognito(USER_PASSWORD_AUTH)で検証して HttpOnly Cookie を発行する。
+// Hosted UI を経由しないアプリ内ログインフォーム用。招待ゲートは Callback と同じく upsert 側で効かせる。
+//
+//	@Summary      ログイン (メール / パスワード)
+//	@Description  email / password を Cognito の USER_PASSWORD_AUTH で 検証 し、 access / refresh token を HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。
+//	@Tags         auth
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body      passwordLoginReq  true  "メール / パスワード"
+//	@Success      200   {object}  messageResponse
+//	@Failure      400   {object}  errorResponse  "入力 不正 (email 形式 / password 欠落)"
+//	@Failure      401   {object}  errorResponse  "資格 情報 誤り"
+//	@Failure      403   {object}  errorResponse  "招待 なし の 新規 user"
+//	@Failure      500   {object}  errorResponse  "Cognito 未 設定"
+//	@Failure      502   {object}  errorResponse  "Cognito 到達 不可"
+//	@Failure      429   {object}  errorResponse  "レート制限超過"
+//	@Header       429  {string}  Retry-After  "再試行までの秒数 (例: 60)"
+//	@Router       /auth/cognito/login [post]
+func (h *AuthHandler) Login(c *gin.Context) {
+	var req passwordLoginReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if h.passwordAuth == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"})
+		return
+	}
+
+	tok, err := h.passwordAuth.Authenticate(c.Request.Context(), req.Email, req.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, cognito.ErrInvalidCredentials):
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid_credentials"})
+		case errors.Is(err, cognito.ErrNotConfigured):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "cognito_not_configured"})
+		default:
+			log.Printf("cognito password login: unexpected error: %v", err)
+			c.JSON(http.StatusBadGateway, gin.H{"error": "cognito_unreachable"})
+		}
+		return
+	}
+
+	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
+	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
+
+	// Callback と同じ招待ゲート。拒否された新規ユーザーは Cookie をクリアしてセッションを残さない。
+	if allowed := h.upsertUserFromIDToken(c, tok.IDToken, ""); !allowed {
+		middleware.ClearAuthCookies(c)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":   "invitation_required",
+			"message": "FreStyle のご利用には管理者からの招待が必要です。招待メールに記載されたリンクからログインしてください。",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
 }
 
 type cognitoCallbackReq struct {

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -145,7 +145,7 @@ func TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin(t *testing.
 		// cognito:groups なし、招待もなし → 拒否されるべき
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
+	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
 	if allowed {
 		t.Fatalf("expected allowed=false for non-invited non-admin signup")
 	}
@@ -165,7 +165,7 @@ func TestUpsertUserFromIDToken_AllowsCognitoAdminWithoutInvitation(t *testing.T)
 		"cognito:groups": []string{"admin"},
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
+	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
 	if !allowed {
 		t.Fatalf("Cognito group admin must be allowed even without invitation")
 	}
@@ -192,7 +192,7 @@ func TestUpsertUserFromIDToken_AllowsInvitedUser_AppliesRoleAndCompany(t *testin
 		"email": "trainee@example.com",
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
+	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
 	if !allowed {
 		t.Fatalf("invited user must be allowed")
 	}
@@ -225,7 +225,7 @@ func TestUpsertUserFromIDToken_ExistingUser_AlwaysAllowed(t *testing.T) {
 		"email": "u@example.com",
 	})
 
-	allowed := h.upsertUserFromIDToken(newGinCtx(), idToken, "")
+	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
 	if !allowed {
 		t.Fatalf("existing user must always be allowed (no invitation re-check)")
 	}
@@ -244,7 +244,7 @@ func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T)
 		"email":          "u@example.com",
 		"cognito:groups": []string{"admin"},
 	})
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.updateRoleID != 5 || users.updateRoleVal != domain.RoleSuperAdmin {
@@ -254,7 +254,7 @@ func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T)
 
 func TestUpsertUserFromIDToken_RejectsMalformedToken(t *testing.T) {
 	h := newTestAuthHandler(&fakeUserRepo{}, &fakeInvitationRepo{})
-	if h.upsertUserFromIDToken(newGinCtx(), "not-a-jwt", "") {
+	if upsertAllowed(h, newGinCtx(), "not-a-jwt", "") {
 		t.Fatal("malformed token must be rejected")
 	}
 }
@@ -279,7 +279,7 @@ func TestUpsertUserFromIDToken_InvitationToken_TakesPrecedenceOverEmail(t *testi
 		"sub":   "google-user-1",
 		"email": "u@example.com",
 	})
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "magic-token-xyz") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "magic-token-xyz") {
 		t.Fatal("must be allowed when token matches a pending invitation")
 	}
 	if users.created == nil {
@@ -310,7 +310,7 @@ func TestUpsertUserFromIDToken_InvalidToken_FallsBackToEmail(t *testing.T) {
 		"sub":   "google-user-2",
 		"email": "u@example.com",
 	})
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "garbage-token") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "garbage-token") {
 		t.Fatal("must fall back to email-based invitation when token is invalid")
 	}
 	if users.created == nil || users.created.Role != domain.RoleTrainee {
@@ -331,7 +331,7 @@ func TestUpsertUserFromIDToken_ExistingTrainee_UpgradedByCompanyAdminInvitation(
 	h := newTestAuthHandler(users, invs)
 	idToken := makeIDToken(t, map[string]any{"sub": "existing-trainee", "email": "u@example.com"})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "magic-xyz") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "magic-xyz") {
 		t.Fatal("must be allowed for existing user with token")
 	}
 	if users.updateRoleVal != domain.RoleCompanyAdmin || users.updateRoleID != 5 {
@@ -357,7 +357,7 @@ func TestUpsertUserFromIDToken_ExistingSuperAdmin_NotDowngradedByInvitation(t *t
 	h := newTestAuthHandler(users, invs)
 	idToken := makeIDToken(t, map[string]any{"sub": "ops", "email": "ops@example.com"})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "t") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "t") {
 		t.Fatal("must be allowed")
 	}
 	if users.updateRoleVal != "" {
@@ -387,7 +387,7 @@ func TestUpsertUserFromIDToken_NewUser_UsesOIDCNameOverEmail(t *testing.T) {
 		"name":  "山田 太郎",
 	})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.created == nil {
@@ -414,7 +414,7 @@ func TestUpsertUserFromIDToken_NewUser_InvitationNameTrumpsOIDCName(t *testing.T
 		"sub": "g-2", "email": "u@example.com", "name": "Google Name",
 	})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.created.DisplayName != "招待された名前" {
@@ -436,7 +436,7 @@ func TestUpsertUserFromIDToken_NewUser_NoOIDCName_FallsBackToEmail(t *testing.T)
 	h := newTestAuthHandler(users, invs)
 	idToken := makeIDToken(t, map[string]any{"sub": "g-3", "email": "a@example.com"})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.created.DisplayName != "a@example.com" {
@@ -457,7 +457,7 @@ func TestUpsertUserFromIDToken_ExistingUser_BackfillDisplayNameFromOIDC(t *testi
 		"sub": "exists", "email": "old@example.com", "name": "本名 太郎",
 	})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.updateDisplayNameID != 5 || users.updateDisplayNameVal != "本名 太郎" {
@@ -479,7 +479,7 @@ func TestUpsertUserFromIDToken_ExistingUser_NoBackfillIfDisplayNameCustomized(t 
 		"sub": "exists", "email": "u@example.com", "name": "Google Name",
 	})
 
-	if !h.upsertUserFromIDToken(newGinCtx(), idToken, "") {
+	if !upsertAllowed(h, newGinCtx(), idToken, "") {
 		t.Fatal("must be allowed")
 	}
 	if users.updateDisplayNameVal != "" {

--- a/backend/internal/handler/auth_handler_testhelper_test.go
+++ b/backend/internal/handler/auth_handler_testhelper_test.go
@@ -3,10 +3,19 @@ package handler
 import (
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
 )
 
 // mustNewRequest はテスト用に最小の *http.Request を返す。
 // auth_handler 配下の handler は c.Request.Context() しか参照しないため、URL / method は何でも良い。
 func mustNewRequest() *http.Request {
 	return httptest.NewRequest(http.MethodGet, "/", nil)
+}
+
+// upsertAllowed は upsertUserFromIDToken の allowed だけを取り出すテスト補助。
+// 内部エラー(err!=nil)の切り分けは password_login_test.go の handler テストで検証する。
+func upsertAllowed(h *AuthHandler, c *gin.Context, idToken, invitationToken string) bool {
+	allowed, _ := h.upsertUserFromIDToken(c, idToken, invitationToken)
+	return allowed
 }

--- a/backend/internal/handler/password_login_test.go
+++ b/backend/internal/handler/password_login_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/cognito"
+)
+
+// fakePasswordAuth は passwordAuthenticator のテスト用スタブ。
+type fakePasswordAuth struct {
+	token       *cognito.Token
+	err         error
+	gotEmail    string
+	gotPassword string
+}
+
+func (f *fakePasswordAuth) Authenticate(_ context.Context, email, password string) (*cognito.Token, error) {
+	f.gotEmail, f.gotPassword = email, password
+	return f.token, f.err
+}
+
+func postLoginCtx(body string) (*gin.Context, *httptest.ResponseRecorder) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/auth/cognito/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+	return c, rec
+}
+
+func TestLogin_Success_ExistingUser(t *testing.T) {
+	users := &fakeUserRepo{existingBySub: map[string]*domain.User{
+		"sub-1": {ID: 1, CognitoSub: "sub-1", Email: "u@example.com", Role: domain.RoleTrainee},
+	}}
+	idTok := makeIDToken(t, map[string]any{"sub": "sub-1", "email": "u@example.com"})
+	pw := &fakePasswordAuth{token: &cognito.Token{AccessToken: "AT", IDToken: idTok, RefreshToken: "RT", ExpiresIn: 3600}}
+	h := &AuthHandler{users: users, invitations: &fakeInvitationRepo{}, passwordAuth: pw}
+
+	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
+	h.Login(c)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if pw.gotEmail != "u@example.com" || pw.gotPassword != "secret123" {
+		t.Errorf("authenticator did not receive credentials: %q / %q", pw.gotEmail, pw.gotPassword)
+	}
+	if len(rec.Result().Cookies()) == 0 {
+		t.Errorf("expected auth cookies to be set on success")
+	}
+}
+
+func TestLogin_InvalidCredentials_401(t *testing.T) {
+	h := &AuthHandler{
+		users:        &fakeUserRepo{},
+		invitations:  &fakeInvitationRepo{},
+		passwordAuth: &fakePasswordAuth{err: cognito.ErrInvalidCredentials},
+	}
+	c, rec := postLoginCtx(`{"email":"u@example.com","password":"wrong"}`)
+	h.Login(c)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLogin_NewUserWithoutInvitation_403(t *testing.T) {
+	idTok := makeIDToken(t, map[string]any{"sub": "new-sub", "email": "new@example.com"})
+	h := &AuthHandler{
+		users:        &fakeUserRepo{},       // 既存ユーザーなし
+		invitations:  &fakeInvitationRepo{}, // pending 招待なし
+		passwordAuth: &fakePasswordAuth{token: &cognito.Token{AccessToken: "AT", IDToken: idTok, RefreshToken: "RT"}},
+	}
+	c, rec := postLoginCtx(`{"email":"new@example.com","password":"secret123"}`)
+	h.Login(c)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLogin_BadRequest_MissingPassword_400(t *testing.T) {
+	h := &AuthHandler{passwordAuth: &fakePasswordAuth{}}
+	c, rec := postLoginCtx(`{"email":"u@example.com"}`)
+	h.Login(c)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestLogin_NotConfigured_500(t *testing.T) {
+	h := &AuthHandler{} // passwordAuth nil
+	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
+	h.Login(c)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}

--- a/backend/internal/handler/password_login_test.go
+++ b/backend/internal/handler/password_login_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -97,6 +98,26 @@ func TestLogin_BadRequest_MissingPassword_400(t *testing.T) {
 
 func TestLogin_NotConfigured_500(t *testing.T) {
 	h := &AuthHandler{} // passwordAuth nil
+	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
+	h.Login(c)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// 認証は成功したが upsert が DB 失敗で落ちたケースは 403 ではなく 500（招待拒否と切り分け）。
+func TestLogin_UpsertInternalError_500(t *testing.T) {
+	idTok := makeIDToken(t, map[string]any{"sub": "s1", "email": "u@example.com"})
+	users := &fakeUserRepo{createErr: errors.New("db down")}
+	inv := &fakeInvitationRepo{pendingByEmail: map[string]*domain.AdminInvitation{
+		"u@example.com": {ID: 1, Role: domain.RoleTrainee, CompanyID: 1},
+	}}
+	h := &AuthHandler{
+		users:        users,
+		invitations:  inv,
+		passwordAuth: &fakePasswordAuth{token: &cognito.Token{AccessToken: "AT", IDToken: idTok, RefreshToken: "RT"}},
+	}
 	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
 	h.Login(c)
 

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -1,24 +1,40 @@
 package handler
 
 import (
+	"context"
+	"log"
+
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// registerAuthPublicRoutes は認証不要の認証エンドポイント（login / logout / refresh）を
+// registerAuthPublicRoutes は認証不要の認証エンドポイント（login / cognito login / logout / refresh）を
 // 登録し、authed group で再利用するため AuthHandler を返す。login / refresh は Cookie を発行・更新するため JWTAuth 対象外。
-// パスは provider 非依存の REST 形（/auth/login = 認可コード→token 交換 / /auth/logout / /auth/refresh）で、frontend の apiRoutes と一致させる。
+// パスは Hosted UI 認可コード交換が /auth/login、アプリ内メール/パスワードが /auth/cognito/login で frontend の apiRoutes と一致させる。
 func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler {
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
 	invitations := persistence.NewAdminInvitationRepository(deps.db)
 	aiAccess := usecase.NewAiChatEnabledForUserUseCase(persistence.NewCompanyRepository(deps.db))
-	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito, aiAccess)
+
+	// USER_PASSWORD_AUTH 用の authenticator。AWS 認証情報の解決に失敗しても起動は止めず、
+	// nil のまま渡して /auth/cognito/login だけ 500 にする（Hosted UI ログインには影響させない）。
+	var pwAuth passwordAuthenticator
+	if pa, err := cognito.NewPasswordAuthenticator(context.Background(), deps.cfg.Cognito.Region, deps.cfg.Cognito.ClientID, deps.cfg.Cognito.ClientSecret); err != nil {
+		log.Printf("password authenticator init failed: %v", err)
+	} else {
+		pwAuth = pa
+	}
+
+	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito, pwAuth, aiAccess)
 
 	g.POST("/auth/logout", authHandler.Logout)
 	// login（認可コード→token 交換）は認証不要のため、総当たり緩和に per-IP 制限を掛ける。
 	g.POST("/auth/login", middleware.RateLimitPerMinute(30, 10), authHandler.Callback)
+	// cognito/login（メール/パスワード）はパスワード総当たり面なので callback より厳しめに絞る。
+	g.POST("/auth/cognito/login", middleware.RateLimitPerMinute(10, 5), authHandler.Login)
 	// refresh は正規ユーザーが定期的に叩くため、NAT 共有 IP を考慮して緩めに設定する。
 	g.POST("/auth/refresh", middleware.RateLimitPerMinute(60, 30), authHandler.Refresh)
 

--- a/backend/internal/infra/cognito/password_authenticator.go
+++ b/backend/internal/infra/cognito/password_authenticator.go
@@ -1,0 +1,102 @@
+package cognito
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	cip "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+)
+
+// ErrInvalidCredentials は email / password 不一致・未確認ユーザー等で認証に失敗したときに返す（401 用）。
+// 真の理由（ユーザー不在 か パスワード違い か）はユーザー列挙対策のため呼び元に伝えない。
+var ErrInvalidCredentials = errors.New("cognito: invalid credentials")
+
+// initiateAuthAPI は InitiateAuth だけを使う最小インターフェイス（テストで fake に差し替えるため）。
+type initiateAuthAPI interface {
+	InitiateAuth(ctx context.Context, in *cip.InitiateAuthInput, optFns ...func(*cip.Options)) (*cip.InitiateAuthOutput, error)
+}
+
+// PasswordAuthenticator は Cognito の USER_PASSWORD_AUTH フローで email / password を検証し、
+// access / id / refresh token を取得する。client secret 付きクライアント用に SECRET_HASH を計算する。
+// Hosted UI(認可コード交換)とは別経路で、フロントの「メール / パスワードフォーム」から使う。
+type PasswordAuthenticator struct {
+	client       initiateAuthAPI
+	clientID     string
+	clientSecret string
+}
+
+// NewPasswordAuthenticator は AWS 既定の認証情報チェーンで cognitoidp クライアントを組み立てる。
+func NewPasswordAuthenticator(ctx context.Context, region, clientID, clientSecret string) (*PasswordAuthenticator, error) {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, err
+	}
+	return &PasswordAuthenticator{
+		client:       cip.NewFromConfig(awsCfg),
+		clientID:     clientID,
+		clientSecret: clientSecret,
+	}, nil
+}
+
+// newPasswordAuthenticatorWithClient はテスト用に InitiateAuth クライアントを差し替える DI コンストラクタ。
+func newPasswordAuthenticatorWithClient(client initiateAuthAPI, clientID, clientSecret string) *PasswordAuthenticator {
+	return &PasswordAuthenticator{client: client, clientID: clientID, clientSecret: clientSecret}
+}
+
+// Authenticate は email / password を Cognito で検証し Token を返す。
+// 資格情報誤りは ErrInvalidCredentials、未設定は ErrNotConfigured、それ以外は元のエラーをラップして返す。
+func (a *PasswordAuthenticator) Authenticate(ctx context.Context, email, password string) (*Token, error) {
+	if a.clientID == "" {
+		return nil, ErrNotConfigured
+	}
+
+	params := map[string]string{
+		"USERNAME": email,
+		"PASSWORD": password,
+	}
+	if a.clientSecret != "" {
+		params["SECRET_HASH"] = a.secretHash(email)
+	}
+
+	out, err := a.client.InitiateAuth(ctx, &cip.InitiateAuthInput{
+		AuthFlow:       types.AuthFlowTypeUserPasswordAuth,
+		ClientId:       aws.String(a.clientID),
+		AuthParameters: params,
+	})
+	if err != nil {
+		// ユーザー不在 / パスワード違い / 未確認は資格情報エラーに丸めて 401 にする（ユーザー列挙対策）。
+		var notAuth *types.NotAuthorizedException
+		var notFound *types.UserNotFoundException
+		var notConfirmed *types.UserNotConfirmedException
+		if errors.As(err, &notAuth) || errors.As(err, &notFound) || errors.As(err, &notConfirmed) {
+			return nil, ErrInvalidCredentials
+		}
+		return nil, err
+	}
+
+	// MFA 等のチャレンジは本アプリの Cognito 設定では発生しない想定。AuthenticationResult が無ければ失敗扱い。
+	if out.AuthenticationResult == nil {
+		return nil, ErrInvalidCredentials
+	}
+	r := out.AuthenticationResult
+	return &Token{
+		AccessToken:  aws.ToString(r.AccessToken),
+		IDToken:      aws.ToString(r.IdToken),
+		RefreshToken: aws.ToString(r.RefreshToken),
+		ExpiresIn:    int(r.ExpiresIn),
+		TokenType:    aws.ToString(r.TokenType),
+	}, nil
+}
+
+// secretHash は Cognito の SECRET_HASH = Base64(HMAC-SHA256(username + clientId, clientSecret)) を計算する。
+func (a *PasswordAuthenticator) secretHash(username string) string {
+	mac := hmac.New(sha256.New, []byte(a.clientSecret))
+	mac.Write([]byte(username + a.clientID))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}

--- a/backend/internal/infra/cognito/password_authenticator_test.go
+++ b/backend/internal/infra/cognito/password_authenticator_test.go
@@ -1,0 +1,104 @@
+package cognito
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	cip "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+)
+
+// fakeInitiateAuth は initiateAuthAPI のテスト用スタブ。
+type fakeInitiateAuth struct {
+	out      *cip.InitiateAuthOutput
+	err      error
+	gotInput *cip.InitiateAuthInput
+}
+
+func (f *fakeInitiateAuth) InitiateAuth(_ context.Context, in *cip.InitiateAuthInput, _ ...func(*cip.Options)) (*cip.InitiateAuthOutput, error) {
+	f.gotInput = in
+	return f.out, f.err
+}
+
+func TestPasswordAuthenticator_Authenticate_Success(t *testing.T) {
+	fake := &fakeInitiateAuth{out: &cip.InitiateAuthOutput{
+		AuthenticationResult: &types.AuthenticationResultType{
+			AccessToken:  aws.String("AT"),
+			IdToken:      aws.String("ID"),
+			RefreshToken: aws.String("RT"),
+			ExpiresIn:    3600,
+			TokenType:    aws.String("Bearer"),
+		},
+	}}
+	a := newPasswordAuthenticatorWithClient(fake, "client-id", "secret")
+
+	tok, err := a.Authenticate(context.Background(), "u@example.com", "pw")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.AccessToken != "AT" || tok.IDToken != "ID" || tok.RefreshToken != "RT" || tok.ExpiresIn != 3600 {
+		t.Errorf("unexpected token: %+v", tok)
+	}
+	// USER_PASSWORD_AUTH フロー + SECRET_HASH が渡る。
+	if fake.gotInput.AuthFlow != types.AuthFlowTypeUserPasswordAuth {
+		t.Errorf("want USER_PASSWORD_AUTH, got %v", fake.gotInput.AuthFlow)
+	}
+	if fake.gotInput.AuthParameters["USERNAME"] != "u@example.com" {
+		t.Errorf("USERNAME not passed: %v", fake.gotInput.AuthParameters)
+	}
+	if fake.gotInput.AuthParameters["SECRET_HASH"] == "" {
+		t.Errorf("expected SECRET_HASH when client secret is set")
+	}
+}
+
+func TestPasswordAuthenticator_Authenticate_InvalidCredentials(t *testing.T) {
+	for _, awsErr := range []error{
+		&types.NotAuthorizedException{},
+		&types.UserNotFoundException{},
+		&types.UserNotConfirmedException{},
+	} {
+		fake := &fakeInitiateAuth{err: awsErr}
+		a := newPasswordAuthenticatorWithClient(fake, "client-id", "secret")
+		if _, err := a.Authenticate(context.Background(), "u", "pw"); !errors.Is(err, ErrInvalidCredentials) {
+			t.Errorf("%T should map to ErrInvalidCredentials, got %v", awsErr, err)
+		}
+	}
+}
+
+func TestPasswordAuthenticator_Authenticate_NoSecretHashWithoutSecret(t *testing.T) {
+	fake := &fakeInitiateAuth{out: &cip.InitiateAuthOutput{
+		AuthenticationResult: &types.AuthenticationResultType{AccessToken: aws.String("AT")},
+	}}
+	a := newPasswordAuthenticatorWithClient(fake, "client-id", "")
+	if _, err := a.Authenticate(context.Background(), "u", "pw"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := fake.gotInput.AuthParameters["SECRET_HASH"]; ok {
+		t.Errorf("SECRET_HASH must be omitted when client secret is empty")
+	}
+}
+
+func TestPasswordAuthenticator_Authenticate_NotConfigured(t *testing.T) {
+	a := newPasswordAuthenticatorWithClient(&fakeInitiateAuth{}, "", "secret")
+	if _, err := a.Authenticate(context.Background(), "u", "pw"); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("want ErrNotConfigured, got %v", err)
+	}
+}
+
+func TestPasswordAuthenticator_SecretHash(t *testing.T) {
+	a := newPasswordAuthenticatorWithClient(nil, "id", "secret")
+	got := a.secretHash("user")
+
+	mac := hmac.New(sha256.New, []byte("secret"))
+	mac.Write([]byte("user" + "id"))
+	want := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	if got != want {
+		t.Errorf("secretHash = %s, want %s", got, want)
+	}
+}

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -89,7 +89,8 @@ func Load() (*Config, error) {
 			RedirectURI:  os.Getenv("COGNITO_REDIRECT_URI"),
 			TokenURI:     os.Getenv("COGNITO_TOKEN_URI"),
 			JwkSetURI:    os.Getenv("COGNITO_JWK_SET_URI"),
-			Region:       getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
+			// Cognito が別リージョンの構成も表現できるよう COGNITO_REGION を優先し、未設定時のみ AWS_REGION。
+			Region: getEnvOrDefault("COGNITO_REGION", getEnvOrDefault("AWS_REGION", "ap-northeast-1")),
 		},
 		S3: S3Config{
 			Region:           getEnvOrDefault("AWS_REGION", "ap-northeast-1"),

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -67,6 +67,8 @@ type CognitoConfig struct {
 	RedirectURI  string
 	TokenURI     string
 	JwkSetURI    string
+	// Region は USER_PASSWORD_AUTH の InitiateAuth を呼ぶ cognitoidp クライアント用。
+	Region string
 }
 
 func Load() (*Config, error) {
@@ -87,6 +89,7 @@ func Load() (*Config, error) {
 			RedirectURI:  os.Getenv("COGNITO_REDIRECT_URI"),
 			TokenURI:     os.Getenv("COGNITO_TOKEN_URI"),
 			JwkSetURI:    os.Getenv("COGNITO_JWK_SET_URI"),
+			Region:       getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
 		},
 		S3: S3Config{
 			Region:           getEnvOrDefault("AWS_REGION", "ap-northeast-1"),

--- a/docs/auth-login.md
+++ b/docs/auth-login.md
@@ -1,0 +1,51 @@
+# ログイン（認証）フロー
+
+FreStyle のログイン画面（`/login`）は **メール / パスワード** と **Google（Hosted UI）** の 2 経路を提供する。
+どちらも最終的に Cognito が発行した token を **HttpOnly Cookie**（access / refresh）に格納し、以降の
+API は Cookie 認証で動く。新規ユーザーは「招待」または Cognito admin group が無いと弾かれる（招待ゲート）。
+
+## 経路
+
+| 経路 | フロント | backend エンドポイント | Cognito |
+|---|---|---|---|
+| メール / パスワード | ログインフォーム送信 | `POST /api/v2/auth/cognito/login` | InitiateAuth `USER_PASSWORD_AUTH` |
+| Google | 「Google でログイン」→ Hosted UI | `POST /api/v2/auth/login`（認可コード交換） | OAuth2 code → token |
+| トークン更新 | 自動 | `POST /api/v2/auth/refresh` | refresh_token |
+
+> 旧 `/auth/login` は Hosted UI の認可コード交換、アプリ内フォームは `/auth/cognito/login`。
+> フロントの `src/constants/apiRoutes.ts` の `AUTH.login` / `AUTH.callback` と一致させている。
+
+## メール / パスワードログインの実装
+
+### backend（Go）
+
+- `internal/infra/cognito/password_authenticator.go`: `PasswordAuthenticator`。
+  Cognito `InitiateAuth(USER_PASSWORD_AUTH)` を呼ぶ。client secret 付きクライアントなので
+  `SECRET_HASH = Base64(HMAC-SHA256(username + clientId, clientSecret))` を計算して渡す。
+  資格情報誤り（`NotAuthorized` / `UserNotFound` / `UserNotConfirmed`）は `ErrInvalidCredentials`
+  に丸めてユーザー列挙を防ぐ。
+- `internal/handler/auth_handler.go` の `Login`: フォームを受けて `Authenticate` → Cookie 発行 →
+  `upsertUserFromIDToken`（Callback と共通の招待ゲート）。拒否時は Cookie をクリアして 403。
+- `internal/handler/routes_auth.go`: `POST /auth/cognito/login`。パスワード総当たり面なので
+  per-IP のレート制限を callback より厳しく（10 req/min, burst 5）。
+
+### frontend
+
+- `src/pages/LoginPage.tsx`: 公開ヘッダー（`PublicHeader`）+ メール / パスワードフォーム +
+  「または」+ Google ボタン + 招待 / 利用申請の案内。
+- `src/hooks/useLoginPage.ts`: フォーム状態 + `handleLogin`。成功時は **フル再読み込み**
+  （`window.location.assign('/')`）でトップへ。SPA 内 navigate では `AuthInitializer` が
+  `/auth/me` を引き直さず role / isAdmin が確定しないため、あえてフルロードする。
+  403（招待なし）は専用文言、それ以外の失敗は「メールアドレスまたはパスワードが正しくありません。」。
+
+## Cognito 前提
+
+`USER_PASSWORD_AUTH` を使うには App Client の `ExplicitAuthFlows` に
+**`ALLOW_USER_PASSWORD_AUTH`** が必要（既存の SRP / REFRESH / Hosted UI code フローは維持）。
+本番クライアントは手動管理のため、有効化手順は infra リポの
+`make enable-cognito-user-password-auth`（docs/18 系）に集約している。
+
+## OpenAPI
+
+`/auth/cognito/login` は swaggo annotation 付き。handler 変更時は `make openapi` で
+`backend/docs/swagger.{json,yaml}` を再生成してコミットする。

--- a/frontend/e2e/local/user-flows.spec.ts
+++ b/frontend/e2e/local/user-flows.spec.ts
@@ -124,7 +124,7 @@ test.describe('演習フロー', () => {
 });
 
 test.describe('ログイン画面', () => {
-  test('未認証で /login を開くと Hosted UI ログイン導線が表示される', async ({ page }) => {
+  test('未認証で /login を開くとメール/パスワードのログインフォームが表示される', async ({ page }) => {
     // すべての API を 401 にして未認証状態にする。
     await page.route('**/api/v2/**', (route) =>
       route.fulfill({
@@ -137,9 +137,10 @@ test.describe('ログイン画面', () => {
     await page.goto('/login');
 
     await expect(page).toHaveURL(/\/login/);
-    // ログインは Cognito Hosted UI に一本化したため「ログイン / 新規登録」ボタンを出す。
-    await expect(
-      page.getByRole('button', { name: 'ログイン / 新規登録' })
-    ).toBeVisible();
+    // メール/パスワードフォーム + Google(Hosted UI) の 2 経路。
+    await expect(page.getByRole('form', { name: 'ログインフォーム' })).toBeVisible();
+    await expect(page.getByLabel('メールアドレス')).toBeVisible();
+    await expect(page.getByLabel('パスワード')).toBeVisible();
+    await expect(page.getByRole('button', { name: /Google/ })).toBeVisible();
   });
 });

--- a/frontend/e2e/local/user-flows.spec.ts
+++ b/frontend/e2e/local/user-flows.spec.ts
@@ -140,7 +140,8 @@ test.describe('ログイン画面', () => {
     // メール/パスワードフォーム + Google(Hosted UI) の 2 経路。
     await expect(page.getByRole('form', { name: 'ログインフォーム' })).toBeVisible();
     await expect(page.getByLabel('メールアドレス')).toBeVisible();
-    await expect(page.getByLabel('パスワード')).toBeVisible();
+    // 「パスワードを表示」トグルボタンと衝突するので完全一致で入力欄だけを取る。
+    await expect(page.getByLabel('パスワード', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: /Google/ })).toBeVisible();
   });
 });

--- a/frontend/src/hooks/__tests__/useLoginPage.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginPage.test.ts
@@ -1,29 +1,80 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useLoginPage } from '../useLoginPage';
+import authRepository from '../../repositories/AuthRepository';
 
-const mockLocationState = { message: '' };
+const mockLocationState: { message: string } = { message: '' };
 
 vi.mock('react-router-dom', () => ({
   useLocation: () => ({ state: mockLocationState }),
 }));
 
-describe('useLoginPage', () => {
-  beforeEach(() => {
-    mockLocationState.message = '';
+vi.mock('../../repositories/AuthRepository', () => ({
+  default: { login: vi.fn() },
+}));
+
+vi.mock('axios', () => ({
+  default: { isAxiosError: (e: unknown) => !!(e as { isAxiosError?: boolean })?.isAxiosError },
+}));
+
+const loginMock = authRepository.login as ReturnType<typeof vi.fn>;
+const assignMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLocationState.message = '';
+  Object.defineProperty(window, 'location', {
+    value: { assign: assignMock },
+    writable: true,
   });
+});
 
-  it('locationState のメッセージを取得する', () => {
+function submitEvent() {
+  return { preventDefault: vi.fn() } as unknown as React.FormEvent<HTMLFormElement>;
+}
+
+describe('useLoginPage', () => {
+  it('flashMessage を location state から取得する', () => {
     mockLocationState.message = '確認メールを送信しました';
-
     const { result } = renderHook(() => useLoginPage());
-
     expect(result.current.flashMessage).toBe('確認メールを送信しました');
   });
 
-  it('メッセージが無い場合は空文字を返す', () => {
+  it('ログイン成功でトップへフル遷移する', async () => {
+    loginMock.mockResolvedValueOnce({});
     const { result } = renderHook(() => useLoginPage());
 
-    expect(result.current.flashMessage).toBe('');
+    await act(async () => {
+      await result.current.handleLogin(submitEvent());
+    });
+
+    expect(loginMock).toHaveBeenCalledWith({ email: '', password: '' });
+    expect(assignMock).toHaveBeenCalledWith('/');
+  });
+
+  it('資格情報誤り（非 403）はエラーメッセージを表示し遷移しない', async () => {
+    loginMock.mockRejectedValueOnce({ response: { status: 401 } });
+    const { result } = renderHook(() => useLoginPage());
+
+    await act(async () => {
+      await result.current.handleLogin(submitEvent());
+    });
+
+    expect(result.current.loginMessage?.text).toContain('正しくありません');
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it('招待なし（403）は招待文言を表示する', async () => {
+    loginMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { status: 403, data: { message: 'FreStyle のご利用には管理者からの招待が必要です。' } },
+    });
+    const { result } = renderHook(() => useLoginPage());
+
+    await act(async () => {
+      await result.current.handleLogin(submitEvent());
+    });
+
+    expect(result.current.loginMessage?.text).toBe('FreStyle のご利用には管理者からの招待が必要です。');
   });
 });

--- a/frontend/src/hooks/useLoginPage.ts
+++ b/frontend/src/hooks/useLoginPage.ts
@@ -1,14 +1,55 @@
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import axios from 'axios';
+import { useFormField } from './useFormField';
+import authRepository from '../repositories/AuthRepository';
+
+interface LoginMessage {
+  type: 'success' | 'error';
+  text: string;
+}
 
 /**
  * LoginPage 用フック。
  *
- * ログインは Cognito Hosted UI に一本化したため、フォーム状態は持たない。
- * ログアウト後や招待受諾後などに遷移元から渡されるフラッシュメッセージだけを取り出す。
+ * メール / パスワードフォームの状態管理とログイン処理を担う。ログインは Cognito の
+ * USER_PASSWORD_AUTH（backend `/auth/cognito/login`）で行う。Google は Hosted UI へ直行する。
+ * 成功時は HttpOnly Cookie が発行されるので、フル再読み込みで AuthInitializer に
+ * `/auth/me` を引かせて role / isAdmin を確定させる（SPA 内 navigate では再取得されないため）。
  */
 export function useLoginPage() {
+  const { form, handleChange } = useFormField({ email: '', password: '' });
+  const [loginMessage, setLoginMessage] = useState<LoginMessage | null>(null);
+  const [loading, setLoading] = useState(false);
+
   const location = useLocation();
   const flashMessage = (location.state as { message?: string })?.message || '';
 
-  return { flashMessage };
+  const handleLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setLoading(true);
+    setLoginMessage(null);
+
+    try {
+      await authRepository.login({ email: form.email, password: form.password });
+      window.location.assign('/');
+    } catch (err) {
+      // 招待なしの新規ユーザーは backend が 403 invitation_required を返す。専用文言を出す。
+      if (axios.isAxiosError(err) && err.response?.status === 403) {
+        const data = err.response.data as { message?: string } | undefined;
+        setLoginMessage({
+          type: 'error',
+          text: data?.message || 'FreStyle のご利用には管理者からの招待が必要です。',
+        });
+      } else {
+        setLoginMessage({
+          type: 'error',
+          text: 'メールアドレスまたはパスワードが正しくありません。',
+        });
+      }
+      setLoading(false);
+    }
+  };
+
+  return { form, loginMessage, flashMessage, loading, handleLogin, handleChange };
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,16 +1,19 @@
 import AuthLayout from '../components/AuthLayout';
 import PublicHeader from '../components/PublicHeader';
+import InputField from '../components/InputField';
+import PrimaryButton from '../components/PrimaryButton';
 import SNSSignInButton from '../components/SNSSignInButton';
 import LinkText from '../components/LinkText';
 import { getCognitoAuthUrl } from '../utils/auth';
 import { useLoginPage } from '../hooks/useLoginPage';
-import { CheckCircleIcon } from '@heroicons/react/24/outline';
+import { XCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
 
 export default function LoginPage() {
-  const { flashMessage } = useLoginPage();
+  const { form, loginMessage, flashMessage, loading, handleLogin, handleChange } = useLoginPage();
 
   return (
     <AuthLayout title="ログイン" header={<PublicHeader />}>
+      {/* フラッシュメッセージ（ログアウト後・招待受諾後などの成功通知） */}
       {flashMessage && (
         <p
           role="status"
@@ -21,17 +24,41 @@ export default function LoginPage() {
         </p>
       )}
 
-      {/* ログインは Cognito Hosted UI に一本化(メール/パスワード + ソーシャルを Hosted UI 側で選択)。 */}
-      <button
-        type="button"
-        onClick={() => {
-          window.location.href = getCognitoAuthUrl();
-        }}
-        className="w-full rounded-lg bg-brand-500 py-2.5 font-medium text-white transition-colors duration-150 hover:bg-brand-600 active:bg-brand-700"
-      >
-        ログイン / 新規登録
-      </button>
+      {/* エラーメッセージ */}
+      {loginMessage?.type === 'error' && (
+        <p
+          role="alert"
+          className="mb-4 flex items-center justify-center gap-1 rounded-lg bg-rose-900/30 p-3 text-center font-medium text-rose-400"
+        >
+          <XCircleIcon className="h-4 w-4" aria-hidden="true" />
+          {loginMessage.text}
+        </p>
+      )}
 
+      {/* メール・パスワードフォーム（Cognito USER_PASSWORD_AUTH） */}
+      <form onSubmit={handleLogin} aria-label="ログインフォーム">
+        <InputField
+          label="メールアドレス"
+          name="email"
+          type="email"
+          value={form.email}
+          onChange={handleChange}
+          disabled={loading}
+        />
+        <InputField
+          label="パスワード"
+          name="password"
+          type="password"
+          value={form.password}
+          onChange={handleChange}
+          disabled={loading}
+        />
+        <PrimaryButton type="submit" loading={loading}>
+          {loading ? 'ログイン中...' : 'ログイン'}
+        </PrimaryButton>
+      </form>
+
+      {/* 区切り線 */}
       <div className="relative my-5">
         <div className="absolute inset-0 flex items-center">
           <div className="w-full border-t border-surface-3"></div>
@@ -41,7 +68,7 @@ export default function LoginPage() {
         </div>
       </div>
 
-      {/* Google で直接ログイン */}
+      {/* Google で直接ログイン（Hosted UI） */}
       <SNSSignInButton
         provider="google"
         onClick={() => {

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -28,9 +28,10 @@ describe('LoginPage', () => {
     expect(screen.getByRole('button', { name: /Google/ })).toBeInTheDocument();
   });
 
-  it('利用申請への導線がある（ヘッダー + 本文）', () => {
+  it('利用申請への導線がヘッダーと本文の両方にある', () => {
     renderLoginPage();
+    // ヘッダー（企業の利用申請）と本文（利用申請）の 2 箇所。
     const applyLinks = screen.getAllByRole('link', { name: /利用申請/ });
-    expect(applyLinks.length).toBeGreaterThan(0);
+    expect(applyLinks.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/frontend/src/pages/__tests__/LoginPage.test.tsx
+++ b/frontend/src/pages/__tests__/LoginPage.test.tsx
@@ -1,18 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import LoginPage from '../LoginPage';
-
-// Hosted UI への遷移は window.location.href への代入で行うため、副作用を検証できるようにする。
-const hrefSetter = vi.fn();
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  Object.defineProperty(window, 'location', {
-    value: { set href(v: string) { hrefSetter(v); } },
-    writable: true,
-  });
-});
 
 function renderLoginPage() {
   return render(
@@ -23,29 +12,25 @@ function renderLoginPage() {
 }
 
 describe('LoginPage', () => {
-  it('Hosted UI ログインへの導線と公開ヘッダーが表示される', () => {
+  it('メール/パスワードフォームと公開ヘッダーが表示される', () => {
     renderLoginPage();
 
     expect(screen.getByRole('heading', { name: 'ログイン' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'ログイン / 新規登録' })).toBeInTheDocument();
-    // SRP のメール/パスワードフォームは廃止されている。
-    expect(screen.queryByLabelText('メールアドレス')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('パスワード')).not.toBeInTheDocument();
+    expect(screen.getByRole('form', { name: 'ログインフォーム' })).toBeInTheDocument();
+    expect(screen.getByLabelText('メールアドレス')).toBeInTheDocument();
+    expect(screen.getByLabelText('パスワード')).toBeInTheDocument();
+    // フォーム送信ボタン（ヘッダーの「ログイン」はリンクなので button では一意になる）。
+    expect(screen.getByRole('button', { name: 'ログイン' })).toBeInTheDocument();
   });
 
-  it('利用申請への導線がある', () => {
+  it('Google ログイン導線がある', () => {
     renderLoginPage();
+    expect(screen.getByRole('button', { name: /Google/ })).toBeInTheDocument();
+  });
 
-    // ヘッダーと本文の双方に企業利用申請への導線がある。
+  it('利用申請への導線がある（ヘッダー + 本文）', () => {
+    renderLoginPage();
     const applyLinks = screen.getAllByRole('link', { name: /利用申請/ });
     expect(applyLinks.length).toBeGreaterThan(0);
-  });
-
-  it('ログインボタンで Cognito Hosted UI へ遷移する', () => {
-    renderLoginPage();
-
-    screen.getByRole('button', { name: 'ログイン / 新規登録' }).click();
-    expect(hrefSetter).toHaveBeenCalledTimes(1);
-    expect(hrefSetter.mock.calls[0][0]).toContain('/oauth2/authorize');
   });
 });


### PR DESCRIPTION
## 概要

Hosted UI 単一ボタンに一本化していたログイン画面を、**メール/パスワードフォーム + Google** の従来レイアウトに戻す（公開ヘッダーは維持）。フォームは Cognito の `USER_PASSWORD_AUTH` で**実際に動作**する（旧フォームは backend 未実装で 404 だったため #1812 で撤去されていた）。

## 変更内容

### backend（Go）
- `internal/infra/cognito/password_authenticator.go`: `InitiateAuth(USER_PASSWORD_AUTH)` + `SECRET_HASH`(HMAC-SHA256)。資格情報誤りは `ErrInvalidCredentials` に丸めユーザー列挙を防止
- `internal/handler/auth_handler.go`: `Login` を追加（Callback と共通の招待ゲート / HttpOnly Cookie 発行）。`passwordAuthenticator` interface で DI
- `internal/handler/routes_auth.go`: `POST /auth/cognito/login`（per-IP レート制限 10/min・burst 5）
- `internal/infra/config/config.go`: `CognitoConfig.Region` を追加
- `make openapi` 再生成

### frontend
- `LoginPage`: 公開ヘッダー + メール/パスワードフォーム + Google + 招待/利用申請の案内
- `useLoginPage`: フォーム状態 + `handleLogin`。成功時はフル再読み込みで `AuthInitializer` に `/auth/me` を引かせ role/isAdmin を確定。403（招待なし）は専用文言

### docs
- `docs/auth-login.md` を新設（2 経路の整理 + 実装 + Cognito 前提）

## テスト

- backend: `go test ./...` ✅ / `go vet` ✅ / `gofumpt -l` 0 / `archlint` OK
  - PasswordAuthenticator（成功 / 資格情報誤り / SECRET_HASH / 未設定）
  - Login handler（200 / 401 / 403 / 400 / 500）
- frontend: `tsc` ✅ / `eslint --max-warnings 0` ✅ / `vitest`（1497 件）✅ / `build` ✅

## 前提（実施済）

本番 Cognito App Client(`user_demo`) の `ExplicitAuthFlows` に `ALLOW_USER_PASSWORD_AUTH` を追加済（SRP / REFRESH / Hosted UI code フローは維持・差分検証済）。reproducible 化は infra リポ側で別 PR。

## 関連

- ログイン導線整理（Hosted UI 一本化）: #1812 を一部巻き戻し

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * メール/パスワードによるログイン機能を追加しました。ログインページにメールアドレスとパスワードのフォームが表示されるようになりました。

* **Documentation**
  * 認証フロー（メール/パスワードとGoogle）の仕様説明ドキュメントを追加しました。

* **Tests**
  * 新規認証機能の動作検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->