### PR TITLE
feat(home): 学習統計を右サイドバーに移動し2カラムレイアウトに変更

### DIFF
--- a/frontend/src/components/dashboard/DashboardStats.tsx
+++ b/frontend/src/components/dashboard/DashboardStats.tsx
@@ -19,8 +19,8 @@ export default function DashboardStats({ dashboard }: Props) {
 
   return (
     <div className="space-y-4 p-4 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)]">
-      {/* KPI バー */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {/* KPI（2×2 グリッド） */}
+      <div className="grid grid-cols-2 gap-3">
         <StatChip
           icon={<FireIcon className="w-4 h-4" />}
           label="連続学習"

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -36,112 +36,120 @@ export default function MenuPage() {
   const { dashboard } = useUserDashboard({ enabled: !isSuperAdmin });
 
   return (
-    <div className="px-4 sm:px-6 pt-8 pb-24 max-w-4xl mx-auto space-y-10">
+    <div className="px-4 sm:px-6 pt-8 pb-24 max-w-6xl mx-auto">
+      <div className="flex flex-col lg:flex-row gap-8 items-start">
 
-      {/* ウェルカムセクション */}
-      <section>
-        <p className="text-xs font-semibold text-brand-500 uppercase tracking-widest mb-1">
-          {isSuperAdmin ? '運営管理者ダッシュボード' : isTrainee ? '学習ダッシュボード' : '管理者ダッシュボード'}
-        </p>
-        <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
-          {isSuperAdmin ? '管理メニュー' : 'FreStyle へようこそ'}
-        </h1>
-        <p className="mt-2 text-sm text-[var(--color-text-muted)]">
-          {isSuperAdmin
-            ? '企業管理・招待などの運営操作を行えます。'
-            : 'コースや演習で学習を進め、AI チャットで疑問を解決しましょう。'}
-        </p>
-      </section>
+        {/* ── 左メインコンテンツ ── */}
+        <div className="flex-1 min-w-0 space-y-10">
 
-      {/* 学習者向けパーソナライズ統計（super_admin には表示しない）*/}
-      {!isSuperAdmin && dashboard && <DashboardStats dashboard={dashboard} />}
+          {/* ウェルカムセクション */}
+          <section>
+            <p className="text-xs font-semibold text-brand-500 uppercase tracking-widest mb-1">
+              {isSuperAdmin ? '運営管理者ダッシュボード' : isTrainee ? '学習ダッシュボード' : '管理者ダッシュボード'}
+            </p>
+            <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
+              {isSuperAdmin ? '管理メニュー' : 'FreStyle へようこそ'}
+            </h1>
+            <p className="mt-2 text-sm text-[var(--color-text-muted)]">
+              {isSuperAdmin
+                ? '企業管理・招待などの運営操作を行えます。'
+                : 'コースや演習で学習を進め、AI チャットで疑問を解決しましょう。'}
+            </p>
+          </section>
 
-      {isSuperAdmin ? (
-        <FeatureSection title="管理機能">
-          <FeatureCard
-            to="/admin/companies"
-            icon={BuildingOffice2Icon}
-            title="会社一覧"
-            description="登録済み企業の管理・閲覧を行います。"
-            color="blue"
-          />
-          <FeatureCard
-            to="/admin/invitations"
-            icon={EnvelopeIcon}
-            title="招待管理"
-            description="企業管理者への招待を作成・管理できます。"
-            color="blue"
-          />
-        </FeatureSection>
-      ) : (
-        <>
-          {/* 学習機能セクション */}
-          <FeatureSection title="学習">
-            <FeatureCard
-              to="/courses"
-              icon={BookOpenIcon}
-              title="コース"
-              description="体系的なカリキュラムで段階的に学べます。"
-              color="emerald"
-              badge="おすすめ"
-            />
-            <FeatureCard
-              to="/code-editor"
-              icon={CodeBracketIcon}
-              title="コード演習"
-              description="実際にコードを書いて手を動かしながら学べます。"
-              color="emerald"
-            />
-          </FeatureSection>
-
-          {/* ツールセクション */}
-          <FeatureSection title="ツール">
-            {showAi && (
+          {isSuperAdmin ? (
+            <FeatureSection title="管理機能">
               <FeatureCard
-                to="/chat/ask-ai"
-                icon={ChatBubbleBottomCenterTextIcon}
-                title="AI チャット"
-                description="質問・要約・コード補助など自由に対話できます。"
-                color="brand"
-              />
-            )}
-            <FeatureCard
-              to="/notes"
-              icon={DocumentTextIcon}
-              title="ノート"
-              description="学習メモを書き留め、いつでも振り返れます。"
-              color="taupe"
-            />
-            <FeatureCard
-              to="/reports"
-              icon={DocumentChartBarIcon}
-              title="学習レポート"
-              description="月次の学習サマリーを確認できます。"
-              color="taupe"
-            />
-          </FeatureSection>
-
-          {/* 管理者にはさらに管理セクションを追加 */}
-          {role === 'company_admin' && (
-            <FeatureSection title="管理">
-              <FeatureCard
-                to="/admin/members"
+                to="/admin/companies"
                 icon={BuildingOffice2Icon}
-                title="従業員一覧"
-                description="所属メンバーの学習状況を確認できます。"
+                title="会社一覧"
+                description="登録済み企業の管理・閲覧を行います。"
                 color="blue"
               />
               <FeatureCard
                 to="/admin/invitations"
                 icon={EnvelopeIcon}
                 title="招待管理"
-                description="メンバーへの招待を作成・管理できます。"
+                description="企業管理者への招待を作成・管理できます。"
                 color="blue"
               />
             </FeatureSection>
+          ) : (
+            <>
+              <FeatureSection title="学習">
+                <FeatureCard
+                  to="/courses"
+                  icon={BookOpenIcon}
+                  title="コース"
+                  description="体系的なカリキュラムで段階的に学べます。"
+                  color="emerald"
+                  badge="おすすめ"
+                />
+                <FeatureCard
+                  to="/code-editor"
+                  icon={CodeBracketIcon}
+                  title="コード演習"
+                  description="実際にコードを書いて手を動かしながら学べます。"
+                  color="emerald"
+                />
+              </FeatureSection>
+
+              <FeatureSection title="ツール">
+                {showAi && (
+                  <FeatureCard
+                    to="/chat/ask-ai"
+                    icon={ChatBubbleBottomCenterTextIcon}
+                    title="AI チャット"
+                    description="質問・要約・コード補助など自由に対話できます。"
+                    color="brand"
+                  />
+                )}
+                <FeatureCard
+                  to="/notes"
+                  icon={DocumentTextIcon}
+                  title="ノート"
+                  description="学習メモを書き留め、いつでも振り返れます。"
+                  color="taupe"
+                />
+                <FeatureCard
+                  to="/reports"
+                  icon={DocumentChartBarIcon}
+                  title="学習レポート"
+                  description="月次の学習サマリーを確認できます。"
+                  color="taupe"
+                />
+              </FeatureSection>
+
+              {role === 'company_admin' && (
+                <FeatureSection title="管理">
+                  <FeatureCard
+                    to="/admin/members"
+                    icon={BuildingOffice2Icon}
+                    title="従業員一覧"
+                    description="所属メンバーの学習状況を確認できます。"
+                    color="blue"
+                  />
+                  <FeatureCard
+                    to="/admin/invitations"
+                    icon={EnvelopeIcon}
+                    title="招待管理"
+                    description="メンバーへの招待を作成・管理できます。"
+                    color="blue"
+                  />
+                </FeatureSection>
+              )}
+            </>
           )}
-        </>
-      )}
+        </div>
+
+        {/* ── 右サイドバー（学習統計）── super_admin には非表示 */}
+        {!isSuperAdmin && dashboard && (
+          <div className="w-full lg:w-72 shrink-0">
+            <DashboardStats dashboard={dashboard} />
+          </div>
+        )}
+
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

ホーム画面の学習統計カードを右サイドバーに移動し、2カラムレイアウトに変更。

## 変更内容

- ホーム画面を **左メイン（機能カード）＋ 右サイドバー（学習統計）** の2カラム構成に変更
- lg（1024px）未満はスタック表示でモバイル対応
- KPI グリッドを `grid-cols-2 sm:grid-cols-4` → `grid-cols-2`（2×2）に調整
- コンテナ幅を `max-w-4xl` → `max-w-6xl` に拡張

## テスト

フロントエンドのレイアウト変更のみ。ロジック・API への影響なし。`tsc --noEmit` 通過。

## 関連 Issue

なし