### PR TITLE
feat: backend イメージを distroless 化（~18MB / コード実行サイドカー Phase 3）

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,6 +23,9 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /out/server /server
 
+# distroless:nonroot は既定 user が nonroot(65532) だが、trivy DS-0002 対策に明示する。
+USER nonroot:nonroot
+
 EXPOSE 8080
 
 ENTRYPOINT ["/server"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,5 @@
 # --- Build stage ---
-# 本サービス本体をビルドする stage。 ランタイム image でも Go ツールチェインを使うため
-# bookworm ベースに揃える（alpine の musl と debian の glibc は互換性がない）。
+# 本サービス本体をビルドする stage。Go ツールチェインで純静的バイナリ（CGO 無効）を作る。
 FROM golang:1.26-bookworm AS builder
 
 WORKDIR /app
@@ -10,44 +9,20 @@ RUN go mod download
 
 COPY . .
 
-# 静的バイナリ・最小サイズ
+# 静的バイナリ・最小サイズ（distroless/static で動かすため CGO 無効の純静的にする）。
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
 
 # --- Runtime stage ---
-# サンドボックスでユーザコードを実行するため、 PHP CLI / Go ツールチェインを同居させる。
-# golang:1.26-bookworm をそのまま runtime に使い、 必要なパッケージのみ apt-install。
-# Java は撤去済み（OOP は PHP で扱う）。JDK が最大の肥大化要因だったため除去してイメージを縮小する。
-FROM golang:1.26-bookworm
+# distroless/static: 静的 Go バイナリのみを載せる（イメージ ~60MB）。go/php ランタイムは含めない。
+# 学習者コードのサンドボックス実行は code-runner サイドカーへ HTTP 委譲する想定で、
+# 本番 ECS は CODE_RUNNER_URL=http://127.0.0.1:9000 を注入する（**distroless backend は
+# CODE_RUNNER_URL 必須**＝in-process 実行はできない。ローカルは `go run ./cmd/server` を使う）。
+# distroless は ca-certificates / tzdata / nonroot(65532) を同梱し、HTTPS 呼び出しが可能。
+FROM gcr.io/distroless/static-debian12:nonroot
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends php-cli ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-WORKDIR /
 COPY --from=builder /out/server /server
 
-# nonroot ユーザー (UID=65532) は distroless 互換値を踏襲。
-RUN groupadd -g 65532 nonroot && useradd -u 65532 -g nonroot -s /sbin/nologin nonroot
-
-# Go の build cache を nonroot が書ける場所に置く（共有してコンパイル高速化）。
-RUN mkdir -p /tmp/go-build-cache && chown -R nonroot:nonroot /tmp/go-build-cache
-ENV GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache
-
-# GOCACHE warmup:
-# 学習者の最初の `go run` で cold compile を 走らせると ECS Fargate の I/O 遅延で
-# 6-8 秒かかり 初回の体験を著しく損なう。 image build 時に hello-world を 1 回
-# `go run` して fmt / runtime / os 等の標準パッケージをプリコンパイルしておくと、
-# 以降の cold start でも 実行は ~1 秒台に収まる。
-#
-# nonroot 切替前に warmup する (cache 所有者を nonroot に揃えるため最後に chown)。
-RUN printf 'package main\nimport "fmt"\nfunc main() { fmt.Println("warmup") }\n' > /tmp/warmup.go && \
-    GOCACHE=/tmp/go-build-cache GO111MODULE=off HOME=/tmp \
-        go run /tmp/warmup.go > /dev/null 2>&1 && \
-    rm /tmp/warmup.go && \
-    chown -R nonroot:nonroot /tmp/go-build-cache
-
-USER nonroot:nonroot
 EXPOSE 8080
 
 ENTRYPOINT ["/server"]

--- a/docs/design/2026年/0004-code-runner-separation.md
+++ b/docs/design/2026年/0004-code-runner-separation.md
@@ -152,10 +152,14 @@ GET  /healthz （200 = 実行可能）
 
 `CODE_RUNNER_URL` 未設定が既定なので、本番は当面 in-process（現行と同挙動・同イメージ）。runtime の切替・イメージ分離は Phase 2 / 3 で行う。
 
-### Phase 2（infra・未着手）
+### Phase 2（infra・実装/本番反映済み）
 
-ECS タスク定義に runner サイドカー（`Dockerfile.coderunner`、`essential:false`）を追加し、backend に `CODE_RUNNER_URL=http://127.0.0.1:9000` を注入。CI で 2 イメージを build/push。コールドスタートを実測。
+ECS タスク定義に runner サイドカー（`Dockerfile.coderunner`、`essential:false`）を追加し、backend に `CODE_RUNNER_URL=http://127.0.0.1:9000` を注入。CI で 2 イメージを build/push。`Memory` 512→1024（runner の go コンパイル用）。**本番反映済み（task def rev78 / 2 コンテナ RUNNING / health 200）**。infra PR norman6464/frestyle-infrastructure#146 / app CD PR #1945。
 
-### Phase 3（distroless 化・未着手）
+### Phase 3（distroless 化・実装済み）
 
-Phase 2 で HTTP 経路が安定したら、`backend/Dockerfile` を distroless（go/php を含まない）に絞り API イメージを ~60MB 化する。
+`backend/Dockerfile` の runtime を `golang:1.26-bookworm`（+php）から **`gcr.io/distroless/static-debian12:nonroot`** に変更し、純静的 Go バイナリのみを載せた。ローカル build で **約 18.8MB**（330MB から大幅縮小、目標 ~60MB を下回る）。
+
+- **重要な不変条件**: distroless backend は go/php を含まないため **`CODE_RUNNER_URL` 必須**（in-process フォールバックは効かない）。本番 ECS は ecs.yml で注入済み。ローカル開発は Docker イメージではなく `go run ./cmd/server` を使うため影響なし
+- distroless は ca-certificates / tzdata / nonroot(65532) 同梱で HTTPS 呼び出し可
+- コールドスタート効果（軽い backend が runner pull 完了前に起動・ALB 登録できるか）は次回の夜間 teardown→朝の start で実測する（docs/36 の「要実証」）


### PR DESCRIPTION
## 概要

コールドスタート短縮（イメージ軽量化）の **Phase 3**。backend の runtime を `golang:1.26-bookworm`（+php）から **`gcr.io/distroless/static-debian12:nonroot`** に変更し、純静的 Go バイナリのみを載せる。Phase 2（サイドカー本番反映済み）でコード実行を runner に分離したため、backend から go/php を外せる。

## 変更内容

- `backend/Dockerfile` の runtime stage を distroless static に変更（go/php / GOCACHE warmup / nonroot 作成を削除）
- Design Doc 0004 §8 を Phase 2/3 実装済みに更新

## 効果

- ローカル build で **約 18.8MB**（330MB から大幅縮小、目標 ~60MB を下回る）
- タスクは backend ~18MB + runner 314MB を pull。**軽い backend が先に起動・ALB 登録できれば API コールドスタートが短縮**（Fargate の pull 並列性に依存＝「要実証」、次回 teardown→朝の start で実測）

## 重要な不変条件

- **distroless backend は go/php を含まないため `CODE_RUNNER_URL` 必須**（in-process フォールバック不可）。本番 ECS は `ecs.yml` で `CODE_RUNNER_URL=http://127.0.0.1:9000` を注入済み
- ローカル開発は Docker イメージではなく `go run ./cmd/server`（host に go/php あり）を使うため影響なし
- distroless は ca-certificates / tzdata / nonroot(65532) 同梱で AWS/Cognito/Bedrock への HTTPS 呼び出し可

## テスト

- `docker build` 成功・イメージ 18.8MB を確認（distroless static + 静的バイナリ）
- 既存の go test / lint は不変（Dockerfile のみの変更）
- 本番反映後に: 両コンテナ RUNNING / **コード実行（php/go/bash）が runner 経由で成功** / health 200 を検証

## 関連

- Phase 1: #1897 / Phase 2: #1945 + infra#146 / runbook: infra docs/36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バックエンドランタイムを軽量化し、セキュリティを強化。非root環境での実行に対応
  
* **Documentation**
  * アーキテクチャドキュメント更新：コードランナー分離実装の完了状況を記録

<!-- end of auto-generated comment: release notes by coderabbit.ai -->