### PR TITLE
feat(ci): cd-backend で code-runner イメージを build/push（サイドカー Phase 2）

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -51,6 +51,13 @@ permissions:
   id-token: write
   contents: read
 
+# 同時実行を直列化する。mutable タグ(:latest / :coderunner-latest)への push と
+# cfn-deploy/force-new-deployment が並行 run で競合し、意図しないイメージが反映されるのを防ぐ。
+# 進行中の deploy は中断しない(cancel-in-progress: false)。後続 run は待機して順に実行する。
+concurrency:
+  group: cd-backend-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   guard:
     name: Confirm input (workflow_dispatch only)

--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -115,6 +115,21 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
 
+      # コード実行サイドカー(code-runner)のイメージを同じ ECR リポに coderunner-* タグで push する。
+      # ECS タスク定義(infra ecs.yml)が CodeRunnerImage=...:coderunner-latest を参照する。
+      # 同一 run の後続 cfn-deploy より前に push されるため、サイドカー参照が解決できる(docs/36 §6)。
+      - name: Build & push code-runner image
+        working-directory: backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_API_SERVER_REPOSITORY }}
+        run: |
+          docker buildx build --platform linux/amd64 \
+            -f Dockerfile.coderunner \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:coderunner-latest" \
+            -t "$ECR_REGISTRY/$ECR_REPOSITORY:coderunner-${{ github.sha }}" \
+            --push .
+
   cfn-deploy:
     name: CloudFormation Deploy (ECS Stack)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

コード実行サイドカー（code-runner）導入の **Phase 2 / CD 側**。ECS タスク定義（infra `ecs.yml`、別 PR）に追加する runner サイドカーが参照するイメージを、backend と同じ ECR リポに `coderunner-*` タグで build/push する。

## 変更内容

- `cd-backend.yml` の `build-and-push` ジョブに **「Build & push code-runner image」ステップ**を追加
  - `backend/Dockerfile.coderunner` を build
  - `coderunner-latest` / `coderunner-<sha>` タグで同じ ECR リポ（`AWS_ECR_API_SERVER_REPOSITORY` = `fre-style`）へ push

## デプロイ順序

同一 CD run 内で「backend + runner を build/push → `cfn-deploy` で `ecs.yml` を deploy」の順に走るため、サイドカーの `CodeRunnerImage`（既定 `coderunner-latest`）参照が解決できる（docs/36 §6）。`ContainerImage` 同様 `CodeRunnerImage` は `ecs.yml` の Default を使うため `parameter-overrides` 追加は不要。

## テスト

- `yaml.safe_load` で構文検証（OK）
- 実反映は infra `ecs.yml` サイドカー PR とあわせて CD 1 回で行う

## 関連

- infra: norman6464/frestyle-infrastructure#146（ecs.yml サイドカー）
- app Phase 1: #1897 / runbook: infra docs/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デプロイメントパイプラインを改善し、コード実行環境のDockerイメージをECRへ自動的にビルド・プッシュするステップを追加しました。これにより、本番環境へのデプロイメント処理がより効率化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->