### PR TITLE
feat(ui): フォーカスリング色を brand に統一・角丸ルール定義

### DIFF
--- a/frontend/src/components/AiSessionListItem.tsx
+++ b/frontend/src/components/AiSessionListItem.tsx
@@ -58,7 +58,7 @@ export default memo(function AiSessionListItem({
                 }
                 if (e.key === 'Escape') onCancelEdit();
               }}
-              className="flex-1 text-xs px-2 py-1 border border-[var(--color-border-hover)] rounded focus:outline-none focus:ring-1 focus:ring-primary-400"
+              className="flex-1 text-xs px-2 py-1 border border-[var(--color-border-hover)] rounded focus:outline-none focus:ring-1 focus:ring-brand-400"
               autoFocus
             />
             <button onClick={() => onSaveTitle(id)} disabled={!editingTitle.trim()} className="p-0.5 hover:bg-green-900/30 rounded disabled:opacity-30 disabled:cursor-not-allowed" aria-label="保存">

--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -206,10 +206,10 @@ export default function NoteMarkdownEditor({
             onDragOver={onImageUpload ? (e) => e.preventDefault() : undefined}
             placeholder="# 見出し&#10;&#10;Markdown でノートを書きましょう..."
             spellCheck={false}
-            className="w-full h-full resize-none p-4 rounded-md bg-surface-1 border border-surface-3 text-sm font-mono text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500/50 transition-colors"
+            className="w-full h-full resize-none p-4 rounded-lg bg-surface-1 border border-surface-3 text-sm font-mono text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-brand-400/50 transition-colors"
           />
         ) : (
-          <div className="w-full h-full overflow-y-auto p-4 rounded-md bg-surface-1 border border-surface-3 prose prose-sm max-w-none">
+          <div className="w-full h-full overflow-y-auto p-4 rounded-lg bg-surface-1 border border-surface-3 prose prose-sm max-w-none">
             {content.trim() ? (
               <MarkdownView content={content} />
             ) : (

--- a/frontend/src/components/__tests__/SkipLink.test.tsx
+++ b/frontend/src/components/__tests__/SkipLink.test.tsx
@@ -64,10 +64,10 @@ describe('SkipLink', () => {
     expect(() => fireEvent.click(link)).not.toThrow();
   });
 
-  it('フォーカス時にprimary-500背景クラスが適用される', () => {
+  it('フォーカス時にbrand-500背景クラスが適用される', () => {
     render(<SkipLink targetId="main-content" />);
     const link = screen.getByText('メインコンテンツへスキップ');
-    expect(link.className).toContain('focus:bg-primary-500');
+    expect(link.className).toContain('focus:bg-brand-500');
   });
 
   it('異なるtargetIdでhrefが正しく設定される', () => {

--- a/frontend/src/components/ui/ActionCard.tsx
+++ b/frontend/src/components/ui/ActionCard.tsx
@@ -44,7 +44,7 @@ export default function ActionCard({
 }: ActionCardProps) {
   const isPrimary = emphasis === 'primary';
 
-  const containerClasses = `group relative flex w-full items-start gap-4 rounded-xl border p-4 text-left transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] ${
+  const containerClasses = `group relative flex w-full items-start gap-4 rounded-xl border p-4 text-left transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-[var(--color-surface)] ${
     isPrimary
       ? 'border-primary-400/40 bg-gradient-to-br from-primary-500/15 to-surface-1 hover:from-primary-500/25 hover:-translate-y-0.5 hover:shadow-lg'
       : 'border-surface-3 bg-surface-1 hover:border-primary-400/40 hover:-translate-y-0.5 hover:shadow-md'

--- a/frontend/src/components/ui/FirstTimeWelcome.tsx
+++ b/frontend/src/components/ui/FirstTimeWelcome.tsx
@@ -63,7 +63,7 @@ export default function FirstTimeWelcome({
         type="button"
         onClick={handleDismiss}
         aria-label="このカードを閉じる"
-        className="absolute right-3 top-3 rounded-full p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-surface-3 focus:outline-none focus:ring-2 focus:ring-primary-400"
+        className="absolute right-3 top-3 rounded-full p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-surface-3 focus:outline-none focus:ring-2 focus:ring-brand-400"
       >
         <XMarkIcon className="h-4 w-4" aria-hidden="true" />
       </button>
@@ -107,7 +107,7 @@ export default function FirstTimeWelcome({
         <button
           type="button"
           onClick={onPrimaryAction}
-          className="mt-5 inline-flex items-center justify-center rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-600 active:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-2 focus:ring-offset-[var(--color-surface-1)]"
+          className="mt-5 inline-flex items-center justify-center rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-600 active:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-2 focus:ring-offset-[var(--color-surface-1)]"
         >
           {primaryActionLabel}
         </button>

--- a/frontend/src/components/ui/GuidedHint.tsx
+++ b/frontend/src/components/ui/GuidedHint.tsx
@@ -81,7 +81,7 @@ export default function GuidedHint({
           type="button"
           onClick={handleDismiss}
           aria-label="ヒントを閉じる"
-          className="shrink-0 rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-surface-3 transition-colors focus:outline-none focus:ring-2 focus:ring-primary-400"
+          className="shrink-0 rounded p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-surface-3 transition-colors focus:outline-none focus:ring-2 focus:ring-brand-400"
         >
           <XMarkIcon className="h-4 w-4" aria-hidden="true" />
         </button>

--- a/frontend/src/components/ui/HelpTooltip.tsx
+++ b/frontend/src/components/ui/HelpTooltip.tsx
@@ -86,7 +86,7 @@ export default function HelpTooltip({
         onBlur={(e) => {
           if (!wrapperRef.current?.contains(e.relatedTarget as Node)) setOpen(false);
         }}
-        className="inline-flex items-center justify-center rounded-full text-[var(--color-text-tertiary)] hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-400 focus:ring-offset-1 focus:ring-offset-[var(--color-surface-1)] transition-colors"
+        className="inline-flex items-center justify-center rounded-full text-[var(--color-text-tertiary)] hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-brand-400 focus:ring-offset-1 focus:ring-offset-[var(--color-surface-1)] transition-colors"
       >
         <QuestionMarkCircleIcon className="w-4 h-4" aria-hidden="true" />
       </button>

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -188,7 +188,7 @@ export default function AskAiPage() {
                 aria-label="セッションを検索"
                 value={sessionSearchQuery}
                 onChange={(e) => setSessionSearchQuery(e.target.value)}
-                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-brand-400 transition-colors"
               />
             </div>
             <button

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -191,7 +191,7 @@ export default function CourseDetailPage() {
                 aria-label="教材を検索"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-brand-400 transition-colors"
               />
             </div>
             {canManage && (

--- a/frontend/src/pages/CoursesListPage.tsx
+++ b/frontend/src/pages/CoursesListPage.tsx
@@ -70,7 +70,7 @@ export default function CoursesListPage() {
           aria-label="コースを検索"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+          className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-brand-400 transition-colors"
         />
       </div>
 
@@ -259,7 +259,7 @@ function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
               maxLength={200}
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded text-sm focus:outline-none focus:border-primary-500"
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
             />
           </label>
           <label className="block">
@@ -269,7 +269,7 @@ function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="このコースで学べる内容の概要"
-              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded text-sm focus:outline-none focus:border-primary-500 resize-y"
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400 resize-y"
             />
           </label>
           <label className="block">
@@ -278,7 +278,7 @@ function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
               type="number"
               value={sortOrder}
               onChange={(e) => setSortOrder(Number(e.target.value) || 0)}
-              className="w-32 px-3 py-1.5 bg-surface-2 border border-surface-3 rounded text-sm focus:outline-none focus:border-primary-500"
+              className="w-32 px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
             />
             <span className="block text-xs text-[var(--color-text-muted)] mt-1">
               小さい値が上に来ます。 既定: 100

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -35,7 +35,7 @@ export default function ExerciseListPage() {
         <select
           value={language}
           onChange={(e) => setLanguage(e.target.value)}
-          className="px-2 py-1 rounded-md bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] focus:outline-none focus:border-primary-500"
+          className="px-2 py-1 rounded-lg bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] focus:outline-none focus:border-brand-400"
         >
           <option value="">すべて</option>
           <option value="php">PHP</option>

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -87,7 +87,7 @@ export default function NotesPage() {
                 aria-label="ノートを検索"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-primary-500 transition-colors"
+                className="w-full pl-8 pr-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-brand-400 transition-colors"
               />
             </div>
             <NoteSortMenu selected={noteSort} onChange={setNoteSort} />

--- a/frontend/src/utils/__tests__/fieldStyles.test.ts
+++ b/frontend/src/utils/__tests__/fieldStyles.test.ts
@@ -8,9 +8,9 @@ describe('getFieldBorderClass', () => {
     expect(result).toContain('focus:border-rose-500');
   });
 
-  it('エラーなしの場合はprimary系のクラスを返す', () => {
+  it('エラーなしの場合はbrand系のクラスを返す', () => {
     const result = getFieldBorderClass(false);
     expect(result).toContain('border-surface-3');
-    expect(result).toContain('focus:border-primary-500');
+    expect(result).toContain('focus:border-brand-400');
   });
 });

--- a/frontend/src/utils/fieldStyles.ts
+++ b/frontend/src/utils/fieldStyles.ts
@@ -1,5 +1,5 @@
 export function getFieldBorderClass(hasError: boolean): string {
   return hasError
     ? 'border-rose-500 focus:border-rose-500 focus:ring-rose-500'
-    : 'border-surface-3 focus:border-primary-500 focus:ring-primary-500';
+    : 'border-surface-3 focus:border-brand-400 focus:ring-brand-400';
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -18,8 +18,10 @@ export default {
           800: '#242220',
           900: '#181716',
         },
-        // FreStyle ブランドカラー（ロゴの青 #2E7DF6）。アクション系ボタンの色をこれに統一する。
-        // primary(taupe) はチャート / プログレス等の非ボタンアクセントに引き続き使う。
+        // FreStyle ブランドカラー（ロゴの青 #2E7DF6）。
+        // 使い分けルール:
+        //   brand-* → CTA ボタン / フォーカスリング / インタラクティブ要素
+        //   primary-* (taupe) → ステップインジケーター / プログレスバー / アバター背景などの非ボタンアクセント
         brand: {
           50: '#EFF5FF',
           100: '#DBE8FE',
@@ -37,6 +39,11 @@ export default {
         'surface-2': 'var(--color-surface-2)',
         'surface-3': 'var(--color-surface-3)',
       },
+      // 角丸ルール:
+      //   rounded-xl  → カード / パネル / モーダル / フローティングメニュー
+      //   rounded-lg  → ボタン / インプット / セレクト / タグ / バッジ
+      //   rounded-full → アバター / 円形アイコンボタン / ドット / ピル
+      //   rounded-md  → 小さいインライン要素（コードブロック枠 / ミニアイコンボタン等）
       borderRadius: {
         xl: '1rem',
         '2xl': '1.5rem',


### PR DESCRIPTION
## 概要

前回の Button プリミティブ PR(#2001) に続く UI 設計改善の第2弾。  
`primary`(タウプ/グレー) に混入していたフォーカスリング色を `brand`(青) に揃え、  
角丸の使い分けルールをコードとして明文化する。

## 変更内容

### フォーカスリング色の統一（15箇所）

`focus:ring-primary-*` / `focus:border-primary-*` が残存していた 11 ファイルを修正。

| ファイル | 変更 |
|---|---|
| `utils/fieldStyles.ts` | `primary-500` → `brand-400` |
| `components/AiSessionListItem.tsx` | `primary-400` → `brand-400` |
| `components/NoteMarkdownEditor.tsx` | `primary-500/50` → `brand-400/50` |
| `components/ui/FirstTimeWelcome.tsx` | 2箇所 `primary-400` → `brand-400` |
| `components/ui/ActionCard.tsx` | `primary-400` → `brand-400` |
| `components/ui/GuidedHint.tsx` | `primary-400` → `brand-400` |
| `components/ui/HelpTooltip.tsx` | `primary-400` → `brand-400` |
| `pages/CoursesListPage.tsx` | 4箇所 `primary-500` → `brand-400` |
| `pages/CourseDetailPage.tsx` | `primary-500` → `brand-400` |
| `pages/ExerciseListPage.tsx` | `primary-500` → `brand-400` |
| `pages/NotesPage.tsx` | `primary-500` → `brand-400` |
| `pages/AskAiPage.tsx` | `primary-500` → `brand-400` |

### 角丸ルール定義

`tailwind.config.js` に 4 段階のルールをコメントで明記:
- `rounded-xl` — カード/パネル/モーダル/フローティングメニュー  
- `rounded-lg` — ボタン/インプット/セレクト/タグ  
- `rounded-full` — アバター/円形アイコンボタン/ドット  
- `rounded-md` — 小さいインライン要素（コードブロック枠等）

あわせて `NoteMarkdownEditor` textarea と `ExerciseListPage` select の `rounded-md` / `rounded`(裸) を `rounded-lg` に修正。

### brand / primary 使い分けコメント化

`tailwind.config.js` に用途ルールを追記:
- `brand-*` → CTA ボタン / フォーカスリング / インタラクティブ要素
- `primary-*`(taupe) → ステップインジケーター / プログレスバー / アバター背景

## テスト

- `npx vitest run` — 1128/1128 グリーン
- `tsc --noEmit` — 型エラーなし
- テスト名を実装に合わせて更新（`SkipLink.test.tsx` / `fieldStyles.test.ts`）

## 関連 Issue

UI 設計レビューより（#2001 の続き）