### PR TITLE
feat(admin): 運営ダッシュボード(概況)を追加 — 会社数 / 承認待ち申請

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ const AdminCompanyApplicationsPage = lazyWithReload(
   () => import('./pages/AdminCompanyApplicationsPage'),
   'AdminCompanyApplicationsPage',
 );
+const AdminDashboardPage = lazyWithReload(() => import('./pages/AdminDashboardPage'), 'AdminDashboardPage');
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
 const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
@@ -118,6 +119,7 @@ export default function App() {
         {/* 旧 /teaching-materials へのアクセスは /courses に redirect */}
         <Route path="/teaching-materials" element={<CoursesListPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
+        <Route path="/admin/dashboard" element={<AdminDashboardPage />} />
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
         <Route path="/admin/applications" element={<AdminCompanyApplicationsPage />} />
         <Route path="/admin/members" element={<AdminMembersPage />} />

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -60,6 +60,13 @@ const adminNavItem: NavItem = {
   label: '管理',
   matchPrefix: '/admin',
   subItems: [
+    // 運営ダッシュボード（概況）は全テナント横断なので super_admin 専用。
+    {
+      label: '概況',
+      to: '/admin/dashboard',
+      matchPrefix: '/admin/dashboard',
+      allowedRoles: ['super_admin'],
+    },
     // 会社一覧は全テナントの管理画面なので運営 (super_admin) 専用。
     // company_admin が見えると越権が起きる印象を与えるため非表示にする。
     {

--- a/frontend/src/hooks/useAdminDashboard.ts
+++ b/frontend/src/hooks/useAdminDashboard.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import CompanyRepository from '../repositories/CompanyRepository';
+import {
+  CompanyApplicationRepository,
+  CompanyApplication,
+} from '../repositories/CompanyApplicationRepository';
+
+/** 運営ダッシュボードの概況サマリ（既存 API の集計）。 */
+export interface AdminDashboardSummary {
+  companyTotal: number;
+  companyActive: number;
+  companyInactive: number;
+  applicationTotal: number;
+  pendingApplications: number;
+  /** 承認待ちの申請（新しい順・最大 5 件）。すぐ承認できるよう一覧に出す。 */
+  recentPending: CompanyApplication[];
+}
+
+/**
+ * useAdminDashboard — 運営（super_admin）ダッシュボードの概況を取得するフック。
+ * 専用の集計 API は持たず、会社一覧 + 利用申請一覧をクライアントで集計する（会社数が少ない前提）。
+ */
+export function useAdminDashboard() {
+  const [summary, setSummary] = useState<AdminDashboardSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const [companies, applications] = await Promise.all([
+          CompanyRepository.list(),
+          CompanyApplicationRepository.adminList(),
+        ]);
+        if (cancelled) return;
+        const companyActive = companies.filter((c) => c.isActive).length;
+        const pending = applications.filter((a) => a.status === 'pending');
+        setSummary({
+          companyTotal: companies.length,
+          companyActive,
+          companyInactive: companies.length - companyActive,
+          applicationTotal: applications.length,
+          pendingApplications: pending.length,
+          recentPending: pending.slice(0, 5),
+        });
+      } catch {
+        if (!cancelled) setError('ダッシュボードの取得に失敗しました');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { summary, loading, error };
+}

--- a/frontend/src/hooks/useAdminDashboard.ts
+++ b/frontend/src/hooks/useAdminDashboard.ts
@@ -19,13 +19,18 @@ export interface AdminDashboardSummary {
 /**
  * useAdminDashboard — 運営（super_admin）ダッシュボードの概況を取得するフック。
  * 専用の集計 API は持たず、会社一覧 + 利用申請一覧をクライアントで集計する（会社数が少ない前提）。
+ * `enabled=false`（super_admin 以外 / 認証確認中）のときは admin API を叩かない。
  */
-export function useAdminDashboard() {
+export function useAdminDashboard(enabled = true) {
   const [summary, setSummary] = useState<AdminDashboardSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
     let cancelled = false;
     (async () => {
       setLoading(true);
@@ -37,7 +42,10 @@ export function useAdminDashboard() {
         ]);
         if (cancelled) return;
         const companyActive = companies.filter((c) => c.isActive).length;
-        const pending = applications.filter((a) => a.status === 'pending');
+        // 直近順は backend の返却順に依存しないよう createdAt 降順で明示的にソートする。
+        const pending = applications
+          .filter((a) => a.status === 'pending')
+          .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
         setSummary({
           companyTotal: companies.length,
           companyActive,
@@ -55,7 +63,7 @@ export function useAdminDashboard() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [enabled]);
 
   return { summary, loading, error };
 }

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -43,11 +43,13 @@ export default function AdminDashboardPage() {
   const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
   const role = useSelector((state: RootState) => state.auth.role);
-  const { summary, loading, error } = useAdminDashboard();
+  // super_admin のときだけ admin API を取得する（リダイレクト対象に権限外アクセスを試行させない）。
+  const canView = isAdmin && role === 'super_admin';
+  const { summary, loading, error } = useAdminDashboard(canView);
 
   if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
   // 運営ダッシュボードは全テナント横断の概況なので super_admin 専用。
-  if (!isAdmin || role !== 'super_admin') return <Navigate to="/" replace />;
+  if (!canView) return <Navigate to="/" replace />;
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">

--- a/frontend/src/pages/AdminDashboardPage.tsx
+++ b/frontend/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,119 @@
+import { useSelector } from 'react-redux';
+import { Navigate, Link } from 'react-router-dom';
+import { BuildingOffice2Icon, InboxArrowDownIcon } from '@heroicons/react/24/outline';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+import { useAdminDashboard } from '../hooks/useAdminDashboard';
+
+/** 概況の数値カード。クリックで該当の管理画面へ遷移する。 */
+function StatCard(props: {
+  label: string;
+  value: number;
+  sub: string;
+  to: string;
+  icon: typeof BuildingOffice2Icon;
+  emphasize?: boolean;
+}) {
+  const { label, value, sub, to, icon: Icon, emphasize } = props;
+  return (
+    <Link
+      to={to}
+      className={`block p-4 border rounded-lg bg-[var(--color-surface-1)] hover:bg-surface-2 transition-colors ${
+        emphasize ? 'border-amber-300' : 'border-surface-3'
+      }`}
+    >
+      <div className="flex items-center gap-2 text-[var(--color-text-muted)]">
+        <Icon className="w-4 h-4" />
+        <span className="text-xs">{label}</span>
+      </div>
+      <p className={`mt-1 text-2xl font-bold ${emphasize ? 'text-amber-700' : 'text-[var(--color-text-primary)]'}`}>
+        {value}
+      </p>
+      <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{sub}</p>
+    </Link>
+  );
+}
+
+/**
+ * AdminDashboardPage — `/admin/dashboard`。super_admin 専用の運営概況。
+ * 会社数（有効/無効）と承認待ちの利用申請件数を一目で把握し、各管理画面へ導く。
+ */
+export default function AdminDashboardPage() {
+  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
+  const authLoading = useSelector((state: RootState) => state.auth.loading);
+  const role = useSelector((state: RootState) => state.auth.role);
+  const { summary, loading, error } = useAdminDashboard();
+
+  if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
+  // 運営ダッシュボードは全テナント横断の概況なので super_admin 専用。
+  if (!isAdmin || role !== 'super_admin') return <Navigate to="/" replace />;
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
+      <PageIntro
+        title="運営ダッシュボード"
+        description="全テナントの概況です。会社数と承認待ちの利用申請を確認し、各管理画面へ移動できます。"
+      />
+
+      {error && (
+        <div role="alert" className="p-3 rounded border border-rose-300 bg-rose-50 text-rose-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <Loading message="読み込み中..." className="min-h-[30vh]" />
+      ) : summary ? (
+        <>
+          <div className="grid grid-cols-2 gap-3">
+            <StatCard
+              label="会社数"
+              value={summary.companyTotal}
+              sub={`有効 ${summary.companyActive} / 無効 ${summary.companyInactive}`}
+              to="/admin/companies"
+              icon={BuildingOffice2Icon}
+            />
+            <StatCard
+              label="承認待ちの申請"
+              value={summary.pendingApplications}
+              sub={`全 ${summary.applicationTotal} 件`}
+              to="/admin/applications"
+              icon={InboxArrowDownIcon}
+              emphasize={summary.pendingApplications > 0}
+            />
+          </div>
+
+          <section className="space-y-2">
+            <h2 className="text-sm font-semibold text-[var(--color-text-secondary)]">承認待ちの利用申請</h2>
+            {summary.recentPending.length === 0 ? (
+              <p className="text-sm text-[var(--color-text-muted)]">承認待ちの申請はありません。</p>
+            ) : (
+              <ul className="space-y-2">
+                {summary.recentPending.map((app) => (
+                  <li
+                    key={app.id}
+                    className="p-3 border border-surface-3 rounded-lg bg-[var(--color-surface-1)] flex items-center justify-between gap-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">{app.companyName}</p>
+                      <p className="text-xs text-[var(--color-text-muted)] truncate">
+                        {app.applicantName}（{app.email}）
+                      </p>
+                    </div>
+                    <Link
+                      to="/admin/applications"
+                      className="text-xs px-3 py-1.5 border border-surface-3 rounded text-[var(--color-text-secondary)] hover:bg-surface-2 transition-colors flex-shrink-0"
+                    >
+                      確認
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/AdminDashboardPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminDashboardPage.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockState = { auth: { isAdmin: true, loading: false, role: 'super_admin' } };
+vi.mock('react-redux', () => ({
+  useSelector: (sel: (s: typeof mockState) => unknown) => sel(mockState),
+  useDispatch: () => vi.fn(),
+}));
+
+function makeHookReturn() {
+  return {
+    summary: {
+      companyTotal: 3,
+      companyActive: 2,
+      companyInactive: 1,
+      applicationTotal: 4,
+      pendingApplications: 2,
+      recentPending: [
+        { id: 1, companyName: 'アクメ社', applicantName: '山田', email: 'y@acme.co.jp', message: '', status: 'pending', createdAt: '', updatedAt: '' },
+        { id: 2, companyName: 'ベータ社', applicantName: '佐藤', email: 's@beta.co.jp', message: '', status: 'pending', createdAt: '', updatedAt: '' },
+      ],
+    },
+    loading: false,
+    error: null as string | null,
+  };
+}
+let hookReturn = makeHookReturn();
+vi.mock('../../hooks/useAdminDashboard', () => ({
+  useAdminDashboard: () => hookReturn,
+}));
+
+import AdminDashboardPage from '../AdminDashboardPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminDashboardPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminDashboardPage（運営ダッシュボード）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.auth = { isAdmin: true, loading: false, role: 'super_admin' };
+    hookReturn = makeHookReturn();
+  });
+
+  it('会社数と承認待ち件数のカードを表示する', () => {
+    renderPage();
+    expect(screen.getByText('会社数')).toBeInTheDocument();
+    expect(screen.getByText('承認待ちの申請')).toBeInTheDocument();
+    expect(screen.getByText('有効 2 / 無効 1')).toBeInTheDocument();
+  });
+
+  it('承認待ちの申請を一覧に出す', () => {
+    renderPage();
+    expect(screen.getByText('アクメ社')).toBeInTheDocument();
+    expect(screen.getByText('ベータ社')).toBeInTheDocument();
+  });
+
+  it('super_admin 以外はリダイレクトする', () => {
+    mockState.auth = { isAdmin: true, loading: false, role: 'company_admin' };
+    renderPage();
+    expect(screen.queryByText('会社数')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

super_admin（運営）機能ギャップ解消の続き（🟡 中）。運営の概況が UI に無く、**会社数や承認待ちの利用申請件数を一目で把握できなかった**ため、ダッシュボードを追加します。専用集計 API は持たず、**既存 API をクライアントで集計**します（会社数が少ない前提・backend 変更なし）。

## 変更内容

- **`AdminDashboardPage`**（`/admin/dashboard`・super_admin 専用）
  - サマリカード: **会社数（有効/無効）** / **承認待ちの申請**（件数が 0 超なら強調。クリックで該当の管理画面へ）
  - **承認待ち申請の直近一覧**（最大 5 件、すぐ確認に飛べる）
- **`useAdminDashboard`** フック: `GET /admin/companies` + `GET /admin/company-applications` を並列取得して集計
- サイドバー **「管理 > 概況」** を super_admin 専用で先頭に追加

## テスト

- 新規 `AdminDashboardPage.test.tsx`（3 件）: カード表示 / 承認待ち一覧 / super_admin 以外はリダイレクト
- `tsc` ✓ / `eslint --max-warnings 0` ✓ / `vitest run`（**1087 passed**） ✓ / `npm run build` ✓

## 補足 / 今後

- 専用集計 API は未導入（会社数が増えたら `GET /admin/dashboard/summary` 等のサーバ集計に切替推奨）
- 残る 🟡: 会社の横断ビュー（各社 trainee 数・アクティブ率＝新規 backend 集計）/ 監査ログ（新規 DB テーブル）は別 PR

## 関連 Issue

なし（super_admin 機能ギャップ解消）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 管理者向けダッシュボード画面を追加。会社の統計情報（総数・有効/無効状態）と承認待ち申請の概況をリアルタイムに表示します。
  * 管理メニューに「概況」メニュー項目を追加し、ダッシュボードへのアクセスを実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->