### PR TITLE
fix(markdown): コードと教材内画像をほんの少し小さくする

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,8 +33,8 @@
   color: #383a42;
   border: 1px solid var(--color-surface-3);
   /* prose-sm は pre(0.857em) × code(0.857em) の複合縮小で本文より小さくなりすぎるため、
-   * 読みやすいサイズ(本文相当)に固定する。 */
-  font-size: 0.875rem;
+   * 読みやすいサイズに固定する（本文よりほんの少し小さめ）。 */
+  font-size: 0.8125rem;
   line-height: 1.6;
 }
 .prose pre code {
@@ -52,7 +52,8 @@
   font-size: 0.9375rem;
 }
 .prose.course-prose pre {
-  font-size: 0.9375rem;
+  /* コース本文(15px)よりほんの少し小さめのコードサイズ。 */
+  font-size: 0.875rem;
 }
 /*
  * @tailwindcss/typography は inline code (`<code>`) の前後に ::before / ::after で

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -589,7 +589,7 @@ function ReadOnlyMarkdown({ content }: { content: string }) {
                   src={url}
                   alt={alt ?? ''}
                   loading="lazy"
-                  className="mx-auto max-w-full h-auto rounded-lg border border-surface-3 bg-white"
+                  className="mx-auto max-w-[90%] h-auto rounded-lg border border-surface-3 bg-white"
                 />
               </a>
               {alt && (


### PR DESCRIPTION
## 概要
要望により、コードスニペットの文字と教材内の画像を**ほんの少しだけ**小さくします。

## 変更
- **コード**: `.prose pre` 14px→13px、コース本文の `.prose.course-prose pre` 15px→14px（本文より少し小さめ）。
- **画像**: 教材本文の `img` を `max-w-full` → `max-w-[90%]`（約9割幅・中央寄せ）。

見た目のみ（CSS/className）。tsc / eslint / vitest(1103) / build green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * コードブロック内のテキスト表示サイズを調整しました。
  * コース内容に表示される画像の幅を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->