### PR TITLE
feat(courses): 教材閲覧の目次を出し入れできるトグルを追加

### DIFF
--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircleIcon,
   ClockIcon,
   ArrowLeftIcon,
+  ListBulletIcon,
 } from '@heroicons/react/24/outline';
 import { CheckCircleIcon as CheckCircleSolidIcon } from '@heroicons/react/24/solid';
 import SecondaryPanel from '../components/layout/SecondaryPanel';
@@ -22,6 +23,7 @@ import { useTeachingMaterials } from '../hooks/useTeachingMaterials';
 import { useTeachingMaterialEditor } from '../hooks/useTeachingMaterialEditor';
 import { useLessonProgress } from '../hooks/useLessonProgress';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
+import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useToast } from '../hooks/useToast';
 import CourseRepository from '../repositories/CourseRepository';
 import type { RootState } from '../store';
@@ -395,9 +397,17 @@ function ReadOnlyDetail({
   completed: boolean;
   onToggleComplete: (done: boolean) => void;
 }) {
+  // 目次の表示状態は localStorage に保持し、 教材を切り替えても選択が続くようにする（既定は表示）。
+  // 横幅が狭いときに本文幅を稼げるよう trainee が出し入れできる。
+  const [tocOpen, setTocOpen] = useLocalStorage('course-toc-open', true);
+
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="mx-auto w-full max-w-6xl px-6 py-6 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_240px] gap-8">
+      <div
+        className={`mx-auto w-full max-w-6xl px-6 py-6 grid grid-cols-1 gap-8 ${
+          tocOpen ? 'lg:grid-cols-[minmax(0,1fr)_240px]' : ''
+        }`}
+      >
         <article className="min-w-0">
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">
             {material.title || '無題の教材'}
@@ -406,7 +416,24 @@ function ReadOnlyDetail({
             <p className="text-xs text-[var(--color-text-muted)]">
               最終更新: {formatDate(material.updatedAt)}
             </p>
-            <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
+            <div className="flex items-center gap-2">
+              {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
+              <button
+                type="button"
+                onClick={() => setTocOpen((v) => !v)}
+                aria-pressed={tocOpen}
+                title={tocOpen ? '目次を隠す' : '目次を表示'}
+                className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                  tocOpen
+                    ? 'border-primary-500 text-primary-400'
+                    : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
+                }`}
+              >
+                <ListBulletIcon className="w-4 h-4" />
+                目次
+              </button>
+              <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
+            </div>
           </div>
           <div className="prose prose-sm max-w-none">
             <ReadOnlyMarkdown content={material.content} />
@@ -418,11 +445,13 @@ function ReadOnlyDetail({
           </div>
         </article>
 
-        <aside className="hidden lg:block">
-          <div className="sticky top-6">
-            <MarkdownTableOfContents content={material.content} />
-          </div>
-        </aside>
+        {tocOpen && (
+          <aside className="hidden lg:block">
+            <div className="sticky top-6">
+              <MarkdownTableOfContents content={material.content} />
+            </div>
+          </aside>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

コース閲覧画面（`/courses/:id`）は「本文 + 右 240px の目次サイドバー」の 2 カラム構成ですが、**横幅に余裕がない**との要望を受け、目次を **trainee が表示/非表示**できるトグルを追加します。隠すと本文が全幅に広がり、読みやすくなります。

## 変更内容

- `ReadOnlyDetail`（[CourseDetailPage.tsx](frontend/src/pages/CourseDetailPage.tsx)）に「**目次**」トグルボタンを追加
  - 目次は `lg` 以上でのみ表示されるため、トグルも `lg` 未満では隠す（モバイルは元から目次非表示で挙動不変）
- **非表示時**: grid を単一カラムにして article を全幅化し、`aside`（目次）は描画しない
- 表示状態は **`useLocalStorage('course-toc-open')`** に保持し、教材を切り替えても選択が継続（**既定は表示**）

## テスト
- `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` green
- `vitest run --coverage` 全 1110 件 PASS、閾値クリア（Stmts 85.57 / Branches 79.25 / Funcs 83.5 / Lines 86.98）

## 関連
- UI 改善（ロジック・API・スキーマ変更なし）