### PR TITLE
perf(courses): 章本文を一覧で先読みせず選択時に都度取得する

### DIFF
--- a/backend/internal/adapter/persistence/teaching_material_repository.go
+++ b/backend/internal/adapter/persistence/teaching_material_repository.go
@@ -33,8 +33,11 @@ ORDER BY updated_at DESC, id DESC`
 
 // ListByCourse はコース内の教材を order_in_course 昇順で返す。
 func (r *teachingMaterialRepository) ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+	// 一覧は content(本文 markdown)を返さない（章ごとに重く、 全章を先読みすると非効率）。
+	// 本文は選択時に GetByID で都度取得する。Content は空文字のままになる。
 	const q = `
-SELECT * FROM teaching_materials
+SELECT id, company_id, course_id, created_by_user_id, title, order_in_course, is_published, created_at, updated_at
+FROM teaching_materials
 WHERE course_id = ? AND (? OR is_published = TRUE)
 ORDER BY order_in_course ASC, id ASC`
 	var rows []domain.TeachingMaterial

--- a/frontend/e2e/local/user-flows.spec.ts
+++ b/frontend/e2e/local/user-flows.spec.ts
@@ -83,7 +83,9 @@ test.describe('コース学習フロー', () => {
     await mockAuthed(page, {
       '**/api/v2/courses': [course],
       '**/api/v2/courses/1': course,
+      // 一覧はメタデータのみ、 本文は選択時に GET /teaching-materials/:id で取得する。
       '**/api/v2/courses/1/materials': [material],
+      '**/api/v2/teaching-materials/11': material,
     });
 
     await page.goto('/courses');

--- a/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
@@ -68,7 +68,7 @@ describe('useTeachingMaterials', () => {
     expect(result.current.error).toBe('教材の取得に失敗しました');
   });
 
-  it('searchQuery でタイトル / 本文がフィルタされる', async () => {
+  it('searchQuery でタイトルがフィルタされる', async () => {
     courseMocks.listMaterials.mockResolvedValue([
       sample(1, { title: 'PHP 入門' }),
       sample(2, { title: 'Go 入門' }),
@@ -78,6 +78,26 @@ describe('useTeachingMaterials', () => {
     act(() => result.current.setSearchQuery('php'));
     expect(result.current.filtered).toHaveLength(1);
     expect(result.current.filtered[0].title).toBe('PHP 入門');
+  });
+
+  it('選択した教材だけ本文を都度取得して selected に入る（全章は先読みしない）', async () => {
+    courseMocks.listMaterials.mockResolvedValue([sample(1), sample(2)]);
+    materialMocks.get.mockResolvedValue({ ...sample(1), content: '# 本文1' });
+    const { result } = renderHook(() => useTeachingMaterials(5));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // 一覧取得だけでは本文取得(get)は呼ばれない。
+    expect(materialMocks.get).not.toHaveBeenCalled();
+
+    act(() => result.current.selectMaterial(1));
+    await waitFor(() => expect(result.current.selected?.content).toBe('# 本文1'));
+    expect(materialMocks.get).toHaveBeenCalledWith(1);
+    expect(materialMocks.get).toHaveBeenCalledTimes(1);
+
+    // 再選択しても キャッシュ済みなら get は増えない。
+    act(() => result.current.selectMaterial(2));
+    act(() => result.current.selectMaterial(1));
+    await waitFor(() => expect(result.current.selected?.id).toBe(1));
+    expect(materialMocks.get).toHaveBeenCalledTimes(2); // 1 と 2 の計2回（1 の再取得は無し）
   });
 
   it('create 成功時にリストに追加され selected になる', async () => {
@@ -101,10 +121,12 @@ describe('useTeachingMaterials', () => {
 
   it('remove 成功時にリストから消え selected もクリア', async () => {
     courseMocks.listMaterials.mockResolvedValue([sample(1)]);
+    materialMocks.get.mockResolvedValue(sample(1));
     materialMocks.remove.mockResolvedValue(undefined);
     const { result } = renderHook(() => useTeachingMaterials(5));
     await waitFor(() => expect(result.current.loading).toBe(false));
     act(() => result.current.selectMaterial(1));
+    await waitFor(() => expect(result.current.selected?.id).toBe(1));
     await act(async () => {
       await result.current.remove(1);
     });

--- a/frontend/src/hooks/useTeachingMaterials.ts
+++ b/frontend/src/hooks/useTeachingMaterials.ts
@@ -7,15 +7,18 @@ import TeachingMaterialRepository, {
 import type { TeachingMaterial } from '../types';
 
 /**
- * useTeachingMaterials — 指定コース配下の教材一覧 + 選択 + CRUD の状態管理。
+ * useTeachingMaterials — 指定コース配下の教材の「一覧(メタデータ) + 選択 + CRUD」の状態管理。
  *
- * `courseId` が 0 / null なら何もせず空配列を保持する（routing で `/courses/:id` に
- * 入った瞬間にコース ID が確定する想定）。 autosave は別 hook (useTeachingMaterialEditor) に分離。
+ * 効率化のため一覧は本文(content)を含まない軽量メタデータで取得し、 選択された教材の本文だけ
+ * `GetByID` で都度取得してキャッシュする（全章を先読みしない）。autosave は useTeachingMaterialEditor。
  */
 export function useTeachingMaterials(courseId: number | null) {
+  // materials は content を持たないメタデータ一覧。 detailCache は本文込みの取得済み教材。
   const [materials, setMaterials] = useState<TeachingMaterial[]>([]);
+  const [detailCache, setDetailCache] = useState<Record<number, TeachingMaterial>>({});
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -41,17 +44,40 @@ export function useTeachingMaterials(courseId: number | null) {
     fetchAll();
   }, [fetchAll]);
 
-  const selected = useMemo(
-    () => materials.find((m) => m.id === selectedId) ?? null,
-    [materials, selectedId],
-  );
+  // コースが変わったら選択 / 本文キャッシュをリセットする。
+  useEffect(() => {
+    setSelectedId(null);
+    setDetailCache({});
+  }, [courseId]);
+
+  // 選択された教材の本文を都度取得してキャッシュする（未取得時のみ）。
+  useEffect(() => {
+    if (selectedId == null || detailCache[selectedId]) return;
+    let active = true;
+    setDetailLoading(true);
+    TeachingMaterialRepository.get(selectedId)
+      .then((m) => {
+        if (active) setDetailCache((prev) => ({ ...prev, [m.id]: m }));
+      })
+      .catch(() => {
+        if (active) setError('教材の取得に失敗しました');
+      })
+      .finally(() => {
+        if (active) setDetailLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [selectedId, detailCache]);
+
+  // selected は本文込みのキャッシュから返す（未取得なら null = 取得中）。
+  const selected = selectedId != null ? (detailCache[selectedId] ?? null) : null;
 
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return materials;
-    return materials.filter(
-      (m) => m.title.toLowerCase().includes(q) || m.content.toLowerCase().includes(q),
-    );
+    // 一覧は本文を持たないためタイトル検索のみ（本文全文検索は別途 backend 検索で対応）。
+    return materials.filter((m) => m.title.toLowerCase().includes(q));
   }, [materials, searchQuery]);
 
   const create = useCallback(
@@ -62,7 +88,8 @@ export function useTeachingMaterials(courseId: number | null) {
       }
       try {
         const created = await TeachingMaterialRepository.create({ ...initial, courseId });
-        setMaterials((prev) => [...prev, created].sort(byOrderThenId));
+        setMaterials((prev) => [...prev, stripContent(created)].sort(byOrderThenId));
+        setDetailCache((prev) => ({ ...prev, [created.id]: created }));
         setSelectedId(created.id);
         return created;
       } catch {
@@ -73,23 +100,26 @@ export function useTeachingMaterials(courseId: number | null) {
     [courseId],
   );
 
-  const update = useCallback(
-    async (id: number, payload: TeachingMaterialUpdatePayload): Promise<void> => {
-      try {
-        const updated = await TeachingMaterialRepository.update(id, payload);
-        setMaterials((prev) => prev.map((m) => (m.id === id ? updated : m)).sort(byOrderThenId));
-      } catch {
-        setError('教材の更新に失敗しました');
-      }
-    },
-    [],
-  );
+  const update = useCallback(async (id: number, payload: TeachingMaterialUpdatePayload): Promise<void> => {
+    try {
+      const updated = await TeachingMaterialRepository.update(id, payload);
+      setMaterials((prev) => prev.map((m) => (m.id === id ? stripContent(updated) : m)).sort(byOrderThenId));
+      setDetailCache((prev) => ({ ...prev, [id]: updated }));
+    } catch {
+      setError('教材の更新に失敗しました');
+    }
+  }, []);
 
   const remove = useCallback(
     async (id: number): Promise<void> => {
       try {
         await TeachingMaterialRepository.remove(id);
         setMaterials((prev) => prev.filter((m) => m.id !== id));
+        setDetailCache((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
         if (selectedId === id) setSelectedId(null);
       } catch {
         setError('教材の削除に失敗しました');
@@ -104,6 +134,7 @@ export function useTeachingMaterials(courseId: number | null) {
     selectedId,
     selected,
     loading,
+    detailLoading,
     error,
     searchQuery,
     setSearchQuery,
@@ -113,6 +144,11 @@ export function useTeachingMaterials(courseId: number | null) {
     update,
     remove,
   };
+}
+
+// 一覧(メタデータ)に本文を持たせない（先読み抑制 + 一貫性のため content を空にする）。
+function stripContent(m: TeachingMaterial): TeachingMaterial {
+  return { ...m, content: '' };
 }
 
 function byOrderThenId(a: TeachingMaterial, b: TeachingMaterial): number {

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -62,6 +62,7 @@ export default function CourseDetailPage() {
     selectedId,
     selected,
     loading,
+    detailLoading,
     error,
     searchQuery,
     setSearchQuery,
@@ -260,7 +261,10 @@ export default function CourseDetailPage() {
 
         {error && <p className="px-6 py-3 text-sm text-red-500">{error}</p>}
 
-        {selected ? (
+        {detailLoading && !selected ? (
+          // 章を選択したら本文を都度取得する。取得中はスピナーを出す。
+          <Loading className="h-full" />
+        ) : selected ? (
           canManage ? (
             <ManagedDetail editor={editor} />
           ) : (


### PR DESCRIPTION
## 概要
コース閲覧で**全章の本文(markdown)を一覧 API で先読み**していて非効率でした（28 章なら 28 本文を一括ロード）。一覧は**メタデータのみ**にし、本文は**章を選択したときに `GET /teaching-materials/:id` で都度取得＋キャッシュ**する方式に変更します。初期ロードと転送量を削減します。

## 変更内容
### backend
- **[ListByCourse](backend/internal/adapter/persistence/teaching_material_repository.go)** の `SELECT` から `content` を除外（id / title / order_in_course / is_published / 日付 等のメタデータのみ）。本文は既存の `GET /teaching-materials/:id` で取得。

### frontend
- **[useTeachingMaterials](frontend/src/hooks/useTeachingMaterials.ts)**: 一覧(メタデータ) と `detailCache`(本文込み) に分離。`selectedId` 変更時に未取得なら `TeachingMaterialRepository.get` で本文を取得しキャッシュ。`detailLoading` を公開。`create`/`update`/`remove` はメタ一覧と本文キャッシュの両方を更新。検索は本文を持たないため**タイトルのみ**。
- **CourseDetailPage**: 章の本文取得中(`detailLoading`)はスピナー表示。
- テスト: 一覧取得だけでは本文 `get` を呼ばず、選択した章だけ取得し、再選択はキャッシュで `get` が増えないことを検証。

## 互換性 / デプロイ順
- frontend は一覧に content があってもなくても lazy 取得するため、どちらの順でも安全。本文取得は detail エンドポイント依存。

## テスト
- backend `build`/test green。frontend `tsc`/`eslint`/`vitest run --coverage`(1103) green・閾値クリア。