### PR TITLE
feat(admin): 従業員アカウントの有効/無効（停止）と論理削除を追加

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -440,6 +440,140 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/members/{userId}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "従業員を一覧から退会させる（論理削除）。以後ログイン/利用不可。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員を論理削除",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "不正な ID / 自分自身",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "従業員が存在しない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}/active": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "無効化すると、その従業員はログイン/利用不可になる（middleware で弾く）。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員アカウントの有効/無効を切り替え",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "active=false で無効化",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.setMemberActiveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "不正な ID / body / 自分自身",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "従業員が存在しない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/members/{userId}/ai-access": {
             "patch": {
                 "security": [
@@ -4289,6 +4423,10 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "isActive": {
+                    "description": "IsActive はアカウントの有効/無効。false = 無効（ログイン/利用不可）。",
+                    "type": "boolean"
+                },
                 "role": {
                     "type": "string"
                 }
@@ -4387,6 +4525,17 @@ const docTemplate = `{
             }
         },
         "internal_handler.setCompanyActiveRequest": {
+            "type": "object",
+            "required": [
+                "active"
+            ],
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_handler.setMemberActiveRequest": {
             "type": "object",
             "required": [
                 "active"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -433,6 +433,140 @@
                 }
             }
         },
+        "/admin/members/{userId}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "従業員を一覧から退会させる（論理削除）。以後ログイン/利用不可。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員を論理削除",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "不正な ID / 自分自身",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "従業員が存在しない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}/active": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "無効化すると、その従業員はログイン/利用不可になる（middleware で弾く）。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員アカウントの有効/無効を切り替え",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "active=false で無効化",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.setMemberActiveRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "不正な ID / body / 自分自身",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "従業員が存在しない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/members/{userId}/ai-access": {
             "patch": {
                 "security": [
@@ -4282,6 +4416,10 @@
                 "id": {
                     "type": "integer"
                 },
+                "isActive": {
+                    "description": "IsActive はアカウントの有効/無効。false = 無効（ログイン/利用不可）。",
+                    "type": "boolean"
+                },
                 "role": {
                     "type": "string"
                 }
@@ -4380,6 +4518,17 @@
             }
         },
         "internal_handler.setCompanyActiveRequest": {
+            "type": "object",
+            "required": [
+                "active"
+            ],
+            "properties": {
+                "active": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_handler.setMemberActiveRequest": {
             "type": "object",
             "required": [
                 "active"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -660,6 +660,9 @@ definitions:
         type: string
       id:
         type: integer
+      isActive:
+        description: IsActive はアカウントの有効/無効。false = 無効（ログイン/利用不可）。
+        type: boolean
       role:
         type: string
     type: object
@@ -726,6 +729,13 @@ definitions:
         type: string
     type: object
   internal_handler.setCompanyActiveRequest:
+    properties:
+      active:
+        type: boolean
+    required:
+    - active
+    type: object
+  internal_handler.setMemberActiveRequest:
     properties:
       active:
         type: boolean
@@ -1116,6 +1126,93 @@ paths:
       security:
       - CookieAuth: []
       summary: 従業員一覧
+      tags:
+      - admin
+  /admin/members/{userId}:
+    delete:
+      description: 従業員を一覧から退会させる（論理削除）。以後ログイン/利用不可。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。
+      parameters:
+      - description: 従業員の数値 ID
+        in: path
+        name: userId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: 不正な ID / 自分自身
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者以外 / 別会社の従業員
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 従業員が存在しない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 内部エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 従業員を論理削除
+      tags:
+      - admin
+  /admin/members/{userId}/active:
+    patch:
+      consumes:
+      - application/json
+      description: 無効化すると、その従業員はログイン/利用不可になる（middleware で弾く）。super_admin は全社、company_admin
+        は自社の従業員のみ。自分自身は不可。
+      parameters:
+      - description: 従業員の数値 ID
+        in: path
+        name: userId
+        required: true
+        type: string
+      - description: active=false で無効化
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/internal_handler.setMemberActiveRequest'
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: 不正な ID / body / 自分自身
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者以外 / 別会社の従業員
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 従業員が存在しない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 内部エラー
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 従業員アカウントの有効/無効を切り替え
       tags:
       - admin
   /admin/members/{userId}/ai-access:

--- a/backend/internal/adapter/persistence/queries/schema.sql
+++ b/backend/internal/adapter/persistence/queries/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE users (
     company_id   bigint,
     role         text NOT NULL,
     ai_chat_enabled boolean,
+    is_active    boolean NOT NULL DEFAULT true,
     onboarded_at timestamptz,
     created_at   timestamptz NOT NULL,
     updated_at   timestamptz NOT NULL,

--- a/backend/internal/adapter/persistence/sqlcgen/models.go
+++ b/backend/internal/adapter/persistence/sqlcgen/models.go
@@ -85,6 +85,7 @@ type User struct {
 	CompanyID     sql.NullInt64
 	Role          string
 	AiChatEnabled sql.NullBool
+	IsActive      bool
 	OnboardedAt   sql.NullTime
 	CreatedAt     time.Time
 	UpdatedAt     time.Time

--- a/backend/internal/adapter/persistence/sqlcgen/user.sql.go
+++ b/backend/internal/adapter/persistence/sqlcgen/user.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const getUserByCognitoSub = `-- name: GetUserByCognitoSub :one
-SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, is_active, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE cognito_sub = $1 AND deleted_at IS NULL
 `
 
@@ -27,6 +27,7 @@ func (q *Queries) GetUserByCognitoSub(ctx context.Context, cognitoSub string) (U
 		&i.CompanyID,
 		&i.Role,
 		&i.AiChatEnabled,
+		&i.IsActive,
 		&i.OnboardedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -36,7 +37,7 @@ func (q *Queries) GetUserByCognitoSub(ctx context.Context, cognitoSub string) (U
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, is_active, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE id = $1 AND deleted_at IS NULL
 `
 
@@ -52,6 +53,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
 		&i.CompanyID,
 		&i.Role,
 		&i.AiChatEnabled,
+		&i.IsActive,
 		&i.OnboardedAt,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -61,7 +63,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (User, error) {
 }
 
 const listUsersByCompanyID = `-- name: ListUsersByCompanyID :many
-SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, is_active, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE company_id = $1 AND deleted_at IS NULL
 ORDER BY id ASC
 `
@@ -84,6 +86,7 @@ func (q *Queries) ListUsersByCompanyID(ctx context.Context, companyID sql.NullIn
 			&i.CompanyID,
 			&i.Role,
 			&i.AiChatEnabled,
+			&i.IsActive,
 			&i.OnboardedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,
@@ -103,7 +106,7 @@ func (q *Queries) ListUsersByCompanyID(ctx context.Context, companyID sql.NullIn
 }
 
 const listUsersByRole = `-- name: ListUsersByRole :many
-SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, onboarded_at, created_at, updated_at, deleted_at FROM users
+SELECT id, cognito_sub, email, display_name, company_id, role, ai_chat_enabled, is_active, onboarded_at, created_at, updated_at, deleted_at FROM users
 WHERE role = $1 AND deleted_at IS NULL
 ORDER BY id ASC
 `
@@ -126,6 +129,7 @@ func (q *Queries) ListUsersByRole(ctx context.Context, role string) ([]User, err
 			&i.CompanyID,
 			&i.Role,
 			&i.AiChatEnabled,
+			&i.IsActive,
 			&i.OnboardedAt,
 			&i.CreatedAt,
 			&i.UpdatedAt,

--- a/backend/internal/adapter/persistence/user_repository.go
+++ b/backend/internal/adapter/persistence/user_repository.go
@@ -35,6 +35,7 @@ func toDomainUser(row sqlcgen.User) *domain.User {
 		Email:       row.Email,
 		DisplayName: row.DisplayName,
 		Role:        row.Role,
+		IsActive:    row.IsActive,
 		CreatedAt:   row.CreatedAt,
 		UpdatedAt:   row.UpdatedAt,
 	}
@@ -141,6 +142,38 @@ func (r *userRepository) UpdateAiChatEnabled(ctx context.Context, userID uint64,
 		Model(&domain.User{}).
 		Where("id = ?", userID).
 		Update("ai_chat_enabled", value).Error
+}
+
+// UpdateActive はユーザーアカウントの有効/無効を更新する（false で無効化 → ログイン/利用不可）。
+// 対象が存在しなければ gorm.ErrRecordNotFound を返す（handler が 404 にマップ）。
+func (r *userRepository) UpdateActive(ctx context.Context, userID uint64, active bool) error {
+	res := r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ?", userID).
+		Update("is_active", active)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// SoftDelete はユーザーを論理削除する（deleted_at = NOW()）。以後 FindByCognitoSub 等で除外され、
+// 認証時にも弾かれる。既に削除済み / 存在しない場合は gorm.ErrRecordNotFound を返す。
+func (r *userRepository) SoftDelete(ctx context.Context, userID uint64) error {
+	res := r.db.WithContext(ctx).
+		Model(&domain.User{}).
+		Where("id = ? AND deleted_at IS NULL", userID).
+		Update("deleted_at", gorm.Expr("NOW()"))
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
 }
 
 func (r *userRepository) UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error {

--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -13,6 +13,9 @@ type User struct {
 	// AiChatEnabled は AI チャット利用可否の個別上書き。nil = 会社設定に従う、
 	// true/false = この user 個別に強制 ON/OFF（company_admin が従業員ごとに設定）。
 	AiChatEnabled *bool `gorm:"column:ai_chat_enabled" json:"aiChatEnabled,omitempty"`
+	// IsActive はユーザーアカウントの有効/無効。false（無効）にすると、このユーザーは
+	// ログイン/利用不可になる（middleware で弾く）。super_admin / company_admin が個別に停止できる。
+	IsActive bool `gorm:"column:is_active;not null;default:true" json:"isActive"`
 	// OnboardedAt は Welcome 完了日時。NULL なら Welcome を表示する。一度入ったら変えない。
 	OnboardedAt *time.Time `gorm:"column:onboarded_at" json:"onboardedAt,omitempty"`
 	CreatedAt   time.Time  `gorm:"column:created_at" json:"createdAt"`

--- a/backend/internal/handler/admin_member_handler.go
+++ b/backend/internal/handler/admin_member_handler.go
@@ -12,15 +12,23 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// AdminMemberHandler は company_admin が自社の従業員一覧と、各従業員の AI 利用可否を管理する。
+// AdminMemberHandler は company_admin / super_admin が従業員一覧と、各従業員の AI 利用可否・
+// アカウントの有効/無効・論理削除を管理する。
 type AdminMemberHandler struct {
-	list   *usecase.ListCompanyMembersUseCase
-	update *usecase.UpdateMemberAiAccessUseCase
+	list       *usecase.ListCompanyMembersUseCase
+	update     *usecase.UpdateMemberAiAccessUseCase
+	setActive  *usecase.SetMemberActiveUseCase
+	softDelete *usecase.SoftDeleteMemberUseCase
 }
 
-// NewAdminMemberHandler は一覧 / AI 更新 usecase を注入して handler を返す。
-func NewAdminMemberHandler(list *usecase.ListCompanyMembersUseCase, update *usecase.UpdateMemberAiAccessUseCase) *AdminMemberHandler {
-	return &AdminMemberHandler{list: list, update: update}
+// NewAdminMemberHandler は一覧 / AI 更新 / 有効無効 / 論理削除 usecase を注入して handler を返す。
+func NewAdminMemberHandler(
+	list *usecase.ListCompanyMembersUseCase,
+	update *usecase.UpdateMemberAiAccessUseCase,
+	setActive *usecase.SetMemberActiveUseCase,
+	softDelete *usecase.SoftDeleteMemberUseCase,
+) *AdminMemberHandler {
+	return &AdminMemberHandler{list: list, update: update, setActive: setActive, softDelete: softDelete}
 }
 
 // memberResponse は従業員一覧の 1 行（cognito_sub 等の機密は出さない）。
@@ -31,6 +39,8 @@ type memberResponse struct {
 	Role        string `json:"role"`
 	// AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。
 	AiChatEnabled *bool `json:"aiChatEnabled"`
+	// IsActive はアカウントの有効/無効。false = 無効（ログイン/利用不可）。
+	IsActive bool `json:"isActive"`
 }
 
 func toMemberResponse(u domain.User) memberResponse {
@@ -40,6 +50,7 @@ func toMemberResponse(u domain.User) memberResponse {
 		DisplayName:   u.DisplayName,
 		Role:          u.Role,
 		AiChatEnabled: u.AiChatEnabled,
+		IsActive:      u.IsActive,
 	}
 }
 
@@ -120,6 +131,100 @@ func (h *AdminMemberHandler) UpdateAiAccess(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// memberOpErrorStatus は従業員の停止/削除 usecase のエラーを HTTP ステータスにマップする。
+func memberOpErrorStatus(err error) (int, string) {
+	switch {
+	case errors.Is(err, usecase.ErrMemberNotFound):
+		return http.StatusNotFound, "member_not_found"
+	case errors.Is(err, usecase.ErrCannotManageSelf):
+		return http.StatusBadRequest, "cannot_manage_self"
+	case errors.Is(err, usecase.ErrMemberNotInActorCompany):
+		return http.StatusForbidden, "forbidden"
+	default:
+		return http.StatusInternalServerError, "internal_error"
+	}
+}
+
+// setMemberActiveRequest は従業員アカウントの有効/無効更新の入力。
+type setMemberActiveRequest struct {
+	Active *bool `json:"active" binding:"required"`
+}
+
+// SetActive は従業員アカウントの有効/無効を切り替える（停止/再開）。
+//
+//	@Summary      従業員アカウントの有効/無効を切り替え
+//	@Description  無効化すると、その従業員はログイン/利用不可になる（middleware で弾く）。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。
+//	@Tags         admin
+//	@Accept       json
+//	@Produce      json
+//	@Param        userId  path  string  true  "従業員の数値 ID"
+//	@Param        body    body  setMemberActiveRequest  true  "active=false で無効化"
+//	@Success      204
+//	@Failure      400  {object}  errorResponse  "不正な ID / body / 自分自身"
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "管理者以外 / 別会社の従業員"
+//	@Failure      404  {object}  errorResponse  "従業員が存在しない"
+//	@Failure      500  {object}  errorResponse  "内部エラー"
+//	@Router       /admin/members/{userId}/active [patch]
+//	@Security     CookieAuth
+func (h *AdminMemberHandler) SetActive(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	if !isAdminActor(actor) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
+	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_user_id"})
+		return
+	}
+	var req setMemberActiveRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_request"})
+		return
+	}
+	if err := h.setActive.Execute(c.Request.Context(), actor, userID, *req.Active); err != nil {
+		code, msg := memberOpErrorStatus(err)
+		c.JSON(code, errorResponse{Error: msg})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// Delete は従業員を論理削除する（deleted_at = NOW()）。
+//
+//	@Summary      従業員を論理削除
+//	@Description  従業員を一覧から退会させる（論理削除）。以後ログイン/利用不可。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。
+//	@Tags         admin
+//	@Produce      json
+//	@Param        userId  path  string  true  "従業員の数値 ID"
+//	@Success      204
+//	@Failure      400  {object}  errorResponse  "不正な ID / 自分自身"
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "管理者以外 / 別会社の従業員"
+//	@Failure      404  {object}  errorResponse  "従業員が存在しない"
+//	@Failure      500  {object}  errorResponse  "内部エラー"
+//	@Router       /admin/members/{userId} [delete]
+//	@Security     CookieAuth
+func (h *AdminMemberHandler) Delete(c *gin.Context) {
+	actor := middleware.CurrentUserFromContext(c)
+	if !isAdminActor(actor) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
+	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_user_id"})
+		return
+	}
+	if err := h.softDelete.Execute(c.Request.Context(), actor, userID); err != nil {
+		code, msg := memberOpErrorStatus(err)
+		c.JSON(code, errorResponse{Error: msg})
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -63,6 +63,8 @@ func (r *fakeUserRepo) UpdateCompanyID(_ context.Context, id uint64, companyID u
 	return nil
 }
 
+func (r *fakeUserRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
+func (r *fakeUserRepo) SoftDelete(context.Context, uint64) error         { return nil }
 func (r *fakeUserRepo) MarkOnboarded(_ context.Context, _ uint64) error {
 	return nil
 }

--- a/backend/internal/handler/middleware/current_user.go
+++ b/backend/internal/handler/middleware/current_user.go
@@ -41,6 +41,12 @@ func CurrentUser(users repository.UserRepository, companies repository.CompanyRe
 			return
 		}
 
+		// ユーザーアカウントが無効化されていれば利用不可（有効な JWT でも即時に弾く）。
+		if !user.IsActive {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "user_disabled"})
+			return
+		}
+
 		// 会社アカウントが無効化されていれば、その会社のユーザーは利用不可。
 		// 会社行が無い（データ不整合）場合は素通り、DB エラーは 500。
 		if user.CompanyID != nil {

--- a/backend/internal/handler/middleware/current_user_test.go
+++ b/backend/internal/handler/middleware/current_user_test.go
@@ -28,6 +28,8 @@ func (s *stubUsers) UpdateAiChatEnabled(context.Context, uint64, *bool) error   
 func (s *stubUsers) UpdateDisplayName(context.Context, uint64, string) error        { return nil }
 func (s *stubUsers) UpdateRole(context.Context, uint64, string) error               { return nil }
 func (s *stubUsers) UpdateCompanyID(context.Context, uint64, uint64) error          { return nil }
+func (s *stubUsers) UpdateActive(context.Context, uint64, bool) error               { return nil }
+func (s *stubUsers) SoftDelete(context.Context, uint64) error                       { return nil }
 func (s *stubUsers) MarkOnboarded(context.Context, uint64) error                    { return nil }
 
 // stubCompanies は CompanyRepository の最小 stub。FindByID で company / err を返す。
@@ -56,7 +58,7 @@ func runCurrentUser(t *testing.T, users *stubUsers, companies *stubCompanies) (*
 func uintPtr(v uint64) *uint64 { return &v }
 
 func TestCurrentUser_BlocksDisabledCompany(t *testing.T) {
-	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, CompanyID: uintPtr(7)}}
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: true, CompanyID: uintPtr(7)}}
 	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: false}}
 
 	w, c := runCurrentUser(t, users, companies)
@@ -70,7 +72,7 @@ func TestCurrentUser_BlocksDisabledCompany(t *testing.T) {
 }
 
 func TestCurrentUser_AllowsActiveCompany(t *testing.T) {
-	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, CompanyID: uintPtr(7)}}
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: true, CompanyID: uintPtr(7)}}
 	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: true}}
 
 	_, c := runCurrentUser(t, users, companies)
@@ -85,7 +87,7 @@ func TestCurrentUser_AllowsActiveCompany(t *testing.T) {
 
 func TestCurrentUser_SuperAdminNoCompany_Allowed(t *testing.T) {
 	// super_admin は company_id なし → 会社チェックをスキップして通す。
-	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, IsActive: true, CompanyID: nil}}
 	companies := &stubCompanies{err: gorm.ErrRecordNotFound}
 
 	_, c := runCurrentUser(t, users, companies)
@@ -97,12 +99,27 @@ func TestCurrentUser_SuperAdminNoCompany_Allowed(t *testing.T) {
 
 func TestCurrentUser_CompanyNotFound_Allowed(t *testing.T) {
 	// company_id はあるが会社行が無い（データ不整合）→ 弾かない。
-	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, CompanyID: uintPtr(99)}}
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: true, CompanyID: uintPtr(99)}}
 	companies := &stubCompanies{err: gorm.ErrRecordNotFound}
 
 	_, c := runCurrentUser(t, users, companies)
 
 	if c.IsAborted() {
 		t.Fatal("会社行なしは弾かない")
+	}
+}
+
+func TestCurrentUser_BlocksDisabledUser(t *testing.T) {
+	// IsActive=false のユーザーは会社が有効でも弾く（即時に利用不可）。
+	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: false, CompanyID: uintPtr(7)}}
+	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: true}}
+
+	w, c := runCurrentUser(t, users, companies)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+	if !c.IsAborted() {
+		t.Fatal("無効ユーザーは abort されるべき")
 	}
 }

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -27,9 +27,14 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	memberHandler := NewAdminMemberHandler(
 		usecase.NewListCompanyMembersUseCase(memberRepo),
 		usecase.NewUpdateMemberAiAccessUseCase(memberRepo),
+		usecase.NewSetMemberActiveUseCase(memberRepo),
+		usecase.NewSoftDeleteMemberUseCase(memberRepo),
 	)
 	g.GET("/admin/members", memberHandler.List)
 	g.PATCH("/admin/members/:userId/ai-access", memberHandler.UpdateAiAccess)
+	// 従業員アカウントの有効/無効（停止）と論理削除（super_admin は全社 / company_admin は自社）。
+	g.PATCH("/admin/members/:userId/active", memberHandler.SetActive)
+	g.DELETE("/admin/members/:userId", memberHandler.Delete)
 
 	// AdminInvitation — SES マジックリンク方式（UUID token 発行 + SES でメール送信）。
 	adminInvRepo := persistence.NewAdminInvitationRepository(deps.db)

--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -46,6 +46,8 @@ func (f *fakeMemberUserRepo) UpdateDisplayName(context.Context, uint64, string) 
 }
 func (f *fakeMemberUserRepo) UpdateRole(context.Context, uint64, string) error      { return nil }
 func (f *fakeMemberUserRepo) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
+func (f *fakeMemberUserRepo) UpdateActive(context.Context, uint64, bool) error      { return nil }
+func (f *fakeMemberUserRepo) SoftDelete(context.Context, uint64) error              { return nil }
 func (f *fakeMemberUserRepo) MarkOnboarded(context.Context, uint64) error           { return nil }
 func (f *fakeMemberUserRepo) UpdateAiChatEnabled(_ context.Context, userID uint64, enabled *bool) error {
 	f.updated[userID] = enabled

--- a/backend/internal/usecase/complete_onboarding_usecase_test.go
+++ b/backend/internal/usecase/complete_onboarding_usecase_test.go
@@ -12,6 +12,8 @@ type stubMarkOnboardedRepo struct {
 	err      error
 }
 
+func (s *stubMarkOnboardedRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
+func (s *stubMarkOnboardedRepo) SoftDelete(context.Context, uint64) error         { return nil }
 func (s *stubMarkOnboardedRepo) MarkOnboarded(_ context.Context, userID uint64) error {
 	s.calledID = userID
 	return s.err

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -45,6 +45,8 @@ func (f *fakeUsersForApp) Create(context.Context, *domain.User) error           
 func (f *fakeUsersForApp) UpdateDisplayName(context.Context, uint64, string) error { return nil }
 func (f *fakeUsersForApp) UpdateRole(context.Context, uint64, string) error        { return nil }
 func (f *fakeUsersForApp) UpdateCompanyID(context.Context, uint64, uint64) error   { return nil }
+func (f *fakeUsersForApp) UpdateActive(context.Context, uint64, bool) error        { return nil }
+func (f *fakeUsersForApp) SoftDelete(context.Context, uint64) error                { return nil }
 func (f *fakeUsersForApp) MarkOnboarded(context.Context, uint64) error             { return nil }
 func (f *fakeUsersForApp) ListByCompanyID(context.Context, uint64) ([]domain.User, error) {
 	return nil, nil

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -45,6 +45,8 @@ func (s *stubUserRepo) UpdateCompanyID(_ context.Context, _ uint64, _ uint64) er
 	return s.err
 }
 
+func (s *stubUserRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
+func (s *stubUserRepo) SoftDelete(context.Context, uint64) error         { return nil }
 func (s *stubUserRepo) MarkOnboarded(_ context.Context, _ uint64) error {
 	return s.err
 }

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -1,0 +1,142 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeManageRepo は SetMemberActive / SoftDeleteMember の認可検証用 fake。
+type fakeManageRepo struct {
+	target          *domain.User // FindByID が返す対象
+	updateActiveGot *bool
+	softDeleted     bool
+}
+
+func (f *fakeManageRepo) FindByID(context.Context, uint64) (*domain.User, error) {
+	return f.target, nil
+}
+
+func (f *fakeManageRepo) UpdateActive(_ context.Context, _ uint64, active bool) error {
+	f.updateActiveGot = &active
+	return nil
+}
+
+func (f *fakeManageRepo) SoftDelete(context.Context, uint64) error {
+	f.softDeleted = true
+	return nil
+}
+
+func (f *fakeManageRepo) FindByCognitoSub(context.Context, string) (*domain.User, error) {
+	return nil, nil
+}
+
+func (f *fakeManageRepo) ListByRole(context.Context, string) ([]domain.User, error) { return nil, nil }
+
+func (f *fakeManageRepo) ListByCompanyID(context.Context, uint64) ([]domain.User, error) {
+	return nil, nil
+}
+
+func (f *fakeManageRepo) Create(context.Context, *domain.User) error { return nil }
+
+func (f *fakeManageRepo) UpdateAiChatEnabled(context.Context, uint64, *bool) error { return nil }
+
+func (f *fakeManageRepo) UpdateDisplayName(context.Context, uint64, string) error { return nil }
+
+func (f *fakeManageRepo) UpdateRole(context.Context, uint64, string) error { return nil }
+
+func (f *fakeManageRepo) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
+
+func (f *fakeManageRepo) MarkOnboarded(context.Context, uint64) error { return nil }
+
+func TestSetMemberActive_CompanyAdmin_OwnCompany_OK(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
+	uc := usecase.NewSetMemberActiveUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
+
+	err := uc.Execute(context.Background(), actor, 2, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo.updateActiveGot)
+	assert.False(t, *repo.updateActiveGot)
+}
+
+func TestSetMemberActive_CompanyAdmin_OtherCompany_Forbidden(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
+	uc := usecase.NewSetMemberActiveUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
+
+	err := uc.Execute(context.Background(), actor, 2, false)
+
+	require.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
+	assert.Nil(t, repo.updateActiveGot, "別会社では更新してはならない")
+}
+
+func TestSetMemberActive_SuperAdmin_AnyCompany_OK(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
+	uc := usecase.NewSetMemberActiveUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+
+	err := uc.Execute(context.Background(), actor, 2, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo.updateActiveGot)
+}
+
+func TestSetMemberActive_Self_Forbidden(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}}
+	uc := usecase.NewSetMemberActiveUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
+
+	err := uc.Execute(context.Background(), actor, 1, false)
+
+	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
+	assert.Nil(t, repo.updateActiveGot, "自分自身は無効化できない")
+}
+
+func TestSetMemberActive_NotFound(t *testing.T) {
+	repo := &fakeManageRepo{target: nil}
+	uc := usecase.NewSetMemberActiveUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+
+	err := uc.Execute(context.Background(), actor, 999, false)
+
+	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
+}
+
+func TestSoftDeleteMember_CompanyAdmin_OwnCompany_OK(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
+
+	err := uc.Execute(context.Background(), actor, 2)
+
+	require.NoError(t, err)
+	assert.True(t, repo.softDeleted)
+}
+
+func TestSoftDeleteMember_Self_Forbidden(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}}
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
+
+	err := uc.Execute(context.Background(), actor, 1)
+
+	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
+	assert.False(t, repo.softDeleted, "自分自身は削除できない")
+}
+
+func TestSoftDeleteMember_CompanyAdmin_OtherCompany_Forbidden(t *testing.T) {
+	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
+
+	err := uc.Execute(context.Background(), actor, 2)
+
+	require.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
+	assert.False(t, repo.softDeleted)
+}

--- a/backend/internal/usecase/repository/user.go
+++ b/backend/internal/usecase/repository/user.go
@@ -19,6 +19,10 @@ type UserRepository interface {
 	Create(ctx context.Context, user *domain.User) error
 	// UpdateAiChatEnabled は AI チャットの個別上書きを更新する（nil で会社設定に従う）。
 	UpdateAiChatEnabled(ctx context.Context, userID uint64, enabled *bool) error
+	// UpdateActive はユーザーアカウントの有効/無効を更新する（false で無効化 → 利用不可）。
+	UpdateActive(ctx context.Context, userID uint64, active bool) error
+	// SoftDelete はユーザーを論理削除する（deleted_at = NOW()）。認証時にも除外される。
+	SoftDelete(ctx context.Context, userID uint64) error
 	// UpdateDisplayName は氏名変更、および OIDC ログイン時の displayName 自動補正で呼ばれる。
 	UpdateDisplayName(ctx context.Context, userID uint64, displayName string) error
 	// UpdateRole は Cognito group → DB role 同期、または招待受諾時に呼ばれる。

--- a/backend/internal/usecase/set_member_active_usecase.go
+++ b/backend/internal/usecase/set_member_active_usecase.go
@@ -1,0 +1,60 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+var (
+	// ErrCannotManageSelf は自分自身を無効化/削除しようとしたときのエラー（自己ロックアウト防止）。
+	ErrCannotManageSelf = errors.New("cannot disable or delete yourself")
+	// ErrMemberNotFound は対象 user が存在しない（404 相当）。
+	ErrMemberNotFound = errors.New("member not found")
+)
+
+// authorizeMemberManagement は actor が target を管理（停止/削除）できるかを判定する。
+// super_admin は全社の user を、company_admin は自社の user のみ操作できる。自分自身は不可。
+func authorizeMemberManagement(actor, target *domain.User) error {
+	if actor == nil || target == nil {
+		return ErrMemberNotInActorCompany
+	}
+	if actor.ID == target.ID {
+		return ErrCannotManageSelf
+	}
+	if actor.Role == domain.RoleSuperAdmin {
+		return nil
+	}
+	// company_admin は自社（同一 company_id）の user のみ。
+	if actor.Role != domain.RoleCompanyAdmin || actor.CompanyID == nil ||
+		target.CompanyID == nil || *actor.CompanyID != *target.CompanyID {
+		return ErrMemberNotInActorCompany
+	}
+	return nil
+}
+
+// SetMemberActiveUseCase は従業員アカウントの有効/無効を切り替える（停止/再開）。
+type SetMemberActiveUseCase struct {
+	users repository.UserRepository
+}
+
+func NewSetMemberActiveUseCase(u repository.UserRepository) *SetMemberActiveUseCase {
+	return &SetMemberActiveUseCase{users: u}
+}
+
+// Execute は actor の権限内で targetUserID の有効/無効を更新する。
+func (uc *SetMemberActiveUseCase) Execute(ctx context.Context, actor *domain.User, targetUserID uint64, active bool) error {
+	target, err := uc.users.FindByID(ctx, targetUserID)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return ErrMemberNotFound
+	}
+	if err := authorizeMemberManagement(actor, target); err != nil {
+		return err
+	}
+	return uc.users.UpdateActive(ctx, targetUserID, active)
+}

--- a/backend/internal/usecase/soft_delete_member_usecase.go
+++ b/backend/internal/usecase/soft_delete_member_usecase.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// SoftDeleteMemberUseCase は従業員を論理削除する（deleted_at = NOW()）。
+// 認可は SetMemberActiveUseCase と同じ（super_admin は全社 / company_admin は自社 / 自分は不可）。
+type SoftDeleteMemberUseCase struct {
+	users repository.UserRepository
+}
+
+func NewSoftDeleteMemberUseCase(u repository.UserRepository) *SoftDeleteMemberUseCase {
+	return &SoftDeleteMemberUseCase{users: u}
+}
+
+// Execute は actor の権限内で targetUserID を論理削除する。
+func (uc *SoftDeleteMemberUseCase) Execute(ctx context.Context, actor *domain.User, targetUserID uint64) error {
+	target, err := uc.users.FindByID(ctx, targetUserID)
+	if err != nil {
+		return err
+	}
+	if target == nil {
+		return ErrMemberNotFound
+	}
+	if err := authorizeMemberManagement(actor, target); err != nil {
+		return err
+	}
+	return uc.users.SoftDelete(ctx, targetUserID)
+}

--- a/docs/admin-account-suspension.md
+++ b/docs/admin-account-suspension.md
@@ -2,7 +2,7 @@
 
 運営（super_admin）・会社管理者（company_admin）が、会社やユーザーのアカウントを**停止（無効化）**したり削除したりするための管理操作。停止は削除と違い**可逆**で、停止中はログイン/利用を**即時に**不可にする。
 
-> 本ドキュメントは段階的に拡張する。**PR1: 会社アカウントの有効/無効（実装済）** / PR2: ユーザーの有効/無効 + ソフト削除（予定）。
+> **PR1: 会社アカウントの有効/無効（実装済）** / **PR2: ユーザーの有効/無効 + ソフト削除（実装済）**。
 
 ## 1. 会社アカウントの有効/無効（super_admin）
 
@@ -21,7 +21,23 @@
    - 会社行が無い（データ不整合）場合は弾かない。会社ひきの DB エラーは `500`。
    - super_admin は `company_id` を持たないため、この会社チェックの対象外（自分が締め出されることはない）。
 
-## 2. レイヤー構成（クリーンアーキテクチャ）
+## 2. ユーザー（従業員）の有効/無効・論理削除（super_admin / company_admin）
+
+- 画面: `/admin/members`（管理 → 従業員一覧）。各従業員に「有効/無効」状態、「無効化 / 有効化」ボタン、「削除」ボタン（確認ダイアログ付き）。
+- API:
+  - `PATCH /api/v2/admin/members/:userId/active` body `{ "active": false }`（停止/再開）
+  - `DELETE /api/v2/admin/members/:userId`（論理削除）
+
+### 認可（テナント境界 + 自己ロックアウト防止）
+
+`super_admin` は全社の従業員を、`company_admin` は**自社（同一 company_id）の従業員のみ**操作できる。**自分自身は無効化/削除できない**（`ErrCannotManageSelf` → `400 cannot_manage_self`）。別会社は `403 forbidden`、存在しない従業員は `404 member_not_found`。
+
+### enforcement（即時ブロック）
+
+- **無効化**: `users.is_active = false` にすると、`CurrentUser` middleware が次のリクエストで `403 user_disabled` を返す（有効な JWT でも即時に弾く）。
+- **論理削除**: `users.deleted_at = NOW()`。`FindByCognitoSub` / `FindByID` は `deleted_at IS NULL` で除外するため、削除済みユーザーは**認証時に自動で `401 user_not_found`** となり、一覧からも消える。
+
+## 3. レイヤー構成（クリーンアーキテクチャ）
 
 ```text
 AdminCompaniesPage / CompanyRepository.updateActive (frontend)
@@ -45,15 +61,28 @@ CurrentUser middleware ── 会社が無効なら 403 で全リクエストを
 | domain | `backend/internal/domain/company.go`（`IsActive`） |
 | frontend | `frontend/src/pages/AdminCompaniesPage.tsx` / `repositories/CompanyRepository.ts` |
 
-> `companies.is_active boolean NOT NULL DEFAULT true` を追加（AutoMigrate が本番に列を追加）。sqlc は `SELECT *` のため `make sqlc` 再生成で `IsActive` を取り込む。
+ユーザー操作の主なファイル:
 
-## 3. テスト
+| 層 | ファイル |
+|---|---|
+| handler | `admin_member_handler.go`（`SetActive` / `Delete`） |
+| middleware | `current_user.go`（ユーザー無効チェック） |
+| usecase | `set_member_active_usecase.go`（認可ヘルパ `authorizeMemberManagement`）/ `soft_delete_member_usecase.go` |
+| repository | `usecase/repository/user.go`（`UpdateActive` / `SoftDelete`）/ `adapter/persistence/user_repository.go` |
+| domain | `backend/internal/domain/user.go`（`IsActive` / 既存 `DeletedAt`） |
+| frontend | `AdminMembersPage.tsx` / `hooks/useAdminMembers.ts` / `repositories/AdminMemberRepository.ts` |
 
-- handler: `SetActive` は super_admin のみ 200・他ロール 403・body 不正 400（`admin_company_handler_test.go`）
-- middleware: 無効会社のユーザーを 403 で弾く / 有効会社は通す / 会社なし super_admin は通す / 会社行なしは通す（`current_user_test.go`）
-- frontend: `CompanyRepository.test.ts`（`updateActive` の PATCH）
+> `companies.is_active` / `users.is_active boolean NOT NULL DEFAULT true` を追加（AutoMigrate が本番に列を追加）。sqlc は `SELECT *` のため `make sqlc` 再生成で `IsActive` を取り込む。
 
-## 4. 安全策
+## 4. テスト
 
-- **自己締め出し防止**: 会社無効化は super_admin のみが行い、super_admin 自身は会社に属さないため締め出されない。
-- 停止は**可逆**（有効化で即復帰）。破壊的なデータ削除は伴わない。
+- handler(company): `SetActive` は super_admin のみ 200・他ロール 403・body 不正 400・会社なし 404（`admin_company_handler_test.go`）
+- usecase(member): super_admin は全社可 / company_admin は自社のみ / 別会社 403 / 自分自身 403(self) / 不在 404（`manage_member_usecase_test.go`）
+- middleware: 無効会社・無効ユーザーを 403 で弾く / 有効は通す / 会社なし super_admin は通す（`current_user_test.go`）
+- frontend: `CompanyRepository.test.ts` / `AdminMemberRepository.test.ts`（`updateActive` PATCH / `remove` DELETE）
+
+## 5. 安全策
+
+- **自己締め出し防止**: 会社無効化は super_admin のみ（会社に属さないため締め出されない）。ユーザー操作は**自分自身を無効化/削除できない**（`ErrCannotManageSelf`）。
+- **テナント境界**: company_admin は自社の従業員のみ操作可能（別会社は 403）。
+- 停止は**可逆**（有効化で即復帰）。論理削除も `deleted_at` のクリアで復旧可能（データは残る）。

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -142,6 +142,10 @@ export const ADMIN = {
   companyActive: (id: number | string) => `${API_V2}/admin/companies/${id}/active`,
   members: `${API_V2}/admin/members`,
   memberAiAccess: (userId: number | string) => `${API_V2}/admin/members/${userId}/ai-access`,
+  /** PATCH /api/v2/admin/members/:userId/active — 従業員アカウントの有効/無効 */
+  memberActive: (userId: number | string) => `${API_V2}/admin/members/${userId}/active`,
+  /** DELETE /api/v2/admin/members/:userId — 従業員の論理削除 */
+  member: (userId: number | string) => `${API_V2}/admin/members/${userId}`,
   invitations: `${API_V2}/admin/invitations`,
   invitationById: (id: number | string) => `${API_V2}/admin/invitations/${id}`,
   scenarios: `${API_V2}/admin/scenarios`,

--- a/frontend/src/hooks/useAdminMembers.ts
+++ b/frontend/src/hooks/useAdminMembers.ts
@@ -1,9 +1,21 @@
 import { useCallback, useEffect, useState } from 'react';
+import axios from 'axios';
 import AdminMemberRepository, { Member } from '../repositories/AdminMemberRepository';
+
+// backend のエラーコードを日本語メッセージにする。cannot_manage_self は自己操作の防止。
+function messageFor(e: unknown, fallback: string): string {
+  if (axios.isAxiosError(e)) {
+    const code = (e.response?.data as { error?: string } | undefined)?.error;
+    if (code === 'cannot_manage_self') return '自分自身は無効化・削除できません';
+    if (code === 'forbidden') return 'この従業員を操作する権限がありません';
+    if (code === 'member_not_found') return '対象の従業員が見つかりません';
+  }
+  return fallback;
+}
 
 /**
  * useAdminMembers — 従業員管理ページの状態管理フック。
- * 自社の従業員一覧の取得と、各従業員の AI 利用可否（個別上書き）の更新を扱う。
+ * 自社の従業員一覧の取得、AI 利用可否の個別上書き、アカウントの有効/無効、論理削除を扱う。
  */
 export function useAdminMembers() {
   const [members, setMembers] = useState<Member[]>([]);
@@ -44,5 +56,37 @@ export function useAdminMembers() {
     [load],
   );
 
-  return { members, loading, error, updatingId, setAiAccess, reload: load };
+  // アカウントの有効/無効を切り替える。楽観的更新 + 失敗時ロールバック。
+  const setActive = useCallback(
+    async (userId: number, active: boolean) => {
+      setUpdatingId(userId);
+      setError(null);
+      setMembers((prev) => prev.map((m) => (m.id === userId ? { ...m, isActive: active } : m)));
+      try {
+        await AdminMemberRepository.updateActive(userId, active);
+      } catch (e) {
+        setMembers((prev) => prev.map((m) => (m.id === userId ? { ...m, isActive: !active } : m)));
+        setError(messageFor(e, 'アカウント状態の更新に失敗しました'));
+      } finally {
+        setUpdatingId(null);
+      }
+    },
+    [],
+  );
+
+  // 従業員を論理削除する。成功したら一覧から除く。
+  const remove = useCallback(async (userId: number) => {
+    setUpdatingId(userId);
+    setError(null);
+    try {
+      await AdminMemberRepository.remove(userId);
+      setMembers((prev) => prev.filter((m) => m.id !== userId));
+    } catch (e) {
+      setError(messageFor(e, '従業員の削除に失敗しました'));
+    } finally {
+      setUpdatingId(null);
+    }
+  }, []);
+
+  return { members, loading, error, updatingId, setAiAccess, setActive, remove, reload: load };
 }

--- a/frontend/src/pages/AdminMembersPage.tsx
+++ b/frontend/src/pages/AdminMembersPage.tsx
@@ -33,7 +33,7 @@ function roleLabel(role: string): string {
 export default function AdminMembersPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
-  const { members, loading, error, updatingId, setAiAccess } = useAdminMembers();
+  const { members, loading, error, updatingId, setAiAccess, setActive, remove } = useAdminMembers();
 
   if (authLoading) return <Loading message="読み込み中..." className="min-h-[50vh]" />;
   if (!isAdmin) return <Navigate to="/" replace />;
@@ -42,13 +42,17 @@ export default function AdminMembersPage() {
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-4xl mx-auto">
       <PageIntro
         title="管理: 従業員一覧"
-        description="自社の従業員の一覧です。各従業員の AI 利用可否を個別に設定できます（会社の一括設定を上書きします）。"
+        description="自社の従業員の一覧です。AI 利用可否の個別設定に加え、アカウントの有効/無効（停止）と削除ができます。無効化された従業員はログイン/利用不可になります。"
       />
+
+      {error && (
+        <p role="alert" className="mt-4 text-rose-600">
+          {error}
+        </p>
+      )}
 
       {loading ? (
         <Loading message="読み込み中..." className="min-h-[30vh]" />
-      ) : error ? (
-        <p className="mt-6 text-rose-600">{error}</p>
       ) : members.length === 0 ? (
         <p className="mt-6 text-[var(--color-text-muted)]">従業員がまだいません。</p>
       ) : (
@@ -60,6 +64,8 @@ export default function AdminMembersPage() {
                 <th className="px-4 py-2 font-medium">メールアドレス</th>
                 <th className="px-4 py-2 font-medium">役割</th>
                 <th className="px-4 py-2 font-medium">AI 利用</th>
+                <th className="px-4 py-2 font-medium">状態</th>
+                <th className="px-4 py-2 font-medium">操作</th>
               </tr>
             </thead>
             <tbody>
@@ -83,6 +89,41 @@ export default function AdminMembersPage() {
                       <option value="on">有効（個別ON）</option>
                       <option value="off">無効（個別OFF）</option>
                     </select>
+                  </td>
+                  <td className="px-4 py-2">
+                    {m.isActive ? (
+                      <span className="text-emerald-600">有効</span>
+                    ) : (
+                      <span className="text-rose-600 font-medium">無効</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    <div className="flex gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setActive(m.id, !m.isActive)}
+                        disabled={updatingId === m.id}
+                        className={`text-xs px-2.5 py-1 rounded border transition-colors disabled:opacity-50 ${
+                          m.isActive
+                            ? 'border-rose-300 text-rose-700 hover:bg-rose-50'
+                            : 'border-emerald-300 text-emerald-700 hover:bg-emerald-50'
+                        }`}
+                      >
+                        {m.isActive ? '無効化' : '有効化'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (window.confirm(`${m.displayName || m.email} を削除します。よろしいですか？`)) {
+                            remove(m.id);
+                          }
+                        }}
+                        disabled={updatingId === m.id}
+                        className="text-xs px-2.5 py-1 rounded border border-surface-3 text-[var(--color-text-muted)] hover:bg-surface-2 transition-colors disabled:opacity-50"
+                      >
+                        削除
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/frontend/src/repositories/AdminMemberRepository.ts
+++ b/frontend/src/repositories/AdminMemberRepository.ts
@@ -9,6 +9,8 @@ export interface Member {
   role: string;
   /** AI 利用可否の個別上書き。null = 会社設定に従う。 */
   aiChatEnabled: boolean | null;
+  /** アカウントの有効/無効。false = 無効（ログイン/利用不可）。 */
+  isActive: boolean;
 }
 
 /**
@@ -26,6 +28,16 @@ const AdminMemberRepository = {
    */
   async updateAiAccess(userId: number, enabled: boolean | null): Promise<void> {
     await api.patch(ADMIN.memberAiAccess(userId), { enabled });
+  },
+
+  /** 従業員アカウントの有効/無効を切り替える（false で停止 → ログイン/利用不可）。 */
+  async updateActive(userId: number, active: boolean): Promise<void> {
+    await api.patch(ADMIN.memberActive(userId), { active });
+  },
+
+  /** 従業員を論理削除する（一覧から退会させる）。 */
+  async remove(userId: number): Promise<void> {
+    await api.delete(ADMIN.member(userId));
   },
 };
 

--- a/frontend/src/repositories/__tests__/AdminMemberRepository.test.ts
+++ b/frontend/src/repositories/__tests__/AdminMemberRepository.test.ts
@@ -4,6 +4,7 @@ vi.mock('../../lib/axios', () => ({
   default: {
     get: vi.fn(),
     patch: vi.fn(),
+    delete: vi.fn(),
   },
 }));
 
@@ -12,6 +13,7 @@ import AdminMemberRepository from '../AdminMemberRepository';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPatch = vi.mocked(apiClient.patch);
+const mockedDelete = vi.mocked(apiClient.delete);
 
 describe('AdminMemberRepository', () => {
   beforeEach(() => {
@@ -37,5 +39,17 @@ describe('AdminMemberRepository', () => {
     mockedPatch.mockResolvedValue({ status: 204 });
     await AdminMemberRepository.updateAiAccess(7, null);
     expect(mockedPatch).toHaveBeenCalledWith('/api/v2/admin/members/7/ai-access', { enabled: null });
+  });
+
+  it('updateActive: 従業員を無効化する PATCH を送る', async () => {
+    mockedPatch.mockResolvedValue({ status: 204 });
+    await AdminMemberRepository.updateActive(7, false);
+    expect(mockedPatch).toHaveBeenCalledWith('/api/v2/admin/members/7/active', { active: false });
+  });
+
+  it('remove: 従業員を論理削除する DELETE を送る', async () => {
+    mockedDelete.mockResolvedValue({ status: 204 });
+    await AdminMemberRepository.remove(7);
+    expect(mockedDelete).toHaveBeenCalledWith('/api/v2/admin/members/7');
   });
 });


### PR DESCRIPTION
## 概要

会社停止（[#1955](https://github.com/norman6464/FreStyle/pull/1955)）に続き、**個別の従業員アカウント**を停止/再開/削除できる管理操作を追加する（会社/ユーザー停止・削除シリーズの **PR2**）。`super_admin` は全社、`company_admin` は自社の従業員のみ操作でき、**自分自身は操作不可**。

## 変更内容

- **API**:
  - `PATCH /api/v2/admin/members/:userId/active` `{ active }`（停止/再開）
  - `DELETE /api/v2/admin/members/:userId`（論理削除）
- **UI**: `/admin/members` に「状態（有効/無効）」列・「無効化 / 有効化」ボタン・「削除」ボタン（確認ダイアログ付き）
- **enforcement（即時）**:
  - 無効化 → `CurrentUser` middleware が `is_active=false` を `403 user_disabled` で弾く（有効な JWT でも即時）
  - 論理削除 → `deleted_at=NOW()`。`FindByCognitoSub` が `deleted_at IS NULL` で除外するため認証時に自動で `401 user_not_found`
- **認可**: `authorizeMemberManagement`（super_admin=全社 / company_admin=自社 / 自分は不可）。別会社 `403` / 自分 `400 cannot_manage_self` / 不在 `404`
- domain `User.IsActive` + `users.is_active`（`make sqlc` 再生成）/ repository `UpdateActive` / `SoftDelete`（`RowsAffected==0` → 404）

## テスト

- usecase（認可 7 ケース）: super_admin 全社 / company_admin 自社 / 別会社 403 / 自分 self / 不在 404（`manage_member_usecase_test.go`）
- middleware: 無効ユーザーを 403 で弾く / 有効は通す（`current_user_test.go`）
- handler: company 404 マップ（PR1 から継続）
- frontend: `AdminMemberRepository.test.ts`（`updateActive` PATCH / `remove` DELETE）
- `go build`/`vet`/全ユニット green、`tsc`/`eslint`/`vitest`(187 files)/`build` green、`make openapi` 再生成済

## ドキュメント

`docs/admin-account-suspension.md` にユーザー操作の章・認可・enforcement・テスト・安全策を追記。