### PR TITLE
refactor: PHP 演習を公開リポから撤去し非公開教材リポの .md を唯一の正本に

### DIFF
--- a/backend/internal/infra/database/seed_master_exercises.go
+++ b/backend/internal/infra/database/seed_master_exercises.go
@@ -1,213 +1,27 @@
 package database
 
 import (
-	"fmt"
 	"log"
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
-// seedMasterExercises は初期演習データを投入する（ON CONFLICT DO NOTHING で冪等）。
-// Language / Slug / IsPublished / Difficulty の共通値は末尾ループで一括設定する。
+// seedMasterExercises は埋め込みの初期演習データを投入する。
+//
+// PHP / Go / Docker / Linux / Git などの言語別演習は、問題文・期待出力を公開リポに露出させない
+// ため本体（公開リポ）には埋め込まず、非公開の教材リポ
+// (frestyle-teaching-materials/exercises/<lang>/*.md) を唯一の正本とする。
+// 教材リポの seed.py が slug をキーに UPSERT する SQL を生成し、Supabase に流して投入する。
+// ここでは本体コードと密結合な「クリーンアーキテクチャ体験用 Go 演習」のみ埋め込みで投入する。
 func seedMasterExercises(db *gorm.DB) error {
-	now := time.Now()
-	exercises := []domain.MasterExercise{
-		{
-			ID:             1,
-			OrderIndex:     1,
-			Category:       "基礎",
-			Title:          "こんにちは世界",
-			Description:    "PHPでの最初のプログラムです。\n`echo` を使って「Hello, World!」と表示してみましょう。\n\n`echo` は文字列を画面に出力する命令です。",
-			StarterCode:    "<?php\n// ここにコードを書いてください\necho \"Hello, World!\\n\";\n",
-			HintText:       "`echo \"文字列\";` の形式で書きます。改行は `\\n` を使います。",
-			ExpectedOutput: "Hello, World!",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             2,
-			OrderIndex:     2,
-			Category:       "基礎",
-			Title:          "変数と文字列",
-			Description:    "変数を使って名前を格納し、文字列を連結して表示しましょう。\n\n変数は `$` で始まります。文字列の連結は `.` を使います。",
-			StarterCode:    "<?php\n$name = \"フレスタイル\";\n$message = \"ようこそ、\" . $name . \" へ！\";\necho $message . \"\\n\";\n",
-			HintText:       "変数は `$変数名 = 値;` で宣言。文字列連結は `.` オペレータを使います。",
-			ExpectedOutput: "ようこそ、フレスタイル へ！",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             3,
-			OrderIndex:     3,
-			Category:       "基礎",
-			Title:          "数値計算",
-			Description:    "PHPで四則演算を行いましょう。\n\n整数・小数の演算や、余り (`%`)、べき乗 (`**`) も試してみてください。",
-			StarterCode:    "<?php\n$a = 10;\n$b = 3;\necho $a + $b . \"\\n\"; // 13\necho $a - $b . \"\\n\"; // 7\necho $a * $b . \"\\n\"; // 30\necho $a / $b . \"\\n\"; // 3.333...\necho $a % $b . \"\\n\"; // 1\n",
-			HintText:       "算術演算子: `+` `-` `*` `/` `%`（余り）`**`（べき乗）",
-			ExpectedOutput: "13\n7\n30\n3.3333333333333\n1",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             4,
-			OrderIndex:     4,
-			Category:       "制御構文",
-			Title:          "条件分岐（if文）",
-			Description:    "点数を受け取り、条件によってメッセージを変えましょう。\n\n`if` / `elseif` / `else` を使います。",
-			StarterCode:    "<?php\n$score = 75;\n\nif ($score >= 80) {\n    echo \"優秀\\n\";\n} elseif ($score >= 60) {\n    echo \"合格\\n\";\n} else {\n    echo \"不合格\\n\";\n}\n",
-			HintText:       "`if (条件) { ... } elseif (条件) { ... } else { ... }` の構造で書きます。",
-			ExpectedOutput: "合格",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             5,
-			OrderIndex:     5,
-			Category:       "配列",
-			Title:          "配列の基本",
-			Description:    "配列を宣言し、要素にアクセスしてみましょう。\n\nPHPの配列は `[]` または `array()` で作れます。",
-			StarterCode:    "<?php\n$fruits = [\"りんご\", \"バナナ\", \"オレンジ\"];\n\necho $fruits[0] . \"\\n\"; // りんご\necho count($fruits) . \"\\n\"; // 3\n\n$fruits[] = \"ぶどう\";\necho count($fruits) . \"\\n\"; // 4\n",
-			HintText:       "インデックスは 0 から始まります。`count()` で要素数を取得できます。",
-			ExpectedOutput: "りんご\n3\n4",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             6,
-			OrderIndex:     6,
-			Category:       "制御構文",
-			Title:          "for文",
-			Description:    "for 文を使って 1 から 5 までの数字を表示しましょう。",
-			StarterCode:    "<?php\nfor ($i = 1; $i <= 5; $i++) {\n    echo $i . \"\\n\";\n}\n",
-			HintText:       "`for (初期値; 条件; 増分) { ... }` の形式です。",
-			ExpectedOutput: "1\n2\n3\n4\n5",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             7,
-			OrderIndex:     7,
-			Category:       "制御構文",
-			Title:          "while文",
-			Description:    "while 文を使ってカウントダウンを表示しましょう。",
-			StarterCode:    "<?php\n$count = 5;\nwhile ($count > 0) {\n    echo $count . \"\\n\";\n    $count--;\n}\necho \"発射！\\n\";\n",
-			HintText:       "`while (条件) { ... }` ループ内で条件を更新するのを忘れずに。",
-			ExpectedOutput: "5\n4\n3\n2\n1\n発射！",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             8,
-			OrderIndex:     8,
-			Category:       "配列",
-			Title:          "foreach文と連想配列",
-			Description:    "連想配列（キーと値のペア）を作り、foreach で全要素を表示しましょう。",
-			StarterCode:    "<?php\n$person = [\n    \"name\" => \"田中太郎\",\n    \"age\"  => 23,\n    \"job\"  => \"エンジニア\",\n];\n\nforeach ($person as $key => $value) {\n    echo $key . \": \" . $value . \"\\n\";\n}\n",
-			HintText:       "`foreach ($array as $key => $value)` でキーと値を同時に取得できます。",
-			ExpectedOutput: "name: 田中太郎\nage: 23\njob: エンジニア",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             9,
-			OrderIndex:     9,
-			Category:       "関数",
-			Title:          "関数の定義と呼び出し",
-			Description:    "2つの数を受け取り、その合計を返す関数を作りましょう。",
-			StarterCode:    "<?php\nfunction add($a, $b) {\n    return $a + $b;\n}\n\necho add(3, 4) . \"\\n\";  // 7\necho add(10, 20) . \"\\n\"; // 30\n",
-			HintText:       "`function 関数名(引数) { return 戻り値; }` の形式で定義します。",
-			ExpectedOutput: "7\n30",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             10,
-			OrderIndex:     10,
-			Category:       "文字列",
-			Title:          "文字列操作",
-			Description:    "PHP の文字列関数を使ってみましょう。\n\n`strlen()`, `strtoupper()`, `str_replace()`, `substr()` を練習します。",
-			StarterCode:    "<?php\n$str = \"Hello, PHP World!\";\n\necho strlen($str) . \"\\n\";              // 17\necho strtoupper($str) . \"\\n\";          // HELLO, PHP WORLD!\necho str_replace(\"PHP\", \"Go\", $str) . \"\\n\"; // Hello, Go World!\necho substr($str, 7, 3) . \"\\n\";        // PHP\n",
-			HintText:       "`strlen` で長さ、`strtoupper` で大文字変換、`str_replace` で置換、`substr(文字列, 開始, 長さ)` で部分文字列を取得します。",
-			ExpectedOutput: "17\nHELLO, PHP WORLD!\nHello, Go World!\nPHP",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             11,
-			OrderIndex:     11,
-			Category:       "OOP",
-			Title:          "クラスの基本",
-			Description:    "クラスを定義してオブジェクトを作成しましょう。\n\nコンストラクタ、プロパティ、メソッドを実装します。",
-			StarterCode:    "<?php\nclass Animal {\n    public $name;\n    public $sound;\n\n    public function __construct($name, $sound) {\n        $this->name  = $name;\n        $this->sound = $sound;\n    }\n\n    public function speak() {\n        echo $this->name . \" は \" . $this->sound . \" と鳴きます\\n\";\n    }\n}\n\n$dog = new Animal(\"犬\", \"ワン\");\n$cat = new Animal(\"猫\", \"ニャン\");\n$dog->speak();\n$cat->speak();\n",
-			HintText:       "`class クラス名 { ... }` でクラスを定義。`new クラス名()` でオブジェクトを生成します。",
-			ExpectedOutput: "犬 は ワン と鳴きます\n猫 は ニャン と鳴きます",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-		{
-			ID:             12,
-			OrderIndex:     12,
-			Category:       "OOP",
-			Title:          "継承",
-			Description:    "基底クラスを継承して子クラスを作りましょう。\n\n`extends` キーワードと `parent::` を使います。",
-			StarterCode:    "<?php\nclass Shape {\n    protected $color;\n\n    public function __construct($color) {\n        $this->color = $color;\n    }\n\n    public function describe() {\n        echo \"色: \" . $this->color . \"\\n\";\n    }\n}\n\nclass Circle extends Shape {\n    private $radius;\n\n    public function __construct($color, $radius) {\n        parent::__construct($color);\n        $this->radius = $radius;\n    }\n\n    public function describe() {\n        parent::describe();\n        echo \"半径: \" . $this->radius . \"\\n\";\n    }\n}\n\n$c = new Circle(\"赤\", 5);\n$c->describe();\n",
-			HintText:       "`class 子クラス extends 親クラス` で継承。`parent::メソッド()` で親のメソッドを呼び出せます。",
-			ExpectedOutput: "色: 赤\n半径: 5",
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		},
-	}
-
-	// PHP 教材の共通 defaults を一括設定する。
-	for i := range exercises {
-		exercises[i].Language = domain.ExerciseLanguagePhp
-		exercises[i].Slug = fmt.Sprintf("php-%d", exercises[i].ID)
-		exercises[i].IsPublished = true
-		if exercises[i].Difficulty == 0 {
-			exercises[i].Difficulty = 1
-		}
-	}
-
-	result := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&exercises)
-	if result.Error != nil {
-		return result.Error
-	}
-	log.Printf("seed: master_exercises (php) %d 件を挿入（既存はスキップ）", result.RowsAffected)
-
-	// 上の php seed は明示 ID(1..N) で insert するが、Postgres は明示 ID の insert で
-	// identity sequence を進めない。そのため後続の autoIncrement insert（clean-arch /
-	// company_admin 作成）が ID=1 で PK 衝突する。sequence を MAX(id) に合わせて回避する。
-	if err := resetMasterExerciseSeq(db); err != nil {
-		return err
-	}
-
-	if err := seedMasterExerciseExamples(db, exercises); err != nil {
-		return err
-	}
-	if err := seedCleanArchitectureExercise(db); err != nil {
-		return err
-	}
-	return nil
-}
-
-// resetMasterExerciseSeq は master_exercises の identity sequence を現在の MAX(id) に合わせる。
-// 明示 ID の seed 後に呼び、autoIncrement insert の PK 衝突を防ぐ（Postgres のみ）。
-// 第 3 引数 is_called=(MAX(id) IS NOT NULL) で、空テーブルでも次の採番が 1 になるよう扱う。
-func resetMasterExerciseSeq(db *gorm.DB) error {
-	if db.Name() != "postgres" {
-		return nil
-	}
-	return db.Exec(
-		`SELECT setval(pg_get_serial_sequence('master_exercises', 'id'), COALESCE(MAX(id), 1), MAX(id) IS NOT NULL) FROM master_exercises`,
-	).Error
+	return seedCleanArchitectureExercise(db)
 }
 
 // seedCleanArchitectureExercise はクリーンアーキテクチャ（依存性逆転）を 1 ファイルの Go で
-// 体験する演習を投入する。PHP 教材の一括 defaults ループとは独立に Language=go で入れる。
-// slug の存在チェックで冪等（autoIncrement で ID を採番し、その ID で example を 1 件作る）。
+// 体験する演習を投入する。slug の存在チェックで冪等（autoIncrement で ID を採番し、その ID で
+// example を 1 件作る）。
 func seedCleanArchitectureExercise(db *gorm.DB) error {
 	const slug = "go-clean-arch-greeting"
 
@@ -307,37 +121,5 @@ func main() {
 		return err
 	}
 	log.Printf("seed: clean-architecture Go 演習を挿入（slug=%s, id=%d）", slug, ex.ID)
-	return nil
-}
-
-// seedMasterExerciseExamples は各 exercise の expected_output を
-// 「OrderIndex=1, InputText=空」の 1 行として examples にバックフィルする（既存があれば skip）。
-func seedMasterExerciseExamples(db *gorm.DB, exercises []domain.MasterExercise) error {
-	now := time.Now()
-	inserted := 0
-	for _, ex := range exercises {
-		var count int64
-		if err := db.Model(&domain.MasterExerciseExample{}).
-			Where("exercise_id = ?", ex.ID).
-			Count(&count).Error; err != nil {
-			return err
-		}
-		if count > 0 {
-			continue
-		}
-		example := domain.MasterExerciseExample{
-			ExerciseID:     ex.ID,
-			OrderIndex:     1,
-			InputText:      "",
-			ExpectedOutput: ex.ExpectedOutput,
-			CreatedAt:      now,
-			UpdatedAt:      now,
-		}
-		if err := db.Create(&example).Error; err != nil {
-			return err
-		}
-		inserted++
-	}
-	log.Printf("seed: master_exercise_examples %d 件をバックフィル（既存 example のある問題は skip）", inserted)
 	return nil
 }

--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -22,7 +22,9 @@
 言語別演習（PHP / Go / Docker / Linux / Git など）の**正本は非公開の教材リポ** [`norman6464/frestyle-teaching-materials`](https://github.com/norman6464/frestyle-teaching-materials) の `exercises/<lang>/*.md`。問題文・期待出力を公開リポに露出させないため、本体（公開リポ）には埋め込まない。
 
 - **追加 / 編集**: 教材リポの `exercises/<lang>/<slug>.md`（YAML frontmatter + 本文）を編集する
-- **DB 反映**: `python3 exercises/_scripts/seed.py > /tmp/seed-exercises.sql` で slug をキーにした `ON CONFLICT (slug) DO UPDATE` の UPSERT SQL を生成し、`frestyle-infrastructure` の `make apply-migration-supabase FILE=/tmp/seed-exercises.sql DATABASE_URL_SECRET_NAME=frestyle-prod/database-url` で Supabase に流す（非破壊・冪等）
+- **DB 反映**: 2 つの作業ディレクトリで順に実行する（公開リポでの誤実行を避けるため実行場所を明示）
+  1. **教材リポ直下**（`frestyle-teaching-materials/`）で SQL を生成: `python3 exercises/_scripts/seed.py > /tmp/seed-exercises.sql`（slug をキーにした `ON CONFLICT (slug) DO UPDATE` の UPSERT SQL）
+  2. **インフラリポ直下**（`frestyle-infrastructure/`）で Supabase に流す: `make apply-migration-supabase FILE=/tmp/seed-exercises.sql DATABASE_URL_SECRET_NAME=frestyle-prod/database-url`（非破壊・冪等）
 - **採点**: `master_exercise_examples` が無い演習は `master_exercises.expected_output` を単一の仮想テストケースとして使う（seed.py は examples を作らず expected_output のみ投入する）
 - company_admin が UI から作成することも可能。その場合は後で教材リポの `.md` にバックポートして整合を取る
 

--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -19,11 +19,14 @@
 
 ## 2. 演習を追加する
 
-初期演習は `backend/internal/infra/database/seed_master_exercises.go` が起動時に投入する（冪等）。
+言語別演習（PHP / Go / Docker / Linux / Git など）の**正本は非公開の教材リポ** [`norman6464/frestyle-teaching-materials`](https://github.com/norman6464/frestyle-teaching-materials) の `exercises/<lang>/*.md`。問題文・期待出力を公開リポに露出させないため、本体（公開リポ）には埋め込まない。
 
-- **PHP 演習**: `exercises []domain.MasterExercise` に追加。末尾の一括ループが `Language=php` / `Slug=php-{ID}` を自動設定する
-- **他言語（go / bash）演習**: 一括ループは php 固定なので、**独立した seed 関数**で `Language` を明示して入れる。参照実装が `seedCleanArchitectureExercise`（slug 存在チェックで冪等 → autoIncrement で採番 → その ID で example を 1 件作成）
-- company_admin が UI から作成することも可能。その場合は後で seed にバックポートして整合を取る
+- **追加 / 編集**: 教材リポの `exercises/<lang>/<slug>.md`（YAML frontmatter + 本文）を編集する
+- **DB 反映**: `python3 exercises/_scripts/seed.py > /tmp/seed-exercises.sql` で slug をキーにした `ON CONFLICT (slug) DO UPDATE` の UPSERT SQL を生成し、`frestyle-infrastructure` の `make apply-migration-supabase FILE=/tmp/seed-exercises.sql DATABASE_URL_SECRET_NAME=frestyle-prod/database-url` で Supabase に流す（非破壊・冪等）
+- **採点**: `master_exercise_examples` が無い演習は `master_exercises.expected_output` を単一の仮想テストケースとして使う（seed.py は examples を作らず expected_output のみ投入する）
+- company_admin が UI から作成することも可能。その場合は後で教材リポの `.md` にバックポートして整合を取る
+
+> **例外（本体コードと密結合な演習のみ埋め込み）**: `backend/internal/infra/database/seed_master_exercises.go` は起動時にクリーンアーキテクチャ体験用の Go 演習（`seedCleanArchitectureExercise` / slug `go-clean-arch-greeting`）だけを冪等に投入する。本プロジェクトの層構造そのものを最小例で示す教材のため例外的に埋め込んでいる。PHP 演習の埋め込み seed は教材リポ `.md` への一本化に伴い撤去済み。
 
 ### 参照: クリーンアーキテクチャの Go 演習
 


### PR DESCRIPTION
## 概要

PHP 演習（12問）が**公開リポ**の `seed_master_exercises.go` に問題文・期待出力ごとハードコードされており、非公開の教材リポ [`frestyle-teaching-materials/exercises/php/*.md`](https://github.com/norman6464/frestyle-teaching-materials)（34問）と**二重管理**になっていた。問題を公開状態にしないため、`.md` を唯一の正本とし、Go 側の PHP 埋め込み seed を撤去する。

## 変更内容

- `backend/internal/infra/database/seed_master_exercises.go`
  - PHP 演習 12問 + 一括 defaults ループ + 明示 ID seed を撤去
  - 不要になった `resetMasterExerciseSeq` / `seedMasterExerciseExamples` を削除
    - 明示 ID insert が無くなり identity sequence のリセットが不要
    - 採点は examples が無ければ `master_exercises.expected_output` にフォールバックするため examples バックフィルも不要（`submit_master_exercise_usecase.go`）
  - 本体コードと密結合な `seedCleanArchitectureExercise`（Go 演習・slug `go-clean-arch-greeting`）のみ埋め込みで存続
- `docs/code-exercises.md`: 言語別演習の正本は `.md`（`seed.py` → `make apply-migration-supabase`）であることを明記

## 安全性 / 本番影響

- 本番 DB は**既に `.md` 適用済み**（`php=34` 件、`php-1`〜`12` の内容も `.md` と一致）。Go seed は `ON CONFLICT DO NOTHING` で既存行を上書きしない**休眠**状態だったため、撤去しても本番の演習は変化しない（DB 変更不要）。
- 採点用 `expected_output` は全 PHP 演習で投入済みのため、grading は従来どおり動作。

## テスト

- `go build ./...` / `go vet` / 全ユニットテスト green
- `seed_clean_arch_integration_test.go`（clean-arch Go 演習の冪等性）は PHP に非依存で影響なし
- handler / repository のテストはインラインの独自フィクスチャを使用しており seed 非依存

## 関連 / フォローアップ

- 教材リポ側: `seed.py` の同期コマンドを `make apply-migration-supabase` に更新済（別 commit）
- **要相談**: クリーンアーキの Go 演習も公開リポに埋め込まれている。これも `.md` へ寄せる場合は別 PR で対応（本体コードと密結合な教材のため今回は存続）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 演習教材の管理方法を更新。言語別演習は専用リポジトリに一元化され、クリーンアーキテクチャ Go 演習のみアプリケーション起動時に自動初期化されるようになりました。

* **Infrastructure**
  * 演習初期化プロセスを簡素化し、メンテナンス効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->