### PR TITLE
fix(nav): ヘッダーの「管理」ボタンを他のナビ項目と同色に揃える

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -179,7 +179,9 @@ export default function Header() {
                 onClick={() => setAdminOpen((p) => !p)}
                 aria-haspopup="true"
                 aria-expanded={adminOpen}
-                className={`${navLinkClass(location.pathname.startsWith('/admin'))} inline-flex items-center gap-1`}
+                // 管理はドロップダウンのトリガーなので、 /admin 配下でもアクティブ背景を付けず
+                // 他のナビ項目と同じ通常表示に揃える（実際のページは sub 項目側でハイライトする）。
+                className={`${navLinkClass(false)} inline-flex items-center gap-1`}
               >
                 管理
                 <ChevronDownIcon className={`w-3.5 h-3.5 transition-transform ${adminOpen ? 'rotate-180' : ''}`} />


### PR DESCRIPTION
## 概要
`/admin` 配下にいると、ヘッダーの「**管理 ▾**」ドロップダウンのトリガーだけアクティブ背景（グレー）が付き、他のヘッダー項目より濃く見えていました。「管理」はドロップダウンのトリガーで実際のページは sub 項目（概況/会社一覧/…）側なので、**アクティブ背景を付けず通常のナビ表示に統一**します。

## 変更
- [Header.tsx](frontend/src/components/layout/Header.tsx) の管理ボタンの className を `navLinkClass(false)` に（常に通常表示）

見た目だけ（className 変更のみ）。tsc / eslint / vitest(Header 9件) / build green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 管理者メニューのトリガーボタンのハイライト表示を改善しました。管理者ページ内での閲覧時に、トリガーボタンではなくサブメニューのみにアクティブ状態を表示するように調整されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->