### PR TITLE
feat(courses): 章本文の取得中ローディングを改善（ちらつき防止 + スケルトン）

### DIFF
--- a/docs/course-chapter-loading.md
+++ b/docs/course-chapter-loading.md
@@ -1,0 +1,35 @@
+# コース教材（章）の遅延ロードとローディング表示
+
+`/courses/:id`（[CourseDetailPage](../frontend/src/pages/CourseDetailPage.tsx)）での章本文の取得と、
+取得中の UX について。
+
+## 遅延ロード方針
+
+教材一覧（左パネル）は本文 `content` を含まない軽量メタデータで取得し、
+**選択された章の本文だけ** を都度 `GET /teaching-materials/:id` で取得してキャッシュする
+（全章を先読みしない）。状態管理は [useTeachingMaterials](../frontend/src/hooks/useTeachingMaterials.ts)。
+
+- `materials` … 本文なしのメタデータ一覧（`stripContent` で `content` を空に）
+- `detailCache` … 取得済みの本文込み教材（`{ [id]: TeachingMaterial }`）
+- `selected` … `detailCache[selectedId] ?? null`（未取得なら `null` = 取得中）
+
+## 取得中のローディング表示
+
+章を選んでから本文取得が終わるまで、ローディングを表示してちらつきを防ぐ。
+
+判定は `detailLoading`（fetch フラグ）ではなく **`selectedId != null && !selected && !error`** で行う。
+理由: `detailLoading` を立てる effect は描画後に走るため、それを待つと選択直後の 1 フレームだけ
+「教材を選択してください」の空状態がちらついてしまう。「章を選んだのに本文が無い = 取得中」と
+みなして即座にローディングへ切り替える。
+
+- 学習者（trainee）には記事レイアウトを模した **スケルトン**（`MaterialSkeleton`）を表示し、
+  レイアウトの跳ねを抑えて体感速度を上げる
+- 編集者（company_admin / super_admin）にはエディタへ遷移するためスピナー（`Loading`）を表示
+
+## エラー時の挙動
+
+`selectMaterial` は選択時に前章で出た取得エラーを先にクリアする。これをしないと別章へ
+切り替えても古い `error` が残り、ローディングに戻せない。取得失敗時は `error` がセットされ、
+本文領域はローディングを抜けて上部のエラーバナーで通知する。
+
+関連テスト: [useTeachingMaterials.test.ts](../frontend/src/hooks/__tests__/useTeachingMaterials.test.ts)

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -8,7 +8,7 @@ interface EmptyStateProps {
 export default function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center h-full text-center px-6">
-      <div className="bg-surface-3 rounded-full p-4 mb-4">
+      <div className="bg-surface-2 rounded-full p-4 mb-4">
         <Icon className="w-8 h-8 text-[var(--color-text-faint)]" />
       </div>
       <h3 className="text-base font-semibold text-[var(--color-text-secondary)] mb-1">{title}</h3>

--- a/frontend/src/components/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/__tests__/EmptyState.test.tsx
@@ -83,9 +83,9 @@ describe('EmptyState', () => {
     expect(screen.getByText('操作')).toBeDefined();
   });
 
-  it('アイコンがbg-surface-3の丸い背景内に表示される', () => {
+  it('アイコンがページ背景と同色(bg-surface-2)の丸い背景内に表示される', () => {
     const { container } = render(<EmptyState icon={ChatBubbleLeftRightIcon} title="テスト" />);
-    const iconWrapper = container.querySelector('.bg-surface-3.rounded-full');
+    const iconWrapper = container.querySelector('.bg-surface-2.rounded-full');
     expect(iconWrapper).toBeTruthy();
     expect(iconWrapper?.querySelector('svg')).toBeTruthy();
   });

--- a/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
@@ -100,6 +100,23 @@ describe('useTeachingMaterials', () => {
     expect(materialMocks.get).toHaveBeenCalledTimes(2); // 1 と 2 の計2回（1 の再取得は無し）
   });
 
+  it('別の章を選択すると前章の取得エラーはクリアされる（取得中ローディングに戻せる）', async () => {
+    courseMocks.listMaterials.mockResolvedValue([sample(1), sample(2)]);
+    materialMocks.get
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ ...sample(2), content: '# 本文2' });
+    const { result } = renderHook(() => useTeachingMaterials(5));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.selectMaterial(1));
+    await waitFor(() => expect(result.current.error).toBe('教材の取得に失敗しました'));
+
+    // 別章へ切り替えた瞬間に error はクリアされ、新章の本文取得が走る。
+    act(() => result.current.selectMaterial(2));
+    expect(result.current.error).toBeNull();
+    await waitFor(() => expect(result.current.selected?.content).toBe('# 本文2'));
+  });
+
   it('create 成功時にリストに追加され selected になる', async () => {
     courseMocks.listMaterials.mockResolvedValue([]);
     materialMocks.create.mockResolvedValue(sample(99, { orderInCourse: 100 }));

--- a/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
@@ -117,6 +117,24 @@ describe('useTeachingMaterials', () => {
     await waitFor(() => expect(result.current.selected?.content).toBe('# 本文2'));
   });
 
+  it('取得失敗後に同じ章を選び直すと再取得が走る（ローディングで固まらない）', async () => {
+    courseMocks.listMaterials.mockResolvedValue([sample(1)]);
+    materialMocks.get
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ ...sample(1), content: '# 本文1' });
+    const { result } = renderHook(() => useTeachingMaterials(5));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.selectMaterial(1));
+    await waitFor(() => expect(result.current.error).toBe('教材の取得に失敗しました'));
+
+    // 同じ章を選び直す → selectedId は不変だが selectionSeq が進むので effect が再実行される。
+    act(() => result.current.selectMaterial(1));
+    expect(result.current.error).toBeNull();
+    await waitFor(() => expect(result.current.selected?.content).toBe('# 本文1'));
+    expect(materialMocks.get).toHaveBeenCalledTimes(2);
+  });
+
   it('create 成功時にリストに追加され selected になる', async () => {
     courseMocks.listMaterials.mockResolvedValue([]);
     materialMocks.create.mockResolvedValue(sample(99, { orderInCourse: 100 }));

--- a/frontend/src/hooks/useTeachingMaterials.ts
+++ b/frontend/src/hooks/useTeachingMaterials.ts
@@ -73,6 +73,13 @@ export function useTeachingMaterials(courseId: number | null) {
   // selected は本文込みのキャッシュから返す（未取得なら null = 取得中）。
   const selected = selectedId != null ? (detailCache[selectedId] ?? null) : null;
 
+  // 章を選ぶときは前章で出た取得エラーを先にクリアする。 こうしないと別章へ切り替えても
+  // 古い error が残り、「取得中ローディング」ではなくエラー扱いのまま表示されてしまう。
+  const selectMaterial = useCallback((id: number | null) => {
+    setError(null);
+    setSelectedId(id);
+  }, []);
+
   const filtered = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
     if (!q) return materials;
@@ -138,7 +145,7 @@ export function useTeachingMaterials(courseId: number | null) {
     error,
     searchQuery,
     setSearchQuery,
-    selectMaterial: setSelectedId,
+    selectMaterial,
     fetchAll,
     create,
     update,

--- a/frontend/src/hooks/useTeachingMaterials.ts
+++ b/frontend/src/hooks/useTeachingMaterials.ts
@@ -17,6 +17,8 @@ export function useTeachingMaterials(courseId: number | null) {
   const [materials, setMaterials] = useState<TeachingMaterial[]>([]);
   const [detailCache, setDetailCache] = useState<Record<number, TeachingMaterial>>({});
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  // 同一章を選び直したときも本文取得 effect を再実行させるためのトリガ（取得失敗からの再試行用）。
+  const [selectionSeq, setSelectionSeq] = useState(0);
   const [loading, setLoading] = useState(true);
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +70,9 @@ export function useTeachingMaterials(courseId: number | null) {
     return () => {
       active = false;
     };
-  }, [selectedId, detailCache]);
+    // selectionSeq を依存に入れることで、 同じ章を選び直したとき（取得失敗後の再試行）も
+    // この effect が再実行され、 ローディングのまま固まらないようにする。
+  }, [selectedId, detailCache, selectionSeq]);
 
   // selected は本文込みのキャッシュから返す（未取得なら null = 取得中）。
   const selected = selectedId != null ? (detailCache[selectedId] ?? null) : null;
@@ -78,6 +82,7 @@ export function useTeachingMaterials(courseId: number | null) {
   const selectMaterial = useCallback((id: number | null) => {
     setError(null);
     setSelectedId(id);
+    setSelectionSeq((v) => v + 1);
   }, []);
 
   const filtered = useMemo(() => {

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -60,7 +60,6 @@ export default function CourseDetailPage() {
     selectedId,
     selected,
     loading,
-    detailLoading,
     error,
     searchQuery,
     setSearchQuery,
@@ -259,9 +258,12 @@ export default function CourseDetailPage() {
 
         {error && <p className="px-6 py-3 text-sm text-red-500">{error}</p>}
 
-        {detailLoading && !selected ? (
-          // 章を選択したら本文を都度取得する。取得中はスピナーを出す。
-          <Loading className="h-full" />
+        {selectedId != null && !selected && !error ? (
+          // 章を選択した瞬間から本文取得が終わるまでローディングを出す。
+          // detailLoading は effect 後に立つため、それを待つと一瞬「未選択」表示が
+          // ちらつく。 selectedId があるのに本文が無い = 取得中、として即座に出す。
+          // 読み手にはレイアウトを保つスケルトン、編集者にはスピナーを表示する。
+          canManage ? <Loading className="h-full" /> : <MaterialSkeleton />
         ) : selected ? (
           canManage ? (
             <ManagedDetail editor={editor} />
@@ -482,6 +484,37 @@ function ReadOnlyDetail({
           </aside>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * MaterialSkeleton は章本文の取得中に出す骨組み。
+ *
+ * バーのスピナーではなく記事レイアウト（タイトル / メタ / 本文行 / 図ブロック）を
+ * 模した pulse プレースホルダにすることで、 章切り替え時のちらつきを抑え体感速度を上げる。
+ */
+function MaterialSkeleton() {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto w-full max-w-[800px] px-6 py-6 animate-pulse" aria-hidden="true">
+        <div className="h-7 w-2/3 rounded bg-surface-3" />
+        <div className="mt-3 h-3 w-32 rounded bg-surface-2" />
+        <div className="mt-8 space-y-3">
+          <div className="h-4 w-full rounded bg-surface-2" />
+          <div className="h-4 w-11/12 rounded bg-surface-2" />
+          <div className="h-4 w-4/5 rounded bg-surface-2" />
+        </div>
+        <div className="mt-6 h-40 w-full rounded-lg bg-surface-2" />
+        <div className="mt-6 space-y-3">
+          <div className="h-4 w-full rounded bg-surface-2" />
+          <div className="h-4 w-10/12 rounded bg-surface-2" />
+          <div className="h-4 w-3/4 rounded bg-surface-2" />
+        </div>
+      </div>
+      <span className="sr-only" role="status">
+        読み込み中
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

`/courses/:id` で章を選択してから本文取得（`GET /teaching-materials/:id`）が終わるまでの
ローディング表示を改善し、章切り替え時の UX を高めます。

これまでは取得中の判定を `detailLoading`（fetch フラグ）で行っていましたが、このフラグを
立てる effect は描画後に走るため、章を選んだ直後の 1 フレームだけ「教材を選択してください」の
空状態がちらついていました。

## 変更内容

- ローディング判定を `selectedId != null && !selected && !error`（「章を選んだのに本文が無い = 取得中」）に変更し、選択直後のちらつきを解消
- 学習者（trainee）には記事レイアウトを模した **スケルトン**（`MaterialSkeleton`）を表示し、レイアウトの跳ねを抑えて体感速度を向上
- 編集者（company_admin / super_admin）にはスピナー（`Loading`）を表示
- `selectMaterial` が選択時に前章の取得 `error` を先にクリアするよう修正（別章へ切り替え時にローディングへ戻せる）
- 上記挙動の単体テストを追加
- `docs/course-chapter-loading.md` に遅延ロード / ローディング設計を記録

## テスト

- `npx tsc --noEmit` ✅
- `npx vitest run src/hooks/__tests__/useTeachingMaterials.test.ts` ✅（8 passed）
- `eslint --max-warnings 0`（変更ファイル）✅
- `npm run build` ✅

## 関連 Issue

なし（UX 改善の単発対応）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 教材選択時の遅延ロード表示を改善。学習者向けにスケルトンローダーを表示してちらつきを軽減

* **バグ修正**
  * 別の章に切り替え時に前の章の取得エラーが表示される問題を解決

* **ドキュメント**
  * 教材章遅延ロード時のUX制御方針を文書化

* **テスト**
  * 章切替時のエラークリア動作に関するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->