### PR TITLE
fix(exercise): コード実行ショートカット(Ctrl/Cmd+Enter)を確実に発火させる

### DIFF
--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -2,6 +2,10 @@
 
 学習者が演習エディタ（Monaco）でコードを書いて実行・採点する機構の設計メモ。
 
+## エディタの実行ショートカット
+
+[CodeEditor.tsx](../frontend/src/components/CodeEditor.tsx) は **Ctrl+Enter / Cmd+Enter** でコード実行（`onRun` = `runCode`）をトリガーする。キーバインドは `editor.addCommand` ではなく **`editor.addAction`** で登録する（ESM バンドルの monaco では `addCommand` のキーバインドが発火しないことがあるため）。`addAction` なら右クリックメニュー / コマンドパレットにも載り発火も安定する。`onRun` は最新の `runCode` を ref 経由で参照するためエディタ再生成は不要。
+
 ## アーキテクチャ
 
 ```text

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -89,8 +89,17 @@ export default function CodeEditor({
     editorRef.current = editor;
 
     // Ctrl+Enter / Cmd+Enter でコードを実行する（CtrlCmd は Win/Linux=Ctrl, Mac=Cmd）。
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-      onRunRef.current?.();
+    // addCommand は ESM バンドルの monaco だとキーバインドが発火しないことがあるため、
+    // 公式に推奨される addAction を使う（キーバインド + 右クリックメニュー + コマンドパレットに登録）。
+    editor.addAction({
+      id: 'frestyle.runCode',
+      label: 'コードを実行 (Ctrl/Cmd + Enter)',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+      contextMenuGroupId: 'navigation',
+      contextMenuOrder: 1,
+      run: () => {
+        onRunRef.current?.();
+      },
     });
 
     const sub = editor.onDidChangeModelContent(() => {

--- a/frontend/src/components/__tests__/CodeEditor.test.tsx
+++ b/frontend/src/components/__tests__/CodeEditor.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+// monaco は jsdom で動かないため最小モックに差し替える。
+// 目的は「Ctrl/Cmd+Enter のアクションが onRun を呼ぶ」配線の検証。
+const editorMock = {
+  addAction: vi.fn(),
+  addCommand: vi.fn(),
+  onDidChangeModelContent: vi.fn(() => ({ dispose: vi.fn() })),
+  onDidContentSizeChange: vi.fn(() => ({ dispose: vi.fn() })),
+  getContentHeight: vi.fn(() => 200),
+  getValue: vi.fn(() => ''),
+  setValue: vi.fn(),
+  getModel: vi.fn(() => ({ isDisposed: () => false })),
+  layout: vi.fn(),
+  updateOptions: vi.fn(),
+  dispose: vi.fn(),
+};
+
+vi.mock('monaco-editor/esm/vs/editor/editor.worker?worker', () => ({
+  default: class {},
+}));
+
+vi.mock('monaco-editor', () => ({
+  editor: {
+    create: vi.fn(() => editorMock),
+    setModelLanguage: vi.fn(),
+  },
+  KeyMod: { CtrlCmd: 2048 },
+  KeyCode: { Enter: 3 },
+}));
+
+import CodeEditor from '../CodeEditor';
+
+describe('CodeEditor の実行ショートカット', () => {
+  beforeEach(() => {
+    editorMock.addAction.mockClear();
+  });
+
+  it('Ctrl/Cmd+Enter のアクションが登録され、run が onRun を呼ぶ', () => {
+    const onRun = vi.fn();
+    render(<CodeEditor value="x" onChange={() => {}} onRun={onRun} />);
+
+    // addAction が Cmd/Ctrl+Enter のキーバインドで登録されている。
+    expect(editorMock.addAction).toHaveBeenCalledTimes(1);
+    const action = editorMock.addAction.mock.calls[0][0];
+    expect(action.keybindings).toEqual([2048 | 3]); // CtrlCmd | Enter
+
+    // 登録された run を呼ぶと onRun が発火する（= ショートカットでコード実行できる）。
+    action.run();
+    expect(onRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('onRun 未指定でも run 実行で例外を投げない', () => {
+    render(<CodeEditor value="x" onChange={() => {}} />);
+    const action = editorMock.addAction.mock.calls[0][0];
+    expect(() => action.run()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

演習エディタ（[ExerciseDetailPage](frontend/src/pages/ExerciseDetailPage.tsx) / Monaco）で **Ctrl+Enter / Cmd+Enter のコード実行ショートカットが反応しない** 問題を修正します。「コード実行」ボタン自体は動くため、原因はキーバインドの登録方法でした。

## 原因

[CodeEditor.tsx](frontend/src/components/CodeEditor.tsx) は `editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, ...)` でショートカットを登録していましたが、**ESM バンドルの monaco では `addCommand` のキーバインドが発火しないことがある** ため、押しても `onRun`（= `runCode`）が呼ばれていませんでした。

## 変更内容

- キーバインド登録を公式推奨の **`editor.addAction`** に変更（キーバインド + 右クリックメニュー + コマンドパレットにも登録され、発火が安定）
- `onRun` は ref 経由で最新の `runCode` を参照（エディタ再生成は不要）
- `monaco-editor` をモックし、「登録アクションの `run` が `onRun` を呼ぶ」配線を単体テスト（Monaco は jsdom で動かないため配線のみ検証）
- `docs/code-exercises.md` にショートカットの実装方針を追記

## テスト

- `npx tsc --noEmit` ✅
- `npx vitest run src/components/__tests__/CodeEditor.test.tsx` ✅（2 passed）
- `eslint --max-warnings 0`（CodeEditor）✅
- `npm run build` ✅

## 関連 Issue

なし（不具合修正）