### PR TITLE
docs(design): 0004 コード実行サンドボックス分離によるイメージ軽量化(Design Doc)

### DIFF
--- a/docs/design/2026年/0004-code-runner-separation.md
+++ b/docs/design/2026年/0004-code-runner-separation.md
@@ -1,0 +1,114 @@
+---
+status: reviewing
+area: infra
+date: 2026-06-10
+issue: norman6464/FreStyle#NN
+---
+
+# 0004 コード実行サンドボックスを backend から分離してイメージを軽量化
+
+> 関連: `backend/Dockerfile` / `backend/internal/usecase/execute_code_usecase.go` / `frestyle-infrastructure` runtime/ecs.yml
+
+## 1. 基本情報
+
+| 項目 | 内容 |
+|---|---|
+| タイトル | コード実行サンドボックス(code-runner)の分離とAPIイメージ軽量化 |
+| 担当者 | @norman6464 |
+| ステータス | Reviewing（実装着手はユーザー承認後） |
+| 関連 | コールドスタート遅延の改善 |
+
+## 2. 背景と目的
+
+**背景**: 本番は夜間 teardown で ECS タスクを 0 に落としている（$0 化）。そのため**朝/初回アクセスがコールドスタート**になり、ユーザーから「最初だけ遅い（その後は速い）」と指摘があった。原因は **backend イメージが 474 MB（圧縮後）と大きく、タスク起動時の image pull に時間がかかる**こと。
+
+肥大化の主因は、**API 本体と「学習者コードを実行する polyglot サンドボックス」が 1 つのイメージに同居**していること。`backend/Dockerfile` の runtime stage は `golang:1.26-bookworm`（Go ツールチェイン同梱）に加えて `php-cli` と `default-jdk-headless`（JDK）を apt-install しており、これらサンドボックス用ランタイムだけで数百 MB を占める。
+
+一方、**コールドスタートのクリティカルパス（ログイン / health / courses / notes）は go・php・java を一切必要としない**。これらは学習者が演習で「実行」を押したときにだけ要る。つまり、初回アクセスを速くするためにサンドボックス用ランタイムをクリティカルパスから外せる。
+
+**目的**: API 本体イメージを distroless ベースの Go 単体（~60 MB 目標）まで絞り、コールドスタート時の pull を高速化する。重い polyglot ランタイムは別コンポーネント（code-runner）に分離し、コード実行が必要なときだけ使う。
+
+## 3. スコープ (Goals / Non-Goals)
+
+**Goals**
+- backend API イメージを ~60 MB（distroless static Go）に縮小し、コールドスタートの image pull 時間を短縮する
+- コード実行（php / go / bash / java）の os/exec ロジックを別バイナリ `cmd/coderunner` に切り出し、HTTP 経由で呼ぶ
+- クリーンアーキテクチャを維持（handler→usecase→**CodeRunner port**→infra クライアント）
+- サンドボックスが backend の機密 env（DATABASE_URL / Cognito secret / ECS Task Role 一時クレデンシャル）と**同一プロセスに同居しない**セキュリティ強化を副次的に得る
+
+**Non-Goals**
+- サンドボックスの言語追加・実行制限の仕様変更（現行の timeout / disable_functions / sandboxEnv はそのまま移設）
+- 夜間 teardown の仕組み変更（runner も同じ stop/start サイクルに乗せる）
+- 採点ロジック（ExecuteCodeOutput の契約）の変更
+
+## 4. アーキテクチャ・設計詳細
+
+### 概要設計（分離後）
+
+```text
+[Client] ──HTTP──> [backend API container]  distroless Go ~60MB（クリティカルパス）
+                        │ handler → usecase(ExecuteCodeUseCase)
+                        │              └ CodeRunner port(interface)
+                        │                   └ infra coderunner.HTTPClient
+                        ▼ POST http://127.0.0.1:9000/run （内部のみ）
+                   [code-runner container]  golang+php+jdk ~474MB
+                        └ os/exec で php / go run / bash / java を実行
+                          （AWS 認証情報・DB secret を一切持たない env）
+```
+
+- **backend API**: `cmd/server`。distroless（`gcr.io/distroless/static`）に静的 Go バイナリのみ。go/php/java/bash ランタイムを含まない
+- **code-runner**: `cmd/coderunner`。現行 Dockerfile の polyglot ランタイム（golang base + php-cli + JDK + GOCACHE warmup）を引き継ぐ。極小 HTTP サーバで `POST /run`（入力 = 現 `ExecuteCodeInput`、出力 = 現 `ExecuteCodeOutput`）と `GET /healthz` を公開。**機密 env を注入しない**（タスク定義で runner コンテナには DB/Cognito/AWS の env を渡さない）
+
+### 変更点（層ごと）
+
+- **usecase**: `ExecuteCodeUseCase` を「os/exec を直接叩く」から「`CodeRunner` port に委譲する」へ変更。port = `Run(ctx, ExecuteCodeInput) (*ExecuteCodeOutput, error)` の 1 メソッド interface（`-er` 命名）。バリデーション（code サイズ / 言語判定）は usecase 側に残すか runner 側に寄せるかは実装時に決める（テスト容易性で usecase 残しが有力）
+- **infra（新規）**: `internal/infra/coderunner/client.go` に HTTP クライアント実装。`CODE_RUNNER_URL`（既定 `http://127.0.0.1:9000`）へ POST。タイムアウトは言語別上限（go=15s / java=20s 等）＋ネットワーク余裕を見て設定
+- **サンドボックス本体（移設）**: 現 `execute_code_usecase.go` の `executePHP/Go/Bash/Java` / `sandboxEnv` / `configureProcessGroup` / `runCommand` を runner パッケージ（`cmd/coderunner` 配下 or `internal/infra/sandbox`）へ移す。**ロジックは変更しない**（移送のみ）
+- **handler**: 変更なし（`code_execute_handler.go` は usecase をそのまま呼ぶ）
+- **Dockerfile**: backend を distroless 化。runner 用 `Dockerfile.coderunner` を新設（現行 Dockerfile を流用）
+- **CI/CD（infra リポ）**: backend と coderunner の 2 イメージを build/push。ECS タスク定義に runner をサイドカーとして追加
+
+### デプロイ構成（重要な決定点）
+
+**推奨: 同一 ECS タスク内のサイドカー（runner は `essential: false`）**
+
+- 1 タスク / 2 コンテナ / 2 イメージ。backend は `127.0.0.1:9000` の runner を呼ぶ
+- runner を `essential: false` とし、backend は runner に `dependsOn` しない。**ALB ヘルスチェックは backend コンテナを叩く**ため、軽い backend イメージが先に pull・起動・healthy になればクリティカルパスは速くなる。runner（重いイメージ）はその裏で pull が続き、起動が遅れてもログイン等は影響を受けない
+- runner 起動前のコード実行は、infra クライアントが runner `/healthz` 未達を検知して **503「実行環境を準備中です。数秒後に再度お試しください」** を返す（学習者が初回アクセス直後に Run を押す確率は低く許容範囲）
+- **追加の常時稼働タスクが不要**＝コスト増なし。夜間 teardown も 1 タスク停止のまま
+- メモリ: JDK ヒープのため `mem512` では不足の可能性 → タスクメモリ引き上げを要検討（コスト影響を実測で判断）
+
+> ⚠️ **要実証**: Fargate が「軽い backend コンテナを、重い runner イメージの pull 完了を待たずに起動・ALB 登録できるか」は環境依存。Phase 2 の検証で計測し、もし pull がタスク全体を律速するなら下記「別サービス案」へ切り替える。
+
+### データ構造 / API（内部）
+
+```text
+POST /run     （code-runner、内部ネットワークのみ）
+  req:  { "code": string, "language": "php|go|bash|java", "stdin": string }
+  res:  { "stdout": string, "stderr": string, "exitCode": int }
+GET  /healthz （200 = 実行可能）
+```
+
+外部公開 API（`POST /api/v2/code/execute`）の契約・OpenAPI は不変。
+
+## 5. 検討した代替案
+
+| 案 | Pros | Cons | 判定 |
+|---|---|---|---|
+| **A. サイドカー（推奨, runner=essential:false）** | 追加タスク無し＝コスト増なし / API イメージ軽量化を即得る / 機密分離 | Fargate の pull 並列性に依存（要実証）/ mem 引き上げの可能性 | ⭕ 採用（実証付き） |
+| B. 別 ECS サービス（内部 service discovery） | API タスクは確実に slim イメージのみ pull / runner を独立スケール | 常時 +1 タスク（active 時間で ~$6/月）/ 別 stop/start 管理 / ネットワークホップ | △ A が pull 律速で失敗した場合のフォールバック |
+| C. 実行ごとに on-demand Fargate RunTask / Lambda | アイドルコスト 0 / 最強の分離 | 実行ごとにコンテナ/JVM コールドスタート（数秒）/ 実装複雑 | ✕ 体験悪化 |
+| D. 現状維持（単一イメージのまま圧縮のみ） | 変更最小 | JDK+Go ツールチェインは本質的に大きく、圧縮の余地が乏しい | ✕ 効果薄 |
+
+## 6. 運用・非機能要件
+
+- **監視・ログ**: runner コンテナの stdout を CloudWatch Logs に分離。`/healthz` を CloudWatch アラーム対象に追加検討
+- **セキュリティ**: runner コンテナには DB/Cognito/AWS の env を**注入しない**。`sandboxEnv` による env フィルタは引き続き多層防御として残す。ネットワークは `127.0.0.1` のみ（サイドカー）で外部到達不可
+- **パフォーマンス**: 目標はコールドスタート時の API 応答開始までの短縮。Phase 2 で「pull → ALB healthy までの秒数」を slim 化前後で計測する
+- **移行・リリース計画**: Phase 1（本体: port 化 + runner バイナリ + 2 Dockerfile、機能は単一タスク内で完結）→ Phase 2（infra: タスク定義サイドカー化 + 計測、ユーザー GO で実反映）。ロールバックは ECS タスク定義 revision を戻すだけ（旧 474MB 単一イメージへ即復帰可）
+
+## 7. テストプラン
+
+- **ユニット**: `ExecuteCodeUseCase` を fake `CodeRunner` でモックし、言語ルーティング / バリデーション / 503 ハンドリングを検証
+- **結合**: runner パッケージのサンドボックス実行テスト（現 `execute_code_usecase_test.go` / `execute_code_sandbox_test.go` を runner 側へ移送）。php/go/bash/java の stdout/exitCode、timeout、secret 非漏洩（sandboxEnv）を担保
+- **手動・本番検証**: Phase 2 で「夜間 teardown → 朝のコールドスタート」を実測し、`/api/v2/health` 200 までの時間が短縮されたことを確認。演習画面で各言語の Run が成功することを確認

--- a/docs/design/2026年/0004-code-runner-separation.md
+++ b/docs/design/2026年/0004-code-runner-separation.md
@@ -1,9 +1,11 @@
 ---
-status: reviewing
+status: approved
 area: infra
 date: 2026-06-10
 issue: norman6464/FreStyle#NN
 ---
+
+> **決定（2026-06-10）**: デプロイ構成は **A. 同一タスク内サイドカー（runner=`essential:false`、コスト増なし）** を採用。Phase 1（本体コード分離）→ Phase 2（infra サイドカー化 + コールドスタート実測、ユーザー GO で実反映）の順で進める。
 
 # 0004 コード実行サンドボックスを backend から分離してイメージを軽量化
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -74,6 +74,7 @@ doc を追加・更新したら **`python3 docs/design/_scripts/build_index.py`*
 | [0001](2026年/0001-trainee-ai-agent-toggle.md) | trainee 向け AI エージェント機能の利用可否トグル | backend | approved | 2026-06-08 |
 | [0002](2026年/0002-backend-java-to-go-revert.md) | バックエンドを Java(Spring Boot) から Go へ差し戻す | backend | approved | 2026-06-09 |
 | [0003](2026年/0003-brand-color-buttons.md) | ブランドカラー（青）でアクションボタンを統一 | frontend | approved | 2026-06-09 |
+| [0004](2026年/0004-code-runner-separation.md) | コード実行サンドボックスを backend から分離してイメージを軽量化 | infra | reviewing | 2026-06-10 |
 <!-- INDEX:END -->
 
 ## テンプレート

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -74,7 +74,7 @@ doc を追加・更新したら **`python3 docs/design/_scripts/build_index.py`*
 | [0001](2026年/0001-trainee-ai-agent-toggle.md) | trainee 向け AI エージェント機能の利用可否トグル | backend | approved | 2026-06-08 |
 | [0002](2026年/0002-backend-java-to-go-revert.md) | バックエンドを Java(Spring Boot) から Go へ差し戻す | backend | approved | 2026-06-09 |
 | [0003](2026年/0003-brand-color-buttons.md) | ブランドカラー（青）でアクションボタンを統一 | frontend | approved | 2026-06-09 |
-| [0004](2026年/0004-code-runner-separation.md) | コード実行サンドボックスを backend から分離してイメージを軽量化 | infra | reviewing | 2026-06-10 |
+| [0004](2026年/0004-code-runner-separation.md) | コード実行サンドボックスを backend から分離してイメージを軽量化 | infra | approved | 2026-06-10 |
 <!-- INDEX:END -->
 
 ## テンプレート


### PR DESCRIPTION
## 概要

コールドスタート遅延（夜間 teardown 後の初回アクセスが遅い）の改善策として、**API 本体イメージの軽量化**を提案する Design Doc。ユーザー計画 (1)「イメージ軽量化」の設計先行ドキュメント。実装着手はユーザー承認後。

## 変更内容

- `docs/design/2026年/0004-code-runner-separation.md` を追加
- `docs/design/README.md` の索引表を再生成（0004 行を追加）

## 設計の要点

- **問題**: backend イメージ 474MB（圧縮後）。主因は API 本体と polyglot コード実行サンドボックス（golang ツールチェイン + JDK + php-cli）の同居。コールドスタートのクリティカルパス（ログイン/health/courses）は go/php/java を必要としない
- **方針**: API 本体を distroless static Go（~60MB 目標）に絞り、コード実行を別バイナリ `cmd/coderunner` へ分離して HTTP 経由で呼ぶ
- **デプロイ**: 同一 ECS タスク内サイドカー（runner=`essential:false`、追加タスク無し＝コスト増なし）を推奨。Fargate の pull 並列性に依存するため Phase 2 で実証し、律速するなら別サービス案にフォールバック
- **クリーンアーキテクチャ維持**: handler→usecase→`CodeRunner` port→infra coderunner クライアント
- **副次効果**: サンドボックスが backend の機密 env（DB/Cognito/AWS 一時クレデンシャル）と同一プロセスに同居しなくなるセキュリティ強化

## テスト

- 本 PR はドキュメントのみ（ロジック変更なし）
- `build_index.py` で索引表を再生成済み

## 関連

- ユーザー計画: (1) イメージ軽量化 →(2) sqlc 移行継続 →(3) pgx 化