### PR TITLE
fix: ホームダッシュボードのメニューと統計を同時表示・レイアウト調整

### DIFF
--- a/docs/dashboard-ui.md
+++ b/docs/dashboard-ui.md
@@ -1,0 +1,45 @@
+# ホームダッシュボード（MenuPage）のレイアウトと表示タイミング
+
+`/`（ホーム＝[MenuPage](../frontend/src/pages/MenuPage.tsx)）のレイアウトと、メニューカード／
+パーソナライズ統計（右サイドバー）の表示タイミングについて。
+
+## 構成
+
+2 カラム構成（`lg` 以上で横並び、それ未満で縦積み）。
+
+- **左カラム**: ロール別のメニューカード群（[FeatureCard](../frontend/src/pages/MenuPage.tsx)）
+  - super_admin … 管理機能のみ
+  - company_admin … 学習 + ツール + 管理
+  - trainee … 学習 + ツール（AI カードは `aiChatEnabledForTrainees` に従う）
+- **右サイドバー**（super_admin 以外）: 学習統計
+  [DashboardStats](../frontend/src/components/dashboard/DashboardStats.tsx)
+  - KPI（連続学習 / 演習数 / 正答率 / 章完了）2×2
+  - 学習カレンダー（過去 90 日のヒートマップ）
+    [LearningCalendar](../frontend/src/components/dashboard/LearningCalendar.tsx)
+
+メニューカードのグリッドは `sm:grid-cols-2`（最大 2 列）。以前は `lg:grid-cols-3` だったが、
+1 セクション 2 カードのとき 3 列目が空いて間延びして見えたため 2 列に統一した。
+
+## 表示タイミング（メニューと統計を同時に出す）
+
+学習者向けダッシュボードでは、**メニューカードと右サイドバー統計を同時に表示**する。
+
+- 統計は `GET /api/v2/me/dashboard`（[useUserDashboard](../frontend/src/hooks/useUserDashboard.ts)）で
+  非同期取得する。以前はメニュー（データ非依存）が先に描画され、統計が遅れて差し込まれていたため
+  「メニューだけ先に出てサイドバーが後からポップインする」ちらつきが発生していた。
+- これを防ぐため、**統計ロード中は左右ともスケルトンを表示**し、ロード完了で両カラムを同時に実カードへ
+  差し替える。判定は `waitingForStats = !isSuperAdmin && loading`。
+- ウェルカム見出し（データ非依存）は即時表示する。
+- super_admin は統計を取得しないため（`enabled: false`）即時にメニューを表示する。
+- 統計取得に失敗（`error`）した場合はロード完了扱いとし、メニューのみ表示してページを使える状態に保つ
+  （サイドバーは出さない）。
+
+スケルトンは実レイアウトと寸法を揃え（カード高さ・KPI グリッド・カレンダー領域）、
+差し替え時のレイアウトシフトを抑える。
+
+## 学習カレンダー（ヒートマップ）
+
+過去 90 日の活動量（exercise + lesson + ai + note の合計）を 4 段階の色で表示する。
+セルは **曜日（行）× 週（列）のグリッド**（`grid-flow-col grid-rows-7`）に並べ、先頭の曜日ぶんを
+空セルで詰めて各列が日曜始まりの 1 週間に揃うようにしている。以前は `flex-wrap` で折り返していたが、
+週の境界が揃わず崩れて見えたためグリッドに変更した。

--- a/frontend/src/components/dashboard/LearningCalendar.tsx
+++ b/frontend/src/components/dashboard/LearningCalendar.tsx
@@ -5,8 +5,11 @@ interface Props {
 }
 
 /**
- * LearningCalendar は過去 90 日間の学習活動を GitHub スタイルのヒートマップで表示する。
+ * LearningCalendar は過去 90 日間の学習活動をヒートマップで表示する。
  * 活動量（exercise + lesson + ai + note の合計）に応じて 4 段階の色を割り当てる。
+ *
+ * セルは曜日（行）× 週（列）のグリッドに並べる。先頭の曜日ぶんは空セルで詰めて
+ * 各列が日曜始まりの 1 週間に揃うようにし、flex-wrap で崩れて見える問題を防ぐ。
  */
 export default function LearningCalendar({ activities }: Props) {
   // date string → 合計アクティビティ数 のマップを作る。
@@ -29,6 +32,9 @@ export default function LearningCalendar({ activities }: Props) {
     days.push(d.toISOString().slice(0, 10));
   }
 
+  // 先頭の曜日に合わせて空セルを詰める（列＝週、行＝曜日 で日曜始まりに揃える）。
+  const leadingPad = new Date(`${days[0]}T00:00:00Z`).getUTCDay();
+
   const colorClass = (count: number) => {
     if (count === 0) return 'bg-[var(--color-surface-3)]';
     if (count <= 2) return 'bg-emerald-200 dark:bg-emerald-900';
@@ -37,11 +43,14 @@ export default function LearningCalendar({ activities }: Props) {
   };
 
   return (
-    <div className="space-y-1.5">
+    <div className="space-y-2">
       <h3 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest">
         学習カレンダー（過去 90 日）
       </h3>
-      <div className="flex flex-wrap gap-[3px]">
+      <div className="grid grid-flow-col grid-rows-7 gap-[3px] w-max">
+        {Array.from({ length: leadingPad }).map((_, i) => (
+          <div key={`pad-${i}`} className="w-3 h-3" />
+        ))}
         {days.map((day) => {
           const count = actMap.get(day) ?? 0;
           return (

--- a/frontend/src/components/dashboard/__tests__/DashboardStats.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/DashboardStats.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DashboardStats from '../DashboardStats';
+import type { UserDashboard } from '../../../types';
+
+function makeDashboard(overrides: Partial<UserDashboard> = {}): UserDashboard {
+  return {
+    streak: 3,
+    totalExercises: 10,
+    totalCorrect: 8,
+    totalLessons: 6,
+    recentActivity: [],
+    recentChapterViews: [],
+    ...overrides,
+  };
+}
+
+describe('DashboardStats', () => {
+  it('KPI（連続学習 / 演習 / 正答率 / 章完了）を表示する', () => {
+    render(<DashboardStats dashboard={makeDashboard()} />);
+
+    expect(screen.getByText('連続学習')).toBeInTheDocument();
+    expect(screen.getByText('3 日')).toBeInTheDocument();
+    expect(screen.getByText('10 問')).toBeInTheDocument();
+    // 8/10 = 80%
+    expect(screen.getByText('80%')).toBeInTheDocument();
+    expect(screen.getByText('6 章')).toBeInTheDocument();
+  });
+
+  it('演習数が 0 のとき正答率カードを出さない', () => {
+    render(<DashboardStats dashboard={makeDashboard({ totalExercises: 0, totalCorrect: 0 })} />);
+
+    expect(screen.queryByText('正答率')).not.toBeInTheDocument();
+  });
+
+  it('学習カレンダーのヒートマップを表示し、活動日にツールチップを付ける', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    render(
+      <DashboardStats
+        dashboard={makeDashboard({
+          recentActivity: [
+            {
+              userId: 1,
+              activityDate: `${today}T00:00:00Z`,
+              exerciseCount: 2,
+              correctCount: 2,
+              lessonCount: 1,
+              aiChatCount: 0,
+              noteCount: 0,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('学習カレンダー（過去 90 日）')).toBeInTheDocument();
+    // 活動 3 件（2+1）の日のセルが title 付きで存在する
+    expect(screen.getByTitle(`${today}: 3 アクティビティ`)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/__tests__/LearningCalendar.test.tsx
+++ b/frontend/src/components/dashboard/__tests__/LearningCalendar.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LearningCalendar from '../LearningCalendar';
+import type { UserDailyActivity } from '../../../types';
+
+function dayOffset(daysAgo: number): string {
+  const t = new Date();
+  const utc = new Date(Date.UTC(t.getUTCFullYear(), t.getUTCMonth(), t.getUTCDate()));
+  utc.setUTCDate(utc.getUTCDate() - daysAgo);
+  return utc.toISOString().slice(0, 10);
+}
+
+function activity(daysAgo: number, exerciseCount: number): UserDailyActivity {
+  return {
+    userId: 1,
+    activityDate: `${dayOffset(daysAgo)}T00:00:00Z`,
+    exerciseCount,
+    correctCount: 0,
+    lessonCount: 0,
+    aiChatCount: 0,
+    noteCount: 0,
+  };
+}
+
+describe('LearningCalendar', () => {
+  it('活動量の各段階（低/中/高）をツールチップ付きセルで描画する', () => {
+    render(
+      <LearningCalendar
+        activities={[
+          activity(1, 1), // <= 2
+          activity(2, 4), // <= 5
+          activity(3, 9), // > 5
+        ]}
+      />,
+    );
+
+    expect(screen.getByTitle(`${dayOffset(1)}: 1 アクティビティ`)).toBeInTheDocument();
+    expect(screen.getByTitle(`${dayOffset(2)}: 4 アクティビティ`)).toBeInTheDocument();
+    expect(screen.getByTitle(`${dayOffset(3)}: 9 アクティビティ`)).toBeInTheDocument();
+  });
+
+  it('活動がない日は 0 アクティビティのセルになる', () => {
+    render(<LearningCalendar activities={[]} />);
+
+    expect(screen.getByText('学習カレンダー（過去 90 日）')).toBeInTheDocument();
+    // 今日のセルは活動 0
+    expect(screen.getByTitle(`${dayOffset(0)}: 0 アクティビティ`)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/__tests__/useUserDashboard.test.ts
+++ b/frontend/src/hooks/__tests__/useUserDashboard.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUserDashboard } from '../useUserDashboard';
+import DashboardRepository from '../../repositories/DashboardRepository';
+import type { UserDashboard } from '../../types';
+
+vi.mock('../../repositories/DashboardRepository');
+
+const mockGet = vi.mocked(DashboardRepository.get);
+
+const sample: UserDashboard = {
+  streak: 1,
+  totalExercises: 3,
+  totalCorrect: 2,
+  totalLessons: 4,
+  recentActivity: [],
+  recentChapterViews: [],
+};
+
+describe('useUserDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('enabled=true のとき取得してダッシュボードを返す', async () => {
+    mockGet.mockResolvedValue(sample);
+    const { result } = renderHook(() => useUserDashboard());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.dashboard).toEqual(sample);
+    expect(result.current.error).toBeNull();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('取得に失敗したらエラーメッセージを立てる', async () => {
+    mockGet.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useUserDashboard());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.dashboard).toBeNull();
+    expect(result.current.error).toBe('ダッシュボードの取得に失敗しました');
+  });
+
+  it('enabled=false のときはリクエストを発行しない', () => {
+    const { result } = renderHook(() => useUserDashboard({ enabled: false }));
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.dashboard).toBeNull();
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -22,8 +22,11 @@ import DashboardStats from '../components/dashboard/DashboardStats';
  *   - company_admin : 管理 + 学習機能（AI はテナント設定に関わらず常時表示）
  *   - trainee       : 学習機能のみ。aiChatEnabledForTrainees が false なら AI カードを非表示
  *
- * API 依存なし（auth store のみ参照）。 将来的に「最近の演習」等の Quick Stats を
- * 追加する場合はここに useXxxStats() を差し込む。
+ * 表示タイミング:
+ *   学習者向けはメニューカードとパーソナライズ統計（右サイドバー）を **同時に** 出す。
+ *   統計 API のロード中はメニューを先出しせずスケルトンで待ち、レイアウトシフトと
+ *   「メニューだけ先に出てサイドバーが後から差し込まれる」ちらつきを防ぐ。
+ *   super_admin は統計を持たないので即時表示。
  */
 export default function MenuPage() {
   const role = useSelector((state: RootState) => state.auth.role);
@@ -33,31 +36,34 @@ export default function MenuPage() {
   const showAi = !isTrainee || aiEnabled;
 
   // ダッシュボード統計（super_admin は学習機能を使わないので取得しない）。
-  const { dashboard } = useUserDashboard({ enabled: !isSuperAdmin });
+  const { dashboard, loading } = useUserDashboard({ enabled: !isSuperAdmin });
+
+  // 学習者向けは統計ロード完了まで本体を出さず、両カラムを同時に出す。
+  const waitingForStats = !isSuperAdmin && loading;
 
   return (
     <div className="px-4 sm:px-6 pt-8 pb-24 max-w-6xl mx-auto">
+      {/* ウェルカムセクション（データ非依存・即時表示） */}
+      <section className="mb-8">
+        <p className="text-xs font-semibold text-brand-500 uppercase tracking-widest mb-1">
+          {isSuperAdmin ? '運営管理者ダッシュボード' : isTrainee ? '学習ダッシュボード' : '管理者ダッシュボード'}
+        </p>
+        <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
+          {isSuperAdmin ? '管理メニュー' : 'FreStyle へようこそ'}
+        </h1>
+        <p className="mt-2 text-sm text-[var(--color-text-muted)]">
+          {isSuperAdmin
+            ? '企業管理・招待などの運営操作を行えます。'
+            : 'コースや演習で学習を進め、AI チャットで疑問を解決しましょう。'}
+        </p>
+      </section>
+
       <div className="flex flex-col lg:flex-row gap-8 items-start">
-
         {/* ── 左メインコンテンツ ── */}
-        <div className="flex-1 min-w-0 space-y-10">
-
-          {/* ウェルカムセクション */}
-          <section>
-            <p className="text-xs font-semibold text-brand-500 uppercase tracking-widest mb-1">
-              {isSuperAdmin ? '運営管理者ダッシュボード' : isTrainee ? '学習ダッシュボード' : '管理者ダッシュボード'}
-            </p>
-            <h1 className="text-3xl font-bold text-[var(--color-text-primary)]">
-              {isSuperAdmin ? '管理メニュー' : 'FreStyle へようこそ'}
-            </h1>
-            <p className="mt-2 text-sm text-[var(--color-text-muted)]">
-              {isSuperAdmin
-                ? '企業管理・招待などの運営操作を行えます。'
-                : 'コースや演習で学習を進め、AI チャットで疑問を解決しましょう。'}
-            </p>
-          </section>
-
-          {isSuperAdmin ? (
+        <div className="flex-1 min-w-0 space-y-8 w-full">
+          {waitingForStats ? (
+            <MenuSkeleton />
+          ) : isSuperAdmin ? (
             <FeatureSection title="管理機能">
               <FeatureCard
                 to="/admin/companies"
@@ -143,12 +149,15 @@ export default function MenuPage() {
         </div>
 
         {/* ── 右サイドバー（学習統計）── super_admin には非表示 */}
-        {!isSuperAdmin && dashboard && (
+        {!isSuperAdmin && (
           <div className="w-full lg:w-72 shrink-0">
-            <DashboardStats dashboard={dashboard} />
+            {waitingForStats ? (
+              <StatsSkeleton />
+            ) : (
+              dashboard && <DashboardStats dashboard={dashboard} />
+            )}
           </div>
         )}
-
       </div>
     </div>
   );
@@ -167,7 +176,7 @@ function FeatureSection({ title, children }: FeatureSectionProps) {
       <h2 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest">
         {title}
       </h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {children}
       </div>
     </section>
@@ -196,28 +205,77 @@ function FeatureCard({ to, icon: Icon, title, description, color, badge }: Featu
   return (
     <Link
       to={to}
-      className="group relative flex flex-col gap-4 p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] hover:border-[var(--color-text-muted)]/40 hover:shadow-sm transition-all duration-150"
+      className="group relative flex h-full flex-col p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] hover:border-[var(--color-text-muted)]/40 hover:shadow-sm transition-all duration-150"
     >
       {badge && (
-        <span className="absolute top-3 right-3 text-[10px] font-semibold px-2 pt-px pb-[3px] rounded-full bg-emerald-100 text-emerald-700">
+        <span className="absolute top-4 right-4 text-[10px] font-semibold px-2 pt-px pb-[3px] rounded-full bg-emerald-100 text-emerald-700">
           {badge}
         </span>
       )}
-      <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBg[color]}`}>
-        <Icon className="w-5 h-5 -translate-y-px" />
+      <div className="flex items-start gap-3">
+        <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBg[color]}`}>
+          <Icon className="w-5 h-5 -translate-y-px" />
+        </div>
+        <div className="min-w-0 pt-1">
+          <h3 className="font-semibold text-[var(--color-text-primary)] text-sm group-hover:text-brand-500 transition-colors">
+            {title}
+          </h3>
+        </div>
       </div>
-      <div className="flex-1 space-y-1">
-        <h3 className="font-semibold text-[var(--color-text-primary)] text-sm group-hover:text-brand-500 transition-colors">
-          {title}
-        </h3>
-        <p className="text-xs text-[var(--color-text-muted)] leading-relaxed">
-          {description}
-        </p>
-      </div>
-      <div className="flex items-center gap-1 text-xs text-[var(--color-text-muted)] group-hover:text-brand-500 transition-colors">
+      <p className="mt-3 text-xs text-[var(--color-text-muted)] leading-relaxed">
+        {description}
+      </p>
+      <div className="mt-4 flex items-center gap-1 text-xs text-[var(--color-text-muted)] group-hover:text-brand-500 transition-colors">
         <span>開く</span>
-        <ArrowRightIcon className="w-3 h-3 translate-x-0 group-hover:translate-x-0.5 transition-transform" />
+        <ArrowRightIcon className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
       </div>
     </Link>
+  );
+}
+
+// ─── スケルトン（ロード中のプレースホルダ）─────────────────────────────────
+
+/** MenuSkeleton はメニューカード読み込み中のプレースホルダ。実レイアウトと寸法を揃える。 */
+function MenuSkeleton() {
+  return (
+    <div className="space-y-8" aria-hidden="true">
+      {[2, 3].map((count, s) => (
+        <section key={s} className="space-y-3">
+          <div className="h-3 w-16 rounded bg-[var(--color-surface-3)] animate-pulse" />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {Array.from({ length: count }).map((_, i) => (
+              <div
+                key={i}
+                className="h-[148px] rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-5"
+              >
+                <div className="w-9 h-9 rounded-lg bg-[var(--color-surface-3)] animate-pulse" />
+                <div className="mt-3 h-3.5 w-24 rounded bg-[var(--color-surface-3)] animate-pulse" />
+                <div className="mt-3 h-3 w-full rounded bg-[var(--color-surface-3)] animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+/** StatsSkeleton は右サイドバー（学習統計）読み込み中のプレースホルダ。 */
+function StatsSkeleton() {
+  return (
+    <div
+      className="space-y-4 p-4 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)]"
+      aria-hidden="true"
+    >
+      <div className="grid grid-cols-2 gap-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-[88px] rounded-lg bg-[var(--color-surface-2)] animate-pulse" />
+        ))}
+      </div>
+      <div className="space-y-2">
+        <div className="h-3 w-40 rounded bg-[var(--color-surface-3)] animate-pulse" />
+        <div className="h-20 w-full rounded bg-[var(--color-surface-2)] animate-pulse" />
+      </div>
+    </div>
   );
 }

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -22,11 +22,11 @@ const sampleDashboard: UserDashboard = {
   recentChapterViews: [],
 };
 
-function renderMenu(role: string) {
+function renderMenu(role: string, aiChatEnabledForTrainees = true) {
   const store = configureStore({
     reducer: { auth: authReducer },
     preloadedState: {
-      auth: { role, aiChatEnabledForTrainees: true } as never,
+      auth: { role, aiChatEnabledForTrainees } as never,
     },
   });
   return render(
@@ -75,6 +75,37 @@ describe('MenuPage', () => {
     expect(screen.getByRole('heading', { name: '管理メニュー', level: 1 })).toBeInTheDocument();
     expect(screen.getByText('会社一覧')).toBeInTheDocument();
     // 学習統計は出さない
+    expect(screen.queryByText('連続学習')).not.toBeInTheDocument();
+  });
+
+  it('company_admin は学習・ツール・管理セクションと AI カードを表示する', () => {
+    mockUseUserDashboard.mockReturnValue({ dashboard: sampleDashboard, loading: false, error: null });
+    renderMenu('company_admin');
+
+    expect(screen.getByRole('heading', { name: 'FreStyle へようこそ', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('コース')).toBeInTheDocument();
+    expect(screen.getByText('AI チャット')).toBeInTheDocument();
+    expect(screen.getByText('従業員一覧')).toBeInTheDocument();
+    expect(screen.getByText('連続学習')).toBeInTheDocument();
+  });
+
+  it('trainee で AI 無効のとき AI チャットカードを出さない', () => {
+    mockUseUserDashboard.mockReturnValue({ dashboard: sampleDashboard, loading: false, error: null });
+    renderMenu('trainee', false);
+
+    expect(screen.getByText('ノート')).toBeInTheDocument();
+    expect(screen.queryByText('AI チャット')).not.toBeInTheDocument();
+  });
+
+  it('統計取得に失敗してもメニューは表示し、サイドバー統計は出さない', () => {
+    mockUseUserDashboard.mockReturnValue({
+      dashboard: null,
+      loading: false,
+      error: 'ダッシュボードの取得に失敗しました',
+    });
+    renderMenu('trainee');
+
+    expect(screen.getByText('コース')).toBeInTheDocument();
     expect(screen.queryByText('連続学習')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/__tests__/MenuPage.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import MenuPage from '../MenuPage';
+import authReducer from '../../store/authSlice';
+import { useUserDashboard } from '../../hooks/useUserDashboard';
+import type { UserDashboard } from '../../types';
+import { createMockStorage } from '../../test/mockStorage';
+
+vi.mock('../../hooks/useUserDashboard');
+
+const mockUseUserDashboard = vi.mocked(useUserDashboard);
+
+const sampleDashboard: UserDashboard = {
+  streak: 2,
+  totalExercises: 5,
+  totalCorrect: 4,
+  totalLessons: 6,
+  recentActivity: [],
+  recentChapterViews: [],
+};
+
+function renderMenu(role: string) {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: { role, aiChatEnabledForTrainees: true } as never,
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <MenuPage />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('MenuPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createMockStorage());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('統計ロード中はメニューカードを出さず（スケルトン待ち）', () => {
+    mockUseUserDashboard.mockReturnValue({ dashboard: null, loading: true, error: null });
+    renderMenu('trainee');
+
+    // ウェルカム見出しは即時表示される
+    expect(screen.getByRole('heading', { name: 'FreStyle へようこそ', level: 1 })).toBeInTheDocument();
+    // メニューカード（コース）はロード完了まで出さない
+    expect(screen.queryByText('コース')).not.toBeInTheDocument();
+  });
+
+  it('統計ロード完了後にメニューカードと統計を同時表示する', () => {
+    mockUseUserDashboard.mockReturnValue({ dashboard: sampleDashboard, loading: false, error: null });
+    renderMenu('trainee');
+
+    // メニューカードと統計（連続学習）が両方出ている
+    expect(screen.getByText('コース')).toBeInTheDocument();
+    expect(screen.getByText('コード演習')).toBeInTheDocument();
+    expect(screen.getByText('連続学習')).toBeInTheDocument();
+  });
+
+  it('super_admin は統計を取得せず即時に管理メニューを表示する', () => {
+    mockUseUserDashboard.mockReturnValue({ dashboard: null, loading: false, error: null });
+    renderMenu('super_admin');
+
+    expect(screen.getByRole('heading', { name: '管理メニュー', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('会社一覧')).toBeInTheDocument();
+    // 学習統計は出さない
+    expect(screen.queryByText('連続学習')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

ホーム（[MenuPage](../frontend/src/pages/MenuPage.tsx)）で、メニューカードが先に描画され右サイドバーの学習統計が後からポップインする「ちらつき」を解消し、全体のレイアウトを調整した。

## 変更内容

- **メニューと統計を同時表示**: 統計 API（`useUserDashboard`）のロード中は左右ともスケルトンを表示し、ロード完了で両カラムを同時に実カードへ差し替え。`waitingForStats = !isSuperAdmin && loading` で判定。ウェルカム見出しは即時表示、super_admin は統計を取得しないため即時表示。統計取得失敗時はメニューのみ表示してページを使える状態に保つ。
- **グリッド調整**: メニューカードを `sm:grid-cols-2` に統一（旧 `lg:grid-cols-3` は 1 セクション 2 カードのとき 3 列目が空いて間延びしていた）。
- **FeatureCard 整理**: アイコン+タイトルを横並びにし、`h-full` でカード高さを均一化。
- **学習カレンダー**: `flex-wrap` から曜日（行）×週（列）のグリッド（`grid-flow-col grid-rows-7`）へ変更し、先頭曜日を空セルで詰めて週境界を揃えた。
- `docs/dashboard-ui.md` を新設してレイアウト・表示タイミングを記録。

## テスト

- 追加: `src/pages/__tests__/MenuPage.test.tsx`（ロード中はメニュー非表示／ロード完了で同時表示／super_admin 即時表示）
- `tsc --noEmit` / `eslint --max-warnings 0` / `vitest run` / `npm run build` すべて green

## 関連 Issue

なし（UI 改善）

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>