### PR TITLE
test(usecase): Go テスト関数名を日本語化（internal/usecase・126 関数）

### DIFF
--- a/backend/internal/usecase/admin_invitation_usecase_test.go
+++ b/backend/internal/usecase/admin_invitation_usecase_test.go
@@ -73,14 +73,14 @@ func fakeBuildMail(link, displayName, _, role string) (string, string, string) {
 	return "subject", "html-" + link + "-" + displayName + "-" + role, "text-" + link
 }
 
-func TestListAdminInvitations_ListByCompanyID_RequiresCompanyID(t *testing.T) {
+func Test_招待一覧_会社ID指定_会社IDが必須(t *testing.T) {
 	uc := NewListAdminInvitationsUseCase(&stubAdminInvRepo{})
 	if _, err := uc.ListByCompanyID(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestListAdminInvitations_ListByCompanyID_DelegatesToRepo(t *testing.T) {
+func Test_招待一覧_会社ID指定_リポジトリへ委譲(t *testing.T) {
 	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 1}}}
 	uc := NewListAdminInvitationsUseCase(repo)
 	got, err := uc.ListByCompanyID(context.Background(), 42)
@@ -95,7 +95,7 @@ func TestListAdminInvitations_ListByCompanyID_DelegatesToRepo(t *testing.T) {
 	}
 }
 
-func TestListAdminInvitations_ListAll_DelegatesToRepo(t *testing.T) {
+func Test_招待一覧_全件_リポジトリへ委譲(t *testing.T) {
 	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 7}, {ID: 8}}}
 	uc := NewListAdminInvitationsUseCase(repo)
 	got, err := uc.ListAll(context.Background())
@@ -110,14 +110,14 @@ func TestListAdminInvitations_ListAll_DelegatesToRepo(t *testing.T) {
 	}
 }
 
-func TestCreateAdminInvitation_Validates(t *testing.T) {
+func Test_招待作成_バリデーション(t *testing.T) {
 	uc := NewCreateAdminInvitationUseCase(&stubAdminInvRepo{}, &stubMailSender{}, fakeBuildLink, fakeBuildMail)
 	if _, err := uc.Execute(context.Background(), CreateAdminInvitationInput{Email: "a@b"}); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestCreateAdminInvitation_OK_GeneratesTokenAndSendsEmail(t *testing.T) {
+func Test_招待作成_正常系_token生成とメール送信(t *testing.T) {
 	repo := &stubAdminInvRepo{}
 	sender := &stubMailSender{}
 	uc := NewCreateAdminInvitationUseCase(repo, sender, fakeBuildLink, fakeBuildMail)
@@ -149,7 +149,7 @@ func TestCreateAdminInvitation_OK_GeneratesTokenAndSendsEmail(t *testing.T) {
 	}
 }
 
-func TestCreateAdminInvitation_SESError_Propagated(t *testing.T) {
+func Test_招待作成_SESエラーを伝播(t *testing.T) {
 	uc := NewCreateAdminInvitationUseCase(&stubAdminInvRepo{}, &stubMailSender{err: errors.New("ses down")}, fakeBuildLink, fakeBuildMail)
 	if _, err := uc.Execute(context.Background(), CreateAdminInvitationInput{
 		CompanyID: 1, Email: "u@example.com", Role: domain.RoleTrainee,
@@ -159,7 +159,7 @@ func TestCreateAdminInvitation_SESError_Propagated(t *testing.T) {
 }
 
 // sender が nil の場合（ローカル開発でフォールバック）は invitation だけ作成して終わる。
-func TestCreateAdminInvitation_NilSender_SkipsEmailWithoutError(t *testing.T) {
+func Test_招待作成_送信者nilはメールをスキップ(t *testing.T) {
 	repo := &stubAdminInvRepo{}
 	uc := NewCreateAdminInvitationUseCase(repo, nil, nil, nil)
 	got, err := uc.Execute(context.Background(), CreateAdminInvitationInput{
@@ -173,7 +173,7 @@ func TestCreateAdminInvitation_NilSender_SkipsEmailWithoutError(t *testing.T) {
 	}
 }
 
-func TestCancelAdminInvitation_RequiresID(t *testing.T) {
+func Test_招待取消_IDが必須(t *testing.T) {
 	uc := NewCancelAdminInvitationUseCase(&stubAdminInvRepo{})
 	if err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")

--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -57,7 +57,7 @@ func (f *fakeMemberUserRepo) UpdateAiChatEnabled(_ context.Context, userID uint6
 func ptrBool(b bool) *bool    { return &b }
 func u64ptr(v uint64) *uint64 { return &v }
 
-func TestListCompanyMembersUseCase(t *testing.T) {
+func Test_会社メンバー一覧ユースケース(t *testing.T) {
 	repo := newFakeMemberUserRepo()
 	repo.byCompany[10] = []domain.User{{ID: 1, CompanyID: u64ptr(10)}, {ID: 2, CompanyID: u64ptr(10)}}
 	uc := usecase.NewListCompanyMembersUseCase(repo)
@@ -74,7 +74,7 @@ func TestListCompanyMembersUseCase(t *testing.T) {
 	})
 }
 
-func TestUpdateMemberAiAccessUseCase(t *testing.T) {
+func Test_メンバーAI利用可否更新ユースケース(t *testing.T) {
 	repo := newFakeMemberUserRepo()
 	repo.byID[1] = &domain.User{ID: 1, CompanyID: u64ptr(10), Role: domain.RoleTrainee}
 	repo.byID[2] = &domain.User{ID: 2, CompanyID: u64ptr(20), Role: domain.RoleTrainee} // 別会社

--- a/backend/internal/usecase/ai_chat_usecase_test.go
+++ b/backend/internal/usecase/ai_chat_usecase_test.go
@@ -36,7 +36,7 @@ func (s *stubAiChatSessionRepo) Delete(_ context.Context, _ uint64) error {
 	return s.err
 }
 
-func TestGetAiChatSessionsByUserID(t *testing.T) {
+func Test_AIチャットセッション一覧_ユーザー別(t *testing.T) {
 	repo := &stubAiChatSessionRepo{rows: []domain.AiChatSession{{ID: 1, UserID: 7, Title: "a"}}}
 	uc := NewGetAiChatSessionsByUserIDUseCase(repo)
 	got, err := uc.Execute(context.Background(), 7)
@@ -48,7 +48,7 @@ func TestGetAiChatSessionsByUserID(t *testing.T) {
 	}
 }
 
-func TestCreateAiChatSession_RequiresTitle(t *testing.T) {
+func Test_AIチャットセッション作成_タイトルが必須(t *testing.T) {
 	uc := NewCreateAiChatSessionUseCase(&stubAiChatSessionRepo{})
 	_, err := uc.Execute(context.Background(), CreateAiChatSessionInput{UserID: 1})
 	if err == nil {
@@ -56,7 +56,7 @@ func TestCreateAiChatSession_RequiresTitle(t *testing.T) {
 	}
 }
 
-func TestCreateAiChatSession_DefaultsTypeToFree(t *testing.T) {
+func Test_AIチャットセッション作成_種別は既定でfree(t *testing.T) {
 	uc := NewCreateAiChatSessionUseCase(&stubAiChatSessionRepo{})
 	got, err := uc.Execute(context.Background(), CreateAiChatSessionInput{UserID: 1, Title: "x"})
 	if err != nil {

--- a/backend/internal/usecase/company_settings_usecase_test.go
+++ b/backend/internal/usecase/company_settings_usecase_test.go
@@ -33,7 +33,7 @@ func (s *settingsCompanyRepo) UpdateAiChatEnabled(_ context.Context, _ uint64, e
 
 func u64p(v uint64) *uint64 { return &v }
 
-func TestGetCompanyAiChatSetting(t *testing.T) {
+func Test_会社AIチャット設定取得(t *testing.T) {
 	t.Run("trainee は forbidden", func(t *testing.T) {
 		uc := usecase.NewGetCompanyAiChatSettingUseCase(&settingsCompanyRepo{})
 		_, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1)})
@@ -55,7 +55,7 @@ func TestGetCompanyAiChatSetting(t *testing.T) {
 	})
 }
 
-func TestUpdateCompanyAiChatSetting(t *testing.T) {
+func Test_会社AIチャット設定更新(t *testing.T) {
 	t.Run("非 admin は forbidden", func(t *testing.T) {
 		uc := usecase.NewUpdateCompanyAiChatSettingUseCase(&settingsCompanyRepo{})
 		_, err := uc.Execute(context.Background(), &domain.User{Role: domain.RoleTrainee, CompanyID: u64p(1)}, false)
@@ -73,7 +73,7 @@ func TestUpdateCompanyAiChatSetting(t *testing.T) {
 	})
 }
 
-func TestAiChatEnabledForUser(t *testing.T) {
+func Test_ユーザーのAIチャット利用可否(t *testing.T) {
 	t.Run("admin は会社設定に関わらず常に true", func(t *testing.T) {
 		repo := &settingsCompanyRepo{company: &domain.Company{AiChatEnabledForTrainees: false}}
 		uc := usecase.NewAiChatEnabledForUserUseCase(repo)

--- a/backend/internal/usecase/complete_onboarding_usecase_test.go
+++ b/backend/internal/usecase/complete_onboarding_usecase_test.go
@@ -19,14 +19,14 @@ func (s *stubMarkOnboardedRepo) MarkOnboarded(_ context.Context, userID uint64) 
 	return s.err
 }
 
-func TestCompleteOnboarding_RequiresUserID(t *testing.T) {
+func Test_オンボーディング完了_ユーザーIDが必須(t *testing.T) {
 	uc := NewCompleteOnboardingUseCase(&stubMarkOnboardedRepo{})
 	if err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error for userID=0")
 	}
 }
 
-func TestCompleteOnboarding_DelegatesToRepo(t *testing.T) {
+func Test_オンボーディング完了_リポジトリへ委譲(t *testing.T) {
 	repo := &stubMarkOnboardedRepo{}
 	uc := NewCompleteOnboardingUseCase(repo)
 	if err := uc.Execute(context.Background(), 42); err != nil {
@@ -37,7 +37,7 @@ func TestCompleteOnboarding_DelegatesToRepo(t *testing.T) {
 	}
 }
 
-func TestCompleteOnboarding_RepoErrorBubbles(t *testing.T) {
+func Test_オンボーディング完了_リポジトリエラーを伝播(t *testing.T) {
 	uc := NewCompleteOnboardingUseCase(&stubMarkOnboardedRepo{err: errors.New("db down")})
 	if err := uc.Execute(context.Background(), 1); err == nil {
 		t.Fatal("expected error to bubble")

--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCourseUseCase_List_TraineeOnlyPublished(t *testing.T) {
+func Test_コース_一覧_traineeは公開のみ(t *testing.T) {
 	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -18,7 +18,7 @@ func TestCourseUseCase_List_TraineeOnlyPublished(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestCourseUseCase_List_NoCompanyReturnsEmpty(t *testing.T) {
+func Test_コース_一覧_会社未所属は空(t *testing.T) {
 	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -27,7 +27,7 @@ func TestCourseUseCase_List_NoCompanyReturnsEmpty(t *testing.T) {
 	assert.Empty(t, out)
 }
 
-func TestCourseUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
+func Test_コース_取得_traineeは下書き不可(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -36,7 +36,7 @@ func TestCourseUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
-func TestCourseUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
+func Test_コース_取得_traineeは自社の公開を読める(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -45,7 +45,7 @@ func TestCourseUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
 	assert.Equal(t, uint64(5), got.ID)
 }
 
-func TestCourseUseCase_Get_CrossCompanyForbidden(t *testing.T) {
+func Test_コース_取得_別会社は禁止(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -53,7 +53,7 @@ func TestCourseUseCase_Get_CrossCompanyForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCourseUseCase_Create_TraineeForbidden(t *testing.T) {
+func Test_コース_作成_traineeは禁止(t *testing.T) {
 	crepo := &fakeCourseRepo{}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -64,7 +64,7 @@ func TestCourseUseCase_Create_TraineeForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCourseUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
+func Test_コース_作成_会社管理者は成功(t *testing.T) {
 	crepo := &fakeCourseRepo{}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -80,7 +80,7 @@ func TestCourseUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
 	assert.Equal(t, 10, got.SortOrder)
 }
 
-func TestCourseUseCase_Create_NoCompanyForbidden(t *testing.T) {
+func Test_コース_作成_会社未所属は禁止(t *testing.T) {
 	crepo := &fakeCourseRepo{}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -91,7 +91,7 @@ func TestCourseUseCase_Create_NoCompanyForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCourseUseCase_Update_CrossCompanyForbidden(t *testing.T) {
+func Test_コース_更新_別会社は禁止(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -102,7 +102,7 @@ func TestCourseUseCase_Update_CrossCompanyForbidden(t *testing.T) {
 	assert.Nil(t, crepo.updated)
 }
 
-func TestCourseUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
+func Test_コース_更新_自社管理者は成功(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -115,7 +115,7 @@ func TestCourseUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
 	assert.NotNil(t, crepo.updated)
 }
 
-func TestCourseUseCase_Delete_TraineeForbidden(t *testing.T) {
+func Test_コース_削除_traineeは禁止(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
@@ -123,7 +123,7 @@ func TestCourseUseCase_Delete_TraineeForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestCourseUseCase_Delete_SameCompanyAdminCascadesMaterials(t *testing.T) {
+func Test_コース_削除_自社管理者は教材も連鎖削除(t *testing.T) {
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
 	mrepo := &fakeTeachingMaterialRepo{}
 	uc := usecase.NewCourseUseCase(crepo, mrepo)

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -69,7 +69,7 @@ func (r *recordingNotifRepo) CountUnread(context.Context, uint64) (int64, error)
 	return 0, nil
 }
 
-func TestCreateCompanyApplication_NotifiesSuperAdmins(t *testing.T) {
+func Test_会社申請作成_運営管理者へ通知(t *testing.T) {
 	apps := &fakeAppRepo{}
 	users := &fakeUsersForApp{admins: []domain.User{{ID: 10}, {ID: 11}}}
 	notifs := &recordingNotifRepo{}
@@ -95,7 +95,7 @@ func TestCreateCompanyApplication_NotifiesSuperAdmins(t *testing.T) {
 	}
 }
 
-func TestCreateCompanyApplication_Validation(t *testing.T) {
+func Test_会社申請作成_バリデーション(t *testing.T) {
 	uc := usecase.NewCreateCompanyApplicationUseCase(&fakeAppRepo{}, &fakeUsersForApp{}, &recordingNotifRepo{})
 	cases := []usecase.CreateCompanyApplicationInput{
 		{CompanyName: "", ApplicantName: "a", Email: "a@b.com"},     // company 欠落
@@ -110,7 +110,7 @@ func TestCreateCompanyApplication_Validation(t *testing.T) {
 	}
 }
 
-func TestCreateCompanyApplication_SavesEvenIfNotifyFails(t *testing.T) {
+func Test_会社申請作成_通知失敗でも保存(t *testing.T) {
 	// 通知作成に失敗しても申請保存は成功扱い（best-effort）。
 	apps := &fakeAppRepo{}
 	users := &fakeUsersForApp{admins: []domain.User{{ID: 10}}}

--- a/backend/internal/usecase/execute_code_usecase_test.go
+++ b/backend/internal/usecase/execute_code_usecase_test.go
@@ -33,7 +33,7 @@ func (f *fakeCodeRunner) Warmup(_ context.Context, language string) error {
 	return f.warmupErr
 }
 
-func TestExecuteCodeUseCase_DelegatesToRunner(t *testing.T) {
+func Test_コード実行_ランナーへ委譲(t *testing.T) {
 	fake := &fakeCodeRunner{result: &domain.CodeExecutionResult{Stdout: "ok", ExitCode: 0}}
 	uc := usecase.NewExecuteCodeUseCase(fake)
 
@@ -49,7 +49,7 @@ func TestExecuteCodeUseCase_DelegatesToRunner(t *testing.T) {
 	assert.Equal(t, "x", fake.gotInput.Stdin)
 }
 
-func TestExecuteCodeUseCase_PropagatesRunnerError(t *testing.T) {
+func Test_コード実行_ランナーエラーを伝播(t *testing.T) {
 	fake := &fakeCodeRunner{runErr: errors.New("boom")}
 	uc := usecase.NewExecuteCodeUseCase(fake)
 
@@ -57,7 +57,7 @@ func TestExecuteCodeUseCase_PropagatesRunnerError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestWarmupCodeUseCase_DelegatesLanguage(t *testing.T) {
+func Test_コードウォームアップ_言語を委譲(t *testing.T) {
 	fake := &fakeCodeRunner{}
 	uc := usecase.NewWarmupCodeUseCase(fake)
 
@@ -65,7 +65,7 @@ func TestWarmupCodeUseCase_DelegatesLanguage(t *testing.T) {
 	assert.Equal(t, "go", fake.gotWarmup)
 }
 
-func TestWarmupCodeUseCase_PropagatesError(t *testing.T) {
+func Test_コードウォームアップ_エラーを伝播(t *testing.T) {
 	fake := &fakeCodeRunner{warmupErr: errors.New("warm failed")}
 	uc := usecase.NewWarmupCodeUseCase(fake)
 

--- a/backend/internal/usecase/get_current_user_usecase_test.go
+++ b/backend/internal/usecase/get_current_user_usecase_test.go
@@ -51,7 +51,7 @@ func (s *stubUserRepo) MarkOnboarded(_ context.Context, _ uint64) error {
 	return s.err
 }
 
-func TestGetCurrentUserUseCase_Found(t *testing.T) {
+func Test_現在ユーザー取得_見つかる(t *testing.T) {
 	want := &domain.User{ID: 1, CognitoSub: "abc", Email: "u@example.com"}
 	uc := NewGetCurrentUserUseCase(&stubUserRepo{user: want})
 	got, err := uc.Execute(context.Background(), "abc")
@@ -63,7 +63,7 @@ func TestGetCurrentUserUseCase_Found(t *testing.T) {
 	}
 }
 
-func TestGetCurrentUserUseCase_NotFound(t *testing.T) {
+func Test_現在ユーザー取得_見つからない(t *testing.T) {
 	uc := NewGetCurrentUserUseCase(&stubUserRepo{user: nil})
 	got, err := uc.Execute(context.Background(), "missing")
 	if err != nil {
@@ -74,7 +74,7 @@ func TestGetCurrentUserUseCase_NotFound(t *testing.T) {
 	}
 }
 
-func TestGetCurrentUserUseCase_Error(t *testing.T) {
+func Test_現在ユーザー取得_エラー(t *testing.T) {
 	uc := NewGetCurrentUserUseCase(&stubUserRepo{err: errors.New("db down")})
 	if _, err := uc.Execute(context.Background(), "x"); err == nil {
 		t.Fatal("expected error")

--- a/backend/internal/usecase/health_usecase_test.go
+++ b/backend/internal/usecase/health_usecase_test.go
@@ -14,7 +14,7 @@ type stubHealthRepo struct {
 
 func (s *stubHealthRepo) PingDB(_ context.Context) error { return s.err }
 
-func TestCheckHealthUseCase_DBUp(t *testing.T) {
+func Test_ヘルスチェック_DB正常(t *testing.T) {
 	uc := NewCheckHealthUseCase(&stubHealthRepo{err: nil})
 	got := uc.Execute(context.Background())
 	if got.Status != domain.StatusUp || got.DBStatus != domain.StatusUp {
@@ -22,7 +22,7 @@ func TestCheckHealthUseCase_DBUp(t *testing.T) {
 	}
 }
 
-func TestCheckHealthUseCase_DBDown(t *testing.T) {
+func Test_ヘルスチェック_DB異常(t *testing.T) {
 	uc := NewCheckHealthUseCase(&stubHealthRepo{err: errors.New("ping failed")})
 	got := uc.Execute(context.Background())
 	if got.Status != domain.StatusDown || got.DBStatus != domain.StatusDown {

--- a/backend/internal/usecase/learning_report_usecase_test.go
+++ b/backend/internal/usecase/learning_report_usecase_test.go
@@ -30,14 +30,14 @@ type stubEnqueuer struct{ err error }
 
 func (s *stubEnqueuer) Enqueue(_ context.Context, _ uint64) error { return s.err }
 
-func TestListLearningReports_RequiresUserID(t *testing.T) {
+func Test_学習レポート一覧_ユーザーIDが必須(t *testing.T) {
 	uc := NewListLearningReportsUseCase(&stubLearningReportRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestRequestLearningReport_Validates(t *testing.T) {
+func Test_学習レポート要求_バリデーション(t *testing.T) {
 	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{})
 	now := time.Now()
 	if _, err := uc.Execute(context.Background(), RequestLearningReportInput{UserID: 1, PeriodFrom: now, PeriodTo: now}); err == nil {
@@ -45,7 +45,7 @@ func TestRequestLearningReport_Validates(t *testing.T) {
 	}
 }
 
-func TestRequestLearningReport_OK(t *testing.T) {
+func Test_学習レポート要求_正常系(t *testing.T) {
 	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{})
 	now := time.Now()
 	got, err := uc.Execute(context.Background(), RequestLearningReportInput{
@@ -56,7 +56,7 @@ func TestRequestLearningReport_OK(t *testing.T) {
 	}
 }
 
-func TestRequestLearningReport_EnqueueError(t *testing.T) {
+func Test_学習レポート要求_enqueueエラー(t *testing.T) {
 	uc := NewRequestLearningReportUseCase(&stubLearningReportRepo{}, &stubEnqueuer{err: errors.New("sqs")})
 	now := time.Now()
 	if _, err := uc.Execute(context.Background(), RequestLearningReportInput{

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -53,7 +53,7 @@ func (f *fakeManageRepo) UpdateCompanyID(context.Context, uint64, uint64) error 
 
 func (f *fakeManageRepo) MarkOnboarded(context.Context, uint64) error { return nil }
 
-func TestSetMemberActive_CompanyAdmin_OwnCompany_OK(t *testing.T) {
+func Test_メンバー有効化_会社管理者_自社_OK(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
@@ -65,7 +65,7 @@ func TestSetMemberActive_CompanyAdmin_OwnCompany_OK(t *testing.T) {
 	assert.False(t, *repo.updateActiveGot)
 }
 
-func TestSetMemberActive_CompanyAdmin_OtherCompany_Forbidden(t *testing.T) {
+func Test_メンバー有効化_会社管理者_別会社_禁止(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
@@ -76,7 +76,7 @@ func TestSetMemberActive_CompanyAdmin_OtherCompany_Forbidden(t *testing.T) {
 	assert.Nil(t, repo.updateActiveGot, "別会社では更新してはならない")
 }
 
-func TestSetMemberActive_SuperAdmin_AnyCompany_OK(t *testing.T) {
+func Test_メンバー有効化_運営管理者_任意の会社_OK(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
@@ -87,7 +87,7 @@ func TestSetMemberActive_SuperAdmin_AnyCompany_OK(t *testing.T) {
 	require.NotNil(t, repo.updateActiveGot)
 }
 
-func TestSetMemberActive_Self_Forbidden(t *testing.T) {
+func Test_メンバー有効化_自分自身_禁止(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}}
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
@@ -98,7 +98,7 @@ func TestSetMemberActive_Self_Forbidden(t *testing.T) {
 	assert.Nil(t, repo.updateActiveGot, "自分自身は無効化できない")
 }
 
-func TestSetMemberActive_NotFound(t *testing.T) {
+func Test_メンバー有効化_見つからない(t *testing.T) {
 	repo := &fakeManageRepo{target: nil}
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
@@ -108,7 +108,7 @@ func TestSetMemberActive_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
 }
 
-func TestSoftDeleteMember_CompanyAdmin_OwnCompany_OK(t *testing.T) {
+func Test_メンバー論理削除_会社管理者_自社_OK(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
@@ -119,7 +119,7 @@ func TestSoftDeleteMember_CompanyAdmin_OwnCompany_OK(t *testing.T) {
 	assert.True(t, repo.softDeleted)
 }
 
-func TestSoftDeleteMember_Self_Forbidden(t *testing.T) {
+func Test_メンバー論理削除_自分自身_禁止(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}}
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
@@ -130,7 +130,7 @@ func TestSoftDeleteMember_Self_Forbidden(t *testing.T) {
 	assert.False(t, repo.softDeleted, "自分自身は削除できない")
 }
 
-func TestSoftDeleteMember_CompanyAdmin_OtherCompany_Forbidden(t *testing.T) {
+func Test_メンバー論理削除_会社管理者_別会社_禁止(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}

--- a/backend/internal/usecase/normalize_output_test.go
+++ b/backend/internal/usecase/normalize_output_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 // normalizeOutput は採点の出力比較で使う正規化。学習者に見えない行末空白で
 // 不合格にしないことを検証する（`fmt.Printf("%d \n")` の余分なスペース等）。
-func TestNormalizeOutput(t *testing.T) {
+func Test_出力の正規化(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string

--- a/backend/internal/usecase/note_image_usecase_test.go
+++ b/backend/internal/usecase/note_image_usecase_test.go
@@ -16,14 +16,14 @@ func (s *stubPresigner) Generate(_ context.Context, _ uint64, _ string) (*domain
 	return s.url, s.err
 }
 
-func TestIssueNoteImageUploadURL_RequiresUserID(t *testing.T) {
+func Test_ノート画像アップロードURL発行_ユーザーIDが必須(t *testing.T) {
 	uc := NewIssueNoteImageUploadURLUseCase(&stubPresigner{})
 	if _, err := uc.Execute(context.Background(), 0, "image/png"); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestIssueNoteImageUploadURL_Returns(t *testing.T) {
+func Test_ノート画像アップロードURL発行_URLを返す(t *testing.T) {
 	uc := NewIssueNoteImageUploadURLUseCase(&stubPresigner{
 		url: &domain.NoteImageUploadURL{URL: "https://example", Key: "k", ExpiresIn: 60},
 	})

--- a/backend/internal/usecase/note_usecase_test.go
+++ b/backend/internal/usecase/note_usecase_test.go
@@ -47,21 +47,21 @@ func (s *stubNoteRepo) Delete(_ context.Context, userID, id uint64) error {
 	return s.err
 }
 
-func TestListNotes_RequiresUserID(t *testing.T) {
+func Test_ノート一覧_ユーザーIDが必須(t *testing.T) {
 	uc := NewListNotesByUserIDUseCase(&stubNoteRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestCreateNote_RequiresTitle(t *testing.T) {
+func Test_ノート作成_タイトルが必須(t *testing.T) {
 	uc := NewCreateNoteUseCase(&stubNoteRepo{})
 	if _, err := uc.Execute(context.Background(), CreateNoteInput{UserID: 1}); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestCreateNote_AssignsID(t *testing.T) {
+func Test_ノート作成_IDを採番(t *testing.T) {
 	uc := NewCreateNoteUseCase(&stubNoteRepo{})
 	got, err := uc.Execute(context.Background(), CreateNoteInput{UserID: 1, Title: "t"})
 	if err != nil || got.ID != 21 {
@@ -69,21 +69,21 @@ func TestCreateNote_AssignsID(t *testing.T) {
 	}
 }
 
-func TestUpdateNote_RequiresUserID(t *testing.T) {
+func Test_ノート更新_ユーザーIDが必須(t *testing.T) {
 	uc := NewUpdateNoteUseCase(&stubNoteRepo{one: &domain.Note{ID: 1, UserID: 1}})
 	if _, err := uc.Execute(context.Background(), UpdateNoteInput{ID: 1, Title: "x"}); err == nil {
 		t.Fatal("expected error when userID is 0")
 	}
 }
 
-func TestUpdateNote_RequiresID(t *testing.T) {
+func Test_ノート更新_IDが必須(t *testing.T) {
 	uc := NewUpdateNoteUseCase(&stubNoteRepo{one: &domain.Note{ID: 1, UserID: 1}})
 	if _, err := uc.Execute(context.Background(), UpdateNoteInput{UserID: 1, Title: "x"}); err == nil {
 		t.Fatal("expected error when id is 0")
 	}
 }
 
-func TestUpdateNote_RejectsForeignOwner(t *testing.T) {
+func Test_ノート更新_他人の所有を拒否(t *testing.T) {
 	repo := &stubNoteRepo{one: &domain.Note{ID: 1, UserID: 99}}
 	uc := NewUpdateNoteUseCase(repo)
 	_, err := uc.Execute(context.Background(), UpdateNoteInput{UserID: 1, ID: 1, Title: "x"})
@@ -95,7 +95,7 @@ func TestUpdateNote_RejectsForeignOwner(t *testing.T) {
 	}
 }
 
-func TestUpdateNote_AllowsOwner(t *testing.T) {
+func Test_ノート更新_所有者は許可(t *testing.T) {
 	repo := &stubNoteRepo{one: &domain.Note{ID: 1, UserID: 1, Title: "old"}}
 	uc := NewUpdateNoteUseCase(repo)
 	got, err := uc.Execute(context.Background(), UpdateNoteInput{UserID: 1, ID: 1, Title: "new"})
@@ -110,21 +110,21 @@ func TestUpdateNote_AllowsOwner(t *testing.T) {
 	}
 }
 
-func TestDeleteNote_RequiresUserID(t *testing.T) {
+func Test_ノート削除_ユーザーIDが必須(t *testing.T) {
 	uc := NewDeleteNoteUseCase(&stubNoteRepo{})
 	if err := uc.Execute(context.Background(), 0, 1); err == nil {
 		t.Fatal("expected error when userID is 0")
 	}
 }
 
-func TestDeleteNote_RequiresID(t *testing.T) {
+func Test_ノート削除_IDが必須(t *testing.T) {
 	uc := NewDeleteNoteUseCase(&stubNoteRepo{})
 	if err := uc.Execute(context.Background(), 1, 0); err == nil {
 		t.Fatal("expected error when id is 0")
 	}
 }
 
-func TestDeleteNote_PassesUserIDToRepo(t *testing.T) {
+func Test_ノート削除_ユーザーIDをリポジトリへ渡す(t *testing.T) {
 	repo := &stubNoteRepo{}
 	uc := NewDeleteNoteUseCase(repo)
 	if err := uc.Execute(context.Background(), 7, 11); err != nil {

--- a/backend/internal/usecase/notification_usecase_test.go
+++ b/backend/internal/usecase/notification_usecase_test.go
@@ -25,35 +25,35 @@ func (s *stubNotificationRepo) CountUnread(_ context.Context, _ uint64) (int64, 
 	return int64(len(s.rows)), s.err
 }
 
-func TestListNotifications_RequiresUserID(t *testing.T) {
+func Test_通知一覧_ユーザーIDが必須(t *testing.T) {
 	uc := NewListNotificationsUseCase(&stubNotificationRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestMarkRead_RequiresUserID(t *testing.T) {
+func Test_既読化_ユーザーIDが必須(t *testing.T) {
 	uc := NewMarkNotificationReadUseCase(&stubNotificationRepo{})
 	if err := uc.Execute(context.Background(), 0, 1); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestMarkRead_RequiresID(t *testing.T) {
+func Test_既読化_IDが必須(t *testing.T) {
 	uc := NewMarkNotificationReadUseCase(&stubNotificationRepo{})
 	if err := uc.Execute(context.Background(), 1, 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestMarkAllNotificationsRead_RequiresUserID(t *testing.T) {
+func Test_全通知既読化_ユーザーIDが必須(t *testing.T) {
 	uc := NewMarkAllNotificationsReadUseCase(&stubNotificationRepo{})
 	if err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestCountUnreadNotifications_RequiresUserID(t *testing.T) {
+func Test_未読数取得_ユーザーIDが必須(t *testing.T) {
 	uc := NewCountUnreadNotificationsUseCase(&stubNotificationRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")

--- a/backend/internal/usecase/profile_image_usecase_test.go
+++ b/backend/internal/usecase/profile_image_usecase_test.go
@@ -31,14 +31,14 @@ func (s *stubProfileImagePresigner) Generate(_ context.Context, userID uint64, f
 	}, nil
 }
 
-func TestIssueProfileImageUploadURL_RequiresUserID(t *testing.T) {
+func Test_プロフィール画像アップロードURL発行_ユーザーIDが必須(t *testing.T) {
 	uc := NewIssueProfileImageUploadURLUseCase(&stubProfileImagePresigner{})
 	if _, err := uc.Execute(context.Background(), 0, "a.png", "image/png"); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestIssueProfileImageUploadURL_PassesArgsToPresigner(t *testing.T) {
+func Test_プロフィール画像アップロードURL発行_presignerへ引数を渡す(t *testing.T) {
 	stub := &stubProfileImagePresigner{}
 	uc := NewIssueProfileImageUploadURLUseCase(stub)
 	got, err := uc.Execute(context.Background(), 7, "icon.jpg", "image/jpeg")

--- a/backend/internal/usecase/profile_usecase_test.go
+++ b/backend/internal/usecase/profile_usecase_test.go
@@ -24,14 +24,14 @@ func (s *stubProfileRepo) Upsert(_ context.Context, p *domain.Profile) error {
 	return nil
 }
 
-func TestGetProfile_RequiresUserID(t *testing.T) {
+func Test_プロフィール取得_ユーザーIDが必須(t *testing.T) {
 	uc := NewGetProfileUseCase(&stubProfileRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestGetProfile_NotFoundReturnsNil(t *testing.T) {
+func Test_プロフィール取得_見つからなければnil(t *testing.T) {
 	uc := NewGetProfileUseCase(&stubProfileRepo{p: nil})
 	got, err := uc.Execute(context.Background(), 1)
 	if err != nil || got != nil {
@@ -39,14 +39,14 @@ func TestGetProfile_NotFoundReturnsNil(t *testing.T) {
 	}
 }
 
-func TestUpdateProfile_RequiresUserID(t *testing.T) {
+func Test_プロフィール更新_ユーザーIDが必須(t *testing.T) {
 	uc := NewUpdateProfileUseCase(&stubProfileRepo{})
 	if _, err := uc.Execute(context.Background(), UpdateProfileInput{}); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestUpdateProfile_Persists(t *testing.T) {
+func Test_プロフィール更新_永続化する(t *testing.T) {
 	repo := &stubProfileRepo{}
 	uc := NewUpdateProfileUseCase(repo)
 	got, err := uc.Execute(context.Background(), UpdateProfileInput{UserID: 1, Bio: "hi"})

--- a/backend/internal/usecase/send_ai_message_stream_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase_test.go
@@ -70,7 +70,7 @@ func (m *mockStreamBedrock) ConverseStream(ctx context.Context, systemPrompt str
 }
 
 // 既存セッションの場合: Delta が逐次流れて、最後に FinalMessage で完了する。
-func TestSendAiMessageStream_ExistingSession_StreamsTokensAndSavesFinal(t *testing.T) {
+func Test_AIメッセージ送信ストリーム_既存セッション_トークン配信と最終保存(t *testing.T) {
 	sessionRepo := new(mockSessionRepo)
 	msgRepo := new(mockMsgRepo)
 	bc := new(mockStreamBedrock)
@@ -120,7 +120,7 @@ func TestSendAiMessageStream_ExistingSession_StreamsTokensAndSavesFinal(t *testi
 }
 
 // 新規セッションの場合: NewSession イベントが先に流れて、token + Final が続く。
-func TestSendAiMessageStream_NewSession_EmitsSessionFirst(t *testing.T) {
+func Test_AIメッセージ送信ストリーム_新規セッション_先にセッションを通知(t *testing.T) {
 	sessionRepo := new(mockSessionRepo)
 	msgRepo := new(mockMsgRepo)
 	bc := new(mockStreamBedrock)
@@ -161,7 +161,7 @@ func TestSendAiMessageStream_NewSession_EmitsSessionFirst(t *testing.T) {
 
 // 添付付き発話: Downloader が S3 から bytes を取得し、Bedrock 呼び出し前に
 // 履歴の最新 user メッセージへ BlobData が詰められる。
-func TestSendAiMessageStream_WithAttachment_FetchesBlobAndSavesMetadata(t *testing.T) {
+func Test_AIメッセージ送信ストリーム_添付あり_blob取得とメタ保存(t *testing.T) {
 	sessionRepo := new(mockSessionRepo)
 	msgRepo := new(mockMsgRepo)
 	bc := new(mockStreamBedrock)
@@ -235,7 +235,7 @@ func (f *fakeDownloader) Download(_ context.Context, key string) ([]byte, error)
 
 // Bedrock が token を 1 つも emit せず Done だけを返した場合、空アシスタントを
 // DDB に保存しないでエラーを伝える（負のループ防止）。
-func TestSendAiMessageStream_EmptyResponse_DoesNotSaveAndPropagatesErr(t *testing.T) {
+func Test_AIメッセージ送信ストリーム_空応答_保存せずエラー伝播(t *testing.T) {
 	sessionRepo := new(mockSessionRepo)
 	msgRepo := new(mockMsgRepo)
 	bc := new(mockStreamBedrock)
@@ -273,7 +273,7 @@ func TestSendAiMessageStream_EmptyResponse_DoesNotSaveAndPropagatesErr(t *testin
 }
 
 // Bedrock 呼び出しで stream エラー: ev.Err が channel に流れて使い手に伝わる。
-func TestSendAiMessageStream_StreamError_PropagatesErr(t *testing.T) {
+func Test_AIメッセージ送信ストリーム_ストリームエラーを伝播(t *testing.T) {
 	sessionRepo := new(mockSessionRepo)
 	msgRepo := new(mockMsgRepo)
 	bc := new(mockStreamBedrock)

--- a/backend/internal/usecase/session_note_usecase_test.go
+++ b/backend/internal/usecase/session_note_usecase_test.go
@@ -24,21 +24,21 @@ func (s *stubSessionNoteRepo) Upsert(_ context.Context, n *domain.SessionNote) e
 	return nil
 }
 
-func TestGetSessionNote_RequiresSessionID(t *testing.T) {
+func Test_セッションノート取得_セッションIDが必須(t *testing.T) {
 	uc := NewGetSessionNoteUseCase(&stubSessionNoteRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestUpsertSessionNote_Validates(t *testing.T) {
+func Test_セッションノート保存_バリデーション(t *testing.T) {
 	uc := NewUpsertSessionNoteUseCase(&stubSessionNoteRepo{})
 	if _, err := uc.Execute(context.Background(), UpsertSessionNoteInput{}); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestUpsertSessionNote_Persists(t *testing.T) {
+func Test_セッションノート保存_永続化する(t *testing.T) {
 	repo := &stubSessionNoteRepo{}
 	uc := NewUpsertSessionNoteUseCase(repo)
 	got, err := uc.Execute(context.Background(), UpsertSessionNoteInput{SessionID: 1, UserID: 2, Content: "hello"})

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -96,7 +96,7 @@ func (f *fakeExecutor) Execute(_ context.Context, in domain.CodeExecutionInput) 
 	return out, nil
 }
 
-func TestSubmitMasterExercise_AllPass(t *testing.T) {
+func Test_演習提出_全テスト成功(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{ID: 7, Slug: "php-7", Language: "php"},
 	}
@@ -128,7 +128,7 @@ func TestSubmitMasterExercise_AllPass(t *testing.T) {
 	assert.Len(t, executor.calls, 2)
 }
 
-func TestSubmitMasterExercise_OneFails(t *testing.T) {
+func Test_演習提出_一部失敗(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{ID: 7, Slug: "php-7", Language: "php"},
 	}
@@ -160,7 +160,7 @@ func TestSubmitMasterExercise_OneFails(t *testing.T) {
 	assert.Len(t, executor.calls, 2)
 }
 
-func TestSubmitMasterExercise_NormalizeOutput(t *testing.T) {
+func Test_演習提出_出力を正規化(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{ID: 1, Slug: "s", Language: "php"},
 	}
@@ -179,7 +179,7 @@ func TestSubmitMasterExercise_NormalizeOutput(t *testing.T) {
 	assert.True(t, out.IsCorrect)
 }
 
-func TestSubmitMasterExercise_NonZeroExit_Fails(t *testing.T) {
+func Test_演習提出_非ゼロ終了は失敗(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{ID: 1, Slug: "s", Language: "php"},
 	}
@@ -204,7 +204,7 @@ func TestSubmitMasterExercise_NonZeroExit_Fails(t *testing.T) {
 
 // examples が登録されていない演習 (seed.py 経由で投入された linux/git/go 等) は
 // exercise 自身の ExpectedOutput を 単一テストケースとして fallback する。
-func TestSubmitMasterExercise_NoExamples_FallbackToExerciseExpected(t *testing.T) {
+func Test_演習提出_例なしは期待出力にフォールバック(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{
 			ID: 1, Slug: "linux-1", Language: "bash",
@@ -229,7 +229,7 @@ func TestSubmitMasterExercise_NoExamples_FallbackToExerciseExpected(t *testing.T
 
 // SubmitMasterExerciseUseCase が exercise.Language を domain.CodeExecutionInput に正しく渡しているか。
 // 旧実装は "php" 固定だったため、 Go / bash / Linux 演習が正しく実行できない不具合があった。
-func TestSubmitMasterExercise_PassesExerciseLanguage(t *testing.T) {
+func Test_演習提出_演習の言語を渡す(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{ID: 9, Slug: "go-1", Language: "go"},
 	}
@@ -248,7 +248,7 @@ func TestSubmitMasterExercise_PassesExerciseLanguage(t *testing.T) {
 	assert.Equal(t, "go", executor.calls[0].Language)
 }
 
-func TestSubmitMasterExercise_QA_Correct(t *testing.T) {
+func Test_演習提出_QA_正解(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{
 			ID: 100, Slug: "docker-1", Language: "shell",
@@ -273,7 +273,7 @@ func TestSubmitMasterExercise_QA_Correct(t *testing.T) {
 	assert.True(t, submissions.created.IsCorrect)
 }
 
-func TestSubmitMasterExercise_QA_Wrong(t *testing.T) {
+func Test_演習提出_QA_不正解(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{
 			ID: 100, Slug: "docker-1", Language: "shell",
@@ -295,7 +295,7 @@ func TestSubmitMasterExercise_QA_Wrong(t *testing.T) {
 }
 
 // QA モードでも 末尾改行 / 空白の差異は normalize で吸収する。
-func TestSubmitMasterExercise_QA_NormalizesTrailingWhitespace(t *testing.T) {
+func Test_演習提出_QA_末尾空白を正規化(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{
 		get: &domain.MasterExercise{
 			ID: 100, Slug: "docker-1", Language: "shell",
@@ -312,7 +312,7 @@ func TestSubmitMasterExercise_QA_NormalizesTrailingWhitespace(t *testing.T) {
 	assert.True(t, out.IsCorrect)
 }
 
-func TestSubmitMasterExercise_ExerciseNotFound(t *testing.T) {
+func Test_演習提出_演習が見つからない(t *testing.T) {
 	exRepo := &fakeMasterExerciseRepo{err: errors.New("record not found")}
 	uc := usecase.NewSubmitMasterExerciseUseCase(exRepo, &fakeExampleRepo{}, &fakeSubmissionRepo{}, &fakeExecutor{})
 	_, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
@@ -321,7 +321,7 @@ func TestSubmitMasterExercise_ExerciseNotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSubmitMasterExercise_RequiresInput(t *testing.T) {
+func Test_演習提出_入力が必須(t *testing.T) {
 	uc := usecase.NewSubmitMasterExerciseUseCase(&fakeMasterExerciseRepo{}, &fakeExampleRepo{}, &fakeSubmissionRepo{}, &fakeExecutor{})
 	_, err := uc.Execute(context.Background(), usecase.SubmitMasterExerciseInput{
 		UserID: 0, Slug: "s", Code: "x",

--- a/backend/internal/usecase/teaching_material_usecase_test.go
+++ b/backend/internal/usecase/teaching_material_usecase_test.go
@@ -95,7 +95,7 @@ func (r *fakeCourseRepo) Delete(_ context.Context, id uint64) error {
 	return nil
 }
 
-func TestTeachingMaterialUseCase_ListByCourse_TraineeOnlyPublished(t *testing.T) {
+func Test_教材_コース別一覧_traineeは公開のみ(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -105,7 +105,7 @@ func TestTeachingMaterialUseCase_ListByCourse_TraineeOnlyPublished(t *testing.T)
 	assert.False(t, mrepo.listIncludeAll, "trainee は draft を含まない")
 }
 
-func TestTeachingMaterialUseCase_ListByCourse_TraineeCannotSeeUnpublishedCourse(t *testing.T) {
+func Test_教材_コース別一覧_traineeは非公開コースを見られない(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -114,7 +114,7 @@ func TestTeachingMaterialUseCase_ListByCourse_TraineeCannotSeeUnpublishedCourse(
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
-func TestTeachingMaterialUseCase_ListByCourse_CompanyAdminIncludesDraft(t *testing.T) {
+func Test_教材_コース別一覧_会社管理者は下書きも含む(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -123,7 +123,7 @@ func TestTeachingMaterialUseCase_ListByCourse_CompanyAdminIncludesDraft(t *testi
 	assert.True(t, mrepo.listIncludeAll)
 }
 
-func TestTeachingMaterialUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
+func Test_教材_取得_traineeは下書き不可(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
 	}}
@@ -134,7 +134,7 @@ func TestTeachingMaterialUseCase_Get_TraineeCannotReadDraft(t *testing.T) {
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
-func TestTeachingMaterialUseCase_Get_TraineeCanReadPublishedSameCompany(t *testing.T) {
+func Test_教材_取得_traineeは自社の公開を読める(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
 	}}
@@ -145,7 +145,7 @@ func TestTeachingMaterialUseCase_Get_TraineeCanReadPublishedSameCompany(t *testi
 	assert.Equal(t, uint64(1), got.ID)
 }
 
-func TestTeachingMaterialUseCase_Get_CrossCompanyForbidden(t *testing.T) {
+func Test_教材_取得_別会社は禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
 	}}
@@ -156,7 +156,7 @@ func TestTeachingMaterialUseCase_Get_CrossCompanyForbidden(t *testing.T) {
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
-func TestTeachingMaterialUseCase_Get_SuperAdminCrossCompanyAllowed(t *testing.T) {
+func Test_教材_取得_運営は別会社も許可(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
 	}}
@@ -167,7 +167,7 @@ func TestTeachingMaterialUseCase_Get_SuperAdminCrossCompanyAllowed(t *testing.T)
 	assert.Equal(t, uint64(1), got.ID)
 }
 
-func TestTeachingMaterialUseCase_Create_TraineeForbidden(t *testing.T) {
+func Test_教材_作成_traineeは禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -178,7 +178,7 @@ func TestTeachingMaterialUseCase_Create_TraineeForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestTeachingMaterialUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
+func Test_教材_作成_会社管理者は成功(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -194,7 +194,7 @@ func TestTeachingMaterialUseCase_Create_CompanyAdminSucceeds(t *testing.T) {
 	assert.Equal(t, "Spring 入門", got.Title)
 }
 
-func TestTeachingMaterialUseCase_Create_MissingCourseIDForbidden(t *testing.T) {
+func Test_教材_作成_コースID欠落は禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -206,7 +206,7 @@ func TestTeachingMaterialUseCase_Create_MissingCourseIDForbidden(t *testing.T) {
 	assert.Contains(t, err.Error(), "course_id")
 }
 
-func TestTeachingMaterialUseCase_Create_CrossCompanyCourseForbidden(t *testing.T) {
+func Test_教材_作成_別会社コースは禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 99}}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -218,7 +218,7 @@ func TestTeachingMaterialUseCase_Create_CrossCompanyCourseForbidden(t *testing.T
 	assert.Contains(t, err.Error(), "forbidden")
 }
 
-func TestTeachingMaterialUseCase_Create_NoCompanyForbidden(t *testing.T) {
+func Test_教材_作成_会社未所属は禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{}
 	crepo := &fakeCourseRepo{}
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
@@ -229,7 +229,7 @@ func TestTeachingMaterialUseCase_Create_NoCompanyForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestTeachingMaterialUseCase_Update_CrossCompanyForbidden(t *testing.T) {
+func Test_教材_更新_別会社は禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
 	}}
@@ -242,7 +242,7 @@ func TestTeachingMaterialUseCase_Update_CrossCompanyForbidden(t *testing.T) {
 	assert.Nil(t, mrepo.updated)
 }
 
-func TestTeachingMaterialUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
+func Test_教材_更新_自社管理者は成功(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
 	}}
@@ -258,7 +258,7 @@ func TestTeachingMaterialUseCase_Update_SameCompanyAdminSucceeds(t *testing.T) {
 	assert.NotNil(t, mrepo.updated)
 }
 
-func TestTeachingMaterialUseCase_Delete_TraineeForbidden(t *testing.T) {
+func Test_教材_削除_traineeは禁止(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5,
 	}}
@@ -268,7 +268,7 @@ func TestTeachingMaterialUseCase_Delete_TraineeForbidden(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestTeachingMaterialUseCase_Delete_SameCompanyAdminSucceeds(t *testing.T) {
+func Test_教材_削除_自社管理者は成功(t *testing.T) {
 	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5,
 	}}

--- a/backend/internal/usecase/update_company_application_status_usecase_test.go
+++ b/backend/internal/usecase/update_company_application_status_usecase_test.go
@@ -24,7 +24,7 @@ func (r *statusRepo) UpdateStatus(_ context.Context, id uint64, status string) e
 	return r.err
 }
 
-func TestUpdateCompanyApplicationStatus_NormalizesAndUpdates(t *testing.T) {
+func Test_会社申請ステータス更新_正規化して更新(t *testing.T) {
 	repo := &statusRepo{}
 	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(repo)
 	if err := uc.Execute(context.Background(), 5, "  Approved "); err != nil {
@@ -35,21 +35,21 @@ func TestUpdateCompanyApplicationStatus_NormalizesAndUpdates(t *testing.T) {
 	}
 }
 
-func TestUpdateCompanyApplicationStatus_RejectsBadStatus(t *testing.T) {
+func Test_会社申請ステータス更新_不正なステータスを拒否(t *testing.T) {
 	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(&statusRepo{})
 	if err := uc.Execute(context.Background(), 5, "banana"); !errors.Is(err, usecase.ErrCompanyApplicationBadStatus) {
 		t.Fatalf("expected ErrCompanyApplicationBadStatus, got %v", err)
 	}
 }
 
-func TestUpdateCompanyApplicationStatus_RequiresID(t *testing.T) {
+func Test_会社申請ステータス更新_IDが必須(t *testing.T) {
 	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(&statusRepo{})
 	if err := uc.Execute(context.Background(), 0, "approved"); err == nil {
 		t.Fatal("expected error when id == 0")
 	}
 }
 
-func TestUpdateCompanyApplicationStatus_PropagatesRepoError(t *testing.T) {
+func Test_会社申請ステータス更新_リポジトリエラーを伝播(t *testing.T) {
 	repo := &statusRepo{err: errors.New("db down")}
 	uc := usecase.NewUpdateCompanyApplicationStatusUseCase(repo)
 	if err := uc.Execute(context.Background(), 5, "rejected"); err == nil {

--- a/backend/internal/usecase/user_stats_usecase_test.go
+++ b/backend/internal/usecase/user_stats_usecase_test.go
@@ -17,21 +17,21 @@ func (s *stubUserStatsRepo) Compute(_ context.Context, _ uint64) (*domain.UserSt
 	return s.stats, s.err
 }
 
-func TestGetUserStats_RequiresUserID(t *testing.T) {
+func Test_ユーザー統計取得_ユーザーIDが必須(t *testing.T) {
 	uc := NewGetUserStatsUseCase(&stubUserStatsRepo{})
 	if _, err := uc.Execute(context.Background(), 0); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestGetUserStats_PropagatesError(t *testing.T) {
+func Test_ユーザー統計取得_エラーを伝播(t *testing.T) {
 	uc := NewGetUserStatsUseCase(&stubUserStatsRepo{err: errors.New("db")})
 	if _, err := uc.Execute(context.Background(), 1); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestGetUserStats_Returns(t *testing.T) {
+func Test_ユーザー統計取得_統計を返す(t *testing.T) {
 	uc := NewGetUserStatsUseCase(&stubUserStatsRepo{stats: &domain.UserStats{UserID: 1, TotalSessions: 3}})
 	got, err := uc.Execute(context.Background(), 1)
 	if err != nil || got.TotalSessions != 3 {

--- a/backend/internal/usecase/validate_invitation_token_usecase_test.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase_test.go
@@ -44,7 +44,7 @@ func (s *stubAdminInvRepoWithToken) FindPendingByToken(_ context.Context, token 
 	return nil, nil
 }
 
-func TestValidateInvitationToken_EmptyToken_ReturnsNil(t *testing.T) {
+func Test_招待token検証_空tokenはnil(t *testing.T) {
 	uc := NewValidateInvitationTokenUseCase(&stubAdminInvRepoWithToken{}, &stubCompanies{})
 	got, err := uc.Execute(context.Background(), "")
 	if err != nil {
@@ -55,7 +55,7 @@ func TestValidateInvitationToken_EmptyToken_ReturnsNil(t *testing.T) {
 	}
 }
 
-func TestValidateInvitationToken_NotFound_ReturnsNil(t *testing.T) {
+func Test_招待token検証_見つからなければnil(t *testing.T) {
 	uc := NewValidateInvitationTokenUseCase(&stubAdminInvRepoWithToken{}, &stubCompanies{})
 	got, err := uc.Execute(context.Background(), "missing-token")
 	if err != nil || got != nil {
@@ -63,7 +63,7 @@ func TestValidateInvitationToken_NotFound_ReturnsNil(t *testing.T) {
 	}
 }
 
-func TestValidateInvitationToken_OK_AttachesCompanyName(t *testing.T) {
+func Test_招待token検証_正常系_会社名を付与(t *testing.T) {
 	repo := &stubAdminInvRepoWithToken{
 		pendingByToken: map[string]*domain.AdminInvitation{
 			"abc-123": {
@@ -97,7 +97,7 @@ func TestValidateInvitationToken_OK_AttachesCompanyName(t *testing.T) {
 	}
 }
 
-func TestValidateInvitationToken_CompanyLookupFails_StillReturnsInvitation(t *testing.T) {
+func Test_招待token検証_会社参照失敗でも招待を返す(t *testing.T) {
 	// company 取得失敗は invitation 自体の有効性を否定しない。
 	// CompanyName 空でも受諾画面を表示できる方が UX として良い。
 	repo := &stubAdminInvRepoWithToken{
@@ -120,7 +120,7 @@ func TestValidateInvitationToken_CompanyLookupFails_StillReturnsInvitation(t *te
 	}
 }
 
-func TestValidateInvitationToken_NormalizesUnknownRole(t *testing.T) {
+func Test_招待token検証_未知のroleを正規化(t *testing.T) {
 	repo := &stubAdminInvRepoWithToken{
 		pendingByToken: map[string]*domain.AdminInvitation{
 			"t": {ID: 9, CompanyID: 1, Role: "garbage_role"},


### PR DESCRIPTION
## 概要

Go の test 関数名が英語だったため、日本語チームの可読性向上のため日本語に統一します（`func Test_日本語名`）。backend 全体への展開の **第 1 弾（usecase パッケージ）** です。

**Go は test 関数名に英語を強制しません**。`Test` プレフィックスさえあれば日本語識別子でも `go test` が検出・実行し、`-run` の日本語マッチも効きます（実機確認済み）。

## 変更内容

- 対象: `internal/usecase` の `*_test.go` 全 **126 関数**（このパッケージに統合テストは無し）
- 例:
  - `TestListCompanyMembersUseCase` → `Test_会社メンバー一覧ユースケース`
  - `TestCourseUseCase_Create_TraineeForbidden` → `Test_コース_作成_traineeは禁止`
  - `TestSendAiMessageStream_WithAttachment_FetchesBlobAndSavesMetadata` → `Test_AIメッセージ送信ストリーム_添付あり_blob取得とメタ保存`
- `t.Run` のサブテスト説明は従来どおり日本語、テスト本体の SUT 識別子（`usecase.NewXxx` 等の生産コード）は英語のまま（**変更は関数名のみ**）

## テスト

- 新名の重複なし（同一パッケージ内の関数名衝突なし）
- `go test ./internal/usecase/` ✓ / `gofumpt -l` 差分なし ✓ / `go build ./...` ✓

## 今後の展開

backend 全体（残り約 228 関数）を順次同様に日本語化します（`handler` / `cmd` / `adapter` 等）。**統合テスト 14 個は `-run Integration` を壊さないため `Integration` を名前に残します**。

## 関連 Issue

なし（テストの可読性向上）