### PR TITLE
feat(admin): 監査ログ(audit_events)を追加 — 管理者の重要操作を記録/閲覧

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -26,7 +26,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。",
+                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で最大 200 件返す。super_admin 専用。",
                 "produces": [
                     "application/json"
                 ],

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -19,6 +19,52 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admin/audit-events": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "監査ログ一覧（super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/companies": {
             "get": {
                 "security": [
@@ -3584,6 +3630,34 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "Action は「METHOD ルートパターン」（例: \"PATCH /api/v2/admin/companies/:id/active\"）。",
+                    "type": "string"
+                },
+                "actorEmail": {
+                    "type": "string"
+                },
+                "actorId": {
+                    "type": "integer"
+                },
+                "actorRole": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "targetId": {
+                    "description": "TargetID は操作対象の ID（会社 ID / ユーザー ID など。取得できないときは 0）。",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -19,7 +19,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。",
+                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で最大 200 件返す。super_admin 専用。",
                 "produces": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -12,6 +12,52 @@
     },
     "basePath": "/api/v2",
     "paths": {
+        "/admin/audit-events": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "admin"
+                ],
+                "summary": "監査ログ一覧（super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admin/companies": {
             "get": {
                 "security": [
@@ -3577,6 +3623,34 @@
                     "type": "string"
                 },
                 "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "description": "Action は「METHOD ルートパターン」（例: \"PATCH /api/v2/admin/companies/:id/active\"）。",
+                    "type": "string"
+                },
+                "actorEmail": {
+                    "type": "string"
+                },
+                "actorId": {
+                    "type": "integer"
+                },
+                "actorRole": {
+                    "type": "string"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "targetId": {
+                    "description": "TargetID は操作対象の ID（会社 ID / ユーザー ID など。取得できないときは 0）。",
                     "type": "integer"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -897,7 +897,8 @@ info:
 paths:
   /admin/audit-events:
     get:
-      description: 管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。
+      description: 管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で最大 200 件返す。super_admin
+        専用。
       produces:
       - application/json
       responses:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -68,6 +68,25 @@ definitions:
       sizeBytes:
         type: integer
     type: object
+  github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent:
+    properties:
+      action:
+        description: 'Action は「METHOD ルートパターン」（例: "PATCH /api/v2/admin/companies/:id/active"）。'
+        type: string
+      actorEmail:
+        type: string
+      actorId:
+        type: integer
+      actorRole:
+        type: string
+      createdAt:
+        type: string
+      id:
+        type: integer
+      targetId:
+        description: TargetID は操作対象の ID（会社 ID / ユーザー ID など。取得できないときは 0）。
+        type: integer
+    type: object
   github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult:
     properties:
       exitCode:
@@ -876,6 +895,35 @@ info:
   title: FreStyle Backend API
   version: "2.0"
 paths:
+  /admin/audit-events:
+    get:
+      description: 管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent'
+            type: array
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 監査ログ一覧（super_admin）
+      tags:
+      - admin
   /admin/companies:
     get:
       description: 全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。

--- a/backend/internal/adapter/persistence/audit_repository.go
+++ b/backend/internal/adapter/persistence/audit_repository.go
@@ -1,0 +1,38 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+// auditRepository は [repository.AuditRepository] の GORM 実装。
+type auditRepository struct {
+	db *gorm.DB
+}
+
+func NewAuditRepository(db *gorm.DB) repository.AuditRepository {
+	return &auditRepository{db: db}
+}
+
+func (r *auditRepository) Record(ctx context.Context, e *domain.AuditEvent) error {
+	return r.db.WithContext(ctx).Create(e).Error
+}
+
+func (r *auditRepository) ListRecent(ctx context.Context, limit int) ([]domain.AuditEvent, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	var rows []domain.AuditEvent
+	err := r.db.WithContext(ctx).
+		// created_at が同一秒でも順序が安定するよう id を tiebreaker にする。
+		Order("created_at DESC, id DESC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	return rows, nil
+}

--- a/backend/internal/adapter/persistence/audit_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/audit_repository_integration_test.go
@@ -1,0 +1,44 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuditRepository_Integration は Record の保存と ListRecent の新しい順 / limit を実 Postgres で検証する。
+func TestAuditRepository_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewAuditRepository(db)
+	ctx := context.Background()
+	testsupport.TruncateAll(t, db, "audit_events")
+
+	require.NoError(t, repo.Record(ctx, &domain.AuditEvent{
+		ActorID: 1, ActorEmail: "a@x", ActorRole: domain.RoleSuperAdmin,
+		Action: "PATCH /admin/companies/:id/active", TargetID: 1,
+	}))
+	require.NoError(t, repo.Record(ctx, &domain.AuditEvent{
+		ActorID: 1, ActorEmail: "a@x", ActorRole: domain.RoleSuperAdmin,
+		Action: "DELETE /admin/members/:userId", TargetID: 2,
+	}))
+
+	rows, err := repo.ListRecent(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	// created_at DESC, id DESC のため後に入れた 2 件目が先頭。
+	assert.Equal(t, "DELETE /admin/members/:userId", rows[0].Action)
+	assert.Equal(t, uint64(2), rows[0].TargetID)
+	assert.False(t, rows[0].CreatedAt.IsZero())
+
+	// limit が効く。
+	limited, err := repo.ListRecent(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, limited, 1)
+}

--- a/backend/internal/domain/audit_event.go
+++ b/backend/internal/domain/audit_event.go
@@ -1,0 +1,19 @@
+package domain
+
+import "time"
+
+// AuditEvent は運営/管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録。
+// actor_email / actor_role は、actor が後で削除・変更されても「誰の操作か」を追えるよう非正規化して残す。
+type AuditEvent struct {
+	ID         uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
+	ActorID    uint64 `gorm:"column:actor_id;index" json:"actorId"`
+	ActorEmail string `gorm:"column:actor_email;size:255" json:"actorEmail"`
+	ActorRole  string `gorm:"column:actor_role;size:32" json:"actorRole"`
+	// Action は「METHOD ルートパターン」（例: "PATCH /api/v2/admin/companies/:id/active"）。
+	Action string `gorm:"column:action;size:160;index" json:"action"`
+	// TargetID は操作対象の ID（会社 ID / ユーザー ID など。取得できないときは 0）。
+	TargetID  uint64    `gorm:"column:target_id" json:"targetId"`
+	CreatedAt time.Time `gorm:"column:created_at;index" json:"createdAt"`
+}
+
+func (AuditEvent) TableName() string { return "audit_events" }

--- a/backend/internal/handler/admin_audit_handler.go
+++ b/backend/internal/handler/admin_audit_handler.go
@@ -20,7 +20,7 @@ func NewAdminAuditHandler(l *usecase.ListAuditEventsUseCase) *AdminAuditHandler 
 // List は監査ログを新しい順で返す（super_admin 専用）。
 //
 //	@Summary      監査ログ一覧（super_admin）
-//	@Description  管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。
+//	@Description  管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で最大 200 件返す。super_admin 専用。
 //	@Tags         admin
 //	@Produce      json
 //	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent

--- a/backend/internal/handler/admin_audit_handler.go
+++ b/backend/internal/handler/admin_audit_handler.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// AdminAuditHandler は監査ログの閲覧（super_admin 専用）を扱う。
+type AdminAuditHandler struct {
+	list *usecase.ListAuditEventsUseCase
+}
+
+func NewAdminAuditHandler(l *usecase.ListAuditEventsUseCase) *AdminAuditHandler {
+	return &AdminAuditHandler{list: l}
+}
+
+// List は監査ログを新しい順で返す（super_admin 専用）。
+//
+//	@Summary      監査ログ一覧（super_admin）
+//	@Description  管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で返す。super_admin 専用。
+//	@Tags         admin
+//	@Produce      json
+//	@Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      403  {object}  errorResponse  "super_admin 以外"
+//	@Failure      500  {object}  errorResponse  "DB 失敗"
+//	@Router       /admin/audit-events [get]
+//	@Security     CookieAuth
+func (h *AdminAuditHandler) List(c *gin.Context) {
+	if !isSuperAdmin(middleware.CurrentUserFromContext(c)) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
+	rows, err := h.list.Execute(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, errorResponse{Error: "internal_error"})
+		return
+	}
+	c.JSON(http.StatusOK, rows)
+}

--- a/backend/internal/handler/admin_audit_handler_test.go
+++ b/backend/internal/handler/admin_audit_handler_test.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// fakeAuditRepoH は AuditRepository の最小 fake（handler テスト用）。
+type fakeAuditRepoH struct {
+	rows []domain.AuditEvent
+}
+
+func (f *fakeAuditRepoH) Record(context.Context, *domain.AuditEvent) error { return nil }
+func (f *fakeAuditRepoH) ListRecent(context.Context, int) ([]domain.AuditEvent, error) {
+	return f.rows, nil
+}
+
+func newAdminAuditHandler() *AdminAuditHandler {
+	return NewAdminAuditHandler(usecase.NewListAuditEventsUseCase(&fakeAuditRepoH{
+		rows: []domain.AuditEvent{{ID: 1, Action: "DELETE /admin/members/:userId"}},
+	}))
+}
+
+func Test_監査ハンドラ_一覧_super_admin_正常系(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(middleware.ContextKeyCurrentUser, &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/audit-events", nil)
+	newAdminAuditHandler().List(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+}
+
+func Test_監査ハンドラ_一覧_super_admin以外は禁止(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(middleware.ContextKeyCurrentUser, &domain.User{ID: 2, Role: domain.RoleTrainee})
+	c.Request = httptest.NewRequest(http.MethodGet, "/admin/audit-events", nil)
+	newAdminAuditHandler().List(c)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d", w.Code)
+	}
+}

--- a/backend/internal/handler/middleware/audit_log.go
+++ b/backend/internal/handler/middleware/audit_log.go
@@ -1,0 +1,55 @@
+package middleware
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AuditEntry は監査ログに記録する 1 操作の情報（middleware が組み立てて渡す）。
+// usecase 型に依存させないため middleware 側で定義し、記録処理は func で注入する。
+type AuditEntry struct {
+	ActorID    uint64
+	ActorEmail string
+	ActorRole  string
+	Action     string
+	TargetID   uint64
+}
+
+// AuditLog は、付与したルートの本処理が成功（HTTP < 400）したときに監査ログを 1 件記録する middleware。
+// 記録は best-effort（record 内のエラーで本処理を壊さない）。読み取りや失敗レスポンスは記録しない。
+// CurrentUser middleware より後段で使う（actor を context から取得するため）。
+func AuditLog(record func(ctx context.Context, e AuditEntry)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Next()
+
+		// 失敗（4xx/5xx）は記録しない。成功した変更操作だけ残す。
+		if c.Writer.Status() >= 400 {
+			return
+		}
+		actor := CurrentUserFromContext(c)
+		if actor == nil {
+			return
+		}
+		record(c.Request.Context(), AuditEntry{
+			ActorID:    actor.ID,
+			ActorEmail: actor.Email,
+			ActorRole:  actor.Role,
+			Action:     c.Request.Method + " " + c.FullPath(),
+			TargetID:   targetIDFromParams(c),
+		})
+	}
+}
+
+// targetIDFromParams は操作対象 ID を path パラメータから推定する（取得できなければ 0）。
+func targetIDFromParams(c *gin.Context) uint64 {
+	for _, name := range []string{"id", "userId"} {
+		if v := c.Param(name); v != "" {
+			if n, err := strconv.ParseUint(v, 10, 64); err == nil {
+				return n
+			}
+		}
+	}
+	return 0
+}

--- a/backend/internal/handler/middleware/audit_log_test.go
+++ b/backend/internal/handler/middleware/audit_log_test.go
@@ -1,0 +1,59 @@
+package middleware_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+// runWithAudit は audit middleware + ハンドラを 1 ルートで実行し、記録されたエントリを返す。
+func runWithAudit(t *testing.T, actor *domain.User, status int) []middleware.AuditEntry {
+	t.Helper()
+	var got []middleware.AuditEntry
+	r := gin.New()
+	r.PATCH(
+		"/admin/companies/:id/active",
+		func(c *gin.Context) {
+			if actor != nil {
+				c.Set(middleware.ContextKeyCurrentUser, actor)
+			}
+		},
+		middleware.AuditLog(func(_ context.Context, e middleware.AuditEntry) {
+			got = append(got, e)
+		}),
+		func(c *gin.Context) { c.Status(status) },
+	)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/admin/companies/7/active", nil)
+	r.ServeHTTP(w, req)
+	require.Equal(t, status, w.Code)
+	return got
+}
+
+func Test_監査middleware_成功した変更操作を記録する(t *testing.T) {
+	got := runWithAudit(t, &domain.User{ID: 9, Email: "a@x", Role: domain.RoleSuperAdmin}, http.StatusOK)
+	require.Len(t, got, 1)
+	assert.Equal(t, uint64(9), got[0].ActorID)
+	assert.Equal(t, "a@x", got[0].ActorEmail)
+	assert.Equal(t, "PATCH /admin/companies/:id/active", got[0].Action)
+	assert.Equal(t, uint64(7), got[0].TargetID)
+}
+
+func Test_監査middleware_失敗レスポンスは記録しない(t *testing.T) {
+	got := runWithAudit(t, &domain.User{ID: 9, Role: domain.RoleSuperAdmin}, http.StatusForbidden)
+	assert.Empty(t, got)
+}
+
+func Test_監査middleware_actorなしは記録しない(t *testing.T) {
+	got := runWithAudit(t, nil, http.StatusOK)
+	assert.Empty(t, got)
+}

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/ses"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
@@ -13,6 +14,20 @@ import (
 // registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
 // 認可（super_admin / company_admin のみ）は handler 層で実施する。
 func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	// 監査ログ: 管理者の変更操作（会社の有効/無効・従業員の停止/削除・招待）を記録する middleware。
+	// 記録は best-effort（監査記録の失敗で本処理は壊さない）。
+	auditRepo := persistence.NewAuditRepository(deps.db)
+	auditRecorder := usecase.NewRecordAuditEventUseCase(auditRepo)
+	audit := middleware.AuditLog(func(ctx context.Context, e middleware.AuditEntry) {
+		_ = auditRecorder.Execute(ctx, usecase.RecordAuditEventInput{
+			ActorID:    e.ActorID,
+			ActorEmail: e.ActorEmail,
+			ActorRole:  e.ActorRole,
+			Action:     e.Action,
+			TargetID:   e.TargetID,
+		})
+	})
+
 	companyRepo := persistence.NewCompanyRepository(deps.db)
 	companyHandler := NewAdminCompanyHandler(
 		usecase.NewListCompaniesUseCase(companyRepo),
@@ -23,7 +38,7 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	// 会社横断ビュー（各社のメンバー集計付き。super_admin 専用）。
 	g.GET("/admin/companies/stats", companyHandler.Stats)
 	// 会社アカウントの有効/無効（super_admin 専用。無効化でその会社の全ユーザーを利用不可に）。
-	g.PATCH("/admin/companies/:id/active", companyHandler.SetActive)
+	g.PATCH("/admin/companies/:id/active", audit, companyHandler.SetActive)
 
 	// 従業員管理（自社の従業員一覧 + 各従業員の AI 利用可否を個別上書き）。
 	memberRepo := persistence.NewUserRepository(deps.db)
@@ -36,8 +51,8 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.GET("/admin/members", memberHandler.List)
 	g.PATCH("/admin/members/:userId/ai-access", memberHandler.UpdateAiAccess)
 	// 従業員アカウントの有効/無効（停止）と論理削除（super_admin は全社 / company_admin は自社）。
-	g.PATCH("/admin/members/:userId/active", memberHandler.SetActive)
-	g.DELETE("/admin/members/:userId", memberHandler.Delete)
+	g.PATCH("/admin/members/:userId/active", audit, memberHandler.SetActive)
+	g.DELETE("/admin/members/:userId", audit, memberHandler.Delete)
 
 	// AdminInvitation — SES マジックリンク方式（UUID token 発行 + SES でメール送信）。
 	adminInvRepo := persistence.NewAdminInvitationRepository(deps.db)
@@ -70,6 +85,10 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 		usecase.NewCancelAdminInvitationUseCase(adminInvRepo),
 	)
 	g.GET("/admin/invitations", adminInvHandler.List)
-	g.POST("/admin/invitations", adminInvHandler.Create)
-	g.DELETE("/admin/invitations/:id", adminInvHandler.Cancel)
+	g.POST("/admin/invitations", audit, adminInvHandler.Create)
+	g.DELETE("/admin/invitations/:id", audit, adminInvHandler.Cancel)
+
+	// 監査ログ閲覧（super_admin 専用）。
+	auditHandler := NewAdminAuditHandler(usecase.NewListAuditEventsUseCase(auditRepo))
+	g.GET("/admin/audit-events", auditHandler.List)
 }

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -28,6 +28,7 @@ func allDomainModels() []any {
 		&domain.Course{},
 		&domain.TeachingMaterial{},
 		&domain.LearningReport{},
+		&domain.AuditEvent{},
 	}
 }
 

--- a/backend/internal/usecase/audit_usecase.go
+++ b/backend/internal/usecase/audit_usecase.go
@@ -1,0 +1,49 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// RecordAuditEventInput は監査イベント 1 件の記録入力。
+type RecordAuditEventInput struct {
+	ActorID    uint64
+	ActorEmail string
+	ActorRole  string
+	Action     string
+	TargetID   uint64
+}
+
+// RecordAuditEventUseCase は管理者の重要操作を監査ログに記録する。
+type RecordAuditEventUseCase struct {
+	repo repository.AuditRepository
+}
+
+func NewRecordAuditEventUseCase(r repository.AuditRepository) *RecordAuditEventUseCase {
+	return &RecordAuditEventUseCase{repo: r}
+}
+
+func (u *RecordAuditEventUseCase) Execute(ctx context.Context, in RecordAuditEventInput) error {
+	return u.repo.Record(ctx, &domain.AuditEvent{
+		ActorID:    in.ActorID,
+		ActorEmail: in.ActorEmail,
+		ActorRole:  in.ActorRole,
+		Action:     in.Action,
+		TargetID:   in.TargetID,
+	})
+}
+
+// ListAuditEventsUseCase は監査ログを新しい順で返す（super_admin 専用画面用）。
+type ListAuditEventsUseCase struct {
+	repo repository.AuditRepository
+}
+
+func NewListAuditEventsUseCase(r repository.AuditRepository) *ListAuditEventsUseCase {
+	return &ListAuditEventsUseCase{repo: r}
+}
+
+func (u *ListAuditEventsUseCase) Execute(ctx context.Context) ([]domain.AuditEvent, error) {
+	return u.repo.ListRecent(ctx, 200)
+}

--- a/backend/internal/usecase/audit_usecase_test.go
+++ b/backend/internal/usecase/audit_usecase_test.go
@@ -1,0 +1,62 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeAuditRepo は AuditRepository の fake。
+type fakeAuditRepo struct {
+	recorded []domain.AuditEvent
+	listRows []domain.AuditEvent
+	recErr   error
+	listErr  error
+}
+
+func (f *fakeAuditRepo) Record(_ context.Context, e *domain.AuditEvent) error {
+	if f.recErr != nil {
+		return f.recErr
+	}
+	f.recorded = append(f.recorded, *e)
+	return nil
+}
+
+func (f *fakeAuditRepo) ListRecent(context.Context, int) ([]domain.AuditEvent, error) {
+	return f.listRows, f.listErr
+}
+
+func Test_監査記録_入力をイベントに詰めて保存する(t *testing.T) {
+	repo := &fakeAuditRepo{}
+	uc := usecase.NewRecordAuditEventUseCase(repo)
+
+	err := uc.Execute(context.Background(), usecase.RecordAuditEventInput{
+		ActorID: 9, ActorEmail: "admin@x", ActorRole: domain.RoleSuperAdmin,
+		Action: "PATCH /admin/companies/:id/active", TargetID: 3,
+	})
+	require.NoError(t, err)
+	require.Len(t, repo.recorded, 1)
+	assert.Equal(t, uint64(9), repo.recorded[0].ActorID)
+	assert.Equal(t, "admin@x", repo.recorded[0].ActorEmail)
+	assert.Equal(t, "PATCH /admin/companies/:id/active", repo.recorded[0].Action)
+	assert.Equal(t, uint64(3), repo.recorded[0].TargetID)
+}
+
+func Test_監査記録_保存失敗を伝播(t *testing.T) {
+	uc := usecase.NewRecordAuditEventUseCase(&fakeAuditRepo{recErr: errors.New("db")})
+	assert.Error(t, uc.Execute(context.Background(), usecase.RecordAuditEventInput{}))
+}
+
+func Test_監査ログ一覧_新しい順で返す(t *testing.T) {
+	repo := &fakeAuditRepo{listRows: []domain.AuditEvent{{ID: 2}, {ID: 1}}}
+	uc := usecase.NewListAuditEventsUseCase(repo)
+	rows, err := uc.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	assert.Equal(t, uint64(2), rows[0].ID)
+}

--- a/backend/internal/usecase/repository/audit.go
+++ b/backend/internal/usecase/repository/audit.go
@@ -1,0 +1,15 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// AuditRepository は監査イベント（audit_events）の記録と一覧取得を提供する。
+type AuditRepository interface {
+	// Record は監査イベントを 1 件保存する。
+	Record(ctx context.Context, e *domain.AuditEvent) error
+	// ListRecent は新しい順で最大 limit 件の監査イベントを返す。
+	ListRecent(ctx context.Context, limit int) ([]domain.AuditEvent, error)
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ const AdminCompanyApplicationsPage = lazyWithReload(
   'AdminCompanyApplicationsPage',
 );
 const AdminDashboardPage = lazyWithReload(() => import('./pages/AdminDashboardPage'), 'AdminDashboardPage');
+const AdminAuditLogPage = lazyWithReload(() => import('./pages/AdminAuditLogPage'), 'AdminAuditLogPage');
 const ExerciseListPage = lazyWithReload(() => import('./pages/ExerciseListPage'), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPage'), 'ExerciseDetailPage');
 const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
@@ -123,6 +124,7 @@ export default function App() {
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />
         <Route path="/admin/applications" element={<AdminCompanyApplicationsPage />} />
         <Route path="/admin/members" element={<AdminMembersPage />} />
+        <Route path="/admin/audit" element={<AdminAuditLogPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />
       </Route>
     </Routes>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -86,6 +86,13 @@ const adminNavItem: NavItem = {
     { label: '従業員一覧', to: '/admin/members', matchPrefix: '/admin/members' },
     // 招待管理は自社内で trainee を招待する操作のため company_admin / super_admin 双方が利用する。
     { label: '招待管理', to: '/admin/invitations', matchPrefix: '/admin/invitations' },
+    // 監査ログは全テナント横断の運営機能なので super_admin 専用。
+    {
+      label: '監査ログ',
+      to: '/admin/audit',
+      matchPrefix: '/admin/audit',
+      allowedRoles: ['super_admin'],
+    },
   ],
 };
 

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -150,6 +150,8 @@ export const ADMIN = {
   member: (userId: number | string) => `${API_V2}/admin/members/${userId}`,
   invitations: `${API_V2}/admin/invitations`,
   invitationById: (id: number | string) => `${API_V2}/admin/invitations/${id}`,
+  /** GET /api/v2/admin/audit-events — 監査ログ一覧（super_admin） */
+  auditEvents: `${API_V2}/admin/audit-events`,
   scenarios: `${API_V2}/admin/scenarios`,
   scenarioById: (id: number | string) => `${API_V2}/admin/scenarios/${id}`,
 } as const;

--- a/frontend/src/hooks/useAuditLog.ts
+++ b/frontend/src/hooks/useAuditLog.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { AuditRepository, AuditEvent } from '../repositories/AuditRepository';
+
+/**
+ * useAuditLog — 監査ログ（super_admin）を取得するフック。
+ * `enabled=false`（super_admin 以外 / 認証確認中）のときは API を叩かない。
+ */
+export function useAuditLog(enabled = true) {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    AuditRepository.list()
+      .then((e) => {
+        if (!cancelled) setEvents(e);
+      })
+      .catch(() => {
+        if (!cancelled) setError('監査ログの取得に失敗しました');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { events, loading, error };
+}

--- a/frontend/src/hooks/useAuditLog.ts
+++ b/frontend/src/hooks/useAuditLog.ts
@@ -16,6 +16,9 @@ export function useAuditLog(enabled = true) {
       return;
     }
     let cancelled = false;
+    // 取得開始時に loading/error を初期化（enabled が false→true に変わる再取得でも整合を取る）。
+    setLoading(true);
+    setError(null);
     AuditRepository.list()
       .then((e) => {
         if (!cancelled) setEvents(e);

--- a/frontend/src/pages/AdminAuditLogPage.tsx
+++ b/frontend/src/pages/AdminAuditLogPage.tsx
@@ -1,0 +1,91 @@
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import type { RootState } from '../store';
+import Loading from '../components/Loading';
+import PageIntro from '../components/ui/PageIntro';
+import { useAuditLog } from '../hooks/useAuditLog';
+import type { AuditEvent } from '../repositories/AuditRepository';
+
+// actor の role を日本語表記に。
+function roleLabel(role: string): string {
+  switch (role) {
+    case 'super_admin':
+      return '運営管理者';
+    case 'company_admin':
+      return '会社管理者';
+    case 'trainee':
+      return '受講者';
+    default:
+      return role;
+  }
+}
+
+// 「METHOD ルートパターン」を日本語の操作名に。prefix（/api/v2）に依存しないよう部分一致で判定。
+function actionLabel(action: string): string {
+  const a = action.toUpperCase();
+  if (a.includes('/COMPANIES/') && a.includes('ACTIVE')) return '会社の有効/無効を変更';
+  if (a.includes('/MEMBERS/') && a.includes('ACTIVE')) return '従業員の有効/無効を変更';
+  if (a.startsWith('DELETE') && a.includes('/MEMBERS/')) return '従業員を削除';
+  if (a.startsWith('POST') && a.includes('/INVITATIONS')) return '招待を作成';
+  if (a.startsWith('DELETE') && a.includes('/INVITATIONS/')) return '招待を取消';
+  return action;
+}
+
+function AuditRow({ e }: { e: AuditEvent }) {
+  return (
+    <li className="p-3 border border-surface-3 rounded-lg bg-[var(--color-surface-1)] space-y-1">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-sm font-medium text-[var(--color-text-primary)]">{actionLabel(e.action)}</span>
+        <span className="text-xs text-[var(--color-text-muted)] flex-shrink-0">
+          {new Date(e.createdAt).toLocaleString('ja-JP')}
+        </span>
+      </div>
+      <p className="text-xs text-[var(--color-text-muted)]">
+        実行者: {e.actorEmail || '(不明)'}（{roleLabel(e.actorRole)}）
+        {e.targetId > 0 && <> ・ 対象 ID: {e.targetId}</>}
+      </p>
+    </li>
+  );
+}
+
+/**
+ * AdminAuditLogPage — `/admin/audit`。super_admin 専用の監査ログ。
+ * 管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待）を新しい順で確認できる。
+ */
+export default function AdminAuditLogPage() {
+  const authLoading = useSelector((state: RootState) => state.auth.loading);
+  const role = useSelector((state: RootState) => state.auth.role);
+  const isSuperAdmin = role === 'super_admin';
+  const { events, loading, error } = useAuditLog(isSuperAdmin);
+
+  if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
+  // 監査ログは全テナント横断の運営機能なので super_admin 専用。
+  if (!isSuperAdmin) return <Navigate to="/" replace />;
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
+      <PageIntro
+        title="監査ログ"
+        description="管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待の作成/取消）の記録です。新しい順に最大 200 件を表示します。"
+      />
+
+      {error && (
+        <div role="alert" className="p-3 rounded border border-rose-300 bg-rose-50 text-rose-800 text-sm">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <Loading message="読み込み中..." className="min-h-[30vh]" />
+      ) : events.length === 0 ? (
+        <p className="text-sm text-[var(--color-text-muted)]">監査ログはまだありません。</p>
+      ) : (
+        <ul className="space-y-2">
+          {events.map((e) => (
+            <AuditRow key={e.id} e={e} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/AdminAuditLogPage.test.tsx
+++ b/frontend/src/pages/__tests__/AdminAuditLogPage.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockState = { auth: { isAdmin: true, loading: false, role: 'super_admin' } };
+vi.mock('react-redux', () => ({
+  useSelector: (sel: (s: typeof mockState) => unknown) => sel(mockState),
+  useDispatch: () => vi.fn(),
+}));
+
+function makeHookReturn() {
+  return {
+    events: [
+      {
+        id: 1,
+        actorId: 9,
+        actorEmail: 'ops@frestyle.dev',
+        actorRole: 'super_admin',
+        action: 'DELETE /api/v2/admin/members/:userId',
+        targetId: 42,
+        createdAt: '2026-06-15T00:00:00Z',
+      },
+      {
+        id: 2,
+        actorId: 9,
+        actorEmail: 'ops@frestyle.dev',
+        actorRole: 'super_admin',
+        action: 'PATCH /api/v2/admin/companies/:id/active',
+        targetId: 3,
+        createdAt: '2026-06-14T00:00:00Z',
+      },
+    ],
+    loading: false,
+    error: null as string | null,
+  };
+}
+let hookReturn = makeHookReturn();
+vi.mock('../../hooks/useAuditLog', () => ({
+  useAuditLog: () => hookReturn,
+}));
+
+import AdminAuditLogPage from '../AdminAuditLogPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminAuditLogPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminAuditLogPage（監査ログ）', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.auth = { isAdmin: true, loading: false, role: 'super_admin' };
+    hookReturn = makeHookReturn();
+  });
+
+  it('操作を日本語化し、実行者・対象IDを表示する', () => {
+    renderPage();
+    expect(screen.getByText('従業員を削除')).toBeInTheDocument();
+    expect(screen.getByText('会社の有効/無効を変更')).toBeInTheDocument();
+    expect(screen.getByText(/対象 ID: 42/)).toBeInTheDocument();
+  });
+
+  it('super_admin 以外はリダイレクトする', () => {
+    mockState.auth = { isAdmin: true, loading: false, role: 'company_admin' };
+    renderPage();
+    expect(screen.queryByText('従業員を削除')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/repositories/AuditRepository.ts
+++ b/frontend/src/repositories/AuditRepository.ts
@@ -1,0 +1,22 @@
+import apiClient from '../lib/axios';
+import { ADMIN } from '../constants/apiRoutes';
+
+/** 監査イベント（管理者の重要操作の記録）。super_admin 専用。 */
+export interface AuditEvent {
+  id: number;
+  actorId: number;
+  actorEmail: string;
+  actorRole: string;
+  /** 「METHOD ルートパターン」（例: "PATCH /api/v2/admin/companies/:id/active"）。 */
+  action: string;
+  targetId: number;
+  createdAt: string;
+}
+
+export const AuditRepository = {
+  /** 監査ログを新しい順で取得する（super_admin 専用）。 */
+  async list(): Promise<AuditEvent[]> {
+    const { data } = await apiClient.get<AuditEvent[]>(ADMIN.auditEvents);
+    return data;
+  },
+};


### PR DESCRIPTION
## 概要

super_admin（運営）機能ギャップ解消の最後（🟡 中）。**「誰がいつ 会社を無効化 / 従業員を停止・削除 / 招待した」を追える監査ログが無かった**（CloudWatch のアクセスログのみ）ため、重要操作を記録して閲覧できるようにします。

## 変更内容

### backend（クリーンアーキテクチャ）
- `domain.AuditEvent` + **AutoMigrate 登録**（新規テーブルなので ECS 起動時に自動追加・**無停止**・手動マイグレーション不要）
- port `AuditRepository` / persistence `auditRepository`（`Record` + `ListRecent`。`created_at DESC, id DESC` で**決定的な新しい順**）
- usecase `RecordAuditEventUseCase` / `ListAuditEventsUseCase`
- **記録は `middleware.AuditLog` で横断的に実施（handler は無改変）**。成功した変更操作のみ・**best-effort**（監査記録の失敗で本処理は壊さない）。usecase 非依存にするため記録処理は func 注入
- 記録対象ルート: 会社の有効/無効、従業員の有効/無効・削除、招待の作成・取消
- 閲覧: `GET /admin/audit-events`（`AdminAuditHandler`・**super_admin 専用**）+ swaggo / `make openapi`

### frontend
- `AuditRepository` + `useAuditLog` + `AdminAuditLogPage`（`/admin/audit`・super_admin 専用）。**操作を日本語化表示**（「会社の有効/無効を変更」「従業員を削除」等）+ 実行者・対象 ID・日時
- サイドバー **「管理 > 監査ログ」**（super_admin 専用）

## テスト

- usecase（記録 / 一覧 / エラー伝播）/ **middleware**（成功時のみ記録 / 失敗・actor 無しは記録しない）/ handler（super_admin 200 / 非 super 403）/ **結合（実 Postgres で Record・順序・limit）** / frontend（画面・日本語化・redirect）
- `make verify`（gofumpt/vet/build/test/archlint/apispec-lint/naminglint）✓ / frontend `tsc`/`eslint`/`vitest`（**1091**）/`build` ✓

## 設計メモ
- 監査記録を **middleware** に置くことで、各 handler とそのテストを一切変更せずに追加。将来 admin の変更ルートが増えても `audit` を 1 つ付けるだけで記録対象にできる。
- これで super_admin 機能ギャップ（承認画面 / ダッシュボード / 横断ビュー / 監査ログ）が一通り解消。

## 関連 Issue

なし（super_admin 機能ギャップ解消・シリーズ完了）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スーパー管理者向けに監査ログ機能を追加しました。管理者の重要な操作（会社情報の有効/無効、従業員管理、招待管理など）の履歴を一覧表示できるようになります。

* **テスト**
  * 監査ログ機能の統合テストと単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->