### PR TITLE
feat(materials): 教材エディタに画像アップロードを追加(draw.io 図の埋め込み用)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -4111,6 +4111,10 @@ const docTemplate = `{
                 "key": {
                     "type": "string"
                 },
+                "publicUrl": {
+                    "description": "PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。",
+                    "type": "string"
+                },
                 "url": {
                     "type": "string"
                 }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4104,6 +4104,10 @@
                 "key": {
                     "type": "string"
                 },
+                "publicUrl": {
+                    "description": "PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。",
+                    "type": "string"
+                },
                 "url": {
                     "type": "string"
                 }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -289,6 +289,9 @@ definitions:
         type: integer
       key:
         type: string
+      publicUrl:
+        description: PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。
+        type: string
       url:
         type: string
     type: object

--- a/backend/internal/adapter/persistence/note_image_repository.go
+++ b/backend/internal/adapter/persistence/note_image_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -10,16 +11,18 @@ import (
 )
 
 // noteImagePresigner は note 画像用の S3 presigner（notes/{userId}/{epochNs}.bin キー）。
+// cdnBase は配信用 CDN URL（NOTE_IMAGES_CDN_URL）。アップロード後の参照 URL 組み立てに使う。
 type noteImagePresigner struct {
-	pre s3Presigner
+	pre     s3Presigner
+	cdnBase string
 }
 
-// NewNoteImagePresigner は本番経路。infra/s3.Presigner を渡して使う。
-func NewNoteImagePresigner(p s3Presigner) repository.NoteImagePresigner {
-	return &noteImagePresigner{pre: p}
+// NewNoteImagePresigner は本番経路。infra/s3.Presigner と配信 CDN base を渡して使う。
+func NewNoteImagePresigner(p s3Presigner, cdnBase string) repository.NoteImagePresigner {
+	return &noteImagePresigner{pre: p, cdnBase: cdnBase}
 }
 
-// NewStubNoteImagePresigner は test / dev 用 stub。
+// NewStubNoteImagePresigner は test / dev 用 stub（CDN 未設定で相対 URL を返す）。
 func NewStubNoteImagePresigner(bucket string) repository.NoteImagePresigner {
 	return &noteImagePresigner{pre: &stubPresigner{bucket: bucket}}
 }
@@ -39,6 +42,15 @@ func (p *noteImagePresigner) Generate(ctx context.Context, userID uint64, conten
 	return &domain.NoteImageUploadURL{
 		URL:       url,
 		Key:       key,
+		PublicURL: p.publicURL(key),
 		ExpiresIn: int(ttl.Seconds()),
 	}, nil
+}
+
+// publicURL は配信用 URL を組み立てる。cdnBase 未設定時は同一オリジンの相対 URL にフォールバック。
+func (p *noteImagePresigner) publicURL(key string) string {
+	if p.cdnBase == "" {
+		return "/" + key
+	}
+	return strings.TrimRight(p.cdnBase, "/") + "/" + key
 }

--- a/backend/internal/domain/note_image.go
+++ b/backend/internal/domain/note_image.go
@@ -2,7 +2,9 @@ package domain
 
 // NoteImageUploadURL は S3 への直接アップロード用に発行する署名付き URL を表す。
 type NoteImageUploadURL struct {
-	URL       string `json:"url"`
-	Key       string `json:"key"`
+	URL string `json:"url"`
+	Key string `json:"key"`
+	// PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。
+	PublicURL string `json:"publicUrl"`
 	ExpiresIn int    `json:"expiresIn"`
 }

--- a/backend/internal/handler/routes_note.go
+++ b/backend/internal/handler/routes_note.go
@@ -54,5 +54,5 @@ func newNoteImagePresignerOrFallback(deps *routeDeps) repository.NoteImagePresig
 		log.Printf("[note-image] failed to init S3 presigner (%v) — falling back to stub", err)
 		return persistence.NewStubNoteImagePresigner(bucket)
 	}
-	return persistence.NewNoteImagePresigner(pre)
+	return persistence.NewNoteImagePresigner(pre, deps.cfg.S3.NoteImagesCDNBase)
 }

--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUturnLeftIcon,
   ArrowUturnRightIcon,
   ClipboardDocumentIcon,
+  PhotoIcon,
 } from '@heroicons/react/24/outline';
 import type { SaveStatus } from '../hooks/useNoteEditor';
 import { useToast } from '../hooks/useToast';
@@ -22,6 +23,9 @@ interface NoteMarkdownEditorProps {
   saveStatus: SaveStatus;
   onTitleChange: (title: string) => void;
   onContentChange: (content: string) => void;
+  // 画像アップロード（任意）。File を受け取り公開 URL を返す。 指定すると textarea への
+  // ドラッグ&ドロップ / 貼り付け / ボタンで画像を挿入できる（教材で draw.io 図を埋め込む用途）。
+  onImageUpload?: (file: File) => Promise<string>;
 }
 
 const SAVE_STATUS_CONFIG: Record<Exclude<SaveStatus, 'idle'>, { label: string; color: string }> = {
@@ -42,10 +46,13 @@ export default function NoteMarkdownEditor({
   saveStatus,
   onTitleChange,
   onContentChange,
+  onImageUpload,
 }: NoteMarkdownEditorProps) {
   const [tab, setTab] = useState<'edit' | 'preview'>('edit');
+  const [uploading, setUploading] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const { showToast } = useToast();
 
   const stats = useMemo(() => getNoteStats(content), [content]);
@@ -97,6 +104,75 @@ export default function NoteMarkdownEditor({
     URL.revokeObjectURL(url);
   }, [content, title]);
 
+  // textarea のカーソル位置に text を挿入する（controlled value を更新）。
+  const insertAtCursor = useCallback(
+    (text: string) => {
+      const ta = textareaRef.current;
+      if (!ta) {
+        onContentChange(content + text);
+        return;
+      }
+      const start = ta.selectionStart ?? content.length;
+      const end = ta.selectionEnd ?? content.length;
+      onContentChange(content.slice(0, start) + text + content.slice(end));
+      requestAnimationFrame(() => {
+        ta.focus();
+        const pos = start + text.length;
+        ta.setSelectionRange(pos, pos);
+      });
+    },
+    [content, onContentChange],
+  );
+
+  // 画像をアップロードして ![alt](url) を挿入する。
+  const uploadImage = useCallback(
+    async (file: File) => {
+      if (!onImageUpload) return;
+      if (!file.type.startsWith('image/')) {
+        showToast('error', '画像ファイルのみアップロードできます');
+        return;
+      }
+      setUploading(true);
+      try {
+        const url = await onImageUpload(file);
+        const alt = file.name.replace(/\.[^.]+$/, '') || 'image';
+        insertAtCursor(`\n![${alt}](${url})\n`);
+        showToast('success', '画像を挿入しました');
+      } catch {
+        showToast('error', '画像のアップロードに失敗しました');
+      } finally {
+        setUploading(false);
+      }
+    },
+    [onImageUpload, showToast, insertAtCursor],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLTextAreaElement>) => {
+      if (!onImageUpload) return;
+      const file = Array.from(e.dataTransfer.files).find((f) => f.type.startsWith('image/'));
+      if (file) {
+        e.preventDefault();
+        uploadImage(file);
+      }
+    },
+    [onImageUpload, uploadImage],
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (!onImageUpload) return;
+      const file = Array.from(e.clipboardData.items)
+        .find((i) => i.type.startsWith('image/'))
+        ?.getAsFile();
+      if (file) {
+        e.preventDefault();
+        uploadImage(file);
+      }
+    },
+    [onImageUpload, uploadImage],
+  );
+
   return (
     <div className="flex flex-col h-full p-6 max-w-6xl mx-auto w-full">
       <input
@@ -125,6 +201,9 @@ export default function NoteMarkdownEditor({
             ref={textareaRef}
             value={content}
             onChange={(e) => onContentChange(e.target.value)}
+            onDrop={handleDrop}
+            onPaste={handlePaste}
+            onDragOver={onImageUpload ? (e) => e.preventDefault() : undefined}
             placeholder="# 見出し&#10;&#10;Markdown でノートを書きましょう..."
             spellCheck={false}
             className="w-full h-full resize-none p-4 rounded-md bg-surface-1 border border-surface-3 text-sm font-mono text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500/50 transition-colors"
@@ -149,7 +228,36 @@ export default function NoteMarkdownEditor({
             {SAVE_STATUS_CONFIG[saveStatus].label}
           </span>
         )}
+        {uploading && (
+          <span className="text-xs text-[var(--color-text-muted)]">画像アップロード中...</span>
+        )}
         <div className="ml-auto flex items-center gap-1">
+          {onImageUpload && (
+            <>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                aria-label="画像を挿入"
+                title="画像を挿入（ドラッグ&ドロップ / 貼り付けも可）"
+                className="p-1.5 rounded hover:bg-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors disabled:opacity-50"
+              >
+                <PhotoIcon className="w-4 h-4" />
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) uploadImage(f);
+                  e.target.value = '';
+                }}
+              />
+              <span className="w-px h-4 bg-surface-3 mx-1" aria-hidden="true" />
+            </>
+          )}
           <button
             type="button"
             onClick={handleUndo}

--- a/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import NoteMarkdownEditor from '../NoteMarkdownEditor';
 import { ToastProvider } from '../ToastProvider';
 
@@ -74,5 +74,57 @@ describe('NoteMarkdownEditor', () => {
     titleInput.focus();
     fireEvent.keyDown(titleInput, { key: 'Enter' });
     expect(document.activeElement).toBe(getMarkdownTextarea());
+  });
+
+  // --- 画像アップロード（onImageUpload 指定時） ---
+
+  function fileInput(): HTMLInputElement {
+    const el = document.querySelector('input[type="file"]');
+    if (!el) throw new Error('file input not found');
+    return el as HTMLInputElement;
+  }
+
+  it('onImageUpload 未指定なら画像挿入ボタンを出さない', () => {
+    renderEditor();
+    expect(screen.queryByLabelText('画像を挿入')).not.toBeInTheDocument();
+    expect(document.querySelector('input[type="file"]')).toBeNull();
+  });
+
+  it('画像を選ぶとアップロードして ![](url) を挿入する', async () => {
+    const onImageUpload = vi.fn().mockResolvedValue('https://cdn/x.png');
+    const onContentChange = vi.fn();
+    renderEditor({ onImageUpload, onContentChange, content: 'A' });
+
+    const file = new File(['x'], 'diagram.png', { type: 'image/png' });
+    fireEvent.change(fileInput(), { target: { files: [file] } });
+
+    await waitFor(() => expect(onImageUpload).toHaveBeenCalledWith(file));
+    await waitFor(() =>
+      expect(onContentChange).toHaveBeenCalledWith(expect.stringContaining('![diagram](https://cdn/x.png)')),
+    );
+  });
+
+  it('画像以外のファイルはアップロードしない', async () => {
+    const onImageUpload = vi.fn().mockResolvedValue('https://cdn/x.png');
+    const onContentChange = vi.fn();
+    renderEditor({ onImageUpload, onContentChange });
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' });
+    fireEvent.change(fileInput(), { target: { files: [file] } });
+    // 非同期を一巡させてから、 アップロード/挿入されていないことを確認（type ガードで弾く）。
+    await new Promise((r) => setTimeout(r, 0));
+    expect(onImageUpload).not.toHaveBeenCalled();
+    expect(onContentChange).not.toHaveBeenCalled();
+  });
+
+  it('textarea への画像ドロップでアップロードして挿入する', async () => {
+    const onImageUpload = vi.fn().mockResolvedValue('https://cdn/y.png');
+    const onContentChange = vi.fn();
+    renderEditor({ onImageUpload, onContentChange, content: 'A' });
+    const file = new File(['x'], 'arch.png', { type: 'image/png' });
+    fireEvent.drop(getMarkdownTextarea(), { dataTransfer: { files: [file] } });
+    await waitFor(() => expect(onImageUpload).toHaveBeenCalledWith(file));
+    await waitFor(() =>
+      expect(onContentChange).toHaveBeenCalledWith(expect.stringContaining('![arch](https://cdn/y.png)')),
+    );
   });
 });

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -61,6 +61,12 @@ export const NOTES = {
     `${API_V2}/notes/${noteId}/images/presigned-url`,
 } as const;
 
+/** 画像アップロード（current user 名義の S3 PUT 署名 URL。ノート/教材で共有）*/
+export const IMAGES = {
+  /** POST /api/v2/notes/images/upload-url — {contentType} → {url, key, publicUrl} */
+  uploadUrl: `${API_V2}/notes/images/upload-url`,
+} as const;
+
 /** SessionNote (セッション固有ノート) */
 export const SESSION_NOTES = {
   byId: (sessionId: number | string) => `${API_V2}/session-notes/${sessionId}`,

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -27,6 +27,7 @@ import { useMobilePanelState } from '../hooks/useMobilePanelState';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useToast } from '../hooks/useToast';
 import CourseRepository from '../repositories/CourseRepository';
+import ImageUploadRepository from '../repositories/ImageUploadRepository';
 import type { RootState } from '../store';
 import type { Course, TeachingMaterial } from '../types';
 
@@ -397,6 +398,7 @@ function ManagedDetail({
           saveStatus={editor.saveStatus}
           onTitleChange={editor.handleTitleChange}
           onContentChange={editor.handleContentChange}
+          onImageUpload={(file) => ImageUploadRepository.upload(file)}
         />
       </div>
     </div>

--- a/frontend/src/repositories/ImageUploadRepository.ts
+++ b/frontend/src/repositories/ImageUploadRepository.ts
@@ -1,0 +1,30 @@
+import apiClient from '../lib/axios';
+import axios from 'axios';
+import { IMAGES } from '../constants/apiRoutes';
+
+interface UploadUrlResponse {
+  url: string; // S3 への PUT 用署名付き URL
+  key: string;
+  publicUrl: string; // アップロード後に参照する配信 URL
+  expiresIn: number;
+}
+
+/**
+ * ImageUploadRepository — 画像を S3 にアップロードして公開 URL を返す（ノート / 教材で共有）。
+ *
+ * フロー: presign 発行(current user 名義) → S3 へ直接 PUT → 配信 URL(publicUrl) を返す。
+ * userId は送らず backend が context の current user で発行する（IDOR 対策）。
+ */
+const ImageUploadRepository = {
+  async upload(file: File): Promise<string> {
+    const { data } = await apiClient.post<UploadUrlResponse>(IMAGES.uploadUrl, {
+      contentType: file.type || 'image/png',
+    });
+    await axios.put(data.url, file, {
+      headers: { 'Content-Type': file.type || 'image/png' },
+    });
+    return data.publicUrl;
+  },
+};
+
+export default ImageUploadRepository;

--- a/frontend/src/repositories/__tests__/ImageUploadRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ImageUploadRepository.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../lib/axios', () => ({
+  default: { post: vi.fn() },
+}));
+vi.mock('axios', () => ({
+  default: { put: vi.fn() },
+}));
+
+import apiClient from '../../lib/axios';
+import axios from 'axios';
+import ImageUploadRepository from '../ImageUploadRepository';
+
+const mockedPost = vi.mocked(apiClient.post);
+const mockedPut = vi.mocked(axios.put);
+
+describe('ImageUploadRepository', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('presign → S3 PUT → publicUrl を返す', async () => {
+    mockedPost.mockResolvedValue({
+      data: { url: 'https://s3/put?sig', key: 'notes/7/1.bin', publicUrl: 'https://cdn/notes/7/1.bin', expiresIn: 600 },
+    });
+    mockedPut.mockResolvedValue({});
+
+    const file = new File(['x'], 'diagram.png', { type: 'image/png' });
+    const url = await ImageUploadRepository.upload(file);
+
+    expect(mockedPost).toHaveBeenCalledWith('/api/v2/notes/images/upload-url', {
+      contentType: 'image/png',
+    });
+    expect(mockedPut).toHaveBeenCalledWith('https://s3/put?sig', file, {
+      headers: { 'Content-Type': 'image/png' },
+    });
+    expect(url).toBe('https://cdn/notes/7/1.bin');
+  });
+});


### PR DESCRIPTION
## 概要
教材本文に **draw.io 等で作った図**を入れたい要望（A案）に対応します。教材エディタで画像を **ドラッグ&ドロップ / 貼り付け / ボタン** で選ぶと S3 にアップロードし、`![](URL)` を本文に自動挿入します。

## 変更内容
### backend
- 画像 presign エンドポイント（`POST /notes/images/upload-url`, current user 名義で既存）のレスポンスに **`publicUrl`** を追加。配信 CDN（`NOTE_IMAGES_CDN_URL`）を presigner に渡し、`key` から配信 URL を組み立てて返す（frontend が URL を推測せず済む）。CDN 未設定時は相対 URL にフォールバック。
- `domain.NoteImageUploadURL` に `PublicURL` / OpenAPI 反映。

### frontend
- **[ImageUploadRepository](frontend/src/repositories/ImageUploadRepository.ts)**: presign → S3 へ直接 PUT → `publicUrl` を返す（ノート/教材で共有）。
- **[NoteMarkdownEditor](frontend/src/components/NoteMarkdownEditor.tsx)**: 任意の `onImageUpload` を追加。指定すると textarea への**ドラッグ&ドロップ / 画像の貼り付け / ツールバーの画像ボタン**でアップロードし、カーソル位置に `![alt](url)` を挿入（アップロード中表示あり）。
- **CourseDetailPage** の教材エディタ（ManagedDetail）に `onImageUpload` を配線。

## 使い方（運用）
1. company_admin が教材編集画面で図（draw.io から書き出した PNG/SVG）をドラッグ&ドロップ or 貼り付け。
2. S3 にアップロードされ `![図名](URL)` が本文に挿入される（[#1992](../../pull/1992) の img レンダリングで中央寄せ表示）。
3. 同じ Markdown を `frestyle-teaching-materials` リポにバックポートして整合を取る。

## テスト
- backend: `make verify` green（presigner/usecase/handler + archlint/apispec-lint/naminglint）。
- frontend: `ImageUploadRepository` と `NoteMarkdownEditor` の画像アップロード（選択/ドロップ/非画像拒否）テスト追加。`vitest run --coverage` 1102 件 PASS・閾値クリア。

## デプロイ
- backend（publicUrl 返却）→ frontend の順で反映が必要。