### PR TITLE
feat(admin): 会社横断ビュー(各社のメンバー集計)を追加

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -53,6 +53,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/admin/companies/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "全 company に、各社の在籍メンバー数（総数 / 有効 / trainee）を付けて返す。super_admin 専用画面用。認可は middleware で別途担保。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社横断ビュー（メンバー集計・super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/companies/{id}/active": {
             "patch": {
                 "security": [
@@ -4012,6 +4058,32 @@ const docTemplate = `{
                 },
                 "url": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat": {
+            "type": "object",
+            "properties": {
+                "activeMembers": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "memberTotal": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "traineeCount": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -46,6 +46,52 @@
                 }
             }
         },
+        "/admin/companies/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "全 company に、各社の在籍メンバー数（総数 / 有効 / trainee）を付けて返す。super_admin 専用画面用。認可は middleware で別途担保。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社横断ビュー（メンバー集計・super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/companies/{id}/active": {
             "patch": {
                 "security": [
@@ -4005,6 +4051,32 @@
                 },
                 "url": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat": {
+            "type": "object",
+            "properties": {
+                "activeMembers": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isActive": {
+                    "type": "boolean"
+                },
+                "memberTotal": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "traineeCount": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -387,6 +387,23 @@ definitions:
       url:
         type: string
     type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat:
+    properties:
+      activeMembers:
+        type: integer
+      createdAt:
+        type: string
+      id:
+        type: integer
+      isActive:
+        type: boolean
+      memberTotal:
+        type: integer
+      name:
+        type: string
+      traineeCount:
+        type: integer
+    type: object
   github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput:
     properties:
       examples:
@@ -927,6 +944,36 @@ paths:
       security:
       - CookieAuth: []
       summary: 会社アカウントの有効/無効を切り替え（super_admin 専用）
+      tags:
+      - admin
+  /admin/companies/stats:
+    get:
+      description: 全 company に、各社の在籍メンバー数（総数 / 有効 / trainee）を付けて返す。super_admin 専用画面用。認可は
+        middleware で別途担保。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat'
+            type: array
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 会社横断ビュー（メンバー集計・super_admin）
       tags:
       - admin
   /admin/company-applications:

--- a/backend/internal/adapter/persistence/company_stats_repository.go
+++ b/backend/internal/adapter/persistence/company_stats_repository.go
@@ -1,0 +1,40 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// companyStatsRepository は [repository.CompanyMemberCounter] の実装。
+// users テーブルを company_id で GROUP BY し、会社ごとのメンバー集計を 1 クエリで返す。
+type companyStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewCompanyStatsRepository は会社メンバー集計 repository を生成する。
+func NewCompanyStatsRepository(db *gorm.DB) repository.CompanyMemberCounter {
+	return &companyStatsRepository{db: db}
+}
+
+func (r *companyStatsRepository) CountMembersByCompany(ctx context.Context) ([]repository.CompanyMemberCount, error) {
+	var rows []repository.CompanyMemberCount
+	err := r.db.WithContext(ctx).
+		Table("users").
+		Select(
+			"company_id AS company_id, "+
+				"COUNT(*) AS total, "+
+				"COUNT(*) FILTER (WHERE is_active) AS active, "+
+				"COUNT(*) FILTER (WHERE role = ?) AS trainees",
+			domain.RoleTrainee,
+		).
+		Where("company_id IS NOT NULL AND deleted_at IS NULL").
+		Group("company_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/backend/internal/adapter/persistence/company_stats_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/company_stats_repository_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompanyStatsRepository_Integration は CountMembersByCompany の集計（FILTER）と、
+// 論理削除済み / 会社未所属の除外を実 Postgres で検証する。
+func TestCompanyStatsRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	counter := persistence.NewCompanyStatsRepository(db)
+	userRepo := persistence.NewUserRepository(db)
+	ctx := context.Background()
+	testsupport.TruncateAll(t, db, "users", "companies")
+
+	require.NoError(t, db.Create(&domain.Company{ID: 1, Name: "C1"}).Error)
+	require.NoError(t, db.Create(&domain.Company{ID: 2, Name: "C2"}).Error)
+
+	c1 := uint64(1)
+	c2 := uint64(2)
+	mk := func(sub string, cid *uint64, role string, active bool) *domain.User {
+		return &domain.User{
+			CognitoSub: sub, Email: sub + "@example.com", DisplayName: sub,
+			Role: role, CompanyID: cid, IsActive: active,
+		}
+	}
+	// 会社1: trainee有効 / trainee無効 / company_admin有効 / trainee(論理削除→除外)
+	require.NoError(t, userRepo.Create(ctx, mk("a", &c1, domain.RoleTrainee, true)))
+	require.NoError(t, userRepo.Create(ctx, mk("b", &c1, domain.RoleTrainee, false)))
+	require.NoError(t, userRepo.Create(ctx, mk("c", &c1, domain.RoleCompanyAdmin, true)))
+	require.NoError(t, userRepo.Create(ctx, mk("d", &c1, domain.RoleTrainee, true)))
+	dUser, err := userRepo.FindByCognitoSub(ctx, "d")
+	require.NoError(t, err)
+	require.NoError(t, userRepo.SoftDelete(ctx, dUser.ID))
+	// 会社2: trainee有効 1
+	require.NoError(t, userRepo.Create(ctx, mk("e", &c2, domain.RoleTrainee, true)))
+	// 会社未所属（super_admin）→ company_id IS NULL で除外
+	require.NoError(t, userRepo.Create(ctx, mk("z", nil, domain.RoleSuperAdmin, true)))
+
+	rows, err := counter.CountMembersByCompany(ctx)
+	require.NoError(t, err)
+
+	byID := map[uint64]repository.CompanyMemberCount{}
+	for _, r := range rows {
+		byID[r.CompanyID] = r
+	}
+
+	// 会社1: total 3（a,b,c。d は論理削除で除外）/ active 2（a,c）/ trainees 2（a,b）
+	require.Equal(t, 3, byID[1].Total)
+	require.Equal(t, 2, byID[1].Active)
+	require.Equal(t, 2, byID[1].Trainees)
+	// 会社2: total 1 / active 1 / trainees 1
+	require.Equal(t, 1, byID[2].Total)
+	require.Equal(t, 1, byID[2].Active)
+	require.Equal(t, 1, byID[2].Trainees)
+	// 会社未所属（company_id NULL）は集計に出ない
+	_, ok := byID[0]
+	require.False(t, ok)
+}

--- a/backend/internal/adapter/persistence/company_stats_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/company_stats_repository_integration_test.go
@@ -35,7 +35,12 @@ func TestCompanyStatsRepository_Integration(t *testing.T) {
 	}
 	// 会社1: trainee有効 / trainee無効 / company_admin有効 / trainee(論理削除→除外)
 	require.NoError(t, userRepo.Create(ctx, mk("a", &c1, domain.RoleTrainee, true)))
-	require.NoError(t, userRepo.Create(ctx, mk("b", &c1, domain.RoleTrainee, false)))
+	// b は無効ユーザー。GORM は is_active の default:true 指定によりゼロ値(false)を省略して
+	// DB デフォルト true で挿入するため、Create 後に明示的に UpdateActive(false) で無効化する。
+	require.NoError(t, userRepo.Create(ctx, mk("b", &c1, domain.RoleTrainee, true)))
+	bUser, err := userRepo.FindByCognitoSub(ctx, "b")
+	require.NoError(t, err)
+	require.NoError(t, userRepo.UpdateActive(ctx, bUser.ID, false))
 	require.NoError(t, userRepo.Create(ctx, mk("c", &c1, domain.RoleCompanyAdmin, true)))
 	require.NoError(t, userRepo.Create(ctx, mk("d", &c1, domain.RoleTrainee, true)))
 	dUser, err := userRepo.FindByCognitoSub(ctx, "d")

--- a/backend/internal/handler/admin_company_handler.go
+++ b/backend/internal/handler/admin_company_handler.go
@@ -17,14 +17,20 @@ func isSuperAdmin(actor *domain.User) bool {
 	return actor != nil && actor.Role == domain.RoleSuperAdmin
 }
 
-// AdminCompanyHandler は super_admin 向けの会社一覧と、会社アカウントの有効/無効を扱う。
+// AdminCompanyHandler は super_admin 向けの会社一覧 / 横断ビュー(メンバー集計) /
+// 会社アカウントの有効・無効を扱う。
 type AdminCompanyHandler struct {
 	list      *usecase.ListCompaniesUseCase
+	stats     *usecase.ListCompanyStatsUseCase
 	setActive *usecase.SetCompanyActiveUseCase
 }
 
-func NewAdminCompanyHandler(l *usecase.ListCompaniesUseCase, s *usecase.SetCompanyActiveUseCase) *AdminCompanyHandler {
-	return &AdminCompanyHandler{list: l, setActive: s}
+func NewAdminCompanyHandler(
+	l *usecase.ListCompaniesUseCase,
+	st *usecase.ListCompanyStatsUseCase,
+	s *usecase.SetCompanyActiveUseCase,
+) *AdminCompanyHandler {
+	return &AdminCompanyHandler{list: l, stats: st, setActive: s}
 }
 
 // @Summary      会社 一覧 (SuperAdmin)
@@ -42,6 +48,31 @@ func (h *AdminCompanyHandler) List(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, companies)
+}
+
+// Stats は各社のメンバー集計を付けた会社横断ビューを返す（super_admin 専用）。
+//
+//	@Summary      会社横断ビュー（メンバー集計・super_admin）
+//	@Description  全 company に、各社の在籍メンバー数（総数 / 有効 / trainee）を付けて返す。super_admin 専用画面用。認可は middleware で別途担保。
+//	@Tags         admin
+//	@Produce      json
+//	@Success      200  {array}   usecase.CompanyStat
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "super_admin 以外"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /admin/companies/stats [get]
+//	@Security     CookieAuth
+func (h *AdminCompanyHandler) Stats(c *gin.Context) {
+	if !isSuperAdmin(middleware.CurrentUserFromContext(c)) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
+	rows, err := h.stats.Execute(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
 }
 
 // setCompanyActiveRequest は会社アカウントの有効/無効更新の入力。

--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -11,8 +11,18 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
 )
+
+// fakeCompanyCounter は CompanyMemberCounter の最小 fake。
+type fakeCompanyCounter struct {
+	rows []repository.CompanyMemberCount
+}
+
+func (f *fakeCompanyCounter) CountMembersByCompany(context.Context) ([]repository.CompanyMemberCount, error) {
+	return f.rows, nil
+}
 
 // fakeCompanyRepo は repository.CompanyRepository の最小 fake。
 type fakeCompanyRepo struct {
@@ -40,8 +50,31 @@ func (f *fakeCompanyRepo) UpdateActive(_ context.Context, id uint64, active bool
 func newAdminCompanyHandler(repo *fakeCompanyRepo) *AdminCompanyHandler {
 	return NewAdminCompanyHandler(
 		usecase.NewListCompaniesUseCase(repo),
+		usecase.NewListCompanyStatsUseCase(repo, &fakeCompanyCounter{}),
 		usecase.NewSetCompanyActiveUseCase(repo),
 	)
+}
+
+func Test_会社管理ハンドラ_横断ビュー_super_admin_正常系(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(middleware.ContextKeyCurrentUser, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/companies/stats", nil)
+	newAdminCompanyHandler(&fakeCompanyRepo{rows: []domain.Company{{ID: 1, Name: "Co"}}}).Stats(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+func Test_会社管理ハンドラ_横断ビュー_super_admin以外は禁止(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(middleware.ContextKeyCurrentUser, &domain.User{ID: 2, Role: domain.RoleCompanyAdmin})
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/companies/stats", nil)
+	newAdminCompanyHandler(&fakeCompanyRepo{}).Stats(c)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
 }
 
 func Test_会社管理ハンドラ_一覧_正常系(t *testing.T) {

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -16,9 +16,12 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	companyRepo := persistence.NewCompanyRepository(deps.db)
 	companyHandler := NewAdminCompanyHandler(
 		usecase.NewListCompaniesUseCase(companyRepo),
+		usecase.NewListCompanyStatsUseCase(companyRepo, persistence.NewCompanyStatsRepository(deps.db)),
 		usecase.NewSetCompanyActiveUseCase(companyRepo),
 	)
 	g.GET("/admin/companies", companyHandler.List)
+	// 会社横断ビュー（各社のメンバー集計付き。super_admin 専用）。
+	g.GET("/admin/companies/stats", companyHandler.Stats)
 	// 会社アカウントの有効/無効（super_admin 専用。無効化でその会社の全ユーザーを利用不可に）。
 	g.PATCH("/admin/companies/:id/active", companyHandler.SetActive)
 

--- a/backend/internal/usecase/list_company_stats_usecase.go
+++ b/backend/internal/usecase/list_company_stats_usecase.go
@@ -1,0 +1,62 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// CompanyStat は会社横断ビューの 1 行（会社情報 + メンバー集計）。handler がそのまま JSON 返却する。
+type CompanyStat struct {
+	ID            uint64    `json:"id"`
+	Name          string    `json:"name"`
+	IsActive      bool      `json:"isActive"`
+	CreatedAt     time.Time `json:"createdAt"`
+	MemberTotal   int       `json:"memberTotal"`
+	ActiveMembers int       `json:"activeMembers"`
+	TraineeCount  int       `json:"traineeCount"`
+}
+
+// ListCompanyStatsUseCase は会社一覧に各社のメンバー集計を付けて返す（super_admin 専用の横断ビュー）。
+type ListCompanyStatsUseCase struct {
+	companies repository.CompanyRepository
+	counter   repository.CompanyMemberCounter
+}
+
+func NewListCompanyStatsUseCase(
+	c repository.CompanyRepository,
+	mc repository.CompanyMemberCounter,
+) *ListCompanyStatsUseCase {
+	return &ListCompanyStatsUseCase{companies: c, counter: mc}
+}
+
+func (u *ListCompanyStatsUseCase) Execute(ctx context.Context) ([]CompanyStat, error) {
+	companies, err := u.companies.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	counts, err := u.counter.CountMembersByCompany(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[uint64]repository.CompanyMemberCount, len(counts))
+	for _, cnt := range counts {
+		byID[cnt.CompanyID] = cnt
+	}
+	stats := make([]CompanyStat, 0, len(companies))
+	for _, co := range companies {
+		// メンバーがいない会社は zero value（0 件）で埋まる。
+		cnt := byID[co.ID]
+		stats = append(stats, CompanyStat{
+			ID:            co.ID,
+			Name:          co.Name,
+			IsActive:      co.IsActive,
+			CreatedAt:     co.CreatedAt,
+			MemberTotal:   cnt.Total,
+			ActiveMembers: cnt.Active,
+			TraineeCount:  cnt.Trainees,
+		})
+	}
+	return stats, nil
+}

--- a/backend/internal/usecase/list_company_stats_usecase_test.go
+++ b/backend/internal/usecase/list_company_stats_usecase_test.go
@@ -1,0 +1,92 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStatsCompanyRepo は CompanyRepository の最小 fake。
+type fakeStatsCompanyRepo struct {
+	rows []domain.Company
+	err  error
+}
+
+func (f *fakeStatsCompanyRepo) ListAll(context.Context) ([]domain.Company, error) {
+	return f.rows, f.err
+}
+
+func (f *fakeStatsCompanyRepo) FindByID(context.Context, uint64) (*domain.Company, error) {
+	return nil, nil
+}
+
+func (f *fakeStatsCompanyRepo) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
+
+func (f *fakeStatsCompanyRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
+
+// fakeCounter は CompanyMemberCounter の fake。
+type fakeCounter struct {
+	rows []repository.CompanyMemberCount
+	err  error
+}
+
+func (f *fakeCounter) CountMembersByCompany(context.Context) ([]repository.CompanyMemberCount, error) {
+	return f.rows, f.err
+}
+
+func Test_会社横断ビュー_会社にメンバー集計をマージして返す(t *testing.T) {
+	companies := &fakeStatsCompanyRepo{rows: []domain.Company{
+		{ID: 1, Name: "アクメ社", IsActive: true},
+		{ID: 2, Name: "ベータ社", IsActive: false},
+		{ID: 3, Name: "メンバー無し社", IsActive: true},
+	}}
+	counter := &fakeCounter{rows: []repository.CompanyMemberCount{
+		{CompanyID: 1, Total: 5, Active: 4, Trainees: 3},
+		{CompanyID: 2, Total: 2, Active: 0, Trainees: 1},
+		// 会社 3 は集計に出てこない（メンバー 0）→ zero value で埋まることを検証
+	}}
+	uc := usecase.NewListCompanyStatsUseCase(companies, counter)
+
+	stats, err := uc.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, stats, 3)
+
+	assert.Equal(t, uint64(1), stats[0].ID)
+	assert.Equal(t, 5, stats[0].MemberTotal)
+	assert.Equal(t, 4, stats[0].ActiveMembers)
+	assert.Equal(t, 3, stats[0].TraineeCount)
+	assert.True(t, stats[0].IsActive)
+
+	assert.Equal(t, 2, stats[1].MemberTotal)
+	assert.Equal(t, 0, stats[1].ActiveMembers)
+	assert.False(t, stats[1].IsActive)
+
+	// メンバーがいない会社は 0 件で返る
+	assert.Equal(t, "メンバー無し社", stats[2].Name)
+	assert.Equal(t, 0, stats[2].MemberTotal)
+	assert.Equal(t, 0, stats[2].TraineeCount)
+}
+
+func Test_会社横断ビュー_会社一覧の取得失敗を伝播(t *testing.T) {
+	uc := usecase.NewListCompanyStatsUseCase(
+		&fakeStatsCompanyRepo{err: errors.New("db down")},
+		&fakeCounter{},
+	)
+	_, err := uc.Execute(context.Background())
+	assert.Error(t, err)
+}
+
+func Test_会社横断ビュー_集計の取得失敗を伝播(t *testing.T) {
+	uc := usecase.NewListCompanyStatsUseCase(
+		&fakeStatsCompanyRepo{rows: []domain.Company{{ID: 1, Name: "X"}}},
+		&fakeCounter{err: errors.New("count failed")},
+	)
+	_, err := uc.Execute(context.Background())
+	assert.Error(t, err)
+}

--- a/backend/internal/usecase/repository/company_stats.go
+++ b/backend/internal/usecase/repository/company_stats.go
@@ -1,0 +1,19 @@
+package repository
+
+import "context"
+
+// CompanyMemberCount は会社単位のメンバー集計（運営の横断ビュー用）。
+type CompanyMemberCount struct {
+	CompanyID uint64
+	Total     int
+	Active    int
+	Trainees  int
+}
+
+// CompanyMemberCounter は会社ごとのメンバー数を集計する単一責務 port（Effective Go 流の -er 命名）。
+// UserRepository を肥大化させないため独立 port として切り出す。
+type CompanyMemberCounter interface {
+	// CountMembersByCompany は会社ごとの在籍メンバー数（総数 / 有効 / trainee）を返す。
+	// 論理削除済み（deleted_at IS NOT NULL）や会社未所属（company_id IS NULL）は除外する。
+	CountMembersByCompany(ctx context.Context) ([]CompanyMemberCount, error)
+}

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -138,6 +138,8 @@ export const WEEKLY_CHALLENGE = {
 /** 管理者ダッシュボード（会社 / 招待 / シナリオ） */
 export const ADMIN = {
   companies: `${API_V2}/admin/companies`,
+  /** GET /api/v2/admin/companies/stats — 各社のメンバー集計付き会社横断ビュー（super_admin） */
+  companiesStats: `${API_V2}/admin/companies/stats`,
   /** PATCH /api/v2/admin/companies/:id/active — 会社アカウントの有効/無効（super_admin） */
   companyActive: (id: number | string) => `${API_V2}/admin/companies/${id}/active`,
   members: `${API_V2}/admin/members`,

--- a/frontend/src/pages/AdminCompaniesPage.tsx
+++ b/frontend/src/pages/AdminCompaniesPage.tsx
@@ -9,9 +9,10 @@ import { logger } from '../lib/logger';
 import { BuildingOffice2Icon, UserPlusIcon } from '@heroicons/react/24/outline';
 
 export default function AdminCompaniesPage() {
-  const isAdmin = useSelector((state: RootState) => state.auth.isAdmin);
   const authLoading = useSelector((state: RootState) => state.auth.loading);
   const role = useSelector((state: RootState) => state.auth.role);
+  // 会社一覧 / 横断ビュー（/admin/companies/stats）は super_admin 専用エンドポイント。
+  // company_admin が到達しても 403 を踏ませないよう、判定は super_admin に統一する。
   const isSuperAdmin = role === 'super_admin';
 
   const [companies, setCompanies] = useState<CompanyStat[]>([]);
@@ -20,7 +21,7 @@ export default function AdminCompaniesPage() {
   const [updatingId, setUpdatingId] = useState<number | null>(null);
 
   useEffect(() => {
-    if (!isAdmin) return;
+    if (!isSuperAdmin) return;
     CompanyRepository.listStats()
       .then(setCompanies)
       .catch((e) => {
@@ -28,7 +29,7 @@ export default function AdminCompaniesPage() {
         logger.error(e);
       })
       .finally(() => setLoading(false));
-  }, [isAdmin]);
+  }, [isSuperAdmin]);
 
   // 会社アカウントの有効/無効を切り替える（super_admin 専用）。楽観的更新 + 失敗時ロールバック。
   const setActive = async (id: number, active: boolean) => {
@@ -47,7 +48,7 @@ export default function AdminCompaniesPage() {
   };
 
   if (authLoading) return <Loading message="認証情報を確認中..." />;
-  if (!isAdmin) return <Navigate to="/" replace />;
+  if (!isSuperAdmin) return <Navigate to="/" replace />;
 
   return (
     <div className="px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">

--- a/frontend/src/pages/AdminCompaniesPage.tsx
+++ b/frontend/src/pages/AdminCompaniesPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, Link } from 'react-router-dom';
-import CompanyRepository, { Company } from '../repositories/CompanyRepository';
+import CompanyRepository, { CompanyStat } from '../repositories/CompanyRepository';
 import type { RootState } from '../store';
 import Loading from '../components/Loading';
 import PageIntro from '../components/ui/PageIntro';
@@ -14,14 +14,14 @@ export default function AdminCompaniesPage() {
   const role = useSelector((state: RootState) => state.auth.role);
   const isSuperAdmin = role === 'super_admin';
 
-  const [companies, setCompanies] = useState<Company[]>([]);
+  const [companies, setCompanies] = useState<CompanyStat[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<number | null>(null);
 
   useEffect(() => {
     if (!isAdmin) return;
-    CompanyRepository.list()
+    CompanyRepository.listStats()
       .then(setCompanies)
       .catch((e) => {
         setError('会社一覧の取得に失敗しました');
@@ -83,6 +83,10 @@ export default function AdminCompaniesPage() {
                         無効
                       </span>
                     )}
+                  </p>
+                  <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
+                    メンバー {company.memberTotal}（有効 {company.activeMembers} / 受講者{' '}
+                    {company.traineeCount}）
                   </p>
                   <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
                     登録日: {new Date(company.createdAt).toLocaleDateString('ja-JP')}

--- a/frontend/src/pages/__tests__/AdminCompaniesPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminCompaniesPage.test.tsx
@@ -53,4 +53,11 @@ describe('AdminCompaniesPage（会社横断ビュー）', () => {
     ).toBeInTheDocument();
     expect(listStats).toHaveBeenCalled();
   });
+
+  it('super_admin 以外はリダイレクトし、集計 API を呼ばない', () => {
+    mockState.auth = { isAdmin: true, loading: false, role: 'company_admin' };
+    renderPage();
+    expect(screen.queryByText('アクメ社')).not.toBeInTheDocument();
+    expect(listStats).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/pages/__tests__/AdminCompaniesPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminCompaniesPage.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockState = { auth: { isAdmin: true, loading: false, role: 'super_admin' } };
+vi.mock('react-redux', () => ({
+  useSelector: (sel: (s: typeof mockState) => unknown) => sel(mockState),
+  useDispatch: () => vi.fn(),
+}));
+
+// CompanyRepository（default export インスタンス）をモック。listStats が横断ビューを返す。
+const listStats = vi.fn();
+const updateActive = vi.fn();
+vi.mock('../../repositories/CompanyRepository', () => ({
+  default: {
+    listStats: () => listStats(),
+    updateActive: (...args: unknown[]) => updateActive(...args),
+  },
+}));
+
+import AdminCompaniesPage from '../AdminCompaniesPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminCompaniesPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminCompaniesPage（会社横断ビュー）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.auth = { isAdmin: true, loading: false, role: 'super_admin' };
+    listStats.mockResolvedValue([
+      {
+        id: 1,
+        name: 'アクメ社',
+        isActive: true,
+        createdAt: '2026-06-01T00:00:00Z',
+        memberTotal: 5,
+        activeMembers: 4,
+        traineeCount: 3,
+      },
+    ]);
+  });
+
+  it('会社と各社のメンバー集計を表示する', async () => {
+    renderPage();
+    expect(await screen.findByText('アクメ社')).toBeInTheDocument();
+    expect(
+      screen.getByText((content, el) => el?.tagName === 'P' && /メンバー\s*5/.test(content)),
+    ).toBeInTheDocument();
+    expect(listStats).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/repositories/CompanyRepository.ts
+++ b/frontend/src/repositories/CompanyRepository.ts
@@ -10,9 +10,29 @@ export interface Company {
   updatedAt: string;
 }
 
+/** 会社横断ビューの 1 行（会社 + メンバー集計）。super_admin 専用。 */
+export interface CompanyStat {
+  id: number;
+  name: string;
+  isActive: boolean;
+  createdAt: string;
+  /** 在籍メンバー総数（論理削除・会社未所属は除外）。 */
+  memberTotal: number;
+  /** 有効（is_active）なメンバー数。 */
+  activeMembers: number;
+  /** trainee（受講者）のメンバー数。 */
+  traineeCount: number;
+}
+
 class CompanyRepository {
   async list(): Promise<Company[]> {
     const res = await apiClient.get<Company[]>(ADMIN.companies);
+    return res.data;
+  }
+
+  /** 各社のメンバー集計付きの会社横断ビューを取得する（super_admin 専用）。 */
+  async listStats(): Promise<CompanyStat[]> {
+    const res = await apiClient.get<CompanyStat[]>(ADMIN.companiesStats);
     return res.data;
   }
 


### PR DESCRIPTION
## 概要

super_admin（運営）機能ギャップ解消の続き（🟡 中）。会社一覧が名前/登録日/有効無効だけで**各社のメンバー数が分からなかった**ため、**各社の在籍メンバー集計（総数 / 有効 / 受講者）**を会社一覧に表示します。

## 変更内容

### backend（クリーンアーキテクチャ）
- **port**: `CompanyMemberCounter`（単一責務の `-er` port。`UserRepository` を肥大化させず既存 fake を壊さない）+ `CompanyMemberCount`
- **persistence**: `companyStatsRepository` — `users` を `company_id` で GROUP BY し、`COUNT(*) FILTER (WHERE ...)` で 総数/有効/trainee を **1 クエリ集計**（**論理削除・会社未所属は除外**）
- **usecase**: `ListCompanyStatsUseCase` — 会社一覧 + 集計をマージして `CompanyStat` を返す
- **handler**: `AdminCompanyHandler.Stats`（`GET /admin/companies/stats`・super_admin 専用）
- swaggo 注釈 + `make openapi` で `docs/` 再生成

### frontend
- `CompanyRepository.listStats()` + `CompanyStat` 型
- `AdminCompaniesPage` を横断ビュー化（各社「**メンバー N（有効 M / 受講者 K）**」を表示）

## テスト

- usecase 単体（マージ / 2 系統のエラー伝播・3 件）
- handler（super_admin 200 / 非 super_admin 403）
- **結合（実 Postgres）**: `FILTER` 集計・論理削除除外・会社未所属除外を検証（`-run Integration` のため関数名は英語維持）
- frontend `AdminCompaniesPage.test`（従来なし → 新規）
- `make verify`（gofumpt/vet/build/test/archlint/apispec-lint/naminglint）✓ / frontend `tsc`/`eslint`/`vitest`（**1088**）/`build` ✓

## 補足

- 専用集計 API（GROUP BY 1 クエリ）。会社数が少ない前提。N 社ぶんを 1 回で返す
- 残る 🟡: 監査ログ（audit_events）は次 PR（DB マイグレーション必須）

## 関連 Issue

なし（super_admin 機能ギャップ解消）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 企業管理画面にメンバー統計情報を追加。各企業の総メンバー数、アクティブメンバー数、研修生数が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->