### PR TITLE
feat(admin): 従業員一覧に検索ボックスを追加（氏名・メール・役割で絞り込み）

### DIFF
--- a/docs/admin-member-management.md
+++ b/docs/admin-member-management.md
@@ -31,3 +31,4 @@ AI チャットを使ってよいかは [`usecase.AiChatEnabledForUserUseCase`](
 
 - backend: `list_company_members_usecase.go` / `update_member_ai_access_usecase.go` / `admin_member_handler.go` / `routes_admin.go`。repository は `UserRepository.ListByCompanyID`（sqlc）+ `UpdateAiChatEnabled`（GORM、`nil` で `NULL` に戻す）
 - frontend: `AdminMembersPage` / `useAdminMembers` / `AdminMemberRepository`。一覧表で各従業員の AI 利用を「会社設定に従う / 有効 / 無効」のセレクトで設定（trainee のみ対象）
+- **一覧の検索**: 一覧上部の検索ボックスで **氏名・メールアドレス・役割**を部分一致（大文字小文字無視）でクライアント側フィルタ（`AdminMembersPage` の `useMemo`）。一覧は自社分のみで件数が少ないため、追加の API は持たずクライアントで絞り込む。一致が無いときは「〜に一致する従業員がいません」を表示。

--- a/frontend/src/pages/AdminMembersPage.tsx
+++ b/frontend/src/pages/AdminMembersPage.tsx
@@ -1,3 +1,4 @@
+import { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate } from 'react-router-dom';
 import type { RootState } from '../store';
@@ -34,6 +35,19 @@ export default function AdminMembersPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
   const { members, loading, error, updatingId, setAiAccess, setActive, remove } = useAdminMembers();
+  const [query, setQuery] = useState('');
+
+  // 氏名・メールアドレス・役割で部分一致（大文字小文字を無視）フィルタ。
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return members;
+    return members.filter(
+      (m) =>
+        (m.displayName || '').toLowerCase().includes(q) ||
+        m.email.toLowerCase().includes(q) ||
+        roleLabel(m.role).toLowerCase().includes(q),
+    );
+  }, [members, query]);
 
   if (authLoading) return <Loading message="読み込み中..." className="min-h-[50vh]" />;
   if (!isAdmin) return <Navigate to="/" replace />;
@@ -56,8 +70,22 @@ export default function AdminMembersPage() {
       ) : members.length === 0 ? (
         <p className="mt-6 text-[var(--color-text-muted)]">従業員がまだいません。</p>
       ) : (
-        <div className="mt-6 overflow-x-auto rounded-lg border border-surface-3">
-          <table className="w-full text-sm">
+        <>
+          <div className="mt-6">
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="氏名・メールアドレス・役割で検索"
+              aria-label="従業員を検索"
+              className="w-full sm:max-w-xs px-3 py-2 rounded-md bg-surface-2 border border-surface-3 text-sm text-[var(--color-text-primary)] focus:outline-none focus:border-brand-500"
+            />
+          </div>
+          {filtered.length === 0 ? (
+            <p className="mt-4 text-[var(--color-text-muted)]">「{query}」に一致する従業員がいません。</p>
+          ) : (
+            <div className="mt-4 overflow-x-auto rounded-lg border border-surface-3">
+              <table className="w-full text-sm">
             <thead>
               <tr className="bg-surface-2 text-left text-[var(--color-text-muted)]">
                 <th className="px-4 py-2 font-medium">氏名</th>
@@ -69,7 +97,7 @@ export default function AdminMembersPage() {
               </tr>
             </thead>
             <tbody>
-              {members.map((m) => (
+              {filtered.map((m) => (
                 <tr key={m.id} className="border-t border-surface-3">
                   <td className="px-4 py-2 text-[var(--color-text-primary)]">{m.displayName || '—'}</td>
                   <td className="px-4 py-2 text-[var(--color-text-muted)]">{m.email}</td>
@@ -128,8 +156,10 @@ export default function AdminMembersPage() {
                 </tr>
               ))}
             </tbody>
-          </table>
-        </div>
+              </table>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/pages/__tests__/AdminMembersPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminMembersPage.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Redux: 会社管理者としてページを表示できる状態にする。
+const mockState = { auth: { isAdmin: true, loading: false } };
+vi.mock('react-redux', () => ({
+  useSelector: (sel: (s: typeof mockState) => unknown) => sel(mockState),
+  useDispatch: () => vi.fn(),
+}));
+
+// 従業員一覧は固定データを返す（API/axios は呼ばない）。
+const members = [
+  {
+    id: 1,
+    displayName: '河野拓真',
+    email: 'kawano@example.com',
+    role: 'company_admin',
+    aiChatEnabled: null,
+    isActive: true,
+  },
+  {
+    id: 2,
+    displayName: '木村',
+    email: 'kimura@example.com',
+    role: 'trainee',
+    aiChatEnabled: null,
+    isActive: true,
+  },
+];
+vi.mock('../../hooks/useAdminMembers', () => ({
+  useAdminMembers: () => ({
+    members,
+    loading: false,
+    error: null,
+    updatingId: null,
+    setAiAccess: vi.fn(),
+    setActive: vi.fn(),
+    remove: vi.fn(),
+  }),
+}));
+
+import AdminMembersPage from '../AdminMembersPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminMembersPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminMembersPage の検索', () => {
+  it('初期は全従業員が表示される', () => {
+    renderPage();
+    expect(screen.getByText('河野拓真')).toBeInTheDocument();
+    expect(screen.getByText('木村')).toBeInTheDocument();
+  });
+
+  it('氏名で部分一致フィルタできる（一致しない行は消える）', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('従業員を検索'), { target: { value: '木村' } });
+    expect(screen.queryByText('河野拓真')).not.toBeInTheDocument();
+    expect(screen.getByText('木村')).toBeInTheDocument();
+  });
+
+  it('メールアドレスでもフィルタできる', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('従業員を検索'), { target: { value: 'kawano' } });
+    expect(screen.getByText('河野拓真')).toBeInTheDocument();
+    expect(screen.queryByText('木村')).not.toBeInTheDocument();
+  });
+
+  it('一致しないと no-results メッセージを出す', () => {
+    renderPage();
+    fireEvent.change(screen.getByLabelText('従業員を検索'), { target: { value: 'zzzznomatch' } });
+    expect(screen.getByText(/に一致する従業員がいません/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

従業員一覧（`/admin/members`）に**検索ボックス**が無く一覧から人を探しづらかったため、一覧上部に検索ボックスを追加。**氏名・メールアドレス・役割**で部分一致（大文字小文字無視）の**クライアント側フィルタ**ができるようにした。

## 変更内容

- `AdminMembersPage.tsx`: `query` state + `filtered`（`useMemo`）+ 検索 `<input type="search">`（`aria-label="従業員を検索"`）。一致が無いときは「〜に一致する従業員がいません」を表示
- 一覧は自社の従業員のみで件数が少ないため、追加 API は持たず**クライアント側で絞り込む**
- テスト: 氏名/メールでの絞り込み・一致なしメッセージ（`AdminMembersPage.test.tsx`、4 ケース）
- `docs/admin-member-management.md` に検索仕様を追記

## テスト

- 新規テスト 4 ケース green、`tsc` / `eslint --max-warnings 0` / `vitest`(188 files) / `npm run build` すべて green
- frontend のみの変更（backend / API 変更なし）

## 補足

スクリーンショット時点の本番は旧版（状態/操作列なし）でしたが、本変更は最新 main（状態/操作列あり）に対する追加です。デプロイ後に検索ボックスが反映されます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 従業員一覧ページに検索機能を追加しました。氏名、メールアドレス、役割で部分一致検索（大文字小文字区別なし）が可能です。

* **テスト**
  * 検索機能のテストケースを追加しました。

* **ドキュメント**
  * 従業員一覧ページの検索仕様をドキュメントに追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->