### PR TITLE
feat(dashboard): ダッシュボードをリデザインし、AI権限のないtraineeにAIカードを非表示にする

### DIFF
--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -1,112 +1,206 @@
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
-  HomeIcon,
   ChatBubbleBottomCenterTextIcon,
   CodeBracketIcon,
   DocumentTextIcon,
   DocumentChartBarIcon,
   BuildingOffice2Icon,
   EnvelopeIcon,
+  BookOpenIcon,
+  ArrowRightIcon,
 } from '@heroicons/react/24/outline';
 import type { RootState } from '../store';
 
 /**
- * シンプルなホーム画面。
- * 旧版で並んでいたゲーミフィケーション系（バッジ / レベル / チャレンジ / 名言 等）は
- * すべて削除し、コア機能（AI / コード学習 / ノート / レポート）への導線だけを残す。
+ * ホーム画面（ダッシュボード）。
  *
- * 設計判断:
- *   - ヘッダーのアイコン + タイトルで現在地を明示
- *   - 4 枚のリンクカードで主要機能に直接遷移
- *   - 表示する数値・進捗系は一切持たない（store / API 依存なし）
- *   - super_admin は trainee 向け学習機能を使わないため、企業管理 / 招待管理のみ表示
+ * ロール別にカードセットを出し分け:
+ *   - super_admin   : 管理系のみ
+ *   - company_admin : 管理 + 学習機能（AI はテナント設定に関わらず常時表示）
+ *   - trainee       : 学習機能のみ。aiChatEnabledForTrainees が false なら AI カードを非表示
+ *
+ * API 依存なし（auth store のみ参照）。 将来的に「最近の演習」等の Quick Stats を
+ * 追加する場合はここに useXxxStats() を差し込む。
  */
 export default function MenuPage() {
   const role = useSelector((state: RootState) => state.auth.role);
+  const aiEnabled = useSelector((state: RootState) => state.auth.aiChatEnabledForTrainees);
   const isSuperAdmin = role === 'super_admin';
+  const isTrainee = role === 'trainee';
+  const showAi = !isTrainee || aiEnabled;
 
   return (
-    <div className="px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">
-      <header className="flex items-center gap-2">
-        <HomeIcon className="w-6 h-6 text-[var(--color-text-muted)]" />
-        <h1 className="text-2xl font-bold">ホーム</h1>
-      </header>
+    <div className="px-4 sm:px-6 pt-8 pb-24 max-w-4xl mx-auto space-y-10">
 
-      <p className="text-sm text-[var(--color-text-muted)] leading-relaxed">
-        {isSuperAdmin
-          ? '管理者向けの操作メニューです。'
-          : '左のメニューから機能を選んでください。下のカードからもアクセスできます。'}
-      </p>
+      {/* ウェルカムセクション */}
+      <section>
+        <p className="text-xs font-semibold text-brand-500 uppercase tracking-widest mb-1">
+          {isSuperAdmin ? '運営管理者ダッシュボード' : isTrainee ? '学習ダッシュボード' : '管理者ダッシュボード'}
+        </p>
+        <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
+          {isSuperAdmin ? '管理メニュー' : 'FreStyle へようこそ'}
+        </h1>
+        <p className="mt-2 text-sm text-[var(--color-text-muted)]">
+          {isSuperAdmin
+            ? '企業管理・招待などの運営操作を行えます。'
+            : 'コースや演習で学習を進め、AI チャットで疑問を解決しましょう。'}
+        </p>
+      </section>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {isSuperAdmin ? (
-          <>
-            <NavCard
-              to="/admin/companies"
-              icon={BuildingOffice2Icon}
-              title="会社一覧"
-              description="登録済み企業の管理を行います。"
+      {isSuperAdmin ? (
+        <FeatureSection title="管理機能">
+          <FeatureCard
+            to="/admin/companies"
+            icon={BuildingOffice2Icon}
+            title="会社一覧"
+            description="登録済み企業の管理・閲覧を行います。"
+            color="blue"
+          />
+          <FeatureCard
+            to="/admin/invitations"
+            icon={EnvelopeIcon}
+            title="招待管理"
+            description="企業管理者への招待を作成・管理できます。"
+            color="blue"
+          />
+        </FeatureSection>
+      ) : (
+        <>
+          {/* 学習機能セクション */}
+          <FeatureSection title="学習">
+            <FeatureCard
+              to="/courses"
+              icon={BookOpenIcon}
+              title="コース"
+              description="体系的なカリキュラムで段階的に学べます。"
+              color="emerald"
+              badge="おすすめ"
             />
-            <NavCard
-              to="/admin/invitations"
-              icon={EnvelopeIcon}
-              title="招待管理"
-              description="企業管理者への招待を作成・管理できます。"
-            />
-          </>
-        ) : (
-          <>
-            <NavCard
-              to="/chat/ask-ai"
-              icon={ChatBubbleBottomCenterTextIcon}
-              title="AI チャット"
-              description="質問・要約・コード補助など、自由に対話できます。"
-            />
-            <NavCard
+            <FeatureCard
               to="/code-editor"
               icon={CodeBracketIcon}
-              title="コード学習"
-              description="演習問題を解いて手を動かしながら学べます。"
+              title="コード演習"
+              description="実際にコードを書いて手を動かしながら学べます。"
+              color="emerald"
             />
-            <NavCard
+          </FeatureSection>
+
+          {/* ツールセクション */}
+          <FeatureSection title="ツール">
+            {showAi && (
+              <FeatureCard
+                to="/chat/ask-ai"
+                icon={ChatBubbleBottomCenterTextIcon}
+                title="AI チャット"
+                description="質問・要約・コード補助など自由に対話できます。"
+                color="brand"
+              />
+            )}
+            <FeatureCard
               to="/notes"
               icon={DocumentTextIcon}
               title="ノート"
-              description="学習メモを残す・振り返ることができます。"
+              description="学習メモを書き留め、いつでも振り返れます。"
+              color="taupe"
             />
-            <NavCard
+            <FeatureCard
               to="/reports"
               icon={DocumentChartBarIcon}
-              title="レポート"
+              title="学習レポート"
               description="月次の学習サマリーを確認できます。"
+              color="taupe"
             />
-          </>
-        )}
-      </div>
+          </FeatureSection>
+
+          {/* 管理者にはさらに管理セクションを追加 */}
+          {role === 'company_admin' && (
+            <FeatureSection title="管理">
+              <FeatureCard
+                to="/admin/members"
+                icon={BuildingOffice2Icon}
+                title="従業員一覧"
+                description="所属メンバーの学習状況を確認できます。"
+                color="blue"
+              />
+              <FeatureCard
+                to="/admin/invitations"
+                icon={EnvelopeIcon}
+                title="招待管理"
+                description="メンバーへの招待を作成・管理できます。"
+                color="blue"
+              />
+            </FeatureSection>
+          )}
+        </>
+      )}
     </div>
   );
 }
 
-interface NavCardProps {
+// ─── サブコンポーネント ──────────────────────────────────────────────────────
+
+interface FeatureSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function FeatureSection({ title, children }: FeatureSectionProps) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest">
+        {title}
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+type CardColor = 'brand' | 'emerald' | 'taupe' | 'blue';
+
+interface FeatureCardProps {
   to: string;
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
+  color: CardColor;
+  badge?: string;
 }
 
-function NavCard({ to, icon: Icon, title, description }: NavCardProps) {
+const iconBg: Record<CardColor, string> = {
+  brand:   'bg-brand-100 text-brand-600',
+  emerald: 'bg-emerald-100 text-emerald-700',
+  taupe:   'bg-taupe-100 text-taupe-600',
+  blue:    'bg-blue-100 text-blue-600',
+};
+
+function FeatureCard({ to, icon: Icon, title, description, color, badge }: FeatureCardProps) {
   return (
     <Link
       to={to}
-      className="block p-4 rounded-lg border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] transition-colors"
+      className="group relative flex flex-col gap-4 p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] hover:border-[var(--color-text-muted)]/40 hover:shadow-sm transition-all duration-150"
     >
-      <div className="flex items-start gap-3">
-        <Icon className="w-5 h-5 mt-0.5 text-[var(--color-text-muted)] flex-shrink-0" />
-        <div className="flex-1">
-          <h2 className="font-medium text-[var(--color-text-primary)]">{title}</h2>
-          <p className="text-xs text-[var(--color-text-muted)] mt-1">{description}</p>
-        </div>
+      {badge && (
+        <span className="absolute top-3 right-3 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">
+          {badge}
+        </span>
+      )}
+      <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBg[color]}`}>
+        <Icon className="w-5 h-5" />
+      </div>
+      <div className="flex-1 space-y-1">
+        <h3 className="font-semibold text-[var(--color-text-primary)] text-sm group-hover:text-brand-500 transition-colors">
+          {title}
+        </h3>
+        <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
+          {description}
+        </p>
+      </div>
+      <div className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] group-hover:text-brand-500 transition-colors">
+        <span>開く</span>
+        <ArrowRightIcon className="w-3 h-3 translate-x-0 group-hover:translate-x-0.5 transition-transform" />
       </div>
     </Link>
   );


### PR DESCRIPTION
## 概要

- AI 権限のない trainee（`aiChatEnabledForTrainees=false`）にダッシュボードの「AI チャット」カードが表示されていたバグを修正
- ダッシュボード全体を SaaS 的なセクション構造にリデザイン

## 変更内容

**バグ修正**
- `MenuPage` に `aiChatEnabledForTrainees` store フラグを追加し、ヘッダーと同じ条件（`!isTrainee || aiEnabled`）で AI カードを出し分け

**ダッシュボード リデザイン**

| 変更点 | 内容 |
|---|---|
| セクション構造 | 「学習」/ 「ツール」/ 「管理」の 3 セクションに整理 |
| カードデザイン | カラーコードアイコン背景 + 矢印 CTA + badge（「おすすめ」）を追加 |
| ウェルカムヘッダー | ロール別サブタイトル（学習ダッシュボード / 管理者ダッシュボード）を表示 |
| company_admin | 「管理」セクション（従業員一覧・招待管理）を追加表示 |
| レイアウト | 最大 3 カラムグリッド（モバイルは 1 カラム）に変更 |

## テスト

- `tsc --noEmit` : エラーなし
- trainee ロール + `aiChatEnabledForTrainees=false` のとき AI カードが非表示になることを確認

## 関連 Issue

なし（スクリーンショットで AI カード非表示漏れを発見）