### PR TITLE
fix(coderunner): SQL の client エラーで #incident が誤報になる問題を修正

### DIFF
--- a/backend/Dockerfile.coderunner
+++ b/backend/Dockerfile.coderunner
@@ -71,6 +71,12 @@ RUN initdb -D /pgdata -U postgres -A trust --encoding=UTF8 --locale=C && \
       echo "synchronous_commit = off"; \
       echo "full_page_writes = off"; \
       echo "max_wal_size = 256MB"; \
+      # 学習者の SQL ミス（構文/権限エラー）は postgres が `ERROR:` で server log に出すが、\
+      # その行が ECS ロググループ経由で incident 監視(?ERROR 一致)に拾われ #incident を誤報で\
+      # 埋めるため、log_min_messages=log で client エラー(ERROR/WARNING)をログに出さない。\
+      # LOG/FATAL は残すので起動診断と真の障害は見える（どちらも ERROR/Exception を含まない）。\
+      echo "log_min_messages = log"; \
+      echo "log_min_error_statement = panic"; \
     } >> /pgdata/postgresql.conf && \
     pg_ctl -D /pgdata -o "-k /tmp/pgsock -h ''" -w -t 30 start && \
     psql -h /tmp/pgsock -U postgres -d postgres -v ON_ERROR_STOP=1 \

--- a/backend/internal/infra/sandbox/runner_sql_test.go
+++ b/backend/internal/infra/sandbox/runner_sql_test.go
@@ -18,7 +18,8 @@ import (
 // executeSQL が参照する CODE_PG_* env をセットする。t.Cleanup で停止 + 後始末する。
 // initdb / pg_ctl / psql が無い環境（Go-only CI コンテナ等）では Skip する。
 // runner コンテナの「socket 専用・非 superuser student」構成をローカルで再現する。
-func startTestPG(t *testing.T) {
+// startTestPG は使い捨て PG を起動し、server log ファイルのパスを返す。
+func startTestPG(t *testing.T) string {
 	t.Helper()
 	for _, bin := range []string{"initdb", "pg_ctl", "psql"} {
 		if _, err := exec.LookPath(bin); err != nil {
@@ -42,6 +43,14 @@ func startTestPG(t *testing.T) {
 	// trust auth + locale C で素早く初期化（使い捨てなので耐久性設定は不要）。
 	run("initdb", "-D", dataDir, "-U", "postgres", "-A", "trust", "--encoding=UTF8", "--locale=C")
 
+	// 本番(Dockerfile.coderunner)と同じく client エラー(ERROR/WARNING)を server log に出さない。
+	// → 学習者の SQL ミスが incident 監視(?ERROR)に拾われて誤報になるのを防ぐ。
+	f, err := os.OpenFile(filepath.Join(dataDir, "postgresql.conf"), os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString("log_min_messages = log\nlog_min_error_statement = panic\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
 	logFile := filepath.Join(dataDir, "pg.log")
 	// -h '' で TCP を開かず socket 専用。-k で socket をテスト用 dir に置く。
 	run("pg_ctl", "-D", dataDir, "-l", logFile, "-o", "-k "+sockDir+" -h ''", "-w", "start")
@@ -60,6 +69,7 @@ func startTestPG(t *testing.T) {
 	t.Setenv("CODE_PG_PORT", "5432")
 	t.Setenv("CODE_PG_ADMIN", "dbadmin")
 	t.Setenv("CODE_PG_STUDENT", "student")
+	return logFile
 }
 
 func Test_ランナー_SQL_単純SELECT(t *testing.T) {
@@ -138,6 +148,27 @@ func Test_ランナー_SQL_COPYPROGRAMは権限拒否(t *testing.T) {
 	assert.NotEqual(t, 0, out.ExitCode)
 	// superuser 限定操作なので permission/ superuser 系のエラーになる。
 	assert.NotEmpty(t, out.Stderr)
+}
+
+// 学習者の SQL ミスは「クライアントにはエラーを返す」が「server log には ERROR を残さない」。
+// postgres の client エラーが ECS ログ経由で incident 監視(?ERROR)に拾われ #incident を
+// 誤報で埋めるのを防ぐための regression（log_min_messages=log）。
+func Test_ランナー_SQL_失敗クエリはserverlogにERRORを残さない(t *testing.T) {
+	logFile := startTestPG(t)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `SELECT * FROM definitely_no_such_table;`,
+		Language: "sql",
+	})
+	require.NoError(t, err)
+	// 学習者にはエラーが返る（学習体験は維持）。
+	assert.NotEqual(t, 0, out.ExitCode)
+	assert.Contains(t, out.Stderr, "definitely_no_such_table")
+
+	// しかし server log（= ECS ログ → incident 監視）には ERROR 行を残さない。
+	logBytes, err := os.ReadFile(logFile)
+	require.NoError(t, err)
+	assert.NotContains(t, string(logBytes), "ERROR", "postgres server log に ERROR 行が出てはいけない")
 }
 
 // denylist は PG 起動前の入力検証なので PG 無しでも動く。

--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -50,6 +50,11 @@ frontend ExerciseDetailPage (Monaco / monacoLanguageOf)
 - `statement_timeout` ほか + 提出ごと throwaway DB（提出間でデータ混在なし）
 - psql には `sandboxEnv`/明示 env で秘匿情報を渡さない（PG 接続 env も `isSensitiveEnvKey` で他言語へは遮断）
 
+### ログと incident 監視
+- 学習者の SQL ミス（構文/権限エラー）は postgres が `ERROR:` で server log に出すが、`/ecs/frestyle-prod` のサブスクリプションフィルタ `?ERROR ?Exception` が拾って Slack #incident を**誤報で埋める**ため、`postgresql.conf` で **`log_min_messages = log`**（+ `log_min_error_statement = panic`）にして client エラーを server log に出さない。
+- 学習者には**クライアント応答としてエラーは返る**ので学習体験は維持される。`LOG:`/`FATAL:` は残すので起動診断・真の障害は見える（どちらも `ERROR`/`Exception` を含まないので incident は鳴らない）。
+- 将来の堅牢化（infra）: incident サブスクリプションフィルタを backend の構造化ログ `{ $.level = "ERROR" }` 一致に絞る / coderunner ログを別ロググループへ分離。
+
 ### 接続設定（env / 既定はコンテナの socket）
 `CODE_PG_HOST`（既定 `/var/run/postgresql`、コンテナでは `/tmp/pgsock`）/ `CODE_PG_PORT` / `CODE_PG_ADMIN`（DB 作成用 CREATEDB ロール・既定 `dbadmin`）/ `CODE_PG_STUDENT`（既定 `student`）/ `CODE_PG_*_PASSWORD`。
 `Dockerfile.coderunner` が build 時に `initdb` + 極小チューニング（`shared_buffers=32MB` / `fsync=off` 等、使い捨て前提）+ `dbadmin`/`student` ロール作成 + pg_hba（postgres reject）を済ませ、entrypoint が socket 専用で `pg_ctl start` する。


### PR DESCRIPTION
## 概要

SQL コード実行（#1982）を本番投入後、**Slack #incident に誤報通知**が飛びました。原因は、同居 PostgreSQL が学習者の SQL ミス（構文/権限エラー）を `ERROR:` で server log に出力し、それが `/ecs/frestyle-prod` ロググループのサブスクリプションフィルタ `?ERROR ?Exception`（→ Lambda `frestyle-prod-incident-notify` → Slack）に拾われてしまうためです。

実際に飛んだ通知は、私のセキュリティ・スモークテスト（`COPY ... TO PROGRAM` の権限拒否）の postgres ERROR ログでした。**学習では SQL エラーが常時発生する**ため、このままだと学習者が SQL を間違えるたびに #incident が誤報で埋まります。

> 本番は障害ではありません（health 200 / ECS steady / active alarm 無し）。通知の誤報のみです。`no-healthy-host` アラームは毎朝の起動時 1 分ブリップ（既知）で本件とは別。

## 変更内容

- **[Dockerfile.coderunner](backend/Dockerfile.coderunner)**: `postgresql.conf` に **`log_min_messages = log`** + `log_min_error_statement = panic` を追加。client エラー（`ERROR`/`WARNING`）を server log に出さない。
  - `log_min_messages` は **server log** のしきい値のみを変えるので、**学習者にはクライアント応答としてエラーは返る**（学習体験は維持）。
  - `LOG:` / `FATAL:` は残すので起動診断・真の障害は見える（どちらも `ERROR`/`Exception` を含まないため incident は鳴らない）。
- **[runner_sql_test.go](backend/internal/infra/sandbox/runner_sql_test.go)**: テスト PG を本番同等のログ設定にし、回帰テストを追加 — 失敗クエリが「**クライアントにはエラーを返すが server log に `ERROR` を残さない**」ことを実 PG で検証。
- **docs**: ログと incident 監視の項を追記。

## テスト
- `go test ./internal/infra/sandbox/ -run SQL`：全 7 ケース PASS（新規 `Test_ランナー_SQL_失敗クエリはserverlogにERRORを残さない` 含む）。

## 関連
- 起点: #1982（SQL コード実行）
- 将来の堅牢化（**infra リポ**で別途）: incident サブスクリプションフィルタを backend の構造化ログ `{ $.level = "ERROR" }` 一致に絞る / coderunner ログを別ロググループに分離（素のテキスト `?ERROR` 一致は脆いため）。

## デプロイ
- マージ後に backend デプロイ（coderunner イメージ再 build/push）で反映。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * PostgreSQL のログ出力ポリシーを調整し、学習者のエラーが誤ったアラート生成を防ぎながら、実障害の検知を維持するよう改善しました。

* **ドキュメント**
  * SQL 実行時のログと incident 監視に関するドキュメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->