### PR TITLE
style(frontend): 公開ヘッダーの CTA をログイン↔新規登録でページに応じて切替

### DIFF
--- a/frontend/src/components/PublicHeader.tsx
+++ b/frontend/src/components/PublicHeader.tsx
@@ -1,13 +1,18 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { BuildingOffice2Icon } from '@heroicons/react/24/outline';
 
 /**
- * 公開ページ(ログイン / 企業利用申請)共通のヘッダー。
+ * 公開ページ(ログイン / 新規登録 / 企業利用申請)共通のヘッダー。
  *
- * 既存ユーザーの「ログイン」と、見込み企業の「利用申請」の 2 導線を提供する。
- * ログインは role を問わず 1 つに統一し、ログイン後にダッシュボードを出し分ける方針。
+ * 見込み企業の「利用申請」と、ログイン↔新規登録を行き来する CTA を提供する。
+ * CTA は現在のページに応じて切り替える（ログインページでは「新規登録」、
+ * 新規登録ページでは「ログイン」）。一般的な認証ページの導線パターンに合わせる。
  */
 export default function PublicHeader() {
+  const { pathname } = useLocation();
+  const onSignup = pathname.startsWith('/signup');
+  const cta = onSignup ? { to: '/login', label: 'ログイン' } : { to: '/signup', label: '新規登録' };
+
   return (
     <header className="w-full border-b border-surface-3 bg-surface-1">
       <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
@@ -27,10 +32,10 @@ export default function PublicHeader() {
             企業の利用申請
           </Link>
           <Link
-            to="/login"
+            to={cta.to}
             className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-600"
           >
-            ログイン
+            {cta.label}
           </Link>
         </nav>
       </div>

--- a/frontend/src/components/__tests__/PublicHeader.test.tsx
+++ b/frontend/src/components/__tests__/PublicHeader.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PublicHeader from '../PublicHeader';
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <PublicHeader />
+    </MemoryRouter>
+  );
+}
+
+describe('PublicHeader', () => {
+  it('ログインページでは CTA が「新規登録」(→/signup)', () => {
+    renderAt('/login');
+    const cta = screen.getByRole('link', { name: '新規登録' });
+    expect(cta).toHaveAttribute('href', '/signup');
+    expect(screen.queryByRole('link', { name: 'ログイン' })).not.toBeInTheDocument();
+  });
+
+  it('新規登録ページでは CTA が「ログイン」(→/login)', () => {
+    renderAt('/signup');
+    const cta = screen.getByRole('link', { name: 'ログイン' });
+    expect(cta).toHaveAttribute('href', '/login');
+    expect(screen.queryByRole('link', { name: '新規登録' })).not.toBeInTheDocument();
+  });
+
+  it('企業の利用申請への導線は常にある', () => {
+    renderAt('/login');
+    expect(screen.getByRole('link', { name: /企業の利用申請/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage.tsx
@@ -1,4 +1,5 @@
 import AuthLayout from '../components/AuthLayout';
+import PublicHeader from '../components/PublicHeader';
 import InputField from '../components/InputField';
 import PrimaryButton from '../components/PrimaryButton';
 import LinkText from '../components/LinkText';
@@ -9,7 +10,7 @@ export default function SignupPage() {
   const { form, message, loading, handleChange, handleSignup, clearMessage } = useSignupPage();
 
   return (
-    <AuthLayout>
+    <AuthLayout header={<PublicHeader />}>
       <FormMessage message={message} onDismiss={clearMessage} />
       <h2 className="text-3xl font-bold mb-2 text-center text-[var(--color-text-primary)]">
         アカウント作成


### PR DESCRIPTION
## 概要

一般的な認証ページの導線パターンに合わせ、`PublicHeader` の CTA ボタンを現在ページに応じて出し分ける。

- `/login`（等）: CTA =「新規登録」（→ `/signup`）
- `/signup`: CTA =「ログイン」（→ `/login`）
- `SignupPage` にも `PublicHeader` を付与してヘッダーを統一

## 変更内容

- `PublicHeader`: `useLocation` で現在パスを見て CTA の label / リンク先を切替
- `SignupPage`: `AuthLayout` に `header={<PublicHeader />}` を追加
- `PublicHeader` のトグル挙動テストを新設

## テスト

- `tsc` ✅ / `eslint --max-warnings 0` ✅ / `vitest`（1500 件）✅ / `build` ✅

## 補足（別途確認したい点）

`/signup`（self-signup フォーム）は現状 backend 未実装（`/auth/cognito/signup`）で送信が通らず、かつ本アプリは招待制のため self-signup したユーザーはログイン時に招待ゲートで 403 になります。本 PR はヘッダー導線のみで、signup 機能の扱い（open registration として実装する / 招待制のまま surface しない）は別途方針確認します。

## 関連

- ログインフォーム復元: #1885