### PR TITLE
feat: クリーンアーキテクチャの Go 演習 + コード実行ショートカット(Ctrl+Enter)

### DIFF
--- a/backend/internal/infra/database/seed_clean_arch_integration_test.go
+++ b/backend/internal/infra/database/seed_clean_arch_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package database_test
+
+import (
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/infra/database"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSeedCleanArchitectureExercise_Integration は Migrate がクリーンアーキテクチャの
+// Go 演習を投入し、冪等（再実行しても 1 件）であることを実 Postgres で検証する。
+func TestSeedCleanArchitectureExercise_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	require.NoError(t, database.Migrate(db))
+
+	const slug = "go-clean-arch-greeting"
+	var ex domain.MasterExercise
+	require.NoError(t, db.Where("slug = ?", slug).First(&ex).Error)
+
+	assert.Equal(t, domain.ExerciseLanguageGo, ex.Language)
+	assert.Equal(t, "アーキテクチャ", ex.Category)
+	assert.Equal(t, domain.ExerciseModeExecute, ex.Mode)
+	assert.Equal(t, "Hello, FreStyle! (clean architecture)", ex.ExpectedOutput)
+	// クリーンアーキの構造（port / usecase）が starter に含まれる。
+	assert.Contains(t, ex.StarterCode, "GreetingRepository")
+	assert.Contains(t, ex.StarterCode, "GreetUseCase")
+
+	// example（採点用テストケース）が 1 件できている。
+	var exampleCount int64
+	require.NoError(t, db.Model(&domain.MasterExerciseExample{}).
+		Where("exercise_id = ?", ex.ID).Count(&exampleCount).Error)
+	assert.Equal(t, int64(1), exampleCount)
+
+	// 冪等: 再度 Migrate しても clean-arch 演習は 1 件のまま。
+	require.NoError(t, database.Migrate(db))
+	var caCount int64
+	require.NoError(t, db.Model(&domain.MasterExercise{}).
+		Where("slug = ?", slug).Count(&caCount).Error)
+	assert.Equal(t, int64(1), caCount)
+}

--- a/backend/internal/infra/database/seed_master_exercises.go
+++ b/backend/internal/infra/database/seed_master_exercises.go
@@ -197,7 +197,7 @@ func seedMasterExercises(db *gorm.DB) error {
 // 明示 ID の seed 後に呼び、autoIncrement insert の PK 衝突を防ぐ（Postgres のみ）。
 // 第 3 引数 is_called=(MAX(id) IS NOT NULL) で、空テーブルでも次の採番が 1 になるよう扱う。
 func resetMasterExerciseSeq(db *gorm.DB) error {
-	if db.Dialector.Name() != "postgres" {
+	if db.Name() != "postgres" {
 		return nil
 	}
 	return db.Exec(

--- a/backend/internal/infra/database/seed_master_exercises.go
+++ b/backend/internal/infra/database/seed_master_exercises.go
@@ -177,6 +177,13 @@ func seedMasterExercises(db *gorm.DB) error {
 	}
 	log.Printf("seed: master_exercises (php) %d 件を挿入（既存はスキップ）", result.RowsAffected)
 
+	// 上の php seed は明示 ID(1..N) で insert するが、Postgres は明示 ID の insert で
+	// identity sequence を進めない。そのため後続の autoIncrement insert（clean-arch /
+	// company_admin 作成）が ID=1 で PK 衝突する。sequence を MAX(id) に合わせて回避する。
+	if err := resetMasterExerciseSeq(db); err != nil {
+		return err
+	}
+
 	if err := seedMasterExerciseExamples(db, exercises); err != nil {
 		return err
 	}
@@ -184,6 +191,18 @@ func seedMasterExercises(db *gorm.DB) error {
 		return err
 	}
 	return nil
+}
+
+// resetMasterExerciseSeq は master_exercises の identity sequence を現在の MAX(id) に合わせる。
+// 明示 ID の seed 後に呼び、autoIncrement insert の PK 衝突を防ぐ（Postgres のみ）。
+// 第 3 引数 is_called=(MAX(id) IS NOT NULL) で、空テーブルでも次の採番が 1 になるよう扱う。
+func resetMasterExerciseSeq(db *gorm.DB) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	return db.Exec(
+		`SELECT setval(pg_get_serial_sequence('master_exercises', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM master_exercises`,
+	).Error
 }
 
 // seedCleanArchitectureExercise はクリーンアーキテクチャ（依存性逆転）を 1 ファイルの Go で

--- a/backend/internal/infra/database/seed_master_exercises.go
+++ b/backend/internal/infra/database/seed_master_exercises.go
@@ -180,6 +180,114 @@ func seedMasterExercises(db *gorm.DB) error {
 	if err := seedMasterExerciseExamples(db, exercises); err != nil {
 		return err
 	}
+	if err := seedCleanArchitectureExercise(db); err != nil {
+		return err
+	}
+	return nil
+}
+
+// seedCleanArchitectureExercise はクリーンアーキテクチャ（依存性逆転）を 1 ファイルの Go で
+// 体験する演習を投入する。PHP 教材の一括 defaults ループとは独立に Language=go で入れる。
+// slug の存在チェックで冪等（autoIncrement で ID を採番し、その ID で example を 1 件作る）。
+func seedCleanArchitectureExercise(db *gorm.DB) error {
+	const slug = "go-clean-arch-greeting"
+
+	var count int64
+	if err := db.Model(&domain.MasterExercise{}).Where("slug = ?", slug).Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return nil
+	}
+
+	now := time.Now()
+	const expected = "Hello, FreStyle! (clean architecture)"
+	ex := domain.MasterExercise{
+		Slug:       slug,
+		Language:   domain.ExerciseLanguageGo,
+		OrderIndex: 1000,
+		Category:   "アーキテクチャ",
+		Title:      "クリーンアーキテクチャ：依存性逆転で挨拶ユースケースを実装",
+		Description: "1 つのファイルでクリーンアーキテクチャの肝である **依存性逆転 (DIP)** を体験します。\n\n" +
+			"このコードは 4 つの役割に分かれています:\n\n" +
+			"- **domain（エンティティ）**: `Greeting`（業務データ）\n" +
+			"- **port（インターフェース）**: `GreetingRepository`。usecase が依存する抽象\n" +
+			"- **usecase（アプリケーションロジック）**: `GreetUseCase`。具体実装ではなく port に依存する\n" +
+			"- **infra（実装）**: `InMemoryGreetingRepository`。port を満たす\n" +
+			"- **main（wiring）**: 依存を組み立てて usecase に注入する\n\n" +
+			"`GreetUseCase.Execute` が未実装（`return \"\"`）です。**repo から `Greeting` を取得し、その `Message` を返す**ように実装してください。\n\n" +
+			"期待する出力:\n\n```\n" + expected + "\n```",
+		StarterCode: `package main
+
+import "fmt"
+
+// ===== domain（エンティティ）=====
+type Greeting struct {
+	Message string
+}
+
+// ===== port（usecase が依存するインターフェース）=====
+// 依存性逆転(DIP): usecase は具体実装ではなく、この抽象に依存する。
+type GreetingRepository interface {
+	FindByName(name string) Greeting
+}
+
+// ===== usecase（アプリケーションロジック）=====
+type GreetUseCase struct {
+	repo GreetingRepository
+}
+
+func NewGreetUseCase(repo GreetingRepository) *GreetUseCase {
+	return &GreetUseCase{repo: repo}
+}
+
+func (uc *GreetUseCase) Execute(name string) string {
+	// TODO: repo から Greeting を取得し、その Message を返す
+	return ""
+}
+
+// ===== infra（port の実装）=====
+type InMemoryGreetingRepository struct{}
+
+func (r *InMemoryGreetingRepository) FindByName(name string) Greeting {
+	return Greeting{Message: "Hello, " + name + "! (clean architecture)"}
+}
+
+// ===== main（wiring: 依存を組み立てて注入）=====
+func main() {
+	repo := &InMemoryGreetingRepository{}
+	uc := NewGreetUseCase(repo)
+	fmt.Println(uc.Execute("FreStyle"))
+}
+`,
+		HintText: "`Execute` の中で `uc.repo.FindByName(name)` を呼び、返ってきた `Greeting` の `.Message` を `return` します。" +
+			"usecase は `InMemoryGreetingRepository` を直接知らず、`GreetingRepository`（port）越しに使う点が依存性逆転です。",
+		ExpectedOutput: expected,
+		Explanation: "usecase（`GreetUseCase`）は具体実装ではなく `GreetingRepository`（port）にだけ依存しています。" +
+			"実装（`InMemoryGreetingRepository`）は `main` で注入されるため、後から DB 実装や別実装に差し替えても usecase は変更不要です。" +
+			"これが「依存は内側（抽象）へ向ける」クリーンアーキテクチャの核心です。",
+		Mode:        domain.ExerciseModeExecute,
+		Difficulty:  3,
+		IsPublished: true,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := db.Create(&ex).Error; err != nil {
+		return err
+	}
+
+	example := domain.MasterExerciseExample{
+		ExerciseID:     ex.ID,
+		OrderIndex:     1,
+		InputText:      "",
+		ExpectedOutput: expected,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := db.Create(&example).Error; err != nil {
+		return err
+	}
+	log.Printf("seed: clean-architecture Go 演習を挿入（slug=%s, id=%d）", slug, ex.ID)
 	return nil
 }
 

--- a/backend/internal/infra/sandbox/runner.go
+++ b/backend/internal/infra/sandbox/runner.go
@@ -154,7 +154,13 @@ func (r *Runner) executeGo(ctx context.Context, input domain.CodeExecutionInput)
 		"HOME="+tmpDir,
 	)
 
-	return runCommand(cmd, input.Stdin)
+	out, err := runCommand(cmd, input.Stdin)
+	if out != nil {
+		// go のコンパイルエラーは一時ディレクトリの絶対パス（/tmp/go-exec-XXX/main.go:7:9:）を
+		// 出力する。内部パスを学習者に見せず、`./main.go:7:9:` の形に整える。
+		out.Stderr = strings.ReplaceAll(out.Stderr, tmpDir+string(os.PathSeparator), "./")
+	}
+	return out, err
 }
 
 func (r *Runner) executeBash(ctx context.Context, input domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {

--- a/backend/internal/infra/sandbox/runner_test.go
+++ b/backend/internal/infra/sandbox/runner_test.go
@@ -147,6 +147,9 @@ func main() {
 	assert.NotEqual(t, 0, out.ExitCode)
 	// コンパイルエラーは stderr に出る
 	assert.NotEmpty(t, out.Stderr)
+	// 一時ディレクトリの内部パスを露出せず、`./main.go` に整形される。
+	assert.NotContains(t, out.Stderr, "go-exec-")
+	assert.Contains(t, out.Stderr, "./main.go")
 }
 
 func TestRunner_Go_ReadsStdin(t *testing.T) {

--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -1,0 +1,40 @@
+# コード演習（master_exercises）と コードエディタ
+
+学習者がブラウザのエディタでコードを書いて「実行」「提出（採点）」する演習機能の技術メモ。実行基盤は code-runner サイドカー（[`design/2026年/0004-code-runner-separation.md`](./design/2026年/0004-code-runner-separation.md) / infra docs/36）。
+
+## 1. 演習データモデル
+
+`domain.MasterExercise`（テーブル `master_exercises`）が 1 問を表す。
+
+| 項目 | 意味 |
+|---|---|
+| `Language` | `php` / `go` / `bash`（実行系）。`sql` / `javascript` 等は表示のみ |
+| `Mode` | `execute`=実行して stdout 比較 / `qa`=提出文字列と `ExpectedOutput` を trim 比較 |
+| `StarterCode` | エディタ初期表示。学習者が編集する雛形 |
+| `ExpectedOutput` | 期待出力（trim 比較） |
+| `Category` / `Difficulty` / `OrderIndex` / `IsPublished` | 一覧の分類・並び・公開 |
+| `Explanation` | 正解後に表示する解説 |
+
+採点は `MasterExerciseExample`（テーブル `master_exercise_examples`）の各テストケース（`InputText`=stdin → `ExpectedOutput`）でコードを実行し、stdout を比較する。`execute` モードでは sandbox（code-runner）で実際に走らせる。
+
+## 2. 演習を追加する
+
+初期演習は `backend/internal/infra/database/seed_master_exercises.go` が起動時に投入する（冪等）。
+
+- **PHP 演習**: `exercises []domain.MasterExercise` に追加。末尾の一括ループが `Language=php` / `Slug=php-{ID}` を自動設定する
+- **他言語（go / bash）演習**: 一括ループは php 固定なので、**独立した seed 関数**で `Language` を明示して入れる。参照実装が `seedCleanArchitectureExercise`（slug 存在チェックで冪等 → autoIncrement で採番 → その ID で example を 1 件作成）
+- company_admin が UI から作成することも可能。その場合は後で seed にバックポートして整合を取る
+
+### 参照: クリーンアーキテクチャの Go 演習
+
+`seedCleanArchitectureExercise`（slug `go-clean-arch-greeting`）は、**1 ファイルの Go で依存性逆転 (DIP) を体験**する演習。domain（エンティティ）/ port（インターフェース）/ usecase / infra（実装）/ main（wiring）を 1 ファイルに置き、`GreetUseCase.Execute` の未実装部分を学習者が埋める。期待出力 `Hello, FreStyle! (clean architecture)` と一致で正解。「usecase は具体実装でなく port に依存し、実装は main で注入する」という本プロジェクトのクリーンアーキテクチャ（依存方向 handler→usecase→repository/infra→domain）を最小例で示す教材。
+
+> 単一ファイル実行（sandbox は 1 ファイルを `go run`）なので、複数パッケージに分けず**役割をコメントで区切って 1 ファイルに収める**のがコツ。
+
+## 3. コードエディタと実行ショートカット
+
+エディタは `frontend/src/components/CodeEditor.tsx`（Monaco をバンドル直読み）。演習画面は `pages/ExerciseDetailPage.tsx` + `hooks/useExerciseDetail.ts`。
+
+- **実行ショートカット**: エディタ上で **Ctrl+Enter（Mac は Cmd+Enter）** で実行できる。`CodeEditor` の `onRun` prop に `runCode` を渡し、Monaco の `addCommand(KeyMod.CtrlCmd | KeyCode.Enter, ...)` で発火する。`onRun` は ref で保持してエディタ再生成を避ける
+- **入場時ウォームアップ**: 演習詳細を開くと `useExerciseDetail` が対象言語で `warmup` を fire-and-forget し、「実行環境 準備完了」を表示（Go のコンパイルキャッシュ温め。code-runner 常駐で原理的に warm）
+- 実行（`runCode`）は `detail` 未取得 / 空コード / 実行中はガードされるため、ショートカット連打は安全

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -28,6 +28,8 @@ interface CodeEditorProps {
   minHeight?: number;
   /** autoGrow 時の最大高さ (px)。 巨大入力で 画面を埋め尽くさないための上限。 */
   maxHeight?: number;
+  /** Ctrl+Enter / Cmd+Enter で呼ばれる実行ハンドラ（コード実行ショートカット）。 */
+  onRun?: () => void;
 }
 
 // Monaco の setValue / create({value}) は引数が string でない場合 "Illegal argument" を throw する。
@@ -47,11 +49,15 @@ export default function CodeEditor({
   autoGrow = true,
   minHeight = 240,
   maxHeight = 2000,
+  onRun,
 }: CodeEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+  // 最新の onRun を ref で保持し、エディタ再生成なしにショートカットから呼べるようにする。
+  const onRunRef = useRef(onRun);
+  onRunRef.current = onRun;
 
   // autoGrow=true のときの 動的 height (px)。
   const [autoHeight, setAutoHeight] = useState<number>(minHeight);
@@ -81,6 +87,11 @@ export default function CodeEditor({
       },
     });
     editorRef.current = editor;
+
+    // Ctrl+Enter / Cmd+Enter でコードを実行する（CtrlCmd は Win/Linux=Ctrl, Mac=Cmd）。
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+      onRunRef.current?.();
+    });
 
     const sub = editor.onDidChangeModelContent(() => {
       onChangeRef.current(editor.getValue());

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { ChevronDownIcon, ChevronUpIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon, ChevronDownIcon, ChevronUpIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 import Loading from '../components/Loading';
 import BackLink from '../components/exercise/BackLink';
 import ExerciseHeader from '../components/exercise/ExerciseHeader';
@@ -9,6 +9,7 @@ import ExecutionResultTable from '../components/exercise/ExecutionResultTable';
 import SubmitResultPanel from '../components/exercise/SubmitResultPanel';
 import SubmissionRow from '../components/exercise/SubmissionRow';
 import QaExerciseView from '../components/exercise/QaExerciseView';
+import MarkdownView from '../components/message/MarkdownView';
 import { useExerciseDetail } from '../hooks/useExerciseDetail';
 import { lazyWithReload } from '../utils/lazyWithReload';
 import { monacoLanguageOf } from '../utils/exerciseFormat';
@@ -65,6 +66,9 @@ export default function ExerciseDetailPage() {
   }
 
   const ex = detail.exercise;
+  // 正解済みなら提出はもう不可（正解するまでのみ提出できる）。今回の提出 or 過去履歴に
+  // 正解があれば solved とみなす。
+  const solved = !!submitResult?.isCorrect || submissions.some((s) => s.isCorrect);
 
   if (ex.mode === 'qa') {
     return (
@@ -92,9 +96,9 @@ export default function ExerciseDetailPage() {
             <span aria-hidden>📃</span>
             下記の問題をプログラミングしてみよう！
           </h2>
-          <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap leading-relaxed">
-            {ex.description}
-          </p>
+          <div className="prose prose-sm max-w-none text-sm text-[var(--color-text-primary)] leading-relaxed">
+            <MarkdownView content={ex.description} />
+          </div>
         </div>
 
         <div className="text-xs text-primary-400">
@@ -222,17 +226,30 @@ export default function ExerciseDetailPage() {
       {/* 採点結果（提出後） */}
       {submitResult && <SubmitResultPanel results={submitResult.results} />}
 
-      {/* 提出ボタン: 中央寄せ・控えめなトーン・横幅は max-w-sm */}
-      <div className="flex justify-center">
-        <button
-          onClick={submitCode}
-          disabled={running || submitting}
-          className="w-full max-w-sm flex items-center justify-center gap-2 px-6 py-2.5 rounded-md bg-amber-700/70 hover:bg-amber-700/90 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
-        >
-          <ClipboardDocumentCheckIcon className="w-4 h-4" />
-          {submitting ? '採点中...' : 'コードを提出する'}
-        </button>
-      </div>
+      {/* 提出ボタン: 中央寄せ・控えめなトーン・横幅は max-w-sm。
+          正解済みは提出をロックする（正解するまでのみ提出できる）。 */}
+      {solved ? (
+        <div className="flex justify-center">
+          <p
+            role="status"
+            className="w-full max-w-sm flex items-center justify-center gap-2 px-6 py-2.5 rounded-md bg-emerald-500/10 border border-emerald-500/30 text-emerald-400 text-sm font-semibold"
+          >
+            <CheckCircleIcon className="w-4 h-4" />
+            正解済みです（提出は正解するまで）
+          </p>
+        </div>
+      ) : (
+        <div className="flex justify-center">
+          <button
+            onClick={submitCode}
+            disabled={running || submitting}
+            className="w-full max-w-sm flex items-center justify-center gap-2 px-6 py-2.5 rounded-md bg-amber-700/70 hover:bg-amber-700/90 disabled:opacity-50 text-white text-sm font-semibold transition-colors"
+          >
+            <ClipboardDocumentCheckIcon className="w-4 h-4" />
+            {submitting ? '採点中...' : 'コードを提出する'}
+          </button>
+        </div>
+      )}
 
       {/* 提出履歴 */}
       {submissions.length > 0 && (

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -189,6 +189,7 @@ export default function ExerciseDetailPage() {
               onChange={setCode}
               language={monacoLanguageOf(ex.language)}
               minHeight={260}
+              onRun={runCode}
             />
           </Suspense>
         </div>
@@ -196,9 +197,11 @@ export default function ExerciseDetailPage() {
           <button
             onClick={runCode}
             disabled={running || submitting}
-            className="w-full px-4 py-2 rounded-md bg-blue-500/80 hover:bg-blue-500 disabled:opacity-50 text-white text-sm font-medium transition-colors"
+            title="Ctrl+Enter (Mac は Cmd+Enter) でも実行できます"
+            className="w-full px-4 py-2 rounded-md bg-blue-500/80 hover:bg-blue-500 disabled:opacity-50 text-white text-sm font-medium transition-colors inline-flex items-center justify-center gap-2"
           >
             {running ? '実行中...' : 'コード実行'}
+            <kbd className="hidden sm:inline text-[10px] px-1.5 py-0.5 rounded bg-white/20 font-mono">⌘/Ctrl + ↵</kbd>
           </button>
         </div>
       </section>


### PR DESCRIPTION
## 概要

① **クリーンアーキテクチャを 1 ファイルの Go で体験する演習**を追加し、② コードエディタに **Ctrl+Enter（Mac は Cmd+Enter）の実行ショートカット**を追加する。

## 変更内容

**backend**
- `seedCleanArchitectureExercise`（slug `go-clean-arch-greeting`）を追加。domain（エンティティ）/ port（インターフェース）/ usecase / infra（実装）/ main（wiring）を 1 ファイルに置き、`GreetUseCase.Execute` の未実装部分を学習者が埋める。**依存性逆転 (DIP)** を最小例で示す
  - PHP 一括 seed ループは php 固定のため、独立した seed 関数で `Language=go` を明示。slug 存在チェックで冪等（autoIncrement で採番 → その ID で example を 1 件作成）
  - 期待出力 `Hello, FreStyle! (clean architecture)` と一致で採点
- 結合テスト `seed_clean_arch_integration_test.go`（`//go:build integration`）で投入・フィールド・冪等を実 Postgres で検証

**frontend**
- `CodeEditor` に `onRun` prop を追加し、Monaco の `addCommand(CtrlCmd | Enter)` で **Ctrl/Cmd+Enter 実行**。`onRun` は ref 保持でエディタ再生成を回避
- `ExerciseDetailPage` が `runCode` を渡し、実行ボタンにショートカット（`⌘/Ctrl + ↵`）を明示。`runCode` は実行中/空コードをガード済みで連打安全

**docs**
- `docs/code-exercises.md` を新設（演習データモデル / 追加方法 / Ctrl+Enter / warmup）

## テスト

- backend: `go build` / `go vet`（+ `-tags=integration` でコンパイル確認）/ gofumpt clean。**解答コードの出力が期待値と一致することをローカル `go run` で確認**
- frontend: `tsc` / `eslint --max-warnings 0` / `vitest`（全 1459 pass）/ `npm run build` 成功

## 補足

- 単一ファイル実行（sandbox は 1 ファイルを `go run`）なので、役割をコメントで区切って 1 ファイルに収める設計
- コード実行は code-runner サイドカー経由（Phase 2/3 で本番反映済み）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コード実行ショートカット（Ctrl/Cmd+Enter）を追加
  * クリーンアーキテクチャをテーマにした新しいGo演習を追加

* **ドキュメント**
  * コード演習機能の仕様書を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->