### PR TITLE
perf(exercise): 演習一覧APIのレスポンスからdescription等の重いフィールドを除外する

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2121,7 +2121,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"
+                                "$ref": "#/definitions/internal_handler.masterExerciseListItemResponse"
                             }
                         }
                     },
@@ -4355,70 +4355,6 @@ const docTemplate = `{
                 }
             }
         },
-        "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
-            "type": "object",
-            "properties": {
-                "category": {
-                    "type": "string"
-                },
-                "chapterId": {
-                    "type": "integer"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "difficulty": {
-                    "type": "integer"
-                },
-                "expectedOutput": {
-                    "type": "string"
-                },
-                "explanation": {
-                    "description": "Explanation は qa モードで正解後に表示する markdown 解説。",
-                    "type": "string"
-                },
-                "hintText": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "isPublished": {
-                    "type": "boolean"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "mode": {
-                    "description": "Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。",
-                    "type": "string"
-                },
-                "orderIndex": {
-                    "type": "integer"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "starterCode": {
-                    "type": "string"
-                },
-                "stats": {
-                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
             "type": "object",
             "properties": {
@@ -4689,6 +4625,45 @@ const docTemplate = `{
             "properties": {
                 "teachingMaterialId": {
                     "type": "integer"
+                }
+            }
+        },
+        "internal_handler.masterExerciseListItemResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "stats": {
+                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
+                },
+                "status": {
+                    "description": "Status は current user の提出状況。\"solved\" / \"in_progress\" / \"\"（未提出）。",
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2114,7 +2114,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"
+                                "$ref": "#/definitions/internal_handler.masterExerciseListItemResponse"
                             }
                         }
                     },
@@ -4348,70 +4348,6 @@
                 }
             }
         },
-        "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
-            "type": "object",
-            "properties": {
-                "category": {
-                    "type": "string"
-                },
-                "chapterId": {
-                    "type": "integer"
-                },
-                "createdAt": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "difficulty": {
-                    "type": "integer"
-                },
-                "expectedOutput": {
-                    "type": "string"
-                },
-                "explanation": {
-                    "description": "Explanation は qa モードで正解後に表示する markdown 解説。",
-                    "type": "string"
-                },
-                "hintText": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "isPublished": {
-                    "type": "boolean"
-                },
-                "language": {
-                    "type": "string"
-                },
-                "mode": {
-                    "description": "Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。",
-                    "type": "string"
-                },
-                "orderIndex": {
-                    "type": "integer"
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "starterCode": {
-                    "type": "string"
-                },
-                "stats": {
-                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "title": {
-                    "type": "string"
-                },
-                "updatedAt": {
-                    "type": "string"
-                }
-            }
-        },
         "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
             "type": "object",
             "properties": {
@@ -4682,6 +4618,45 @@
             "properties": {
                 "teachingMaterialId": {
                     "type": "integer"
+                }
+            }
+        },
+        "internal_handler.masterExerciseListItemResponse": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "difficulty": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "isPublished": {
+                    "type": "boolean"
+                },
+                "language": {
+                    "type": "string"
+                },
+                "mode": {
+                    "type": "string"
+                },
+                "orderIndex": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "stats": {
+                    "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
+                },
+                "status": {
+                    "description": "Status は current user の提出状況。\"solved\" / \"in_progress\" / \"\"（未提出）。",
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -450,50 +450,6 @@ definitions:
       exercise:
         $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise'
     type: object
-  github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus:
-    properties:
-      category:
-        type: string
-      chapterId:
-        type: integer
-      createdAt:
-        type: string
-      description:
-        type: string
-      difficulty:
-        type: integer
-      expectedOutput:
-        type: string
-      explanation:
-        description: Explanation は qa モードで正解後に表示する markdown 解説。
-        type: string
-      hintText:
-        type: string
-      id:
-        type: integer
-      isPublished:
-        type: boolean
-      language:
-        type: string
-      mode:
-        description: Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput
-          を trim 比較。
-        type: string
-      orderIndex:
-        type: integer
-      slug:
-        type: string
-      starterCode:
-        type: string
-      stats:
-        $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats'
-      status:
-        type: string
-      title:
-        type: string
-      updatedAt:
-        type: string
-    type: object
   github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput:
     properties:
       isCorrect:
@@ -672,6 +628,32 @@ definitions:
         type: integer
     required:
     - teachingMaterialId
+    type: object
+  internal_handler.masterExerciseListItemResponse:
+    properties:
+      category:
+        type: string
+      difficulty:
+        type: integer
+      id:
+        type: integer
+      isPublished:
+        type: boolean
+      language:
+        type: string
+      mode:
+        type: string
+      orderIndex:
+        type: integer
+      slug:
+        type: string
+      stats:
+        $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats'
+      status:
+        description: Status は current user の提出状況。"solved" / "in_progress" / ""（未提出）。
+        type: string
+      title:
+        type: string
     type: object
   internal_handler.meResponse:
     properties:
@@ -2283,7 +2265,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus'
+              $ref: '#/definitions/internal_handler.masterExerciseListItemResponse'
             type: array
         "500":
           description: DB / 集計 失敗

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	repository "github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
@@ -25,6 +26,24 @@ func NewMasterExerciseHandler(
 	return &MasterExerciseHandler{listExercises: list, listWithStatus: listWithStatus, getExercise: get}
 }
 
+// masterExerciseListItemResponse は一覧カード表示に必要な最小フィールドのみを持つレスポンス型。
+// description / starterCode / hintText / expectedOutput / explanation などの重いフィールドは
+// 詳細 API (GetBySlug) でのみ返す。
+type masterExerciseListItemResponse struct {
+	ID          uint64 `json:"id"`
+	Slug        string `json:"slug"`
+	Language    string `json:"language"`
+	OrderIndex  int    `json:"orderIndex"`
+	Category    string `json:"category"`
+	Title       string `json:"title"`
+	Difficulty  int16  `json:"difficulty"`
+	Mode        string `json:"mode"`
+	IsPublished bool   `json:"isPublished"`
+	// Status は current user の提出状況。"solved" / "in_progress" / ""（未提出）。
+	Status string                            `json:"status"`
+	Stats  repository.ExerciseSubmissionStats `json:"stats"`
+}
+
 // List は演習問題一覧を query language で絞り込んで返す。
 // current user の提出状況と全ユーザ集計を同時に返す（未ログイン時は status 空）。
 //
@@ -33,7 +52,7 @@ func NewMasterExerciseHandler(
 //	@Tags         exercises
 //	@Produce      json
 //	@Param        language  query     string  false  "言語 フィルタ (例: php, go, javascript)"
-//	@Success      200       {array}   usecase.MasterExerciseWithStatus
+//	@Success      200       {array}   masterExerciseListItemResponse
 //	@Failure      500       {object}  errorResponse  "DB / 集計 失敗"
 //	@Router       /exercises [get]
 //	@Security     CookieAuth
@@ -48,7 +67,23 @@ func (h *MasterExerciseHandler) List(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "演習問題の取得に失敗しました"})
 		return
 	}
-	c.JSON(http.StatusOK, rows)
+	items := make([]masterExerciseListItemResponse, len(rows))
+	for i, r := range rows {
+		items[i] = masterExerciseListItemResponse{
+			ID:          r.ID,
+			Slug:        r.Slug,
+			Language:    r.Language,
+			OrderIndex:  r.OrderIndex,
+			Category:    r.Category,
+			Title:       r.Title,
+			Difficulty:  r.Difficulty,
+			Mode:        r.Mode,
+			IsPublished: r.IsPublished,
+			Status:      r.Status,
+			Stats:       r.Stats,
+		}
+	}
+	c.JSON(http.StatusOK, items)
 }
 
 // GetBySlug は入出力例を含む詳細を返す。

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -100,10 +100,6 @@ function ExerciseCard({ ex }: { ex: MasterExerciseWithStatus }) {
         <StatusBadge status={ex.status} />
       </div>
 
-      <p className="text-xs text-[var(--color-text-tertiary)] line-clamp-2">
-        {ex.description}
-      </p>
-
       <div className="flex items-center gap-4 text-xs text-[var(--color-text-muted)] pt-1 border-t border-surface-3">
         <span>提出 {ex.stats.totalSubmissions}</span>
         <span>正答ユーザ {ex.stats.solvedUsers}</span>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -608,9 +608,21 @@ export interface ExerciseSubmissionStats {
   solvedUsers: number;
 }
 
-/** 一覧 API のレスポンス 1 行。 MasterExercise + current user 状態 + 全体集計。
- *  status: "solved" | "in_progress" | "" （未提出）。 */
-export interface MasterExerciseWithStatus extends MasterExercise {
+/**
+ * 一覧 API のレスポンス 1 行。詳細 API (MasterExercise) より軽量で
+ * description / starterCode / hintText / expectedOutput / explanation は含まない。
+ * status: "solved" | "in_progress" | "" （未提出）。
+ */
+export interface MasterExerciseWithStatus {
+  id: number;
+  slug: string;
+  language: string;
+  orderIndex: number;
+  category: string;
+  title: string;
+  difficulty: number;
+  mode: 'execute' | 'qa';
+  isPublished: boolean;
   status: '' | 'solved' | 'in_progress';
   stats: ExerciseSubmissionStats;
 }


### PR DESCRIPTION
## 概要

演習一覧カードに不要な重いフィールド（`description` / `starterCode` / `hintText` / `expectedOutput` / `explanation`）を一覧 API のレスポンスから削除する。これらは詳細 API (`GET /exercises/:slug`) でのみ必要なフィールド。

## 変更内容

**backend**
- `MasterExerciseHandler.List` に `masterExerciseListItemResponse` (handler local 型) を追加
- 必要な 10 フィールド（id / slug / language / orderIndex / category / title / difficulty / mode / isPublished / status / stats）のみにマッピングして返す
- `swag init` で OpenAPI spec を再生成

**frontend**
- `MasterExerciseWithStatus` を `MasterExercise` の extends からフラットな独立型に変更（軽量フィールドのみ）
- `ExerciseListPage` カードから `<p>{ex.description}</p>` の行を削除

## テスト

- `go build ./internal/handler/...` : エラーなし
- `tsc --noEmit` : エラーなし

## 関連 Issue

なし（スクリーンショットで description プレビューが不要と判断）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 演習問題一覧APIレスポンスを最適化し、必要な情報に絞りました。

* **UI変更**
  * 演習カード上の説明文表示を削除し、レイアウトを簡潔にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->