### PR TITLE
style: サイドバー項目から○アイコンと章番号プレフィックスを削除

### DIFF
--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -228,15 +228,13 @@ export default function CourseDetailPage() {
               />
             </div>
           ) : (
-            filtered.map((m, idx) => (
+            filtered.map((m) => (
               <MaterialListItem
                 key={m.id}
                 material={m}
-                index={idx + 1}
                 isActive={selectedId === m.id}
                 onSelect={handleSelect}
                 onDelete={canManage ? (mid) => setDeleteTargetId(mid) : undefined}
-                showCompletion={!canManage}
                 completed={progress.completedIds.has(m.id)}
               />
             ))
@@ -303,19 +301,15 @@ export default function CourseDetailPage() {
 
 function MaterialListItem({
   material,
-  index,
   isActive,
   onSelect,
   onDelete,
-  showCompletion = false,
   completed = false,
 }: {
   material: TeachingMaterial;
-  index?: number;
   isActive: boolean;
   onSelect: (id: number) => void;
   onDelete?: (id: number) => void;
-  showCompletion?: boolean;
   completed?: boolean;
 }) {
   return (
@@ -335,29 +329,11 @@ function MaterialListItem({
           : 'border-transparent hover:bg-[var(--color-nav-hover)]'
       }`}
     >
-      {/* 完了アイコン（trainee）/ 公開ステータスドット（管理者） */}
-      <span className="mt-[3px] flex-shrink-0">
-        {showCompletion ? (
-          completed ? (
-            <CheckCircleSolidIcon className="w-4 h-4 text-green-500" />
-          ) : (
-            <span className="block w-4 h-4 rounded-full border border-[var(--color-text-muted)]/50" />
-          )
-        ) : (
-          <span className={`block w-2 h-2 mt-1 rounded-full ${
-            material.isPublished ? 'bg-green-500' : 'bg-[var(--color-text-muted)]/30'
-          }`} />
-        )}
-      </span>
-
       <p className={`flex-1 min-w-0 text-[13px] leading-snug line-clamp-2 ${
         isActive
           ? 'font-medium text-[var(--color-text-primary)]'
           : 'text-[var(--color-text-secondary)]'
       }`}>
-        {index !== undefined && (
-          <span className="text-[var(--color-text-muted)] mr-1.5 font-normal">{index}.</span>
-        )}
         {material.title || '無題の教材'}
       </p>
 


### PR DESCRIPTION
## 概要

前PR (#2018) で追加した○アイコンと章番号プレフィックスを削除します。
教材タイトルに既に「1.」「2.」の番号が入っているため、追加番号が二重表示になっていました。

## 変更内容

- 空円 / チェックアイコンの完了インジケーターを削除
- `1.` `2.` の章番号プレフィックスを削除
- タイトルテキストのみのクリーンな表示に変更
- 左ボーダーによるアクティブアクセント・`line-clamp-2` の折り返しは維持

## テスト

- `npx tsc --noEmit` — ✅

## 関連 Issue

なし（#2018 の修正）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 教材リストの表示を簡潔化しました。完了ステータスアイコン、公開状態インジケーター、およびリスト項目の番号表示を削除し、より整理されたUIへと改善しました。教材の基本情報と操作機能に焦点を当てた表示となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->