### PR TITLE
test(backend): サブテスト名(t.Run)を英語から日本語に統一

### DIFF
--- a/backend/cmd/apispec-lint/main_test.go
+++ b/backend/cmd/apispec-lint/main_test.go
@@ -184,7 +184,7 @@ func (h *H) Create(c *gin.Context) {}
 func (h *H) Get(c *gin.Context) {}
 `
 
-	t.Run("missing annotation is a violation", func(t *testing.T) {
+	t.Run("注釈なしは違反", func(t *testing.T) {
 		handlerRoot := mkHandlerTree(t, map[string]string{
 			"h.go": annotatedHandler,
 			"routes.go": `package handler
@@ -203,7 +203,7 @@ func reg(g *gin.RouterGroup, h *H) {
 		}
 	})
 
-	t.Run("path mismatch is a violation", func(t *testing.T) {
+	t.Run("path 不一致は違反", func(t *testing.T) {
 		// 注釈は /things/{id} だが実ルートは /items/{id} → 不一致。
 		handlerRoot := mkHandlerTree(t, map[string]string{
 			"h.go": annotatedHandler,
@@ -222,7 +222,7 @@ func reg(g *gin.RouterGroup, h *H) {
 		}
 	})
 
-	t.Run("method mismatch is a violation", func(t *testing.T) {
+	t.Run("method 不一致は違反", func(t *testing.T) {
 		// 注釈は [get] だが実ルートは PUT → 不一致。
 		handlerRoot := mkHandlerTree(t, map[string]string{
 			"h.go": annotatedHandler,
@@ -241,7 +241,7 @@ func reg(g *gin.RouterGroup, h *H) {
 		}
 	})
 
-	t.Run("all annotated -> no violation", func(t *testing.T) {
+	t.Run("全て注釈あり → 違反なし", func(t *testing.T) {
 		handlerRoot := mkHandlerTree(t, map[string]string{
 			"h.go": annotatedHandler,
 			"routes.go": `package handler
@@ -260,7 +260,7 @@ func reg(g *gin.RouterGroup, h *H) {
 		}
 	})
 
-	t.Run("//apispec:allow suppresses", func(t *testing.T) {
+	t.Run("//apispec:allow で抑制される", func(t *testing.T) {
 		handlerRoot := mkHandlerTree(t, map[string]string{
 			"h.go": annotatedHandler,
 			"routes.go": `package handler
@@ -278,7 +278,7 @@ func reg(g *gin.RouterGroup, h *H) {
 		}
 	})
 
-	t.Run("//apispec:ignore-file skips file", func(t *testing.T) {
+	t.Run("//apispec:ignore-file でファイルをスキップ", func(t *testing.T) {
 		handlerRoot := mkHandlerTree(t, map[string]string{
 			"h.go": annotatedHandler,
 			"routes.go": `//apispec:ignore-file レガシー
@@ -310,7 +310,7 @@ func TestRunCLI(t *testing.T) {
 		})
 	}
 
-	t.Run("clean returns 0", func(t *testing.T) {
+	t.Run("クリーンなら 0 を返す", func(t *testing.T) {
 		root := filepath.Dir(filepath.Dir(handlerRoot(t, false))) // root that contains internal/handler
 		var out, errBuf bytes.Buffer
 		if code := runCLI([]string{root}, &out, &errBuf); code != 0 {
@@ -321,7 +321,7 @@ func TestRunCLI(t *testing.T) {
 		}
 	})
 
-	t.Run("violation returns 1", func(t *testing.T) {
+	t.Run("違反があれば 1 を返す", func(t *testing.T) {
 		root := filepath.Dir(filepath.Dir(handlerRoot(t, true)))
 		var out, errBuf bytes.Buffer
 		if code := runCLI([]string{root}, &out, &errBuf); code != 1 {

--- a/backend/cmd/archlint/main_test.go
+++ b/backend/cmd/archlint/main_test.go
@@ -76,49 +76,49 @@ func TestIsWiringFile(t *testing.T) {
 func TestViolationsFor(t *testing.T) {
 	imp := func(target string) importRef { return importRef{path: "p", line: 1, target: target} }
 
-	t.Run("domain importing usecase is a violation", func(t *testing.T) {
+	t.Run("domain が usecase を import するのは違反", func(t *testing.T) {
 		vs := violationsFor(layerDomain, "domain", "user.go", "internal/domain/user.go", []importRef{imp(layerUsecase)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("usecase importing persistence is a violation (DIP)", func(t *testing.T) {
+	t.Run("usecase が persistence を import するのは違反（DIP）", func(t *testing.T) {
 		vs := violationsFor(layerUsecase, "usecase", "foo_usecase.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("usecase importing infra is allowed", func(t *testing.T) {
+	t.Run("usecase が infra を import するのは許容", func(t *testing.T) {
 		vs := violationsFor(layerUsecase, "usecase", "foo_usecase.go", "p", []importRef{imp(layerInfra)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("usecase importing gin is a violation", func(t *testing.T) {
+	t.Run("usecase が gin を import するのは違反", func(t *testing.T) {
 		vs := violationsFor(layerUsecase, "usecase", "foo_usecase.go", "p", []importRef{imp(targetGin)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("handler importing persistence in wiring file is allowed", func(t *testing.T) {
+	t.Run("wiring ファイルでの handler→persistence import は許容", func(t *testing.T) {
 		vs := violationsFor(layerHandler, "handler", "router.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 0 {
 			t.Fatalf("wiring file should be exempt, got %d", len(vs))
 		}
 	})
 
-	t.Run("handler importing persistence in non-wiring file is a violation", func(t *testing.T) {
+	t.Run("非 wiring ファイルでの handler→persistence import は違反", func(t *testing.T) {
 		vs := violationsFor(layerHandler, "handler", "foo_handler.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("wiring-named file in handler subdir is NOT exempt", func(t *testing.T) {
+	t.Run("handler サブディレクトリの wiring 名ファイルは例外扱いしない", func(t *testing.T) {
 		// handler/middleware/routes_x.go のような別ディレクトリでは wiring 例外を効かせない。
 		vs := violationsFor(layerHandler, "handler/middleware", "routes_x.go", "p", []importRef{imp(layerPersistence)})
 		if len(vs) != 1 {
@@ -126,35 +126,35 @@ func TestViolationsFor(t *testing.T) {
 		}
 	})
 
-	t.Run("handler importing infra is allowed (pragmatic exception)", func(t *testing.T) {
+	t.Run("handler が infra を import するのは許容（実用上の例外）", func(t *testing.T) {
 		vs := violationsFor(layerHandler, "handler", "auth_handler.go", "p", []importRef{imp(layerInfra)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("infra importing net/http is allowed (client use)", func(t *testing.T) {
+	t.Run("infra が net/http を import するのは許容（クライアント用途）", func(t *testing.T) {
 		vs := violationsFor(layerInfra, "infra/embed", "fetcher.go", "p", []importRef{imp(targetNetHTTP)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("persistence importing usecase business is a violation", func(t *testing.T) {
+	t.Run("persistence が usecase 本体を import するのは違反", func(t *testing.T) {
 		vs := violationsFor(layerPersistence, "adapter/persistence", "user_repository.go", "p", []importRef{imp(layerUsecase)})
 		if len(vs) != 1 {
 			t.Fatalf("want 1 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("persistence importing port is allowed", func(t *testing.T) {
+	t.Run("persistence が port を import するのは許容", func(t *testing.T) {
 		vs := violationsFor(layerPersistence, "adapter/persistence", "user_repository.go", "p", []importRef{imp(layerUsecaseRepo)})
 		if len(vs) != 0 {
 			t.Fatalf("want 0 violation, got %d", len(vs))
 		}
 	})
 
-	t.Run("suppressed import is skipped", func(t *testing.T) {
+	t.Run("抑制された import はスキップ", func(t *testing.T) {
 		ref := importRef{path: "p", line: 1, target: layerUsecase, suppressed: true}
 		vs := violationsFor(layerDomain, "domain", "user.go", "p", []importRef{ref})
 		if len(vs) != 0 {
@@ -175,7 +175,7 @@ func TestParseImports(t *testing.T) {
 		return p
 	}
 
-	t.Run("classifies and detects suppression", func(t *testing.T) {
+	t.Run("分類し抑制を検出する", func(t *testing.T) {
 		p := write("a.go", `package x
 
 import (
@@ -295,7 +295,7 @@ func TestRunIntegration(t *testing.T) {
 }
 
 func TestRunCLI(t *testing.T) {
-	t.Run("clean tree returns 0", func(t *testing.T) {
+	t.Run("クリーンなツリーは 0 を返す", func(t *testing.T) {
 		root := buildTree(t, false)
 		var out, errBuf bytes.Buffer
 		if code := runCLI([]string{root}, &out, &errBuf); code != 0 {
@@ -306,7 +306,7 @@ func TestRunCLI(t *testing.T) {
 		}
 	})
 
-	t.Run("violating tree returns 1", func(t *testing.T) {
+	t.Run("違反のあるツリーは 1 を返す", func(t *testing.T) {
 		root := buildTree(t, true)
 		var out, errBuf bytes.Buffer
 		if code := runCLI([]string{root}, &out, &errBuf); code != 1 {
@@ -317,7 +317,7 @@ func TestRunCLI(t *testing.T) {
 		}
 	})
 
-	t.Run("missing go.mod returns 2", func(t *testing.T) {
+	t.Run("go.mod なしは 2 を返す", func(t *testing.T) {
 		var out, errBuf bytes.Buffer
 		if code := runCLI([]string{t.TempDir()}, &out, &errBuf); code != 2 {
 			t.Fatalf("want exit 2, got %d", code)

--- a/backend/cmd/naminglint/main_test.go
+++ b/backend/cmd/naminglint/main_test.go
@@ -128,7 +128,7 @@ func mkUsecaseTree(t *testing.T, files map[string]string) string {
 }
 
 func TestRunIntegration(t *testing.T) {
-	t.Run("missing Execute is a violation", func(t *testing.T) {
+	t.Run("Execute なしは違反", func(t *testing.T) {
 		usecaseRoot := mkUsecaseTree(t, map[string]string{
 			"a.go": `package usecase
 type FooUseCase struct{}
@@ -144,7 +144,7 @@ func NewFooUseCase() *FooUseCase { return &FooUseCase{} }
 		}
 	})
 
-	t.Run("missing constructor is a violation", func(t *testing.T) {
+	t.Run("コンストラクタなしは違反", func(t *testing.T) {
 		usecaseRoot := mkUsecaseTree(t, map[string]string{
 			"a.go": `package usecase
 type FooUseCase struct{}
@@ -160,7 +160,7 @@ func (u *FooUseCase) Execute() {}
 		}
 	})
 
-	t.Run("compliant usecase passes", func(t *testing.T) {
+	t.Run("規約準拠の usecase は通過", func(t *testing.T) {
 		usecaseRoot := mkUsecaseTree(t, map[string]string{
 			"a.go": `package usecase
 type FooUseCase struct{}
@@ -177,7 +177,7 @@ func (u *FooUseCase) Execute() {}
 		}
 	})
 
-	t.Run("//naminglint:allow suppresses Execute requirement", func(t *testing.T) {
+	t.Run("//naminglint:allow で Execute 必須を抑制", func(t *testing.T) {
 		usecaseRoot := mkUsecaseTree(t, map[string]string{
 			"a.go": `package usecase
 
@@ -196,7 +196,7 @@ func (u *FooUseCase) List() {}
 		}
 	})
 
-	t.Run("repository subpackage is ignored", func(t *testing.T) {
+	t.Run("repository サブパッケージは対象外", func(t *testing.T) {
 		usecaseRoot := mkUsecaseTree(t, map[string]string{
 			"a.go": `package usecase
 type FooUseCase struct{}
@@ -216,7 +216,7 @@ type BrokenUseCase struct{}
 		}
 	})
 
-	t.Run("//naminglint:ignore-file skips file", func(t *testing.T) {
+	t.Run("//naminglint:ignore-file でファイルをスキップ", func(t *testing.T) {
 		usecaseRoot := mkUsecaseTree(t, map[string]string{
 			"a.go": `//naminglint:ignore-file レガシー
 package usecase

--- a/backend/internal/adapter/persistence/course_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/course_repository_integration_test.go
@@ -47,7 +47,7 @@ func TestCourseRepository_Integration(t *testing.T) {
 		require.Equal(t, "published", all[1].Title)
 	})
 
-	t.Run("Create→GetByID→Update→Delete", func(t *testing.T) {
+	t.Run("Create→GetByID→Update→Delete の一連", func(t *testing.T) {
 		testsupport.TruncateAll(t, db, "courses")
 
 		c := mk(1, "lifecycle", true, 1)

--- a/backend/internal/handler/ai_chat_attachment_handler_test.go
+++ b/backend/internal/handler/ai_chat_attachment_handler_test.go
@@ -23,7 +23,7 @@ func newAttachHandler(p repository.AiChatAttachmentPresigner) *AiChatAttachmentH
 }
 
 func TestAiChatAttachmentHandler_IssueUploadURL(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 		newAttachHandler(fakeAttachPresigner{}).IssueUploadURL(c)
 		if w.Code != http.StatusUnauthorized {
@@ -37,14 +37,14 @@ func TestAiChatAttachmentHandler_IssueUploadURL(t *testing.T) {
 			t.Fatalf("want 503, got %d", w.Code)
 		}
 	})
-	t.Run("invalid json -> 400", func(t *testing.T) {
+	t.Run("不正な JSON → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `not-json`, 7, "")
 		newAttachHandler(fakeAttachPresigner{}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("missing contentType -> 400", func(t *testing.T) {
+	t.Run("contentType 欠落 → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"filename":"a.png","sizeBytes":100}`, 7, "")
 		newAttachHandler(fakeAttachPresigner{}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/course_handler_test.go
+++ b/backend/internal/handler/course_handler_test.go
@@ -66,21 +66,21 @@ func superAdminCo() *domain.User {
 }
 
 func TestCourseHandler_List(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, nil)
 		newCourseHandler(&fakeCourseRepo{}).List(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, superAdminCo())
 		newCourseHandler(&fakeCourseRepo{rows: []domain.Course{{ID: 1, Title: "C"}}}).List(c)
 		if w.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", w.Code)
 		}
 	})
-	t.Run("repo error -> 500", func(t *testing.T) {
+	t.Run("リポジトリエラー → 500", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, superAdminCo())
 		newCourseHandler(&fakeCourseRepo{listErr: context.DeadlineExceeded}).List(c)
 		if w.Code != http.StatusInternalServerError {
@@ -90,14 +90,14 @@ func TestCourseHandler_List(t *testing.T) {
 }
 
 func TestCourseHandler_Get(t *testing.T) {
-	t.Run("bad id -> 400", func(t *testing.T) {
+	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Get(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", idParam("5"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1, Title: "C"}}).Get(c)
 		if w.Code != http.StatusOK {
@@ -107,14 +107,14 @@ func TestCourseHandler_Get(t *testing.T) {
 }
 
 func TestCourseHandler_Create(t *testing.T) {
-	t.Run("bad json -> 400", func(t *testing.T) {
+	t.Run("不正な JSON → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodPost, `{`, nil, superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Create(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 201", func(t *testing.T) {
+	t.Run("正常系 → 201", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodPost, `{"title":"New"}`, nil, superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Create(c)
 		if w.Code != http.StatusCreated {
@@ -124,14 +124,14 @@ func TestCourseHandler_Create(t *testing.T) {
 }
 
 func TestCourseHandler_Update(t *testing.T) {
-	t.Run("bad id -> 400", func(t *testing.T) {
+	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("abc"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Update(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 200", func(t *testing.T) {
+	t.Run("正常系 → 200", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("5"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1}}).Update(c)
 		if w.Code != http.StatusOK {
@@ -141,14 +141,14 @@ func TestCourseHandler_Update(t *testing.T) {
 }
 
 func TestCourseHandler_Delete(t *testing.T) {
-	t.Run("bad id -> 400", func(t *testing.T) {
+	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodDelete, "", idParam("abc"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Delete(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 204", func(t *testing.T) {
+	t.Run("正常系 → 204", func(t *testing.T) {
 		_, c := ctxJSON(http.MethodDelete, "", idParam("5"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1}}).Delete(c)
 		if c.Writer.Status() != http.StatusNoContent {

--- a/backend/internal/handler/note_handler_test.go
+++ b/backend/internal/handler/note_handler_test.go
@@ -63,21 +63,21 @@ func noteCtx(method, body string, uid uint64, idVal string) (*httptest.ResponseR
 }
 
 func TestNoteHandler_List(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodGet, "", 0, "")
 		newNoteHandler(&fakeNoteRepo{}).List(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := noteCtx(http.MethodGet, "", 7, "")
 		newNoteHandler(&fakeNoteRepo{rows: []domain.Note{{ID: 1, Title: "n"}}}).List(c)
 		if w.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", w.Code)
 		}
 	})
-	t.Run("repo error -> 400", func(t *testing.T) {
+	t.Run("リポジトリエラー → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodGet, "", 7, "")
 		newNoteHandler(&fakeNoteRepo{err: context.DeadlineExceeded}).List(c)
 		if w.Code != http.StatusBadRequest {
@@ -87,21 +87,21 @@ func TestNoteHandler_List(t *testing.T) {
 }
 
 func TestNoteHandler_Create(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"title":"X"}`, 0, "")
 		newNoteHandler(&fakeNoteRepo{}).Create(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("missing title -> 400", func(t *testing.T) {
+	t.Run("title 欠落 → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{}`, 7, "")
 		newNoteHandler(&fakeNoteRepo{}).Create(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 201", func(t *testing.T) {
+	t.Run("正常系 → 201", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"title":"X"}`, 7, "")
 		newNoteHandler(&fakeNoteRepo{}).Create(c)
 		if w.Code != http.StatusCreated {
@@ -111,21 +111,21 @@ func TestNoteHandler_Create(t *testing.T) {
 }
 
 func TestNoteHandler_Update(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPut, `{"title":"X"}`, 0, "5")
 		newNoteHandler(&fakeNoteRepo{}).Update(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("missing title -> 400", func(t *testing.T) {
+	t.Run("title 欠落 → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPut, `{}`, 7, "5")
 		newNoteHandler(&fakeNoteRepo{}).Update(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 200", func(t *testing.T) {
+	t.Run("正常系 → 200", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPut, `{"title":"X"}`, 7, "5")
 		newNoteHandler(&fakeNoteRepo{one: &domain.Note{ID: 5, UserID: 7}}).Update(c)
 		if w.Code != http.StatusOK {
@@ -135,21 +135,21 @@ func TestNoteHandler_Update(t *testing.T) {
 }
 
 func TestNoteHandler_Delete(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodDelete, "", 0, "5")
 		newNoteHandler(&fakeNoteRepo{}).Delete(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 204", func(t *testing.T) {
+	t.Run("正常系 → 204", func(t *testing.T) {
 		_, c := noteCtx(http.MethodDelete, "", 7, "5")
 		newNoteHandler(&fakeNoteRepo{}).Delete(c)
 		if c.Writer.Status() != http.StatusNoContent {
 			t.Fatalf("want 204, got %d", c.Writer.Status())
 		}
 	})
-	t.Run("repo error -> 400", func(t *testing.T) {
+	t.Run("リポジトリエラー → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodDelete, "", 7, "5")
 		newNoteHandler(&fakeNoteRepo{err: context.DeadlineExceeded}).Delete(c)
 		if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/note_image_handler_test.go
+++ b/backend/internal/handler/note_image_handler_test.go
@@ -24,28 +24,28 @@ func newNoteImageHandler(p repository.NoteImagePresigner) *NoteImageHandler {
 }
 
 func TestNoteImageHandler_IssueUploadURL(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 		newNoteImageHandler(fakeNoteImagePresigner{}).IssueUploadURL(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("invalid json -> 400", func(t *testing.T) {
+	t.Run("不正な JSON → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `not-json`, 7, "")
 		newNoteImageHandler(fakeNoteImagePresigner{}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png"}`, 7, "")
 		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
 		if w.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", w.Code)
 		}
 	})
-	t.Run("presigner error -> 400", func(t *testing.T) {
+	t.Run("presigner エラー → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png"}`, 7, "")
 		newNoteImageHandler(fakeNoteImagePresigner{err: context.DeadlineExceeded}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/notification_handler_test.go
+++ b/backend/internal/handler/notification_handler_test.go
@@ -53,21 +53,21 @@ func notifCtx(uid uint64, idVal string) (*httptest.ResponseRecorder, *gin.Contex
 }
 
 func TestNotificationHandler_List(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "")
 		newNotifHandler(&fakeNotifRepo{}).List(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := notifCtx(7, "")
 		newNotifHandler(&fakeNotifRepo{rows: []domain.Notification{{ID: 1}}}).List(c)
 		if w.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", w.Code)
 		}
 	})
-	t.Run("repo error -> 400", func(t *testing.T) {
+	t.Run("リポジトリエラー → 400", func(t *testing.T) {
 		w, c := notifCtx(7, "")
 		newNotifHandler(&fakeNotifRepo{err: context.DeadlineExceeded}).List(c)
 		if w.Code != http.StatusBadRequest {
@@ -77,21 +77,21 @@ func TestNotificationHandler_List(t *testing.T) {
 }
 
 func TestNotificationHandler_MarkRead(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "1")
 		newNotifHandler(&fakeNotifRepo{}).MarkRead(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 204", func(t *testing.T) {
+	t.Run("正常系 → 204", func(t *testing.T) {
 		_, c := notifCtx(7, "1")
 		newNotifHandler(&fakeNotifRepo{}).MarkRead(c)
 		if c.Writer.Status() != http.StatusNoContent {
 			t.Fatalf("want 204, got %d", c.Writer.Status())
 		}
 	})
-	t.Run("repo error -> 400", func(t *testing.T) {
+	t.Run("リポジトリエラー → 400", func(t *testing.T) {
 		w, c := notifCtx(7, "1")
 		newNotifHandler(&fakeNotifRepo{err: context.DeadlineExceeded}).MarkRead(c)
 		if w.Code != http.StatusBadRequest {
@@ -101,21 +101,21 @@ func TestNotificationHandler_MarkRead(t *testing.T) {
 }
 
 func TestNotificationHandler_MarkAllRead(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "")
 		newNotifHandler(&fakeNotifRepo{}).MarkAllRead(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok -> 204", func(t *testing.T) {
+	t.Run("正常系 → 204", func(t *testing.T) {
 		_, c := notifCtx(7, "")
 		newNotifHandler(&fakeNotifRepo{}).MarkAllRead(c)
 		if c.Writer.Status() != http.StatusNoContent {
 			t.Fatalf("want 204, got %d", c.Writer.Status())
 		}
 	})
-	t.Run("repo error -> 400", func(t *testing.T) {
+	t.Run("リポジトリエラー → 400", func(t *testing.T) {
 		w, c := notifCtx(7, "")
 		newNotifHandler(&fakeNotifRepo{err: context.DeadlineExceeded}).MarkAllRead(c)
 		if w.Code != http.StatusBadRequest {
@@ -125,21 +125,21 @@ func TestNotificationHandler_MarkAllRead(t *testing.T) {
 }
 
 func TestNotificationHandler_UnreadCount(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "")
 		newNotifHandler(&fakeNotifRepo{}).UnreadCount(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := notifCtx(7, "")
 		newNotifHandler(&fakeNotifRepo{count: 3}).UnreadCount(c)
 		if w.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", w.Code)
 		}
 	})
-	t.Run("repo error -> 400", func(t *testing.T) {
+	t.Run("リポジトリエラー → 400", func(t *testing.T) {
 		w, c := notifCtx(7, "")
 		newNotifHandler(&fakeNotifRepo{err: context.DeadlineExceeded}).UnreadCount(c)
 		if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/profile_image_handler_test.go
+++ b/backend/internal/handler/profile_image_handler_test.go
@@ -41,7 +41,7 @@ func userIDCtx(body string, cur uint64, userIDParam string) (*httptest.ResponseR
 }
 
 func TestProfileImageHandler_IssueUploadURL(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := userIDCtx(`{}`, 0, "me")
 		newProfileImageHandler(fakeProfileImagePresigner{}).IssueUploadURL(c)
 		if w.Code != http.StatusUnauthorized {
@@ -55,14 +55,14 @@ func TestProfileImageHandler_IssueUploadURL(t *testing.T) {
 			t.Fatalf("want 403, got %d", w.Code)
 		}
 	})
-	t.Run("presigner error -> 400", func(t *testing.T) {
+	t.Run("presigner エラー → 400", func(t *testing.T) {
 		w, c := userIDCtx(`{"contentType":"image/png"}`, 7, "me")
 		newProfileImageHandler(fakeProfileImagePresigner{err: context.DeadlineExceeded}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := userIDCtx(`{"contentType":"image/png"}`, 7, "me")
 		newProfileImageHandler(fakeProfileImagePresigner{url: &domain.ProfileImageUploadURL{}}).IssueUploadURL(c)
 		if w.Code != http.StatusOK {

--- a/backend/internal/handler/teaching_material_handler_test.go
+++ b/backend/internal/handler/teaching_material_handler_test.go
@@ -15,14 +15,14 @@ func newTMHandler() *TeachingMaterialHandler {
 }
 
 func TestTeachingMaterialHandler_List(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, nil)
 		newTMHandler().List(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("ok", func(t *testing.T) {
+	t.Run("正常系", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, superAdminCo())
 		newTMHandler().List(c)
 		if w.Code != http.StatusOK {
@@ -32,14 +32,14 @@ func TestTeachingMaterialHandler_List(t *testing.T) {
 }
 
 func TestTeachingMaterialHandler_ListByCourse(t *testing.T) {
-	t.Run("unauthorized", func(t *testing.T) {
+	t.Run("未認証", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", idParam("1"), nil)
 		newTMHandler().ListByCourse(c)
 		if w.Code != http.StatusUnauthorized {
 			t.Fatalf("want 401, got %d", w.Code)
 		}
 	})
-	t.Run("bad id -> 400", func(t *testing.T) {
+	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
 		newTMHandler().ListByCourse(c)
 		if w.Code != http.StatusBadRequest {


### PR DESCRIPTION
## 概要

backend の `t.Run` サブテスト説明が英語/日本語で混在していた（125 件中 45 件のみ日本語）ため、英語の **80 件を日本語に統一**します。テストの**説明文字列のみ**の変更で、ロジックは不変です。

`describe` 相当の SUT 識別子や Go の `func TestXxx` 名は、CLAUDE.md §3.1「識別子は英語」の方針どおり英語のまま残します。

## 変更内容

- 対象 11 ファイル（80 件）:
  - `cmd/archlint` / `cmd/apispec-lint` / `cmd/naminglint` の `main_test.go`
  - `internal/handler/*_test.go`（course / note / notification / teaching_material / note_image / profile_image / ai_chat_attachment）
  - `adapter/persistence/course_repository_integration_test.go`
- 訳の例:
  - `"unauthorized"` → `"未認証"` / `"ok"` → `"正常系"` / `"bad id -> 400"` → `"不正な id → 400"`
  - `"domain importing usecase is a violation"` → `"domain が usecase を import するのは違反"`
- frontend は対象外（既に大半が日本語。英語の `describe` は `useXxx` 等の SUT 識別子のため変更しない）

## テスト

- `go build ./...` ✓ / `go test`（archlint / apispec-lint / naminglint / handler）✓
- `gofumpt -l` 差分なし ✓ / integration タグのコンパイル ✓
- 差分は 80 insertions / 80 deletions（1:1 の文字列置換のみ）

## 関連 Issue

なし（テストの可読性・一貫性向上）