### PR TITLE
feat(ui): インタラクティブ要素のリンク・ボタンテキスト色を brand に統一

### DIFF
--- a/frontend/src/components/LinkText.tsx
+++ b/frontend/src/components/LinkText.tsx
@@ -10,7 +10,7 @@ export default function LinkText({ to, children }: LinkTextProps) {
   return (
     <Link
       to={to}
-      className="text-sm text-primary-500 hover:text-primary-400 font-medium transition-colors duration-150 hover:underline"
+      className="text-sm text-brand-500 hover:text-brand-600 font-medium transition-colors duration-150 hover:underline"
     >
       {children}
     </Link>

--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -337,7 +337,7 @@ function MarkdownView({ content }: { content: string }) {
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-400 underline-offset-2 hover:underline"
+            className="text-brand-400 underline-offset-2 hover:underline"
           >
             {children as ReactNode}
           </a>

--- a/frontend/src/components/__tests__/LinkText.test.tsx
+++ b/frontend/src/components/__tests__/LinkText.test.tsx
@@ -42,7 +42,7 @@ describe('LinkText', () => {
     );
 
     const link = screen.getByText('テスト').closest('a');
-    expect(link?.className).toContain('text-primary-500');
+    expect(link?.className).toContain('text-brand-500');
     expect(link?.className).toContain('font-medium');
   });
 

--- a/frontend/src/components/message/MarkdownView.tsx
+++ b/frontend/src/components/message/MarkdownView.tsx
@@ -20,7 +20,7 @@ export default function MarkdownView({ content }: { content: string }) {
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-400 underline-offset-2 hover:underline"
+            className="text-brand-400 underline-offset-2 hover:underline"
           >
             {children as ReactNode}
           </a>

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -606,7 +606,7 @@ function ReadOnlyMarkdown({ content }: { content: string }) {
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-400 underline-offset-2 hover:underline"
+            className="text-brand-400 underline-offset-2 hover:underline"
           >
             {children as ReactNode}
           </a>

--- a/frontend/src/pages/LearningReportPage.tsx
+++ b/frontend/src/pages/LearningReportPage.tsx
@@ -32,7 +32,7 @@ export default function LearningReportPage() {
         <button
           onClick={handleGenerate}
           disabled={generating}
-          className="text-xs text-primary-500 hover:text-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="text-xs text-brand-500 hover:text-brand-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {generating ? '生成中...' : '今月のレポートを生成'}
         </button>

--- a/frontend/src/pages/MarkdownSyntaxHelpPage.tsx
+++ b/frontend/src/pages/MarkdownSyntaxHelpPage.tsx
@@ -92,7 +92,7 @@ export default function MarkdownSyntaxHelpPage() {
               href="https://normanblog.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary-400 underline-offset-2 hover:underline"
+              className="text-brand-400 underline-offset-2 hover:underline"
             >
               FreStyle
             </a>
@@ -167,7 +167,7 @@ export default function MarkdownSyntaxHelpPage() {
               href="https://normanblog.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary-400 underline-offset-2 hover:underline"
+              className="text-brand-400 underline-offset-2 hover:underline"
             >
               https://normanblog.com
             </a>
@@ -182,7 +182,7 @@ export default function MarkdownSyntaxHelpPage() {
           href="https://github.github.com/gfm/"
           target="_blank"
           rel="noopener noreferrer"
-          className="text-primary-400 underline-offset-2 hover:underline"
+          className="text-brand-400 underline-offset-2 hover:underline"
         >
           GitHub Flavored Markdown 仕様
         </a>{' '}


### PR DESCRIPTION
## 概要

UI 設計改善シリーズ第3弾。 `text-primary-*`(タウプ/グレー) がクリック可能な
リンクやボタンに使われていた箇所を `text-brand-*`(青) に統一する。

Web の慣習として「青 = クリック可能」であり、グレーのリンクはクリックできると
気付かれにくい問題がある。

## 変更内容

| ファイル | 変更 |
|---|---|
| `components/LinkText.tsx` | `text-primary-500 hover:text-primary-400` → `text-brand-500 hover:text-brand-600` |
| `components/message/MarkdownView.tsx` | リンクの `text-primary-400 underline-offset-2` → `text-brand-400` |
| `components/NoteMarkdownEditor.tsx` | 同上 |
| `pages/CourseDetailPage.tsx` | 同上 |
| `pages/MarkdownSyntaxHelpPage.tsx` | 同上（3箇所） |
| `pages/LearningReportPage.tsx` | ボタンテキスト `text-primary-500 hover:text-primary-600` → `text-brand-500 hover:text-brand-600` |

なお `primary`(taupe) がアクセント色として使われているデコレーティブ要素
（アイコン色・ステータスドット・統計数値等）はこのPRでは変更しない。

## テスト

- `npx vitest run` — 1128/1128 グリーン（`LinkText.test.tsx` 更新済み）
- `tsc --noEmit` — 型エラーなし

## 関連 Issue

UI 設計レビューより（#2001/#2002 の続き）