### PR TITLE
fix(exercise): QA演習の問題文・解説欄をMarkdown描画に統一する

### DIFF
--- a/frontend/src/components/exercise/QaExerciseView.tsx
+++ b/frontend/src/components/exercise/QaExerciseView.tsx
@@ -1,9 +1,6 @@
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks';
-import rehypeHighlight from 'rehype-highlight';
 import { CheckCircleIcon, XCircleIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 import ExerciseHeader from './ExerciseHeader';
+import MarkdownView from '../message/MarkdownView';
 import { MasterExercise, ExerciseSubmitResult } from '../../types';
 
 interface Props {
@@ -78,9 +75,9 @@ export default function QaExerciseView({
         <p className="text-xs text-[var(--color-text-muted)]">
           以下の問題に対応するコマンドを入力してください。
         </p>
-        <p className="text-sm text-[var(--color-text-primary)] whitespace-pre-wrap leading-relaxed">
-          {ex.description}
-        </p>
+        <div className="prose prose-sm max-w-none text-sm text-[var(--color-text-primary)] leading-relaxed">
+          <MarkdownView content={ex.description} />
+        </div>
 
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-[#1e1e1e] border border-surface-3 font-mono text-sm">
@@ -139,12 +136,7 @@ export default function QaExerciseView({
                 説明
               </p>
               <div className="prose prose-sm max-w-none text-sm text-[var(--color-text-primary)]">
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm, remarkBreaks]}
-                  rehypePlugins={[rehypeHighlight]}
-                >
-                  {ex.explanation}
-                </ReactMarkdown>
+                <MarkdownView content={ex.explanation} />
               </div>
             </div>
           )}


### PR DESCRIPTION
## 概要

bash/git 演習（`mode=qa`）の問題文（`description`）が `<p>` タグ + `whitespace-pre-wrap` でプレーンテキスト描画されており、`**太字**` やコードフェンスがそのままの文字として表示されていた（スクリーンショット参照）。

## 変更内容

- `QaExerciseView.tsx` の `description` 描画を `<p>` → `<div class="prose ..."><MarkdownView /></div>` に差し替え
- `explanation` 欄の `ReactMarkdown` 直書き（`remarkGfm + remarkBreaks + rehypeHighlight` 個別指定）を `MarkdownView` に統一し、インポートを整理

## テスト

- `tsc --noEmit` : エラーなし
- 既存演習（git-2 等）で `**ステージング**` が太字に、コードブロックがシンタックスハイライト付きで表示されることをローカルで確認

## 関連 Issue

なし（スクリーンショットで発見した表示バグ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 練習問題の説明および解説の表示方式を改善しました。マークダウンコンテンツのレンダリング品質が向上し、より適切な形式でコンテンツが表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->