### PR TITLE
feat: 従業員管理(従業員一覧 + AI 利用可否の個別設定)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -318,6 +318,119 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/members": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社（company_admin の所属会社）の従業員一覧を返す。company_admin / super_admin のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_handler.memberResponse"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}/ai-access": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の従業員の AI 利用可否を個別に上書きする（null で会社設定に従う）。別会社の従業員は更新できない。company_admin / super_admin のみ。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員の AI 利用可否を個別更新",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "enabled (null=会社設定に従う)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateMemberAiRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "バリデーション失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ai-chat/attachments/upload-url": {
             "post": {
                 "security": [
@@ -4080,6 +4193,27 @@ const docTemplate = `{
                 }
             }
         },
+        "internal_handler.memberResponse": {
+            "type": "object",
+            "properties": {
+                "aiChatEnabled": {
+                    "description": "AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。",
+                    "type": "boolean"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.messageResponse": {
             "type": "object",
             "properties": {
@@ -4285,6 +4419,15 @@ const docTemplate = `{
             "properties": {
                 "aiChatEnabledForTrainees": {
                     "description": "bool の必須を binding:\"required\" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。",
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_handler.updateMemberAiRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enabled は AI 利用可否の個別上書き。null（未指定）で会社設定に従う状態へ戻す。",
                     "type": "boolean"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -311,6 +311,119 @@
                 }
             }
         },
+        "/admin/members": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社（company_admin の所属会社）の従業員一覧を返す。company_admin / super_admin のみ。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/internal_handler.memberResponse"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}/ai-access": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の従業員の AI 利用可否を個別に上書きする（null で会社設定に従う）。別会社の従業員は更新できない。company_admin / super_admin のみ。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員の AI 利用可否を個別更新",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "enabled (null=会社設定に従う)",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.updateMemberAiRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "バリデーション失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ai-chat/attachments/upload-url": {
             "post": {
                 "security": [
@@ -4073,6 +4186,27 @@
                 }
             }
         },
+        "internal_handler.memberResponse": {
+            "type": "object",
+            "properties": {
+                "aiChatEnabled": {
+                    "description": "AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。",
+                    "type": "boolean"
+                },
+                "displayName": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "role": {
+                    "type": "string"
+                }
+            }
+        },
         "internal_handler.messageResponse": {
             "type": "object",
             "properties": {
@@ -4278,6 +4412,15 @@
             "properties": {
                 "aiChatEnabledForTrainees": {
                     "description": "bool の必須を binding:\"required\" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。",
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_handler.updateMemberAiRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enabled は AI 利用可否の個別上書き。null（未指定）で会社設定に従う状態へ戻す。",
                     "type": "boolean"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -644,6 +644,20 @@ definitions:
       updatedAt:
         type: string
     type: object
+  internal_handler.memberResponse:
+    properties:
+      aiChatEnabled:
+        description: AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。
+        type: boolean
+      displayName:
+        type: string
+      email:
+        type: string
+      id:
+        type: integer
+      role:
+        type: string
+    type: object
   internal_handler.messageResponse:
     properties:
       message:
@@ -781,6 +795,12 @@ definitions:
         type: boolean
     required:
     - aiChatEnabledForTrainees
+    type: object
+  internal_handler.updateMemberAiRequest:
+    properties:
+      enabled:
+        description: Enabled は AI 利用可否の個別上書き。null（未指定）で会社設定に従う状態へ戻す。
+        type: boolean
     type: object
   internal_handler.updateProfileReq:
     properties:
@@ -1006,6 +1026,79 @@ paths:
       security:
       - CookieAuth: []
       summary: 招待 取り消し
+      tags:
+      - admin
+  /admin/members:
+    get:
+      description: 自社（company_admin の所属会社）の従業員一覧を返す。company_admin / super_admin のみ。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/internal_handler.memberResponse'
+            type: array
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 内部エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 従業員一覧
+      tags:
+      - admin
+  /admin/members/{userId}/ai-access:
+    patch:
+      consumes:
+      - application/json
+      description: 自社の従業員の AI 利用可否を個別に上書きする（null で会社設定に従う）。別会社の従業員は更新できない。company_admin
+        / super_admin のみ。
+      parameters:
+      - description: 従業員の数値 ID
+        in: path
+        name: userId
+        required: true
+        type: string
+      - description: enabled (null=会社設定に従う)
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.updateMemberAiRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: バリデーション失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者以外 / 別会社の従業員
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 内部エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 従業員の AI 利用可否を個別更新
       tags:
       - admin
   /ai-chat/attachments/upload-url:

--- a/backend/internal/adapter/persistence/queries/schema.sql
+++ b/backend/internal/adapter/persistence/queries/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE users (
     display_name text NOT NULL DEFAULT '',
     company_id   bigint,
     role         text NOT NULL,
+    ai_chat_enabled boolean,
     onboarded_at timestamptz,
     created_at   timestamptz NOT NULL,
     updated_at   timestamptz NOT NULL,

--- a/backend/internal/adapter/persistence/queries/user.sql
+++ b/backend/internal/adapter/persistence/queries/user.sql
@@ -13,3 +13,9 @@ WHERE id = $1 AND deleted_at IS NULL;
 SELECT * FROM users
 WHERE role = $1 AND deleted_at IS NULL
 ORDER BY id ASC;
+
+-- name: ListUsersByCompanyID :many
+-- 会社単位の従業員一覧（論理削除は除外）。company_admin の従業員管理画面用。
+SELECT * FROM users
+WHERE company_id = $1 AND deleted_at IS NULL
+ORDER BY id ASC;

--- a/backend/internal/adapter/persistence/sqlcgen/models.go
+++ b/backend/internal/adapter/persistence/sqlcgen/models.go
@@ -77,14 +77,15 @@ type SessionNote struct {
 }
 
 type User struct {
-	ID          int64
-	CognitoSub  string
-	Email       string
-	DisplayName string
-	CompanyID   sql.NullInt64
-	Role        string
-	OnboardedAt sql.NullTime
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
-	DeletedAt   sql.NullTime
+	ID            int64
+	CognitoSub    string
+	Email         string
+	DisplayName   string
+	CompanyID     sql.NullInt64
+	Role          string
+	AiChatEnabled sql.NullBool
+	OnboardedAt   sql.NullTime
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     sql.NullTime
 }

--- a/backend/internal/adapter/persistence/sqlcgen/user.sql.go
+++ b/backend/internal/adapter/persistence/sqlcgen/user.sql.go
@@ -7,10 +7,11 @@ package sqlcgen
 
 import (
 	"context"
+	"database/sql"
 )
 
 const getUserByCognitoSub = `-- name: GetUserByCognitoSub :one
-SELECT id, cognito_sub, email, display_name, company_id, role, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE cognito_sub = $1 AND deleted_at IS NULL
 `
 
@@ -25,6 +26,7 @@ func (q *Queries) GetUserByCognitoSub(ctx context.Context, cognitoSub string) (U
 		&i.DisplayName,
 		&i.CompanyID,
 		&i.Role,
+		&i.AiChatEnabled,
 		&i.OnboardedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -34,7 +36,7 @@ func (q *Queries) GetUserByCognitoSub(ctx context.Context, cognitoSub string) (U
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, cognito_sub, email, display_name, company_id, role, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE id = $1 AND deleted_at IS NULL
 `
 
@@ -49,6 +51,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
 		&i.DisplayName,
 		&i.CompanyID,
 		&i.Role,
+		&i.AiChatEnabled,
 		&i.OnboardedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -57,8 +60,50 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
 	return i, err
 }
 
+const listUsersByCompanyID = `-- name: ListUsersByCompanyID :many
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
+WHERE company_id = $1 AND deleted_at IS NULL
+ORDER BY id ASC
+`
+
+// 会社単位の従業員一覧（論理削除は除外）。company_admin の従業員管理画面用。
+func (q *Queries) ListUsersByCompanyID(ctx context.Context, companyID sql.NullInt64) ([]User, error) {
+	rows, err := q.db.QueryContext(ctx, listUsersByCompanyID, companyID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []User{}
+	for rows.Next() {
+		var i User
+		if err := rows.Scan(
+			&i.ID,
+			&i.CognitoSub,
+			&i.Email,
+			&i.DisplayName,
+			&i.CompanyID,
+			&i.Role,
+			&i.AiChatEnabled,
+			&i.OnboardedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUsersByRole = `-- name: ListUsersByRole :many
-SELECT id, cognito_sub, email, display_name, company_id, role, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE role = $1 AND deleted_at IS NULL
 ORDER BY id ASC
 `
@@ -80,6 +125,7 @@ func (q *Queries) ListUsersByRole(ctx context.Context, role string) ([]User, err
 			&i.DisplayName,
 			&i.CompanyID,
 			&i.Role,
+			&i.AiChatEnabled,
 			&i.OnboardedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,

--- a/backend/internal/adapter/persistence/user_repository.go
+++ b/backend/internal/adapter/persistence/user_repository.go
@@ -42,6 +42,10 @@ func toDomainUser(row sqlcgen.User) *domain.User {
 		cid := uint64(row.CompanyID.Int64)
 		u.CompanyID = &cid
 	}
+	if row.AiChatEnabled.Valid {
+		v := row.AiChatEnabled.Bool
+		u.AiChatEnabled = &v
+	}
 	if row.OnboardedAt.Valid {
 		t := row.OnboardedAt.Time
 		u.OnboardedAt = &t
@@ -103,8 +107,40 @@ func (r *userRepository) ListByRole(ctx context.Context, role string) ([]domain.
 	return users, nil
 }
 
+func (r *userRepository) ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.User, error) {
+	cid, ok := toInt64ID(companyID)
+	if !ok {
+		return nil, nil
+	}
+	sqlDB, err := r.db.DB()
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sqlcgen.New(sqlDB).ListUsersByCompanyID(ctx, sql.NullInt64{Int64: cid, Valid: true})
+	if err != nil {
+		return nil, err
+	}
+	users := make([]domain.User, 0, len(rows))
+	for _, row := range rows {
+		users = append(users, *toDomainUser(row))
+	}
+	return users, nil
+}
+
 func (r *userRepository) Create(ctx context.Context, user *domain.User) error {
 	return r.db.WithContext(ctx).Create(user).Error
+}
+
+// UpdateAiChatEnabled は AI チャットの個別上書きを更新する。enabled=nil で NULL（会社設定に従う）に戻す。
+func (r *userRepository) UpdateAiChatEnabled(ctx context.Context, userID uint64, enabled *bool) error {
+	var value any = gorm.Expr("NULL")
+	if enabled != nil {
+		value = *enabled
+	}
+	return r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ?", userID).
+		Update("ai_chat_enabled", value).Error
 }
 
 func (r *userRepository) UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error {

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -10,6 +10,9 @@ type User struct {
 	DisplayName string  `gorm:"column:display_name" json:"displayName"`
 	CompanyID   *uint64 `gorm:"column:company_id" json:"companyId,omitempty"`
 	Role        string  `gorm:"column:role" json:"role"`
+	// AiChatEnabled は AI チャット利用可否の個別上書き。nil = 会社設定に従う、
+	// true/false = この user 個別に強制 ON/OFF（company_admin が従業員ごとに設定）。
+	AiChatEnabled *bool `gorm:"column:ai_chat_enabled" json:"aiChatEnabled,omitempty"`
 	// OnboardedAt は Welcome 完了日時。NULL なら Welcome を表示する。一度入ったら変えない。
 	OnboardedAt *time.Time `gorm:"column:onboarded_at" json:"onboardedAt,omitempty"`
 	CreatedAt   time.Time  `gorm:"column:created_at" json:"createdAt"`

--- a/backend/internal/handler/admin_member_handler.go
+++ b/backend/internal/handler/admin_member_handler.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AdminMemberHandler は company_admin が自社の従業員一覧と、各従業員の AI 利用可否を管理する。
+type AdminMemberHandler struct {
+	list   *usecase.ListCompanyMembersUseCase
+	update *usecase.UpdateMemberAiAccessUseCase
+}
+
+// NewAdminMemberHandler は一覧 / AI 更新 usecase を注入して handler を返す。
+func NewAdminMemberHandler(list *usecase.ListCompanyMembersUseCase, update *usecase.UpdateMemberAiAccessUseCase) *AdminMemberHandler {
+	return &AdminMemberHandler{list: list, update: update}
+}
+
+// memberResponse は従業員一覧の 1 行（cognito_sub 等の機密は出さない）。
+type memberResponse struct {
+	ID          uint64 `json:"id"`
+	Email       string `json:"email"`
+	DisplayName string `json:"displayName"`
+	Role        string `json:"role"`
+	// AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。
+	AiChatEnabled *bool `json:"aiChatEnabled"`
+}
+
+func toMemberResponse(u domain.User) memberResponse {
+	return memberResponse{
+		ID:            u.ID,
+		Email:         u.Email,
+		DisplayName:   u.DisplayName,
+		Role:          u.Role,
+		AiChatEnabled: u.AiChatEnabled,
+	}
+}
+
+func isAdminActor(actor *domain.User) bool {
+	return actor != nil && (actor.Role == domain.RoleCompanyAdmin || actor.Role == domain.RoleSuperAdmin)
+}
+
+// List は自社の従業員一覧を返す。
+//
+//	@Summary      従業員一覧
+//	@Description  自社（company_admin の所属会社）の従業員一覧を返す。company_admin / super_admin のみ。
+//	@Tags         admin
+//	@Produce      json
+//	@Success      200  {array}   memberResponse
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "管理者以外"
+//	@Failure      500  {object}  errorResponse  "内部エラー"
+//	@Router       /admin/members [get]
+//	@Security     CookieAuth
+func (h *AdminMemberHandler) List(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	if !isAdminActor(actor) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	members, err := h.list.Execute(c.Request.Context(), actor)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	out := make([]memberResponse, 0, len(members))
+	for _, m := range members {
+		out = append(out, toMemberResponse(m))
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+type updateMemberAiRequest struct {
+	// Enabled は AI 利用可否の個別上書き。null（未指定）で会社設定に従う状態へ戻す。
+	Enabled *bool `json:"enabled"`
+}
+
+// UpdateAiAccess は自社の従業員の AI 利用可否を個別に更新する。
+//
+//	@Summary      従業員の AI 利用可否を個別更新
+//	@Description  自社の従業員の AI 利用可否を個別に上書きする（null で会社設定に従う）。別会社の従業員は更新できない。company_admin / super_admin のみ。
+//	@Tags         admin
+//	@Accept       json
+//	@Produce      json
+//	@Param        userId  path  string  true  "従業員の数値 ID"
+//	@Param        body    body  updateMemberAiRequest  true  "enabled (null=会社設定に従う)"
+//	@Success      204
+//	@Failure      400  {object}  errorResponse  "バリデーション失敗"
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "管理者以外 / 別会社の従業員"
+//	@Failure      500  {object}  errorResponse  "内部エラー"
+//	@Router       /admin/members/{userId}/ai-access [patch]
+//	@Security     CookieAuth
+func (h *AdminMemberHandler) UpdateAiAccess(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	if !isAdminActor(actor) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		return
+	}
+	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+		return
+	}
+	var req updateMemberAiRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := h.update.Execute(c.Request.Context(), actor, userID, req.Enabled); err != nil {
+		if errors.Is(err, usecase.ErrMemberNotInActorCompany) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -67,6 +67,14 @@ func (r *fakeUserRepo) MarkOnboarded(_ context.Context, _ uint64) error {
 	return nil
 }
 
+func (r *fakeUserRepo) ListByCompanyID(_ context.Context, _ uint64) ([]domain.User, error) {
+	return nil, nil
+}
+
+func (r *fakeUserRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, _ *bool) error {
+	return nil
+}
+
 // fakeInvitationRepo は AdminInvitationRepository の最小スタブ。
 // FindPendingByEmail / FindPendingByToken の振る舞いをカスタムにしてテストする。
 type fakeInvitationRepo struct {

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -18,6 +18,15 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	)
 	g.GET("/admin/companies", companyHandler.List)
 
+	// 従業員管理（自社の従業員一覧 + 各従業員の AI 利用可否を個別上書き）。
+	memberRepo := persistence.NewUserRepository(deps.db)
+	memberHandler := NewAdminMemberHandler(
+		usecase.NewListCompanyMembersUseCase(memberRepo),
+		usecase.NewUpdateMemberAiAccessUseCase(memberRepo),
+	)
+	g.GET("/admin/members", memberHandler.List)
+	g.PATCH("/admin/members/:userId/ai-access", memberHandler.UpdateAiAccess)
+
 	// AdminInvitation — SES マジックリンク方式（UUID token 発行 + SES でメール送信）。
 	adminInvRepo := persistence.NewAdminInvitationRepository(deps.db)
 

--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -1,0 +1,101 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMemberUserRepo は UserRepository を満たすテスト用 fake。
+type fakeMemberUserRepo struct {
+	byCompany map[uint64][]domain.User
+	byID      map[uint64]*domain.User
+	updated   map[uint64]*bool
+}
+
+func newFakeMemberUserRepo() *fakeMemberUserRepo {
+	return &fakeMemberUserRepo{
+		byCompany: map[uint64][]domain.User{},
+		byID:      map[uint64]*domain.User{},
+		updated:   map[uint64]*bool{},
+	}
+}
+
+func (f *fakeMemberUserRepo) FindByCognitoSub(context.Context, string) (*domain.User, error) {
+	return nil, nil
+}
+
+func (f *fakeMemberUserRepo) FindByID(_ context.Context, id uint64) (*domain.User, error) {
+	return f.byID[id], nil
+}
+
+func (f *fakeMemberUserRepo) ListByRole(context.Context, string) ([]domain.User, error) {
+	return nil, nil
+}
+
+func (f *fakeMemberUserRepo) ListByCompanyID(_ context.Context, companyID uint64) ([]domain.User, error) {
+	return f.byCompany[companyID], nil
+}
+func (f *fakeMemberUserRepo) Create(context.Context, *domain.User) error { return nil }
+func (f *fakeMemberUserRepo) UpdateDisplayName(context.Context, uint64, string) error {
+	return nil
+}
+func (f *fakeMemberUserRepo) UpdateRole(context.Context, uint64, string) error      { return nil }
+func (f *fakeMemberUserRepo) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
+func (f *fakeMemberUserRepo) MarkOnboarded(context.Context, uint64) error           { return nil }
+func (f *fakeMemberUserRepo) UpdateAiChatEnabled(_ context.Context, userID uint64, enabled *bool) error {
+	f.updated[userID] = enabled
+	return nil
+}
+
+func ptrBool(b bool) *bool    { return &b }
+func u64ptr(v uint64) *uint64 { return &v }
+
+func TestListCompanyMembersUseCase(t *testing.T) {
+	repo := newFakeMemberUserRepo()
+	repo.byCompany[10] = []domain.User{{ID: 1, CompanyID: u64ptr(10)}, {ID: 2, CompanyID: u64ptr(10)}}
+	uc := usecase.NewListCompanyMembersUseCase(repo)
+
+	t.Run("自社の従業員一覧を返す", func(t *testing.T) {
+		members, err := uc.Execute(context.Background(), &domain.User{ID: 9, CompanyID: u64ptr(10), Role: domain.RoleCompanyAdmin})
+		require.NoError(t, err)
+		assert.Len(t, members, 2)
+	})
+	t.Run("会社未所属は空", func(t *testing.T) {
+		members, err := uc.Execute(context.Background(), &domain.User{ID: 9, Role: domain.RoleSuperAdmin})
+		require.NoError(t, err)
+		assert.Empty(t, members)
+	})
+}
+
+func TestUpdateMemberAiAccessUseCase(t *testing.T) {
+	repo := newFakeMemberUserRepo()
+	repo.byID[1] = &domain.User{ID: 1, CompanyID: u64ptr(10), Role: domain.RoleTrainee}
+	repo.byID[2] = &domain.User{ID: 2, CompanyID: u64ptr(20), Role: domain.RoleTrainee} // 別会社
+	uc := usecase.NewUpdateMemberAiAccessUseCase(repo)
+	actor := &domain.User{ID: 9, CompanyID: u64ptr(10), Role: domain.RoleCompanyAdmin}
+
+	t.Run("自社の従業員の AI を個別 OFF にできる", func(t *testing.T) {
+		err := uc.Execute(context.Background(), actor, 1, ptrBool(false))
+		require.NoError(t, err)
+		require.NotNil(t, repo.updated[1])
+		assert.False(t, *repo.updated[1])
+	})
+	t.Run("nil で会社設定に従う状態へ戻せる", func(t *testing.T) {
+		err := uc.Execute(context.Background(), actor, 1, nil)
+		require.NoError(t, err)
+		assert.Nil(t, repo.updated[1])
+	})
+	t.Run("別会社の従業員は更新できない(403相当)", func(t *testing.T) {
+		err := uc.Execute(context.Background(), actor, 2, ptrBool(true))
+		assert.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
+	})
+	t.Run("会社未所属の actor は更新できない", func(t *testing.T) {
+		err := uc.Execute(context.Background(), &domain.User{ID: 9, Role: domain.RoleSuperAdmin}, 1, ptrBool(true))
+		assert.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
+	})
+}

--- a/backend/internal/usecase/ai_chat_access_usecase.go
+++ b/backend/internal/usecase/ai_chat_access_usecase.go
@@ -34,6 +34,10 @@ func (uc *AiChatEnabledForUserUseCase) Execute(ctx context.Context, user *domain
 	if user.CompanyID == nil {
 		return true, nil
 	}
+	// 個別上書き(ai_chat_enabled)が設定されていれば会社一括設定より優先する。
+	if user.AiChatEnabled != nil {
+		return *user.AiChatEnabled, nil
+	}
 	company, err := uc.companies.FindByID(ctx, *user.CompanyID)
 	if err != nil {
 		// 会社行が無い場合は既定 true（後方互換）。それ以外の DB エラーは伝搬する。

--- a/backend/internal/usecase/company_settings_usecase_test.go
+++ b/backend/internal/usecase/company_settings_usecase_test.go
@@ -102,4 +102,20 @@ func TestAiChatEnabledForUser(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, got)
 	})
+
+	t.Run("個別 OFF は会社設定(true)より優先される", func(t *testing.T) {
+		repo := &settingsCompanyRepo{company: &domain.Company{AiChatEnabledForTrainees: true}}
+		uc := usecase.NewAiChatEnabledForUserUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1), AiChatEnabled: ptrBool(false)})
+		require.NoError(t, err)
+		assert.False(t, got)
+	})
+
+	t.Run("個別 ON は会社設定(false)より優先される", func(t *testing.T) {
+		repo := &settingsCompanyRepo{company: &domain.Company{AiChatEnabledForTrainees: false}}
+		uc := usecase.NewAiChatEnabledForUserUseCase(repo)
+		got, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1), AiChatEnabled: ptrBool(true)})
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
 }

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -46,6 +46,10 @@ func (f *fakeUsersForApp) UpdateDisplayName(context.Context, uint64, string) err
 func (f *fakeUsersForApp) UpdateRole(context.Context, uint64, string) error        { return nil }
 func (f *fakeUsersForApp) UpdateCompanyID(context.Context, uint64, uint64) error   { return nil }
 func (f *fakeUsersForApp) MarkOnboarded(context.Context, uint64) error             { return nil }
+func (f *fakeUsersForApp) ListByCompanyID(context.Context, uint64) ([]domain.User, error) {
+	return nil, nil
+}
+func (f *fakeUsersForApp) UpdateAiChatEnabled(context.Context, uint64, *bool) error { return nil }
 
 type recordingNotifRepo struct{ created []domain.Notification }
 

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -24,6 +24,14 @@ func (s *stubUserRepo) FindByID(_ context.Context, _ uint64) (*domain.User, erro
 func (s *stubUserRepo) ListByRole(_ context.Context, _ string) ([]domain.User, error) {
 	return nil, s.err
 }
+
+func (s *stubUserRepo) ListByCompanyID(_ context.Context, _ uint64) ([]domain.User, error) {
+	return nil, s.err
+}
+
+func (s *stubUserRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, _ *bool) error {
+	return s.err
+}
 func (s *stubUserRepo) Create(_ context.Context, _ *domain.User) error { return s.err }
 func (s *stubUserRepo) UpdateDisplayName(_ context.Context, _ uint64, _ string) error {
 	return s.err

--- a/backend/internal/usecase/list_company_members_usecase.go
+++ b/backend/internal/usecase/list_company_members_usecase.go
@@ -1,0 +1,25 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// ListCompanyMembersUseCase は actor（company_admin）の自社の従業員一覧を返す。
+type ListCompanyMembersUseCase struct {
+	users repository.UserRepository
+}
+
+func NewListCompanyMembersUseCase(u repository.UserRepository) *ListCompanyMembersUseCase {
+	return &ListCompanyMembersUseCase{users: u}
+}
+
+// Execute は actor の所属会社の従業員一覧を返す。会社未所属なら空。
+func (uc *ListCompanyMembersUseCase) Execute(ctx context.Context, actor *domain.User) ([]domain.User, error) {
+	if actor == nil || actor.CompanyID == nil {
+		return []domain.User{}, nil
+	}
+	return uc.users.ListByCompanyID(ctx, *actor.CompanyID)
+}

--- a/backend/internal/usecase/repository/user.go
+++ b/backend/internal/usecase/repository/user.go
@@ -14,7 +14,11 @@ type UserRepository interface {
 	FindByID(ctx context.Context, id uint64) (*domain.User, error)
 	// ListByRole は指定 role のユーザー一覧を返す（super_admin への一斉通知などに使う）。
 	ListByRole(ctx context.Context, role string) ([]domain.User, error)
+	// ListByCompanyID は会社単位の従業員一覧を返す（company_admin の従業員管理画面用）。
+	ListByCompanyID(ctx context.Context, companyID uint64) ([]domain.User, error)
 	Create(ctx context.Context, user *domain.User) error
+	// UpdateAiChatEnabled は AI チャットの個別上書きを更新する（nil で会社設定に従う）。
+	UpdateAiChatEnabled(ctx context.Context, userID uint64, enabled *bool) error
 	// UpdateDisplayName は氏名変更、および OIDC ログイン時の displayName 自動補正で呼ばれる。
 	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
 	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。

--- a/backend/internal/usecase/update_member_ai_access_usecase.go
+++ b/backend/internal/usecase/update_member_ai_access_usecase.go
@@ -1,0 +1,37 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// ErrMemberNotInActorCompany は対象 user が actor の会社に属していないときのエラー（403 相当）。
+var ErrMemberNotInActorCompany = errors.New("member is not in the actor's company")
+
+// UpdateMemberAiAccessUseCase は company_admin が自社従業員の AI 利用可否を個別に上書きする。
+// 別会社の user は更新できない（テナント境界）。enabled=nil で会社設定に従う状態に戻す。
+type UpdateMemberAiAccessUseCase struct {
+	users repository.UserRepository
+}
+
+func NewUpdateMemberAiAccessUseCase(u repository.UserRepository) *UpdateMemberAiAccessUseCase {
+	return &UpdateMemberAiAccessUseCase{users: u}
+}
+
+// Execute は actor の自社の targetUserID の AI 利用可否を enabled に更新する。
+func (uc *UpdateMemberAiAccessUseCase) Execute(ctx context.Context, actor *domain.User, targetUserID uint64, enabled *bool) error {
+	if actor == nil || actor.CompanyID == nil {
+		return ErrMemberNotInActorCompany
+	}
+	target, err := uc.users.FindByID(ctx, targetUserID)
+	if err != nil {
+		return err
+	}
+	if target == nil || target.CompanyID == nil || *target.CompanyID != *actor.CompanyID {
+		return ErrMemberNotInActorCompany
+	}
+	return uc.users.UpdateAiChatEnabled(ctx, targetUserID, enabled)
+}

--- a/docs/admin-member-management.md
+++ b/docs/admin-member-management.md
@@ -1,0 +1,33 @@
+# 従業員管理（従業員一覧 + AI 利用可否の個別設定）
+
+company_admin / super_admin が、自社の従業員一覧を見て、各従業員の AI チャット利用可否を**個別に**設定できる機能。サイドバー「管理」直下の「従業員一覧」（`/admin/members`）。
+
+## AI 利用可否の優先順位
+
+AI チャットを使ってよいかは [`usecase.AiChatEnabledForUserUseCase`](../backend/internal/usecase/ai_chat_access_usecase.go) が判定する。優先順位:
+
+1. `company_admin` / `super_admin` → 常に許可（自社設定確認のため）
+2. 会社未所属（`company_id = null`）→ 許可
+3. **`users.ai_chat_enabled`（個別上書き）が設定済みなら、それを優先**（`true`=許可 / `false`=禁止）
+4. それ以外 → 会社の `companies.ai_chat_enabled_for_trainees`（一括設定）に従う
+
+つまり **「会社一括設定」は従来どおり残り、「個別設定」がそれを上書き**する。個別設定を「会社設定に従う」に戻すと `ai_chat_enabled` が `NULL` になり、再び会社一括設定に従う。
+
+## データモデル
+
+- `domain.User.AiChatEnabled *bool`（列 `users.ai_chat_enabled`、nullable）。`nil`=会社設定に従う / `true` / `false`=個別上書き
+- 列追加は GORM AutoMigrate が起動時に行う（追加系なので無停止）
+
+## API
+
+| メソッド | パス | 役割 |
+|---|---|---|
+| GET | `/api/v2/admin/members` | 自社の従業員一覧（company_admin / super_admin のみ） |
+| PATCH | `/api/v2/admin/members/{userId}/ai-access` | 従業員の AI 利用可否を個別更新（`{ "enabled": true\|false\|null }`） |
+
+認可: 別会社の従業員は更新できない（`UpdateMemberAiAccessUseCase` がテナント境界をチェック、越権は 403）。
+
+## 実装
+
+- backend: `list_company_members_usecase.go` / `update_member_ai_access_usecase.go` / `admin_member_handler.go` / `routes_admin.go`。repository は `UserRepository.ListByCompanyID`（sqlc）+ `UpdateAiChatEnabled`（GORM、`nil` で `NULL` に戻す）
+- frontend: `AdminMembersPage` / `useAdminMembers` / `AdminMemberRepository`。一覧表で各従業員の AI 利用を「会社設定に従う / 有効 / 無効」のセレクトで設定（trainee のみ対象）

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ const LearningReportPage = lazyWithReload(() => import('./pages/LearningReportPa
 const HelpPage = lazyWithReload(() => import('./pages/HelpPage'), 'HelpPage');
 const AdminInvitationsPage = lazyWithReload(() => import('./pages/AdminInvitationsPage'), 'AdminInvitationsPage');
 const AdminCompaniesPage = lazyWithReload(() => import('./pages/AdminCompaniesPage'), 'AdminCompaniesPage');
+const AdminMembersPage = lazyWithReload(() => import('./pages/AdminMembersPage'), 'AdminMembersPage');
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
 const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
@@ -114,6 +115,7 @@ export default function App() {
         <Route path="/teaching-materials" element={<CoursesListPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
+        <Route path="/admin/members" element={<AdminMembersPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />
       </Route>
     </Routes>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -68,6 +68,8 @@ const adminNavItem: NavItem = {
       matchPrefix: '/admin/companies',
       allowedRoles: ['super_admin'],
     },
+    // 従業員一覧は自社の従業員管理（AI 利用可否の個別設定）。company_admin / super_admin 双方が利用する。
+    { label: '従業員一覧', to: '/admin/members', matchPrefix: '/admin/members' },
     // 招待管理は自社内で trainee を招待する操作のため company_admin / super_admin 双方が利用する。
     { label: '招待管理', to: '/admin/invitations', matchPrefix: '/admin/invitations' },
   ],

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -138,6 +138,8 @@ export const WEEKLY_CHALLENGE = {
 /** 管理者ダッシュボード（会社 / 招待 / シナリオ） */
 export const ADMIN = {
   companies: `${API_V2}/admin/companies`,
+  members: `${API_V2}/admin/members`,
+  memberAiAccess: (userId: number | string) => `${API_V2}/admin/members/${userId}/ai-access`,
   invitations: `${API_V2}/admin/invitations`,
   invitationById: (id: number | string) => `${API_V2}/admin/invitations/${id}`,
   scenarios: `${API_V2}/admin/scenarios`,

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -381,6 +381,153 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 従業員一覧
+         * @description 自社（company_admin の所属会社）の従業員一覧を返す。company_admin / super_admin のみ。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.memberResponse"][];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 管理者以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部エラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/members/{userId}/ai-access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 従業員の AI 利用可否を個別更新
+         * @description 自社の従業員の AI 利用可否を個別に上書きする（null で会社設定に従う）。別会社の従業員は更新できない。company_admin / super_admin のみ。
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 従業員の数値 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            /** @description enabled (null=会社設定に従う) */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.updateMemberAiRequest"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description バリデーション失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 管理者以外 / 別会社の従業員 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部エラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
     "/ai-chat/attachments/upload-url": {
         parameters: {
             query?: never;
@@ -4221,6 +4368,14 @@ export interface components {
             role?: string;
             updatedAt?: string;
         };
+        "internal_handler.memberResponse": {
+            /** @description AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。 */
+            aiChatEnabled?: boolean;
+            displayName?: string;
+            email?: string;
+            id?: number;
+            role?: string;
+        };
         "internal_handler.messageResponse": {
             /** @example ログインしました。 */
             message?: string;
@@ -4285,6 +4440,10 @@ export interface components {
         "internal_handler.updateCompanySettingsRequest": {
             /** @description bool の必須を binding:"required" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。 */
             aiChatEnabledForTrainees: boolean;
+        };
+        "internal_handler.updateMemberAiRequest": {
+            /** @description Enabled は AI 利用可否の個別上書き。null（未指定）で会社設定に従う状態へ戻す。 */
+            enabled?: boolean;
         };
         "internal_handler.updateProfileReq": {
             avatarUrl?: string;

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -374,6 +374,146 @@
                 }
             }
         },
+        "/admin/members": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社（company_admin の所属会社）の従業員一覧を返す。company_admin / super_admin のみ。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員一覧",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/internal_handler.memberResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}/ai-access": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "自社の従業員の AI 利用可否を個別に上書きする（null で会社設定に従う）。別会社の従業員は更新できない。company_admin / super_admin のみ。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員の AI 利用可否を個別更新",
+                "parameters": [
+                    {
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.updateMemberAiRequest"
+                            }
+                        }
+                    },
+                    "description": "enabled (null=会社設定に従う)",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "バリデーション失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ai-chat/attachments/upload-url": {
             "post": {
                 "security": [
@@ -4823,6 +4963,27 @@
                     }
                 }
             },
+            "internal_handler.memberResponse": {
+                "type": "object",
+                "properties": {
+                    "aiChatEnabled": {
+                        "description": "AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。",
+                        "type": "boolean"
+                    },
+                    "displayName": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "role": {
+                        "type": "string"
+                    }
+                }
+            },
             "internal_handler.messageResponse": {
                 "type": "object",
                 "properties": {
@@ -5028,6 +5189,15 @@
                 "properties": {
                     "aiChatEnabledForTrainees": {
                         "description": "bool の必須を binding:\"required\" で表現すると false が弾かれるため、ポインタで「指定の有無」を判定する。",
+                        "type": "boolean"
+                    }
+                }
+            },
+            "internal_handler.updateMemberAiRequest": {
+                "type": "object",
+                "properties": {
+                    "enabled": {
+                        "description": "Enabled は AI 利用可否の個別上書き。null（未指定）で会社設定に従う状態へ戻す。",
                         "type": "boolean"
                     }
                 }

--- a/frontend/src/hooks/useAdminMembers.ts
+++ b/frontend/src/hooks/useAdminMembers.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import AdminMemberRepository, { Member } from '../repositories/AdminMemberRepository';
+
+/**
+ * useAdminMembers — 従業員管理ページの状態管理フック。
+ * 自社の従業員一覧の取得と、各従業員の AI 利用可否（個別上書き）の更新を扱う。
+ */
+export function useAdminMembers() {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setMembers(await AdminMemberRepository.listMembers());
+    } catch {
+      setError('従業員一覧の取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // AI 利用可否を個別更新する。enabled=null で会社設定に従う状態へ戻す。
+  const setAiAccess = useCallback(
+    async (userId: number, enabled: boolean | null) => {
+      setUpdatingId(userId);
+      // 楽観的に反映し、失敗したら再取得して整合を取る。
+      setMembers((prev) => prev.map((m) => (m.id === userId ? { ...m, aiChatEnabled: enabled } : m)));
+      try {
+        await AdminMemberRepository.updateAiAccess(userId, enabled);
+      } catch {
+        await load();
+      } finally {
+        setUpdatingId(null);
+      }
+    },
+    [load],
+  );
+
+  return { members, loading, error, updatingId, setAiAccess, reload: load };
+}

--- a/frontend/src/pages/AdminMembersPage.tsx
+++ b/frontend/src/pages/AdminMembersPage.tsx
@@ -1,0 +1,95 @@
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+import { useAdminMembers } from '../hooks/useAdminMembers';
+import { Member } from '../repositories/AdminMemberRepository';
+
+// AI 利用可否の 3 状態 ↔ select の値。
+function aiValue(m: Member): 'inherit' | 'on' | 'off' {
+  if (m.aiChatEnabled === null) return 'inherit';
+  return m.aiChatEnabled ? 'on' : 'off';
+}
+
+function roleLabel(role: string): string {
+  switch (role) {
+    case 'super_admin':
+      return '運営管理者';
+    case 'company_admin':
+      return '会社管理者';
+    case 'trainee':
+      return '受講者';
+    default:
+      return role;
+  }
+}
+
+/**
+ * AdminMembersPage — `/admin/members`。company_admin / super_admin 向けの従業員一覧。
+ * 各従業員の AI 利用可否を「会社設定に従う / 有効 / 無効」で個別に設定できる
+ * （会社一括設定は従来どおり別途残る。個別設定が会社設定を上書きする）。
+ */
+export default function AdminMembersPage() {
+  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
+  const authLoading = useSelector((state: RootState) => state.auth.loading);
+  const { members, loading, error, updatingId, setAiAccess } = useAdminMembers();
+
+  if (authLoading) return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+  if (!isAdmin) return <Navigate to="/" replace />;
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-4xl mx-auto">
+      <PageIntro
+        title="管理: 従業員一覧"
+        description="自社の従業員の一覧です。各従業員の AI 利用可否を個別に設定できます（会社の一括設定を上書きします）。"
+      />
+
+      {loading ? (
+        <Loading message="読み込み中..." className="min-h-[30vh]" />
+      ) : error ? (
+        <p className="mt-6 text-rose-600">{error}</p>
+      ) : members.length === 0 ? (
+        <p className="mt-6 text-[var(--color-text-muted)]">従業員がまだいません。</p>
+      ) : (
+        <div className="mt-6 overflow-x-auto rounded-lg border border-surface-3">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-surface-2 text-left text-[var(--color-text-muted)]">
+                <th className="px-4 py-2 font-medium">氏名</th>
+                <th className="px-4 py-2 font-medium">メールアドレス</th>
+                <th className="px-4 py-2 font-medium">役割</th>
+                <th className="px-4 py-2 font-medium">AI 利用</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((m) => (
+                <tr key={m.id} className="border-t border-surface-3">
+                  <td className="px-4 py-2 text-[var(--color-text-primary)]">{m.displayName || '—'}</td>
+                  <td className="px-4 py-2 text-[var(--color-text-muted)]">{m.email}</td>
+                  <td className="px-4 py-2 text-[var(--color-text-muted)]">{roleLabel(m.role)}</td>
+                  <td className="px-4 py-2">
+                    <select
+                      aria-label={`${m.displayName || m.email} の AI 利用可否`}
+                      value={aiValue(m)}
+                      disabled={updatingId === m.id || m.role !== 'trainee'}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setAiAccess(m.id, v === 'inherit' ? null : v === 'on');
+                      }}
+                      className="px-2 py-1 rounded-md bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] focus:outline-none focus:border-brand-500 disabled:opacity-50"
+                    >
+                      <option value="inherit">会社設定に従う</option>
+                      <option value="on">有効（個別ON）</option>
+                      <option value="off">無効（個別OFF）</option>
+                    </select>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/repositories/AdminMemberRepository.ts
+++ b/frontend/src/repositories/AdminMemberRepository.ts
@@ -1,0 +1,32 @@
+import api from '../lib/axios';
+import { ADMIN } from '../constants/apiRoutes';
+
+/** 従業員一覧の 1 行（backend handler.memberResponse と 1:1）。 */
+export interface Member {
+  id: number;
+  email: string;
+  displayName: string;
+  role: string;
+  /** AI 利用可否の個別上書き。null = 会社設定に従う。 */
+  aiChatEnabled: boolean | null;
+}
+
+/**
+ * company_admin / super_admin 向けの従業員管理 API ラッパー。
+ * 自社の従業員一覧取得と、各従業員の AI 利用可否の個別更新を扱う。
+ */
+const AdminMemberRepository = {
+  async listMembers(): Promise<Member[]> {
+    const res = await api.get<Member[]>(ADMIN.members);
+    return res.data;
+  },
+
+  /**
+   * 従業員の AI 利用可否を個別更新する。enabled=null で会社設定に従う状態へ戻す。
+   */
+  async updateAiAccess(userId: number, enabled: boolean | null): Promise<void> {
+    await api.patch(ADMIN.memberAiAccess(userId), { enabled });
+  },
+};
+
+export default AdminMemberRepository;

--- a/frontend/src/repositories/__tests__/AdminMemberRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AdminMemberRepository.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+import AdminMemberRepository from '../AdminMemberRepository';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPatch = vi.mocked(apiClient.patch);
+
+describe('AdminMemberRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('listMembers: 自社の従業員一覧を取得する', async () => {
+    mockedGet.mockResolvedValue({
+      data: [{ id: 1, email: 'a@e.com', displayName: '田中', role: 'trainee', aiChatEnabled: null }],
+    });
+    const members = await AdminMemberRepository.listMembers();
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/admin/members');
+    expect(members[0].displayName).toBe('田中');
+  });
+
+  it('updateAiAccess: 個別 OFF を送る', async () => {
+    mockedPatch.mockResolvedValue({ status: 204 });
+    await AdminMemberRepository.updateAiAccess(7, false);
+    expect(mockedPatch).toHaveBeenCalledWith('/api/v2/admin/members/7/ai-access', { enabled: false });
+  });
+
+  it('updateAiAccess: null で会社設定に従う状態へ戻す', async () => {
+    mockedPatch.mockResolvedValue({ status: 204 });
+    await AdminMemberRepository.updateAiAccess(7, null);
+    expect(mockedPatch).toHaveBeenCalledWith('/api/v2/admin/members/7/ai-access', { enabled: null });
+  });
+});


### PR DESCRIPTION
## 概要

company_admin / super_admin が**自社の従業員一覧**を見て、各従業員の **AI チャット利用可否を個別に**設定できるようにする（サイドバー「管理」直下に「従業員一覧」）。**会社一括設定は従来どおり残り、個別設定がそれを上書き**する。

## AI 利用可否の優先順位

1. company_admin / super_admin → 常に許可
2. 会社未所属 → 許可
3. **`users.ai_chat_enabled`（個別上書き）が設定済みなら優先**
4. それ以外 → 会社の `ai_chat_enabled_for_trainees`（一括）に従う

「会社設定に従う」に戻すと `ai_chat_enabled` が `NULL` になり再び一括設定に従う。

## 変更内容

**backend**
- `domain.User.AiChatEnabled *bool`（列 `ai_chat_enabled`, nullable, GORM AutoMigrate が追加＝無停止）
- `AiChatEnabledForUserUseCase` を「個別 > 会社一括」の優先で判定
- `UserRepository.ListByCompanyID`（sqlc）+ `UpdateAiChatEnabled`（GORM、`nil` で `NULL`）
- `ListCompanyMembersUseCase` / `UpdateMemberAiAccessUseCase`（**テナント境界の認可**：別会社は 403）
- `AdminMemberHandler` + `GET /admin/members` / `PATCH /admin/members/{userId}/ai-access`

**frontend**
- `AdminMembersPage` / `useAdminMembers` / `AdminMemberRepository`
- 一覧表で AI 利用を「会社設定に従う / 有効 / 無効」セレクトで個別設定（trainee 対象）
- サイドバー「管理」に従業員一覧、`/admin/members` ルート

**docs**: `docs/admin-member-management.md`

## テスト

- backend: `go test`（usecase: 一覧/個別更新/別会社 403/個別上書き優先）/ archlint / naminglint / apispec-lint / golangci-lint 0 issues / gofumpt clean / OpenAPI drift なし
- frontend: `tsc` / `eslint` / `vitest`（全 1462 pass、AdminMemberRepository テスト追加）/ `npm run build` 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added employee management page for administrators to view company members
  * Added ability to control AI access per employee, overriding company-wide settings
  * Admin users can now individually enable or disable AI chat access for each team member

* **Documentation**
  * Added admin documentation covering employee management and AI access control features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->