### PR TITLE
fix(courses): 教材リストの完了状態の丸アイコンを削除

### DIFF
--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -6,8 +6,6 @@ import {
   MagnifyingGlassIcon,
   Bars3Icon,
   TrashIcon,
-  CheckCircleIcon,
-  ClockIcon,
   ArrowLeftIcon,
   ArrowRightIcon,
   ListBulletIcon,
@@ -334,22 +332,9 @@ function MaterialListItem({
       }`}
     >
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-1.5">
-          {showCompletion ? (
-            completed ? (
-              <CheckCircleSolidIcon className="w-4 h-4 text-green-500 flex-shrink-0" />
-            ) : (
-              <span className="w-3.5 h-3.5 rounded-full border-2 border-[var(--color-text-muted)] flex-shrink-0" />
-            )
-          ) : material.isPublished ? (
-            <CheckCircleIcon className="w-3 h-3 text-green-400 flex-shrink-0" />
-          ) : (
-            <ClockIcon className="w-3 h-3 text-amber-400 flex-shrink-0" />
-          )}
-          <p className="text-sm text-[var(--color-text-primary)] truncate font-medium">
-            {material.title || '無題の教材'}
-          </p>
-        </div>
+        <p className="text-sm text-[var(--color-text-primary)] truncate font-medium">
+          {material.title || '無題の教材'}
+        </p>
         <p className="text-xs text-[var(--color-text-muted)] mt-0.5 truncate">
           {showCompletion
             ? completed


### PR DESCRIPTION
## 概要
コース詳細の左サイドバー（教材リスト）の各項目タイトル横にあった **○(未完了) / ✓(完了済み) / 公開状態アイコンを削除**します。冗長だったため。状態は下の「完了済み / 未完了」「公開中 / 下書き」テキストで分かります。

## 変更
- [CourseDetailPage.tsx](frontend/src/pages/CourseDetailPage.tsx) の MaterialListItem からアイコンを除去（未使用 import も削除）。

見た目のみ（markup/className）。tsc / eslint / vitest(1103) / build green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * 教材リストの表示を簡潔化しました。アイコンの表示を削除し、タイトル表示をシンプルにしています。ステータス情報（完了済み/未完了/公開中/下書き）と最終更新日時は引き続き表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->