### PR TITLE
feat(courses): 左の章一覧パネルをデスクトップで折りたたみ可能にする

### DIFF
--- a/frontend/src/components/layout/SecondaryPanel.tsx
+++ b/frontend/src/components/layout/SecondaryPanel.tsx
@@ -1,4 +1,4 @@
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, ChevronDoubleLeftIcon, ChevronDoubleRightIcon } from '@heroicons/react/24/outline';
 
 interface SecondaryPanelProps {
   title: string;
@@ -7,9 +7,25 @@ interface SecondaryPanelProps {
   children: React.ReactNode;
   mobileOpen?: boolean;
   onMobileClose?: () => void;
+  /** デスクトップでパネルを折りたたみ可能にする（章一覧などで本文幅を稼ぐ用途）。 */
+  collapsible?: boolean;
+  /** collapsible のとき、 折りたたみ中かどうか。 */
+  collapsed?: boolean;
+  /** 折りたたみ / 展開のトグル。 */
+  onToggleCollapsed?: () => void;
 }
 
-export default function SecondaryPanel({ title, badge, headerContent, children, mobileOpen = false, onMobileClose }: SecondaryPanelProps) {
+export default function SecondaryPanel({
+  title,
+  badge,
+  headerContent,
+  children,
+  mobileOpen = false,
+  onMobileClose,
+  collapsible = false,
+  collapsed = false,
+  onToggleCollapsed,
+}: SecondaryPanelProps) {
   return (
     <>
       {/* モバイルオーバーレイ */}
@@ -44,16 +60,42 @@ export default function SecondaryPanel({ title, badge, headerContent, children, 
       </div>
 
       {/* デスクトップパネル: 右側の縦罫線は背景色の差分で十分なので border-r は付けない */}
-      <div className="hidden md:flex w-72 bg-[var(--color-nav)] flex-col h-full flex-shrink-0">
-        <div className="px-4 py-3 border-b border-surface-3">
-          <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
-            {title}
-            {badge && <span className="ml-2 text-xs font-normal text-[var(--color-text-muted)]">{badge}</span>}
-          </h2>
-          {headerContent && <div className="mt-2">{headerContent}</div>}
+      {collapsible && collapsed ? (
+        // 折りたたみ中: 細い帯に「開く」ボタンだけ出す。本文が全幅に広がる。
+        <div className="hidden md:flex w-10 bg-[var(--color-nav)] flex-col items-center pt-3 h-full flex-shrink-0">
+          <button
+            onClick={onToggleCollapsed}
+            title="パネルを開く"
+            aria-label="パネルを開く"
+            className="p-1.5 rounded-md text-[var(--color-text-muted)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)] transition-colors"
+          >
+            <ChevronDoubleRightIcon className="w-4 h-4" />
+          </button>
         </div>
-        <div className="flex-1 overflow-y-auto">{children}</div>
-      </div>
+      ) : (
+        <div className="hidden md:flex w-72 bg-[var(--color-nav)] flex-col h-full flex-shrink-0">
+          <div className="px-4 py-3 border-b border-surface-3">
+            <div className="flex items-center justify-between gap-2">
+              <h2 className="text-sm font-semibold text-[var(--color-text-primary)]">
+                {title}
+                {badge && <span className="ml-2 text-xs font-normal text-[var(--color-text-muted)]">{badge}</span>}
+              </h2>
+              {collapsible && (
+                <button
+                  onClick={onToggleCollapsed}
+                  title="パネルを折りたたむ"
+                  aria-label="パネルを折りたたむ"
+                  className="p-1 rounded-md text-[var(--color-text-muted)] hover:bg-[var(--color-nav-hover)] hover:text-[var(--color-text-primary)] transition-colors flex-shrink-0"
+                >
+                  <ChevronDoubleLeftIcon className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+            {headerContent && <div className="mt-2">{headerContent}</div>}
+          </div>
+          <div className="flex-1 overflow-y-auto">{children}</div>
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/components/layout/__tests__/SecondaryPanel.test.tsx
+++ b/frontend/src/components/layout/__tests__/SecondaryPanel.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import SecondaryPanel from '../SecondaryPanel';
 
 describe('SecondaryPanel', () => {
@@ -40,5 +40,30 @@ describe('SecondaryPanel', () => {
       </SecondaryPanel>
     );
     expect(screen.getByLabelText('パネルを閉じる')).toBeDefined();
+  });
+
+  it('collapsible のとき折りたたみボタンを出し、クリックでトグルを呼ぶ', () => {
+    const onToggle = vi.fn();
+    render(
+      <SecondaryPanel title="テスト" collapsible collapsed={false} onToggleCollapsed={onToggle}>
+        <div>内容</div>
+      </SecondaryPanel>
+    );
+    const btn = screen.getByLabelText('パネルを折りたたむ');
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('折りたたみ中は「開く」ボタンを出し、折りたたみボタンは出さない', () => {
+    const onToggle = vi.fn();
+    render(
+      <SecondaryPanel title="テスト" collapsible collapsed onToggleCollapsed={onToggle}>
+        <div>章リスト内容</div>
+      </SecondaryPanel>
+    );
+    // 折りたたみ中はデスクトップの全幅パネル（折りたたむボタン）を描画しない。
+    expect(screen.queryByLabelText('パネルを折りたたむ')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('パネルを開く'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -47,6 +47,8 @@ export default function CourseDetailPage() {
 
   const { showToast } = useToast();
   const { isOpen: mobilePanelOpen, open: openMobilePanel, close: closeMobilePanel } = useMobilePanelState();
+  // デスクトップの章一覧パネルの開閉。 教材を切り替えても継続するよう localStorage に保持（既定は表示）。
+  const [panelOpen, setPanelOpen] = useLocalStorage('course-panel-open', true);
 
   const [course, setCourse] = useState<Course | null>(null);
   const [courseLoading, setCourseLoading] = useState(true);
@@ -162,6 +164,9 @@ export default function CourseDetailPage() {
         badge={`${materials.length}件`}
         mobileOpen={mobilePanelOpen}
         onMobileClose={closeMobilePanel}
+        collapsible
+        collapsed={!panelOpen}
+        onToggleCollapsed={() => setPanelOpen((v) => !v)}
         headerContent={
           <div className="space-y-2">
             <Link


### PR DESCRIPTION
## 概要
目次トグルと同様に、コース閲覧画面の**左パネル（章一覧）も表示/非表示**できるようにします。隠すと本文が全幅に広がり、横幅を本文に回せます。

## 変更内容
- **[SecondaryPanel.tsx](frontend/src/components/layout/SecondaryPanel.tsx)**: 任意の `collapsible` / `collapsed` / `onToggleCollapsed` を追加（既定 off なので既存利用は不変）。
  - 展開時: パネルヘッダーに « (折りたたむ) ボタン
  - 折りたたみ中: 細い帯に » (開く) ボタンだけ表示し、本文が全幅に広がる
- **[CourseDetailPage.tsx](frontend/src/pages/CourseDetailPage.tsx)**: `useLocalStorage('course-panel-open')` で開閉状態を保持（既定は表示）し SecondaryPanel に渡す。教材を切り替えても継続
- SecondaryPanel テストに折りたたみ系ケースを追加

## テスト
- tsc / eslint / build green、`vitest run --coverage` 全件 PASS・閾値クリア（Branches 79.06 など）
- 既存利用（Notes / AskAi）は `collapsible` 未指定で挙動不変

## 関連
- UI 改善（[[#1984]] の目次トグルと同方針）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * デスクトップ画面で章一覧パネルを折りたたむことができるようになりました。
  * パネルの開閉状態が保存されるようになりました。

* **テスト**
  * パネルの折りたたみ機能のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->