### PR TITLE
style(frontend): 認証メッセージをライトテーマ向けの読みやすい配色に修正

### DIFF
--- a/frontend/src/components/FormMessage.tsx
+++ b/frontend/src/components/FormMessage.tsx
@@ -22,8 +22,8 @@ export default function FormMessage({ message, onDismiss }: FormMessageProps) {
       role="alert"
       className={`mb-4 p-3 rounded-lg text-sm font-medium flex items-start gap-2 ${
         isError
-          ? 'bg-rose-900/30 text-rose-400 border border-rose-800'
-          : 'bg-emerald-900/30 text-emerald-400 border border-emerald-800'
+          ? 'bg-rose-50 text-rose-700 border border-rose-200'
+          : 'bg-emerald-50 text-emerald-700 border border-emerald-200'
       }`}
     >
       {isError ? (

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
       {flashMessage && (
         <p
           role="status"
-          className="mb-4 flex items-center justify-center gap-1 rounded-lg bg-emerald-900/30 p-3 text-center font-medium text-emerald-400"
+          className="mb-4 flex items-center justify-center gap-1 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-center font-medium text-emerald-700"
         >
           <CheckCircleIcon className="h-4 w-4" aria-hidden="true" />
           {flashMessage}
@@ -28,7 +28,7 @@ export default function LoginPage() {
       {loginMessage?.type === 'error' && (
         <p
           role="alert"
-          className="mb-4 flex items-center justify-center gap-1 rounded-lg bg-rose-900/30 p-3 text-center font-medium text-rose-400"
+          className="mb-4 flex items-center justify-center gap-1 rounded-lg border border-rose-200 bg-rose-50 p-3 text-center font-medium text-rose-700"
         >
           <XCircleIcon className="h-4 w-4" aria-hidden="true" />
           {loginMessage.text}


### PR DESCRIPTION
## 概要

ログイン失敗時のエラーメッセージが**薄赤背景に薄赤文字**（ダークテーマ用の `bg-rose-900/30` + `text-rose-400`）で低コントラストだったため、ライトテーマ向けに「薄い背景 + 濃い文字」へ修正して可読性を上げる。

## 変更内容

- `FormMessage`（共有の認証メッセージ）: error= `bg-rose-50 / text-rose-700 / border-rose-200`、success= `bg-emerald-50 / text-emerald-700 / border-emerald-200`
- `LoginPage` のインライン成功（flash）/ エラー表示も同配色に統一

## テスト

- `tsc` ✅ / `eslint --max-warnings 0` ✅ / `vitest`（1457 件）✅ / `build` ✅

## 補足

同じ `bg-X-900/30 + text-X-400`（ダークテーマ由来）の配色はバッジ / カード等でも使われているが、本 PR は **認証のエラー/成功メッセージ**に限定。