### PR TITLE
feat: 演習問題一覧にスクロール型ページネーションを実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2099,19 +2099,31 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。",
+                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み。 limit/offset で ページネーション。 current user の 提出 状況 と 全 user 集計 を 返す。",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "exercises"
                 ],
-                "summary": "演習問題 一覧 (status + stats 付き)",
+                "summary": "演習問題 一覧 (status + stats + ページネーション付き)",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "言語 フィルタ (例: php, go, javascript)",
+                        "description": "言語 フィルタ (例: php, go, bash, git)",
                         "name": "language",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "1 ページの 件数 (デフォルト 20、最大 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "取得 開始 位置 (デフォルト 0)",
+                        "name": "offset",
                         "in": "query"
                     }
                 ],
@@ -2119,10 +2131,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/internal_handler.masterExerciseListItemResponse"
-                            }
+                            "$ref": "#/definitions/internal_handler.exercisePageResponse"
                         }
                     },
                     "500": {
@@ -4732,6 +4741,26 @@ const docTemplate = `{
                 "error": {
                     "type": "string",
                     "example": "unauthorized"
+                }
+            }
+        },
+        "internal_handler.exercisePageResponse": {
+            "type": "object",
+            "properties": {
+                "hasNext": {
+                    "type": "boolean"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handler.masterExerciseListItemResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "offset": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2092,19 +2092,31 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。",
+                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み。 limit/offset で ページネーション。 current user の 提出 状況 と 全 user 集計 を 返す。",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "exercises"
                 ],
-                "summary": "演習問題 一覧 (status + stats 付き)",
+                "summary": "演習問題 一覧 (status + stats + ページネーション付き)",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "言語 フィルタ (例: php, go, javascript)",
+                        "description": "言語 フィルタ (例: php, go, bash, git)",
                         "name": "language",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "1 ページの 件数 (デフォルト 20、最大 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "取得 開始 位置 (デフォルト 0)",
+                        "name": "offset",
                         "in": "query"
                     }
                 ],
@@ -2112,10 +2124,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/internal_handler.masterExerciseListItemResponse"
-                            }
+                            "$ref": "#/definitions/internal_handler.exercisePageResponse"
                         }
                     },
                     "500": {
@@ -4725,6 +4734,26 @@
                 "error": {
                     "type": "string",
                     "example": "unauthorized"
+                }
+            }
+        },
+        "internal_handler.exercisePageResponse": {
+            "type": "object",
+            "properties": {
+                "hasNext": {
+                    "type": "boolean"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/internal_handler.masterExerciseListItemResponse"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "offset": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -646,6 +646,19 @@ definitions:
         example: unauthorized
         type: string
     type: object
+  internal_handler.exercisePageResponse:
+    properties:
+      hasNext:
+        type: boolean
+      items:
+        items:
+          $ref: '#/definitions/internal_handler.masterExerciseListItemResponse'
+        type: array
+      limit:
+        type: integer
+      offset:
+        type: integer
+    type: object
   internal_handler.invitationValidateResponse:
     properties:
       companyId:
@@ -2299,29 +2312,35 @@ paths:
       - embeds
   /exercises:
     get:
-      description: '運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current
-        user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。'
+      description: 運営 マスタ 演習問題 を 取得。 query language で 絞り込み。 limit/offset で ページネーション。
+        current user の 提出 状況 と 全 user 集計 を 返す。
       parameters:
-      - description: '言語 フィルタ (例: php, go, javascript)'
+      - description: '言語 フィルタ (例: php, go, bash, git)'
         in: query
         name: language
         type: string
+      - description: 1 ページの 件数 (デフォルト 20、最大 100)
+        in: query
+        name: limit
+        type: integer
+      - description: 取得 開始 位置 (デフォルト 0)
+        in: query
+        name: offset
+        type: integer
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/internal_handler.masterExerciseListItemResponse'
-            type: array
+            $ref: '#/definitions/internal_handler.exercisePageResponse'
         "500":
           description: DB / 集計 失敗
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:
       - CookieAuth: []
-      summary: 演習問題 一覧 (status + stats 付き)
+      summary: 演習問題 一覧 (status + stats + ページネーション付き)
       tags:
       - exercises
   /exercises/{slug}:

--- a/backend/internal/adapter/persistence/master_exercise_repository.go
+++ b/backend/internal/adapter/persistence/master_exercise_repository.go
@@ -46,12 +46,9 @@ func (r *masterExerciseRepository) GetBySlug(ctx context.Context, slug string) (
 }
 
 // ListWithStatusByLanguage は公開済み問題を「current user の提出状態 + 全体集計」付きで 1 クエリで返す。
-// 旧実装は usecase 側で 3 回（一覧 / ユーザ状態 batch / 集計 batch）DB に往復していたが、
-// master_exercises に exercise_submissions の集計を LEFT JOIN し、 Postgres の FILTER 句で
-// 1 パスに統合した（生 SQL 直書き）。一覧ページのたびに走るホットパスのため往復 3→1 に削減。
+// in.Limit > 0 のとき LIMIT/OFFSET を適用する。Limit=0 は全件取得。
 // userID=0（未ログイン）は usr サブクエリが空になり status は全て "".
-func (r *masterExerciseRepository) ListWithStatusByLanguage(ctx context.Context, userID uint64, language string) ([]repository.MasterExerciseWithStatus, error) {
-	// 集計列を埋め込み MasterExercise と一緒に 1 行へスキャンする。
+func (r *masterExerciseRepository) ListWithStatusByLanguage(ctx context.Context, in repository.ListWithStatusInput) ([]repository.MasterExerciseWithStatus, error) {
 	type row struct {
 		domain.MasterExercise
 
@@ -60,7 +57,7 @@ func (r *masterExerciseRepository) ListWithStatusByLanguage(ctx context.Context,
 		SolvedUsers      int64  `gorm:"column:solved_users"`
 	}
 
-	const q = `
+	const baseQ = `
 SELECT e.*,
        COALESCE(agg.total_submissions, 0) AS total_submissions,
        COALESCE(agg.solved_users, 0)      AS solved_users,
@@ -88,10 +85,19 @@ WHERE e.is_published = TRUE
   AND (? = '' OR e.language = ?)
 ORDER BY e.order_index ASC`
 
+	var q string
+	var args []interface{}
+	args = []interface{}{domain.ExerciseKindMaster, domain.ExerciseKindMaster, in.UserID, in.Language, in.Language}
+
+	if in.Limit > 0 {
+		q = baseQ + "\nLIMIT ? OFFSET ?"
+		args = append(args, in.Limit, in.Offset)
+	} else {
+		q = baseQ
+	}
+
 	var rows []row
-	if err := r.db.WithContext(ctx).
-		Raw(q, domain.ExerciseKindMaster, domain.ExerciseKindMaster, userID, language, language).
-		Scan(&rows).Error; err != nil {
+	if err := r.db.WithContext(ctx).Raw(q, args...).Scan(&rows).Error; err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/adapter/persistence/master_exercise_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/master_exercise_repository_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,8 +48,12 @@ func TestMasterExerciseRepository_ListWithStatusByLanguage_Integration(t *testin
 		require.NoError(t, subRepo.Create(ctx, &subs[i]))
 	}
 
+	in := func(userID uint64, language string) repository.ListWithStatusInput {
+		return repository.ListWithStatusInput{UserID: userID, Language: language}
+	}
+
 	t.Run("言語フィルタ + 非公開除外 + order_index 昇順", func(t *testing.T) {
-		rows, err := exRepo.ListWithStatusByLanguage(ctx, 0, "php")
+		rows, err := exRepo.ListWithStatusByLanguage(ctx, in(0, "php"))
 		require.NoError(t, err)
 		require.Len(t, rows, 2, "php の公開問題のみ（draft は除外）")
 		require.Equal(t, "php-1", rows[0].Slug)
@@ -56,24 +61,36 @@ func TestMasterExerciseRepository_ListWithStatusByLanguage_Integration(t *testin
 	})
 
 	t.Run("未ログイン(userID=0)は status 空 + 全体集計は付く", func(t *testing.T) {
-		rows, err := exRepo.ListWithStatusByLanguage(ctx, 0, "php")
+		rows, err := exRepo.ListWithStatusByLanguage(ctx, in(0, "php"))
 		require.NoError(t, err)
 		require.Equal(t, "", rows[0].Status)
 		require.Equal(t, int64(3), rows[0].Stats.TotalSubmissions)
 		require.Equal(t, int64(2), rows[0].Stats.SolvedUsers)
-		require.Equal(t, int64(0), rows[1].Stats.TotalSubmissions) // php-2 は提出なし
+		require.Equal(t, int64(0), rows[1].Stats.TotalSubmissions)
 	})
 
 	t.Run("ログインユーザの status(solved)が付く", func(t *testing.T) {
-		rows, err := exRepo.ListWithStatusByLanguage(ctx, 7, "php")
+		rows, err := exRepo.ListWithStatusByLanguage(ctx, in(7, "php"))
 		require.NoError(t, err)
 		require.Equal(t, "solved", rows[0].Status, "user7 は php-1 を正解済み")
 		require.Equal(t, "", rows[1].Status, "php-2 は未提出")
 	})
 
 	t.Run("language 空なら全公開問題", func(t *testing.T) {
-		rows, err := exRepo.ListWithStatusByLanguage(ctx, 0, "")
+		rows, err := exRepo.ListWithStatusByLanguage(ctx, in(0, ""))
 		require.NoError(t, err)
 		require.Len(t, rows, 3, "php-1 / php-2 / go-1（draft 除外）")
+	})
+
+	t.Run("LIMIT/OFFSET でページネーション", func(t *testing.T) {
+		rows1, err := exRepo.ListWithStatusByLanguage(ctx, repository.ListWithStatusInput{UserID: 0, Language: "", Offset: 0, Limit: 2})
+		require.NoError(t, err)
+		require.Len(t, rows1, 2)
+
+		rows2, err := exRepo.ListWithStatusByLanguage(ctx, repository.ListWithStatusInput{UserID: 0, Language: "", Offset: 2, Limit: 2})
+		require.NoError(t, err)
+		require.Len(t, rows2, 1, "3 件目（残り 1 件）")
+
+		require.NotEqual(t, rows1[0].Slug, rows2[0].Slug, "ページが重複しない")
 	})
 }

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
@@ -40,33 +41,73 @@ type masterExerciseListItemResponse struct {
 	Mode        string `json:"mode"`
 	IsPublished bool   `json:"isPublished"`
 	// Status は current user の提出状況。"solved" / "in_progress" / ""（未提出）。
-	Status string                            `json:"status"`
+	Status string                             `json:"status"`
 	Stats  repository.ExerciseSubmissionStats `json:"stats"`
 }
 
-// List は演習問題一覧を query language で絞り込んで返す。
-// current user の提出状況と全ユーザ集計を同時に返す（未ログイン時は status 空）。
+// exercisePageResponse はスクロール型ページネーションのレスポンス。
+// Items は limit 件以下の問題リスト。HasNext が true のとき次のページが存在する。
+type exercisePageResponse struct {
+	Items   []masterExerciseListItemResponse `json:"items"`
+	HasNext bool                             `json:"hasNext"`
+	Offset  int                              `json:"offset"`
+	Limit   int                              `json:"limit"`
+}
+
+const (
+	exerciseDefaultLimit = 20
+	exerciseMaxLimit     = 100
+)
+
+// List は演習問題一覧をスクロール型ページネーションで返す。
+// limit（デフォルト 20・最大 100）と offset（デフォルト 0）で取得範囲を指定する。
+// hasNext が true のとき次ページが存在する。
 //
-//	@Summary      演習問題 一覧 (status + stats 付き)
-//	@Description  運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。
+//	@Summary      演習問題 一覧 (status + stats + ページネーション付き)
+//	@Description  運営 マスタ 演習問題 を 取得。 query language で 絞り込み。 limit/offset で ページネーション。 current user の 提出 状況 と 全 user 集計 を 返す。
 //	@Tags         exercises
 //	@Produce      json
-//	@Param        language  query     string  false  "言語 フィルタ (例: php, go, javascript)"
-//	@Success      200       {array}   masterExerciseListItemResponse
+//	@Param        language  query     string  false  "言語 フィルタ (例: php, go, bash, git)"
+//	@Param        limit     query     int     false  "1 ページの 件数 (デフォルト 20、最大 100)"
+//	@Param        offset    query     int     false  "取得 開始 位置 (デフォルト 0)"
+//	@Success      200       {object}  exercisePageResponse
 //	@Failure      500       {object}  errorResponse  "DB / 集計 失敗"
 //	@Router       /exercises [get]
 //	@Security     CookieAuth
 func (h *MasterExerciseHandler) List(c *gin.Context) {
 	language := c.Query("language")
 	uid := middleware.CurrentUserIDOrZero(c)
+
+	limit := exerciseDefaultLimit
+	if v := c.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = min(n, exerciseMaxLimit)
+		}
+	}
+	offset := 0
+	if v := c.Query("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+
+	// limit+1 件取得して hasNext を判定する（COUNT クエリを別途発行しない）。
 	rows, err := h.listWithStatus.Execute(c.Request.Context(), usecase.ListMasterExercisesWithStatusInput{
 		UserID:   uid,
 		Language: language,
+		Offset:   offset,
+		Limit:    limit + 1,
 	})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "演習問題の取得に失敗しました"})
 		return
 	}
+
+	hasNext := len(rows) > limit
+	if hasNext {
+		rows = rows[:limit]
+	}
+
 	items := make([]masterExerciseListItemResponse, len(rows))
 	for i, r := range rows {
 		items[i] = masterExerciseListItemResponse{
@@ -83,7 +124,21 @@ func (h *MasterExerciseHandler) List(c *gin.Context) {
 			Stats:       r.Stats,
 		}
 	}
-	c.JSON(http.StatusOK, items)
+	c.JSON(http.StatusOK, exercisePageResponse{
+		Items:   items,
+		HasNext: hasNext,
+		Offset:  offset,
+		Limit:   limit,
+	})
+}
+
+// min は Go 1.21+ 組み込みと競合しないよう、ローカル定義は不要。
+// Go 1.21+ では builtin の min を使える。
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // GetBySlug は入出力例を含む詳細を返す。

--- a/backend/internal/handler/master_exercise_handler_test.go
+++ b/backend/internal/handler/master_exercise_handler_test.go
@@ -30,11 +30,15 @@ func (r *fakeMasterExerciseRepo) ListByLanguage(_ context.Context, language stri
 	return r.listResult, nil
 }
 
-func (r *fakeMasterExerciseRepo) ListWithStatusByLanguage(_ context.Context, _ uint64, language string) ([]repository.MasterExerciseWithStatus, error) {
-	r.listLanguage = language
+func (r *fakeMasterExerciseRepo) ListWithStatusByLanguage(_ context.Context, in repository.ListWithStatusInput) ([]repository.MasterExerciseWithStatus, error) {
+	r.listLanguage = in.Language
 	out := make([]repository.MasterExerciseWithStatus, 0, len(r.listResult))
 	for _, e := range r.listResult {
 		out = append(out, repository.MasterExerciseWithStatus{MasterExercise: e})
+	}
+	// Limit+1 件要求に対して limit+1 件まで返す（hasNext 判定テスト用）。
+	if in.Limit > 0 && len(out) > in.Limit {
+		out = out[:in.Limit]
 	}
 	return out, nil
 }
@@ -102,12 +106,15 @@ func Test_演習問題ハンドラ_一覧_言語で絞り込み(t *testing.T) {
 	if repo.listLanguage != "php" {
 		t.Errorf("listLanguage = %q, want %q", repo.listLanguage, "php")
 	}
-	var got []domain.MasterExercise
+	var got struct {
+		Items   []domain.MasterExercise `json:"items"`
+		HasNext bool                    `json:"hasNext"`
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if len(got) != 2 {
-		t.Errorf("len = %d, want 2", len(got))
+	if len(got.Items) != 2 {
+		t.Errorf("len(items) = %d, want 2", len(got.Items))
 	}
 }
 

--- a/backend/internal/usecase/list_master_exercises_with_status_usecase.go
+++ b/backend/internal/usecase/list_master_exercises_with_status_usecase.go
@@ -23,11 +23,19 @@ func NewListMasterExercisesWithStatusUseCase(
 }
 
 // ListMasterExercisesWithStatusInput は入力。 UserID=0 は未ログイン扱いで status は全部 ""。
+// Offset/Limit はスクロール型ページネーション用。Limit=0 は全件取得。
 type ListMasterExercisesWithStatusInput struct {
 	UserID   uint64
 	Language string
+	Offset   int
+	Limit    int
 }
 
 func (uc *ListMasterExercisesWithStatusUseCase) Execute(ctx context.Context, in ListMasterExercisesWithStatusInput) ([]repository.MasterExerciseWithStatus, error) {
-	return uc.exercises.ListWithStatusByLanguage(ctx, in.UserID, in.Language)
+	return uc.exercises.ListWithStatusByLanguage(ctx, repository.ListWithStatusInput{
+		UserID:   in.UserID,
+		Language: in.Language,
+		Offset:   in.Offset,
+		Limit:    in.Limit,
+	})
 }

--- a/backend/internal/usecase/repository/master_exercise.go
+++ b/backend/internal/usecase/repository/master_exercise.go
@@ -15,6 +15,15 @@ type MasterExerciseWithStatus struct {
 	Stats  ExerciseSubmissionStats `json:"stats"`
 }
 
+// ListWithStatusInput は ListWithStatusByLanguage の入力パラメータ。
+// Limit=0 はページネーション無効（全件）を表す。Offset は 0-based。
+type ListWithStatusInput struct {
+	UserID   uint64
+	Language string
+	Offset   int
+	Limit    int
+}
+
 // MasterExerciseRepository は運営マスタ演習問題の永続化を担う（言語フィルタは ListByLanguage）。
 type MasterExerciseRepository interface {
 	ListByLanguage(ctx context.Context, language string) ([]domain.MasterExercise, error)
@@ -23,5 +32,6 @@ type MasterExerciseRepository interface {
 
 	// ListWithStatusByLanguage は公開済み問題を、 current user の提出状態 + 全体集計付きで
 	// 1 クエリ（master_exercises ⟕ exercise_submissions 集計）で返す。userID=0 は未ログイン扱いで status="".
-	ListWithStatusByLanguage(ctx context.Context, userID uint64, language string) ([]MasterExerciseWithStatus, error)
+	// Limit > 0 のとき LIMIT/OFFSET を適用する。Limit=0 は全件取得。
+	ListWithStatusByLanguage(ctx context.Context, in ListWithStatusInput) ([]MasterExerciseWithStatus, error)
 }

--- a/backend/internal/usecase/submit_master_exercise_usecase_test.go
+++ b/backend/internal/usecase/submit_master_exercise_usecase_test.go
@@ -30,7 +30,7 @@ func (r *fakeMasterExerciseRepo) GetBySlug(context.Context, string) (*domain.Mas
 	return r.get, r.err
 }
 
-func (r *fakeMasterExerciseRepo) ListWithStatusByLanguage(context.Context, uint64, string) ([]repository.MasterExerciseWithStatus, error) {
+func (r *fakeMasterExerciseRepo) ListWithStatusByLanguage(context.Context, repository.ListWithStatusInput) ([]repository.MasterExerciseWithStatus, error) {
 	return nil, nil
 }
 

--- a/frontend/src/hooks/__tests__/useExerciseList.test.ts
+++ b/frontend/src/hooks/__tests__/useExerciseList.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useExerciseList } from '../useExerciseList';
 import ExerciseRepository from '../../repositories/ExerciseRepository';
+import { ExercisePage } from '../../types';
 
 vi.mock('../../repositories/ExerciseRepository', () => ({
   default: { listExercises: vi.fn() },
@@ -9,23 +10,35 @@ vi.mock('../../repositories/ExerciseRepository', () => ({
 
 const mockList = vi.mocked(ExerciseRepository.listExercises);
 
+const emptyPage: ExercisePage = { items: [], hasNext: false, offset: 0, limit: 20 };
+
+function makePage(items: ExercisePage['items'], hasNext = false): ExercisePage {
+  return { items, hasNext, offset: 0, limit: 20 };
+}
+
+const baseItem = {
+  id: 1, slug: 'a', category: '基礎', orderIndex: 1, language: 'php',
+  title: '', difficulty: 1, mode: 'qa' as const, isPublished: true,
+  status: '' as const, stats: { totalSubmissions: 0, solvedUsers: 0 },
+};
+
 describe('useExerciseList', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('初期化時に PHP の一覧を取得する', async () => {
-    mockList.mockResolvedValue([]);
+    mockList.mockResolvedValue(emptyPage);
     const { result } = renderHook(() => useExerciseList());
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(mockList).toHaveBeenCalledWith('php');
+    expect(mockList).toHaveBeenCalledWith('php', 0, 20);
   });
 
-  it('language を切り替えると再 fetch する', async () => {
-    mockList.mockResolvedValue([]);
+  it('language を切り替えると items をリセットして再 fetch する', async () => {
+    mockList.mockResolvedValue(emptyPage);
     const { result } = renderHook(() => useExerciseList());
     await waitFor(() => expect(result.current.loading).toBe(false));
     act(() => result.current.setLanguage(''));
     await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
-    expect(mockList).toHaveBeenLastCalledWith(undefined);
+    expect(mockList).toHaveBeenLastCalledWith(undefined, 0, 20);
   });
 
   it('取得失敗時は error をセットする', async () => {
@@ -36,13 +49,38 @@ describe('useExerciseList', () => {
   });
 
   it('カテゴリのユニーク一覧を返す', async () => {
-    mockList.mockResolvedValue([
-      { id: 1, slug: 'a', category: '基礎', orderIndex: 1, language: 'php', title: '', description: '', starterCode: '', hintText: '', expectedOutput: '', difficulty: 1, isPublished: true, createdAt: '', updatedAt: '', status: '' as const, stats: { totalSubmissions: 0, solvedUsers: 0 } },
-      { id: 2, slug: 'b', category: '基礎', orderIndex: 2, language: 'php', title: '', description: '', starterCode: '', hintText: '', expectedOutput: '', difficulty: 1, isPublished: true, createdAt: '', updatedAt: '', status: '' as const, stats: { totalSubmissions: 0, solvedUsers: 0 } },
-      { id: 3, slug: 'c', category: '応用', orderIndex: 3, language: 'php', title: '', description: '', starterCode: '', hintText: '', expectedOutput: '', difficulty: 2, isPublished: true, createdAt: '', updatedAt: '', status: '' as const, stats: { totalSubmissions: 0, solvedUsers: 0 } },
-    ]);
+    mockList.mockResolvedValue(makePage([
+      { ...baseItem, id: 1, slug: 'a', category: '基礎' },
+      { ...baseItem, id: 2, slug: 'b', category: '基礎' },
+      { ...baseItem, id: 3, slug: 'c', category: '応用', difficulty: 2 },
+    ]));
     const { result } = renderHook(() => useExerciseList());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.categories).toEqual(['基礎', '応用']);
+  });
+
+  it('hasNext が true のとき loadMore を呼ぶと追記される', async () => {
+    mockList
+      .mockResolvedValueOnce(makePage([{ ...baseItem, id: 1, slug: 'p1' }], true))
+      .mockResolvedValueOnce(makePage([{ ...baseItem, id: 2, slug: 'p2' }], false));
+
+    const { result } = renderHook(() => useExerciseList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.exercises).toHaveLength(1);
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+    expect(result.current.exercises).toHaveLength(2);
+    expect(result.current.hasNext).toBe(false);
+  });
+
+  it('hasNext が false のとき loadMore は何もしない', async () => {
+    mockList.mockResolvedValue(emptyPage);
+    const { result } = renderHook(() => useExerciseList());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.loadingMore).toBe(false));
+    expect(mockList).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
+++ b/frontend/src/hooks/__tests__/useTeachingMaterials.test.ts
@@ -68,18 +68,6 @@ describe('useTeachingMaterials', () => {
     expect(result.current.error).toBe('教材の取得に失敗しました');
   });
 
-  it('searchQuery でタイトルがフィルタされる', async () => {
-    courseMocks.listMaterials.mockResolvedValue([
-      sample(1, { title: 'PHP 入門' }),
-      sample(2, { title: 'Go 入門' }),
-    ]);
-    const { result } = renderHook(() => useTeachingMaterials(5));
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    act(() => result.current.setSearchQuery('php'));
-    expect(result.current.filtered).toHaveLength(1);
-    expect(result.current.filtered[0].title).toBe('PHP 入門');
-  });
-
   it('選択した教材だけ本文を都度取得して selected に入る（全章は先読みしない）', async () => {
     courseMocks.listMaterials.mockResolvedValue([sample(1), sample(2)]);
     materialMocks.get.mockResolvedValue({ ...sample(1), content: '# 本文1' });

--- a/frontend/src/hooks/useExerciseList.ts
+++ b/frontend/src/hooks/useExerciseList.ts
@@ -1,13 +1,10 @@
-import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import ExerciseRepository from '../repositories/ExerciseRepository';
 import { MasterExerciseWithStatus } from '../types';
 
-// 言語フィルタを localStorage に保存するキー。 ページ離脱 / リロードしても
-// 前回選んだ言語を復元できるよう、 ブラウザに永続化する。
 const LANGUAGE_STORAGE_KEY = 'frestyle:exercise-list:language';
-
-// localStorage が許す言語コード集合 (許容されない値は default に戻す)。
-const VALID_LANGUAGES = new Set(['', 'php', 'go', 'bash', 'docker']);
+const VALID_LANGUAGES = new Set(['', 'php', 'go', 'bash', 'git', 'docker']);
+const PAGE_SIZE = 20;
 
 function loadStoredLanguage(fallback: string): string {
   if (typeof window === 'undefined') return fallback;
@@ -15,7 +12,7 @@ function loadStoredLanguage(fallback: string): string {
     const v = window.localStorage.getItem(LANGUAGE_STORAGE_KEY);
     if (v !== null && VALID_LANGUAGES.has(v)) return v;
   } catch {
-    // SSR / プライベートブラウジング 等で localStorage が使えない場合は fallback。
+    // SSR / プライベートブラウジング等で localStorage が使えない場合は fallback。
   }
   return fallback;
 }
@@ -25,20 +22,16 @@ function persistLanguage(value: string) {
   try {
     window.localStorage.setItem(LANGUAGE_STORAGE_KEY, value);
   } catch {
-    // 容量制限 / 拒否設定 で書き込めない場合は黙って無視。
+    // 容量制限 / 拒否設定で書き込めない場合は黙って無視。
   }
 }
 
 /**
  * useExerciseList — 演習問題リストページの状態管理フック。
  *
- * 一覧 API は current user のステータス（solved / in_progress / 未着手）と
- * 全ユーザ合計の集計（提出数 / 正答ユーザ数）を含むので、 リスト UI で
- * バッジ + 解答率を直接表示できる。
- *
- * 言語フィルタは UI 側の `language` state に応じて再 fetch する。
- * 空文字なら全言語を返す。 selectedLanguage は localStorage で 永続化するので、
- * 演習詳細ページから戻っても 前回の選択が復元される。
+ * スクロール型ページネーション（無限スクロール）対応。
+ * 言語フィルタを切り替えると蓄積リストをリセットしてページ先頭から再取得する。
+ * loadMore() を呼ぶと次ページを取得して items に追記する。
  */
 export function useExerciseList(initialLanguage: string = 'php') {
   const [language, setLanguageState] = useState(() => loadStoredLanguage(initialLanguage));
@@ -47,17 +40,29 @@ export function useExerciseList(initialLanguage: string = 'php') {
     setLanguageState(next);
     persistLanguage(next);
   }, []);
-  const [exercises, setExercises] = useState<MasterExerciseWithStatus[]>([]);
+
+  const [items, setItems] = useState<MasterExerciseWithStatus[]>([]);
+  const [hasNext, setHasNext] = useState(false);
+  const [offset, setOffset] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // 言語変更時にリストをリセットして最初のページを再取得する。
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    ExerciseRepository.listExercises(language || undefined)
-      .then((list) => {
-        if (!cancelled) setExercises(list);
+    setItems([]);
+    setOffset(0);
+    setHasNext(false);
+
+    ExerciseRepository.listExercises(language || undefined, 0, PAGE_SIZE)
+      .then((page) => {
+        if (cancelled) return;
+        setItems(page.items);
+        setHasNext(page.hasNext);
+        setOffset(PAGE_SIZE);
       })
       .catch(() => {
         if (!cancelled) setError('演習問題の取得に失敗しました');
@@ -65,22 +70,61 @@ export function useExerciseList(initialLanguage: string = 'php') {
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
-    return () => {
-      cancelled = true;
-    };
+
+    return () => { cancelled = true; };
   }, [language]);
 
+  // 次ページを追加取得する（IntersectionObserver から呼ばれる）。
+  const loadMore = useCallback(() => {
+    if (loadingMore || !hasNext) return;
+    setLoadingMore(true);
+
+    ExerciseRepository.listExercises(language || undefined, offset, PAGE_SIZE)
+      .then((page) => {
+        setItems((prev) => [...prev, ...page.items]);
+        setHasNext(page.hasNext);
+        setOffset((prev) => prev + PAGE_SIZE);
+      })
+      .catch(() => {
+        setError('追加取得に失敗しました');
+      })
+      .finally(() => {
+        setLoadingMore(false);
+      });
+  }, [language, offset, hasNext, loadingMore]);
+
+  // カテゴリのユニーク一覧（出現順）。
   const categories = useMemo(
-    () => Array.from(new Set(exercises.map((e) => e.category))),
-    [exercises],
+    () => Array.from(new Set(items.map((e) => e.category))),
+    [items],
   );
+
+  // sentinelRef を渡し、要素が viewport に入ったら loadMore を呼ぶ。
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasNext) return;
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) loadMore();
+      },
+      { rootMargin: '200px' },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [hasNext, loadMore]);
 
   return {
     language,
     setLanguage,
-    exercises,
+    exercises: items,
     categories,
     loading,
+    loadingMore,
+    hasNext,
     error,
+    sentinelRef,
+    loadMore,
   };
 }

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -6,16 +6,21 @@ import { MasterExerciseWithStatus } from '../types';
 /**
  * ExerciseListPage — `/code-editor` のリスト画面。
  *
- * - カード形式で全演習問題を一覧表示
- * - 各カードに current user のステータス（解いた / 取り組み中 / 未着手）と
- *   全体集計（提出数 / 正答ユーザ数）を表示
- * - クリックで詳細ページ `/code-editor/:slug` へ遷移
- *
- * 言語フィルタは UI 上で切替可能。 PHP のみ運用中の現時点では実用性は薄いが、
- * 多言語化を見据えて入口だけ用意する。
+ * - カード形式で演習問題を一覧表示
+ * - スクロール型ページネーション（IntersectionObserver）で次ページを自動取得
+ * - カテゴリ見出しは蓄積されたリストから動的に生成する
  */
 export default function ExerciseListPage() {
-  const { language, setLanguage, exercises, categories, loading, error } = useExerciseList();
+  const {
+    language,
+    setLanguage,
+    exercises,
+    categories,
+    loading,
+    loadingMore,
+    error,
+    sentinelRef,
+  } = useExerciseList();
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-5xl mx-auto space-y-6">
@@ -40,6 +45,7 @@ export default function ExerciseListPage() {
           <option value="">すべて</option>
           <option value="php">PHP</option>
           <option value="go">Go</option>
+          <option value="git">Git</option>
           <option value="bash">Bash / Linux</option>
           <option value="docker">Docker</option>
         </select>
@@ -70,6 +76,13 @@ export default function ExerciseListPage() {
           </div>
         </section>
       ))}
+
+      {/* IntersectionObserver のターゲット。viewport に入ると次ページを自動取得する。 */}
+      <div ref={sentinelRef} className="h-1" aria-hidden />
+
+      {loadingMore && (
+        <p className="text-sm text-center text-[var(--color-text-muted)] py-4">読み込み中...</p>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ExerciseListPage from '../ExerciseListPage';
 import ExerciseRepository from '../../repositories/ExerciseRepository';
+import { ExercisePage } from '../../types';
 
 vi.mock('../../repositories/ExerciseRepository', () => ({
   default: {
@@ -11,6 +12,8 @@ vi.mock('../../repositories/ExerciseRepository', () => ({
 }));
 
 const mockListExercises = vi.mocked(ExerciseRepository.listExercises);
+
+const emptyPage: ExercisePage = { items: [], hasNext: false, offset: 0, limit: 20 };
 
 function renderPage() {
   return render(
@@ -26,7 +29,7 @@ describe('ExerciseListPage', () => {
   });
 
   it('ヘッダーに「コード学習」が表示される', async () => {
-    mockListExercises.mockResolvedValue([]);
+    mockListExercises.mockResolvedValue(emptyPage);
     renderPage();
     await waitFor(() => expect(screen.getByRole('heading', { name: 'コード学習' })).toBeInTheDocument());
   });
@@ -38,22 +41,23 @@ describe('ExerciseListPage', () => {
   });
 
   it('空配列なら「該当する問題がありません」を表示する', async () => {
-    mockListExercises.mockResolvedValue([]);
+    mockListExercises.mockResolvedValue(emptyPage);
     renderPage();
     await waitFor(() => expect(screen.getByText('該当する問題がありません。')).toBeInTheDocument());
   });
 
   it('問題カードが status バッジと統計を表示する', async () => {
-    mockListExercises.mockResolvedValue([
-      {
+    mockListExercises.mockResolvedValue({
+      items: [{
         id: 1, slug: 'php-1', language: 'php', orderIndex: 1, category: '基礎',
-        title: 'Hello World', description: '出力する', starterCode: '', hintText: '',
-        expectedOutput: 'Hello', difficulty: 1, isPublished: true,
-        createdAt: '', updatedAt: '',
+        title: 'Hello World', difficulty: 1, mode: 'execute', isPublished: true,
         status: 'solved' as const,
         stats: { totalSubmissions: 12, solvedUsers: 10 },
-      },
-    ]);
+      }],
+      hasNext: false,
+      offset: 0,
+      limit: 20,
+    });
     renderPage();
     await waitFor(() => expect(screen.getByText('Hello World')).toBeInTheDocument());
     expect(screen.getByText('解いた')).toBeInTheDocument();
@@ -62,32 +66,34 @@ describe('ExerciseListPage', () => {
   });
 
   it('未着手のカードには未着手バッジが付く', async () => {
-    mockListExercises.mockResolvedValue([
-      {
+    mockListExercises.mockResolvedValue({
+      items: [{
         id: 2, slug: 'php-2', language: 'php', orderIndex: 2, category: '基礎',
-        title: '変数', description: '変数を使う', starterCode: '', hintText: '',
-        expectedOutput: '1', difficulty: 1, isPublished: true,
-        createdAt: '', updatedAt: '',
+        title: '変数', difficulty: 1, mode: 'execute', isPublished: true,
         status: '' as const,
         stats: { totalSubmissions: 0, solvedUsers: 0 },
-      },
-    ]);
+      }],
+      hasNext: false,
+      offset: 0,
+      limit: 20,
+    });
     renderPage();
     await waitFor(() => expect(screen.getByText('変数')).toBeInTheDocument());
     expect(screen.getByText('未着手')).toBeInTheDocument();
   });
 
   it('カードクリックで /code-editor/:slug へのリンクを描画する', async () => {
-    mockListExercises.mockResolvedValue([
-      {
+    mockListExercises.mockResolvedValue({
+      items: [{
         id: 3, slug: 'php-3', language: 'php', orderIndex: 3, category: '基礎',
-        title: '配列', description: '', starterCode: '', hintText: '',
-        expectedOutput: '', difficulty: 2, isPublished: true,
-        createdAt: '', updatedAt: '',
+        title: '配列', difficulty: 2, mode: 'execute', isPublished: true,
         status: 'in_progress' as const,
         stats: { totalSubmissions: 5, solvedUsers: 2 },
-      },
-    ]);
+      }],
+      hasNext: false,
+      offset: 0,
+      limit: 20,
+    });
     renderPage();
     await waitFor(() => expect(screen.getByText('配列')).toBeInTheDocument());
     const link = screen.getByRole('link', { name: /配列/ });

--- a/frontend/src/repositories/ExerciseRepository.ts
+++ b/frontend/src/repositories/ExerciseRepository.ts
@@ -1,7 +1,7 @@
 import api from '../lib/axios';
 import { EXERCISES, CODE } from '../constants/apiRoutes';
 import {
-  MasterExerciseWithStatus,
+  ExercisePage,
   MasterExerciseDetail,
   CodeExecutionResult,
   ExerciseSubmitResult,
@@ -16,11 +16,13 @@ import {
  * 提出 API はテストケース全件を採点して履歴に保存する。
  */
 const ExerciseRepository = {
-  async listExercises(language?: string): Promise<MasterExerciseWithStatus[]> {
-    const url = language
-      ? `${EXERCISES.list}?language=${encodeURIComponent(language)}`
-      : EXERCISES.list;
-    const res = await api.get<MasterExerciseWithStatus[]>(url);
+  async listExercises(language?: string, offset = 0, limit = 20): Promise<ExercisePage> {
+    const params = new URLSearchParams();
+    if (language) params.set('language', language);
+    params.set('offset', String(offset));
+    params.set('limit', String(limit));
+    const url = `${EXERCISES.list}?${params.toString()}`;
+    const res = await api.get<ExercisePage>(url);
     return res.data;
   },
 

--- a/frontend/src/repositories/__tests__/ExerciseRepository.test.ts
+++ b/frontend/src/repositories/__tests__/ExerciseRepository.test.ts
@@ -19,15 +19,21 @@ describe('ExerciseRepository', () => {
   });
 
   it('listExercises: 言語フィルタ付きで一覧を取得する', async () => {
-    mockedGet.mockResolvedValue({ data: [] });
+    mockedGet.mockResolvedValue({ data: { items: [], hasNext: false, offset: 0, limit: 20 } });
     await ExerciseRepository.listExercises('php');
-    expect(mockedGet).toHaveBeenCalledWith('/api/v2/exercises?language=php');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/exercises?language=php&offset=0&limit=20');
   });
 
   it('listExercises: 言語未指定なら全言語を取得する', async () => {
-    mockedGet.mockResolvedValue({ data: [] });
+    mockedGet.mockResolvedValue({ data: { items: [], hasNext: false, offset: 0, limit: 20 } });
     await ExerciseRepository.listExercises();
-    expect(mockedGet).toHaveBeenCalledWith('/api/v2/exercises');
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/exercises?offset=0&limit=20');
+  });
+
+  it('listExercises: offset と limit を指定できる', async () => {
+    mockedGet.mockResolvedValue({ data: { items: [], hasNext: true, offset: 20, limit: 20 } });
+    await ExerciseRepository.listExercises('go', 20, 20);
+    expect(mockedGet).toHaveBeenCalledWith('/api/v2/exercises?language=go&offset=20&limit=20');
   });
 
   it('getDetail: slug で詳細を取得する', async () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -627,6 +627,14 @@ export interface MasterExerciseWithStatus {
   stats: ExerciseSubmissionStats;
 }
 
+/** 演習問題一覧 API のページネーションレスポンス。 */
+export interface ExercisePage {
+  items: MasterExerciseWithStatus[];
+  hasNext: boolean;
+  offset: number;
+  limit: number;
+}
+
 /** 提出 API (`POST /api/v2/exercises/:slug/submit`) のレスポンス 1 件あたりの採点結果。 */
 export interface ExerciseTestCaseResult {
   orderIndex: number;


### PR DESCRIPTION
## 概要

`/code-editor` の演習問題一覧が全件取得だったため、問題数増加に備えてスクロール型ページネーション（無限スクロール）を実装した。

## 変更内容

**バックエンド**
- `ListWithStatusInput` に `Offset` / `Limit` フィールドを追加
- persistence の SQL に `LIMIT ? OFFSET ?` を適用（`Limit=0` は全件取得に後方互換）
- handler が `limit+1` 件取得して `hasNext` を判定（COUNT クエリ不要）
- API レスポンスを `{ items, hasNext, offset, limit }` のラッパーに変更
- デフォルト `limit=20`、最大 `limit=100`

**フロントエンド**
- `ExercisePage` 型を追加
- `useExerciseList` を蓄積型に書き換え（言語変更時はリセット）
- `sentinelRef` で IntersectionObserver を組み込み、スクロール末尾で自動追記
- 言語フィルタに「Git」を追加（次PR でラベル修正・問題追加予定）
- `useTeachingMaterials` テストの `searchQuery` 残骸（PR #2021 の消し忘れ）を削除

## テスト

- `go test ./internal/...` → 全 PASS
- `vitest run` → 140 ファイル 1130 テスト全 PASS
- OpenAPI spec 再生成済み（`make openapi`）

## 関連 Issue

<!-- 該当 Issue があれば記載 -->