### PR TITLE
feat(admin): super_admin 専用の read-only SQL コンソールを追加

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -431,6 +431,57 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/sql": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "super_admin が入力した単一の SELECT / WITH クエリを read-only トランザクション内で実行し、列・行を返す。書き込み系は DB レベルで拒否され、行数は上限で打ち切られる（truncated=true）。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "read-only SQL を実行（super_admin 専用）",
+                "parameters": [
+                    {
+                        "description": "実行する SELECT / WITH クエリ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.runSQLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.runSQLResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "クエリが空 / 読み取り専用でない / SQL エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ai-chat/attachments/upload-url": {
             "post": {
                 "security": [
@@ -4295,6 +4346,41 @@ const docTemplate = `{
                     "type": "integer",
                     "maximum": 2100,
                     "minimum": 2000
+                }
+            }
+        },
+        "internal_handler.runSQLRequest": {
+            "type": "object",
+            "required": [
+                "query"
+            ],
+            "properties": {
+                "query": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.runSQLResponse": {
+            "type": "object",
+            "properties": {
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rowCount": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {}
+                    }
+                },
+                "truncated": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -424,6 +424,57 @@
                 }
             }
         },
+        "/admin/sql": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "super_admin が入力した単一の SELECT / WITH クエリを read-only トランザクション内で実行し、列・行を返す。書き込み系は DB レベルで拒否され、行数は上限で打ち切られる（truncated=true）。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "read-only SQL を実行（super_admin 専用）",
+                "parameters": [
+                    {
+                        "description": "実行する SELECT / WITH クエリ",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.runSQLRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.runSQLResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "クエリが空 / 読み取り専用でない / SQL エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/ai-chat/attachments/upload-url": {
             "post": {
                 "security": [
@@ -4288,6 +4339,41 @@
                     "type": "integer",
                     "maximum": 2100,
                     "minimum": 2000
+                }
+            }
+        },
+        "internal_handler.runSQLRequest": {
+            "type": "object",
+            "required": [
+                "query"
+            ],
+            "properties": {
+                "query": {
+                    "type": "string"
+                }
+            }
+        },
+        "internal_handler.runSQLResponse": {
+            "type": "object",
+            "properties": {
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "rowCount": {
+                    "type": "integer"
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {}
+                    }
+                },
+                "truncated": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -715,6 +715,29 @@ definitions:
     - month
     - year
     type: object
+  internal_handler.runSQLRequest:
+    properties:
+      query:
+        type: string
+    required:
+    - query
+    type: object
+  internal_handler.runSQLResponse:
+    properties:
+      columns:
+        items:
+          type: string
+        type: array
+      rowCount:
+        type: integer
+      rows:
+        items:
+          items: {}
+          type: array
+        type: array
+      truncated:
+        type: boolean
+    type: object
   internal_handler.sessionNoteUpsertReq:
     properties:
       content:
@@ -1099,6 +1122,39 @@ paths:
       security:
       - CookieAuth: []
       summary: 従業員の AI 利用可否を個別更新
+      tags:
+      - admin
+  /admin/sql:
+    post:
+      consumes:
+      - application/json
+      description: super_admin が入力した単一の SELECT / WITH クエリを read-only トランザクション内で実行し、列・行を返す。書き込み系は
+        DB レベルで拒否され、行数は上限で打ち切られる（truncated=true）。
+      parameters:
+      - description: 実行する SELECT / WITH クエリ
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.runSQLRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.runSQLResponse'
+        "400":
+          description: クエリが空 / 読み取り専用でない / SQL エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: read-only SQL を実行（super_admin 専用）
       tags:
       - admin
   /ai-chat/attachments/upload-url:

--- a/backend/internal/adapter/persistence/sql_console_repository.go
+++ b/backend/internal/adapter/persistence/sql_console_repository.go
@@ -1,0 +1,74 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// sqlConsoleRepository は read-only SQL コンソールの実装。
+// クエリは read-only トランザクション内で実行し、statement_timeout と行数上限を課す。
+type sqlConsoleRepository struct {
+	db *gorm.DB
+}
+
+// NewSQLConsoleRepository は SQLConsoleRepository 実装を生成する。
+func NewSQLConsoleRepository(db *gorm.DB) repository.SQLConsoleRepository {
+	return &sqlConsoleRepository{db: db}
+}
+
+// RunReadOnly は read-only トランザクション内で query を実行し、最大 maxRows 行を返す。
+// SET TRANSACTION READ ONLY により、万一 write クエリが渡っても Postgres が拒否する（最終防壁）。
+func (r *sqlConsoleRepository) RunReadOnly(ctx context.Context, query string, maxRows int) (*repository.SQLQueryResult, error) {
+	result := &repository.SQLQueryResult{Columns: []string{}, Rows: [][]any{}}
+
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// 読み取り専用 + タイムアウトをトランザクション全体に課す。
+		if err := tx.Exec("SET TRANSACTION READ ONLY").Error; err != nil {
+			return err
+		}
+		if err := tx.Exec("SET LOCAL statement_timeout = 5000").Error; err != nil {
+			return err
+		}
+
+		rows, err := tx.Raw(query).Rows()
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		cols, err := rows.Columns()
+		if err != nil {
+			return err
+		}
+		result.Columns = cols
+
+		for rows.Next() {
+			if len(result.Rows) >= maxRows {
+				result.Truncated = true
+				break
+			}
+			cells := make([]any, len(cols))
+			ptrs := make([]any, len(cols))
+			for i := range cells {
+				ptrs[i] = &cells[i]
+			}
+			if err := rows.Scan(ptrs...); err != nil {
+				return err
+			}
+			// []byte（text / bytea 等）は JSON で扱いやすいよう文字列化する。
+			for i, c := range cells {
+				if b, ok := c.([]byte); ok {
+					cells[i] = string(b)
+				}
+			}
+			result.Rows = append(result.Rows, cells)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}

--- a/backend/internal/adapter/persistence/sql_console_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/sql_console_repository_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLConsoleRepository_Integration は実 Postgres で read-only SQL コンソールの
+// ①SELECT が結果を返す ②maxRows で打ち切る ③書き込みは read-only トランザクションが拒否する
+// を検証する（DB レベルの最終防壁の確認）。
+func TestSQLConsoleRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewSQLConsoleRepository(db)
+	ctx := context.Background()
+
+	t.Run("SELECT は列と行を返す", func(t *testing.T) {
+		res, err := repo.RunReadOnly(ctx, "SELECT generate_series(1, 3) AS n", 1000)
+		require.NoError(t, err)
+		require.Equal(t, []string{"n"}, res.Columns)
+		require.Len(t, res.Rows, 3)
+		require.False(t, res.Truncated)
+	})
+
+	t.Run("maxRows を超えると truncated", func(t *testing.T) {
+		res, err := repo.RunReadOnly(ctx, "SELECT generate_series(1, 10) AS n", 4)
+		require.NoError(t, err)
+		require.Len(t, res.Rows, 4)
+		require.True(t, res.Truncated)
+	})
+
+	t.Run("書き込みは read-only トランザクションが拒否する", func(t *testing.T) {
+		// master_exercises は AutoMigrate で存在する。read-only tx なので DELETE は失敗する。
+		_, err := repo.RunReadOnly(ctx, "DELETE FROM master_exercises", 1000)
+		require.Error(t, err)
+		require.Contains(t, strings.ToLower(err.Error()), "read-only")
+	})
+}

--- a/backend/internal/handler/admin_sql_handler.go
+++ b/backend/internal/handler/admin_sql_handler.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AdminSQLHandler は super_admin 専用の read-only SQL コンソールを扱う。
+type AdminSQLHandler struct {
+	execute *usecase.ExecuteReadOnlySQLUseCase
+}
+
+// NewAdminSQLHandler は AdminSQLHandler を生成する。
+func NewAdminSQLHandler(execute *usecase.ExecuteReadOnlySQLUseCase) *AdminSQLHandler {
+	return &AdminSQLHandler{execute: execute}
+}
+
+// isSuperAdmin は actor が super_admin（運営管理者）かを判定する。
+func isSuperAdmin(actor *domain.User) bool {
+	return actor != nil && actor.Role == domain.RoleSuperAdmin
+}
+
+// runSQLRequest は read-only SQL 実行の入力。
+type runSQLRequest struct {
+	Query string `json:"query" binding:"required"`
+}
+
+// runSQLResponse は read-only SQL の実行結果。
+type runSQLResponse struct {
+	Columns   []string `json:"columns"`
+	Rows      [][]any  `json:"rows"`
+	RowCount  int      `json:"rowCount"`
+	Truncated bool     `json:"truncated"`
+}
+
+// Run は super_admin が入力した read-only SQL を実行して結果を返すハンドラ。
+//
+//	@Summary      read-only SQL を実行（super_admin 専用）
+//	@Description  super_admin が入力した単一の SELECT / WITH クエリを read-only トランザクション内で実行し、列・行を返す。書き込み系は DB レベルで拒否され、行数は上限で打ち切られる（truncated=true）。
+//	@Tags         admin
+//	@Accept       json
+//	@Produce      json
+//	@Param        body  body      runSQLRequest  true  "実行する SELECT / WITH クエリ"
+//	@Success      200   {object}  runSQLResponse
+//	@Failure      400   {object}  errorResponse  "クエリが空 / 読み取り専用でない / SQL エラー"
+//	@Failure      403   {object}  errorResponse  "super_admin 以外"
+//	@Router       /admin/sql [post]
+//	@Security     CookieAuth
+func (h *AdminSQLHandler) Run(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	if !isSuperAdmin(actor) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
+
+	var body runSQLRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_request"})
+		return
+	}
+
+	// 監査: 誰がどの SQL を実行したかを必ず残す。
+	log.Printf("AUDIT sql-console: super_admin(id=%d email=%s) query=%q", actor.ID, actor.Email, body.Query)
+
+	result, err := h.execute.Execute(c.Request.Context(), usecase.ExecuteReadOnlySQLInput{Query: body.Query})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, runSQLResponse{
+		Columns:   result.Columns,
+		Rows:      result.Rows,
+		RowCount:  len(result.Rows),
+		Truncated: result.Truncated,
+	})
+}

--- a/backend/internal/handler/admin_sql_handler_test.go
+++ b/backend/internal/handler/admin_sql_handler_test.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// fakeSQLConsoleRepo は handler テスト用の最小 fake。
+type fakeSQLConsoleRepo struct {
+	called bool
+	result *repository.SQLQueryResult
+}
+
+func (f *fakeSQLConsoleRepo) RunReadOnly(context.Context, string, int) (*repository.SQLQueryResult, error) {
+	f.called = true
+	if f.result != nil {
+		return f.result, nil
+	}
+	return &repository.SQLQueryResult{Columns: []string{"n"}, Rows: [][]any{{int64(1)}}}, nil
+}
+
+func newAdminSQLHandler(repo *fakeSQLConsoleRepo) *AdminSQLHandler {
+	return NewAdminSQLHandler(usecase.NewExecuteReadOnlySQLUseCase(repo))
+}
+
+func postSQL(t *testing.T, actor *domain.User, body string, repo *fakeSQLConsoleRepo) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/admin/sql", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	if actor != nil {
+		c.Set(middleware.ContextKeyCurrentUser, actor)
+	}
+	newAdminSQLHandler(repo).Run(c)
+	return w
+}
+
+func TestAdminSQLHandler_SuperAdmin_OK(t *testing.T) {
+	repo := &fakeSQLConsoleRepo{}
+	actor := &domain.User{ID: 1, Email: "ops@example.com", Role: domain.RoleSuperAdmin}
+
+	w := postSQL(t, actor, `{"query":"SELECT 1 AS n"}`, repo)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if !repo.called {
+		t.Fatal("repository が呼ばれていない")
+	}
+}
+
+func TestAdminSQLHandler_NonSuperAdmin_Forbidden(t *testing.T) {
+	for _, role := range []string{domain.RoleCompanyAdmin, domain.RoleTrainee} {
+		t.Run(role, func(t *testing.T) {
+			repo := &fakeSQLConsoleRepo{}
+			actor := &domain.User{ID: 2, Email: "u@example.com", Role: role}
+
+			w := postSQL(t, actor, `{"query":"SELECT 1"}`, repo)
+
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("want 403, got %d", w.Code)
+			}
+			if repo.called {
+				t.Fatal("非 super_admin で repository を呼んではならない")
+			}
+		})
+	}
+}
+
+func TestAdminSQLHandler_NoUser_Forbidden(t *testing.T) {
+	repo := &fakeSQLConsoleRepo{}
+	w := postSQL(t, nil, `{"query":"SELECT 1"}`, repo)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+}
+
+func TestAdminSQLHandler_MissingQuery_BadRequest(t *testing.T) {
+	repo := &fakeSQLConsoleRepo{}
+	actor := &domain.User{ID: 1, Email: "ops@example.com", Role: domain.RoleSuperAdmin}
+	w := postSQL(t, actor, `{}`, repo)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestAdminSQLHandler_WriteQuery_BadRequest(t *testing.T) {
+	repo := &fakeSQLConsoleRepo{}
+	actor := &domain.User{ID: 1, Email: "ops@example.com", Role: domain.RoleSuperAdmin}
+
+	w := postSQL(t, actor, `{"query":"DELETE FROM users"}`, repo)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+	if repo.called {
+		t.Fatal("write クエリで repository を呼んではならない")
+	}
+}

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -27,6 +27,12 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.GET("/admin/members", memberHandler.List)
 	g.PATCH("/admin/members/:userId/ai-access", memberHandler.UpdateAiAccess)
 
+	// read-only SQL コンソール（super_admin 専用。認可は handler 層 + DB の read-only トランザクションで二重に担保）。
+	sqlHandler := NewAdminSQLHandler(
+		usecase.NewExecuteReadOnlySQLUseCase(persistence.NewSQLConsoleRepository(deps.db)),
+	)
+	g.POST("/admin/sql", sqlHandler.Run)
+
 	// AdminInvitation — SES マジックリンク方式（UUID token 発行 + SES でメール送信）。
 	adminInvRepo := persistence.NewAdminInvitationRepository(deps.db)
 

--- a/backend/internal/usecase/execute_readonly_sql_usecase.go
+++ b/backend/internal/usecase/execute_readonly_sql_usecase.go
@@ -1,0 +1,61 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// SQLConsoleMaxRows は read-only SQL コンソールが 1 回に返す行数の上限。
+const SQLConsoleMaxRows = 1000
+
+var (
+	// ErrEmptyQuery はクエリが空のとき。
+	ErrEmptyQuery = errors.New("クエリが空です")
+	// ErrNotReadOnlyQuery は SELECT / WITH 以外（書き込み等）のとき。
+	ErrNotReadOnlyQuery = errors.New("読み取り専用の単一 SELECT / WITH クエリのみ実行できます")
+)
+
+// ExecuteReadOnlySQLInput は read-only SQL コンソールの入力。
+type ExecuteReadOnlySQLInput struct {
+	Query string
+}
+
+// ExecuteReadOnlySQLUseCase は super_admin が入力した SQL を、読み取り専用の前提で実行する。
+// バリデーション（SELECT / WITH のみ）は防御の一段目で、最終保証は repository の
+// read-only トランザクション。
+type ExecuteReadOnlySQLUseCase struct {
+	repo repository.SQLConsoleRepository
+}
+
+// NewExecuteReadOnlySQLUseCase は ExecuteReadOnlySQLUseCase を生成する。
+func NewExecuteReadOnlySQLUseCase(r repository.SQLConsoleRepository) *ExecuteReadOnlySQLUseCase {
+	return &ExecuteReadOnlySQLUseCase{repo: r}
+}
+
+// Execute はクエリを検証し、読み取り専用で実行して結果を返す。
+func (u *ExecuteReadOnlySQLUseCase) Execute(ctx context.Context, in ExecuteReadOnlySQLInput) (*repository.SQLQueryResult, error) {
+	q := strings.TrimSpace(in.Query)
+	if q == "" {
+		return nil, ErrEmptyQuery
+	}
+	if !isReadOnlyQuery(q) {
+		return nil, ErrNotReadOnlyQuery
+	}
+	return u.repo.RunReadOnly(ctx, q, SQLConsoleMaxRows)
+}
+
+// isReadOnlyQuery は単一の SELECT / WITH クエリのみを許可する。
+// 末尾の単一セミコロンは許容するが、文中のセミコロン（複文）は拒否する。
+// 最終的な書き込み拒否は repository の read-only トランザクションが担保する。
+func isReadOnlyQuery(q string) bool {
+	s := strings.TrimSpace(q)
+	s = strings.TrimRight(s, ";")
+	if strings.Contains(s, ";") {
+		return false
+	}
+	lower := strings.ToLower(s)
+	return strings.HasPrefix(lower, "select") || strings.HasPrefix(lower, "with")
+}

--- a/backend/internal/usecase/execute_readonly_sql_usecase_test.go
+++ b/backend/internal/usecase/execute_readonly_sql_usecase_test.go
@@ -1,0 +1,83 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSQLConsoleRepo は呼び出されたクエリ / 上限を記録するだけの fake。
+type fakeSQLConsoleRepo struct {
+	gotQuery   string
+	gotMaxRows int
+	called     bool
+	result     *repository.SQLQueryResult
+}
+
+func (f *fakeSQLConsoleRepo) RunReadOnly(_ context.Context, query string, maxRows int) (*repository.SQLQueryResult, error) {
+	f.called = true
+	f.gotQuery = query
+	f.gotMaxRows = maxRows
+	if f.result != nil {
+		return f.result, nil
+	}
+	return &repository.SQLQueryResult{Columns: []string{}, Rows: [][]any{}}, nil
+}
+
+func TestExecuteReadOnlySQL_RejectsEmpty(t *testing.T) {
+	repo := &fakeSQLConsoleRepo{}
+	uc := usecase.NewExecuteReadOnlySQLUseCase(repo)
+
+	_, err := uc.Execute(context.Background(), usecase.ExecuteReadOnlySQLInput{Query: "   "})
+
+	require.ErrorIs(t, err, usecase.ErrEmptyQuery)
+	assert.False(t, repo.called, "空クエリで repository を呼んではならない")
+}
+
+func TestExecuteReadOnlySQL_RejectsNonSelect(t *testing.T) {
+	cases := []string{
+		"DELETE FROM users",
+		"UPDATE users SET role = 'super_admin'",
+		"INSERT INTO users (id) VALUES (1)",
+		"DROP TABLE users",
+		"TRUNCATE users",
+		"SELECT 1; DELETE FROM users", // 複文（文中セミコロン）は拒否
+		"  alter table users add column x int",
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			repo := &fakeSQLConsoleRepo{}
+			uc := usecase.NewExecuteReadOnlySQLUseCase(repo)
+
+			_, err := uc.Execute(context.Background(), usecase.ExecuteReadOnlySQLInput{Query: q})
+
+			require.ErrorIs(t, err, usecase.ErrNotReadOnlyQuery)
+			assert.False(t, repo.called, "非 SELECT で repository を呼んではならない: %q", q)
+		})
+	}
+}
+
+func TestExecuteReadOnlySQL_AllowsSelectAndWith(t *testing.T) {
+	cases := []string{
+		"SELECT 1",
+		"select id, email from users limit 10",
+		"WITH t AS (SELECT 1 AS n) SELECT n FROM t",
+		"SELECT count(*) FROM master_exercises;", // 末尾セミコロンは許容
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			repo := &fakeSQLConsoleRepo{}
+			uc := usecase.NewExecuteReadOnlySQLUseCase(repo)
+
+			_, err := uc.Execute(context.Background(), usecase.ExecuteReadOnlySQLInput{Query: q})
+
+			require.NoError(t, err)
+			require.True(t, repo.called, "SELECT/WITH は repository を呼ぶ: %q", q)
+			assert.Equal(t, usecase.SQLConsoleMaxRows, repo.gotMaxRows)
+		})
+	}
+}

--- a/backend/internal/usecase/repository/sql_console.go
+++ b/backend/internal/usecase/repository/sql_console.go
@@ -1,0 +1,18 @@
+package repository
+
+import "context"
+
+// SQLQueryResult は read-only SQL コンソールの実行結果。列名と行（各セルは任意の型）を持つ。
+// MaxRows を超えた場合は Truncated=true で打ち切る。
+type SQLQueryResult struct {
+	Columns   []string `json:"columns"`
+	Rows      [][]any  `json:"rows"`
+	Truncated bool     `json:"truncated"`
+}
+
+// SQLConsoleRepository は super_admin 向け read-only SQL コンソールの実行ポート。
+// 実装は read-only トランザクション内で 1 クエリのみ実行し、行数上限とタイムアウトを課す
+// （万一バリデーションをすり抜けた write も Postgres の read-only トランザクションが拒否する）。
+type SQLConsoleRepository interface {
+	RunReadOnly(ctx context.Context, query string, maxRows int) (*SQLQueryResult, error)
+}

--- a/docs/admin-sql-console.md
+++ b/docs/admin-sql-console.md
@@ -1,0 +1,54 @@
+# 運営 SQL コンソール（super_admin 専用・読み取り専用）
+
+super_admin（運営管理者）が、アプリ画面から本番 DB に対して **read-only の SQL** を直接実行できる管理ツール。外部 BI を導入せず、調査・確認用のアドホッククエリをその場で叩くための最小機能。
+
+- 画面: `/admin/sql`（サイドバー「管理 → SQL コンソール」。super_admin にのみ表示）
+- API: `POST /api/v2/admin/sql` body `{ "query": "SELECT ..." }`
+
+## セキュリティ（多層防御）
+
+任意 SQL を本番 DB に投げる高リスク機能のため、以下を**多層**で担保する。
+
+1. **認可**: handler で `super_admin` のみ許可（`isSuperAdmin`）。company_admin / trainee / 未認証は `403`。フロントも `role !== 'super_admin'` を `/` にリダイレクト（UI 二重化）。
+2. **DB レベルの読み取り専用トランザクション（最終防壁）**: repository は `BEGIN; SET TRANSACTION READ ONLY; ...` 内でクエリを実行する。万一バリデーションをすり抜けた書き込み（INSERT/UPDATE/DELETE/DDL や、関数経由の副作用）も **Postgres が "cannot execute ... in a read-only transaction" で拒否**する。
+3. **クエリ検証（前段）**: usecase が「単一の `SELECT` / `WITH` で始まる」クエリのみ許可。文中セミコロン（複文）は拒否。末尾の単一セミコロンのみ許容。
+4. **DoS / OOM 抑止**: `SET LOCAL statement_timeout = 5000`（5 秒）+ 行数上限 **1000 行**（超過は `truncated=true` で打ち切り）。
+5. **監査ログ**: 実行のたびに `AUDIT sql-console: super_admin(id, email) query=...` を出力（誰がいつ何を実行したか追跡可能）。
+
+> 補足: super_admin は最も信頼されたロールのため、DB エラー（構文エラー / relation does not exist 等）は調査の利便性を優先してそのまま画面に返す。文中セミコロンを含む文字列リテラル（例 `LIKE '%;%'`）は複文判定で弾かれる既知の制限がある。
+
+## レイヤー構成（クリーンアーキテクチャ）
+
+```
+AdminSqlPage / useAdminSql / AdminSqlRepository (frontend)
+        │  POST /api/v2/admin/sql
+        ▼
+AdminSQLHandler (super_admin チェック + 監査ログ)
+        ▼
+ExecuteReadOnlySQLUseCase (SELECT/WITH 検証)
+        ▼
+SQLConsoleRepository(port) ← persistence.sqlConsoleRepository(impl)
+        ▼
+read-only トランザクション + statement_timeout + 行数上限
+```
+
+| 層 | ファイル |
+|---|---|
+| handler | `backend/internal/handler/admin_sql_handler.go` |
+| usecase | `backend/internal/usecase/execute_readonly_sql_usecase.go` |
+| repository(port) | `backend/internal/usecase/repository/sql_console.go` |
+| repository(impl) | `backend/internal/adapter/persistence/sql_console_repository.go` |
+| frontend | `frontend/src/pages/AdminSqlPage.tsx` / `hooks/useAdminSql.ts` / `repositories/AdminSqlRepository.ts` |
+
+## 使い方
+
+1. super_admin でログイン → サイドバー「管理 → SQL コンソール」
+2. テキストエリアに `SELECT` / `WITH` クエリを入力（`⌘ / Ctrl + Enter` でも実行）
+3. 結果はテーブル表示。`NULL` は `NULL`、boolean は `true/false` を明示。1000 行超は打ち切り表示。
+
+## テスト
+
+- usecase: 空 / 非 SELECT（DELETE・UPDATE・複文等）の拒否、SELECT/WITH の許可（`execute_readonly_sql_usecase_test.go`）
+- handler: super_admin のみ 200・他ロール/未認証は 403・query 欠落 400・write は 400（`admin_sql_handler_test.go`）
+- repository(integration): 実 Postgres で SELECT 取得・`maxRows` 打ち切り・**write が read-only tx で拒否される**ことを検証（`sql_console_repository_integration_test.go`）
+- frontend: `AdminSqlRepository.test.ts`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ const HelpPage = lazyWithReload(() => import('./pages/HelpPage'), 'HelpPage');
 const AdminInvitationsPage = lazyWithReload(() => import('./pages/AdminInvitationsPage'), 'AdminInvitationsPage');
 const AdminCompaniesPage = lazyWithReload(() => import('./pages/AdminCompaniesPage'), 'AdminCompaniesPage');
 const AdminMembersPage = lazyWithReload(() => import('./pages/AdminMembersPage'), 'AdminMembersPage');
+const AdminSqlPage = lazyWithReload(() => import('./pages/AdminSqlPage'), 'AdminSqlPage');
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
 const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
@@ -116,6 +117,7 @@ export default function App() {
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
         <Route path="/admin/members" element={<AdminMembersPage />} />
+        <Route path="/admin/sql" element={<AdminSqlPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />
       </Route>
     </Routes>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -72,6 +72,13 @@ const adminNavItem: NavItem = {
     { label: '従業員一覧', to: '/admin/members', matchPrefix: '/admin/members' },
     // 招待管理は自社内で trainee を招待する操作のため company_admin / super_admin 双方が利用する。
     { label: '招待管理', to: '/admin/invitations', matchPrefix: '/admin/invitations' },
+    // SQL コンソールは本番 DB への read-only クエリ。運営 (super_admin) 専用。
+    {
+      label: 'SQL コンソール',
+      to: '/admin/sql',
+      matchPrefix: '/admin/sql',
+      allowedRoles: ['super_admin'],
+    },
   ],
 };
 

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -140,6 +140,8 @@ export const ADMIN = {
   companies: `${API_V2}/admin/companies`,
   members: `${API_V2}/admin/members`,
   memberAiAccess: (userId: number | string) => `${API_V2}/admin/members/${userId}/ai-access`,
+  /** POST /api/v2/admin/sql — super_admin 専用 read-only SQL コンソール */
+  sql: `${API_V2}/admin/sql`,
   invitations: `${API_V2}/admin/invitations`,
   invitationById: (id: number | string) => `${API_V2}/admin/invitations/${id}`,
   scenarios: `${API_V2}/admin/scenarios`,

--- a/frontend/src/hooks/useAdminSql.ts
+++ b/frontend/src/hooks/useAdminSql.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import axios from 'axios';
+import AdminSqlRepository, { SqlResult } from '../repositories/AdminSqlRepository';
+
+/**
+ * useAdminSql — super_admin 向け read-only SQL コンソールの状態管理フック。
+ * クエリ実行と、結果 / 実行中 / エラー（SQL エラーや読み取り専用違反は backend のメッセージをそのまま表示）を扱う。
+ */
+export function useAdminSql() {
+  const [result, setResult] = useState<SqlResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = useCallback(async (query: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      setResult(await AdminSqlRepository.run(query));
+    } catch (e) {
+      setResult(null);
+      const msg = axios.isAxiosError(e)
+        ? (e.response?.data as { error?: string } | undefined)?.error
+        : undefined;
+      setError(msg || 'クエリの実行に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { result, loading, error, run };
+}

--- a/frontend/src/pages/AdminSqlPage.tsx
+++ b/frontend/src/pages/AdminSqlPage.tsx
@@ -1,0 +1,126 @@
+import { useState, useCallback, KeyboardEvent } from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+import { useAdminSql } from '../hooks/useAdminSql';
+
+// セルの表示。null は NULL、boolean は true/false を明示する。
+function renderCell(v: string | number | boolean | null): string {
+  if (v === null) return 'NULL';
+  if (typeof v === 'boolean') return v ? 'true' : 'false';
+  return String(v);
+}
+
+/**
+ * AdminSqlPage — `/admin/sql`。super_admin（運営管理者）専用の read-only SQL コンソール。
+ * 本番 DB に対して SELECT / WITH クエリのみを実行できる（書き込みは backend / DB 側で拒否）。
+ */
+export default function AdminSqlPage() {
+  const role = useSelector((s: RootState) => s.auth.role);
+  const authLoading = useSelector((s: RootState) => s.auth.loading);
+  const { result, loading, error, run } = useAdminSql();
+  const [query, setQuery] = useState('SELECT id, email, role FROM users ORDER BY id LIMIT 20;');
+
+  const onRun = useCallback(() => {
+    const q = query.trim();
+    if (q && !loading) run(q);
+  }, [query, loading, run]);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        onRun();
+      }
+    },
+    [onRun],
+  );
+
+  if (authLoading) return <Loading message="読み込み中..." className="min-h-[50vh]" />;
+  // 運営管理者(super_admin)専用。company_admin / trainee は弾く。
+  if (role !== 'super_admin') return <Navigate to="/" replace />;
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-6xl mx-auto">
+      <PageIntro
+        title="運営: SQL コンソール（読み取り専用）"
+        description="本番 DB に対して SELECT / WITH クエリだけを実行できます。書き込み（INSERT/UPDATE/DELETE 等）は実行できません。結果は最大 1000 行で打ち切られます。"
+      />
+
+      <div className="mt-4 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+        ⚠️ 運営管理者専用の読み取り専用ツールです。実行内容（誰がどのクエリを実行したか）は監査ログに記録されます。
+      </div>
+
+      <textarea
+        aria-label="SQL クエリ"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={onKeyDown}
+        spellCheck={false}
+        rows={6}
+        placeholder="SELECT ..."
+        className="mt-4 w-full font-mono text-sm rounded-lg bg-surface-2 border border-surface-3 px-3 py-2 text-[var(--color-text-primary)] focus:outline-none focus:border-brand-500"
+      />
+
+      <div className="mt-2 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onRun}
+          disabled={loading || query.trim() === ''}
+          className="px-5 py-2 rounded-lg bg-brand-500 text-white text-sm font-medium hover:bg-brand-600 active:bg-brand-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? '実行中...' : '実行'}
+        </button>
+        <span className="text-xs text-[var(--color-text-muted)]">⌘ / Ctrl + Enter で実行</span>
+      </div>
+
+      {error && (
+        <pre className="mt-4 overflow-x-auto whitespace-pre-wrap rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {error}
+        </pre>
+      )}
+
+      {result && !error && (
+        <div className="mt-6">
+          <div className="mb-2 text-sm text-[var(--color-text-muted)]">
+            {result.rowCount} 行
+            {result.truncated && '（上限の 1000 行で打ち切られました）'}
+          </div>
+          {result.columns.length === 0 ? (
+            <p className="text-[var(--color-text-muted)]">結果なし（0 列）</p>
+          ) : (
+            <div className="overflow-x-auto rounded-lg border border-surface-3">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-surface-2 text-left text-[var(--color-text-muted)]">
+                    {result.columns.map((col) => (
+                      <th key={col} className="px-3 py-2 font-medium whitespace-nowrap">
+                        {col}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {result.rows.map((row, ri) => (
+                    <tr key={ri} className="border-t border-surface-3 align-top">
+                      {row.map((cell, ci) => (
+                        <td
+                          key={ci}
+                          className="px-3 py-2 font-mono text-xs text-[var(--color-text-primary)] whitespace-pre-wrap break-all"
+                        >
+                          {renderCell(cell)}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/repositories/AdminSqlRepository.ts
+++ b/frontend/src/repositories/AdminSqlRepository.ts
@@ -1,0 +1,25 @@
+import api from '../lib/axios';
+import { ADMIN } from '../constants/apiRoutes';
+
+/** read-only SQL の実行結果（backend handler.runSQLResponse と 1:1）。 */
+export interface SqlResult {
+  columns: string[];
+  /** 各行は列順のセル配列。セルは string | number | boolean | null。 */
+  rows: Array<Array<string | number | boolean | null>>;
+  rowCount: number;
+  /** 行数上限で打ち切られたら true。 */
+  truncated: boolean;
+}
+
+/**
+ * super_admin 向け read-only SQL コンソールの API ラッパー。
+ * 単一の SELECT / WITH クエリを実行し、列・行を取得する。
+ */
+const AdminSqlRepository = {
+  async run(query: string): Promise<SqlResult> {
+    const res = await api.post<SqlResult>(ADMIN.sql, { query });
+    return res.data;
+  },
+};
+
+export default AdminSqlRepository;

--- a/frontend/src/repositories/__tests__/AdminSqlRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AdminSqlRepository.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+import AdminSqlRepository from '../AdminSqlRepository';
+
+const mockedPost = vi.mocked(apiClient.post);
+
+describe('AdminSqlRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('run: /api/v2/admin/sql に query を POST し結果を返す', async () => {
+    mockedPost.mockResolvedValue({
+      data: {
+        columns: ['id', 'email'],
+        rows: [[1, 'a@e.com']],
+        rowCount: 1,
+        truncated: false,
+      },
+    });
+
+    const res = await AdminSqlRepository.run('SELECT id, email FROM users LIMIT 1');
+
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/admin/sql', {
+      query: 'SELECT id, email FROM users LIMIT 1',
+    });
+    expect(res.columns).toEqual(['id', 'email']);
+    expect(res.rows[0][1]).toBe('a@e.com');
+    expect(res.truncated).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

外部 BI を導入せず、**アプリ画面から本番 DB に read-only SQL を直接実行**できる運営（super_admin）向け管理ツールを追加する。調査・確認用のアドホッククエリをその場で叩くための最小機能。

- 画面: `/admin/sql`（サイドバー「管理 → SQL コンソール」。super_admin にのみ表示）
- API: `POST /api/v2/admin/sql` body `{ "query": "SELECT ..." }`

## セキュリティ（多層防御）

任意 SQL を本番に投げる高リスク機能のため、多層で担保:

1. **認可**: handler で `super_admin` のみ（他ロール / 未認証は `403`）。フロントも `role !== 'super_admin'` を `/` にリダイレクト
2. **DB レベルの read-only トランザクション（最終防壁）**: `SET TRANSACTION READ ONLY` 内で実行。万一バリデーションをすり抜けた write も Postgres が `cannot execute ... in a read-only transaction` で拒否
3. **クエリ検証（前段）**: 単一の `SELECT` / `WITH` のみ許可。複文（文中セミコロン）は拒否
4. **DoS/OOM 抑止**: `statement_timeout = 5s` + 行数上限 **1000**（超過は `truncated`）
5. **監査ログ**: `AUDIT sql-console: super_admin(id, email) query=...`

## レイヤー構成（クリーンアーキテクチャ）

| 層 | ファイル |
|---|---|
| handler | `admin_sql_handler.go`（super_admin チェック + 監査） |
| usecase | `execute_readonly_sql_usecase.go`（SELECT/WITH 検証） |
| repository(port/impl) | `usecase/repository/sql_console.go` / `adapter/persistence/sql_console_repository.go` |
| frontend | `pages/AdminSqlPage.tsx` / `hooks/useAdminSql.ts` / `repositories/AdminSqlRepository.ts` / Sidebar |

## テスト

- usecase: 空 / 非 SELECT（DELETE・UPDATE・複文等）拒否、SELECT/WITH 許可
- handler: super_admin のみ 200・他ロール/未認証 403・query 欠落 400・write 400
- repository(integration): 実 Postgres で SELECT 取得・`maxRows` 打ち切り・**write が read-only tx で拒否**
- frontend: `AdminSqlRepository.test.ts`
- `go build` / `vet` / 全ユニット green、`tsc` / `eslint --max-warnings 0` / `vitest` / `npm run build` green、`make openapi` 再生成済

## ドキュメント

- `docs/admin-sql-console.md`（セキュリティモデル・レイヤー・使い方・テスト）