### PR TITLE
feat(admin): super_admin の利用申請 承認画面を追加 + 死んだシナリオリンク除去

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,10 @@ const HelpPage = lazyWithReload(() => import('./pages/HelpPage'), 'HelpPage');
 const AdminInvitationsPage = lazyWithReload(() => import('./pages/AdminInvitationsPage'), 'AdminInvitationsPage');
 const AdminCompaniesPage = lazyWithReload(() => import('./pages/AdminCompaniesPage'), 'AdminCompaniesPage');
 const AdminMembersPage = lazyWithReload(() => import('./pages/AdminMembersPage'), 'AdminMembersPage');
+const AdminCompanyApplicationsPage = lazyWithReload(
+  () => import('./pages/AdminCompanyApplicationsPage'),
+  'AdminCompanyApplicationsPage',
+);
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
 const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
@@ -115,6 +119,7 @@ export default function App() {
         <Route path="/teaching-materials" element={<CoursesListPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
+        <Route path="/admin/applications" element={<AdminCompanyApplicationsPage />} />
         <Route path="/admin/members" element={<AdminMembersPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />
       </Route>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -68,6 +68,13 @@ const adminNavItem: NavItem = {
       matchPrefix: '/admin/companies',
       allowedRoles: ['super_admin'],
     },
+    // 利用申請の承認は全テナント横断の運営機能なので super_admin 専用。
+    {
+      label: '利用申請',
+      to: '/admin/applications',
+      matchPrefix: '/admin/applications',
+      allowedRoles: ['super_admin'],
+    },
     // 従業員一覧は自社の従業員管理（AI 利用可否の個別設定）。company_admin / super_admin 双方が利用する。
     { label: '従業員一覧', to: '/admin/members', matchPrefix: '/admin/members' },
     // 招待管理は自社内で trainee を招待する操作のため company_admin / super_admin 双方が利用する。

--- a/frontend/src/hooks/useCompanyApplications.ts
+++ b/frontend/src/hooks/useCompanyApplications.ts
@@ -37,24 +37,36 @@ export function useCompanyApplications() {
     [applications],
   );
 
-  // status を更新する。楽観的に反映し、失敗時は再取得で整合を取る。
+  // status を更新する。楽観的に反映し、失敗時は更新前の status へ確実にロールバックする
+  // （再取得 load 依存だと、再取得自体が失敗したときにサーバー未反映の状態が画面に残るため）。
   const setStatus = useCallback(
     async (id: number, status: CompanyApplicationStatus): Promise<boolean> => {
       setUpdatingId(id);
       setError(null);
-      setApplications((prev) => prev.map((a) => (a.id === id ? { ...a, status } : a)));
+      let previous: CompanyApplicationStatus | undefined;
+      setApplications((prev) =>
+        prev.map((a) => {
+          if (a.id !== id) return a;
+          previous = a.status;
+          return { ...a, status };
+        }),
+      );
       try {
         await CompanyApplicationRepository.adminUpdateStatus(id, status);
         return true;
       } catch {
-        await load();
+        if (previous !== undefined) {
+          setApplications((prev) =>
+            prev.map((a) => (a.id === id ? { ...a, status: previous as CompanyApplicationStatus } : a)),
+          );
+        }
         setError('ステータスの更新に失敗しました');
         return false;
       } finally {
         setUpdatingId(null);
       }
     },
-    [load],
+    [],
   );
 
   return { applications, pendingCount, loading, error, updatingId, setStatus, reload: load };

--- a/frontend/src/hooks/useCompanyApplications.ts
+++ b/frontend/src/hooks/useCompanyApplications.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  CompanyApplicationRepository,
+  CompanyApplication,
+  CompanyApplicationStatus,
+} from '../repositories/CompanyApplicationRepository';
+
+/**
+ * useCompanyApplications — 利用申請（企業）の承認ページの状態管理フック。
+ * super_admin 専用。一覧取得と status 更新（承認 / 却下 / 保留）を扱う。
+ */
+export function useCompanyApplications() {
+  const [applications, setApplications] = useState<CompanyApplication[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [updatingId, setUpdatingId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setApplications(await CompanyApplicationRepository.adminList());
+    } catch {
+      setError('利用申請の取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // 承認待ちの件数（サイドバー/ヘッダーのバッジ表示に使う）。
+  const pendingCount = useMemo(
+    () => applications.filter((a) => a.status === 'pending').length,
+    [applications],
+  );
+
+  // status を更新する。楽観的に反映し、失敗時は再取得で整合を取る。
+  const setStatus = useCallback(
+    async (id: number, status: CompanyApplicationStatus): Promise<boolean> => {
+      setUpdatingId(id);
+      setError(null);
+      setApplications((prev) => prev.map((a) => (a.id === id ? { ...a, status } : a)));
+      try {
+        await CompanyApplicationRepository.adminUpdateStatus(id, status);
+        return true;
+      } catch {
+        await load();
+        setError('ステータスの更新に失敗しました');
+        return false;
+      } finally {
+        setUpdatingId(null);
+      }
+    },
+    [load],
+  );
+
+  return { applications, pendingCount, loading, error, updatingId, setStatus, reload: load };
+}

--- a/frontend/src/pages/AdminCompaniesPage.tsx
+++ b/frontend/src/pages/AdminCompaniesPage.tsx
@@ -6,7 +6,7 @@ import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
 import { logger } from '../lib/logger';
-import { BuildingOffice2Icon, UserPlusIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
+import { BuildingOffice2Icon, UserPlusIcon } from '@heroicons/react/24/outline';
 
 export default function AdminCompaniesPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
@@ -53,7 +53,7 @@ export default function AdminCompaniesPage() {
     <div className="px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
       <PageIntro
         title="管理: 会社一覧"
-        description="登録されている会社の一覧です。会社を選択してシナリオや招待を管理できます。"
+        description="登録されている会社の一覧です。各社のアカウントの有効/無効を切り替えたり、招待を管理できます。"
       />
 
       {error && (
@@ -105,13 +105,6 @@ export default function AdminCompaniesPage() {
                     {company.isActive ? '無効化' : '有効化'}
                   </button>
                 )}
-                <Link
-                  to={`/admin/scenarios?companyId=${company.id}`}
-                  className="flex items-center gap-1 text-xs px-3 py-1.5 border rounded text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors"
-                >
-                  <Cog6ToothIcon className="w-3.5 h-3.5" />
-                  シナリオ
-                </Link>
                 <Link
                   to={`/admin/invitations?companyId=${company.id}`}
                   className="flex items-center gap-1 text-xs px-3 py-1.5 border rounded text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors"

--- a/frontend/src/pages/AdminCompanyApplicationsPage.tsx
+++ b/frontend/src/pages/AdminCompanyApplicationsPage.tsx
@@ -1,0 +1,157 @@
+import { useSelector } from 'react-redux';
+import { Navigate, Link } from 'react-router-dom';
+import { BuildingOffice2Icon, CheckIcon, XMarkIcon, UserPlusIcon } from '@heroicons/react/24/outline';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+import { useToast } from '../hooks/useToast';
+import { useCompanyApplications } from '../hooks/useCompanyApplications';
+import type {
+  CompanyApplication,
+  CompanyApplicationStatus,
+} from '../repositories/CompanyApplicationRepository';
+
+const STATUS_LABEL: Record<CompanyApplicationStatus, string> = {
+  pending: '承認待ち',
+  approved: '承認済み',
+  rejected: '却下',
+};
+
+const STATUS_CLASS: Record<CompanyApplicationStatus, string> = {
+  pending: 'bg-amber-100 text-amber-800',
+  approved: 'bg-emerald-100 text-emerald-700',
+  rejected: 'bg-rose-100 text-rose-700',
+};
+
+/**
+ * AdminCompanyApplicationsPage — `/admin/applications`。super_admin 専用。
+ * 公開フォームから届いた企業の利用申請を一覧し、承認 / 却下する。
+ * 承認しても会社は自動作成されないため、承認後は「招待管理」から会社管理者を招待する。
+ */
+export default function AdminCompanyApplicationsPage() {
+  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
+  const authLoading = useSelector((state: RootState) => state.auth.loading);
+  const role = useSelector((state: RootState) => state.auth.role);
+  const { applications, pendingCount, loading, error, updatingId, setStatus } =
+    useCompanyApplications();
+  const { showToast } = useToast();
+
+  if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
+  // 利用申請は全テナント横断の運営機能なので super_admin のみ。
+  if (!isAdmin || role !== 'super_admin') return <Navigate to="/" replace />;
+
+  const update = async (app: CompanyApplication, status: CompanyApplicationStatus) => {
+    const ok = await setStatus(app.id, status);
+    if (ok) {
+      showToast(
+        'success',
+        status === 'approved'
+          ? `「${app.companyName}」を承認しました。招待管理から会社管理者を招待してください。`
+          : `「${app.companyName}」を却下しました。`,
+      );
+    }
+  };
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
+      <PageIntro
+        title="管理: 利用申請"
+        description="公開フォームから届いた企業の利用申請です。内容を確認して承認または却下します。承認しても会社は自動作成されないため、承認後は「招待管理」から会社管理者を招待してください。"
+      />
+
+      {error && (
+        <div role="alert" className="p-3 rounded border border-rose-300 bg-rose-50 text-rose-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <Loading message="読み込み中..." className="min-h-[30vh]" />
+      ) : applications.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">利用申請はまだありません。</p>
+      ) : (
+        <>
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            承認待ち:{' '}
+            <span className="font-semibold text-amber-700">{pendingCount}</span> 件 / 全{' '}
+            {applications.length} 件
+          </p>
+
+          <ul className="space-y-3">
+            {applications.map((app) => (
+              <li
+                key={app.id}
+                className="p-4 border rounded-lg bg-[var(--color-surface-1)] space-y-2"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <BuildingOffice2Icon className="w-7 h-7 text-[var(--color-text-muted)] flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="font-semibold text-sm flex items-center gap-2 flex-wrap">
+                        <span className="truncate">{app.companyName}</span>
+                        <span
+                          className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${STATUS_CLASS[app.status]}`}
+                        >
+                          {STATUS_LABEL[app.status]}
+                        </span>
+                      </p>
+                      <p className="text-xs text-[var(--color-text-muted)] mt-0.5 truncate">
+                        {app.applicantName}（{app.email}）
+                      </p>
+                      <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+                        申請日: {new Date(app.createdAt).toLocaleDateString('ja-JP')}
+                      </p>
+                    </div>
+                  </div>
+
+                  {app.status === 'pending' && (
+                    <div className="flex gap-2 flex-shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => update(app, 'approved')}
+                        disabled={updatingId === app.id}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded border border-emerald-300 text-emerald-700 hover:bg-emerald-50 transition-colors disabled:opacity-50"
+                      >
+                        <CheckIcon className="w-3.5 h-3.5" />
+                        承認
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (window.confirm(`「${app.companyName}」の申請を却下しますか？`)) {
+                            update(app, 'rejected');
+                          }
+                        }}
+                        disabled={updatingId === app.id}
+                        className="flex items-center gap-1 text-xs px-3 py-1.5 rounded border border-rose-300 text-rose-700 hover:bg-rose-50 transition-colors disabled:opacity-50"
+                      >
+                        <XMarkIcon className="w-3.5 h-3.5" />
+                        却下
+                      </button>
+                    </div>
+                  )}
+
+                  {app.status === 'approved' && (
+                    <Link
+                      to="/admin/invitations"
+                      className="flex items-center gap-1 text-xs px-3 py-1.5 border rounded text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors flex-shrink-0"
+                    >
+                      <UserPlusIcon className="w-3.5 h-3.5" />
+                      招待へ
+                    </Link>
+                  )}
+                </div>
+
+                {app.message && (
+                  <p className="text-xs text-[var(--color-text-secondary)] whitespace-pre-wrap border-t border-surface-3 pt-2">
+                    {app.message}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/AdminCompanyApplicationsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminCompanyApplicationsPage.test.tsx
@@ -36,7 +36,6 @@ const applications = [
     updatedAt: '2026-05-21T00:00:00Z',
   },
 ];
-let hookReturn: ReturnType<typeof makeHookReturn>;
 function makeHookReturn() {
   return {
     applications,
@@ -48,6 +47,8 @@ function makeHookReturn() {
     reload: vi.fn(),
   };
 }
+// 宣言時に初期化しておく（モック factory がモジュール読み込み時に評価されても undefined にならないように）。
+let hookReturn = makeHookReturn();
 vi.mock('../../hooks/useCompanyApplications', () => ({
   useCompanyApplications: () => hookReturn,
 }));

--- a/frontend/src/pages/__tests__/AdminCompanyApplicationsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminCompanyApplicationsPage.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Redux: super_admin としてページを表示できる状態。テストごとに role を差し替える。
+const mockState = { auth: { isAdmin: true, loading: false, role: 'super_admin' } };
+vi.mock('react-redux', () => ({
+  useSelector: (sel: (s: typeof mockState) => unknown) => sel(mockState),
+  useDispatch: () => vi.fn(),
+}));
+
+const showToast = vi.fn();
+vi.mock('../../hooks/useToast', () => ({ useToast: () => ({ showToast }) }));
+
+// useCompanyApplications フックは固定データを返す（API/axios は呼ばない）。
+const setStatus = vi.fn().mockResolvedValue(true);
+const applications = [
+  {
+    id: 1,
+    companyName: 'アクメ社',
+    applicantName: '山田',
+    email: 'yamada@acme.co.jp',
+    message: '新卒研修で使いたい',
+    status: 'pending',
+    createdAt: '2026-06-01T00:00:00Z',
+    updatedAt: '2026-06-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    companyName: '承認済み社',
+    applicantName: '佐藤',
+    email: 'sato@ok.co.jp',
+    message: '',
+    status: 'approved',
+    createdAt: '2026-05-20T00:00:00Z',
+    updatedAt: '2026-05-21T00:00:00Z',
+  },
+];
+let hookReturn: ReturnType<typeof makeHookReturn>;
+function makeHookReturn() {
+  return {
+    applications,
+    pendingCount: 1,
+    loading: false,
+    error: null as string | null,
+    updatingId: null as number | null,
+    setStatus,
+    reload: vi.fn(),
+  };
+}
+vi.mock('../../hooks/useCompanyApplications', () => ({
+  useCompanyApplications: () => hookReturn,
+}));
+
+import AdminCompanyApplicationsPage from '../AdminCompanyApplicationsPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminCompanyApplicationsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminCompanyApplicationsPage（利用申請の承認）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setStatus.mockResolvedValue(true);
+    mockState.auth = { isAdmin: true, loading: false, role: 'super_admin' };
+    hookReturn = makeHookReturn();
+  });
+
+  it('申請の一覧を表示し、承認済みには招待への導線を出す', () => {
+    renderPage();
+    expect(screen.getByText('アクメ社')).toBeInTheDocument();
+    expect(screen.getByText('承認済み社')).toBeInTheDocument();
+    expect(screen.getByText('招待へ')).toBeInTheDocument();
+  });
+
+  it('承認ボタンで status を approved に更新し、トーストを出す', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '承認' }));
+    expect(setStatus).toHaveBeenCalledWith(1, 'approved');
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith('success', expect.stringContaining('承認')));
+  });
+
+  it('却下は確認ダイアログで OK のとき rejected に更新する', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '却下' }));
+    expect(setStatus).toHaveBeenCalledWith(1, 'rejected');
+  });
+
+  it('却下をキャンセルしたら更新しない', () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: '却下' }));
+    expect(setStatus).not.toHaveBeenCalled();
+  });
+
+  it('super_admin 以外はリダイレクトして一覧を表示しない', () => {
+    mockState.auth = { isAdmin: true, loading: false, role: 'company_admin' };
+    renderPage();
+    expect(screen.queryByText('アクメ社')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/CompanyApplicationRepository.ts
+++ b/frontend/src/repositories/CompanyApplicationRepository.ts
@@ -9,9 +9,35 @@ export interface CompanyApplicationForm {
   message: string;
 }
 
+/** 企業利用申請のステータス（backend の domain と一致）。 */
+export type CompanyApplicationStatus = 'pending' | 'approved' | 'rejected';
+
+/** 企業利用申請（super_admin が一覧で確認し、承認 / 却下する）。 */
+export interface CompanyApplication {
+  id: number;
+  companyName: string;
+  applicantName: string;
+  email: string;
+  message: string;
+  status: CompanyApplicationStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export const CompanyApplicationRepository = {
   /** 企業利用申請を送信する。認証不要。 */
   async apply(form: CompanyApplicationForm): Promise<void> {
     await apiClient.post(COMPANY_APPLICATIONS.create, form);
+  },
+
+  /** super_admin: 全申請を新しい順で取得する。 */
+  async adminList(): Promise<CompanyApplication[]> {
+    const { data } = await apiClient.get<CompanyApplication[]>(COMPANY_APPLICATIONS.adminList);
+    return data;
+  },
+
+  /** super_admin: 申請の status を更新する（approved / rejected / pending）。 */
+  async adminUpdateStatus(id: number, status: CompanyApplicationStatus): Promise<void> {
+    await apiClient.patch(COMPANY_APPLICATIONS.adminUpdateStatus(id), { status });
   },
 };


### PR DESCRIPTION
## 概要

super_admin（運営）機能のギャップ解消（🔴 高）。**利用申請の承認 API は backend に実装済みだったのに frontend に画面が無く、super_admin が UI から会社の利用申請を承認/却下できない**状態でした（オンボーディング導線の肝が欠落）。既存 API を使う承認画面を追加し、導線を UI で完結させます。あわせて AdminCompaniesPage に残っていた**死んだリンク**を除去します。

## 変更内容

### 新機能：利用申請の承認画面
- **`AdminCompanyApplicationsPage`**（`/admin/applications`・**super_admin 専用**）
  - 申請一覧（会社名 / 申請者 / メール / メッセージ / 申請日 / ステータス）
  - **承認待ち件数**の表示
  - **承認 / 却下**（楽観的更新 + トースト、却下は確認ダイアログ）
  - 承認しても会社は自動作成されないため、**承認後は「招待管理」から会社管理者を招待**する旨を明記（承認済みカードに「招待へ」導線）
- **`useCompanyApplications`** フック（一覧取得 / status 更新 / `pendingCount`）
- **`CompanyApplicationRepository`** に `adminList` / `adminUpdateStatus` を追加（`apiRoutes` の `COMPANY_APPLICATIONS.adminList` / `adminUpdateStatus` は定義済みを利用）
- サイドバー **「管理 > 利用申請」** を super_admin 専用で追加

> backend は既存の `GET /admin/company-applications` / `PATCH /admin/company-applications/:id/status` をそのまま利用。**backend 変更なし**。

### バグ修正：死んだリンク除去
- `AdminCompaniesPage` の `/admin/scenarios?companyId=` リンクを除去（**scenarios 機能は 2026-05 に撤去済**で 404 遷移になっていた）。説明文からも「シナリオ」を削除。

## テスト

- 新規 `AdminCompanyApplicationsPage.test.tsx`（5 件）: 一覧表示 / 承認→approved / 却下（確認 OK）→rejected / 却下キャンセルは更新しない / **super_admin 以外はリダイレクト**
- `tsc --noEmit` ✓ / `eslint --max-warnings 0` ✓ / `vitest run`（**1084 passed**） ✓ / `npm run build` ✓

## フォローアップ（別途）

- pdm `04-feature-catalog` の「利用申請の承認フロー」を 🟡計画 → ✅実装 に更新（別リポ）
- 中優先のギャップ（会社の横断ビュー / 運営ダッシュボード / 監査ログ）は別 PR で

## 関連 Issue

なし（super_admin 機能ギャップ解消）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 企業利用申請管理ページを新規追加。申請一覧表示、ステータス管理（承認/却下/保留）、申請詳細の確認が可能に。
  * 管理者メニューに「利用申請」へのナビゲーションリンクを新規追加。

* **改善**
  * 管理者向け企業管理ページの説明文およびアクション導線を更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->