### PR TITLE
fix(ci): 夜間起動の monitoring デプロイに AlarmTopicArn を渡す(本番メンテ画面の根本対処)

### DIFF
--- a/.github/workflows/scheduled-start.yml
+++ b/.github/workflows/scheduled-start.yml
@@ -203,22 +203,31 @@ jobs:
       # 監視スタックは scheduled-stop で毎晩消えるため、ここで作り直す。
       # alb の Export を ImportValue し、ecs が作る LogGroup(/ecs/frestyle-prod)に
       # メトリクスフィルタを張るので、alb・ecs より後に deploy する。
-      # 注: SNS 購読(メール通知)を将来足す場合、毎晩 topic が作り直されると購読が消える。
-      #     その時は SNS topic を別の永続スタックに分離すること(現状は購読 0 件で無害)。
+      # アラーム通知トピック(AlarmTopic)は永続 chatbot スタック側にあり、monitoring はその ARN を
+      # 参照するだけ(毎朝 recreate で Chatbot 購読が切れるのを防ぐ。infra docs/33)。cloudwatch.yml は
+      # AlarmTopicArn を必須パラメータにしているため、ここで chatbot スタックの Output から解決して渡す。
       - name: Deploy monitoring stack
         run: |
-          # 永続 chatbot スタックがあれば ERROR ログ整形 Lambda の ARN を取得し、
-          # ERROR サブスクリプションフィルタ(→Slack #incident)を毎朝張り直す。
+          # 永続 chatbot スタックから ERROR 整形 Lambda ARN(サブスクリプションフィルタ用)と
+          # アラーム通知トピック ARN を取得する。
           NOTIFY_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
             --stack-name $STACK_PFX-chatbot \
             --query 'Stacks[0].Outputs[?OutputKey==`ErrorNotifyLambdaArn`].OutputValue' \
             --output text 2>/dev/null || true)
           [ "$NOTIFY_ARN" = "None" ] && NOTIFY_ARN=""
           echo "ErrorNotifyLambdaArn=${NOTIFY_ARN:-(なし)}"
+          ALARM_TOPIC_ARN=$(aws cloudformation describe-stacks --region $AWS_REGION \
+            --stack-name $STACK_PFX-chatbot \
+            --query 'Stacks[0].Outputs[?OutputKey==`AlarmTopicArn`].OutputValue' \
+            --output text 2>/dev/null || true)
+          if [ -z "$ALARM_TOPIC_ARN" ] || [ "$ALARM_TOPIC_ARN" = "None" ]; then
+            ALARM_TOPIC_ARN="arn:aws:sns:${AWS_REGION}:$(aws sts get-caller-identity --query Account --output text):${STACK_PFX}-alarms"
+          fi
+          echo "AlarmTopicArn=$ALARM_TOPIC_ARN"
           aws cloudformation deploy --region $AWS_REGION \
             --stack-name $STACK_PFX-monitoring \
             --template-file iac/infrastructure/cloudformation/templates/monitoring/cloudwatch.yml \
-            --parameter-overrides Environment=prod AlbStackName=$STACK_PFX-alb ErrorNotifyLambdaArn="$NOTIFY_ARN" \
+            --parameter-overrides Environment=prod AlbStackName=$STACK_PFX-alb AlarmTopicArn="$ALARM_TOPIC_ARN" ErrorNotifyLambdaArn="$NOTIFY_ARN" \
             --capabilities CAPABILITY_IAM --no-fail-on-empty-changeset \
             --tags Project=FreStyle Environment=prod ManagedBy=CloudFormation
 


### PR DESCRIPTION
## 概要

夜間 teardown→翌朝 start で本番がメンテナンス画面になっていた障害の根本対処。`scheduled-start.yml` の monitoring デプロイステップが `AlarmTopicArn` を渡しておらず、毎朝の起動が失敗していた。

## 背景（障害の連鎖）

1. アラーム通知トピック(`AlarmTopic`)を毎晩 recreate される monitoring スタックから**永続 chatbot スタック**へ分離し、`cloudwatch.yml` は `AlarmTopicArn` を**必須パラメータ**化した(Chatbot 購読が毎朝切れるのを防ぐため)
2. しかし `scheduled-start.yml` の "Deploy monitoring stack" ステップはこの新パラメータを渡しておらず、`Parameters: [AlarmTopicArn] must have values` で**失敗**
3. monitoring ステップが失敗するとその後の **Route53 alias 更新ステップまで到達しない** → `api.normanblog.com` が削除済みの旧 ALB を指したまま → `useBackendHealth` がメンテナンス画面を表示

## 変更内容

- "Deploy monitoring stack" ステップで、chatbot スタックの Output から `AlarmTopicArn` を解決して `--parameter-overrides` に追加
- Output 取得不可時は構築済み ARN(`arn:aws:sns:<region>:<account>:frestyle-prod-alarms`)へフォールバック
- `ErrorNotifyLambdaArn` と同じ解決方式に揃え、Makefile の `deploy-monitoring` ターゲットと一貫させた
- 古くなったコメント(SNS topic が毎晩 recreate される前提)を、永続スタック分離後の事実に更新

## テスト

- chatbot スタックに `AlarmTopicArn` Output が実在することを確認: `arn:aws:sns:ap-northeast-1:****:frestyle-prod-alarms`
- 編集後の YAML を `yaml.safe_load` で構文検証(OK)
- 本障害は手動復旧済み(Route53 alias を新 ALB へ付け替え + monitoring デプロイ)。ALB 直 health=200 / ECS タスク healthy を確認
- 本 PR マージ後、次回の自動 start(翌朝 07:00 JST)で monitoring → Route53 まで完走することで最終確認する

## 関連

- 障害: 2026-06-10 早朝、夜間 teardown 後の自動 start 失敗によるメンテナンス画面

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 自動デプロイワークフローの監視スタック設定を改善しました。アラーム通知の設定の信頼性が向上し、設定値が利用できない場合の自動フォールバック処理が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->