### PR TITLE
fix(courses): コース一覧カードの公開状態アイコン(緑チェック)を削除

### DIFF
--- a/frontend/src/pages/CoursesListPage.tsx
+++ b/frontend/src/pages/CoursesListPage.tsx
@@ -3,8 +3,6 @@ import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
   PlusIcon,
-  CheckCircleIcon,
-  ClockIcon,
   PencilSquareIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
@@ -173,11 +171,6 @@ function CourseCard({
     >
       <div className="flex items-start justify-between gap-2 mb-2">
         <div className="flex items-center gap-2 min-w-0">
-          {course.isPublished ? (
-            <CheckCircleIcon className="w-4 h-4 text-green-500 flex-shrink-0" />
-          ) : (
-            <ClockIcon className="w-4 h-4 text-amber-500 flex-shrink-0" />
-          )}
           <h2 className="text-base font-semibold text-[var(--color-text-primary)] truncate">
             {course.title || '無題のコース'}
           </h2>


### PR DESCRIPTION
## 概要
コース一覧の各カードのタイトル横にあった**緑チェック(公開中)/時計(下書き)アイコンを削除**します。冗長でノイズになっていたため。状態は既存の「公開中 / 下書き」テキストで表現します。

## 変更
- [CoursesListPage.tsx](frontend/src/pages/CoursesListPage.tsx) の CourseCard からアイコンの条件分岐を除去（未使用になった import も削除）。

見た目のみ（className/markup）。tsc / eslint / vitest / build green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **スタイル**
  * コースカードに表示される公開状態アイコンを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->