### PR TITLE
feat: コード実行を CodeRunner port に分離 + エディタ入場 warmup(イメージ軽量化 Phase 1)

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -27,10 +27,10 @@ linters:
     - unconvert
   exclusions:
     rules:
-      # サンドボックス(execute_code_usecase)はユーザコードを意図的に exec する。
+      # サンドボックス(infra/sandbox)はユーザコードを意図的に exec する。
       # 引数(filename/tmpDir)は内部生成で外部入力をそのまま渡していない。G204 は
       # このファイルに限定して除外し、他箇所の危険な exec は検出を維持する。
-      - path: internal/usecase/execute_code_usecase\.go
+      - path: internal/infra/sandbox/runner\.go
         linters:
           - gosec
         text: 'G204'

--- a/backend/Dockerfile.coderunner
+++ b/backend/Dockerfile.coderunner
@@ -1,0 +1,48 @@
+# --- Build stage ---
+# code-runner（cmd/coderunner）をビルドする。go/php 実行のため runtime も bookworm に揃える。
+FROM golang:1.26-bookworm AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN go build -trimpath -ldflags="-s -w" -o /out/coderunner ./cmd/coderunner
+
+# --- Runtime stage ---
+# 学習者コード（php / go / bash）をサンドボックス実行するため、PHP CLI / Go ツールチェインを同居させる。
+# backend 本体（cmd/server）はこのランタイムを含まない distroless に分離する（Design Doc 0004）。
+# runner には DB / Cognito / AWS の機密 env を注入しない（ECS タスク定義で env を渡さない）。
+FROM golang:1.26-bookworm
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends php-cli ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /
+COPY --from=builder /out/coderunner /coderunner
+
+# nonroot ユーザー (UID=65532) は distroless 互換値を踏襲。
+RUN groupadd -g 65532 nonroot && useradd -u 65532 -g nonroot -s /sbin/nologin nonroot
+
+# Go の build cache を nonroot が書ける場所に置く（共有してコンパイル高速化）。
+RUN mkdir -p /tmp/go-build-cache && chown -R nonroot:nonroot /tmp/go-build-cache
+ENV GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache
+
+# GOCACHE warmup:
+# 学習者の最初の `go run` の cold compile は ECS Fargate の I/O 遅延で 6-8 秒かかる。
+# image build 時に hello-world を 1 回 `go run` して標準パッケージをプリコンパイルしておくと、
+# 以降の cold start でも実行は ~1 秒台に収まる。nonroot 切替前に warmup する。
+RUN printf 'package main\nimport "fmt"\nfunc main() { fmt.Println("warmup") }\n' > /tmp/warmup.go && \
+    GOCACHE=/tmp/go-build-cache GO111MODULE=off HOME=/tmp \
+        go run /tmp/warmup.go > /dev/null 2>&1 && \
+    rm /tmp/warmup.go && \
+    chown -R nonroot:nonroot /tmp/go-build-cache
+
+USER nonroot:nonroot
+EXPOSE 9000
+
+ENTRYPOINT ["/coderunner"]

--- a/backend/cmd/coderunner/main.go
+++ b/backend/cmd/coderunner/main.go
@@ -1,0 +1,91 @@
+// Command coderunner は学習者コード（php / go / bash）をサンドボックス実行する
+// 軽量 HTTP サーバ。backend 本体（cmd/server）から HTTP 越しに呼ばれるサイドカーとして動く。
+//
+// backend 本体イメージを distroless（go/php を含まない）まで絞れるよう、go/php ランタイムは
+// この runner イメージ側にだけ同梱する。runner には DB / Cognito / AWS の機密 env を注入しない。
+//
+// エンドポイント:
+//
+//	POST /run     { code, language, stdin } -> { stdout, stderr, exitCode }
+//	POST /warmup  { language }              -> { ready }
+//	GET  /healthz                           -> 200 OK
+package main
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/sandbox"
+)
+
+func main() {
+	port := os.Getenv("CODE_RUNNER_PORT")
+	if port == "" {
+		port = "9000"
+	}
+	addr := ":" + port
+
+	srv := &http.Server{
+		Addr:    addr,
+		Handler: newMux(sandbox.NewRunner()),
+		// Slowloris 対策にヘッダ読み取りの上限だけ設定する。実行（go run のコンパイル）は
+		// 長くなりうるため body 読み取り後の処理時間に WriteTimeout は掛けない。
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	slog.Info("code-runner starting", "addr", addr)
+	if err := srv.ListenAndServe(); err != nil {
+		slog.Error("code-runner stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+// newMux は runner を HTTP に載せた ServeMux を返す（テストで httptest から使う）。
+func newMux(runner *sandbox.Runner) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST /run", func(w http.ResponseWriter, r *http.Request) {
+		var in domain.CodeExecutionInput
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		out, err := runner.Run(r.Context(), in)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, out)
+	})
+
+	mux.HandleFunc("POST /warmup", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Language string `json:"language"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		if err := runner.Warmup(r.Context(), req.Language); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, map[string]bool{"ready": true})
+	})
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	return mux
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/backend/cmd/coderunner/main_test.go
+++ b/backend/cmd/coderunner/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/sandbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestServer() *httptest.Server {
+	return httptest.NewServer(newMux(sandbox.NewRunner()))
+}
+
+func TestServer_Healthz(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/healthz")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestServer_Run_PHP(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php not found in PATH")
+	}
+	srv := newTestServer()
+	defer srv.Close()
+
+	body, _ := json.Marshal(domain.CodeExecutionInput{Code: `<?php echo "hi";`, Language: "php"})
+	resp, err := http.Post(srv.URL+"/run", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out domain.CodeExecutionResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	assert.Equal(t, "hi", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestServer_Run_InvalidBody(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/run", "application/json", bytes.NewReader([]byte("not-json")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestServer_Warmup(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]string{"language": "php"})
+	resp, err := http.Post(srv.URL+"/warmup", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var out map[string]bool
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&out))
+	assert.True(t, out["ready"])
+}

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1047,11 +1047,62 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult"
                         }
                     },
                     "400": {
                         "description": "バリデーション or 実行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/code/warmup": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "code-execution"
+                ],
+                "summary": "実行環境 ウォームアップ",
+                "parameters": [
+                    {
+                        "description": "言語",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.codeWarmupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.codeWarmupResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -3168,6 +3219,20 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult": {
+            "type": "object",
+            "properties": {
+                "exitCode": {
+                    "type": "integer"
+                },
+                "stderr": {
+                    "type": "string"
+                },
+                "stdout": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
             "type": "object",
             "properties": {
@@ -3623,20 +3688,6 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
-            "type": "object",
-            "properties": {
-                "exitCode": {
-                    "type": "integer"
-                },
-                "stderr": {
-                    "type": "string"
-                },
-                "stdout": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
             "type": "object",
             "properties": {
@@ -3805,6 +3856,25 @@ const docTemplate = `{
                 },
                 "language": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.codeWarmupRequest": {
+            "type": "object",
+            "required": [
+                "language"
+            ],
+            "properties": {
+                "language": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.codeWarmupResponse": {
+            "type": "object",
+            "properties": {
+                "ready": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1040,11 +1040,62 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult"
                         }
                     },
                     "400": {
                         "description": "バリデーション or 実行 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/code/warmup": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "code-execution"
+                ],
+                "summary": "実行環境 ウォームアップ",
+                "parameters": [
+                    {
+                        "description": "言語",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.codeWarmupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.codeWarmupResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -3161,6 +3212,20 @@
                 }
             }
         },
+        "github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult": {
+            "type": "object",
+            "properties": {
+                "exitCode": {
+                    "type": "integer"
+                },
+                "stderr": {
+                    "type": "string"
+                },
+                "stdout": {
+                    "type": "string"
+                }
+            }
+        },
         "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
             "type": "object",
             "properties": {
@@ -3616,20 +3681,6 @@
                 }
             }
         },
-        "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
-            "type": "object",
-            "properties": {
-                "exitCode": {
-                    "type": "integer"
-                },
-                "stderr": {
-                    "type": "string"
-                },
-                "stdout": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
             "type": "object",
             "properties": {
@@ -3798,6 +3849,25 @@
                 },
                 "language": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.codeWarmupRequest": {
+            "type": "object",
+            "required": [
+                "language"
+            ],
+            "properties": {
+                "language": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.codeWarmupResponse": {
+            "type": "object",
+            "properties": {
+                "ready": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -68,6 +68,15 @@ definitions:
       sizeBytes:
         type: integer
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult:
+    properties:
+      exitCode:
+        type: integer
+      stderr:
+        type: string
+      stdout:
+        type: string
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Company:
     properties:
       aiChatEnabledForTrainees:
@@ -373,15 +382,6 @@ definitions:
       url:
         type: string
     type: object
-  github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput:
-    properties:
-      exitCode:
-        type: integer
-      stderr:
-        type: string
-      stdout:
-        type: string
-    type: object
   github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput:
     properties:
       examples:
@@ -494,6 +494,18 @@ definitions:
         type: string
     required:
     - code
+    type: object
+  internal_handler.codeWarmupRequest:
+    properties:
+      language:
+        type: string
+    required:
+    - language
+    type: object
+  internal_handler.codeWarmupResponse:
+    properties:
+      ready:
+        type: boolean
     type: object
   internal_handler.cognitoCallbackReq:
     properties:
@@ -1475,7 +1487,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput'
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult'
         "400":
           description: バリデーション or 実行 失敗
           schema:
@@ -1487,6 +1499,39 @@ paths:
       security:
       - CookieAuth: []
       summary: コード サンドボックス 実行
+      tags:
+      - code-execution
+  /code/warmup:
+    post:
+      consumes:
+      - application/json
+      description: コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash
+        は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
+      parameters:
+      - description: 言語
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.codeWarmupRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.codeWarmupResponse'
+        "400":
+          description: バリデーション 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 実行環境 ウォームアップ
       tags:
       - code-execution
   /company-applications:

--- a/backend/internal/domain/code_execution.go
+++ b/backend/internal/domain/code_execution.go
@@ -1,0 +1,16 @@
+package domain
+
+// CodeExecutionInput は学習者コードのサンドボックス実行入力。
+// Language は "php" / "go" / "bash"。Stdin はテストケース採点で標準入力として流す。
+type CodeExecutionInput struct {
+	Code     string `json:"code"`
+	Language string `json:"language"`
+	Stdin    string `json:"stdin"`
+}
+
+// CodeExecutionResult はサンドボックス実行の結果。
+type CodeExecutionResult struct {
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	ExitCode int    `json:"exitCode"`
+}

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -4,16 +4,20 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // CodeExecuteHandler は trainee が書いたコードをサーバ側サンドボックスで実行する。
+// エディタ入場時の事前ウォームアップ（warmup）も担う。
 type CodeExecuteHandler struct {
 	executeCode *usecase.ExecuteCodeUseCase
+	warmupCode  *usecase.WarmupCodeUseCase
 }
 
-func NewCodeExecuteHandler(exec *usecase.ExecuteCodeUseCase) *CodeExecuteHandler {
-	return &CodeExecuteHandler{executeCode: exec}
+// NewCodeExecuteHandler は実行 / ウォームアップ usecase を注入して handler を返す。
+func NewCodeExecuteHandler(exec *usecase.ExecuteCodeUseCase, warmup *usecase.WarmupCodeUseCase) *CodeExecuteHandler {
+	return &CodeExecuteHandler{executeCode: exec, warmupCode: warmup}
 }
 
 type codeExecuteRequest struct {
@@ -27,7 +31,7 @@ type codeExecuteRequest struct {
 // @Accept       json
 // @Produce      json
 // @Param        body  body      codeExecuteRequest  true  "コード + 言語"
-// @Success      200   {object}  usecase.ExecuteCodeOutput
+// @Success      200   {object}  domain.CodeExecutionResult
 // @Failure      400   {object}  errorResponse  "バリデーション or 実行 失敗"
 // @Failure      401   {object}  errorResponse  "未 認証"
 // @Router       /code/execute [post]
@@ -43,7 +47,7 @@ func (h *CodeExecuteHandler) Execute(c *gin.Context) {
 		req.Language = "php"
 	}
 
-	out, err := h.executeCode.Execute(c.Request.Context(), usecase.ExecuteCodeInput{
+	out, err := h.executeCode.Execute(c.Request.Context(), domain.CodeExecutionInput{
 		Code:     req.Code,
 		Language: req.Language,
 	})
@@ -52,4 +56,37 @@ func (h *CodeExecuteHandler) Execute(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, out)
+}
+
+type codeWarmupRequest struct {
+	Language string `json:"language" binding:"required"`
+}
+
+// codeWarmupResponse はウォームアップ結果。ready=true で実行環境が準備済み。
+type codeWarmupResponse struct {
+	Ready bool `json:"ready"`
+}
+
+// @Summary      実行環境 ウォームアップ
+// @Description  コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
+// @Tags         code-execution
+// @Accept       json
+// @Produce      json
+// @Param        body  body      codeWarmupRequest  true  "言語"
+// @Success      200   {object}  codeWarmupResponse
+// @Failure      400   {object}  errorResponse  "バリデーション 失敗"
+// @Failure      401   {object}  errorResponse  "未 認証"
+// @Router       /code/warmup [post]
+// @Security     CookieAuth
+func (h *CodeExecuteHandler) Warmup(c *gin.Context) {
+	var req codeWarmupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.warmupCode.Execute(c.Request.Context(), req.Language); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, codeWarmupResponse{Ready: true})
 }

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -48,8 +48,8 @@ func (r *fakeFullSubmissionRepo) HasAttempted(context.Context, uint64, uint64, s
 // stubExecutorForHandlerTest は ExecuteCodeUseCase の代替。
 type stubExecutorForHandlerTest struct{ stdout string }
 
-func (s *stubExecutorForHandlerTest) Execute(_ context.Context, in usecase.ExecuteCodeInput) (*usecase.ExecuteCodeOutput, error) {
-	return &usecase.ExecuteCodeOutput{Stdout: s.stdout}, nil
+func (s *stubExecutorForHandlerTest) Execute(_ context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	return &domain.CodeExecutionResult{Stdout: s.stdout}, nil
 }
 
 func newSubmissionTestRouter(t *testing.T, exercise *domain.MasterExercise, examples []domain.MasterExerciseExample, executorOut string, listed []domain.ExerciseSubmission) (*gin.Engine, *fakeFullSubmissionRepo) {

--- a/backend/internal/handler/routes_exercises.go
+++ b/backend/internal/handler/routes_exercises.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/infra/coderunner"
+	"github.com/norman6464/FreStyle/backend/internal/infra/sandbox"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
@@ -11,7 +13,12 @@ func registerExerciseRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	exerciseRepo := persistence.NewMasterExerciseRepository(deps.db)
 	examplesRepo := persistence.NewMasterExerciseExampleRepository(deps.db)
 	submissionsRepo := persistence.NewExerciseSubmissionRepository(deps.db)
-	executor := usecase.NewExecuteCodeUseCase()
+
+	// CODE_RUNNER_URL がセットされていれば別コンテナ（サイドカー）の code-runner へ HTTP 委譲、
+	// 未設定なら同プロセス内でサンドボックス実行する（ローカル / 単一イメージ運用）。
+	runner := codeRunner(deps.cfg.CodeRunnerURL)
+	executor := usecase.NewExecuteCodeUseCase(runner)
+	warmup := usecase.NewWarmupCodeUseCase(runner)
 
 	exerciseHandler := NewMasterExerciseHandler(
 		usecase.NewListMasterExercisesUseCase(exerciseRepo),
@@ -28,6 +35,15 @@ func registerExerciseRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.POST("/exercises/:slug/submit", submissionHandler.Submit)
 	g.GET("/exercises/:slug/submissions", submissionHandler.List)
 
-	codeExecuteHandler := NewCodeExecuteHandler(executor)
+	codeExecuteHandler := NewCodeExecuteHandler(executor, warmup)
 	g.POST("/code/execute", codeExecuteHandler.Execute)
+	g.POST("/code/warmup", codeExecuteHandler.Warmup)
+}
+
+// codeRunner は CODE_RUNNER_URL の有無で実行系（HTTP サイドカー / in-process）を選ぶ。
+func codeRunner(url string) usecase.CodeRunner {
+	if url != "" {
+		return coderunner.NewClient(url)
+	}
+	return sandbox.NewRunner()
 }

--- a/backend/internal/infra/coderunner/client.go
+++ b/backend/internal/infra/coderunner/client.go
@@ -1,0 +1,79 @@
+// Package coderunner は、別コンテナ（サイドカー）で動く code-runner（cmd/coderunner）への
+// HTTP クライアントを提供する。backend 本体イメージから go/php ランタイムを外せるよう、
+// コード実行を HTTP 越しに runner へ委譲する（usecase.CodeRunner を満たす）。
+package coderunner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// Client は code-runner への HTTP クライアント。
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// NewClient は runner の baseURL（例 http://127.0.0.1:9000）を受け取りクライアントを返す。
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		// go run のコンパイルを含むため全体タイムアウトは長め。runner 側も言語別に上限を持つ。
+		http: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Run は runner の POST /run にコードを渡して実行結果を得る。
+func (c *Client) Run(ctx context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	var out domain.CodeExecutionResult
+	if err := c.postJSON(ctx, "/run", in, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+type warmupRequest struct {
+	Language string `json:"language"`
+}
+
+// Warmup は runner の POST /warmup に言語を渡し実行環境を温める。
+func (c *Client) Warmup(ctx context.Context, language string) error {
+	return c.postJSON(ctx, "/warmup", warmupRequest{Language: language}, nil)
+}
+
+// postJSON は body を JSON で POST し、out が非 nil ならレスポンスを out にデコードする。
+func (c *Client) postJSON(ctx context.Context, path string, body, out any) error {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("リクエストのエンコードに失敗: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(buf))
+	if err != nil {
+		return fmt.Errorf("リクエスト生成に失敗: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("code-runner への接続に失敗: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("code-runner が異常応答: status=%d", resp.StatusCode)
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return fmt.Errorf("code-runner 応答のデコードに失敗: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/infra/coderunner/client_test.go
+++ b/backend/internal/infra/coderunner/client_test.go
@@ -1,0 +1,62 @@
+package coderunner_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/coderunner"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_Run_SendsInputAndDecodesResult(t *testing.T) {
+	var gotPath string
+	var gotBody domain.CodeExecutionInput
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(domain.CodeExecutionResult{Stdout: "hi\n", ExitCode: 0})
+	}))
+	defer srv.Close()
+
+	c := coderunner.NewClient(srv.URL)
+	out, err := c.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `<?php echo "hi";`, Language: "php", Stdin: "x",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/run", gotPath)
+	assert.Equal(t, "php", gotBody.Language)
+	assert.Equal(t, "x", gotBody.Stdin)
+	assert.Equal(t, "hi\n", out.Stdout)
+}
+
+func TestClient_Warmup_SendsLanguage(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ready": true})
+	}))
+	defer srv.Close()
+
+	c := coderunner.NewClient(srv.URL)
+	require.NoError(t, c.Warmup(context.Background(), "go"))
+	assert.Equal(t, "/warmup", gotPath)
+	assert.Equal(t, "go", gotBody["language"])
+}
+
+func TestClient_Run_ErrorsOnNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := coderunner.NewClient(srv.URL)
+	_, err := c.Run(context.Background(), domain.CodeExecutionInput{Language: "go"})
+	assert.Error(t, err)
+}

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	// 例: https://normanblog.com (末尾スラッシュ無し / 有り どちらも可)
 	AppBaseURL string
 
+	// CodeRunnerURL はコード実行サイドカー（cmd/coderunner）の baseURL。
+	// セットされていると backend 本体は os/exec せず HTTP 越しに runner へ委譲する
+	// （例: http://127.0.0.1:9000）。未設定なら in-process サンドボックスで実行する。
+	CodeRunnerURL string
+
 	Cognito  CognitoConfig
 	S3       S3Config
 	Bedrock  BedrockConfig
@@ -73,16 +78,17 @@ type CognitoConfig struct {
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		AppEnv:      getEnvOrDefault("APP_ENV", "local"),
-		ServerPort:  getEnvOrDefault("PORT", "8080"),
-		DatabaseURL: os.Getenv("DATABASE_URL"),
-		DBHost:      os.Getenv("DB_HOST"),
-		DBPort:      getEnvOrDefault("DB_PORT", "5432"),
-		DBUser:      getEnvOrDefault("DB_USER", "postgres"),
-		DBPassword:  os.Getenv("DB_PASSWORD"),
-		DBName:      getEnvOrDefault("DB_NAME", "fre_style"),
-		DBSSLMode:   getEnvOrDefault("DB_SSLMODE", "require"),
-		AppBaseURL:  getEnvOrDefault("APP_BASE_URL", ""),
+		AppEnv:        getEnvOrDefault("APP_ENV", "local"),
+		ServerPort:    getEnvOrDefault("PORT", "8080"),
+		DatabaseURL:   os.Getenv("DATABASE_URL"),
+		DBHost:        os.Getenv("DB_HOST"),
+		DBPort:        getEnvOrDefault("DB_PORT", "5432"),
+		DBUser:        getEnvOrDefault("DB_USER", "postgres"),
+		DBPassword:    os.Getenv("DB_PASSWORD"),
+		DBName:        getEnvOrDefault("DB_NAME", "fre_style"),
+		DBSSLMode:     getEnvOrDefault("DB_SSLMODE", "require"),
+		AppBaseURL:    getEnvOrDefault("APP_BASE_URL", ""),
+		CodeRunnerURL: os.Getenv("CODE_RUNNER_URL"),
 		Cognito: CognitoConfig{
 			ClientID:     os.Getenv("COGNITO_CLIENT_ID"),
 			ClientSecret: os.Getenv("COGNITO_CLIENT_SECRET"),

--- a/backend/internal/infra/sandbox/env_test.go
+++ b/backend/internal/infra/sandbox/env_test.go
@@ -1,4 +1,4 @@
-package usecase
+package sandbox
 
 import (
 	"os"
@@ -17,6 +17,7 @@ func TestIsSensitiveEnvKey(t *testing.T) {
 		"COGNITO_CLIENT_SECRET",
 		"SES_FROM_ADDRESS",
 		"BEDROCK_MODEL_ID",
+		"CODE_RUNNER_URL",
 		"SOME_API_TOKEN",
 		"MY_PRIVATE_KEY",
 	}

--- a/backend/internal/infra/sandbox/runner.go
+++ b/backend/internal/infra/sandbox/runner.go
@@ -1,0 +1,275 @@
+// Package sandbox は学習者コード（php / go / bash）を os/exec でサンドボックス実行する
+// in-process 実装を提供する。backend 本体に同居させる場合（CODE_RUNNER_URL 未設定）と、
+// 別バイナリ cmd/coderunner（HTTP サーバ）の中身の双方から共有して使う。
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+const (
+	maxCodeBytes = 64 * 1024 // 64 KB
+	// execTimeout は PHP / bash の上限。
+	execTimeout = 8 * time.Second
+	// goExecTimeout は Go 専用。go run はコンパイルも走るため余裕を持たせる（cold compile ~6-8s）。
+	goExecTimeout  = 15 * time.Second
+	maxOutputBytes = 64 * 1024 // 64 KB
+)
+
+// 実行を禁止する PHP 関数。ファイル操作・OS 操作・ネットワーク通信などを封じる。
+var disableFunctions = strings.Join([]string{
+	"exec", "system", "shell_exec", "passthru", "popen", "proc_open",
+	"pcntl_exec", "proc_get_status", "proc_terminate", "proc_close",
+	"file_get_contents", "file_put_contents", "file", "fopen", "fwrite",
+	"fread", "fclose", "fgets", "fputs", "file_exists", "unlink",
+	"rename", "copy", "mkdir", "rmdir", "opendir", "readdir", "closedir",
+	"glob", "scandir", "tempnam", "tmpfile",
+	"socket_create", "fsockopen", "pfsockopen",
+	"curl_init", "curl_exec", "curl_multi_exec",
+	"dl", "phpinfo", "posix_kill", "posix_setuid",
+	"getenv", "putenv", "apache_getenv",
+	"syslog", "openlog", "closelog",
+}, ",")
+
+// Runner は php / go / bash を os/exec でサンドボックス実行する in-process 実装。
+// 共通制約: timeout / 64 KB code-size / 64 KB output-size。
+type Runner struct{}
+
+// NewRunner は in-process サンドボックス Runner を返す。
+func NewRunner() *Runner {
+	return &Runner{}
+}
+
+// Run は言語別にサンドボックス実行する。
+func (r *Runner) Run(ctx context.Context, input domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	if len(input.Code) > maxCodeBytes {
+		return nil, fmt.Errorf("コードが大きすぎます (最大 64 KB)")
+	}
+	switch input.Language {
+	case "php":
+		return r.executePHP(ctx, input)
+	case "go":
+		return r.executeGo(ctx, input)
+	case "bash":
+		return r.executeBash(ctx, input)
+	default:
+		return nil, fmt.Errorf("未対応の言語: %s", input.Language)
+	}
+}
+
+// Warmup は実行環境を事前に温める。Go は go run のコンパイルキャッシュを温めるため
+// trivial なプログラムを 1 回コンパイル/実行する。php / bash は起動が軽量なので no-op。
+func (r *Runner) Warmup(ctx context.Context, language string) error {
+	if language != "go" {
+		return nil
+	}
+	_, err := r.executeGo(ctx, domain.CodeExecutionInput{
+		Code:     "package main\n\nfunc main() {}\n",
+		Language: "go",
+	})
+	return err
+}
+
+func (r *Runner) executePHP(ctx context.Context, input domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	// 開始タグが無いと PHP はソースをそのまま stdout に流すため、別言語の誤貼付けを明示的に弾く。
+	if !strings.Contains(input.Code, "<?php") && !strings.Contains(input.Code, "<?=") {
+		return &domain.CodeExecutionResult{
+			Stdout:   "",
+			Stderr:   "PHP コードには `<?php` 開始タグが必要です。 PHP 以外のコードは現在実行できません。",
+			ExitCode: 1,
+		}, nil
+	}
+
+	tmpDir := os.TempDir()
+	filename := filepath.Join(tmpDir, "code_"+uuid.NewString()+".php")
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+	defer os.Remove(filename)
+
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(
+		ctx,
+		"php",
+		"-d", "max_execution_time=5",
+		"-d", "memory_limit=32M",
+		"-d", "disable_functions="+disableFunctions,
+		"-d", "open_basedir="+tmpDir,
+		"-d", "display_errors=stderr",
+		"-d", "log_errors=0",
+		// variables_order から E を外し $_ENV を空にする（disable_functions=getenv の抜け穴を塞ぐ）。
+		"-d", "variables_order=GPCS",
+		filename,
+	)
+	// AWS 認証情報・注入シークレットを子プロセスに渡さない。
+	cmd.Env = sandboxEnv()
+
+	return runCommand(cmd, input.Stdin)
+}
+
+func (r *Runner) executeGo(ctx context.Context, input domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	// 別言語コードが意味不明なコンパイルエラーになるのを避けるため package main を必須にする。
+	if !strings.Contains(input.Code, "package main") {
+		return &domain.CodeExecutionResult{
+			Stdout:   "",
+			Stderr:   "Go コードには `package main` と `func main()` が必要です。",
+			ExitCode: 1,
+		}, nil
+	}
+
+	// リクエストごとに独立した HOME を作る。build cache は共有で compile 短縮。
+	tmpDir, err := os.MkdirTemp("", "go-exec-")
+	if err != nil {
+		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filename := filepath.Join(tmpDir, "main.go")
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, goExecTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", filename)
+	// GO111MODULE=off で単一ファイル実行（go.mod 不要）。AWS 認証情報・注入シークレットは
+	// sandboxEnv が除外する。
+	cmd.Env = sandboxEnv(
+		"GO111MODULE=off",
+		"HOME="+tmpDir,
+	)
+
+	return runCommand(cmd, input.Stdin)
+}
+
+func (r *Runner) executeBash(ctx context.Context, input domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	// リクエストごとに独立した temp dir を HOME / PWD に固定し、副作用を temp に閉じる。
+	tmpDir, err := os.MkdirTemp("", "bash-exec-")
+	if err != nil {
+		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filename := filepath.Join(tmpDir, "script.sh")
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/bin/bash", filename)
+	cmd.Dir = tmpDir
+	// AWS credential や DB password 等を子プロセスに継承しないため、 環境変数は最小限に絞る。
+	cmd.Env = []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOME=" + tmpDir,
+		"PWD=" + tmpDir,
+		"LANG=C.UTF-8",
+		"LC_ALL=C.UTF-8",
+	}
+
+	// bash はバックグラウンド子プロセスを起動しうるので、独立プロセスグループに置いて一括 kill する。
+	configureProcessGroup(cmd)
+
+	return runCommand(cmd, input.Stdin)
+}
+
+// configureProcessGroup は cmd を独立 process group に置き、cancel 時にグループ全体へ SIGKILL を送る。
+// bash など、子孫プロセスを起動しうる言語の leak を防ぐ用途で使う。
+func configureProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		// -pid でグループ全体に signal（POSIX）。失敗しても ExitError 上書き防止に nil を返す。
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		return nil
+	}
+	// 残存子孫がいても Wait が張り付かないよう WaitDelay を付ける。
+	cmd.WaitDelay = 1 * time.Second
+}
+
+func runCommand(cmd *exec.Cmd, stdin string) (*domain.CodeExecutionResult, error) {
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+
+	err := cmd.Run()
+
+	out := &domain.CodeExecutionResult{
+		Stdout: truncate(stdout.String(), maxOutputBytes),
+		Stderr: truncate(stderr.String(), maxOutputBytes),
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			out.ExitCode = exitErr.ExitCode()
+		} else {
+			out.ExitCode = 1
+		}
+	}
+	return out, nil
+}
+
+// sandboxEnv は os.Environ() から認証情報・秘密の env を除いて返す（末尾に extra を足す）。
+// 特に AWS_CONTAINER_CREDENTIALS_* を落とすことで、ユーザコードが ECS Task Role の
+// 一時クレデンシャル取得エンドポイントへ到達する経路を塞ぐ。DATABASE_URL や
+// COGNITO_CLIENT_SECRET 等の注入シークレットも読めないようにする。
+func sandboxEnv(extra ...string) []string {
+	base := os.Environ()
+	out := make([]string, 0, len(base)+len(extra))
+	for _, kv := range base {
+		eq := strings.IndexByte(kv, '=')
+		if eq <= 0 {
+			continue
+		}
+		if isSensitiveEnvKey(kv[:eq]) {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, extra...)
+}
+
+// isSensitiveEnvKey はユーザコードに渡してはいけない env 名かを判定する。
+func isSensitiveEnvKey(key string) bool {
+	k := strings.ToUpper(key)
+	for _, p := range []string{"AWS_", "COGNITO_", "DB_", "DATABASE", "SES_", "DYNAMODB_", "NOTE_IMAGES", "BEDROCK_", "CODE_RUNNER"} {
+		if strings.HasPrefix(k, p) {
+			return true
+		}
+	}
+	for _, s := range []string{"SECRET", "PASSWORD", "TOKEN", "CREDENTIAL", "_KEY"} {
+		if strings.Contains(k, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n...(出力が長すぎるため省略されました)"
+}

--- a/backend/internal/infra/sandbox/runner_test.go
+++ b/backend/internal/infra/sandbox/runner_test.go
@@ -1,0 +1,298 @@
+package sandbox_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/sandbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunner_PHP_HelloWorld(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php not found in PATH, skipping integration test")
+	}
+
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `<?php echo "Hello, World!\n";`,
+		Language: "php",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestRunner_PHP_SyntaxError(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php not found in PATH, skipping integration test")
+	}
+
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `<?php echo "unclosed`,
+		Language: "php",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, out.ExitCode)
+}
+
+func TestRunner_UnsupportedLanguage(t *testing.T) {
+	r := sandbox.NewRunner()
+	_, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `print("hi")`,
+		Language: "python",
+	})
+	assert.Error(t, err)
+}
+
+func TestRunner_CodeTooLarge(t *testing.T) {
+	r := sandbox.NewRunner()
+	bigCode := make([]byte, 65*1024)
+	_, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     string(bigCode),
+		Language: "php",
+	})
+	assert.Error(t, err)
+}
+
+// `<?php` 開始タグが無いコードは、 PHP CLI のデフォルトで「ソースをそのまま stdout に
+// 出力して exit 0」になるため、 検証層で弾いて分かりやすい stderr メッセージに置き換える。
+func TestRunner_PHP_RejectsCodeWithoutOpenTag(t *testing.T) {
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `import java.util.*;
+class Main {
+    public static void main(String[] args) {
+        System.out.println("Hello World");
+    }
+}`,
+		Language: "php",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.Stdout)
+	assert.NotEqual(t, 0, out.ExitCode)
+	assert.Contains(t, out.Stderr, "<?php")
+}
+
+// `<?=` (short echo tag) も PHP として扱われる必要があるので、 こちらは通す。
+func TestRunner_PHP_AllowsShortEchoTag(t *testing.T) {
+	if _, err := exec.LookPath("php"); err != nil {
+		t.Skip("php not found in PATH")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `<?= "Hello"; ?>`,
+		Language: "php",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// --- Go ---
+
+func TestRunner_Go_HelloWorld(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not found in PATH, skipping integration test")
+	}
+
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+`,
+		Language: "go",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestRunner_Go_RejectsMissingPackageMain(t *testing.T) {
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `fmt.Println("hi")`,
+		Language: "go",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, out.Stdout)
+	assert.NotEqual(t, 0, out.ExitCode)
+	assert.Contains(t, out.Stderr, "package main")
+}
+
+func TestRunner_Go_CompileError(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not found in PATH")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `package main
+
+func main() {
+	undefinedFn()
+}
+`,
+		Language: "go",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, out.ExitCode)
+	// コンパイルエラーは stderr に出る
+	assert.NotEmpty(t, out.Stderr)
+}
+
+func TestRunner_Go_ReadsStdin(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not found in PATH")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+func main() {
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		fmt.Println("got:", scanner.Text())
+	}
+}
+`,
+		Language: "go",
+		Stdin:    "hello\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "got: hello\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// Warmup(go) はコンパイルキャッシュを温める。go があれば成功する。
+func TestRunner_Warmup_Go(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not found in PATH")
+	}
+	r := sandbox.NewRunner()
+	require.NoError(t, r.Warmup(context.Background(), "go"))
+}
+
+// Warmup(php/bash/未対応) は no-op で常に成功する。
+func TestRunner_Warmup_NonGoIsNoop(t *testing.T) {
+	r := sandbox.NewRunner()
+	require.NoError(t, r.Warmup(context.Background(), "php"))
+	require.NoError(t, r.Warmup(context.Background(), "bash"))
+	require.NoError(t, r.Warmup(context.Background(), "unknown"))
+}
+
+// --- Bash ---
+
+func TestRunner_Bash_HelloWorld(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `echo "Hello, World!"`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// HOME / PWD は temp dir に固定されるため、 副作用は外に漏れない。
+func TestRunner_Bash_HomeIsTempDir(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `echo "$HOME"`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, out.ExitCode)
+	// macOS は /var/folders/... 、 Linux は /tmp/... と OS により分岐するため、
+	// "bash-exec-" prefix が含まれることだけ確認する。
+	assert.Contains(t, out.Stdout, "bash-exec-")
+}
+
+// AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
+func TestRunner_Bash_DropsParentEnv(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	t.Setenv("FRESTYLE_SECRET_TEST", "must-not-leak")
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `echo "value=${FRESTYLE_SECRET_TEST:-missing}"`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value=missing\n", out.Stdout)
+}
+
+func TestRunner_Bash_ReadsStdin(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `read line && echo "got: $line"`,
+		Language: "bash",
+		Stdin:    "ping\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "got: ping\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func TestRunner_Bash_ExitCodePropagated(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `echo "before" && exit 7`,
+		Language: "bash",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "before\n", out.Stdout)
+	assert.Equal(t, 7, out.ExitCode)
+}
+
+// timeout 時に bash 配下の子孫プロセスもまとめて kill されることを確認する regression test。
+// `Setpgid + cmd.Cancel = group SIGKILL + WaitDelay 1s` で、timeout(1s)+WaitDelay(1s) で
+// 必ず数秒以内に return する。
+func TestRunner_Bash_TimeoutKillsBackgroundChildren(t *testing.T) {
+	if _, err := exec.LookPath("/bin/bash"); err != nil {
+		t.Skip("/bin/bash not found")
+	}
+	r := sandbox.NewRunner()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	out, err := r.Run(ctx, domain.CodeExecutionInput{
+		Code: `sleep 30 &
+sleep 30
+`,
+		Language: "bash",
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.NotZero(t, out.ExitCode, "process should be killed by timeout")
+	assert.Less(t, elapsed, 5*time.Second, "should NOT wait for orphan sleep child to exit")
+}

--- a/backend/internal/usecase/execute_code_usecase.go
+++ b/backend/internal/usecase/execute_code_usecase.go
@@ -1,271 +1,31 @@
 package usecase
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"syscall"
-	"time"
 
-	"github.com/google/uuid"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
-const (
-	maxCodeBytes = 64 * 1024 // 64 KB
-	// execTimeout は PHP / bash の上限。
-	execTimeout = 8 * time.Second
-	// goExecTimeout は Go 専用。go run はコンパイルも走るため余裕を持たせる（cold compile ~6-8s）。
-	goExecTimeout  = 15 * time.Second
-	maxOutputBytes = 64 * 1024 // 64 KB
-)
-
-// 実行を禁止する PHP 関数。ファイル操作・OS 操作・ネットワーク通信などを封じる。
-var disableFunctions = strings.Join([]string{
-	"exec", "system", "shell_exec", "passthru", "popen", "proc_open",
-	"pcntl_exec", "proc_get_status", "proc_terminate", "proc_close",
-	"file_get_contents", "file_put_contents", "file", "fopen", "fwrite",
-	"fread", "fclose", "fgets", "fputs", "file_exists", "unlink",
-	"rename", "copy", "mkdir", "rmdir", "opendir", "readdir", "closedir",
-	"glob", "scandir", "tempnam", "tmpfile",
-	"socket_create", "fsockopen", "pfsockopen",
-	"curl_init", "curl_exec", "curl_multi_exec",
-	"dl", "phpinfo", "posix_kill", "posix_setuid",
-	"getenv", "putenv", "apache_getenv",
-	"syslog", "openlog", "closelog",
-}, ",")
-
-// ExecuteCodeInput はコード実行の入力。
-type ExecuteCodeInput struct {
-	Code     string
-	Language string // "php" / "go" / "bash"
-	// Stdin は実行時に標準入力として流す内容（テストケース採点で使う）。
-	Stdin string
+// CodeRunner は php / go / bash のコード実行とウォームアップを抽象化する port。
+// in-process 実装（infra/sandbox.Runner）か HTTP クライアント（infra/coderunner.Client）を
+// router が CODE_RUNNER_URL の有無で注入する。テストでは fake を差し替える。
+type CodeRunner interface {
+	Run(ctx context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error)
+	Warmup(ctx context.Context, language string) error
 }
 
-// ExecuteCodeOutput はコード実行の結果。
-type ExecuteCodeOutput struct {
-	Stdout   string `json:"stdout"`
-	Stderr   string `json:"stderr"`
-	ExitCode int    `json:"exitCode"`
+// ExecuteCodeUseCase は学習者コードをサンドボックスで実行する。実行自体は CodeRunner に委譲し、
+// usecase は実行系（in-process / sidecar）に依存しない。
+type ExecuteCodeUseCase struct {
+	runner CodeRunner
 }
 
-// ExecuteCodeUseCase は PHP / Go / bash のコードをサンドボックスで実行する。
-// 共通制約: timeout / 64 KB code-size / 64 KB output-size。
-type ExecuteCodeUseCase struct{}
-
-func NewExecuteCodeUseCase() *ExecuteCodeUseCase {
-	return &ExecuteCodeUseCase{}
+// NewExecuteCodeUseCase は CodeRunner を注入して ExecuteCodeUseCase を返す。
+func NewExecuteCodeUseCase(runner CodeRunner) *ExecuteCodeUseCase {
+	return &ExecuteCodeUseCase{runner: runner}
 }
 
-func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	if len(input.Code) > maxCodeBytes {
-		return nil, fmt.Errorf("コードが大きすぎます (最大 64 KB)")
-	}
-	switch input.Language {
-	case "php":
-		return uc.executePHP(ctx, input)
-	case "go":
-		return uc.executeGo(ctx, input)
-	case "bash":
-		return uc.executeBash(ctx, input)
-	default:
-		return nil, fmt.Errorf("未対応の言語: %s", input.Language)
-	}
-}
-
-func (uc *ExecuteCodeUseCase) executePHP(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	// 開始タグが無いと PHP はソースをそのまま stdout に流すため、別言語の誤貼付けを明示的に弾く。
-	if !strings.Contains(input.Code, "<?php") && !strings.Contains(input.Code, "<?=") {
-		return &ExecuteCodeOutput{
-			Stdout:   "",
-			Stderr:   "PHP コードには `<?php` 開始タグが必要です。 PHP 以外のコードは現在実行できません。",
-			ExitCode: 1,
-		}, nil
-	}
-
-	tmpDir := os.TempDir()
-	filename := filepath.Join(tmpDir, "code_"+uuid.NewString()+".php")
-	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
-		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
-	}
-	defer os.Remove(filename)
-
-	ctx, cancel := context.WithTimeout(ctx, execTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(
-		ctx,
-		"php",
-		"-d", "max_execution_time=5",
-		"-d", "memory_limit=32M",
-		"-d", "disable_functions="+disableFunctions,
-		"-d", "open_basedir="+tmpDir,
-		"-d", "display_errors=stderr",
-		"-d", "log_errors=0",
-		// variables_order から E を外し $_ENV を空にする（disable_functions=getenv の抜け穴を塞ぐ）。
-		"-d", "variables_order=GPCS",
-		filename,
-	)
-	// AWS 認証情報・注入シークレットを子プロセスに渡さない。
-	cmd.Env = sandboxEnv()
-
-	return runCommand(cmd, input.Stdin)
-}
-
-func (uc *ExecuteCodeUseCase) executeGo(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	// 別言語コードが意味不明なコンパイルエラーになるのを避けるため package main を必須にする。
-	if !strings.Contains(input.Code, "package main") {
-		return &ExecuteCodeOutput{
-			Stdout:   "",
-			Stderr:   "Go コードには `package main` と `func main()` が必要です。",
-			ExitCode: 1,
-		}, nil
-	}
-
-	// リクエストごとに独立した HOME を作る。build cache は共有で compile 短縮。
-	tmpDir, err := os.MkdirTemp("", "go-exec-")
-	if err != nil {
-		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	filename := filepath.Join(tmpDir, "main.go")
-	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
-		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, goExecTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "go", "run", filename)
-	// GO111MODULE=off で単一ファイル実行（go.mod 不要）。AWS 認証情報・注入シークレットは
-	// sandboxEnv が除外する。
-	cmd.Env = sandboxEnv(
-		"GO111MODULE=off",
-		"HOME="+tmpDir,
-	)
-
-	return runCommand(cmd, input.Stdin)
-}
-
-func (uc *ExecuteCodeUseCase) executeBash(ctx context.Context, input ExecuteCodeInput) (*ExecuteCodeOutput, error) {
-	// リクエストごとに独立した temp dir を HOME / PWD に固定し、副作用を temp に閉じる。
-	tmpDir, err := os.MkdirTemp("", "bash-exec-")
-	if err != nil {
-		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	filename := filepath.Join(tmpDir, "script.sh")
-	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
-		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, execTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "/bin/bash", filename)
-	cmd.Dir = tmpDir
-	// AWS credential や DB password 等を子プロセスに継承しないため、 環境変数は最小限に絞る。
-	cmd.Env = []string{
-		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"HOME=" + tmpDir,
-		"PWD=" + tmpDir,
-		"LANG=C.UTF-8",
-		"LC_ALL=C.UTF-8",
-	}
-
-	// bash はバックグラウンド子プロセスを起動しうるので、独立プロセスグループに置いて一括 kill する。
-	configureProcessGroup(cmd)
-
-	return runCommand(cmd, input.Stdin)
-}
-
-// configureProcessGroup は cmd を独立 process group に置き、cancel 時にグループ全体へ SIGKILL を送る。
-// bash / Java など、子孫プロセスを起動しうる言語の leak を防ぐ用途で使う。
-func configureProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return os.ErrProcessDone
-		}
-		// -pid でグループ全体に signal（POSIX）。失敗しても ExitError 上書き防止に nil を返す。
-		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-		return nil
-	}
-	// 残存子孫がいても Wait が張り付かないよう WaitDelay を付ける。
-	cmd.WaitDelay = 1 * time.Second
-}
-
-func runCommand(cmd *exec.Cmd, stdin string) (*ExecuteCodeOutput, error) {
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if stdin != "" {
-		cmd.Stdin = strings.NewReader(stdin)
-	}
-
-	err := cmd.Run()
-
-	out := &ExecuteCodeOutput{
-		Stdout: truncate(stdout.String(), maxOutputBytes),
-		Stderr: truncate(stderr.String(), maxOutputBytes),
-	}
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			out.ExitCode = exitErr.ExitCode()
-		} else {
-			out.ExitCode = 1
-		}
-	}
-	return out, nil
-}
-
-// sandboxEnv は os.Environ() から認証情報・秘密の env を除いて返す（末尾に extra を足す）。
-// 特に AWS_CONTAINER_CREDENTIALS_* を落とすことで、ユーザコードが ECS Task Role の
-// 一時クレデンシャル取得エンドポイントへ到達する経路を塞ぐ。DATABASE_URL や
-// COGNITO_CLIENT_SECRET 等の注入シークレットも読めないようにする。
-func sandboxEnv(extra ...string) []string {
-	base := os.Environ()
-	out := make([]string, 0, len(base)+len(extra))
-	for _, kv := range base {
-		eq := strings.IndexByte(kv, '=')
-		if eq <= 0 {
-			continue
-		}
-		if isSensitiveEnvKey(kv[:eq]) {
-			continue
-		}
-		out = append(out, kv)
-	}
-	return append(out, extra...)
-}
-
-// isSensitiveEnvKey はユーザコードに渡してはいけない env 名かを判定する。
-func isSensitiveEnvKey(key string) bool {
-	k := strings.ToUpper(key)
-	for _, p := range []string{"AWS_", "COGNITO_", "DB_", "DATABASE", "SES_", "DYNAMODB_", "NOTE_IMAGES", "BEDROCK_"} {
-		if strings.HasPrefix(k, p) {
-			return true
-		}
-	}
-	for _, s := range []string{"SECRET", "PASSWORD", "TOKEN", "CREDENTIAL", "_KEY"} {
-		if strings.Contains(k, s) {
-			return true
-		}
-	}
-	return false
-}
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max] + "\n...(出力が長すぎるため省略されました)"
+// Execute は入力コードを CodeRunner で実行し結果を返す。
+func (uc *ExecuteCodeUseCase) Execute(ctx context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	return uc.runner.Run(ctx, in)
 }

--- a/backend/internal/usecase/execute_code_usecase_test.go
+++ b/backend/internal/usecase/execute_code_usecase_test.go
@@ -2,293 +2,72 @@ package usecase_test
 
 import (
 	"context"
-	"os/exec"
+	"errors"
 	"testing"
-	"time"
 
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestExecuteCodeUseCase_PHP_HelloWorld(t *testing.T) {
-	_, err := exec.LookPath("php")
-	if err != nil {
-		t.Skip("php not found in PATH, skipping integration test")
-	}
-
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `<?php echo "Hello, World!\n";`,
-		Language: "php",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "Hello, World!\n", out.Stdout)
-	assert.Equal(t, 0, out.ExitCode)
+// fakeCodeRunner は CodeRunner を満たすテスト用 fake。
+type fakeCodeRunner struct {
+	gotInput  domain.CodeExecutionInput
+	gotWarmup string
+	result    *domain.CodeExecutionResult
+	runErr    error
+	warmupErr error
 }
 
-func TestExecuteCodeUseCase_PHP_SyntaxError(t *testing.T) {
-	_, err := exec.LookPath("php")
-	if err != nil {
-		t.Skip("php not found in PATH, skipping integration test")
+func (f *fakeCodeRunner) Run(_ context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	f.gotInput = in
+	if f.runErr != nil {
+		return nil, f.runErr
 	}
-
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `<?php echo "unclosed`,
-		Language: "php",
-	})
-	require.NoError(t, err)
-	assert.NotEqual(t, 0, out.ExitCode)
+	return f.result, nil
 }
 
-func TestExecuteCodeUseCase_UnsupportedLanguage(t *testing.T) {
-	uc := usecase.NewExecuteCodeUseCase()
-	_, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `print("hi")`,
-		Language: "python",
+func (f *fakeCodeRunner) Warmup(_ context.Context, language string) error {
+	f.gotWarmup = language
+	return f.warmupErr
+}
+
+func TestExecuteCodeUseCase_DelegatesToRunner(t *testing.T) {
+	fake := &fakeCodeRunner{result: &domain.CodeExecutionResult{Stdout: "ok", ExitCode: 0}}
+	uc := usecase.NewExecuteCodeUseCase(fake)
+
+	out, err := uc.Execute(context.Background(), domain.CodeExecutionInput{
+		Code:     `<?php echo "ok";`,
+		Language: "php",
+		Stdin:    "x",
 	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", out.Stdout)
+	// 入力がそのまま runner に渡る。
+	assert.Equal(t, "php", fake.gotInput.Language)
+	assert.Equal(t, "x", fake.gotInput.Stdin)
+}
+
+func TestExecuteCodeUseCase_PropagatesRunnerError(t *testing.T) {
+	fake := &fakeCodeRunner{runErr: errors.New("boom")}
+	uc := usecase.NewExecuteCodeUseCase(fake)
+
+	_, err := uc.Execute(context.Background(), domain.CodeExecutionInput{Language: "go"})
 	assert.Error(t, err)
 }
 
-func TestExecuteCodeUseCase_CodeTooLarge(t *testing.T) {
-	uc := usecase.NewExecuteCodeUseCase()
-	bigCode := make([]byte, 65*1024)
-	_, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     string(bigCode),
-		Language: "php",
-	})
-	assert.Error(t, err)
+func TestWarmupCodeUseCase_DelegatesLanguage(t *testing.T) {
+	fake := &fakeCodeRunner{}
+	uc := usecase.NewWarmupCodeUseCase(fake)
+
+	require.NoError(t, uc.Execute(context.Background(), "go"))
+	assert.Equal(t, "go", fake.gotWarmup)
 }
 
-// `<?php` 開始タグが無いコード（例: Java を貼り付けた）は、 PHP CLI のデフォルトで
-// 「ソースをそのまま stdout に出力して exit 0」になるため、 検証層で弾いて分かりやすい
-// stderr メッセージに置き換える。
-func TestExecuteCodeUseCase_PHP_RejectsCodeWithoutOpenTag(t *testing.T) {
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code: `import java.util.*;
-class Main {
-    public static void main(String[] args) {
-        System.out.println("Hello World");
-    }
-}`,
-		Language: "php",
-	})
-	require.NoError(t, err)
-	assert.Empty(t, out.Stdout)
-	assert.NotEqual(t, 0, out.ExitCode)
-	assert.Contains(t, out.Stderr, "<?php")
-}
+func TestWarmupCodeUseCase_PropagatesError(t *testing.T) {
+	fake := &fakeCodeRunner{warmupErr: errors.New("warm failed")}
+	uc := usecase.NewWarmupCodeUseCase(fake)
 
-// `<?=` (short echo tag) も PHP として扱われる必要があるので、 こちらは通す。
-func TestExecuteCodeUseCase_PHP_AllowsShortEchoTag(t *testing.T) {
-	_, err := exec.LookPath("php")
-	if err != nil {
-		t.Skip("php not found in PATH")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `<?= "Hello"; ?>`,
-		Language: "php",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 0, out.ExitCode)
-}
-
-// --- Go ---
-
-func TestExecuteCodeUseCase_Go_HelloWorld(t *testing.T) {
-	_, err := exec.LookPath("go")
-	if err != nil {
-		t.Skip("go not found in PATH, skipping integration test")
-	}
-
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code: `package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello, World!")
-}
-`,
-		Language: "go",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "Hello, World!\n", out.Stdout)
-	assert.Equal(t, 0, out.ExitCode)
-}
-
-func TestExecuteCodeUseCase_Go_RejectsMissingPackageMain(t *testing.T) {
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `fmt.Println("hi")`,
-		Language: "go",
-	})
-	require.NoError(t, err)
-	assert.Empty(t, out.Stdout)
-	assert.NotEqual(t, 0, out.ExitCode)
-	assert.Contains(t, out.Stderr, "package main")
-}
-
-func TestExecuteCodeUseCase_Go_CompileError(t *testing.T) {
-	_, err := exec.LookPath("go")
-	if err != nil {
-		t.Skip("go not found in PATH")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code: `package main
-
-func main() {
-	undefinedFn()
-}
-`,
-		Language: "go",
-	})
-	require.NoError(t, err)
-	assert.NotEqual(t, 0, out.ExitCode)
-	// コンパイルエラーは stderr に出る
-	assert.NotEmpty(t, out.Stderr)
-}
-
-func TestExecuteCodeUseCase_Go_ReadsStdin(t *testing.T) {
-	_, err := exec.LookPath("go")
-	if err != nil {
-		t.Skip("go not found in PATH")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code: `package main
-
-import (
-	"bufio"
-	"fmt"
-	"os"
-)
-
-func main() {
-	scanner := bufio.NewScanner(os.Stdin)
-	if scanner.Scan() {
-		fmt.Println("got:", scanner.Text())
-	}
-}
-`,
-		Language: "go",
-		Stdin:    "hello\n",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "got: hello\n", out.Stdout)
-	assert.Equal(t, 0, out.ExitCode)
-}
-
-// --- Bash ---
-
-func TestExecuteCodeUseCase_Bash_HelloWorld(t *testing.T) {
-	if _, err := exec.LookPath("/bin/bash"); err != nil {
-		t.Skip("/bin/bash not found")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `echo "Hello, World!"`,
-		Language: "bash",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "Hello, World!\n", out.Stdout)
-	assert.Equal(t, 0, out.ExitCode)
-}
-
-// HOME / PWD は temp dir に固定されるため、 副作用は外に漏れない。
-// echo "$HOME" の結果が `/tmp/...` 始まりであることを確認する。
-func TestExecuteCodeUseCase_Bash_HomeIsTempDir(t *testing.T) {
-	if _, err := exec.LookPath("/bin/bash"); err != nil {
-		t.Skip("/bin/bash not found")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `echo "$HOME"`,
-		Language: "bash",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, 0, out.ExitCode)
-	// macOS は /var/folders/... 、 Linux は /tmp/... と OS により分岐するため、
-	// "bash-exec-" prefix が含まれることだけ確認する。
-	assert.Contains(t, out.Stdout, "bash-exec-")
-}
-
-// AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
-func TestExecuteCodeUseCase_Bash_DropsParentEnv(t *testing.T) {
-	if _, err := exec.LookPath("/bin/bash"); err != nil {
-		t.Skip("/bin/bash not found")
-	}
-	t.Setenv("FRESTYLE_SECRET_TEST", "must-not-leak")
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `echo "value=${FRESTYLE_SECRET_TEST:-missing}"`,
-		Language: "bash",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "value=missing\n", out.Stdout)
-}
-
-func TestExecuteCodeUseCase_Bash_ReadsStdin(t *testing.T) {
-	if _, err := exec.LookPath("/bin/bash"); err != nil {
-		t.Skip("/bin/bash not found")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `read line && echo "got: $line"`,
-		Language: "bash",
-		Stdin:    "ping\n",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "got: ping\n", out.Stdout)
-	assert.Equal(t, 0, out.ExitCode)
-}
-
-func TestExecuteCodeUseCase_Bash_ExitCodePropagated(t *testing.T) {
-	if _, err := exec.LookPath("/bin/bash"); err != nil {
-		t.Skip("/bin/bash not found")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-	out, err := uc.Execute(context.Background(), usecase.ExecuteCodeInput{
-		Code:     `echo "before" && exit 7`,
-		Language: "bash",
-	})
-	require.NoError(t, err)
-	assert.Equal(t, "before\n", out.Stdout)
-	assert.Equal(t, 7, out.ExitCode)
-}
-
-// timeout 時に bash 配下の子孫プロセスもまとめて kill されることを確認する regression test。
-//
-// 既定の `exec.CommandContext` は親 bash のみに SIGKILL を投げるため、 ユーザコードが
-// バックグラウンドで投げた子孫 (例: sleep 30 &) が stdout パイプを保持し続け、
-// `cmd.Wait()` が 30 秒間ブロックする問題があった。
-//
-// `runCommand` で `Setpgid + cmd.Cancel = group SIGKILL + WaitDelay 1s` を入れたので、
-// timeout (1 秒) + WaitDelay (1 秒) で必ず数秒以内に return するはず。
-func TestExecuteCodeUseCase_Bash_TimeoutKillsBackgroundChildren(t *testing.T) {
-	if _, err := exec.LookPath("/bin/bash"); err != nil {
-		t.Skip("/bin/bash not found")
-	}
-	uc := usecase.NewExecuteCodeUseCase()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-
-	start := time.Now()
-	out, err := uc.Execute(ctx, usecase.ExecuteCodeInput{
-		Code: `sleep 30 &
-sleep 30
-`,
-		Language: "bash",
-	})
-	elapsed := time.Since(start)
-	require.NoError(t, err)
-	assert.NotZero(t, out.ExitCode, "process should be killed by timeout")
-	// 修正前: 30 秒 ブロック / 修正後: timeout 1s + WaitDelay 1s で 数秒以内に return。
-	assert.Less(t, elapsed, 5*time.Second, "should NOT wait for orphan sleep child to exit")
+	assert.Error(t, uc.Execute(context.Background(), "go"))
 }

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -12,7 +12,7 @@ import (
 
 // CodeExecutor は ExecuteCodeUseCase を抽象化し、usecase 同士の直接依存を避ける。
 type CodeExecutor interface {
-	Execute(ctx context.Context, in ExecuteCodeInput) (*ExecuteCodeOutput, error)
+	Execute(ctx context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error)
 }
 
 // SubmitMasterExerciseInput は提出 API への入力。
@@ -113,7 +113,7 @@ func (uc *SubmitMasterExerciseUseCase) Execute(ctx context.Context, in SubmitMas
 	var representativeExit int
 
 	for _, tc := range examples {
-		out, err := uc.executor.Execute(ctx, ExecuteCodeInput{
+		out, err := uc.executor.Execute(ctx, domain.CodeExecutionInput{
 			Code:     in.Code,
 			Language: ex.Language,
 			Stdin:    tc.InputText,

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -74,7 +74,7 @@ func (r *fakeSubmissionRepo) HasAttempted(context.Context, uint64, uint64, strin
 
 // fakeExecutor は ExecuteCodeUseCase の代わり。 入力 stdin で出力を切り替える。
 type fakeExecutor struct {
-	calls []usecase.ExecuteCodeInput
+	calls []domain.CodeExecutionInput
 	// stdinToOut: stdin に対応する stdout を返す。 なければ空。
 	stdinToOut map[string]string
 	// runErr が non-nil なら Execute がエラーを返す。
@@ -83,12 +83,12 @@ type fakeExecutor struct {
 	failExit map[string]int
 }
 
-func (f *fakeExecutor) Execute(_ context.Context, in usecase.ExecuteCodeInput) (*usecase.ExecuteCodeOutput, error) {
+func (f *fakeExecutor) Execute(_ context.Context, in domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
 	if f.runErr != nil {
 		return nil, f.runErr
 	}
 	f.calls = append(f.calls, in)
-	out := &usecase.ExecuteCodeOutput{Stdout: f.stdinToOut[in.Stdin]}
+	out := &domain.CodeExecutionResult{Stdout: f.stdinToOut[in.Stdin]}
 	if code, ok := f.failExit[in.Stdin]; ok {
 		out.ExitCode = code
 		out.Stderr = "boom"
@@ -227,7 +227,7 @@ func TestSubmitMasterExercise_NoExamples_FallbackToExerciseExpected(t *testing.T
 	assert.Equal(t, "bash", executor.calls[0].Language)
 }
 
-// SubmitMasterExerciseUseCase が exercise.Language を ExecuteCodeInput に正しく渡しているか。
+// SubmitMasterExerciseUseCase が exercise.Language を domain.CodeExecutionInput に正しく渡しているか。
 // 旧実装は "php" 固定だったため、 Go / bash / Linux 演習が正しく実行できない不具合があった。
 func TestSubmitMasterExercise_PassesExerciseLanguage(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{

--- a/backend/internal/usecase/warmup_code_usecase.go
+++ b/backend/internal/usecase/warmup_code_usecase.go
@@ -1,0 +1,19 @@
+package usecase
+
+import "context"
+
+// WarmupCodeUseCase は指定言語の実行環境を事前に温める。学習者がコードエディタ
+// （演習詳細）ページに入った時点で呼び、最初の Run を即時化する用途。
+type WarmupCodeUseCase struct {
+	runner CodeRunner
+}
+
+// NewWarmupCodeUseCase は CodeRunner を注入して WarmupCodeUseCase を返す。
+func NewWarmupCodeUseCase(runner CodeRunner) *WarmupCodeUseCase {
+	return &WarmupCodeUseCase{runner: runner}
+}
+
+// Execute は language の実行環境を温める（Go はコンパイルキャッシュ、php/bash は no-op）。
+func (uc *WarmupCodeUseCase) Execute(ctx context.Context, language string) error {
+	return uc.runner.Warmup(ctx, language)
+}

--- a/docs/design/2026年/0004-code-runner-separation.md
+++ b/docs/design/2026年/0004-code-runner-separation.md
@@ -133,3 +133,29 @@ GET  /healthz （200 = 実行可能）
 - **ユニット**: `ExecuteCodeUseCase` を fake `CodeRunner` でモックし、言語ルーティング / バリデーション / 503 ハンドリングを検証
 - **結合**: runner パッケージのサンドボックス実行テスト（現 `execute_code_usecase_test.go` / `execute_code_sandbox_test.go` を runner 側へ移送）。php/go/bash の stdout/exitCode、timeout、secret 非漏洩（sandboxEnv）を担保
 - **手動・本番検証**: Phase 2 で「夜間 teardown → 朝のコールドスタート」を実測し、`/api/v2/health` 200 までの時間が短縮されたことを確認。演習画面で各言語の Run が成功することを確認
+
+## 8. 実装状況
+
+### Phase 1（アプリコード分離・挙動不変）— 実装済み
+
+| 役割 | 配置 |
+|---|---|
+| 境界の値型 | `backend/internal/domain/code_execution.go`（`CodeExecutionInput` / `CodeExecutionResult`） |
+| port（usecase が依存する抽象） | `backend/internal/usecase/execute_code_usecase.go` の `CodeRunner` interface（`Run` + `Warmup`） |
+| in-process 実装（os/exec サンドボックス） | `backend/internal/infra/sandbox/runner.go`（php / go / bash） |
+| HTTP クライアント（サイドカー委譲） | `backend/internal/infra/coderunner/client.go` |
+| runner サーバ（別バイナリ） | `backend/cmd/coderunner/main.go`（`POST /run` / `POST /warmup` / `GET /healthz`） |
+| warmup usecase / handler | `WarmupCodeUseCase` + `POST /api/v2/code/warmup` |
+| 実行系の選択 | `routes_exercises.go` が `CODE_RUNNER_URL` の有無で `coderunner.Client`（HTTP）か `sandbox.Runner`（in-process）を注入 |
+| frontend warmup | `useExerciseDetail` が detail ロード時に `ExerciseRepository.warmup(language)` を fire-and-forget、`warmupReady` で「実行環境 準備完了」を表示 |
+| runner イメージ | `backend/Dockerfile.coderunner`（golang+php、Phase 2 で CI が build） |
+
+`CODE_RUNNER_URL` 未設定が既定なので、本番は当面 in-process（現行と同挙動・同イメージ）。runtime の切替・イメージ分離は Phase 2 / 3 で行う。
+
+### Phase 2（infra・未着手）
+
+ECS タスク定義に runner サイドカー（`Dockerfile.coderunner`、`essential:false`）を追加し、backend に `CODE_RUNNER_URL=http://127.0.0.1:9000` を注入。CI で 2 イメージを build/push。コールドスタートを実測。
+
+### Phase 3（distroless 化・未着手）
+
+Phase 2 で HTTP 経路が安定したら、`backend/Dockerfile` を distroless（go/php を含まない）に絞り API イメージを ~60MB 化する。

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -165,6 +165,7 @@ export const EXERCISES = {
 
 export const CODE = {
   execute: `${API_V2}/code/execute`,
+  warmup: `${API_V2}/code/warmup`,
 } as const;
 
 /** コース（company_admin が作成、 自社 trainee + 同社 admin が閲覧）*/

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -900,7 +900,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/auth/cognito/callback": {
+    "/auth/cognito/login": {
         parameters: {
             query?: never;
             header?: never;
@@ -910,7 +910,107 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Cognito callback (認可 コード → token 交換)
+         * ログイン (メール / パスワード)
+         * @description email / password を Cognito の USER_PASSWORD_AUTH で 検証 し、 access / refresh token を HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description メール / パスワード */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.passwordLoginReq"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.messageResponse"];
+                    };
+                };
+                /** @description 入力 不正 (email 形式 / password 欠落) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 資格 情報 誤り */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 招待 なし の 新規 user */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description レート制限超過 */
+                429: {
+                    headers: {
+                        /** @description 再試行までの秒数 (例: 60) */
+                        "Retry-After"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部 エラー (Cognito 未 設定 / DB 失敗 等) */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description Cognito 到達 不可 */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ログイン (認可 コード → token 交換)
          * @description Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。
          */
         post: {
@@ -1000,7 +1100,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/auth/cognito/logout": {
+    "/auth/logout": {
         parameters: {
             query?: never;
             header?: never;
@@ -1029,74 +1129,6 @@ export interface paths {
                     };
                     content: {
                         "application/json": components["schemas"]["internal_handler.messageResponse"];
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/cognito/refresh-token": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * アクセス トークン リフレッシュ
-         * @description refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.messageResponse"];
-                    };
-                };
-                /** @description refresh_token 欠落 / 無効 */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.errorResponse"];
-                    };
-                };
-                /** @description レート制限超過 */
-                429: {
-                    headers: {
-                        /** @description 再試行までの秒数 (例: 60) */
-                        "Retry-After"?: string;
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.errorResponse"];
-                    };
-                };
-                /** @description Cognito 到達 不可 */
-                502: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
             };
@@ -1173,6 +1205,74 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * アクセス トークン リフレッシュ
+         * @description refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.messageResponse"];
+                    };
+                };
+                /** @description refresh_token 欠落 / 無効 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description レート制限超過 */
+                429: {
+                    headers: {
+                        /** @description 再試行までの秒数 (例: 60) */
+                        "Retry-After"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description Cognito 到達 不可 */
+                502: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/code/execute": {
         parameters: {
             query?: never;
@@ -1184,7 +1284,7 @@ export interface paths {
         put?: never;
         /**
          * コード サンドボックス 実行
-         * @description trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。
+         * @description trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。
          */
         post: {
             parameters: {
@@ -1206,10 +1306,72 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"];
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult"];
                     };
                 };
                 /** @description バリデーション or 実行 失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/code/warmup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 実行環境 ウォームアップ
+         * @description コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description 言語 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.codeWarmupRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.codeWarmupResponse"];
+                    };
+                };
+                /** @description バリデーション 失敗 */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -1302,6 +1464,136 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/company/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 会社設定 取得 (AI 有効化)
+         * @description 自社の trainee への AI チャット有効化フラグを返す。company_admin / super_admin のみ。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.companySettingsResponse"];
+                    };
+                };
+                /** @description 会社未所属 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 管理者以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 会社が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        /**
+         * 会社設定 更新 (AI 有効化)
+         * @description 自社の trainee への AI チャット有効化フラグを更新する。company_admin / super_admin のみ。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description aiChatEnabledForTrainees */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.updateCompanySettingsRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.companySettingsResponse"];
+                    };
+                };
+                /** @description バリデーション / 会社未所属 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 管理者以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3617,7 +3909,17 @@ export interface components {
             kind?: string;
             sizeBytes?: number;
         };
+        "github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult": {
+            exitCode?: number;
+            stderr?: string;
+            stdout?: string;
+        };
         "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
+            /**
+             * @description AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。
+             *     company_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。
+             */
+            aiChatEnabledForTrainees?: boolean;
             createdAt?: string;
             id?: number;
             name?: string;
@@ -3777,11 +4079,6 @@ export interface components {
             title?: string;
             url?: string;
         };
-        "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
-            exitCode?: number;
-            stderr?: string;
-            stdout?: string;
-        };
         "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
             examples?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"][];
             exercise?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise"];
@@ -3840,10 +4137,19 @@ export interface components {
             code: string;
             language?: string;
         };
+        "internal_handler.codeWarmupRequest": {
+            language: string;
+        };
+        "internal_handler.codeWarmupResponse": {
+            ready?: boolean;
+        };
         "internal_handler.cognitoCallbackReq": {
             code: string;
             /** @description InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。 */
             invitationToken?: string;
+        };
+        "internal_handler.companySettingsResponse": {
+            aiChatEnabledForTrainees?: boolean;
         };
         "internal_handler.courseRequest": {
             description?: string;
@@ -3931,6 +4237,11 @@ export interface components {
             isPublic?: boolean;
             title: string;
         };
+        "internal_handler.passwordLoginReq": {
+            /** Format: email */
+            email: string;
+            password: string;
+        };
         "internal_handler.requestReportReq": {
             month: number;
             year: number;
@@ -3970,6 +4281,10 @@ export interface components {
         };
         "internal_handler.updateCompanyApplicationStatusReq": {
             status: string;
+        };
+        "internal_handler.updateCompanySettingsRequest": {
+            /** @description bool の必須を binding:"required" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。 */
+            aiChatEnabledForTrainees: boolean;
         };
         "internal_handler.updateProfileReq": {
             avatarUrl?: string;

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -913,13 +913,113 @@
                 }
             }
         },
-        "/auth/cognito/callback": {
+        "/auth/cognito/login": {
+            "post": {
+                "description": "email / password を Cognito の USER_PASSWORD_AUTH で 検証 し、 access / refresh token を HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
+                "tags": [
+                    "auth"
+                ],
+                "summary": "ログイン (メール / パスワード)",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.passwordLoginReq"
+                            }
+                        }
+                    },
+                    "description": "メール / パスワード",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.messageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "入力 不正 (email 形式 / password 欠落)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "資格 情報 誤り",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "招待 なし の 新規 user",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "再試行までの秒数 (例: 60)",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部 エラー (Cognito 未 設定 / DB 失敗 等)",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Cognito 到達 不可",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/auth/login": {
             "post": {
                 "description": "Cognito Hosted UI から の callback。 authorization code を access / refresh / id token に 交換 し HttpOnly Cookie で 返す。 新規 user は 招待 or Cognito admin group 必須。",
                 "tags": [
                     "auth"
                 ],
-                "summary": "Cognito callback (認可 コード → token 交換)",
+                "summary": "ログイン (認可 コード → token 交換)",
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -1013,7 +1113,7 @@
                 }
             }
         },
-        "/auth/cognito/logout": {
+        "/auth/logout": {
             "post": {
                 "description": "HttpOnly Cookie の access / refresh token を 消去 する。 Cognito 側 の セッション は 別途 hosted UI で 切る。",
                 "tags": [
@@ -1027,65 +1127,6 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/internal_handler.messageResponse"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/cognito/refresh-token": {
-            "post": {
-                "description": "refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。",
-                "tags": [
-                    "auth"
-                ],
-                "summary": "アクセス トークン リフレッシュ",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.messageResponse"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "refresh_token 欠落 / 無効",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "レート制限超過",
-                        "headers": {
-                            "Retry-After": {
-                                "description": "再試行までの秒数 (例: 60)",
-                                "schema": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
-                                }
-                            }
-                        }
-                    },
-                    "502": {
-                        "description": "Cognito 到達 不可",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
                                 }
                             }
                         }
@@ -1149,6 +1190,65 @@
                 }
             }
         },
+        "/auth/refresh": {
+            "post": {
+                "description": "refresh_token Cookie で access_token を 再 発行 し HttpOnly Cookie に セット する。 失敗 (refresh 切れ 等) は 401 で Cookie クリア。",
+                "tags": [
+                    "auth"
+                ],
+                "summary": "アクセス トークン リフレッシュ",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.messageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "refresh_token 欠落 / 無効",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "429": {
+                        "description": "レート制限超過",
+                        "headers": {
+                            "Retry-After": {
+                                "description": "再試行までの秒数 (例: 60)",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Cognito 到達 不可",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/code/execute": {
             "post": {
                 "security": [
@@ -1156,7 +1256,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go 等。",
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。",
                 "tags": [
                     "code-execution"
                 ],
@@ -1178,13 +1278,70 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput"
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult"
                                 }
                             }
                         }
                     },
                     "400": {
                         "description": "バリデーション or 実行 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/code/warmup": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "tags": [
+                    "code-execution"
+                ],
+                "summary": "実行環境 ウォームアップ",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.codeWarmupRequest"
+                            }
+                        }
+                    },
+                    "description": "言語",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.codeWarmupResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション 失敗",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1265,6 +1422,137 @@
                     },
                     "500": {
                         "description": "内部エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/company/settings": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の trainee への AI チャット有効化フラグを返す。company_admin / super_admin のみ。",
+                "tags": [
+                    "company"
+                ],
+                "summary": "会社設定 取得 (AI 有効化)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.companySettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "会社未所属",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "会社が存在しない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の trainee への AI チャット有効化フラグを更新する。company_admin / super_admin のみ。",
+                "tags": [
+                    "company"
+                ],
+                "summary": "会社設定 更新 (AI 有効化)",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.updateCompanySettingsRequest"
+                            }
+                        }
+                    },
+                    "description": "aiChatEnabledForTrainees",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.companySettingsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "バリデーション / 会社未所属",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3674,9 +3962,27 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult": {
+                "type": "object",
+                "properties": {
+                    "exitCode": {
+                        "type": "integer"
+                    },
+                    "stderr": {
+                        "type": "string"
+                    },
+                    "stdout": {
+                        "type": "string"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_domain.Company": {
                 "type": "object",
                 "properties": {
+                    "aiChatEnabledForTrainees": {
+                        "description": "AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。\ncompany_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。",
+                        "type": "boolean"
+                    },
                     "createdAt": {
                         "type": "string"
                     },
@@ -4125,20 +4431,6 @@
                     }
                 }
             },
-            "github_com_norman6464_FreStyle_backend_internal_usecase.ExecuteCodeOutput": {
-                "type": "object",
-                "properties": {
-                    "exitCode": {
-                        "type": "integer"
-                    },
-                    "stderr": {
-                        "type": "string"
-                    },
-                    "stdout": {
-                        "type": "string"
-                    }
-                }
-            },
             "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
                 "type": "object",
                 "properties": {
@@ -4310,6 +4602,25 @@
                     }
                 }
             },
+            "internal_handler.codeWarmupRequest": {
+                "type": "object",
+                "required": [
+                    "language"
+                ],
+                "properties": {
+                    "language": {
+                        "type": "string"
+                    }
+                }
+            },
+            "internal_handler.codeWarmupResponse": {
+                "type": "object",
+                "properties": {
+                    "ready": {
+                        "type": "boolean"
+                    }
+                }
+            },
             "internal_handler.cognitoCallbackReq": {
                 "type": "object",
                 "required": [
@@ -4322,6 +4633,14 @@
                     "invitationToken": {
                         "description": "InvitationToken は招待マジックリンク経由の UUID（任意）。指定時は email 検索より優先して照合する。",
                         "type": "string"
+                    }
+                }
+            },
+            "internal_handler.companySettingsResponse": {
+                "type": "object",
+                "properties": {
+                    "aiChatEnabledForTrainees": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -4553,6 +4872,22 @@
                     }
                 }
             },
+            "internal_handler.passwordLoginReq": {
+                "type": "object",
+                "required": [
+                    "email",
+                    "password"
+                ],
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "password": {
+                        "type": "string"
+                    }
+                }
+            },
             "internal_handler.requestReportReq": {
                 "type": "object",
                 "required": [
@@ -4682,6 +5017,18 @@
                 "properties": {
                     "status": {
                         "type": "string"
+                    }
+                }
+            },
+            "internal_handler.updateCompanySettingsRequest": {
+                "type": "object",
+                "required": [
+                    "aiChatEnabledForTrainees"
+                ],
+                "properties": {
+                    "aiChatEnabledForTrainees": {
+                        "description": "bool の必須を binding:\"required\" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。",
+                        "type": "boolean"
                     }
                 }
             },

--- a/frontend/src/hooks/__tests__/useExerciseDetail.test.ts
+++ b/frontend/src/hooks/__tests__/useExerciseDetail.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../repositories/ExerciseRepository', () => ({
   default: {
     getDetail: vi.fn(),
     execute: vi.fn(),
+    warmup: vi.fn(),
     submit: vi.fn(),
     listSubmissions: vi.fn(),
   },
@@ -25,6 +26,7 @@ describe('useExerciseDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.listSubmissions.mockResolvedValue([]);
+    mocks.warmup.mockResolvedValue(undefined);
   });
 
   it('slug を渡すと detail と starterCode をロードする', async () => {
@@ -34,6 +36,14 @@ describe('useExerciseDetail', () => {
     expect(result.current.detail?.exercise.slug).toBe('php-1');
     expect(result.current.code).toBe('<?php echo "hi";');
     expect(mocks.listSubmissions).toHaveBeenCalledWith('php-1');
+  });
+
+  it('入場時に exercise の言語で warmup を呼び warmupReady を立てる', async () => {
+    mocks.getDetail.mockResolvedValue({ exercise: baseExercise, examples: [] });
+    const { result } = renderHook(() => useExerciseDetail('php-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mocks.warmup).toHaveBeenCalledWith('php');
+    await waitFor(() => expect(result.current.warmupReady).toBe(true));
   });
 
   it('runCode は実行結果を保存する', async () => {

--- a/frontend/src/hooks/useExerciseDetail.ts
+++ b/frontend/src/hooks/useExerciseDetail.ts
@@ -24,6 +24,8 @@ export function useExerciseDetail(slug: string | undefined) {
 
   const [running, setRunning] = useState(false);
   const [executionResult, setExecutionResult] = useState<CodeExecutionResult | null>(null);
+  // エディタ入場時の事前ウォームアップが完了したか（UI に「実行環境 準備完了」を出す用）。
+  const [warmupReady, setWarmupReady] = useState(false);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitResult, setSubmitResult] = useState<ExerciseSubmitResult | null>(null);
@@ -52,11 +54,21 @@ export function useExerciseDetail(slug: string | undefined) {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setWarmupReady(false);
     ExerciseRepository.getDetail(slug)
       .then((d) => {
         if (cancelled) return;
         setDetail(d);
         setCode(d.exercise.starterCode ?? '');
+        // 言語が確定した時点で実行環境を warm にしておく（最初の Run を即時化）。
+        // 失敗してもエディタは使えるので fire-and-forget の silent fail 扱い。
+        ExerciseRepository.warmup(d.exercise.language)
+          .then(() => {
+            if (!cancelled) setWarmupReady(true);
+          })
+          .catch(() => {
+            /* warmup 失敗は無視（実行自体は可能） */
+          });
       })
       .catch(() => {
         if (!cancelled) setError('演習問題の取得に失敗しました');
@@ -121,6 +133,7 @@ export function useExerciseDetail(slug: string | undefined) {
     error,
     running,
     executionResult,
+    warmupReady,
     submitting,
     submitResult,
     submitError,

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -40,6 +40,7 @@ export default function ExerciseDetailPage() {
     error,
     running,
     executionResult,
+    warmupReady,
     submitting,
     submitResult,
     submitError,
@@ -171,6 +172,12 @@ export default function ExerciseDetailPage() {
             <span className="text-xs px-2 py-0.5 rounded bg-surface-3 text-[var(--color-text-muted)] font-mono uppercase">
               {ex.language}
             </span>
+            {warmupReady && (
+              <span className="text-xs px-2 py-0.5 rounded bg-emerald-500/15 text-emerald-400 inline-flex items-center gap-1">
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" aria-hidden />
+                実行環境 準備完了
+              </span>
+            )}
           </div>
         </div>
         <div className="bg-[#1e1e1e]">

--- a/frontend/src/repositories/ExerciseRepository.ts
+++ b/frontend/src/repositories/ExerciseRepository.ts
@@ -34,6 +34,14 @@ const ExerciseRepository = {
     return res.data;
   },
 
+  /**
+   * エディタ入場時に実行環境を事前ウォームアップする（Go はコンパイルキャッシュ、php/bash は no-op）。
+   * 実行時に立ち上げるのではなく、入場時に warm にしておき最初の Run を即時化する。
+   */
+  async warmup(language: string): Promise<void> {
+    await api.post(CODE.warmup, { language });
+  },
+
   async submit(slug: string, code: string): Promise<ExerciseSubmitResult> {
     const res = await api.post<ExerciseSubmitResult>(EXERCISES.submit(slug), { code });
     return res.data;

--- a/frontend/src/repositories/__tests__/ExerciseRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ExerciseRepository.test.ts
@@ -43,6 +43,12 @@ describe('ExerciseRepository', () => {
     expect(mockedPost).toHaveBeenCalledWith('/api/v2/code/execute', { code: '<?php echo "ok";', language: 'php' });
   });
 
+  it('warmup: 言語を指定して実行環境を温める', async () => {
+    mockedPost.mockResolvedValue({ data: { ready: true } });
+    await ExerciseRepository.warmup('go');
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/code/warmup', { language: 'go' });
+  });
+
   it('submit: コードを提出する', async () => {
     mockedPost.mockResolvedValue({ data: { submissionId: 1, isCorrect: true, results: [] } });
     const out = await ExerciseRepository.submit('php-1', '<?php');


### PR DESCRIPTION
## 概要

イメージ軽量化（Design Doc 0004 / サイドカー分離）の **Phase 1**。コード実行を `CodeRunner` port に抽象化し、os/exec サンドボックスを infra へ分離。あわせて**エディタ入場時の事前ウォームアップ**を実装。

**挙動は不変**: `CODE_RUNNER_URL` 未設定が既定なので、本番は当面 in-process 実行（現行と同じ・同イメージ）。runtime の切替とイメージ分離は Phase 2 / 3 で行う。

## 背景（ユーザー方針）

- 「実行時に起動するのではなく、コードエディタに入った時点で実行環境が warm であってほしい」→ サイドカー runner は常駐で warm。加えてエディタ入場で warmup ping を送り Go のコンパイルキャッシュを温め、UI に「実行環境 準備完了」を表示
- Java は前 PR(#1896) で撤去済み。対応言語は php / go / bash

## 変更内容

**backend**
- `domain/code_execution.go`: 境界値型 `CodeExecutionInput` / `CodeExecutionResult` を新設（handler は §2.4 どおり domain 型を返す）
- `usecase`: `CodeRunner` port（`Run` + `Warmup`）を定義。`ExecuteCodeUseCase` は実行を委譲するだけに。`WarmupCodeUseCase` を追加
- `infra/sandbox/runner.go`: os/exec サンドボックス実装を移設（php/go/bash、`sandboxEnv` / プロセスグループ kill はそのまま）
- `infra/coderunner/client.go`: サイドカーへの HTTP クライアント（`CodeRunner` を満たす）
- `cmd/coderunner`: 別バイナリの runner サーバ（`POST /run` / `POST /warmup` / `GET /healthz`）
- `handler`: `POST /api/v2/code/warmup` を追加。`routes_exercises` が `CODE_RUNNER_URL` の有無で実行系を選択
- `Dockerfile.coderunner`: runner イメージ（golang+php、Phase 2 で CI が build）
- `.golangci.yml`: gosec G204 除外パスを `infra/sandbox/runner.go` に更新

**frontend**
- `useExerciseDetail` が detail ロード時に `ExerciseRepository.warmup(language)` を fire-and-forget、`warmupReady` で「実行環境 準備完了」を表示

## クリーンアーキテクチャ

handler → usecase（`CodeRunner` port）→ infra（`sandbox.Runner` / `coderunner.Client`）。archlint / naminglint / apispec-lint いずれも green。

## テスト

- backend: `go test ./...` 全 pass（sandbox 実行テストを `infra/sandbox` へ移送 / usecase は fake CodeRunner / coderunner は httptest / cmd/coderunner は httptest）。`golangci-lint run ./...` 0 issues / gofumpt clean / OpenAPI drift なし。カバレッジ 48.6%（floor 45%）
- frontend: `tsc` / `eslint --max-warnings 0` / `vitest`（全 1459 pass、warmup の repository・hook テスト追加）/ `npm run build` 成功。生成型 `src/generated/*` を再生成

## 関連

- Design Doc: docs/design/2026年/0004-code-runner-separation.md（§8 に実装状況）
- 前提: #1896（Java 撤去）
- 後続: Phase 2（infra サイドカー化, ECS タスク定義, ユーザー GO 必要）/ Phase 3（backend distroless 化）