### PR TITLE
fix: 演習一覧で items が null のときクラッシュする問題を修正

### DIFF
--- a/frontend/src/hooks/useExerciseList.ts
+++ b/frontend/src/hooks/useExerciseList.ts
@@ -60,8 +60,9 @@ export function useExerciseList(initialLanguage: string = 'php') {
     ExerciseRepository.listExercises(language || undefined, 0, PAGE_SIZE)
       .then((page) => {
         if (cancelled) return;
-        setItems(page.items);
-        setHasNext(page.hasNext);
+        // page.items が null/undefined のとき（旧バックエンドが配列を直接返す等）でもクラッシュしない。
+        setItems(Array.isArray(page?.items) ? page.items : []);
+        setHasNext(page?.hasNext ?? false);
         setOffset(PAGE_SIZE);
       })
       .catch(() => {
@@ -81,8 +82,9 @@ export function useExerciseList(initialLanguage: string = 'php') {
 
     ExerciseRepository.listExercises(language || undefined, offset, PAGE_SIZE)
       .then((page) => {
-        setItems((prev) => [...prev, ...page.items]);
-        setHasNext(page.hasNext);
+        const newItems = Array.isArray(page?.items) ? page.items : [];
+        setItems((prev) => [...prev, ...newItems]);
+        setHasNext(page?.hasNext ?? false);
         setOffset((prev) => prev + PAGE_SIZE);
       })
       .catch(() => {


### PR DESCRIPTION
## 概要

演習一覧ページで `TypeError: i.map is not a function` が発生していた問題を修正。

## 原因

`useExerciseList` フックの `setItems(page.items)` にて、`page.items` が `null` / `undefined` のとき（ネットワーク瞬断・旧フォーマット応答・予期外レスポンス等）、`items` ステートが配列以外になっていた。その後 `useMemo(() => items.map(...))` が実行されると `items.map is not a function` でクラッシュ。

## 変更内容

`frontend/src/hooks/useExerciseList.ts`

- 初回フェッチ: `setItems(page.items)` → `setItems(Array.isArray(page?.items) ? page.items : [])`
- 追加フェッチ: `...page.items` → `...(Array.isArray(page?.items) ? page.items : [])`
- `hasNext` も `page?.hasNext ?? false` でオプショナルチェーン付き

## テスト

- `tsc --noEmit` : エラーなし
- `vitest run useExerciseList.test.ts` : 6/6 Pass

## 関連 Issue

ユーザー報告のコンソールエラー:
```
TypeError: i.map is not a function
    at ExerciseListPage-BC7nO2pI.js:1:1447
    at Object.ws [as useMemo] (vendor-react-N2z0p55G.js:8:56292)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* エクササイズリスト取得時の安定性を改善しました。レスポンスデータが想定外の形式であっても、アプリケーションがクラッシュしなくなります。初回読み込みと追加読み込みの両方で、不正なレスポンスに対して適切なデフォルト値が使用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->