### PR TITLE
fix(markdown): コードを VS Code Dark 風の鮮やか配色に + 本文拡大 + 図の埋め込み対応

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,36 +1,36 @@
 /*
- * highlight.js の GitHub Light テーマを import。
- * rehype-highlight が `<span class="hljs-keyword">` 等にトークンを分けるが、
- * 対応する CSS が無いと色付けされず読めなくなる。
- * FreStyle はライトテーマ単一構成なので、 GitHub README と同じ light を採用。
+ * highlight.js の Atom One Dark テーマ（VS Code Dark 風）を import。
+ * rehype-highlight が `<span class="hljs-keyword">` 等にトークンを分けるが、対応する CSS が
+ * 無いと色付けされない。 GitHub Light は配色が地味（文字列 #032f62 がほぼ黒に見える等）で
+ * 「赤しか無い」印象になるため、 キーワード / 型 / 関数 / 文字列 / 数値がはっきり色分けされる
+ * Atom One Dark を採用し、 コードブロックはエディタ風のダーク背景にする。
  *
  * ⚠️ `@import` は CSS 仕様上すべての規則より前に置く必要がある（@tailwind より後ろだと
  *    postcss-import に無視され、 コードがハイライトされなくなる）。 必ずこの位置に置く。
  */
-@import 'highlight.js/styles/github.css';
+@import 'highlight.js/styles/atom-one-dark.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 /*
- * prose のコードブロックを GitHub README 風（明るい背景 + 黒文字）にする。
- * @tailwindcss/typography の既定では <pre> は dark navy 背景になるが、
- * FreStyle のライトテーマと噛み合わないので CSS 変数で override する。
+ * prose のコードブロックを VS Code Dark 風（ダーク背景 + Atom One Dark の鮮やかな配色）にする。
+ * 本文はライトのまま、 コードブロックだけエディタ風のダークにして可読性と色分けを上げる。
  *
  * - --tw-prose-pre-bg: コードブロック全体の背景
  * - --tw-prose-pre-code: コードブロック内のフォールバック文字色（hljs 未色付け部）
  * - --tw-prose-pre-border: 枠線色
  */
 .prose {
-  --tw-prose-pre-bg: var(--color-surface-2);
-  --tw-prose-pre-code: var(--color-text-primary);
-  --tw-prose-pre-border: var(--color-surface-3);
+  --tw-prose-pre-bg: #282c34;
+  --tw-prose-pre-code: #abb2bf;
+  --tw-prose-pre-border: #3a3f4b;
 }
 .prose pre {
-  background-color: var(--color-surface-2);
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-surface-3);
+  background-color: #282c34;
+  color: #abb2bf;
+  border: 1px solid #3a3f4b;
   /* prose-sm は pre(0.857em) × code(0.857em) の複合縮小で本文より小さくなりすぎるため、
    * 読みやすいサイズ(本文相当)に固定する。 */
   font-size: 0.875rem;
@@ -38,10 +38,20 @@
 }
 .prose pre code {
   background-color: transparent;
-  /* color は hljs のトークン色を活かすための未色付け部フォールバックのみ。 */
-  color: var(--color-text-primary);
+  /* Atom One Dark の token 色 / .hljs ベース色(#abb2bf)をそのまま活かす。 */
+  color: inherit;
   /* typography の code(0.857em) による二重縮小を打ち消し、 pre のサイズを継承する。 */
   font-size: inherit;
+}
+/*
+ * コース閲覧の本文は prose-sm(14px) だと少し小さいので、 少し大きく(15px)して読みやすくする。
+ * 子要素は em 指定なので比例して大きくなる。 コードブロックも本文サイズに合わせる。
+ */
+.prose.course-prose {
+  font-size: 0.9375rem;
+}
+.prose.course-prose pre {
+  font-size: 0.9375rem;
 }
 /*
  * @tailwindcss/typography は inline code (`<code>`) の前後に ::before / ::after で

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -462,7 +462,7 @@ function ReadOnlyDetail({
               <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
             </div>
           </div>
-          <div className="prose prose-sm max-w-none">
+          <div className="prose prose-sm max-w-none course-prose">
             <ReadOnlyMarkdown content={material.content} />
           </div>
 
@@ -587,6 +587,28 @@ function ReadOnlyMarkdown({ content }: { content: string }) {
             {children as ReactNode}
           </a>
         ),
+        // 図（draw.io から書き出した PNG/SVG 等）を本文に埋め込めるようにする。
+        // 中央寄せ + 枠 + 白背景（透過 SVG が見えるよう）+ クリックで原寸を別タブ表示。
+        img: ({ src, alt }) => {
+          const url = typeof src === 'string' ? src : undefined;
+          return (
+            <figure className="my-5">
+              <a href={url} target="_blank" rel="noopener noreferrer" className="block">
+                <img
+                  src={url}
+                  alt={alt ?? ''}
+                  loading="lazy"
+                  className="mx-auto max-w-full h-auto rounded-lg border border-surface-3 bg-white"
+                />
+              </a>
+              {alt && (
+                <figcaption className="mt-2 text-center text-xs text-[var(--color-text-muted)]">
+                  {alt}
+                </figcaption>
+              )}
+            </figure>
+          );
+        },
         code: ({ className, children, ...props }) => {
           const isBlock = className?.includes('language-');
           if (isBlock) {


### PR DESCRIPTION
## 概要
教材のコードが「赤しか色が付かない」「本文が少し小さい」点と、draw.io 図を本文に入れたい要望に対応します。

## 変更内容
1. **コードの配色（VS Code Dark 風）**: GitHub Light テーマは配色が地味（文字列 #032f62 がほぼ黒に見える等）で「赤しか無い」印象だった。**Atom One Dark** に切替え、コードブロックをエディタ風のダーク背景にして、**キーワード / 型 / 関数 / 文字列 / 数値**をはっきり色分け。`.prose pre code` の color を `inherit` にしてダークテーマの token 色を活かす（従来は黒固定で潰れていた）。
2. **本文サイズ**: コース閲覧の本文を `prose-sm`(14px) から少し大きく（**15px**, `.course-prose`）。子要素は em 指定で比例、コードも 15px に合わせる。
3. **図の埋め込み**: `ReadOnlyMarkdown` に `img` コンポーネントを追加。draw.io から書き出した PNG/SVG を `![説明](URL)` で本文に挿入でき、**中央寄せ + 枠 + 白背景（透過 SVG 可）+ クリックで原寸表示 + alt をキャプション**表示。

## 補足（フェンスの挙動）
` ```go ` / ` ```sql ` でフェンスすれば rehype-highlight が言語判定してトークン分けします（go/sql とも highlight.js 標準対応）。今回テーマを鮮やかにしたので GitHub/VS Code プレビューのように色が付きます。

## 確認
- ビルド成果物に Atom One Dark の配色(#282c34 等)が含まれることを確認
- tsc / eslint / vitest(1097) / build green
- 効果範囲: コース/ノート/演習/チャットのコードブロックが一貫してダーク+鮮やか配色に

見た目のみ（CSS + 画像/テーマのプレゼン変更、ロジック変更なし）。