### PR TITLE
feat(admin): 利用申請の承認/却下も監査ログに記録する

### DIFF
--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -76,19 +76,22 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	authed.Use(middleware.JWTAuth(buildJWTVerify(cfg)))
 	authed.Use(middleware.CurrentUser(deps.userRepo, persistence.NewCompanyRepository(deps.db)))
 
+	// 監査ログ記録 middleware（admin の変更操作で共有する）。
+	audit := newAuditMiddleware(deps.db)
+
 	registerAuthAuthedRoutes(authed, authHandler)
 	registerChatRoutes(authed, deps)
 	registerProfileRoutes(authed, deps)
 	registerNoteRoutes(authed, deps)
 	registerSocialRoutes(authed, deps)
-	registerAdminRoutes(authed, deps)
+	registerAdminRoutes(authed, deps, audit)
 	registerEmbedRoutes(authed)
 	registerExerciseRoutes(authed, deps)
 	registerCourseRoutes(authed, deps)
 	registerTeachingMaterialRoutes(authed, deps)
 	registerLearningReportRoutes(authed, deps)
 	registerCompanySettingsRoutes(authed, deps)
-	registerCompanyApplicationAdminRoutes(authed, companyAppHandler)
+	registerCompanyApplicationAdminRoutes(authed, companyAppHandler, audit)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 	return r
 }

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -9,17 +9,15 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/ses"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"gorm.io/gorm"
 )
 
-// registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
-// 認可（super_admin / company_admin のみ）は handler 層で実施する。
-func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
-	// 監査ログ: 管理者の変更操作（会社の有効/無効・従業員の停止/削除・招待）を記録する middleware。
-	// 記録は best-effort（監査記録の失敗で本処理は壊さない）。
-	auditRepo := persistence.NewAuditRepository(deps.db)
-	auditRecorder := usecase.NewRecordAuditEventUseCase(auditRepo)
-	audit := middleware.AuditLog(func(ctx context.Context, e middleware.AuditEntry) {
-		_ = auditRecorder.Execute(ctx, usecase.RecordAuditEventInput{
+// newAuditMiddleware は管理者の変更操作（会社の有効/無効・従業員の停止/削除・招待・利用申請の承認/却下）
+// を監査ログに記録する middleware を作る。記録は best-effort（監査記録の失敗で本処理は壊さない）。
+func newAuditMiddleware(db *gorm.DB) gin.HandlerFunc {
+	recorder := usecase.NewRecordAuditEventUseCase(persistence.NewAuditRepository(db))
+	return middleware.AuditLog(func(ctx context.Context, e middleware.AuditEntry) {
+		_ = recorder.Execute(ctx, usecase.RecordAuditEventInput{
 			ActorID:    e.ActorID,
 			ActorEmail: e.ActorEmail,
 			ActorRole:  e.ActorRole,
@@ -27,7 +25,12 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 			TargetID:   e.TargetID,
 		})
 	})
+}
 
+// registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
+// 認可（super_admin / company_admin のみ）は handler 層で実施する。
+// audit は変更操作を監査ログに記録する middleware（router で生成して共有する）。
+func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps, audit gin.HandlerFunc) {
 	companyRepo := persistence.NewCompanyRepository(deps.db)
 	companyHandler := NewAdminCompanyHandler(
 		usecase.NewListCompaniesUseCase(companyRepo),
@@ -88,7 +91,7 @@ func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	g.POST("/admin/invitations", audit, adminInvHandler.Create)
 	g.DELETE("/admin/invitations/:id", audit, adminInvHandler.Cancel)
 
-	// 監査ログ閲覧（super_admin 専用）。
-	auditHandler := NewAdminAuditHandler(usecase.NewListAuditEventsUseCase(auditRepo))
+	// 監査ログ閲覧（super_admin 専用）。記録は audit middleware が横断的に行う。
+	auditHandler := NewAdminAuditHandler(usecase.NewListAuditEventsUseCase(persistence.NewAuditRepository(deps.db)))
 	g.GET("/admin/audit-events", auditHandler.List)
 }

--- a/backend/internal/handler/routes_company_application.go
+++ b/backend/internal/handler/routes_company_application.go
@@ -25,7 +25,8 @@ func registerCompanyApplicationPublicRoutes(g *gin.RouterGroup, h *CompanyApplic
 }
 
 // registerCompanyApplicationAdminRoutes は super_admin 用の一覧 / status 更新を登録する（認可は handler 層）。
-func registerCompanyApplicationAdminRoutes(g *gin.RouterGroup, h *CompanyApplicationHandler) {
+// audit は status 更新（承認/却下）を監査ログに記録する middleware。
+func registerCompanyApplicationAdminRoutes(g *gin.RouterGroup, h *CompanyApplicationHandler, audit gin.HandlerFunc) {
 	g.GET("/admin/company-applications", h.List)
-	g.PATCH("/admin/company-applications/:id/status", h.UpdateStatus)
+	g.PATCH("/admin/company-applications/:id/status", audit, h.UpdateStatus)
 }

--- a/frontend/src/pages/AdminAuditLogPage.tsx
+++ b/frontend/src/pages/AdminAuditLogPage.tsx
@@ -28,6 +28,7 @@ function actionLabel(action: string): string {
   if (a.startsWith('DELETE') && a.includes('/MEMBERS/')) return '従業員を削除';
   if (a.startsWith('POST') && a.includes('/INVITATIONS')) return '招待を作成';
   if (a.startsWith('DELETE') && a.includes('/INVITATIONS/')) return '招待を取消';
+  if (a.includes('/COMPANY-APPLICATIONS/') && a.includes('STATUS')) return '利用申請を承認/却下';
   return action;
 }
 


### PR DESCRIPTION
## 概要

監査ログの記録対象に **利用申請の承認/却下**（`PATCH /admin/company-applications/:id/status`）を追加します。これで super_admin の主要な変更操作（会社の有効/無効・従業員の停止/削除・招待の作成/取消・**利用申請の承認/却下**）が監査ログに残ります。

## 変更内容

- 監査 middleware を **`newAuditMiddleware`** に共通化し、`router` で 1 つ生成して admin ルートと利用申請ルートで**共有**（重複生成を避ける）
- `registerAdminRoutes` / `registerCompanyApplicationAdminRoutes` は `audit` を引数で受け取る形に
- 利用申請の status 更新ルートに `audit` を適用
- frontend: `AdminAuditLogPage` の `actionLabel` に「**利用申請を承認/却下**」を追加

## テスト

- `go build` / `go test ./...` / `archlint` ✓
- frontend `tsc` / `eslint` / `vitest` / `build` ✓
- **OpenAPI 変更なし**（既存ルートへ middleware を追加しただけで spec は不変）

## 補足

- 監査記録は引き続き **best-effort**（記録失敗で本処理は壊さない）・成功した変更操作のみ。
- 現状の記録は「誰が・いつ・どの申請を操作したか」（承認/却下の別までは body を見ないため記録しない）。区別が必要なら別途 detail カラムを足す形で拡張可能。

## 関連 Issue

なし（監査ログの対象拡張）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 管理画面の操作に対する監査ログ記録を実装しました。企業申請の承認・却下などの管理者操作が監査ログに記録されるようになります。
  * 監査ログページで企業申請ステータス更新操作の表示ラベルが改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->