### PR TITLE
style: 錯視・面積効果・重心の3原則に基づくUI微調整

### DIFF
--- a/frontend/src/components/dashboard/DashboardStats.tsx
+++ b/frontend/src/components/dashboard/DashboardStats.tsx
@@ -67,7 +67,7 @@ function StatChip({
   color: string;
 }) {
   return (
-    <div className="flex flex-col gap-1 p-3 rounded-lg bg-[var(--color-surface-2)]">
+    <div className="flex flex-col gap-1 pt-3 px-3 pb-4 rounded-lg bg-[var(--color-surface-2)]">
       <span className={`${color}`}>{icon}</span>
       <span className="text-xs text-[var(--color-text-muted)]">{label}</span>
       <span className="text-base font-bold text-[var(--color-text-primary)]">{value}</span>

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -504,7 +504,7 @@ function CourseProgressBar({ completed, total }: { completed: number; total: num
       </div>
       <div className="h-1.5 w-full rounded-full bg-surface-3 overflow-hidden">
         <div
-          className="h-full rounded-full bg-green-500 transition-all"
+          className="h-full rounded-full bg-green-400 transition-all"
           style={{ width: `${pct}%` }}
           role="progressbar"
           aria-label="学習の進捗"
@@ -533,7 +533,7 @@ function CompleteToggleButton({
       onClick={() => onToggle(!completed)}
       aria-pressed={completed}
       className={`inline-flex items-center justify-center gap-1.5 rounded-lg font-medium transition-colors ${
-        large ? 'px-5 py-2.5 text-sm' : 'px-3 py-1.5 text-sm'
+        large ? 'px-5 pt-[9px] pb-[11px] text-sm' : 'px-3 pt-[5px] pb-[7px] text-sm'
       } ${
         completed
           ? 'bg-green-500/15 text-green-500 hover:bg-green-500/25'

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -199,12 +199,12 @@ function FeatureCard({ to, icon: Icon, title, description, color, badge }: Featu
       className="group relative flex flex-col gap-4 p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] hover:border-[var(--color-text-muted)]/40 hover:shadow-sm transition-all duration-150"
     >
       {badge && (
-        <span className="absolute top-3 right-3 text-[10px] font-semibold px-2 py-0.5 rounded-full bg-emerald-100 text-emerald-700">
+        <span className="absolute top-3 right-3 text-[10px] font-semibold px-2 pt-px pb-[3px] rounded-full bg-emerald-100 text-emerald-700">
           {badge}
         </span>
       )}
       <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBg[color]}`}>
-        <Icon className="w-5 h-5" />
+        <Icon className="w-5 h-5 -translate-y-px" />
       </div>
       <div className="flex-1 space-y-1">
         <h3 className="font-semibold text-[var(--color-text-primary)] text-sm group-hover:text-brand-500 transition-colors">


### PR DESCRIPTION
## 概要

デザイナーが意識する3つの錯視原則をFreStyleのUIに適用します。

## 変更内容

### ① 上下のマージンがちがう（上方距離過大の錯視）
数値で上下均等にするとテキストが下にずれて見える錯視の補正。

| 箇所 | Before | After |
|---|---|---|
| FeatureCard バッジ | `py-0.5`（上下2px同値） | `pt-px pb-[3px]`（上詰め） |
| 完了ボタン | `py-2.5` / `py-1.5` | `pt-[9px] pb-[11px]` / `pt-[5px] pb-[7px]` |
| StatChip カード | `p-3` | `pt-3 px-3 pb-4`（下余白+1） |

### ② 色が微妙に違う（面積効果）
同じ `#4ade80`（green-500）でも面積が大きいと濃く・強く見える。

| 箇所 | Before | After |
|---|---|---|
| 進捗バー（全幅） | `bg-green-500` | `bg-green-400`（1段階淡く） |

### ③ 数字じゃなくて重心でデザインしてる
数値上の中央は視覚的に下に見える。

| 箇所 | Before | After |
|---|---|---|
| FeatureCard アイコン | `items-center justify-center` | + `-translate-y-px`（1px上） |

## テスト

- `npx tsc --noEmit` — ✅
- ロジック変更なし（デザインのみ）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ダッシュボード、コース詳細ページ、メニューページの UI 要素における余白と位置の細部調整を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->