### PR TITLE
style: 認証画面のダークモード残骸を light テーマに統一

### DIFF
--- a/frontend/src/pages/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/AcceptInvitationPage.tsx
@@ -70,7 +70,7 @@ export default function AcceptInvitationPage() {
           管理者から招待が届いています。下記の内容でアカウントを作成します。
         </p>
 
-        <dl className="bg-[var(--color-surface-alt)] rounded-lg p-4 space-y-2 text-sm">
+        <dl className="bg-surface-2 rounded-lg p-4 space-y-2 text-sm">
           {invitation.companyName && (
             <div className="flex justify-between gap-4">
               <dt className="text-[var(--color-text-muted)]">招待元の会社</dt>

--- a/frontend/src/pages/CompanyApplicationPage.tsx
+++ b/frontend/src/pages/CompanyApplicationPage.tsx
@@ -26,7 +26,7 @@ export default function CompanyApplicationPage() {
       {submitted ? (
         <p
           role="status"
-          className="flex items-center justify-center gap-1 text-emerald-400 text-center p-4 bg-emerald-900/30 rounded-lg font-medium"
+          className="flex items-center justify-center gap-1 text-emerald-700 text-center p-4 bg-emerald-50 border border-emerald-200 rounded-lg font-medium"
         >
           <CheckCircleIcon className="w-5 h-5" aria-hidden="true" />
           申請を受け付けました。担当者より追ってご連絡いたします。
@@ -40,7 +40,7 @@ export default function CompanyApplicationPage() {
           {error && (
             <p
               role="alert"
-              className="flex items-center justify-center gap-1 text-rose-400 text-center mb-4 p-3 bg-rose-900/30 rounded-lg font-medium"
+              className="flex items-center justify-center gap-1 text-rose-700 text-center mb-4 p-3 bg-rose-50 border border-rose-200 rounded-lg font-medium"
             >
               <XCircleIcon className="w-4 h-4" aria-hidden="true" />
               {error}


### PR DESCRIPTION
ログイン/企業申請/招待画面の body 背景はダッシュボード(bg-surface #FAFAF8)と元々一致。light テーマで浮くダークモード残骸(bg-emerald-900/30 等・未定義 --color-surface-alt)を統一。tsc/build OK・デザイン専用。