### PR TITLE
fix(markdown): コードブロックの色付け有効化 + 文字サイズを読みやすく

### DIFF
--- a/frontend/src/components/message/MarkdownView.tsx
+++ b/frontend/src/components/message/MarkdownView.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
-import 'highlight.js/styles/github-dark.css';
 import CodeBlock from './CodeBlock';
 
 /**

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,14 +1,17 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 /*
  * highlight.js の GitHub Light テーマを import。
  * rehype-highlight が `<span class="hljs-keyword">` 等にトークンを分けるが、
  * 対応する CSS が無いと色付けされず読めなくなる。
  * FreStyle はライトテーマ単一構成なので、 GitHub README と同じ light を採用。
+ *
+ * ⚠️ `@import` は CSS 仕様上すべての規則より前に置く必要がある（@tailwind より後ろだと
+ *    postcss-import に無視され、 コードがハイライトされなくなる）。 必ずこの位置に置く。
  */
 @import 'highlight.js/styles/github.css';
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /*
  * prose のコードブロックを GitHub README 風（明るい背景 + 黒文字）にする。
@@ -28,10 +31,17 @@
   background-color: var(--color-surface-2);
   color: var(--color-text-primary);
   border: 1px solid var(--color-surface-3);
+  /* prose-sm は pre(0.857em) × code(0.857em) の複合縮小で本文より小さくなりすぎるため、
+   * 読みやすいサイズ(本文相当)に固定する。 */
+  font-size: 0.875rem;
+  line-height: 1.6;
 }
 .prose pre code {
   background-color: transparent;
+  /* color は hljs のトークン色を活かすための未色付け部フォールバックのみ。 */
   color: var(--color-text-primary);
+  /* typography の code(0.857em) による二重縮小を打ち消し、 pre のサイズを継承する。 */
+  font-size: inherit;
 }
 /*
  * @tailwindcss/typography は inline code (`<code>`) の前後に ::before / ::after で


### PR DESCRIPTION
## 概要
教材/ノートのコードスニペットが **①ハイライトされず黒一色** **②本文より小さい** 2 点を修正します。

## 原因と修正
1. **色が付かない**: [index.css](frontend/src/index.css) の `@import 'highlight.js/styles/github.css'` が `@tailwind` ディレクティブより**後ろ**にあり、CSS 仕様上 postcss-import に無視されてテーマが読み込まれていなかった（コース閲覧時はチャットも開いていないため hljs テーマが皆無 → 黒一色）。**@import をファイル先頭（全規則より前）に移動**して github light テーマを確実にバンドル。
2. **文字が小さい**: `prose-sm` は `pre`(0.857em) × `code`(0.857em) の複合縮小で本文より小さくなる。`.prose pre` を本文相当（0.875rem / line-height 1.6）に固定し、`.prose pre code` は `font-size: inherit` で二重縮小を打ち消す。
3. **テーマ統一**: チャット([MarkdownView](frontend/src/components/message/MarkdownView.tsx))だけ `github-dark` を import していたが、`CodeBlock` 背景は light（surface-3）で低コントラストだった。ライトテーマ単一構成に合わせ **github-dark を撤去**し全体を github light に統一（テーマの競合も解消）。

## 確認
- ビルド成果物の CSS に `hljs-keyword` が含まれることを確認（=ハイライト有効）、`github-dark` は不在（=競合なし）
- tsc / eslint / vitest(1097) / build green
- 効果範囲: コース / ノート / 演習 / チャットのコードブロックが一貫して github light で色付け + 読みやすいサイズに

見た目のみ（CSS + CSS import 撤去、ロジック変更なし）。