### PR TITLE
fix(ci): frontend デプロイで index.html を no-cache + assets を immutable に

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -23,6 +23,12 @@ env:
 permissions:
   contents: read
 
+# 同時実行を直列化する。並行 deploy が s3 sync --delete + CloudFront 無効化で競合し、
+# index.html が存在しないチャンクを参照して 404(MIME text/html) になる事故を防ぐ。
+concurrency:
+  group: cd-frontend-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   guard:
     name: Confirm input (workflow_dispatch only)
@@ -81,8 +87,21 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync to S3
-        run: aws s3 sync dist/ s3://fre-style-bucket --delete
+      # 1) ハッシュ付きアセットは内容不変なので immutable + 長期キャッシュで配信する。
+      #    index.html は別ステップで no-cache にするため、ここでは除外する。
+      - name: Sync hashed assets to S3 (immutable, long cache)
+        run: |
+          aws s3 sync dist/ s3://fre-style-bucket --delete \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html"
+
+      # 2) index.html は no-cache。これがないと古い index.html がブラウザにキャッシュされ、
+      #    次デプロイの --delete で消えた旧チャンクを参照して 404(MIME text/html)になる。
+      - name: Upload index.html (no-cache)
+        run: |
+          aws s3 cp dist/index.html s3://fre-style-bucket/index.html \
+            --cache-control "no-cache, must-revalidate" \
+            --content-type "text/html; charset=utf-8"
 
       - name: Invalidate CloudFront cache
         run: |


### PR DESCRIPTION
## 概要
古い index.html がブラウザにキャッシュされ、次デプロイの `s3 sync --delete` で消えた旧チャンク(`AskAiPage-*.js/.css` 等)を参照して **404(MIME text/html)** になり、AI ページが読めなくなる事故の恒久対策(「Bedrock 接続できない」の正体)。

## 変更内容
- ハッシュ付き assets: `public, max-age=31536000, immutable`
- **index.html: `no-cache, must-revalidate`**(常に最新を取得 → 存在するチャンクを参照)
- `concurrency` を追加し、並行 deploy の競合(`--delete` × invalidation)を防ぐ

## 即時対応(済)
本番 index.html を手動で `no-cache` に設定 + CloudFront を無効化済み。既にページを開いていたユーザーは**ハードリロード(Cmd+Shift+R)**で復旧。

## テスト
- `yaml.safe_load` OK。次回 frontend デプロイから適用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * デプロイプロセスの最適化により、デプロイ中の競合を軽減し、より安定した配信を実現しました。
  * キャッシュ戦略を改善し、静的アセットはより長く保持、HTMLファイルはアップデート時に最新版を確実に取得するよう調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->