### PR TITLE
test(handler): Go テスト関数名を日本語化（internal/handler・149 関数）

### DIFF
--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -44,7 +44,7 @@ func newAdminCompanyHandler(repo *fakeCompanyRepo) *AdminCompanyHandler {
 	)
 }
 
-func TestAdminCompanyHandler_List_OK(t *testing.T) {
+func Test_会社管理ハンドラ_一覧_正常系(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/admin/companies", nil)
@@ -54,7 +54,7 @@ func TestAdminCompanyHandler_List_OK(t *testing.T) {
 	}
 }
 
-func TestAdminCompanyHandler_List_Error(t *testing.T) {
+func Test_会社管理ハンドラ_一覧_エラー(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/admin/companies", nil)
@@ -78,7 +78,7 @@ func patchCompanyActive(t *testing.T, actor *domain.User, id, body string, repo 
 	return w
 }
 
-func TestAdminCompanyHandler_SetActive_SuperAdmin_OK(t *testing.T) {
+func Test_会社管理ハンドラ_有効化_運営管理者_正常系(t *testing.T) {
 	repo := &fakeCompanyRepo{}
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
 
@@ -92,7 +92,7 @@ func TestAdminCompanyHandler_SetActive_SuperAdmin_OK(t *testing.T) {
 	}
 }
 
-func TestAdminCompanyHandler_SetActive_NonSuperAdmin_Forbidden(t *testing.T) {
+func Test_会社管理ハンドラ_有効化_運営管理者以外_禁止(t *testing.T) {
 	for _, role := range []string{domain.RoleCompanyAdmin, domain.RoleTrainee} {
 		t.Run(role, func(t *testing.T) {
 			repo := &fakeCompanyRepo{}
@@ -107,7 +107,7 @@ func TestAdminCompanyHandler_SetActive_NonSuperAdmin_Forbidden(t *testing.T) {
 	}
 }
 
-func TestAdminCompanyHandler_SetActive_InvalidBody_BadRequest(t *testing.T) {
+func Test_会社管理ハンドラ_有効化_不正なボディ_400(t *testing.T) {
 	repo := &fakeCompanyRepo{}
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
 	w := patchCompanyActive(t, actor, "5", `{}`, repo)
@@ -116,7 +116,7 @@ func TestAdminCompanyHandler_SetActive_InvalidBody_BadRequest(t *testing.T) {
 	}
 }
 
-func TestAdminCompanyHandler_SetActive_NotFound(t *testing.T) {
+func Test_会社管理ハンドラ_有効化_見つからない(t *testing.T) {
 	// 存在しない会社 ID（0 件更新）は repository が ErrRecordNotFound を返し、handler が 404 にマップ。
 	repo := &fakeCompanyRepo{err: gorm.ErrRecordNotFound}
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}

--- a/backend/internal/handler/admin_invitation_handler_test.go
+++ b/backend/internal/handler/admin_invitation_handler_test.go
@@ -63,7 +63,7 @@ func newTestHandler(repo *fakeAdminInvRepo, currentUser *domain.User) (*AdminInv
 	return h, r
 }
 
-func TestAdminInvitationHandler_List_SuperAdmin_AllScope(t *testing.T) {
+func Test_招待ハンドラ_一覧_運営管理者_全件(t *testing.T) {
 	repo := &fakeAdminInvRepo{
 		all:     []domain.AdminInvitation{{ID: 1}, {ID: 2}},
 		company: []domain.AdminInvitation{{ID: 99}},
@@ -87,7 +87,7 @@ func TestAdminInvitationHandler_List_SuperAdmin_AllScope(t *testing.T) {
 	}
 }
 
-func TestAdminInvitationHandler_List_SuperAdmin_WithCompanyIDQuery(t *testing.T) {
+func Test_招待ハンドラ_一覧_運営管理者_会社IDクエリ付き(t *testing.T) {
 	repo := &fakeAdminInvRepo{company: []domain.AdminInvitation{{ID: 99}}}
 	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
 
@@ -103,7 +103,7 @@ func TestAdminInvitationHandler_List_SuperAdmin_WithCompanyIDQuery(t *testing.T)
 	}
 }
 
-func TestAdminInvitationHandler_List_CompanyAdmin_AutoFiltersOwnCompany(t *testing.T) {
+func Test_招待ハンドラ_一覧_会社管理者_自社に自動絞り込み(t *testing.T) {
 	repo := &fakeAdminInvRepo{company: []domain.AdminInvitation{{ID: 7}}}
 	cid := uint64(123)
 	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: &cid})
@@ -120,7 +120,7 @@ func TestAdminInvitationHandler_List_CompanyAdmin_AutoFiltersOwnCompany(t *testi
 	}
 }
 
-func TestAdminInvitationHandler_List_CompanyAdmin_WithoutCompanyIDIsForbidden(t *testing.T) {
+func Test_招待ハンドラ_一覧_会社管理者_会社IDなしは禁止(t *testing.T) {
 	repo := &fakeAdminInvRepo{}
 	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: nil})
 
@@ -133,7 +133,7 @@ func TestAdminInvitationHandler_List_CompanyAdmin_WithoutCompanyIDIsForbidden(t 
 	}
 }
 
-func TestAdminInvitationHandler_List_Trainee_Forbidden(t *testing.T) {
+func Test_招待ハンドラ_一覧_traineeは禁止(t *testing.T) {
 	repo := &fakeAdminInvRepo{}
 	_, r := newTestHandler(repo, &domain.User{ID: 1, Role: domain.RoleTrainee})
 
@@ -149,7 +149,7 @@ func TestAdminInvitationHandler_List_Trainee_Forbidden(t *testing.T) {
 	}
 }
 
-func TestAdminInvitationHandler_List_Unauthenticated(t *testing.T) {
+func Test_招待ハンドラ_一覧_未認証(t *testing.T) {
 	repo := &fakeAdminInvRepo{}
 	_, r := newTestHandler(repo, nil) // current user 未設定
 
@@ -210,7 +210,7 @@ func postJSON(t *testing.T, r *gin.Engine, body string) *httptest.ResponseRecord
 	return w
 }
 
-func TestAdminInvitationHandler_Create_SuperAdmin_CompanyAdmin_OK(t *testing.T) {
+func Test_招待ハンドラ_作成_運営管理者_会社管理者_正常系(t *testing.T) {
 	repo := &fakeAdminInvRepoWithCreate{}
 	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
 
@@ -224,7 +224,7 @@ func TestAdminInvitationHandler_Create_SuperAdmin_CompanyAdmin_OK(t *testing.T) 
 	}
 }
 
-func TestAdminInvitationHandler_Create_SuperAdmin_Trainee_Forbidden(t *testing.T) {
+func Test_招待ハンドラ_作成_運営管理者_trainee_禁止(t *testing.T) {
 	repo := &fakeAdminInvRepoWithCreate{}
 	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
 
@@ -241,7 +241,7 @@ func TestAdminInvitationHandler_Create_SuperAdmin_Trainee_Forbidden(t *testing.T
 	}
 }
 
-func TestAdminInvitationHandler_Create_CompanyAdmin_Trainee_OK_AndCompanyForcedToOwn(t *testing.T) {
+func Test_招待ハンドラ_作成_会社管理者_trainee_正常系かつ自社に強制(t *testing.T) {
 	repo := &fakeAdminInvRepoWithCreate{}
 	cid := uint64(42)
 	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: &cid})
@@ -257,7 +257,7 @@ func TestAdminInvitationHandler_Create_CompanyAdmin_Trainee_OK_AndCompanyForcedT
 	}
 }
 
-func TestAdminInvitationHandler_Create_CompanyAdmin_CompanyAdmin_Forbidden(t *testing.T) {
+func Test_招待ハンドラ_作成_会社管理者_会社管理者_禁止(t *testing.T) {
 	repo := &fakeAdminInvRepoWithCreate{}
 	cid := uint64(42)
 	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: &cid})
@@ -272,7 +272,7 @@ func TestAdminInvitationHandler_Create_CompanyAdmin_CompanyAdmin_Forbidden(t *te
 	}
 }
 
-func TestAdminInvitationHandler_Create_Trainee_Forbidden(t *testing.T) {
+func Test_招待ハンドラ_作成_traineeは禁止(t *testing.T) {
 	repo := &fakeAdminInvRepoWithCreate{}
 	r := newTestCreateHandler(repo, &domain.User{ID: 1, Role: domain.RoleTrainee})
 
@@ -283,7 +283,7 @@ func TestAdminInvitationHandler_Create_Trainee_Forbidden(t *testing.T) {
 	}
 }
 
-func TestAdminInvitationHandler_Create_Unauthenticated(t *testing.T) {
+func Test_招待ハンドラ_作成_未認証(t *testing.T) {
 	repo := &fakeAdminInvRepoWithCreate{}
 	r := newTestCreateHandler(repo, nil)
 

--- a/backend/internal/handler/ai_chat_attachment_handler_test.go
+++ b/backend/internal/handler/ai_chat_attachment_handler_test.go
@@ -22,7 +22,7 @@ func newAttachHandler(p repository.AiChatAttachmentPresigner) *AiChatAttachmentH
 	return NewAiChatAttachmentHandler(usecase.NewIssueAiChatAttachmentUploadURLUseCase(p))
 }
 
-func TestAiChatAttachmentHandler_IssueUploadURL(t *testing.T) {
+func Test_AIチャット添付ハンドラ_アップロードURL発行(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 		newAttachHandler(fakeAttachPresigner{}).IssueUploadURL(c)

--- a/backend/internal/handler/ai_chat_handler_test.go
+++ b/backend/internal/handler/ai_chat_handler_test.go
@@ -8,7 +8,7 @@ import (
 // ai_chat_handler のガード分岐（401 / 400）を zero-value handler で検証する。
 // いずれも usecase 到達前に早期 return するため nil usecase で安全。
 
-func TestAiChatHandler_GetSessions_Unauthorized(t *testing.T) {
+func Test_AIチャットハンドラ_セッション一覧_未認証(t *testing.T) {
 	w, c := noteCtx(http.MethodGet, "", 0, "")
 	(&AiChatHandler{}).GetSessions(c)
 	if w.Code != http.StatusUnauthorized {
@@ -16,7 +16,7 @@ func TestAiChatHandler_GetSessions_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestAiChatHandler_CreateSession_Unauthorized(t *testing.T) {
+func Test_AIチャットハンドラ_セッション作成_未認証(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 	(&AiChatHandler{}).CreateSession(c)
 	if w.Code != http.StatusUnauthorized {
@@ -24,7 +24,7 @@ func TestAiChatHandler_CreateSession_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestAiChatHandler_CreateSession_BadJSON(t *testing.T) {
+func Test_AIチャットハンドラ_セッション作成_不正なJSON(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `not-json`, 7, "")
 	(&AiChatHandler{}).CreateSession(c)
 	if w.Code != http.StatusBadRequest {
@@ -32,7 +32,7 @@ func TestAiChatHandler_CreateSession_BadJSON(t *testing.T) {
 	}
 }
 
-func TestAiChatHandler_GetSession_BadID(t *testing.T) {
+func Test_AIチャットハンドラ_セッション取得_不正なID(t *testing.T) {
 	w, c := noteCtx(http.MethodGet, "", 0, "abc")
 	(&AiChatHandler{}).GetSession(c)
 	if w.Code != http.StatusBadRequest {
@@ -40,7 +40,7 @@ func TestAiChatHandler_GetSession_BadID(t *testing.T) {
 	}
 }
 
-func TestAiChatHandler_UpdateSessionTitle_BadID(t *testing.T) {
+func Test_AIチャットハンドラ_セッションタイトル更新_不正なID(t *testing.T) {
 	w, c := noteCtx(http.MethodPut, `{"title":"X"}`, 0, "abc")
 	(&AiChatHandler{}).UpdateSessionTitle(c)
 	if w.Code != http.StatusBadRequest {
@@ -48,7 +48,7 @@ func TestAiChatHandler_UpdateSessionTitle_BadID(t *testing.T) {
 	}
 }
 
-func TestAiChatHandler_UpdateSessionTitle_MissingTitle(t *testing.T) {
+func Test_AIチャットハンドラ_セッションタイトル更新_タイトル欠落(t *testing.T) {
 	w, c := noteCtx(http.MethodPut, `{}`, 0, "5")
 	(&AiChatHandler{}).UpdateSessionTitle(c)
 	if w.Code != http.StatusBadRequest {
@@ -56,7 +56,7 @@ func TestAiChatHandler_UpdateSessionTitle_MissingTitle(t *testing.T) {
 	}
 }
 
-func TestAiChatHandler_DeleteSession_Unauthorized(t *testing.T) {
+func Test_AIチャットハンドラ_セッション削除_未認証(t *testing.T) {
 	w, c := noteCtx(http.MethodDelete, "", 0, "5")
 	(&AiChatHandler{}).DeleteSession(c)
 	if w.Code != http.StatusUnauthorized {

--- a/backend/internal/handler/ai_chat_sse_handler_test.go
+++ b/backend/internal/handler/ai_chat_sse_handler_test.go
@@ -8,7 +8,7 @@ import (
 
 // buildAttachmentsFromRequest はクロスユーザの S3 key を弾く必要がある。
 // userID=7 のユーザーが userID=42 配下の key を渡してきたら attachment_key_not_allowed を返す。
-func TestBuildAttachmentsFromRequest_RejectsCrossUserKey(t *testing.T) {
+func Test_リクエストから添付構築_別ユーザーのkeyを拒否(t *testing.T) {
 	_, err := buildAttachmentsFromRequest(7, []sseAttachmentRequest{
 		{
 			Key:         "ai-chat/42/abc.png",
@@ -21,7 +21,7 @@ func TestBuildAttachmentsFromRequest_RejectsCrossUserKey(t *testing.T) {
 }
 
 // 自分の userID 配下の key は正しく domain.Attachment に変換されること。
-func TestBuildAttachmentsFromRequest_AcceptsOwnKey(t *testing.T) {
+func Test_リクエストから添付構築_自分のkeyは許可(t *testing.T) {
 	out, err := buildAttachmentsFromRequest(7, []sseAttachmentRequest{
 		{
 			Key:         "ai-chat/7/abc.png",
@@ -38,7 +38,7 @@ func TestBuildAttachmentsFromRequest_AcceptsOwnKey(t *testing.T) {
 }
 
 // MIME 未対応 / 容量超過 / ai-chat 以外の prefix はそれぞれ専用エラーで弾く。
-func TestBuildAttachmentsFromRequest_RejectsUnsupportedAndOversize(t *testing.T) {
+func Test_リクエストから添付構築_非対応とサイズ超過を拒否(t *testing.T) {
 	cases := []struct {
 		name string
 		req  sseAttachmentRequest

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -144,7 +144,7 @@ func newGinCtx() *gin.Context {
 	return c
 }
 
-func TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin(t *testing.T) {
+func Test_IDトークンからユーザー登録_招待もadminもない新規を拒否(t *testing.T) {
 	users := &fakeUserRepo{}
 	invs := &fakeInvitationRepo{}
 	h := newTestAuthHandler(users, invs)
@@ -164,7 +164,7 @@ func TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin(t *testing.
 	}
 }
 
-func TestUpsertUserFromIDToken_AllowsCognitoAdminWithoutInvitation(t *testing.T) {
+func Test_IDトークンからユーザー登録_Cognito_adminは招待なしでも許可(t *testing.T) {
 	users := &fakeUserRepo{}
 	invs := &fakeInvitationRepo{}
 	h := newTestAuthHandler(users, invs)
@@ -184,7 +184,7 @@ func TestUpsertUserFromIDToken_AllowsCognitoAdminWithoutInvitation(t *testing.T)
 	}
 }
 
-func TestUpsertUserFromIDToken_AllowsInvitedUser_AppliesRoleAndCompany(t *testing.T) {
+func Test_IDトークンからユーザー登録_招待済みはroleと会社を適用(t *testing.T) {
 	users := &fakeUserRepo{}
 	cid := uint64(42)
 	invs := &fakeInvitationRepo{
@@ -224,7 +224,7 @@ func TestUpsertUserFromIDToken_AllowsInvitedUser_AppliesRoleAndCompany(t *testin
 	}
 }
 
-func TestUpsertUserFromIDToken_ExistingUser_AlwaysAllowed(t *testing.T) {
+func Test_IDトークンからユーザー登録_既存ユーザーは常に許可(t *testing.T) {
 	existing := &domain.User{ID: 5, CognitoSub: "existing", Email: "u@example.com", Role: domain.RoleTrainee}
 	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing": existing}}
 	invs := &fakeInvitationRepo{}
@@ -244,7 +244,7 @@ func TestUpsertUserFromIDToken_ExistingUser_AlwaysAllowed(t *testing.T) {
 	}
 }
 
-func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T) {
+func Test_IDトークンからユーザー登録_既存ユーザーはCognito_adminで昇格(t *testing.T) {
 	existing := &domain.User{ID: 5, CognitoSub: "existing", Email: "u@example.com", Role: domain.RoleTrainee}
 	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing": existing}}
 	h := newTestAuthHandler(users, &fakeInvitationRepo{})
@@ -262,7 +262,7 @@ func TestUpsertUserFromIDToken_ExistingUser_PromotedByCognitoAdmin(t *testing.T)
 	}
 }
 
-func TestUpsertUserFromIDToken_RejectsMalformedToken(t *testing.T) {
+func Test_IDトークンからユーザー登録_不正な形式のトークンを拒否(t *testing.T) {
 	h := newTestAuthHandler(&fakeUserRepo{}, &fakeInvitationRepo{})
 	if upsertAllowed(h, newGinCtx(), "not-a-jwt", "") {
 		t.Fatal("malformed token must be rejected")
@@ -271,7 +271,7 @@ func TestUpsertUserFromIDToken_RejectsMalformedToken(t *testing.T) {
 
 // invitationToken が指定されているとき、email ベースより token ベースが優先されることを確認する。
 // email ベースで見つかる古い invitation よりも、token ベースの新しい invitation を採用する。
-func TestUpsertUserFromIDToken_InvitationToken_TakesPrecedenceOverEmail(t *testing.T) {
+func Test_IDトークンからユーザー登録_招待tokenはメールより優先(t *testing.T) {
 	cidByToken := uint64(99)
 	cidByEmail := uint64(1)
 	users := &fakeUserRepo{}
@@ -307,7 +307,7 @@ func TestUpsertUserFromIDToken_InvitationToken_TakesPrecedenceOverEmail(t *testi
 }
 
 // invitationToken が無効でも、email ベースで見つかれば許可する（旧フロー互換）。
-func TestUpsertUserFromIDToken_InvalidToken_FallsBackToEmail(t *testing.T) {
+func Test_IDトークンからユーザー登録_無効なtokenはメールにフォールバック(t *testing.T) {
 	users := &fakeUserRepo{}
 	invs := &fakeInvitationRepo{
 		pendingByEmail: map[string]*domain.AdminInvitation{
@@ -330,7 +330,7 @@ func TestUpsertUserFromIDToken_InvalidToken_FallsBackToEmail(t *testing.T) {
 
 // 既存の trainee ユーザーが company_admin 招待を受けた場合、role を昇格 + company を反映する。
 // 過去に signup した既存ユーザーが後から CompanyAdmin として招待されたケースの救済。
-func TestUpsertUserFromIDToken_ExistingTrainee_UpgradedByCompanyAdminInvitation(t *testing.T) {
+func Test_IDトークンからユーザー登録_既存traineeは会社管理者招待で昇格(t *testing.T) {
 	existing := &domain.User{ID: 5, CognitoSub: "existing-trainee", Email: "u@example.com", Role: domain.RoleTrainee}
 	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing-trainee": existing}}
 	invs := &fakeInvitationRepo{
@@ -356,7 +356,7 @@ func TestUpsertUserFromIDToken_ExistingTrainee_UpgradedByCompanyAdminInvitation(
 }
 
 // 既存 super_admin は招待を受けても降格しない。
-func TestUpsertUserFromIDToken_ExistingSuperAdmin_NotDowngradedByInvitation(t *testing.T) {
+func Test_IDトークンからユーザー登録_既存運営管理者は招待で降格しない(t *testing.T) {
 	existing := &domain.User{ID: 1, CognitoSub: "ops", Email: "ops@example.com", Role: domain.RoleSuperAdmin}
 	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"ops": existing}}
 	invs := &fakeInvitationRepo{
@@ -379,7 +379,7 @@ func TestUpsertUserFromIDToken_ExistingSuperAdmin_NotDowngradedByInvitation(t *t
 var _ = strings.Contains
 
 // 新規ユーザ作成時に id_token の `name` claim が DisplayName に使われる（email にフォールバックしない）。
-func TestUpsertUserFromIDToken_NewUser_UsesOIDCNameOverEmail(t *testing.T) {
+func Test_IDトークンからユーザー登録_新規はOIDC名をメールより優先(t *testing.T) {
 	users := &fakeUserRepo{}
 	invs := &fakeInvitationRepo{
 		pendingByEmail: map[string]*domain.AdminInvitation{
@@ -409,7 +409,7 @@ func TestUpsertUserFromIDToken_NewUser_UsesOIDCNameOverEmail(t *testing.T) {
 }
 
 // 招待 displayName が指定されているときは招待値が優先で OIDC name は無視。
-func TestUpsertUserFromIDToken_NewUser_InvitationNameTrumpsOIDCName(t *testing.T) {
+func Test_IDトークンからユーザー登録_新規は招待名がOIDC名に優先(t *testing.T) {
 	users := &fakeUserRepo{}
 	invs := &fakeInvitationRepo{
 		pendingByEmail: map[string]*domain.AdminInvitation{
@@ -433,7 +433,7 @@ func TestUpsertUserFromIDToken_NewUser_InvitationNameTrumpsOIDCName(t *testing.T
 }
 
 // name claim が無いケースは email にフォールバックする（後方互換）。
-func TestUpsertUserFromIDToken_NewUser_NoOIDCName_FallsBackToEmail(t *testing.T) {
+func Test_IDトークンからユーザー登録_新規でOIDC名なしはメールにフォールバック(t *testing.T) {
 	users := &fakeUserRepo{}
 	invs := &fakeInvitationRepo{
 		pendingByEmail: map[string]*domain.AdminInvitation{
@@ -455,7 +455,7 @@ func TestUpsertUserFromIDToken_NewUser_NoOIDCName_FallsBackToEmail(t *testing.T)
 }
 
 // 既存ユーザの DisplayName が email と一致 + id_token に name → name で上書きされる。
-func TestUpsertUserFromIDToken_ExistingUser_BackfillDisplayNameFromOIDC(t *testing.T) {
+func Test_IDトークンからユーザー登録_既存ユーザーは表示名をOIDCから補完(t *testing.T) {
 	existing := &domain.User{
 		ID: 5, CognitoSub: "exists",
 		Email: "old@example.com", DisplayName: "old@example.com",
@@ -477,7 +477,7 @@ func TestUpsertUserFromIDToken_ExistingUser_BackfillDisplayNameFromOIDC(t *testi
 }
 
 // 既存ユーザが既にプロフィール編集済（DisplayName != email）なら OIDC name で上書きしない。
-func TestUpsertUserFromIDToken_ExistingUser_NoBackfillIfDisplayNameCustomized(t *testing.T) {
+func Test_IDトークンからユーザー登録_表示名カスタム済みは補完しない(t *testing.T) {
 	existing := &domain.User{
 		ID: 5, CognitoSub: "exists",
 		Email: "u@example.com", DisplayName: "ユーザ自身が編集した名前",

--- a/backend/internal/handler/code_execute_handler_test.go
+++ b/backend/internal/handler/code_execute_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestCodeExecuteHandler_Execute_BadJSON(t *testing.T) {
+func Test_コード実行ハンドラ_実行_不正なJSON(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `not-json`, 0, "")
 	(&CodeExecuteHandler{}).Execute(c)
 	if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/company_application_handler_test.go
+++ b/backend/internal/handler/company_application_handler_test.go
@@ -57,7 +57,7 @@ func companyAdmin() *domain.User { return &domain.User{ID: 2, Role: domain.RoleC
 
 // --- List ---
 
-func TestCompanyApplicationHandler_List_Unauthorized(t *testing.T) {
+func Test_会社申請ハンドラ_一覧_未認証(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodGet, "", nil, nil)
 	h.List(c)
@@ -66,7 +66,7 @@ func TestCompanyApplicationHandler_List_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_List_Forbidden(t *testing.T) {
+func Test_会社申請ハンドラ_一覧_禁止(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodGet, "", nil, companyAdmin())
 	h.List(c)
@@ -75,7 +75,7 @@ func TestCompanyApplicationHandler_List_Forbidden(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_List_OK(t *testing.T) {
+func Test_会社申請ハンドラ_一覧_正常系(t *testing.T) {
 	repo := &fakeCompanyAppRepo{listRows: []domain.CompanyApplication{{ID: 1, CompanyName: "A"}}}
 	h := newCompanyAppHandler(repo)
 	w, c := ctxJSON(http.MethodGet, "", nil, superAdmin())
@@ -88,7 +88,7 @@ func TestCompanyApplicationHandler_List_OK(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_List_RepoErrorIs500(t *testing.T) {
+func Test_会社申請ハンドラ_一覧_リポジトリエラーは500(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{listErr: context.DeadlineExceeded})
 	w, c := ctxJSON(http.MethodGet, "", nil, superAdmin())
 	h.List(c)
@@ -101,7 +101,7 @@ func TestCompanyApplicationHandler_List_RepoErrorIs500(t *testing.T) {
 
 func idParam(v string) gin.Params { return gin.Params{{Key: "id", Value: v}} }
 
-func TestCompanyApplicationHandler_UpdateStatus_Forbidden(t *testing.T) {
+func Test_会社申請ハンドラ_ステータス更新_禁止(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodPatch, `{"status":"approved"}`, idParam("1"), companyAdmin())
 	h.UpdateStatus(c)
@@ -110,7 +110,7 @@ func TestCompanyApplicationHandler_UpdateStatus_Forbidden(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_UpdateStatus_BadID(t *testing.T) {
+func Test_会社申請ハンドラ_ステータス更新_不正なID(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodPatch, `{"status":"approved"}`, idParam("abc"), superAdmin())
 	h.UpdateStatus(c)
@@ -119,7 +119,7 @@ func TestCompanyApplicationHandler_UpdateStatus_BadID(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_UpdateStatus_BadJSON(t *testing.T) {
+func Test_会社申請ハンドラ_ステータス更新_不正なJSON(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodPatch, `{`, idParam("1"), superAdmin())
 	h.UpdateStatus(c)
@@ -128,7 +128,7 @@ func TestCompanyApplicationHandler_UpdateStatus_BadJSON(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_UpdateStatus_BadStatusIs400(t *testing.T) {
+func Test_会社申請ハンドラ_ステータス更新_不正なステータスは400(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodPatch, `{"status":"weird"}`, idParam("1"), superAdmin())
 	h.UpdateStatus(c)
@@ -137,7 +137,7 @@ func TestCompanyApplicationHandler_UpdateStatus_BadStatusIs400(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_UpdateStatus_OK(t *testing.T) {
+func Test_会社申請ハンドラ_ステータス更新_正常系(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	_, c := ctxJSON(http.MethodPatch, `{"status":"approved"}`, idParam("1"), superAdmin())
 	h.UpdateStatus(c)
@@ -148,7 +148,7 @@ func TestCompanyApplicationHandler_UpdateStatus_OK(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_UpdateStatus_RepoErrorIs500(t *testing.T) {
+func Test_会社申請ハンドラ_ステータス更新_リポジトリエラーは500(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{updateErr: context.DeadlineExceeded})
 	w, c := ctxJSON(http.MethodPatch, `{"status":"approved"}`, idParam("1"), superAdmin())
 	h.UpdateStatus(c)
@@ -159,7 +159,7 @@ func TestCompanyApplicationHandler_UpdateStatus_RepoErrorIs500(t *testing.T) {
 
 // --- Create（公開 / 入力検証のみ）---
 
-func TestCompanyApplicationHandler_Create_BadJSON(t *testing.T) {
+func Test_会社申請ハンドラ_作成_不正なJSON(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	w, c := ctxJSON(http.MethodPost, `{`, nil, nil)
 	h.Create(c)
@@ -168,7 +168,7 @@ func TestCompanyApplicationHandler_Create_BadJSON(t *testing.T) {
 	}
 }
 
-func TestCompanyApplicationHandler_Create_InvalidEmailIs400(t *testing.T) {
+func Test_会社申請ハンドラ_作成_不正なメールは400(t *testing.T) {
 	h := newCompanyAppHandler(&fakeCompanyAppRepo{})
 	body := `{"companyName":"X","applicantName":"Y","email":"not-an-email"}`
 	w, c := ctxJSON(http.MethodPost, body, nil, nil)

--- a/backend/internal/handler/company_settings_handler_test.go
+++ b/backend/internal/handler/company_settings_handler_test.go
@@ -53,7 +53,7 @@ func newCompanySettingsTestRouter(repo *settingsCompanyRepo, actor *domain.User)
 	return r
 }
 
-func TestCompanySettingsHandler_Get_Admin(t *testing.T) {
+func Test_会社設定ハンドラ_取得_管理者(t *testing.T) {
 	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1, AiChatEnabledForTrainees: false}}
 	actor := &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(1)}
 	r := newCompanySettingsTestRouter(repo, actor)
@@ -73,7 +73,7 @@ func TestCompanySettingsHandler_Get_Admin(t *testing.T) {
 	}
 }
 
-func TestCompanySettingsHandler_Get_TraineeForbidden(t *testing.T) {
+func Test_会社設定ハンドラ_取得_traineeは禁止(t *testing.T) {
 	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1}}
 	actor := &domain.User{Role: domain.RoleTrainee, CompanyID: u64ptr(1)}
 	r := newCompanySettingsTestRouter(repo, actor)
@@ -85,7 +85,7 @@ func TestCompanySettingsHandler_Get_TraineeForbidden(t *testing.T) {
 	}
 }
 
-func TestCompanySettingsHandler_Update_Admin(t *testing.T) {
+func Test_会社設定ハンドラ_更新_管理者(t *testing.T) {
 	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1, AiChatEnabledForTrainees: true}}
 	actor := &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(1)}
 	r := newCompanySettingsTestRouter(repo, actor)
@@ -103,7 +103,7 @@ func TestCompanySettingsHandler_Update_Admin(t *testing.T) {
 	}
 }
 
-func TestCompanySettingsHandler_Update_MissingBody(t *testing.T) {
+func Test_会社設定ハンドラ_更新_ボディ欠落(t *testing.T) {
 	repo := &settingsCompanyRepo{company: &domain.Company{ID: 1}}
 	actor := &domain.User{Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(1)}
 	r := newCompanySettingsTestRouter(repo, actor)

--- a/backend/internal/handler/course_handler_test.go
+++ b/backend/internal/handler/course_handler_test.go
@@ -65,7 +65,7 @@ func superAdminCo() *domain.User {
 	return &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: &cid}
 }
 
-func TestCourseHandler_List(t *testing.T) {
+func Test_コースハンドラ_一覧(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, nil)
 		newCourseHandler(&fakeCourseRepo{}).List(c)
@@ -89,7 +89,7 @@ func TestCourseHandler_List(t *testing.T) {
 	})
 }
 
-func TestCourseHandler_Get(t *testing.T) {
+func Test_コースハンドラ_取得(t *testing.T) {
 	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Get(c)
@@ -106,7 +106,7 @@ func TestCourseHandler_Get(t *testing.T) {
 	})
 }
 
-func TestCourseHandler_Create(t *testing.T) {
+func Test_コースハンドラ_作成(t *testing.T) {
 	t.Run("不正な JSON → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodPost, `{`, nil, superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Create(c)
@@ -123,7 +123,7 @@ func TestCourseHandler_Create(t *testing.T) {
 	})
 }
 
-func TestCourseHandler_Update(t *testing.T) {
+func Test_コースハンドラ_更新(t *testing.T) {
 	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("abc"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Update(c)
@@ -140,7 +140,7 @@ func TestCourseHandler_Update(t *testing.T) {
 	})
 }
 
-func TestCourseHandler_Delete(t *testing.T) {
+func Test_コースハンドラ_削除(t *testing.T) {
 	t.Run("不正な id → 400", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodDelete, "", idParam("abc"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{}).Delete(c)

--- a/backend/internal/handler/embed_handler_test.go
+++ b/backend/internal/handler/embed_handler_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestEmbedHandler_Resolve_MissingURL は url クエリ欠落で 400 を返すことを検証する。
 // fetcher 到達前のガードのため fetcher は nil で安全。
-func TestEmbedHandler_Resolve_MissingURL(t *testing.T) {
+func Test_埋め込みハンドラ_解決_URL欠落(t *testing.T) {
 	h := &EmbedHandler{}
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/backend/internal/handler/exercise_submission_handler_test.go
+++ b/backend/internal/handler/exercise_submission_handler_test.go
@@ -74,7 +74,7 @@ func newSubmissionTestRouter(t *testing.T, exercise *domain.MasterExercise, exam
 	return r, subRepo
 }
 
-func TestSubmissionHandler_Submit_Success(t *testing.T) {
+func Test_演習提出ハンドラ_提出_成功(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	exercise := &domain.MasterExercise{ID: 7, Slug: "php-7"}
 	examples := []domain.MasterExerciseExample{
@@ -102,7 +102,7 @@ func TestSubmissionHandler_Submit_Success(t *testing.T) {
 	}
 }
 
-func TestSubmissionHandler_Submit_Unauthorized(t *testing.T) {
+func Test_演習提出ハンドラ_提出_未認証(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	exercise := &domain.MasterExercise{ID: 7, Slug: "php-7"}
 	r, _ := newSubmissionTestRouter(t, exercise, []domain.MasterExerciseExample{
@@ -138,7 +138,7 @@ func TestSubmissionHandler_Submit_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestSubmissionHandler_List_Success(t *testing.T) {
+func Test_演習提出ハンドラ_一覧_成功(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	exercise := &domain.MasterExercise{ID: 7, Slug: "php-7"}
 	listed := []domain.ExerciseSubmission{

--- a/backend/internal/handler/health_handler_test.go
+++ b/backend/internal/handler/health_handler_test.go
@@ -27,7 +27,7 @@ func runHealthGet(t *testing.T, repoErr error) *httptest.ResponseRecorder {
 	return w
 }
 
-func TestHealthHandler_Get_Up(t *testing.T) {
+func Test_ヘルスハンドラ_取得_正常(t *testing.T) {
 	w := runHealthGet(t, nil)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
@@ -41,7 +41,7 @@ func TestHealthHandler_Get_Up(t *testing.T) {
 	}
 }
 
-func TestHealthHandler_Get_Down(t *testing.T) {
+func Test_ヘルスハンドラ_取得_異常(t *testing.T) {
 	w := runHealthGet(t, errors.New("db unreachable"))
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("want 503, got %d", w.Code)

--- a/backend/internal/handler/learning_report_handler_test.go
+++ b/backend/internal/handler/learning_report_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestLearningReportHandler_List_Unauthorized(t *testing.T) {
+func Test_学習レポートハンドラ_一覧_未認証(t *testing.T) {
 	w, c := noteCtx(http.MethodGet, "", 0, "")
 	(&LearningReportHandler{}).List(c)
 	if w.Code != http.StatusUnauthorized {
@@ -13,7 +13,7 @@ func TestLearningReportHandler_List_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestLearningReportHandler_Request_Unauthorized(t *testing.T) {
+func Test_学習レポートハンドラ_要求_未認証(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 	(&LearningReportHandler{}).Request(c)
 	if w.Code != http.StatusUnauthorized {
@@ -21,7 +21,7 @@ func TestLearningReportHandler_Request_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestLearningReportHandler_Request_BadJSON(t *testing.T) {
+func Test_学習レポートハンドラ_要求_不正なJSON(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `not-json`, 7, "")
 	(&LearningReportHandler{}).Request(c)
 	if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/master_exercise_handler_test.go
+++ b/backend/internal/handler/master_exercise_handler_test.go
@@ -83,7 +83,7 @@ func newMasterExerciseTestHandler(repo *fakeMasterExerciseRepo, examples *fakeEx
 }
 
 // /exercises?language=php → repo に "php" が伝わり、結果が JSON で返る。
-func TestMasterExerciseHandler_List_FiltersByLanguage(t *testing.T) {
+func Test_演習問題ハンドラ_一覧_言語で絞り込み(t *testing.T) {
 	repo := &fakeMasterExerciseRepo{
 		listResult: []domain.MasterExercise{
 			{ID: 1, Slug: "php-1", Language: "php", Title: "Hello", IsPublished: true},
@@ -112,7 +112,7 @@ func TestMasterExerciseHandler_List_FiltersByLanguage(t *testing.T) {
 }
 
 // language 未指定なら全言語（repo 側に空文字が伝わる）。
-func TestMasterExerciseHandler_List_AllLanguages(t *testing.T) {
+func Test_演習問題ハンドラ_一覧_全言語(t *testing.T) {
 	repo := &fakeMasterExerciseRepo{}
 	r := newMasterExerciseTestHandler(repo, nil)
 	w := httptest.NewRecorder()
@@ -126,7 +126,7 @@ func TestMasterExerciseHandler_List_AllLanguages(t *testing.T) {
 }
 
 // /exercises/:slug → exercise + examples を含むレスポンスを返す。
-func TestMasterExerciseHandler_GetBySlug_Success(t *testing.T) {
+func Test_演習問題ハンドラ_slug取得_成功(t *testing.T) {
 	repo := &fakeMasterExerciseRepo{
 		getResult: &domain.MasterExercise{ID: 7, Slug: "php-7", Language: "php", Title: "OOP"},
 	}
@@ -165,7 +165,7 @@ func TestMasterExerciseHandler_GetBySlug_Success(t *testing.T) {
 }
 
 // 存在しない slug → 404 (`gorm.ErrRecordNotFound` のケース)。
-func TestMasterExerciseHandler_GetBySlug_NotFound(t *testing.T) {
+func Test_演習問題ハンドラ_slug取得_見つからない(t *testing.T) {
 	repo := &fakeMasterExerciseRepo{getErr: gorm.ErrRecordNotFound}
 	r := newMasterExerciseTestHandler(repo, nil)
 	w := httptest.NewRecorder()
@@ -176,7 +176,7 @@ func TestMasterExerciseHandler_GetBySlug_NotFound(t *testing.T) {
 }
 
 // `gorm.ErrRecordNotFound` 以外の DB エラーは 500 として返す（404 と区別する）。
-func TestMasterExerciseHandler_GetBySlug_InternalError(t *testing.T) {
+func Test_演習問題ハンドラ_slug取得_内部エラー(t *testing.T) {
 	repo := &fakeMasterExerciseRepo{getErr: errors.New("connection refused")}
 	r := newMasterExerciseTestHandler(repo, nil)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/middleware/auth_cookie_test.go
+++ b/backend/internal/handler/middleware/auth_cookie_test.go
@@ -22,7 +22,7 @@ func runHandler(handler gin.HandlerFunc) *httptest.ResponseRecorder {
 	return w
 }
 
-func TestSetAccessTokenCookie_DefaultsMaxAge(t *testing.T) {
+func Test_アクセストークンCookie設定_MaxAge既定(t *testing.T) {
 	w := runHandler(func(c *gin.Context) {
 		SetAccessTokenCookie(c, "AT", 0)
 	})
@@ -44,7 +44,7 @@ func TestSetAccessTokenCookie_DefaultsMaxAge(t *testing.T) {
 	}
 }
 
-func TestSetAccessTokenCookie_RespectsExplicitMaxAge(t *testing.T) {
+func Test_アクセストークンCookie設定_明示MaxAgeを尊重(t *testing.T) {
 	w := runHandler(func(c *gin.Context) {
 		SetAccessTokenCookie(c, "AT", 7200)
 	})
@@ -54,7 +54,7 @@ func TestSetAccessTokenCookie_RespectsExplicitMaxAge(t *testing.T) {
 	}
 }
 
-func TestSetRefreshTokenCookie_SkipsEmpty(t *testing.T) {
+func Test_リフレッシュトークンCookie設定_空はスキップ(t *testing.T) {
 	w := runHandler(func(c *gin.Context) {
 		SetRefreshTokenCookie(c, "")
 	})
@@ -65,7 +65,7 @@ func TestSetRefreshTokenCookie_SkipsEmpty(t *testing.T) {
 	}
 }
 
-func TestSetRefreshTokenCookie_LongMaxAge(t *testing.T) {
+func Test_リフレッシュトークンCookie設定_長いMaxAge(t *testing.T) {
 	w := runHandler(func(c *gin.Context) {
 		SetRefreshTokenCookie(c, "RT")
 	})
@@ -78,7 +78,7 @@ func TestSetRefreshTokenCookie_LongMaxAge(t *testing.T) {
 	}
 }
 
-func TestClearAuthCookies_BothExpired(t *testing.T) {
+func Test_認証Cookieクリア_両方失効(t *testing.T) {
 	w := runHandler(ClearAuthCookies)
 	for _, name := range []string{CookieAccessToken, CookieRefreshToken} {
 		cookie := findCookie(t, w, name)

--- a/backend/internal/handler/middleware/cors_test.go
+++ b/backend/internal/handler/middleware/cors_test.go
@@ -2,7 +2,7 @@ package middleware
 
 import "testing"
 
-func TestIsAllowedOrigin(t *testing.T) {
+func Test_許可オリジン判定(t *testing.T) {
 	cases := []struct {
 		origin string
 		want   bool

--- a/backend/internal/handler/middleware/current_user_test.go
+++ b/backend/internal/handler/middleware/current_user_test.go
@@ -57,7 +57,7 @@ func runCurrentUser(t *testing.T, users *stubUsers, companies *stubCompanies) (*
 
 func uintPtr(v uint64) *uint64 { return &v }
 
-func TestCurrentUser_BlocksDisabledCompany(t *testing.T) {
+func Test_カレントユーザー_無効な会社を遮断(t *testing.T) {
 	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: true, CompanyID: uintPtr(7)}}
 	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: false}}
 
@@ -71,7 +71,7 @@ func TestCurrentUser_BlocksDisabledCompany(t *testing.T) {
 	}
 }
 
-func TestCurrentUser_AllowsActiveCompany(t *testing.T) {
+func Test_カレントユーザー_有効な会社は許可(t *testing.T) {
 	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: true, CompanyID: uintPtr(7)}}
 	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: true}}
 
@@ -85,7 +85,7 @@ func TestCurrentUser_AllowsActiveCompany(t *testing.T) {
 	}
 }
 
-func TestCurrentUser_SuperAdminNoCompany_Allowed(t *testing.T) {
+func Test_カレントユーザー_運営管理者は会社なしでも許可(t *testing.T) {
 	// super_admin は company_id なし → 会社チェックをスキップして通す。
 	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, IsActive: true, CompanyID: nil}}
 	companies := &stubCompanies{err: gorm.ErrRecordNotFound}
@@ -97,7 +97,7 @@ func TestCurrentUser_SuperAdminNoCompany_Allowed(t *testing.T) {
 	}
 }
 
-func TestCurrentUser_CompanyNotFound_Allowed(t *testing.T) {
+func Test_カレントユーザー_会社が見つからなくても許可(t *testing.T) {
 	// company_id はあるが会社行が無い（データ不整合）→ 弾かない。
 	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: true, CompanyID: uintPtr(99)}}
 	companies := &stubCompanies{err: gorm.ErrRecordNotFound}
@@ -109,7 +109,7 @@ func TestCurrentUser_CompanyNotFound_Allowed(t *testing.T) {
 	}
 }
 
-func TestCurrentUser_BlocksDisabledUser(t *testing.T) {
+func Test_カレントユーザー_無効なユーザーを遮断(t *testing.T) {
 	// IsActive=false のユーザーは会社が有効でも弾く（即時に利用不可）。
 	users := &stubUsers{user: &domain.User{ID: 1, Role: domain.RoleTrainee, IsActive: false, CompanyID: uintPtr(7)}}
 	companies := &stubCompanies{company: &domain.Company{ID: 7, IsActive: true}}

--- a/backend/internal/handler/middleware/jwt_test.go
+++ b/backend/internal/handler/middleware/jwt_test.go
@@ -35,7 +35,7 @@ func encodeSegment(t *testing.T, v any) string {
 	return s
 }
 
-func TestDecodeClaims_Success(t *testing.T) {
+func Test_クレームデコード_成功(t *testing.T) {
 	want := map[string]any{
 		"sub":            "abc-123",
 		"email":          "u@example.com",
@@ -54,7 +54,7 @@ func TestDecodeClaims_Success(t *testing.T) {
 	}
 }
 
-func TestDecodeClaims_InvalidFormat(t *testing.T) {
+func Test_クレームデコード_不正な形式(t *testing.T) {
 	cases := []string{"", "only.two", "a.b.c.d"}
 	for _, c := range cases {
 		if _, err := DecodeClaims(c); !errors.Is(err, ErrInvalidJWT) {
@@ -63,14 +63,14 @@ func TestDecodeClaims_InvalidFormat(t *testing.T) {
 	}
 }
 
-func TestDecodeClaims_InvalidBase64(t *testing.T) {
+func Test_クレームデコード_不正なBase64(t *testing.T) {
 	tok := "header.!!!notbase64!!!.sig"
 	if _, err := DecodeClaims(tok); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
-func TestDecodeClaims_InvalidJSON(t *testing.T) {
+func Test_クレームデコード_不正なJSON(t *testing.T) {
 	header := encodeSegment(t, map[string]any{"alg": "RS256"})
 	bogus := strings.NewReplacer("+", "-", "/", "_").Replace(
 		strings.TrimRight(base64.StdEncoding.EncodeToString([]byte("not-json")), "="),
@@ -81,7 +81,7 @@ func TestDecodeClaims_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestIsAdminFromGroups(t *testing.T) {
+func Test_グループからadmin判定(t *testing.T) {
 	if !IsAdminFromGroups([]string{"trainee", "admin"}) {
 		t.Fatal("admin should be detected")
 	}
@@ -93,7 +93,7 @@ func TestIsAdminFromGroups(t *testing.T) {
 	}
 }
 
-func TestToStringSliceFromClaim(t *testing.T) {
+func Test_クレームから文字列スライス変換(t *testing.T) {
 	got := ToStringSliceFromClaim([]any{"a", "b", 42, "c"})
 	want := []string{"a", "b", "c"}
 	if len(got) != len(want) {
@@ -130,14 +130,14 @@ func runJWTAuth(t *testing.T, verify VerifyFunc, cookie string) (int, string) {
 	return w.Code, gotSub
 }
 
-func TestJWTAuth_NoCookie(t *testing.T) {
+func Test_JWT認証_Cookieなし(t *testing.T) {
 	verify := func(context.Context, string) (map[string]any, error) { return nil, nil }
 	if code, _ := runJWTAuth(t, verify, ""); code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", code)
 	}
 }
 
-func TestJWTAuth_VerifyFails(t *testing.T) {
+func Test_JWT認証_検証失敗(t *testing.T) {
 	// 偽造トークン相当: verify がエラーを返したら 401 で弾く。
 	verify := func(context.Context, string) (map[string]any, error) {
 		return nil, errors.New("bad signature")
@@ -147,7 +147,7 @@ func TestJWTAuth_VerifyFails(t *testing.T) {
 	}
 }
 
-func TestJWTAuth_VerifySucceeds(t *testing.T) {
+func Test_JWT認証_検証成功(t *testing.T) {
 	verify := func(context.Context, string) (map[string]any, error) {
 		return map[string]any{"sub": "user-9"}, nil
 	}
@@ -160,7 +160,7 @@ func TestJWTAuth_VerifySucceeds(t *testing.T) {
 	}
 }
 
-func TestJWTAuth_MissingSub(t *testing.T) {
+func Test_JWT認証_sub欠落(t *testing.T) {
 	verify := func(context.Context, string) (map[string]any, error) {
 		return map[string]any{"email": "u@example.com"}, nil
 	}

--- a/backend/internal/handler/middleware/rate_limit_test.go
+++ b/backend/internal/handler/middleware/rate_limit_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func TestIPRateLimiter_BurstThenDeny(t *testing.T) {
+func Test_IPレートリミッタ_バースト後に拒否(t *testing.T) {
 	l := newIPRateLimiter(60, 3) // 3 burst
 	for i := 0; i < 3; i++ {
 		if !l.allow("1.2.3.4") {
@@ -21,7 +21,7 @@ func TestIPRateLimiter_BurstThenDeny(t *testing.T) {
 	}
 }
 
-func TestIPRateLimiter_PerKeyIndependent(t *testing.T) {
+func Test_IPレートリミッタ_キーごとに独立(t *testing.T) {
 	l := newIPRateLimiter(60, 1)
 	if !l.allow("a") || !l.allow("b") {
 		t.Fatal("different IPs should have independent buckets")
@@ -31,7 +31,7 @@ func TestIPRateLimiter_PerKeyIndependent(t *testing.T) {
 	}
 }
 
-func TestIPRateLimiter_RefillsOverTime(t *testing.T) {
+func Test_IPレートリミッタ_時間経過で回復(t *testing.T) {
 	cur := time.Now()
 	l := newIPRateLimiter(60, 1) // 1 token/sec
 	l.now = func() time.Time { return cur }
@@ -49,7 +49,7 @@ func TestIPRateLimiter_RefillsOverTime(t *testing.T) {
 	}
 }
 
-func TestRateLimitPerMinute_Returns429(t *testing.T) {
+func Test_分間レートリミット_429を返す(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.GET("/x", RateLimitPerMinute(60, 2), func(c *gin.Context) {

--- a/backend/internal/handler/middleware/request_logger_test.go
+++ b/backend/internal/handler/middleware/request_logger_test.go
@@ -38,7 +38,7 @@ func captureLogs(t *testing.T, run func(r *gin.Engine)) []map[string]any {
 	return out
 }
 
-func TestRequestLogger_EmitsStructuredFields(t *testing.T) {
+func Test_リクエストロガー_構造化フィールドを出力(t *testing.T) {
 	logs := captureLogs(t, func(r *gin.Engine) {
 		r.Use(RequestLogger())
 		r.GET("/ping", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
@@ -73,7 +73,7 @@ func TestRequestLogger_EmitsStructuredFields(t *testing.T) {
 	}
 }
 
-func TestRequestLogger_SkipPaths(t *testing.T) {
+func Test_リクエストロガー_スキップパス(t *testing.T) {
 	logs := captureLogs(t, func(r *gin.Engine) {
 		r.Use(RequestLogger("/api/v2/health"))
 		r.GET("/api/v2/health", func(c *gin.Context) { c.Status(http.StatusOK) })
@@ -85,7 +85,7 @@ func TestRequestLogger_SkipPaths(t *testing.T) {
 	}
 }
 
-func TestRequestLogger_5xxIsErrorLevel(t *testing.T) {
+func Test_リクエストロガー_5xxはErrorレベル(t *testing.T) {
 	logs := captureLogs(t, func(r *gin.Engine) {
 		r.Use(RequestLogger())
 		r.GET("/boom", func(c *gin.Context) { c.Status(http.StatusInternalServerError) })
@@ -97,7 +97,7 @@ func TestRequestLogger_5xxIsErrorLevel(t *testing.T) {
 	}
 }
 
-func TestRequestLogger_HonorsIncomingRequestID(t *testing.T) {
+func Test_リクエストロガー_受信RequestIDを尊重(t *testing.T) {
 	const incoming = "abc-123"
 	logs := captureLogs(t, func(r *gin.Engine) {
 		r.Use(RequestLogger())

--- a/backend/internal/handler/note_handler_test.go
+++ b/backend/internal/handler/note_handler_test.go
@@ -62,7 +62,7 @@ func noteCtx(method, body string, uid uint64, idVal string) (*httptest.ResponseR
 	return w, c
 }
 
-func TestNoteHandler_List(t *testing.T) {
+func Test_ノートハンドラ_一覧(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodGet, "", 0, "")
 		newNoteHandler(&fakeNoteRepo{}).List(c)
@@ -86,7 +86,7 @@ func TestNoteHandler_List(t *testing.T) {
 	})
 }
 
-func TestNoteHandler_Create(t *testing.T) {
+func Test_ノートハンドラ_作成(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"title":"X"}`, 0, "")
 		newNoteHandler(&fakeNoteRepo{}).Create(c)
@@ -110,7 +110,7 @@ func TestNoteHandler_Create(t *testing.T) {
 	})
 }
 
-func TestNoteHandler_Update(t *testing.T) {
+func Test_ノートハンドラ_更新(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPut, `{"title":"X"}`, 0, "5")
 		newNoteHandler(&fakeNoteRepo{}).Update(c)
@@ -134,7 +134,7 @@ func TestNoteHandler_Update(t *testing.T) {
 	})
 }
 
-func TestNoteHandler_Delete(t *testing.T) {
+func Test_ノートハンドラ_削除(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodDelete, "", 0, "5")
 		newNoteHandler(&fakeNoteRepo{}).Delete(c)

--- a/backend/internal/handler/note_image_handler_test.go
+++ b/backend/internal/handler/note_image_handler_test.go
@@ -23,7 +23,7 @@ func newNoteImageHandler(p repository.NoteImagePresigner) *NoteImageHandler {
 	return NewNoteImageHandler(usecase.NewIssueNoteImageUploadURLUseCase(p))
 }
 
-func TestNoteImageHandler_IssueUploadURL(t *testing.T) {
+func Test_ノート画像ハンドラ_アップロードURL発行(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 		newNoteImageHandler(fakeNoteImagePresigner{}).IssueUploadURL(c)

--- a/backend/internal/handler/notification_handler_test.go
+++ b/backend/internal/handler/notification_handler_test.go
@@ -52,7 +52,7 @@ func notifCtx(uid uint64, idVal string) (*httptest.ResponseRecorder, *gin.Contex
 	return w, c
 }
 
-func TestNotificationHandler_List(t *testing.T) {
+func Test_通知ハンドラ_一覧(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "")
 		newNotifHandler(&fakeNotifRepo{}).List(c)
@@ -76,7 +76,7 @@ func TestNotificationHandler_List(t *testing.T) {
 	})
 }
 
-func TestNotificationHandler_MarkRead(t *testing.T) {
+func Test_通知ハンドラ_既読化(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "1")
 		newNotifHandler(&fakeNotifRepo{}).MarkRead(c)
@@ -100,7 +100,7 @@ func TestNotificationHandler_MarkRead(t *testing.T) {
 	})
 }
 
-func TestNotificationHandler_MarkAllRead(t *testing.T) {
+func Test_通知ハンドラ_全既読化(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "")
 		newNotifHandler(&fakeNotifRepo{}).MarkAllRead(c)
@@ -124,7 +124,7 @@ func TestNotificationHandler_MarkAllRead(t *testing.T) {
 	})
 }
 
-func TestNotificationHandler_UnreadCount(t *testing.T) {
+func Test_通知ハンドラ_未読数(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := notifCtx(0, "")
 		newNotifHandler(&fakeNotifRepo{}).UnreadCount(c)

--- a/backend/internal/handler/onboarding_handler_test.go
+++ b/backend/internal/handler/onboarding_handler_test.go
@@ -10,7 +10,7 @@ import (
 
 // TestOnboardingHandler_Complete_Unauthorized は current user 無しで 401 を返すことを検証する。
 // uid==0 のガードで usecase 到達前に返るため usecase は nil で安全。
-func TestOnboardingHandler_Complete_Unauthorized(t *testing.T) {
+func Test_オンボーディングハンドラ_完了_未認証(t *testing.T) {
 	h := &OnboardingHandler{}
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/backend/internal/handler/password_login_test.go
+++ b/backend/internal/handler/password_login_test.go
@@ -35,7 +35,7 @@ func postLoginCtx(body string) (*gin.Context, *httptest.ResponseRecorder) {
 	return c, rec
 }
 
-func TestLogin_Success_ExistingUser(t *testing.T) {
+func Test_ログイン_成功_既存ユーザー(t *testing.T) {
 	users := &fakeUserRepo{existingBySub: map[string]*domain.User{
 		"sub-1": {ID: 1, CognitoSub: "sub-1", Email: "u@example.com", Role: domain.RoleTrainee},
 	}}
@@ -57,7 +57,7 @@ func TestLogin_Success_ExistingUser(t *testing.T) {
 	}
 }
 
-func TestLogin_InvalidCredentials_401(t *testing.T) {
+func Test_ログイン_認証情報不正_401(t *testing.T) {
 	h := &AuthHandler{
 		users:        &fakeUserRepo{},
 		invitations:  &fakeInvitationRepo{},
@@ -71,7 +71,7 @@ func TestLogin_InvalidCredentials_401(t *testing.T) {
 	}
 }
 
-func TestLogin_NewUserWithoutInvitation_403(t *testing.T) {
+func Test_ログイン_招待なし新規ユーザー_403(t *testing.T) {
 	idTok := makeIDToken(t, map[string]any{"sub": "new-sub", "email": "new@example.com"})
 	h := &AuthHandler{
 		users:        &fakeUserRepo{},       // 既存ユーザーなし
@@ -86,7 +86,7 @@ func TestLogin_NewUserWithoutInvitation_403(t *testing.T) {
 	}
 }
 
-func TestLogin_BadRequest_MissingPassword_400(t *testing.T) {
+func Test_ログイン_パスワード欠落_400(t *testing.T) {
 	h := &AuthHandler{passwordAuth: &fakePasswordAuth{}}
 	c, rec := postLoginCtx(`{"email":"u@example.com"}`)
 	h.Login(c)
@@ -96,7 +96,7 @@ func TestLogin_BadRequest_MissingPassword_400(t *testing.T) {
 	}
 }
 
-func TestLogin_NotConfigured_500(t *testing.T) {
+func Test_ログイン_未設定_500(t *testing.T) {
 	h := &AuthHandler{} // passwordAuth nil
 	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
 	h.Login(c)
@@ -107,7 +107,7 @@ func TestLogin_NotConfigured_500(t *testing.T) {
 }
 
 // 認証は成功したが upsert が DB 失敗で落ちたケースは 403 ではなく 500（招待拒否と切り分け）。
-func TestLogin_UpsertInternalError_500(t *testing.T) {
+func Test_ログイン_upsert内部エラー_500(t *testing.T) {
 	idTok := makeIDToken(t, map[string]any{"sub": "s1", "email": "u@example.com"})
 	users := &fakeUserRepo{createErr: errors.New("db down")}
 	inv := &fakeInvitationRepo{pendingByEmail: map[string]*domain.AdminInvitation{

--- a/backend/internal/handler/profile_handler_test.go
+++ b/backend/internal/handler/profile_handler_test.go
@@ -24,7 +24,7 @@ func makeCtx(currentUserID uint64, paramUserID string) *gin.Context {
 	return c
 }
 
-func TestProfileResolveUserID_MeKeyword(t *testing.T) {
+func Test_プロフィール_ユーザーID解決_meキーワード(t *testing.T) {
 	h := &ProfileHandler{}
 	uid, err := h.resolveUserID(makeCtx(7, "me"))
 	if err != nil || uid != 7 {
@@ -32,7 +32,7 @@ func TestProfileResolveUserID_MeKeyword(t *testing.T) {
 	}
 }
 
-func TestProfileResolveUserID_EmptyParam(t *testing.T) {
+func Test_プロフィール_ユーザーID解決_空パラメータ(t *testing.T) {
 	h := &ProfileHandler{}
 	uid, err := h.resolveUserID(makeCtx(7, ""))
 	if err != nil || uid != 7 {
@@ -40,7 +40,7 @@ func TestProfileResolveUserID_EmptyParam(t *testing.T) {
 	}
 }
 
-func TestProfileResolveUserID_MatchingNumeric(t *testing.T) {
+func Test_プロフィール_ユーザーID解決_一致する数値(t *testing.T) {
 	h := &ProfileHandler{}
 	uid, err := h.resolveUserID(makeCtx(7, "7"))
 	if err != nil || uid != 7 {
@@ -48,14 +48,14 @@ func TestProfileResolveUserID_MatchingNumeric(t *testing.T) {
 	}
 }
 
-func TestProfileResolveUserID_MismatchNumericIsForbidden(t *testing.T) {
+func Test_プロフィール_ユーザーID解決_不一致の数値は禁止(t *testing.T) {
 	h := &ProfileHandler{}
 	if _, err := h.resolveUserID(makeCtx(7, "99")); !errors.Is(err, errProfileForbidden) {
 		t.Fatalf("mismatch numeric should be forbidden; got %v", err)
 	}
 }
 
-func TestProfileResolveUserID_NoCurrentUserIsUnauthorized(t *testing.T) {
+func Test_プロフィール_ユーザーID解決_カレントユーザーなしは未認証(t *testing.T) {
 	h := &ProfileHandler{}
 	if _, err := h.resolveUserID(makeCtx(0, "me")); !errors.Is(err, errProfileUnauthorized) {
 		t.Fatalf("no current user should be unauthorized; got %v", err)

--- a/backend/internal/handler/profile_image_handler_test.go
+++ b/backend/internal/handler/profile_image_handler_test.go
@@ -40,7 +40,7 @@ func userIDCtx(body string, cur uint64, userIDParam string) (*httptest.ResponseR
 	return w, c
 }
 
-func TestProfileImageHandler_IssueUploadURL(t *testing.T) {
+func Test_プロフィール画像ハンドラ_アップロードURL発行(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := userIDCtx(`{}`, 0, "me")
 		newProfileImageHandler(fakeProfileImagePresigner{}).IssueUploadURL(c)

--- a/backend/internal/handler/session_note_handler_test.go
+++ b/backend/internal/handler/session_note_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestSessionNoteHandler_Upsert_Unauthorized(t *testing.T) {
+func Test_セッションノートハンドラ_保存_未認証(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `{}`, 0, "")
 	(&SessionNoteHandler{}).Upsert(c)
 	if w.Code != http.StatusUnauthorized {
@@ -13,7 +13,7 @@ func TestSessionNoteHandler_Upsert_Unauthorized(t *testing.T) {
 	}
 }
 
-func TestSessionNoteHandler_Upsert_BadJSON(t *testing.T) {
+func Test_セッションノートハンドラ_保存_不正なJSON(t *testing.T) {
 	w, c := noteCtx(http.MethodPost, `not-json`, 7, "")
 	(&SessionNoteHandler{}).Upsert(c)
 	if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/teaching_material_handler_test.go
+++ b/backend/internal/handler/teaching_material_handler_test.go
@@ -14,7 +14,7 @@ func newTMHandler() *TeachingMaterialHandler {
 	return NewTeachingMaterialHandler(usecase.NewTeachingMaterialUseCase(fakeMaterialRepo{}, &fakeCourseRepo{}))
 }
 
-func TestTeachingMaterialHandler_List(t *testing.T) {
+func Test_教材ハンドラ_一覧(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", nil, nil)
 		newTMHandler().List(c)
@@ -31,7 +31,7 @@ func TestTeachingMaterialHandler_List(t *testing.T) {
 	})
 }
 
-func TestTeachingMaterialHandler_ListByCourse(t *testing.T) {
+func Test_教材ハンドラ_コース別一覧(t *testing.T) {
 	t.Run("未認証", func(t *testing.T) {
 		w, c := ctxJSON(http.MethodGet, "", idParam("1"), nil)
 		newTMHandler().ListByCourse(c)
@@ -48,7 +48,7 @@ func TestTeachingMaterialHandler_ListByCourse(t *testing.T) {
 	})
 }
 
-func TestTeachingMaterialHandler_Get_BadID(t *testing.T) {
+func Test_教材ハンドラ_取得_不正なID(t *testing.T) {
 	w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
 	newTMHandler().Get(c)
 	if w.Code != http.StatusBadRequest {
@@ -56,7 +56,7 @@ func TestTeachingMaterialHandler_Get_BadID(t *testing.T) {
 	}
 }
 
-func TestTeachingMaterialHandler_Create_BadJSON(t *testing.T) {
+func Test_教材ハンドラ_作成_不正なJSON(t *testing.T) {
 	w, c := ctxJSON(http.MethodPost, `{`, nil, superAdminCo())
 	newTMHandler().Create(c)
 	if w.Code != http.StatusBadRequest {
@@ -64,7 +64,7 @@ func TestTeachingMaterialHandler_Create_BadJSON(t *testing.T) {
 	}
 }
 
-func TestTeachingMaterialHandler_Update_BadID(t *testing.T) {
+func Test_教材ハンドラ_更新_不正なID(t *testing.T) {
 	w, c := ctxJSON(http.MethodPut, `{"title":"X"}`, idParam("abc"), superAdminCo())
 	newTMHandler().Update(c)
 	if w.Code != http.StatusBadRequest {
@@ -72,7 +72,7 @@ func TestTeachingMaterialHandler_Update_BadID(t *testing.T) {
 	}
 }
 
-func TestTeachingMaterialHandler_Delete_BadID(t *testing.T) {
+func Test_教材ハンドラ_削除_不正なID(t *testing.T) {
 	w, c := ctxJSON(http.MethodDelete, "", idParam("abc"), superAdminCo())
 	newTMHandler().Delete(c)
 	if w.Code != http.StatusBadRequest {

--- a/backend/internal/handler/user_stats_handler_test.go
+++ b/backend/internal/handler/user_stats_handler_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestUserStatsResolveUserID_MeKeyword(t *testing.T) {
+func Test_ユーザー統計_ユーザーID解決_meキーワード(t *testing.T) {
 	h := &UserStatsHandler{}
 	uid, err := h.resolveUserID(makeCtx(7, "me"))
 	if err != nil || uid != 7 {
@@ -13,14 +13,14 @@ func TestUserStatsResolveUserID_MeKeyword(t *testing.T) {
 	}
 }
 
-func TestUserStatsResolveUserID_MismatchNumericIsForbidden(t *testing.T) {
+func Test_ユーザー統計_ユーザーID解決_不一致の数値は禁止(t *testing.T) {
 	h := &UserStatsHandler{}
 	if _, err := h.resolveUserID(makeCtx(7, "99")); !errors.Is(err, errUserStatsForbidden) {
 		t.Fatalf("mismatch numeric should be forbidden; got %v", err)
 	}
 }
 
-func TestUserStatsResolveUserID_NoCurrentUserIsUnauthorized(t *testing.T) {
+func Test_ユーザー統計_ユーザーID解決_カレントユーザーなしは未認証(t *testing.T) {
 	h := &UserStatsHandler{}
 	if _, err := h.resolveUserID(makeCtx(0, "me")); !errors.Is(err, errUserStatsUnauthorized) {
 		t.Fatalf("no current user should be unauthorized; got %v", err)

--- a/backend/internal/handler/ws_protocol_test.go
+++ b/backend/internal/handler/ws_protocol_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestBuildChatMessage(t *testing.T) {
+func Test_チャットメッセージ構築(t *testing.T) {
 	now := time.Date(2026, 4, 28, 6, 30, 0, 0, time.UTC)
 	got, ok := BuildChatMessage(ChatInbound{Type: "send", Content: "hi"}, "42", 7, "alice", now)
 	if !ok {
@@ -28,19 +28,19 @@ func TestBuildChatMessage(t *testing.T) {
 	}
 }
 
-func TestBuildChatMessage_RejectsNonSend(t *testing.T) {
+func Test_チャットメッセージ構築_send以外を拒否(t *testing.T) {
 	if _, ok := BuildChatMessage(ChatInbound{Type: "delete", Content: "x"}, "1", 1, "a", time.Now()); ok {
 		t.Fatal("should reject non-send type")
 	}
 }
 
-func TestBuildChatMessage_RejectsEmptyContent(t *testing.T) {
+func Test_チャットメッセージ構築_空内容を拒否(t *testing.T) {
 	if _, ok := BuildChatMessage(ChatInbound{Type: "send"}, "1", 1, "a", time.Now()); ok {
 		t.Fatal("should reject empty content")
 	}
 }
 
-func TestBuildChatDelete(t *testing.T) {
+func Test_チャット削除構築(t *testing.T) {
 	got, ok := BuildChatDelete(ChatInbound{Type: "delete", CreatedAtRef: "2026-04-28T00:00:00Z"}, "42")
 	if !ok {
 		t.Fatal("should succeed for valid delete")
@@ -50,13 +50,13 @@ func TestBuildChatDelete(t *testing.T) {
 	}
 }
 
-func TestBuildChatDelete_RequiresRef(t *testing.T) {
+func Test_チャット削除構築_refが必須(t *testing.T) {
 	if _, ok := BuildChatDelete(ChatInbound{Type: "delete"}, "1"); ok {
 		t.Fatal("should reject empty CreatedAtRef")
 	}
 }
 
-func TestDecodeInbound(t *testing.T) {
+func Test_受信デコード(t *testing.T) {
 	in, err := DecodeInbound([]byte(`{"type":"send","content":"hello"}`))
 	if err != nil {
 		t.Fatalf("err: %v", err)
@@ -66,7 +66,7 @@ func TestDecodeInbound(t *testing.T) {
 	}
 }
 
-func TestEncodeOutbound(t *testing.T) {
+func Test_送信エンコード(t *testing.T) {
 	raw, err := EncodeOutbound(ChatOutbound{Type: "message", Content: "hi"})
 	if err != nil {
 		t.Fatalf("err: %v", err)


### PR DESCRIPTION
## 概要

Go test 関数名の日本語化 **第 2 弾（handler パッケージ）**。`internal/handler` と `internal/handler/middleware` の test 関数名を日本語に統一します（`func Test_日本語名`）。第 1 弾は usecase（#1965）。

## 変更内容

- 対象: `internal/handler` / `internal/handler/middleware` の `*_test.go` 全 **149 関数**
- 例:
  - `TestAdminInvitationHandler_Create_Trainee_Forbidden` → `Test_招待ハンドラ_作成_traineeは禁止`
  - `TestUpsertUserFromIDToken_BlocksNewUserWithoutInvitationOrAdmin` → `Test_IDトークンからユーザー登録_招待もadminもない新規を拒否`
  - `TestJWTAuth_NoCookie` → `Test_JWT認証_Cookieなし`
- `t.Run` の説明・テスト本体の SUT 識別子は据え置き（**変更は関数名のみ**）

## テスト

- 新名の重複なし / `go test ./internal/handler/...` ✓ / `gofumpt -l` 差分なし ✓
- handler に統合テストは無し（`Integration` は `adapter/persistence` のみ・別 PR で名前維持）

## 関連 Issue

なし（テストの可読性向上）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

このリリースには、エンドユーザー向けの新機能、バグ修正、または機能改善はありません。

* **Tests**
  * 内部テストコードの命名規則を整備しました。テスト関数名を日本語に統一し、コード保守性を向上させました。ユーザーが使用するアプリケーション機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->