### PR TITLE
fix(grading): 採点で各行末の空白を無視する(見えない末尾空白で不合格にしない)

### DIFF
--- a/backend/internal/usecase/normalize_output_test.go
+++ b/backend/internal/usecase/normalize_output_test.go
@@ -1,0 +1,27 @@
+package usecase
+
+import "testing"
+
+// normalizeOutput は採点の出力比較で使う正規化。学習者に見えない行末空白で
+// 不合格にしないことを検証する（`fmt.Printf("%d \n")` の余分なスペース等）。
+func TestNormalizeOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"行末スペースを除去", "田中: 23 \n佐藤: 30 \n", "田中: 23\n佐藤: 30"},
+		{"行末タブを除去", "a\t\nb\t", "a\nb"},
+		{"CRLF を LF に統一", "a\r\nb\r\n", "a\nb"},
+		{"先頭インデントは保持", "  x\ny ", "  x\ny"},
+		{"末尾の空行を除去", "a\nb\n\n  \n", "a\nb"},
+		{"完全一致はそのまま", "田中: 23\n佐藤: 30", "田中: 23\n佐藤: 30"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeOutput(tt.in); got != tt.want {
+				t.Errorf("normalizeOutput(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/submit_master_exercise_usecase.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase.go
@@ -205,9 +205,15 @@ func (uc *SubmitMasterExerciseUseCase) submitQA(ctx context.Context, in SubmitMa
 	}, nil
 }
 
-// normalizeOutput は CRLF/CR を LF に統一し末尾の改行・空白を除去する（行内の空白は厳密一致）。
+// normalizeOutput は CRLF/CR を LF に統一し、各行末と出力全体末尾の空白・改行を除去する。
+// 学習者に見えない行末の空白（例: `fmt.Printf("%d \n")` の余分なスペース）で不合格にしない
+// ため、行内（先頭側）の空白は保持しつつ行末の空白/タブだけを落とす。
 func normalizeOutput(s string) string {
 	s = strings.ReplaceAll(s, "\r\n", "\n")
 	s = strings.ReplaceAll(s, "\r", "\n")
-	return strings.TrimRight(s, " \t\n")
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), " \t\n")
 }


### PR DESCRIPTION
## 概要
出力は見た目どおり正解なのに不合格になる問題の修正。`normalizeOutput` が出力**全体**の末尾しかトリムせず、**各行末**の空白を残していたため、`fmt.Printf("%d \\n")` のような行末スペースで不一致になっていた。

## 変更内容
- `normalizeOutput` を各行末の空白/タブも除去するよう修正（先頭インデントは保持、CRLF→LF、末尾空行除去はそのまま）
- white-box テスト `normalize_output_test.go` を追加（行末スペース/タブ/CRLF/先頭インデント保持/末尾空行/完全一致）

## テスト
- `go test ./internal/usecase/ -run TestNormalizeOutput` 全 6 ケース pass / gofumpt clean / build OK

## 補足
オンラインジャッジ一般の挙動（行末空白に寛容）に合わせ、初学者が見えない空白で落ちないようにする。