### PR TITLE
feat: Git演習問題を30問に拡充しlanguage表示をGitに統一

### DIFF
--- a/backend/internal/domain/master_exercise.go
+++ b/backend/internal/domain/master_exercise.go
@@ -29,10 +29,12 @@ func (MasterExercise) TableName() string { return "master_exercises" }
 
 // 対応言語の定数。追加時は usecase / フロント側の許容セットも揃える。
 const (
-	ExerciseLanguagePhp = "php"
-	ExerciseLanguageSql = "sql"
-	ExerciseLanguageGo  = "go"
-	ExerciseLanguageJs  = "javascript"
+	ExerciseLanguagePhp  = "php"
+	ExerciseLanguageSql  = "sql"
+	ExerciseLanguageGo   = "go"
+	ExerciseLanguageJs   = "javascript"
+	ExerciseLanguageBash = "bash"
+	ExerciseLanguageGit  = "git"
 )
 
 // 採点モードの定数。


### PR DESCRIPTION
## 概要

- 演習問題一覧 (`/code-editor`) で Git 演習が「BASH」と表示されていた問題を修正
- Git 演習問題を既存の10問から30問に拡充

## 変更内容

### backend
- `domain/master_exercise.go`: `ExerciseLanguageBash = "bash"` と `ExerciseLanguageGit = "git"` 定数を追加

### frestyle-teaching-materials（教材リポジトリ / Supabase への適用済み）
- `exercises/git/git-1〜git-10`: `language: bash` → `language: git` に変更
- `exercises/git/git-11〜git-30`: 新規20問を追加
  - カテゴリ: 基本操作 / リモート / ブランチ / 差分確認 / 履歴操作
  - 追加コマンド: git pull, git clone, git branch, git switch, git branch -d, git restore, git stash, git stash pop, git commit --amend, git remote -v, git fetch, git blame, git show, git rebase, git cherry-pick, git rm --cached, git reflog, git tag, git reset --soft, git bisect

### DB 適用
- `make apply-migration-supabase` で Supabase 本番 DB に適用済み

## テスト

- `go test ./...` : 全 PASS
- `vitest run` : 1130/1130 PASS（PR #2023 時点と変わらず）
- Supabase: git 演習 30 件 UPSERT 確認済み

## 関連 Issue

なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 演習問題で利用可能な言語に「Bash」と「Git」が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->