### PR TITLE
fix(ui): ヘッダーのロゴを favicon に戻す + コース本文の幅を読みやすく

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -140,11 +140,9 @@ export default function Header() {
     <>
       {loggingOut && <Loading fullscreen message="ログアウト中..." />}
       <header className="flex-shrink-0 h-14 bg-[var(--color-nav)] border-b border-surface-3 flex items-center gap-2 px-3">
-        {/* ロゴ（色付き箱 + サービス名） */}
+        {/* ロゴ（いつもの favicon をそのまま + サービス名）。色付き箱で囲うとロゴ自体が青いため埋もれる。 */}
         <Link to="/" className="flex items-center gap-2 flex-shrink-0 mr-2" aria-label="FreStyle ホーム">
-          <span className="flex items-center justify-center w-8 h-8 rounded-md bg-brand-500">
-            <img src="/favicon.svg" alt="" className="w-5 h-5" />
-          </span>
+          <img src="/favicon.svg" alt="" className="w-7 h-7 flex-shrink-0" />
           <span className="hidden sm:block text-sm font-semibold text-[var(--color-text-primary)]">FreStyle</span>
         </Link>
 

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -408,7 +408,9 @@ function ReadOnlyDetail({
           tocOpen ? 'lg:grid-cols-[minmax(0,1fr)_240px]' : ''
         }`}
       >
-        <article className="min-w-0">
+        {/* 目次を隠したときは本文が全幅に伸びて読みにくいため、 読みやすい幅(~896px)に
+            収めて中央寄せする。 目次表示時は 1fr カラムが既に同程度の幅になる。 */}
+        <article className={`min-w-0 ${!tocOpen ? 'mx-auto w-full max-w-4xl' : ''}`}>
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">
             {material.title || '無題の教材'}
           </h1>


### PR DESCRIPTION
## 概要
デザインの細かい不具合 2 点を修正します（いずれも見た目だけ・ロジック変更なし）。

## 変更内容
1. **ヘッダーのロゴ** ([Header.tsx](frontend/src/components/layout/Header.tsx)): 参考デザインに寄せて favicon を `bg-brand-500` の色付き箱で囲ったが、FreStyle のロゴ自体が青いため箱に埋もれ「いつものアイコンと違う」見た目になっていた。**サイドバーで使っていた favicon をそのまま表示**に戻す（= 従来から使っているアイコン）。
2. **コース本文の幅** ([CourseDetailPage.tsx](frontend/src/pages/CourseDetailPage.tsx)): 目次を隠すと本文が全幅(~1050px)に伸びて読みにくかった。**読みやすい幅(max-w-4xl ~896px)に収めて中央寄せ**し、目次表示時(~880px)とほぼ同じバランスの良い行長にする。

## テスト
- tsc / eslint --max-warnings 0 / vitest(1095) / build すべて green