### PR TITLE
style(ui): 完了・進捗ステップをエメラルド緑に変更（動機付け向上）③

### DIFF
--- a/frontend/src/components/ui/StepIndicator.tsx
+++ b/frontend/src/components/ui/StepIndicator.tsx
@@ -41,9 +41,9 @@ export default function StepIndicator({ steps, currentStep, className = '' }: St
               <span
                 className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-xs font-semibold transition-colors ${
                   isCompleted
-                    ? 'bg-primary-500 border-primary-500 text-white'
+                    ? 'bg-emerald-500 border-emerald-500 text-white'
                     : isActive
-                    ? 'bg-primary-500/20 border-primary-400 text-primary-300'
+                    ? 'bg-emerald-100 border-emerald-400 text-emerald-700'
                     : 'bg-surface-2 border-surface-3 text-[var(--color-text-muted)]'
                 }`}
                 aria-hidden="true"
@@ -75,7 +75,7 @@ export default function StepIndicator({ steps, currentStep, className = '' }: St
             {index < steps.length - 1 && (
               <div
                 className={`hidden sm:block h-0.5 flex-1 rounded ${
-                  isCompleted ? 'bg-primary-500' : 'bg-surface-3'
+                  isCompleted ? 'bg-emerald-500' : 'bg-surface-3'
                 }`}
                 aria-hidden="true"
               />


### PR DESCRIPTION
## 概要

色彩心理学の研究に基づき、`StepIndicator` コンポーネントの完了・進捗ステップの色を taupe 系から emerald 系へ変更。

## 変更内容

- `StepIndicator.tsx`:
  - 完了ステップ: `bg-primary-500 border-primary-500` → `bg-emerald-500 border-emerald-500`
  - アクティブステップ: `bg-primary-500/20 border-primary-400 text-primary-300` → `bg-emerald-100 border-emerald-400 text-emerald-700`
  - コネクターライン: `bg-primary-500` → `bg-emerald-500`

## 科学的根拠

Lichtenfeld et al. (2012)「Fertile Green」の研究により、緑色は達成感・継続的注意・創造的作業を促進することが示されている。完了済みステップに緑を使うことで学習者の動機付けを高める効果が期待できる。

## テスト

- `npx vitest run`: 1128 件すべてパス
- `StepIndicator.test.tsx` はARIA属性・ラベル検証のみのため更新不要

## 関連 Issue

UI 科学的色彩改善シリーズ（② `#2004` 暖白化 → ③ 本PR → ④ ⑤ 続く）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ステップインジケーターの完了・アクティブ時の色をエメラルドグリーンに変更しました。
  * ステップ間の進捗ラインの色をエメラルドグリーンに統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->