### PR TITLE
test(cmd,infra): Go テスト関数名を日本語化（残り 79 関数・最終）

### DIFF
--- a/backend/cmd/apispec-lint/main_test.go
+++ b/backend/cmd/apispec-lint/main_test.go
@@ -23,7 +23,7 @@ func parseSrc(t *testing.T, src string) (*token.FileSet, *ast.File) {
 	return fset, f
 }
 
-func TestExtractRouterKeys(t *testing.T) {
+func Test_ルーターキー抽出(t *testing.T) {
 	_, f := parseSrc(t, `package handler
 
 // Create は作る。
@@ -52,7 +52,7 @@ func (h *H) List(c *gin.Context) {}
 	}
 }
 
-func TestParseRouterLine(t *testing.T) {
+func Test_ルーター行のパース(t *testing.T) {
 	cases := []struct {
 		text         string
 		method, path string
@@ -72,7 +72,7 @@ func TestParseRouterLine(t *testing.T) {
 	}
 }
 
-func TestNormalizeGinPath(t *testing.T) {
+func Test_Ginパス正規化(t *testing.T) {
 	cases := map[string]string{
 		"/profile/:userId":        "/profile/{userId}",
 		"/a/:id/b/:slug":          "/a/{id}/b/{slug}",
@@ -87,7 +87,7 @@ func TestNormalizeGinPath(t *testing.T) {
 	}
 }
 
-func TestExtractRoutes(t *testing.T) {
+func Test_ルート抽出(t *testing.T) {
 	fset, f := parseSrc(t, `package handler
 
 func reg(g *gin.RouterGroup, h *H) {
@@ -126,7 +126,7 @@ func reg(g *gin.RouterGroup, h *H) {
 	}
 }
 
-func TestHandlerName(t *testing.T) {
+func Test_ハンドラ名抽出(t *testing.T) {
 	mustExpr := func(src string) ast.Expr {
 		_, f := parseSrc(t, "package p\nvar _ = "+src+"\n")
 		return f.Decls[0].(*ast.GenDecl).Specs[0].(*ast.ValueSpec).Values[0]
@@ -142,7 +142,7 @@ func TestHandlerName(t *testing.T) {
 	}
 }
 
-func TestHasIgnoreFile(t *testing.T) {
+func Test_ignoreファイル判定(t *testing.T) {
 	_, lead := parseSrc(t, "//apispec:ignore-file 生成物\npackage handler\n")
 	if !hasIgnoreFile(lead) {
 		t.Error("leading //apispec:ignore-file should be detected")
@@ -298,7 +298,7 @@ func reg(g *gin.RouterGroup, h *H) {
 	})
 }
 
-func TestRunCLI(t *testing.T) {
+func Test_CLI実行(t *testing.T) {
 	handlerRoot := func(t *testing.T, violating bool) string {
 		routes := "g.POST(\"/things\", h.Create)"
 		if violating {

--- a/backend/cmd/archlint/main_test.go
+++ b/backend/cmd/archlint/main_test.go
@@ -10,7 +10,7 @@ import (
 
 const testPrefix = "github.com/norman6464/FreStyle/backend/internal/"
 
-func TestClassifyRel(t *testing.T) {
+func Test_相対パス分類(t *testing.T) {
 	cases := map[string]string{
 		"domain":                       layerDomain,
 		"domain/sub":                   layerDomain,
@@ -35,7 +35,7 @@ func TestClassifyRel(t *testing.T) {
 	}
 }
 
-func TestClassifyImport(t *testing.T) {
+func Test_import分類(t *testing.T) {
 	cases := map[string]string{
 		"net/http":                         targetNetHTTP,
 		"github.com/gin-gonic/gin":         targetGin,
@@ -57,7 +57,7 @@ func TestClassifyImport(t *testing.T) {
 	}
 }
 
-func TestIsWiringFile(t *testing.T) {
+func Test_wiringファイル判定(t *testing.T) {
 	cases := map[string]bool{
 		"router.go":                     true,
 		"routes_auth.go":                true,
@@ -73,7 +73,7 @@ func TestIsWiringFile(t *testing.T) {
 	}
 }
 
-func TestViolationsFor(t *testing.T) {
+func Test_違反検出(t *testing.T) {
 	imp := func(target string) importRef { return importRef{path: "p", line: 1, target: target} }
 
 	t.Run("domain が usecase を import するのは違反", func(t *testing.T) {
@@ -164,7 +164,7 @@ func TestViolationsFor(t *testing.T) {
 }
 
 // TestParseImports は実ファイルを書き出して import 解析と抑制を検証する。
-func TestParseImports(t *testing.T) {
+func Test_import解析(t *testing.T) {
 	dir := t.TempDir()
 
 	write := func(name, content string) string {
@@ -294,7 +294,7 @@ func TestRunIntegration(t *testing.T) {
 	}
 }
 
-func TestRunCLI(t *testing.T) {
+func Test_CLI実行(t *testing.T) {
 	t.Run("クリーンなツリーは 0 を返す", func(t *testing.T) {
 		root := buildTree(t, false)
 		var out, errBuf bytes.Buffer
@@ -325,7 +325,7 @@ func TestRunCLI(t *testing.T) {
 	})
 }
 
-func TestReadModulePath(t *testing.T) {
+func Test_モジュールパス読み取り(t *testing.T) {
 	dir := t.TempDir()
 	good := filepath.Join(dir, "go.mod")
 	if err := os.WriteFile(good, []byte("// comment\nmodule example.com/foo/bar\n\ngo 1.26\n"), 0o600); err != nil {

--- a/backend/cmd/coderunner/main_test.go
+++ b/backend/cmd/coderunner/main_test.go
@@ -18,7 +18,7 @@ func newTestServer() *httptest.Server {
 	return httptest.NewServer(newMux(sandbox.NewRunner()))
 }
 
-func TestServer_Healthz(t *testing.T) {
+func Test_サーバー_ヘルスチェック(t *testing.T) {
 	srv := newTestServer()
 	defer srv.Close()
 
@@ -28,7 +28,7 @@ func TestServer_Healthz(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-func TestServer_Run_PHP(t *testing.T) {
+func Test_サーバー_実行_PHP(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not found in PATH")
 	}
@@ -47,7 +47,7 @@ func TestServer_Run_PHP(t *testing.T) {
 	assert.Equal(t, 0, out.ExitCode)
 }
 
-func TestServer_Run_InvalidBody(t *testing.T) {
+func Test_サーバー_実行_不正なボディ(t *testing.T) {
 	srv := newTestServer()
 	defer srv.Close()
 
@@ -57,7 +57,7 @@ func TestServer_Run_InvalidBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
-func TestServer_Warmup(t *testing.T) {
+func Test_サーバー_ウォームアップ(t *testing.T) {
 	srv := newTestServer()
 	defer srv.Close()
 

--- a/backend/cmd/naminglint/main_test.go
+++ b/backend/cmd/naminglint/main_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func TestAnalyzeFile(t *testing.T) {
+func Test_ファイル解析(t *testing.T) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, "x.go", `package usecase
 
@@ -84,7 +84,7 @@ func toSet(ss []string) map[string]bool {
 	return m
 }
 
-func TestReceiverTypeName(t *testing.T) {
+func Test_レシーバ型名(t *testing.T) {
 	fset := token.NewFileSet()
 	f, _ := parser.ParseFile(fset, "x.go", `package p
 type T struct{}
@@ -233,7 +233,7 @@ type FooUseCase struct{}
 	})
 }
 
-func TestRunCLI(t *testing.T) {
+func Test_CLI実行(t *testing.T) {
 	good := mkUsecaseTree(t, map[string]string{
 		"a.go": `package usecase
 type FooUseCase struct{}

--- a/backend/internal/infra/coderunner/client_test.go
+++ b/backend/internal/infra/coderunner/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestClient_Run_SendsInputAndDecodesResult(t *testing.T) {
+func Test_クライアント_実行_入力送信と結果デコード(t *testing.T) {
 	var gotPath string
 	var gotBody domain.CodeExecutionInput
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,7 +34,7 @@ func TestClient_Run_SendsInputAndDecodesResult(t *testing.T) {
 	assert.Equal(t, "hi\n", out.Stdout)
 }
 
-func TestClient_Warmup_SendsLanguage(t *testing.T) {
+func Test_クライアント_ウォームアップ_言語送信(t *testing.T) {
 	var gotPath string
 	var gotBody map[string]string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -50,7 +50,7 @@ func TestClient_Warmup_SendsLanguage(t *testing.T) {
 	assert.Equal(t, "go", gotBody["language"])
 }
 
-func TestClient_Run_ErrorsOnNon200(t *testing.T) {
+func Test_クライアント_実行_非200でエラー(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)
 	}))

--- a/backend/internal/infra/cognito/jwt_verifier_test.go
+++ b/backend/internal/infra/cognito/jwt_verifier_test.go
@@ -80,7 +80,7 @@ func validClaims() map[string]any {
 	}
 }
 
-func TestVerify_Success(t *testing.T) {
+func Test_検証_成功(t *testing.T) {
 	s := newTestSigner(t)
 	v := newVerifier(t, s)
 	tok := s.sign(t, validClaims(), "RS256", s.kid)
@@ -93,7 +93,7 @@ func TestVerify_Success(t *testing.T) {
 	}
 }
 
-func TestVerify_TamperedSignature(t *testing.T) {
+func Test_検証_署名改ざん(t *testing.T) {
 	s := newTestSigner(t)
 	v := newVerifier(t, s)
 	tok := s.sign(t, validClaims(), "RS256", s.kid)
@@ -110,7 +110,7 @@ func TestVerify_TamperedSignature(t *testing.T) {
 	}
 }
 
-func TestVerify_Expired(t *testing.T) {
+func Test_検証_期限切れ(t *testing.T) {
 	s := newTestSigner(t)
 	v := newVerifier(t, s)
 	c := validClaims()
@@ -121,7 +121,7 @@ func TestVerify_Expired(t *testing.T) {
 	}
 }
 
-func TestVerify_BadIssuer(t *testing.T) {
+func Test_検証_不正なissuer(t *testing.T) {
 	s := newTestSigner(t)
 	v := newVerifier(t, s)
 	c := validClaims()
@@ -132,7 +132,7 @@ func TestVerify_BadIssuer(t *testing.T) {
 	}
 }
 
-func TestVerify_RejectNonRS256(t *testing.T) {
+func Test_検証_RS256以外を拒否(t *testing.T) {
 	s := newTestSigner(t)
 	v := newVerifier(t, s)
 	tok := s.sign(t, validClaims(), "none", s.kid)
@@ -141,7 +141,7 @@ func TestVerify_RejectNonRS256(t *testing.T) {
 	}
 }
 
-func TestVerify_UnknownKid(t *testing.T) {
+func Test_検証_未知のkid(t *testing.T) {
 	s := newTestSigner(t)
 	v := newVerifier(t, s)
 	tok := s.sign(t, validClaims(), "RS256", "some-other-kid")
@@ -150,14 +150,14 @@ func TestVerify_UnknownKid(t *testing.T) {
 	}
 }
 
-func TestVerify_Malformed(t *testing.T) {
+func Test_検証_不正な形式(t *testing.T) {
 	v := newVerifier(t, newTestSigner(t))
 	if _, err := v.Verify(context.Background(), "not-a-jwt"); !errors.Is(err, ErrJWTMalformed) {
 		t.Fatalf("expected ErrJWTMalformed, got %v", err)
 	}
 }
 
-func TestVerify_DisabledWhenNoJWKS(t *testing.T) {
+func Test_検証_JWKSなしは無効(t *testing.T) {
 	v := NewVerifier("")
 	if _, err := v.Verify(context.Background(), "a.b.c"); !errors.Is(err, ErrVerifierDisabled) {
 		t.Fatalf("expected ErrVerifierDisabled, got %v", err)
@@ -166,7 +166,7 @@ func TestVerify_DisabledWhenNoJWKS(t *testing.T) {
 
 // TestVerify_EmptyJWKSDoesNotWipeCache は空 JWKS が来ても既存の有効キャッシュを保持し、
 // 既知トークンが通り続けることを確認する。
-func TestVerify_EmptyJWKSDoesNotWipeCache(t *testing.T) {
+func Test_検証_空JWKSはキャッシュを消さない(t *testing.T) {
 	s := newTestSigner(t)
 	empty := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/backend/internal/infra/cognito/password_authenticator_test.go
+++ b/backend/internal/infra/cognito/password_authenticator_test.go
@@ -25,7 +25,7 @@ func (f *fakeInitiateAuth) InitiateAuth(_ context.Context, in *cip.InitiateAuthI
 	return f.out, f.err
 }
 
-func TestPasswordAuthenticator_Authenticate_Success(t *testing.T) {
+func Test_パスワード認証_成功(t *testing.T) {
 	fake := &fakeInitiateAuth{out: &cip.InitiateAuthOutput{
 		AuthenticationResult: &types.AuthenticationResultType{
 			AccessToken:  aws.String("AT"),
@@ -56,7 +56,7 @@ func TestPasswordAuthenticator_Authenticate_Success(t *testing.T) {
 	}
 }
 
-func TestPasswordAuthenticator_Authenticate_InvalidCredentials(t *testing.T) {
+func Test_パスワード認証_認証情報不正(t *testing.T) {
 	for _, awsErr := range []error{
 		&types.NotAuthorizedException{},
 		&types.UserNotFoundException{},
@@ -70,7 +70,7 @@ func TestPasswordAuthenticator_Authenticate_InvalidCredentials(t *testing.T) {
 	}
 }
 
-func TestPasswordAuthenticator_Authenticate_NoSecretHashWithoutSecret(t *testing.T) {
+func Test_パスワード認証_secretなしはSecretHashなし(t *testing.T) {
 	fake := &fakeInitiateAuth{out: &cip.InitiateAuthOutput{
 		AuthenticationResult: &types.AuthenticationResultType{AccessToken: aws.String("AT")},
 	}}
@@ -83,14 +83,14 @@ func TestPasswordAuthenticator_Authenticate_NoSecretHashWithoutSecret(t *testing
 	}
 }
 
-func TestPasswordAuthenticator_Authenticate_NotConfigured(t *testing.T) {
+func Test_パスワード認証_未設定(t *testing.T) {
 	a := newPasswordAuthenticatorWithClient(&fakeInitiateAuth{}, "", "secret")
 	if _, err := a.Authenticate(context.Background(), "u", "pw"); !errors.Is(err, ErrNotConfigured) {
 		t.Fatalf("want ErrNotConfigured, got %v", err)
 	}
 }
 
-func TestPasswordAuthenticator_SecretHash(t *testing.T) {
+func Test_パスワード認証_SecretHash算出(t *testing.T) {
 	a := newPasswordAuthenticatorWithClient(nil, "id", "secret")
 	got := a.secretHash("user")
 

--- a/backend/internal/infra/cognito/token_exchanger_test.go
+++ b/backend/internal/infra/cognito/token_exchanger_test.go
@@ -25,7 +25,7 @@ func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, Co
 	return srv, cfg
 }
 
-func TestExchangeAuthorizationCode_Success(t *testing.T) {
+func Test_認可コード交換_成功(t *testing.T) {
 	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
 			t.Errorf("Content-Type = %q", got)
@@ -51,7 +51,7 @@ func TestExchangeAuthorizationCode_Success(t *testing.T) {
 	}
 }
 
-func TestRefreshAccessToken_Success(t *testing.T) {
+func Test_アクセストークン更新_成功(t *testing.T) {
 	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		form := string(body)
@@ -74,7 +74,7 @@ func TestRefreshAccessToken_Success(t *testing.T) {
 	}
 }
 
-func TestExchange_NotConfigured(t *testing.T) {
+func Test_トークン交換_未設定(t *testing.T) {
 	tx := NewTokenExchanger(Config{}) // ClientID / TokenURI 共に空
 	_, err := tx.ExchangeAuthorizationCode(context.Background(), "code")
 	if !errors.Is(err, ErrNotConfigured) {
@@ -82,7 +82,7 @@ func TestExchange_NotConfigured(t *testing.T) {
 	}
 }
 
-func TestExchange_TokenExchangeFailedWraps(t *testing.T) {
+func Test_トークン交換_失敗をラップ(t *testing.T) {
 	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
@@ -105,7 +105,7 @@ func TestExchange_TokenExchangeFailedWraps(t *testing.T) {
 	}
 }
 
-func TestExchange_InvalidResponse(t *testing.T) {
+func Test_トークン交換_不正なレスポンス(t *testing.T) {
 	_, cfg := newTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`not-json`))
 	})
@@ -117,7 +117,7 @@ func TestExchange_InvalidResponse(t *testing.T) {
 	}
 }
 
-func TestExchange_Unreachable(t *testing.T) {
+func Test_トークン交換_到達不能(t *testing.T) {
 	cfg := Config{ClientID: "x", TokenURI: "http://127.0.0.1:1"} // 接続失敗
 	tx := NewTokenExchangerWithClient(cfg, &http.Client{Timeout: 100 * time.Millisecond})
 	_, err := tx.ExchangeAuthorizationCode(context.Background(), "code")
@@ -126,7 +126,7 @@ func TestExchange_Unreachable(t *testing.T) {
 	}
 }
 
-func TestExchange_OmitsSecretWhenEmpty(t *testing.T) {
+func Test_トークン交換_secret空は省略(t *testing.T) {
 	_, cfg := newTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		if strings.Contains(string(body), "client_secret=") {

--- a/backend/internal/infra/embed/oembed_fetcher_test.go
+++ b/backend/internal/infra/embed/oembed_fetcher_test.go
@@ -23,7 +23,7 @@ func newTestFetcher(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *
 	return srv, tx
 }
 
-func TestResolve_Success(t *testing.T) {
+func Test_解決_成功(t *testing.T) {
 	srv, tx := newTestFetcher(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write([]byte(`
@@ -54,7 +54,7 @@ func TestResolve_Success(t *testing.T) {
 	}
 }
 
-func TestResolve_FallbackTitleTag(t *testing.T) {
+func Test_解決_titleタグにフォールバック(t *testing.T) {
 	srv, tx := newTestFetcher(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`<html><head><title>Plain Title</title></head><body></body></html>`))
 	})
@@ -68,7 +68,7 @@ func TestResolve_FallbackTitleTag(t *testing.T) {
 	}
 }
 
-func TestResolve_RejectsNonHTTPS(t *testing.T) {
+func Test_解決_非HTTPSを拒否(t *testing.T) {
 	tx := NewFetcher()
 	_, err := tx.Resolve(context.Background(), "http://example.com")
 	if !errors.Is(err, ErrInvalidURL) {
@@ -76,7 +76,7 @@ func TestResolve_RejectsNonHTTPS(t *testing.T) {
 	}
 }
 
-func TestResolve_RejectsInvalidURL(t *testing.T) {
+func Test_解決_不正なURLを拒否(t *testing.T) {
 	tx := NewFetcher()
 	_, err := tx.Resolve(context.Background(), "::not a url::")
 	if !errors.Is(err, ErrInvalidURL) {
@@ -84,7 +84,7 @@ func TestResolve_RejectsInvalidURL(t *testing.T) {
 	}
 }
 
-func TestResolve_RejectsPrivateHost(t *testing.T) {
+func Test_解決_プライベートホストを拒否(t *testing.T) {
 	tx := NewFetcher()
 	for _, host := range []string{
 		"https://localhost/",
@@ -99,7 +99,7 @@ func TestResolve_RejectsPrivateHost(t *testing.T) {
 	}
 }
 
-func TestResolve_Unreachable(t *testing.T) {
+func Test_解決_到達不能(t *testing.T) {
 	srv, tx := newTestFetcher(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
@@ -109,7 +109,7 @@ func TestResolve_Unreachable(t *testing.T) {
 	}
 }
 
-func TestResolve_Cache(t *testing.T) {
+func Test_解決_キャッシュ(t *testing.T) {
 	calls := 0
 	srv, tx := newTestFetcher(t, func(w http.ResponseWriter, _ *http.Request) {
 		calls++
@@ -126,7 +126,7 @@ func TestResolve_Cache(t *testing.T) {
 	}
 }
 
-func TestResolve_FallbackHostAsTitle(t *testing.T) {
+func Test_解決_ホスト名をタイトルにフォールバック(t *testing.T) {
 	srv, tx := newTestFetcher(t, func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`<html><body>no title</body></html>`))
 	})

--- a/backend/internal/infra/sandbox/env_test.go
+++ b/backend/internal/infra/sandbox/env_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestIsSensitiveEnvKey(t *testing.T) {
+func Test_機密env判定(t *testing.T) {
 	sensitive := []string{
 		"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
 		"AWS_ACCESS_KEY_ID",
@@ -34,7 +34,7 @@ func TestIsSensitiveEnvKey(t *testing.T) {
 	}
 }
 
-func TestSandboxEnv_StripsSecretsKeepsBenign(t *testing.T) {
+func Test_サンドボックスenv_機密を除去し無害は残す(t *testing.T) {
 	t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/abc")
 	t.Setenv("DATABASE_URL", "postgresql://user:pw@host/db")
 	t.Setenv("COGNITO_CLIENT_SECRET", "super-secret")

--- a/backend/internal/infra/sandbox/runner_test.go
+++ b/backend/internal/infra/sandbox/runner_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRunner_PHP_HelloWorld(t *testing.T) {
+func Test_ランナー_PHP_HelloWorld(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not found in PATH, skipping integration test")
 	}
@@ -27,7 +27,7 @@ func TestRunner_PHP_HelloWorld(t *testing.T) {
 	assert.Equal(t, 0, out.ExitCode)
 }
 
-func TestRunner_PHP_SyntaxError(t *testing.T) {
+func Test_ランナー_PHP_構文エラー(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not found in PATH, skipping integration test")
 	}
@@ -41,7 +41,7 @@ func TestRunner_PHP_SyntaxError(t *testing.T) {
 	assert.NotEqual(t, 0, out.ExitCode)
 }
 
-func TestRunner_UnsupportedLanguage(t *testing.T) {
+func Test_ランナー_非対応言語(t *testing.T) {
 	r := sandbox.NewRunner()
 	_, err := r.Run(context.Background(), domain.CodeExecutionInput{
 		Code:     `print("hi")`,
@@ -50,7 +50,7 @@ func TestRunner_UnsupportedLanguage(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestRunner_CodeTooLarge(t *testing.T) {
+func Test_ランナー_コードが大きすぎる(t *testing.T) {
 	r := sandbox.NewRunner()
 	bigCode := make([]byte, 65*1024)
 	_, err := r.Run(context.Background(), domain.CodeExecutionInput{
@@ -62,7 +62,7 @@ func TestRunner_CodeTooLarge(t *testing.T) {
 
 // `<?php` 開始タグが無いコードは、 PHP CLI のデフォルトで「ソースをそのまま stdout に
 // 出力して exit 0」になるため、 検証層で弾いて分かりやすい stderr メッセージに置き換える。
-func TestRunner_PHP_RejectsCodeWithoutOpenTag(t *testing.T) {
+func Test_ランナー_PHP_開始タグなしを拒否(t *testing.T) {
 	r := sandbox.NewRunner()
 	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
 		Code: `import java.util.*;
@@ -80,7 +80,7 @@ class Main {
 }
 
 // `<?=` (short echo tag) も PHP として扱われる必要があるので、 こちらは通す。
-func TestRunner_PHP_AllowsShortEchoTag(t *testing.T) {
+func Test_ランナー_PHP_短縮echoタグを許可(t *testing.T) {
 	if _, err := exec.LookPath("php"); err != nil {
 		t.Skip("php not found in PATH")
 	}
@@ -95,7 +95,7 @@ func TestRunner_PHP_AllowsShortEchoTag(t *testing.T) {
 
 // --- Go ---
 
-func TestRunner_Go_HelloWorld(t *testing.T) {
+func Test_ランナー_Go_HelloWorld(t *testing.T) {
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go not found in PATH, skipping integration test")
 	}
@@ -117,7 +117,7 @@ func main() {
 	assert.Equal(t, 0, out.ExitCode)
 }
 
-func TestRunner_Go_RejectsMissingPackageMain(t *testing.T) {
+func Test_ランナー_Go_package_main欠落を拒否(t *testing.T) {
 	r := sandbox.NewRunner()
 	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
 		Code:     `fmt.Println("hi")`,
@@ -129,7 +129,7 @@ func TestRunner_Go_RejectsMissingPackageMain(t *testing.T) {
 	assert.Contains(t, out.Stderr, "package main")
 }
 
-func TestRunner_Go_CompileError(t *testing.T) {
+func Test_ランナー_Go_コンパイルエラー(t *testing.T) {
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go not found in PATH")
 	}
@@ -152,7 +152,7 @@ func main() {
 	assert.Contains(t, out.Stderr, "./main.go")
 }
 
-func TestRunner_Go_ReadsStdin(t *testing.T) {
+func Test_ランナー_Go_標準入力を読む(t *testing.T) {
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go not found in PATH")
 	}
@@ -182,7 +182,7 @@ func main() {
 }
 
 // Warmup(go) はコンパイルキャッシュを温める。go があれば成功する。
-func TestRunner_Warmup_Go(t *testing.T) {
+func Test_ランナー_ウォームアップ_Go(t *testing.T) {
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("go not found in PATH")
 	}
@@ -191,7 +191,7 @@ func TestRunner_Warmup_Go(t *testing.T) {
 }
 
 // Warmup(php/bash/未対応) は no-op で常に成功する。
-func TestRunner_Warmup_NonGoIsNoop(t *testing.T) {
+func Test_ランナー_ウォームアップ_Go以外は何もしない(t *testing.T) {
 	r := sandbox.NewRunner()
 	require.NoError(t, r.Warmup(context.Background(), "php"))
 	require.NoError(t, r.Warmup(context.Background(), "bash"))
@@ -200,7 +200,7 @@ func TestRunner_Warmup_NonGoIsNoop(t *testing.T) {
 
 // --- Bash ---
 
-func TestRunner_Bash_HelloWorld(t *testing.T) {
+func Test_ランナー_Bash_HelloWorld(t *testing.T) {
 	if _, err := exec.LookPath("/bin/bash"); err != nil {
 		t.Skip("/bin/bash not found")
 	}
@@ -215,7 +215,7 @@ func TestRunner_Bash_HelloWorld(t *testing.T) {
 }
 
 // HOME / PWD は temp dir に固定されるため、 副作用は外に漏れない。
-func TestRunner_Bash_HomeIsTempDir(t *testing.T) {
+func Test_ランナー_Bash_HOMEは一時ディレクトリ(t *testing.T) {
 	if _, err := exec.LookPath("/bin/bash"); err != nil {
 		t.Skip("/bin/bash not found")
 	}
@@ -232,7 +232,7 @@ func TestRunner_Bash_HomeIsTempDir(t *testing.T) {
 }
 
 // AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
-func TestRunner_Bash_DropsParentEnv(t *testing.T) {
+func Test_ランナー_Bash_親envを落とす(t *testing.T) {
 	if _, err := exec.LookPath("/bin/bash"); err != nil {
 		t.Skip("/bin/bash not found")
 	}
@@ -246,7 +246,7 @@ func TestRunner_Bash_DropsParentEnv(t *testing.T) {
 	assert.Equal(t, "value=missing\n", out.Stdout)
 }
 
-func TestRunner_Bash_ReadsStdin(t *testing.T) {
+func Test_ランナー_Bash_標準入力を読む(t *testing.T) {
 	if _, err := exec.LookPath("/bin/bash"); err != nil {
 		t.Skip("/bin/bash not found")
 	}
@@ -261,7 +261,7 @@ func TestRunner_Bash_ReadsStdin(t *testing.T) {
 	assert.Equal(t, 0, out.ExitCode)
 }
 
-func TestRunner_Bash_ExitCodePropagated(t *testing.T) {
+func Test_ランナー_Bash_終了コードを伝播(t *testing.T) {
 	if _, err := exec.LookPath("/bin/bash"); err != nil {
 		t.Skip("/bin/bash not found")
 	}
@@ -278,7 +278,7 @@ func TestRunner_Bash_ExitCodePropagated(t *testing.T) {
 // timeout 時に bash 配下の子孫プロセスもまとめて kill されることを確認する regression test。
 // `Setpgid + cmd.Cancel = group SIGKILL + WaitDelay 1s` で、timeout(1s)+WaitDelay(1s) で
 // 必ず数秒以内に return する。
-func TestRunner_Bash_TimeoutKillsBackgroundChildren(t *testing.T) {
+func Test_ランナー_Bash_タイムアウトで子プロセスを停止(t *testing.T) {
 	if _, err := exec.LookPath("/bin/bash"); err != nil {
 		t.Skip("/bin/bash not found")
 	}

--- a/backend/internal/infra/ses/invitation_mail_test.go
+++ b/backend/internal/infra/ses/invitation_mail_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestBuildInvitationMail_IncludesMagicLinkAndDisplayName(t *testing.T) {
+func Test_招待メール構築_マジックリンクと表示名を含む(t *testing.T) {
 	link := "https://normanblog.com/invitations/accept?token=abc-123"
 	subject, htmlBody, textBody := BuildInvitationMail(link, "山田太郎", "株式会社FreStyle", "company_admin")
 
@@ -30,7 +30,7 @@ func TestBuildInvitationMail_IncludesMagicLinkAndDisplayName(t *testing.T) {
 // HTML body には displayName / companyName / role がそのまま埋め込まれるため、< / > が
 // エスケープされ、HTML タグとして解釈されないことを検証する。
 // （`onerror=alert(1)` のような文字列自体は残るが、タグが閉じていなければ XSS は成立しない）。
-func TestBuildInvitationMail_EscapesHTMLInjection(t *testing.T) {
+func Test_招待メール構築_HTMLインジェクションをエスケープ(t *testing.T) {
 	_, htmlBody, _ := BuildInvitationMail(
 		"https://example.com/x?token=t",
 		`<script>alert(1)</script>`,
@@ -49,7 +49,7 @@ func TestBuildInvitationMail_EscapesHTMLInjection(t *testing.T) {
 	}
 }
 
-func TestBuildInvitationMail_OmitsScopeWhenEmpty(t *testing.T) {
+func Test_招待メール構築_scope空は省略(t *testing.T) {
 	_, htmlBody, textBody := BuildInvitationMail("https://x", "", "", "")
 	if strings.Contains(htmlBody, "招待元の会社") || strings.Contains(textBody, "招待元の会社") {
 		t.Errorf("scope sections should be omitted when companyName is empty")
@@ -59,7 +59,7 @@ func TestBuildInvitationMail_OmitsScopeWhenEmpty(t *testing.T) {
 // role の生値（company_admin / trainee 等）はメール本文に出さない。
 // 一般受信者には社内ロール体系の名称が伝わらないため、本文では会社名と表示名のみ示し、
 // 権限はログイン後の機能体験で暗黙的に理解してもらう設計。
-func TestBuildInvitationMail_DoesNotExposeRawRole(t *testing.T) {
+func Test_招待メール構築_生のroleを露出しない(t *testing.T) {
 	for _, role := range []string{"company_admin", "trainee", "super_admin"} {
 		_, htmlBody, textBody := BuildInvitationMail("https://x", "", "ACME", role)
 		if strings.Contains(htmlBody, role) {
@@ -74,7 +74,7 @@ func TestBuildInvitationMail_DoesNotExposeRawRole(t *testing.T) {
 	}
 }
 
-func TestMagicLinkURL_TrimsTrailingSlash(t *testing.T) {
+func Test_マジックリンクURL_末尾スラッシュを除去(t *testing.T) {
 	got := MagicLinkURL("https://normanblog.com/", "abc")
 	want := "https://normanblog.com/invitations/accept?token=abc"
 	if got != want {
@@ -82,7 +82,7 @@ func TestMagicLinkURL_TrimsTrailingSlash(t *testing.T) {
 	}
 }
 
-func TestMagicLinkURL_EncodesToken(t *testing.T) {
+func Test_マジックリンクURL_tokenをエンコード(t *testing.T) {
 	// UUID v4 はエンコード不要だが、万一 token にメタ文字が含まれた場合の安全性を確認。
 	got := MagicLinkURL("https://example.com", "abc def&x=1")
 	if !strings.Contains(got, "token=abc+def%26x%3D1") {


### PR DESCRIPTION
## 概要

Go test 関数名の日本語化 **第 3 弾（最終）**。`cmd/*` と `internal/infra/*` の test 関数名を日本語に統一します。これで **backend の全 unit テスト関数（計 354）の日本語化が完了**します（第 1 弾 usecase #1965 / 第 2 弾 handler #1966）。

## 変更内容

- 対象（79 関数）:
  - `cmd/archlint` / `cmd/apispec-lint` / `cmd/naminglint` / `cmd/coderunner`
  - `internal/infra/coderunner` / `cognito` / `embed` / `sandbox` / `ses`
- 例:
  - `TestVerify_TamperedSignature` → `Test_検証_署名改ざん`
  - `TestRunner_PHP_RejectsCodeWithoutOpenTag` → `Test_ランナー_PHP_開始タグなしを拒否`
  - `TestBuildInvitationMail_EscapesHTMLInjection` → `Test_招待メール構築_HTMLインジェクションをエスケープ`

## 統合テストの扱い

`adapter/persistence` の **`*Integration` 14 関数は英語名を維持**します（CI / make が `go test -run Integration` で選別実行するため。backend/README の規約）。

## テスト

- `go test ./...` 全緑 / `gofumpt -l` 差分なし / 新名の重複なし

## 関連 Issue

なし（テストの可読性向上・日本語化シリーズ完了）