### PR TITLE
feat(admin): 会社アカウントの有効/無効（停止）を追加 — super_admin

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -53,6 +53,70 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/companies/{id}/active": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "会社を無効化すると、その会社の全ユーザーがログイン/利用不可になる（middleware で弾く）。super_admin のみ。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社アカウントの有効/無効を切り替え（super_admin 専用）",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "会社 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "active=false で無効化",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.setCompanyActiveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.messageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "不正な ID / body",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "更新失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/company-applications": {
             "get": {
                 "security": [
@@ -3359,6 +3423,10 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "isActive": {
+                    "description": "IsActive は会社アカウントの有効/無効。false（無効）にすると、その会社の全ユーザーが\nログイン/利用不可になる（middleware で弾く）。super_admin が会社一覧から切り替える。",
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4303,6 +4371,17 @@ const docTemplate = `{
             "properties": {
                 "content": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.setCompanyActiveRequest": {
+            "type": "object",
+            "required": [
+                "active"
+            ],
+            "properties": {
+                "active": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -102,8 +102,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "403": {
                         "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "会社が存在しない",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -46,6 +46,70 @@
                 }
             }
         },
+        "/admin/companies/{id}/active": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "会社を無効化すると、その会社の全ユーザーがログイン/利用不可になる（middleware で弾く）。super_admin のみ。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社アカウントの有効/無効を切り替え（super_admin 専用）",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "会社 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "active=false で無効化",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.setCompanyActiveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.messageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "不正な ID / body",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "更新失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/company-applications": {
             "get": {
                 "security": [
@@ -3352,6 +3416,10 @@
                 "id": {
                     "type": "integer"
                 },
+                "isActive": {
+                    "description": "IsActive は会社アカウントの有効/無効。false（無効）にすると、その会社の全ユーザーが\nログイン/利用不可になる（middleware で弾く）。super_admin が会社一覧から切り替える。",
+                    "type": "boolean"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -4296,6 +4364,17 @@
             "properties": {
                 "content": {
                     "type": "string"
+                }
+            }
+        },
+        "internal_handler.setCompanyActiveRequest": {
+            "type": "object",
+            "required": [
+                "active"
+            ],
+            "properties": {
+                "active": {
+                    "type": "boolean"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -95,8 +95,20 @@
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
                     "403": {
                         "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "会社が存在しない",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -88,6 +88,11 @@ definitions:
         type: string
       id:
         type: integer
+      isActive:
+        description: |-
+          IsActive は会社アカウントの有効/無効。false（無効）にすると、その会社の全ユーザーが
+          ログイン/利用不可になる（middleware で弾く）。super_admin が会社一覧から切り替える。
+        type: boolean
       name:
         type: string
       updatedAt:
@@ -720,6 +725,13 @@ definitions:
       content:
         type: string
     type: object
+  internal_handler.setCompanyActiveRequest:
+    properties:
+      active:
+        type: boolean
+    required:
+    - active
+    type: object
   internal_handler.sseAttachmentRequest:
     properties:
       contentType:
@@ -856,6 +868,47 @@ paths:
       security:
       - CookieAuth: []
       summary: 会社 一覧 (SuperAdmin)
+      tags:
+      - admin
+  /admin/companies/{id}/active:
+    patch:
+      consumes:
+      - application/json
+      description: 会社を無効化すると、その会社の全ユーザーがログイン/利用不可になる（middleware で弾く）。super_admin のみ。
+      parameters:
+      - description: 会社 ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      - description: active=false で無効化
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.setCompanyActiveRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/internal_handler.messageResponse'
+        "400":
+          description: 不正な ID / body
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 更新失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 会社アカウントの有効/無効を切り替え（super_admin 専用）
       tags:
       - admin
   /admin/company-applications:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -898,8 +898,16 @@ paths:
           description: 不正な ID / body
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
         "403":
           description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 会社が存在しない
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "500":

--- a/backend/internal/adapter/persistence/company_repository.go
+++ b/backend/internal/adapter/persistence/company_repository.go
@@ -24,6 +24,7 @@ func toDomainCompany(row sqlcgen.Company) domain.Company {
 		ID:                       uint64(row.ID),
 		Name:                     row.Name,
 		AiChatEnabledForTrainees: row.AiChatEnabledForTrainees,
+		IsActive:                 row.IsActive,
 		CreatedAt:                row.CreatedAt,
 		UpdatedAt:                row.UpdatedAt,
 	}
@@ -70,4 +71,10 @@ func (r *companyRepository) FindByID(ctx context.Context, id uint64) (*domain.Co
 func (r *companyRepository) UpdateAiChatEnabled(ctx context.Context, companyID uint64, enabled bool) error {
 	const q = `UPDATE companies SET ai_chat_enabled_for_trainees = ?, updated_at = NOW() WHERE id = ?`
 	return r.db.WithContext(ctx).Exec(q, enabled, companyID).Error
+}
+
+// UpdateActive は会社アカウントの有効/無効を更新する。false で無効化（その会社の全ユーザーが利用不可）。
+func (r *companyRepository) UpdateActive(ctx context.Context, companyID uint64, active bool) error {
+	const q = `UPDATE companies SET is_active = ?, updated_at = NOW() WHERE id = ?`
+	return r.db.WithContext(ctx).Exec(q, active, companyID).Error
 }

--- a/backend/internal/adapter/persistence/company_repository.go
+++ b/backend/internal/adapter/persistence/company_repository.go
@@ -74,7 +74,15 @@ func (r *companyRepository) UpdateAiChatEnabled(ctx context.Context, companyID u
 }
 
 // UpdateActive は会社アカウントの有効/無効を更新する。false で無効化（その会社の全ユーザーが利用不可）。
+// 対象会社が存在せず 0 件更新だった場合は gorm.ErrRecordNotFound を返す（handler が 404 にマップ）。
 func (r *companyRepository) UpdateActive(ctx context.Context, companyID uint64, active bool) error {
 	const q = `UPDATE companies SET is_active = ?, updated_at = NOW() WHERE id = ?`
-	return r.db.WithContext(ctx).Exec(q, active, companyID).Error
+	res := r.db.WithContext(ctx).Exec(q, active, companyID)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }

--- a/backend/internal/adapter/persistence/queries/schema.sql
+++ b/backend/internal/adapter/persistence/queries/schema.sql
@@ -79,6 +79,7 @@ CREATE TABLE companies (
     id                           bigint PRIMARY KEY,
     name                         text NOT NULL,
     ai_chat_enabled_for_trainees boolean NOT NULL DEFAULT true,
+    is_active                    boolean NOT NULL DEFAULT true,
     created_at                   timestamptz NOT NULL,
     updated_at                   timestamptz NOT NULL
 );

--- a/backend/internal/adapter/persistence/sqlcgen/company.sql.go
+++ b/backend/internal/adapter/persistence/sqlcgen/company.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getCompanyByID = `-- name: GetCompanyByID :one
-SELECT id, name, ai_chat_enabled_for_trainees, created_at, updated_at FROM companies
+SELECT id, name, ai_chat_enabled_for_trainees, is_active, created_at, updated_at FROM companies
 WHERE id = $1
 `
 
@@ -22,6 +22,7 @@ func (q *Queries) GetCompanyByID(ctx context.Context, id int64) (Company, error)
 		&i.ID,
 		&i.Name,
 		&i.AiChatEnabledForTrainees,
+		&i.IsActive,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -29,7 +30,7 @@ func (q *Queries) GetCompanyByID(ctx context.Context, id int64) (Company, error)
 }
 
 const listCompanies = `-- name: ListCompanies :many
-SELECT id, name, ai_chat_enabled_for_trainees, created_at, updated_at FROM companies
+SELECT id, name, ai_chat_enabled_for_trainees, is_active, created_at, updated_at FROM companies
 ORDER BY name ASC
 `
 
@@ -47,6 +48,7 @@ func (q *Queries) ListCompanies(ctx context.Context) ([]Company, error) {
 			&i.ID,
 			&i.Name,
 			&i.AiChatEnabledForTrainees,
+			&i.IsActive,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/backend/internal/adapter/persistence/sqlcgen/models.go
+++ b/backend/internal/adapter/persistence/sqlcgen/models.go
@@ -13,6 +13,7 @@ type Company struct {
 	ID                       int64
 	Name                     string
 	AiChatEnabledForTrainees bool
+	IsActive                 bool
 	CreatedAt                time.Time
 	UpdatedAt                time.Time
 }

--- a/backend/internal/domain/company.go
+++ b/backend/internal/domain/company.go
@@ -7,9 +7,12 @@ type Company struct {
 	Name string `gorm:"column:name;not null" json:"name"`
 	// AiChatEnabledForTrainees は自社 trainee に AI チャットを許可するか（既定 true）。
 	// company_admin / super_admin が /company/settings で切り替える。AutoMigrate が列を追加する。
-	AiChatEnabledForTrainees bool      `gorm:"column:ai_chat_enabled_for_trainees;not null;default:true" json:"aiChatEnabledForTrainees"`
-	CreatedAt                time.Time `gorm:"column:created_at" json:"createdAt"`
-	UpdatedAt                time.Time `gorm:"column:updated_at" json:"updatedAt"`
+	AiChatEnabledForTrainees bool `gorm:"column:ai_chat_enabled_for_trainees;not null;default:true" json:"aiChatEnabledForTrainees"`
+	// IsActive は会社アカウントの有効/無効。false（無効）にすると、その会社の全ユーザーが
+	// ログイン/利用不可になる（middleware で弾く）。super_admin が会社一覧から切り替える。
+	IsActive  bool      `gorm:"column:is_active;not null;default:true" json:"isActive"`
+	CreatedAt time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
 func (Company) TableName() string { return "companies" }

--- a/backend/internal/handler/admin_company_handler.go
+++ b/backend/internal/handler/admin_company_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -8,6 +9,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
 )
 
 // isSuperAdmin は actor が super_admin（運営管理者）かを判定する。
@@ -58,7 +60,9 @@ type setCompanyActiveRequest struct {
 //	@Param        body  body      setCompanyActiveRequest  true  "active=false で無効化"
 //	@Success      200   {object}  messageResponse
 //	@Failure      400   {object}  errorResponse  "不正な ID / body"
+//	@Failure      401   {object}  errorResponse  "未認証"
 //	@Failure      403   {object}  errorResponse  "super_admin 以外"
+//	@Failure      404   {object}  errorResponse  "会社が存在しない"
 //	@Failure      500   {object}  errorResponse  "更新失敗"
 //	@Router       /admin/companies/{id}/active [patch]
 //	@Security     CookieAuth
@@ -81,10 +85,15 @@ func (h *AdminCompanyHandler) SetActive(c *gin.Context) {
 		return
 	}
 
-	if err := h.setActive.Execute(c.Request.Context(), usecase.SetCompanyActiveInput{
+	err = h.setActive.Execute(c.Request.Context(), usecase.SetCompanyActiveInput{
 		CompanyID: id,
 		Active:    *body.Active,
-	}); err != nil {
+	})
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		c.JSON(http.StatusNotFound, errorResponse{Error: "company_not_found"})
+		return
+	case err != nil:
 		c.JSON(http.StatusInternalServerError, errorResponse{Error: "update_failed"})
 		return
 	}

--- a/backend/internal/handler/admin_company_handler.go
+++ b/backend/internal/handler/admin_company_handler.go
@@ -2,17 +2,27 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-type AdminCompanyHandler struct {
-	list *usecase.ListCompaniesUseCase
+// isSuperAdmin は actor が super_admin（運営管理者）かを判定する。
+func isSuperAdmin(actor *domain.User) bool {
+	return actor != nil && actor.Role == domain.RoleSuperAdmin
 }
 
-func NewAdminCompanyHandler(l *usecase.ListCompaniesUseCase) *AdminCompanyHandler {
-	return &AdminCompanyHandler{list: l}
+// AdminCompanyHandler は super_admin 向けの会社一覧と、会社アカウントの有効/無効を扱う。
+type AdminCompanyHandler struct {
+	list      *usecase.ListCompaniesUseCase
+	setActive *usecase.SetCompanyActiveUseCase
+}
+
+func NewAdminCompanyHandler(l *usecase.ListCompaniesUseCase, s *usecase.SetCompanyActiveUseCase) *AdminCompanyHandler {
+	return &AdminCompanyHandler{list: l, setActive: s}
 }
 
 // @Summary      会社 一覧 (SuperAdmin)
@@ -30,4 +40,54 @@ func (h *AdminCompanyHandler) List(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, companies)
+}
+
+// setCompanyActiveRequest は会社アカウントの有効/無効更新の入力。
+type setCompanyActiveRequest struct {
+	Active *bool `json:"active" binding:"required"`
+}
+
+// SetActive は会社アカウントの有効/無効を切り替えるハンドラ（super_admin 専用）。
+//
+//	@Summary      会社アカウントの有効/無効を切り替え（super_admin 専用）
+//	@Description  会社を無効化すると、その会社の全ユーザーがログイン/利用不可になる（middleware で弾く）。super_admin のみ。
+//	@Tags         admin
+//	@Accept       json
+//	@Produce      json
+//	@Param        id    path      int                      true  "会社 ID"
+//	@Param        body  body      setCompanyActiveRequest  true  "active=false で無効化"
+//	@Success      200   {object}  messageResponse
+//	@Failure      400   {object}  errorResponse  "不正な ID / body"
+//	@Failure      403   {object}  errorResponse  "super_admin 以外"
+//	@Failure      500   {object}  errorResponse  "更新失敗"
+//	@Router       /admin/companies/{id}/active [patch]
+//	@Security     CookieAuth
+func (h *AdminCompanyHandler) SetActive(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	if !isSuperAdmin(actor) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
+
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_id"})
+		return
+	}
+
+	var body setCompanyActiveRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_request"})
+		return
+	}
+
+	if err := h.setActive.Execute(c.Request.Context(), usecase.SetCompanyActiveInput{
+		CompanyID: id,
+		Active:    *body.Active,
+	}); err != nil {
+		c.JSON(http.StatusInternalServerError, errorResponse{Error: "update_failed"})
+		return
+	}
+
+	c.JSON(http.StatusOK, messageResponse{Message: "会社の状態を更新しました"})
 }

--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
 )
 
 // fakeCompanyRepo は repository.CompanyRepository の最小 fake。
@@ -112,5 +113,15 @@ func TestAdminCompanyHandler_SetActive_InvalidBody_BadRequest(t *testing.T) {
 	w := patchCompanyActive(t, actor, "5", `{}`, repo)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestAdminCompanyHandler_SetActive_NotFound(t *testing.T) {
+	// 存在しない会社 ID（0 件更新）は repository が ErrRecordNotFound を返し、handler が 404 にマップ。
+	repo := &fakeCompanyRepo{err: gorm.ErrRecordNotFound}
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+	w := patchCompanyActive(t, actor, "999", `{"active":false}`, repo)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
 	}
 }

--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -4,17 +4,22 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // fakeCompanyRepo は repository.CompanyRepository の最小 fake。
 type fakeCompanyRepo struct {
-	rows []domain.Company
-	err  error
+	rows         []domain.Company
+	err          error
+	activeCalled bool
+	gotActiveID  uint64
+	gotActive    bool
 }
 
 func (f *fakeCompanyRepo) ListAll(context.Context) ([]domain.Company, error) { return f.rows, f.err }
@@ -24,9 +29,18 @@ func (f *fakeCompanyRepo) FindByID(context.Context, uint64) (*domain.Company, er
 }
 
 func (f *fakeCompanyRepo) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
+func (f *fakeCompanyRepo) UpdateActive(_ context.Context, id uint64, active bool) error {
+	f.activeCalled = true
+	f.gotActiveID = id
+	f.gotActive = active
+	return f.err
+}
 
 func newAdminCompanyHandler(repo *fakeCompanyRepo) *AdminCompanyHandler {
-	return NewAdminCompanyHandler(usecase.NewListCompaniesUseCase(repo))
+	return NewAdminCompanyHandler(
+		usecase.NewListCompaniesUseCase(repo),
+		usecase.NewSetCompanyActiveUseCase(repo),
+	)
 }
 
 func TestAdminCompanyHandler_List_OK(t *testing.T) {
@@ -46,5 +60,57 @@ func TestAdminCompanyHandler_List_Error(t *testing.T) {
 	newAdminCompanyHandler(&fakeCompanyRepo{err: context.DeadlineExceeded}).List(c)
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", w.Code)
+	}
+}
+
+func patchCompanyActive(t *testing.T, actor *domain.User, id, body string, repo *fakeCompanyRepo) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/admin/companies/"+id+"/active", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: id}}
+	if actor != nil {
+		c.Set(middleware.ContextKeyCurrentUser, actor)
+	}
+	newAdminCompanyHandler(repo).SetActive(c)
+	return w
+}
+
+func TestAdminCompanyHandler_SetActive_SuperAdmin_OK(t *testing.T) {
+	repo := &fakeCompanyRepo{}
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+
+	w := patchCompanyActive(t, actor, "5", `{"active":false}`, repo)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", w.Code, w.Body.String())
+	}
+	if !repo.activeCalled || repo.gotActiveID != 5 || repo.gotActive != false {
+		t.Fatalf("repo not called correctly: %+v", repo)
+	}
+}
+
+func TestAdminCompanyHandler_SetActive_NonSuperAdmin_Forbidden(t *testing.T) {
+	for _, role := range []string{domain.RoleCompanyAdmin, domain.RoleTrainee} {
+		t.Run(role, func(t *testing.T) {
+			repo := &fakeCompanyRepo{}
+			w := patchCompanyActive(t, &domain.User{ID: 2, Role: role}, "5", `{"active":false}`, repo)
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("want 403, got %d", w.Code)
+			}
+			if repo.activeCalled {
+				t.Fatal("非 super_admin で UpdateActive を呼んではならない")
+			}
+		})
+	}
+}
+
+func TestAdminCompanyHandler_SetActive_InvalidBody_BadRequest(t *testing.T) {
+	repo := &fakeCompanyRepo{}
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+	w := patchCompanyActive(t, actor, "5", `{}`, repo)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
 	}
 }

--- a/backend/internal/handler/company_settings_handler_test.go
+++ b/backend/internal/handler/company_settings_handler_test.go
@@ -27,6 +27,8 @@ func (s *settingsCompanyRepo) FindByID(_ context.Context, _ uint64) (*domain.Com
 	return s.company, nil
 }
 
+func (s *settingsCompanyRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
+
 func (s *settingsCompanyRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, enabled bool) error {
 	s.updated = &enabled
 	return nil

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
 )
 
 const (
@@ -15,7 +17,8 @@ const (
 )
 
 // CurrentUser は cognito sub から users 行を引いて currentUserID / currentUser を context にセットする。
-func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
+// 併せて、所属会社が無効化されている場合はその会社の全ユーザーを弾く（即時にログイン/利用不可）。
+func CurrentUser(users repository.UserRepository, companies repository.CompanyRepository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		raw, ok := c.Get(ContextKeyCognitoSub)
 		if !ok {
@@ -37,6 +40,23 @@ func CurrentUser(users repository.UserRepository) gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "user_not_found"})
 			return
 		}
+
+		// 会社アカウントが無効化されていれば、その会社のユーザーは利用不可。
+		// 会社行が無い（データ不整合）場合は素通り、DB エラーは 500。
+		if user.CompanyID != nil {
+			company, err := companies.FindByID(c.Request.Context(), *user.CompanyID)
+			switch {
+			case errors.Is(err, gorm.ErrRecordNotFound):
+				// 会社行なし: 何もしない（弾かない）。
+			case err != nil:
+				c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "company_lookup_failed"})
+				return
+			case company != nil && !company.IsActive:
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "company_disabled"})
+				return
+			}
+		}
+
 		c.Set(ContextKeyCurrentUserID, user.ID)
 		c.Set(ContextKeyCurrentUser, user)
 		c.Next()

--- a/backend/internal/handler/middleware/current_user_test.go
+++ b/backend/internal/handler/middleware/current_user_test.go
@@ -17,8 +17,11 @@ type stubUsers struct{ user *domain.User }
 func (s *stubUsers) FindByCognitoSub(context.Context, string) (*domain.User, error) {
 	return s.user, nil
 }
-func (s *stubUsers) FindByID(context.Context, uint64) (*domain.User, error)         { return s.user, nil }
-func (s *stubUsers) ListByRole(context.Context, string) ([]domain.User, error)      { return nil, nil }
+
+func (s *stubUsers) FindByID(context.Context, uint64) (*domain.User, error) { return s.user, nil }
+
+func (s *stubUsers) ListByRole(context.Context, string) ([]domain.User, error) { return nil, nil }
+
 func (s *stubUsers) ListByCompanyID(context.Context, uint64) ([]domain.User, error) { return nil, nil }
 func (s *stubUsers) Create(context.Context, *domain.User) error                     { return nil }
 func (s *stubUsers) UpdateAiChatEnabled(context.Context, uint64, *bool) error       { return nil }

--- a/backend/internal/handler/middleware/current_user_test.go
+++ b/backend/internal/handler/middleware/current_user_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"gorm.io/gorm"
+)
+
+// stubUsers は UserRepository の最小 stub。FindByCognitoSub だけ返す。
+type stubUsers struct{ user *domain.User }
+
+func (s *stubUsers) FindByCognitoSub(context.Context, string) (*domain.User, error) {
+	return s.user, nil
+}
+func (s *stubUsers) FindByID(context.Context, uint64) (*domain.User, error)         { return s.user, nil }
+func (s *stubUsers) ListByRole(context.Context, string) ([]domain.User, error)      { return nil, nil }
+func (s *stubUsers) ListByCompanyID(context.Context, uint64) ([]domain.User, error) { return nil, nil }
+func (s *stubUsers) Create(context.Context, *domain.User) error                     { return nil }
+func (s *stubUsers) UpdateAiChatEnabled(context.Context, uint64, *bool) error       { return nil }
+func (s *stubUsers) UpdateDisplayName(context.Context, uint64, string) error        { return nil }
+func (s *stubUsers) UpdateRole(context.Context, uint64, string) error               { return nil }
+func (s *stubUsers) UpdateCompanyID(context.Context, uint64, uint64) error          { return nil }
+func (s *stubUsers) MarkOnboarded(context.Context, uint64) error                    { return nil }
+
+// stubCompanies は CompanyRepository の最小 stub。FindByID で company / err を返す。
+type stubCompanies struct {
+	company *domain.Company
+	err     error
+}
+
+func (s *stubCompanies) ListAll(context.Context) ([]domain.Company, error) { return nil, nil }
+func (s *stubCompanies) FindByID(context.Context, uint64) (*domain.Company, error) {
+	return s.company, s.err
+}
+func (s *stubCompanies) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
+func (s *stubCompanies) UpdateActive(context.Context, uint64, bool) error        { return nil }
+
+func runCurrentUser(t *testing.T, users *stubUsers, companies *stubCompanies) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Set(ContextKeyCognitoSub, "sub-123")
+	CurrentUser(users, companies)(c)
+	return w, c
+}
+
+func uintPtr(v uint64) *uint64 { return &v }
+
+func TestCurrentUser_BlocksDisabledCompany(t *testing.T) {
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, CompanyID: uintPtr(7)}}
+	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: false}}
+
+	w, c := runCurrentUser(t, users, companies)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+	if !c.IsAborted() {
+		t.Fatal("無効会社のユーザーは abort されるべき")
+	}
+}
+
+func TestCurrentUser_AllowsActiveCompany(t *testing.T) {
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, CompanyID: uintPtr(7)}}
+	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: true}}
+
+	_, c := runCurrentUser(t, users, companies)
+
+	if c.IsAborted() {
+		t.Fatal("有効会社のユーザーは通すべき")
+	}
+	if CurrentUserFromContext(c) == nil {
+		t.Fatal("currentUser が context にセットされるべき")
+	}
+}
+
+func TestCurrentUser_SuperAdminNoCompany_Allowed(t *testing.T) {
+	// super_admin は company_id なし → 会社チェックをスキップして通す。
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
+	companies := &stubCompanies{err: gorm.ErrRecordNotFound}
+
+	_, c := runCurrentUser(t, users, companies)
+
+	if c.IsAborted() {
+		t.Fatal("company なしの super_admin は通すべき")
+	}
+}
+
+func TestCurrentUser_CompanyNotFound_Allowed(t *testing.T) {
+	// company_id はあるが会社行が無い（データ不整合）→ 弾かない。
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, CompanyID: uintPtr(99)}}
+	companies := &stubCompanies{err: gorm.ErrRecordNotFound}
+
+	_, c := runCurrentUser(t, users, companies)
+
+	if c.IsAborted() {
+		t.Fatal("会社行なしは弾かない")
+	}
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -74,7 +74,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 
 	authed := v2.Group("")
 	authed.Use(middleware.JWTAuth(buildJWTVerify(cfg)))
-	authed.Use(middleware.CurrentUser(deps.userRepo))
+	authed.Use(middleware.CurrentUser(deps.userRepo, persistence.NewCompanyRepository(deps.db)))
 
 	registerAuthAuthedRoutes(authed, authHandler)
 	registerChatRoutes(authed, deps)

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -13,10 +13,14 @@ import (
 // registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
 // 認可（super_admin / company_admin のみ）は handler 層で実施する。
 func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	companyRepo := persistence.NewCompanyRepository(deps.db)
 	companyHandler := NewAdminCompanyHandler(
-		usecase.NewListCompaniesUseCase(persistence.NewCompanyRepository(deps.db)),
+		usecase.NewListCompaniesUseCase(companyRepo),
+		usecase.NewSetCompanyActiveUseCase(companyRepo),
 	)
 	g.GET("/admin/companies", companyHandler.List)
+	// 会社アカウントの有効/無効（super_admin 専用。無効化でその会社の全ユーザーを利用不可に）。
+	g.PATCH("/admin/companies/:id/active", companyHandler.SetActive)
 
 	// 従業員管理（自社の従業員一覧 + 各従業員の AI 利用可否を個別上書き）。
 	memberRepo := persistence.NewUserRepository(deps.db)

--- a/backend/internal/usecase/company_settings_usecase_test.go
+++ b/backend/internal/usecase/company_settings_usecase_test.go
@@ -24,6 +24,8 @@ func (s *settingsCompanyRepo) FindByID(context.Context, uint64) (*domain.Company
 	return s.company, s.findErr
 }
 
+func (s *settingsCompanyRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
+
 func (s *settingsCompanyRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, enabled bool) error {
 	s.lastEnable = &enabled
 	return nil

--- a/backend/internal/usecase/repository/company.go
+++ b/backend/internal/usecase/repository/company.go
@@ -12,4 +12,6 @@ type CompanyRepository interface {
 	FindByID(ctx context.Context, id uint64) (*domain.Company, error)
 	// UpdateAiChatEnabled は trainee への AI チャット許可フラグを更新する。
 	UpdateAiChatEnabled(ctx context.Context, companyID uint64, enabled bool) error
+	// UpdateActive は会社アカウントの有効/無効を更新する（false で無効化）。
+	UpdateActive(ctx context.Context, companyID uint64, active bool) error
 }

--- a/backend/internal/usecase/set_company_active_usecase.go
+++ b/backend/internal/usecase/set_company_active_usecase.go
@@ -1,0 +1,29 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// SetCompanyActiveInput は会社アカウントの有効/無効更新の入力。
+type SetCompanyActiveInput struct {
+	CompanyID uint64
+	Active    bool
+}
+
+// SetCompanyActiveUseCase は会社アカウントの有効/無効を切り替える（super_admin 用）。
+// 無効化すると、その会社の全ユーザーが middleware でログイン/利用を弾かれる。
+type SetCompanyActiveUseCase struct {
+	companies repository.CompanyRepository
+}
+
+// NewSetCompanyActiveUseCase は SetCompanyActiveUseCase を生成する。
+func NewSetCompanyActiveUseCase(c repository.CompanyRepository) *SetCompanyActiveUseCase {
+	return &SetCompanyActiveUseCase{companies: c}
+}
+
+// Execute は会社の有効/無効を更新する。
+func (u *SetCompanyActiveUseCase) Execute(ctx context.Context, in SetCompanyActiveInput) error {
+	return u.companies.UpdateActive(ctx, in.CompanyID, in.Active)
+}

--- a/backend/internal/usecase/validate_invitation_token_usecase_test.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase_test.go
@@ -15,6 +15,7 @@ type stubCompanies struct {
 
 func (s *stubCompanies) ListAll(_ context.Context) ([]domain.Company, error)     { return nil, s.err }
 func (s *stubCompanies) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
+func (s *stubCompanies) UpdateActive(context.Context, uint64, bool) error        { return nil }
 func (s *stubCompanies) FindByID(_ context.Context, id uint64) (*domain.Company, error) {
 	if s.err != nil {
 		return nil, s.err

--- a/docs/admin-account-suspension.md
+++ b/docs/admin-account-suspension.md
@@ -23,7 +23,7 @@
 
 ## 2. レイヤー構成（クリーンアーキテクチャ）
 
-```
+```text
 AdminCompaniesPage / CompanyRepository.updateActive (frontend)
         │  PATCH /api/v2/admin/companies/:id/active
         ▼

--- a/docs/admin-account-suspension.md
+++ b/docs/admin-account-suspension.md
@@ -1,0 +1,59 @@
+# 会社 / ユーザーのアカウント停止・削除（管理操作）
+
+運営（super_admin）・会社管理者（company_admin）が、会社やユーザーのアカウントを**停止（無効化）**したり削除したりするための管理操作。停止は削除と違い**可逆**で、停止中はログイン/利用を**即時に**不可にする。
+
+> 本ドキュメントは段階的に拡張する。**PR1: 会社アカウントの有効/無効（実装済）** / PR2: ユーザーの有効/無効 + ソフト削除（予定）。
+
+## 1. 会社アカウントの有効/無効（super_admin）
+
+- 画面: `/admin/companies`（管理 → 会社一覧）。各会社に「無効化 / 有効化」ボタン（super_admin にのみ表示）と「無効」バッジ。
+- API: `PATCH /api/v2/admin/companies/:id/active` body `{ "active": false }`（super_admin 専用）
+
+### 振る舞い
+
+- `companies.is_active = false` にすると、**その会社に属する全ユーザー**が次のリクエストから利用不可になる。
+- 有効化（`active=true`）で即座に復帰する（可逆）。
+
+### 認可 / enforcement（多層）
+
+1. **更新権限**: `AdminCompanyHandler.SetActive` が `super_admin` のみ許可（他ロールは `403`）。フロントもボタンを super_admin にのみ表示。
+2. **利用ブロック（即時）**: `CurrentUser` middleware が全認証リクエストで、ユーザーの所属会社をひき、`is_active=false` なら `403 company_disabled` を返す。これにより、無効化された会社のユーザーは**有効な JWT を持っていても**その時点でアクセス不可になる。
+   - 会社行が無い（データ不整合）場合は弾かない。会社ひきの DB エラーは `500`。
+   - super_admin は `company_id` を持たないため、この会社チェックの対象外（自分が締め出されることはない）。
+
+## 2. レイヤー構成（クリーンアーキテクチャ）
+
+```
+AdminCompaniesPage / CompanyRepository.updateActive (frontend)
+        │  PATCH /api/v2/admin/companies/:id/active
+        ▼
+AdminCompanyHandler.SetActive (super_admin チェック)
+        ▼
+SetCompanyActiveUseCase
+        ▼
+CompanyRepository.UpdateActive(impl: 生 SQL の UPDATE companies SET is_active=...)
+
+CurrentUser middleware ── 会社が無効なら 403 で全リクエストを弾く（enforcement）
+```
+
+| 層 | ファイル |
+|---|---|
+| handler | `backend/internal/handler/admin_company_handler.go`（`SetActive`） |
+| middleware | `backend/internal/handler/middleware/current_user.go`（会社無効チェック） |
+| usecase | `backend/internal/usecase/set_company_active_usecase.go` |
+| repository | `usecase/repository/company.go`（`UpdateActive`）/ `adapter/persistence/company_repository.go` |
+| domain | `backend/internal/domain/company.go`（`IsActive`） |
+| frontend | `frontend/src/pages/AdminCompaniesPage.tsx` / `repositories/CompanyRepository.ts` |
+
+> `companies.is_active boolean NOT NULL DEFAULT true` を追加（AutoMigrate が本番に列を追加）。sqlc は `SELECT *` のため `make sqlc` 再生成で `IsActive` を取り込む。
+
+## 3. テスト
+
+- handler: `SetActive` は super_admin のみ 200・他ロール 403・body 不正 400（`admin_company_handler_test.go`）
+- middleware: 無効会社のユーザーを 403 で弾く / 有効会社は通す / 会社なし super_admin は通す / 会社行なしは通す（`current_user_test.go`）
+- frontend: `CompanyRepository.test.ts`（`updateActive` の PATCH）
+
+## 4. 安全策
+
+- **自己締め出し防止**: 会社無効化は super_admin のみが行い、super_admin 自身は会社に属さないため締め出されない。
+- 停止は**可逆**（有効化で即復帰）。破壊的なデータ削除は伴わない。

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -138,6 +138,8 @@ export const WEEKLY_CHALLENGE = {
 /** 管理者ダッシュボード（会社 / 招待 / シナリオ） */
 export const ADMIN = {
   companies: `${API_V2}/admin/companies`,
+  /** PATCH /api/v2/admin/companies/:id/active — 会社アカウントの有効/無効（super_admin） */
+  companyActive: (id: number | string) => `${API_V2}/admin/companies/${id}/active`,
   members: `${API_V2}/admin/members`,
   memberAiAccess: (userId: number | string) => `${API_V2}/admin/members/${userId}/ai-access`,
   invitations: `${API_V2}/admin/invitations`,

--- a/frontend/src/pages/AdminCompaniesPage.tsx
+++ b/frontend/src/pages/AdminCompaniesPage.tsx
@@ -11,10 +11,13 @@ import { BuildingOffice2Icon, UserPlusIcon, Cog6ToothIcon } from '@heroicons/rea
 export default function AdminCompaniesPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
+  const role = useSelector((state: RootState) => state.auth.role);
+  const isSuperAdmin = role === 'super_admin';
 
   const [companies, setCompanies] = useState<Company[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!isAdmin) return;
@@ -26,6 +29,22 @@ export default function AdminCompaniesPage() {
       })
       .finally(() => setLoading(false));
   }, [isAdmin]);
+
+  // 会社アカウントの有効/無効を切り替える（super_admin 専用）。楽観的更新 + 失敗時ロールバック。
+  const setActive = async (id: number, active: boolean) => {
+    setUpdatingId(id);
+    setError(null);
+    setCompanies((prev) => prev.map((c) => (c.id === id ? { ...c, isActive: active } : c)));
+    try {
+      await CompanyRepository.updateActive(id, active);
+    } catch (e) {
+      logger.error(e);
+      setCompanies((prev) => prev.map((c) => (c.id === id ? { ...c, isActive: !active } : c)));
+      setError('会社状態の更新に失敗しました');
+    } finally {
+      setUpdatingId(null);
+    }
+  };
 
   if (authLoading) return <Loading message="認証情報を確認中..." />;
   if (!isAdmin) return <Navigate to="/" replace />;
@@ -57,14 +76,35 @@ export default function AdminCompaniesPage() {
               <div className="flex items-center gap-3 flex-1">
                 <BuildingOffice2Icon className="w-8 h-8 text-[var(--color-text-muted)] flex-shrink-0" />
                 <div>
-                  <p className="font-semibold text-sm">{company.name}</p>
+                  <p className="font-semibold text-sm flex items-center gap-2">
+                    {company.name}
+                    {!company.isActive && (
+                      <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-rose-100 text-rose-700">
+                        無効
+                      </span>
+                    )}
+                  </p>
                   <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
                     登録日: {new Date(company.createdAt).toLocaleDateString('ja-JP')}
                   </p>
                 </div>
               </div>
 
-              <div className="flex gap-2 flex-shrink-0">
+              <div className="flex gap-2 flex-shrink-0 items-center">
+                {isSuperAdmin && (
+                  <button
+                    type="button"
+                    onClick={() => setActive(company.id, !company.isActive)}
+                    disabled={updatingId === company.id}
+                    className={`text-xs px-3 py-1.5 rounded border transition-colors disabled:opacity-50 ${
+                      company.isActive
+                        ? 'border-rose-300 text-rose-700 hover:bg-rose-50'
+                        : 'border-emerald-300 text-emerald-700 hover:bg-emerald-50'
+                    }`}
+                  >
+                    {company.isActive ? '無効化' : '有効化'}
+                  </button>
+                )}
                 <Link
                   to={`/admin/scenarios?companyId=${company.id}`}
                   className="flex items-center gap-1 text-xs px-3 py-1.5 border rounded text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors"

--- a/frontend/src/repositories/CompanyRepository.ts
+++ b/frontend/src/repositories/CompanyRepository.ts
@@ -4,6 +4,8 @@ import { ADMIN } from '../constants/apiRoutes';
 export interface Company {
   id: number;
   name: string;
+  /** 会社アカウントの有効/無効。false = 無効（その会社の全ユーザーが利用不可）。 */
+  isActive: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -12,6 +14,11 @@ class CompanyRepository {
   async list(): Promise<Company[]> {
     const res = await apiClient.get<Company[]>(ADMIN.companies);
     return res.data;
+  }
+
+  /** 会社アカウントの有効/無効を切り替える（super_admin 専用）。 */
+  async updateActive(id: number, active: boolean): Promise<void> {
+    await apiClient.patch(ADMIN.companyActive(id), { active });
   }
 }
 

--- a/frontend/src/repositories/__tests__/CompanyRepository.test.ts
+++ b/frontend/src/repositories/__tests__/CompanyRepository.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: {
+    get: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+import apiClient from '../../lib/axios';
+import CompanyRepository from '../CompanyRepository';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPatch = vi.mocked(apiClient.patch);
+
+describe('CompanyRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('list: 会社一覧を取得する', async () => {
+    mockedGet.mockResolvedValue({
+      data: [{ id: 1, name: 'A社', isActive: true, createdAt: '', updatedAt: '' }],
+    });
+    const companies = await CompanyRepository.list();
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/admin/companies');
+    expect(companies[0].isActive).toBe(true);
+  });
+
+  it('updateActive: 会社を無効化する PATCH を送る', async () => {
+    mockedPatch.mockResolvedValue({ status: 200 });
+    await CompanyRepository.updateActive(5, false);
+    expect(mockedPatch).toHaveBeenCalledWith('/api/v2/admin/companies/5/active', { active: false });
+  });
+});


### PR DESCRIPTION
## 概要

SQL コンソール（任意 SQL）の代わりに、より安全な**構造化された管理操作**として「会社アカウントの停止（無効化）」を追加する。会社を無効化すると、その会社の全ユーザーが**即時に**ログイン/利用不可になる。停止は**可逆**（有効化で即復帰）で、破壊的なデータ削除は伴わない。

（会社/ユーザー停止・削除シリーズの **PR1**。PR2 でユーザーの有効/無効 + ソフト削除を追加予定。）

## 変更内容

- **API**: `PATCH /api/v2/admin/companies/:id/active` `{ active }`（super_admin 専用）
- **UI**: `/admin/companies` に「無効化 / 有効化」ボタン（super_admin にのみ表示）と「無効」バッジ
- **enforcement**: `CurrentUser` middleware が全認証リクエストで所属会社の `is_active` を確認し、無効なら `403 company_disabled`
- **domain/schema**: `Company.IsActive` + `companies.is_active boolean NOT NULL DEFAULT true`（AutoMigrate が本番に列追加 / `make sqlc` 再生成）
- usecase `SetCompanyActiveUseCase` / repository `UpdateActive`

## 認可（多層）

1. 更新権限: handler で `super_admin` のみ（他ロール 403）。フロントもボタンを super_admin 限定表示
2. 利用ブロック（即時）: middleware が無効会社のユーザーを 403。**有効な JWT でもその時点で締め出す**
3. 自己締め出し防止: super_admin は `company_id` を持たないため対象外

## テスト

- handler: super_admin のみ 200 / 他ロール 403 / body 不正 400
- middleware: 無効会社のユーザーを 403 / 有効会社は通す / 会社なし super_admin は通す / 会社行なしは通す
- frontend: `CompanyRepository.test.ts`
- `go build`/`vet`/全ユニット green、`tsc`/`eslint`/`vitest`(187 files)/`build` green、`make openapi` 再生成済

## ドキュメント

`docs/admin-account-suspension.md`（振る舞い・enforcement・レイヤー・テスト・安全策）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 会社アカウントの有効/無効切り替え機能を追加しました。管理者は管理画面から対象会社のアカウント状態を管理できるようになります。会社を無効にすると、当該会社に属するすべてのユーザーは次のリクエスト以降ログイン・利用ができなくなります。機能の復旧は即座に反映されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->