### PR TITLE
refactor: handler の認証actor取得とエラーレスポンスを共通化

### DIFF
--- a/backend/internal/domain/user.go
+++ b/backend/internal/domain/user.go
@@ -4,12 +4,12 @@ import "time"
 
 // User はアプリケーション利用者のドメインモデル。
 type User struct {
-	ID          uint64  `gorm:"primaryKey" json:"id"`
-	CognitoSub  string  `gorm:"column:cognito_sub;uniqueIndex" json:"cognitoSub"`
-	Email       string  `gorm:"column:email" json:"email"`
-	Name string  `gorm:"column:name" json:"name"`
-	CompanyID   *uint64 `gorm:"column:company_id" json:"companyId,omitempty"`
-	Role        string  `gorm:"column:role" json:"role"`
+	ID         uint64  `gorm:"primaryKey" json:"id"`
+	CognitoSub string  `gorm:"column:cognito_sub;uniqueIndex" json:"cognitoSub"`
+	Email      string  `gorm:"column:email" json:"email"`
+	Name       string  `gorm:"column:name" json:"name"`
+	CompanyID  *uint64 `gorm:"column:company_id" json:"companyId,omitempty"`
+	Role       string  `gorm:"column:role" json:"role"`
 	// AiChatEnabled は AI チャット利用可否の個別上書き。nil = 会社設定に従う、
 	// true/false = この user 個別に強制 ON/OFF（company_admin が従業員ごとに設定）。
 	AiChatEnabled *bool `gorm:"column:ai_chat_enabled" json:"aiChatEnabled,omitempty"`
@@ -24,6 +24,15 @@ type User struct {
 }
 
 func (User) TableName() string { return "users" }
+
+// CompanyIDValue は CompanyID を非ポインタで返す。未所属(nil)なら 0。
+// handler/usecase で「nil なら 0」の展開を繰り返さないための小道具。
+func (u User) CompanyIDValue() uint64 {
+	if u.CompanyID == nil {
+		return 0
+	}
+	return *u.CompanyID
+}
 
 const (
 	RoleSuperAdmin   = "super_admin"

--- a/backend/internal/handler/chapter_view_handler.go
+++ b/backend/internal/handler/chapter_view_handler.go
@@ -43,10 +43,7 @@ func (h *ChapterViewHandler) RecordView(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_id"})
 		return
 	}
-	var companyID uint64
-	if user.CompanyID != nil {
-		companyID = *user.CompanyID
-	}
+	companyID := user.CompanyIDValue()
 	// ベストエフォート — 失敗しても 204 で返す。
 	_ = h.record.Execute(c.Request.Context(), usecase.RecordChapterViewInput{
 		UserID:             user.ID,

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -1,14 +1,11 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
-	"gorm.io/gorm"
 )
 
 // CourseHandler はコースの CRUD API を扱う。
@@ -18,19 +15,6 @@ type CourseHandler struct {
 
 func NewCourseHandler(uc *usecase.CourseUseCase) *CourseHandler {
 	return &CourseHandler{uc: uc}
-}
-
-func (h *CourseHandler) actorContext(c *gin.Context) (uint64, uint64, string, bool) {
-	user := middleware.CurrentUserFromContext(c)
-	if user == nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		return 0, 0, "", false
-	}
-	companyID := uint64(0)
-	if user.CompanyID != nil {
-		companyID = *user.CompanyID
-	}
-	return user.ID, companyID, user.Role, true
 }
 
 // @Summary      コース 一覧
@@ -43,7 +27,7 @@ func (h *CourseHandler) actorContext(c *gin.Context) (uint64, uint64, string, bo
 // @Router       /courses [get]
 // @Security     CookieAuth
 func (h *CourseHandler) List(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -68,7 +52,7 @@ func (h *CourseHandler) List(c *gin.Context) {
 // @Router       /courses/{id} [get]
 // @Security     CookieAuth
 func (h *CourseHandler) Get(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -79,7 +63,7 @@ func (h *CourseHandler) Get(c *gin.Context) {
 	}
 	course, err := h.uc.Get(c.Request.Context(), id, companyID, role)
 	if err != nil {
-		respondCourseErr(c, err, "コースの取得に失敗しました")
+		respondEntityErr(c, err, "コースが見つかりません", "コースの取得に失敗しました")
 		return
 	}
 	c.JSON(http.StatusOK, course)
@@ -105,7 +89,7 @@ type courseRequest struct {
 // @Router       /courses [post]
 // @Security     CookieAuth
 func (h *CourseHandler) Create(c *gin.Context) {
-	uid, companyID, role, ok := h.actorContext(c)
+	uid, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -124,7 +108,7 @@ func (h *CourseHandler) Create(c *gin.Context) {
 		IsPublished:    req.IsPublished,
 	})
 	if err != nil {
-		respondCourseErr(c, err, "コースの作成に失敗しました")
+		respondEntityErr(c, err, "コースが見つかりません", "コースの作成に失敗しました")
 		return
 	}
 	c.JSON(http.StatusCreated, course)
@@ -145,7 +129,7 @@ func (h *CourseHandler) Create(c *gin.Context) {
 // @Router       /courses/{id} [put]
 // @Security     CookieAuth
 func (h *CourseHandler) Update(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -169,7 +153,7 @@ func (h *CourseHandler) Update(c *gin.Context) {
 		IsPublished:    req.IsPublished,
 	})
 	if err != nil {
-		respondCourseErr(c, err, "コースの更新に失敗しました")
+		respondEntityErr(c, err, "コースが見つかりません", "コースの更新に失敗しました")
 		return
 	}
 	c.JSON(http.StatusOK, course)
@@ -188,7 +172,7 @@ func (h *CourseHandler) Update(c *gin.Context) {
 // @Router       /courses/{id} [delete]
 // @Security     CookieAuth
 func (h *CourseHandler) Delete(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -198,20 +182,8 @@ func (h *CourseHandler) Delete(c *gin.Context) {
 		return
 	}
 	if err := h.uc.Delete(c.Request.Context(), id, companyID, role); err != nil {
-		respondCourseErr(c, err, "コースの削除に失敗しました")
+		respondEntityErr(c, err, "コースが見つかりません", "コースの削除に失敗しました")
 		return
 	}
 	c.Status(http.StatusNoContent)
-}
-
-func respondCourseErr(c *gin.Context, err error, fallback string) {
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "コースが見つかりません"})
-		return
-	}
-	if err.Error() == "forbidden" || err.Error() == "forbidden: only company_admin or super_admin can create courses" || err.Error() == "actor must belong to a company" {
-		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
-		return
-	}
-	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
 }

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -1,0 +1,38 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"gorm.io/gorm"
+)
+
+// actorFromContext は middleware が注入した current user から (userID, companyID, role) を取り出す。
+// 未認証なら 401 を書き込んで ok=false を返すので、呼び出し側は ok を見て早期 return する。
+// 各 handler が同じ「user 取得 + companyID 展開 + 401」を書かずに済むための共通小道具。
+func actorFromContext(c *gin.Context) (userID, companyID uint64, role string, ok bool) {
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return 0, 0, "", false
+	}
+	return user.ID, user.CompanyIDValue(), user.Role, true
+}
+
+// respondEntityErr は usecase が返したエラーを HTTP ステータスへ振り分ける共通処理。
+// レコード未検出は 404(notFoundMsg)、認可エラー(forbidden* / 会社未所属)は 403、
+// それ以外は 500(fallback) を返す。エンティティ別の文言は notFoundMsg / fallback で渡す。
+func respondEntityErr(c *gin.Context, err error, notFoundMsg, fallback string) {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": notFoundMsg})
+		return
+	}
+	if strings.HasPrefix(err.Error(), "forbidden") || err.Error() == "actor must belong to a company" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
+}

--- a/backend/internal/handler/helpers_test.go
+++ b/backend/internal/handler/helpers_test.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+func TestActorFromContext(t *testing.T) {
+	t.Run("認証済み user から id/companyID/role を取り出す", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		companyID := uint64(7)
+		c.Set(middleware.ContextKeyCurrentUser, &domain.User{ID: 42, CompanyID: &companyID, Role: domain.RoleCompanyAdmin})
+
+		uid, cid, role, ok := actorFromContext(c)
+
+		assert.True(t, ok)
+		assert.Equal(t, uint64(42), uid)
+		assert.Equal(t, uint64(7), cid)
+		assert.Equal(t, domain.RoleCompanyAdmin, role)
+	})
+
+	t.Run("会社未所属(nil)なら companyID は 0", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Set(middleware.ContextKeyCurrentUser, &domain.User{ID: 1, CompanyID: nil, Role: domain.RoleSuperAdmin})
+
+		_, cid, _, ok := actorFromContext(c)
+
+		assert.True(t, ok)
+		assert.Equal(t, uint64(0), cid)
+	})
+
+	t.Run("未認証なら 401 を書き ok=false", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		_, _, _, ok := actorFromContext(c)
+
+		assert.False(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}
+
+func TestRespondEntityErr(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode int
+	}{
+		{"レコード未検出は 404", gorm.ErrRecordNotFound, http.StatusNotFound},
+		{"forbidden は 403", errors.New("forbidden"), http.StatusForbidden},
+		{"forbidden 詳細付きも 403", errors.New("forbidden: only company_admin or super_admin can create materials"), http.StatusForbidden},
+		{"会社未所属は 403", errors.New("actor must belong to a company"), http.StatusForbidden},
+		{"その他は 500", errors.New("db down"), http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+
+			respondEntityErr(c, tc.err, "見つかりません", "失敗しました")
+
+			assert.Equal(t, tc.wantCode, w.Code)
+		})
+	}
+}
+
+func TestUserCompanyIDValue(t *testing.T) {
+	cid := uint64(9)
+	assert.Equal(t, uint64(9), domain.User{CompanyID: &cid}.CompanyIDValue())
+	assert.Equal(t, uint64(0), domain.User{CompanyID: nil}.CompanyIDValue())
+}

--- a/backend/internal/handler/lesson_progress_handler.go
+++ b/backend/internal/handler/lesson_progress_handler.go
@@ -82,10 +82,7 @@ func (h *LessonProgressHandler) Complete(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, errorResponse{Error: "invalid_request"})
 		return
 	}
-	var companyID uint64
-	if user.CompanyID != nil {
-		companyID = *user.CompanyID
-	}
+	companyID := user.CompanyIDValue()
 	err := h.complete.Execute(c.Request.Context(), usecase.MarkLessonCompletedInput{
 		UserID:             user.ID,
 		ActorCompanyID:     companyID,

--- a/backend/internal/handler/teaching_material_handler.go
+++ b/backend/internal/handler/teaching_material_handler.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
@@ -18,19 +17,6 @@ type TeachingMaterialHandler struct {
 
 func NewTeachingMaterialHandler(uc *usecase.TeachingMaterialUseCase) *TeachingMaterialHandler {
 	return &TeachingMaterialHandler{uc: uc}
-}
-
-func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, string, bool) {
-	user := middleware.CurrentUserFromContext(c)
-	if user == nil {
-		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
-		return 0, 0, "", false
-	}
-	companyID := uint64(0)
-	if user.CompanyID != nil {
-		companyID = *user.CompanyID
-	}
-	return user.ID, companyID, user.Role, true
 }
 
 // List は company 内全教材を返す backward-compat 用（コース対応完了後に削除予定）。
@@ -46,7 +32,7 @@ func (h *TeachingMaterialHandler) actorContext(c *gin.Context) (uint64, uint64, 
 //	@Security     CookieAuth
 //	@Deprecated
 func (h *TeachingMaterialHandler) List(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -73,7 +59,7 @@ func (h *TeachingMaterialHandler) List(c *gin.Context) {
 //	@Router       /courses/{id}/materials [get]
 //	@Security     CookieAuth
 func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -84,7 +70,7 @@ func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
 	}
 	rows, err := h.uc.ListByCourse(c.Request.Context(), courseID, companyID, role)
 	if err != nil {
-		respondTeachingMaterialErr(c, err, "教材の取得に失敗しました")
+		respondEntityErr(c, err, "教材が見つかりません", "教材の取得に失敗しました")
 		return
 	}
 	c.JSON(http.StatusOK, rows)
@@ -103,7 +89,7 @@ func (h *TeachingMaterialHandler) ListByCourse(c *gin.Context) {
 // @Router       /teaching-materials/{id} [get]
 // @Security     CookieAuth
 func (h *TeachingMaterialHandler) Get(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -156,7 +142,7 @@ type teachingMaterialUpdateRequest struct {
 // @Router       /teaching-materials [post]
 // @Security     CookieAuth
 func (h *TeachingMaterialHandler) Create(c *gin.Context) {
-	uid, companyID, role, ok := h.actorContext(c)
+	uid, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -176,7 +162,7 @@ func (h *TeachingMaterialHandler) Create(c *gin.Context) {
 		IsPublished:    req.IsPublished,
 	})
 	if err != nil {
-		respondTeachingMaterialErr(c, err, "教材の作成に失敗しました")
+		respondEntityErr(c, err, "教材が見つかりません", "教材の作成に失敗しました")
 		return
 	}
 	c.JSON(http.StatusCreated, m)
@@ -197,7 +183,7 @@ func (h *TeachingMaterialHandler) Create(c *gin.Context) {
 // @Router       /teaching-materials/{id} [put]
 // @Security     CookieAuth
 func (h *TeachingMaterialHandler) Update(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -221,7 +207,7 @@ func (h *TeachingMaterialHandler) Update(c *gin.Context) {
 		IsPublished:    req.IsPublished,
 	})
 	if err != nil {
-		respondTeachingMaterialErr(c, err, "教材の更新に失敗しました")
+		respondEntityErr(c, err, "教材が見つかりません", "教材の更新に失敗しました")
 		return
 	}
 	c.JSON(http.StatusOK, m)
@@ -240,7 +226,7 @@ func (h *TeachingMaterialHandler) Update(c *gin.Context) {
 // @Router       /teaching-materials/{id} [delete]
 // @Security     CookieAuth
 func (h *TeachingMaterialHandler) Delete(c *gin.Context) {
-	_, companyID, role, ok := h.actorContext(c)
+	_, companyID, role, ok := actorFromContext(c)
 	if !ok {
 		return
 	}
@@ -250,20 +236,8 @@ func (h *TeachingMaterialHandler) Delete(c *gin.Context) {
 		return
 	}
 	if err := h.uc.Delete(c.Request.Context(), id, companyID, role); err != nil {
-		respondTeachingMaterialErr(c, err, "教材の削除に失敗しました")
+		respondEntityErr(c, err, "教材が見つかりません", "教材の削除に失敗しました")
 		return
 	}
 	c.Status(http.StatusNoContent)
-}
-
-func respondTeachingMaterialErr(c *gin.Context, err error, fallback string) {
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "教材が見つかりません"})
-		return
-	}
-	if err.Error() == "forbidden" || err.Error() == "forbidden: only company_admin or super_admin can create materials" || err.Error() == "actor must belong to a company" {
-		c.JSON(http.StatusForbidden, gin.H{"error": "操作権限がありません"})
-		return
-	}
-	c.JSON(http.StatusInternalServerError, gin.H{"error": fallback})
 }

--- a/docs/backend-handler-helpers.md
+++ b/docs/backend-handler-helpers.md
@@ -1,0 +1,44 @@
+# backend handler の共通ヘルパー
+
+handler 層で繰り返し書かれていた「認証 actor の取り出し」と「usecase エラーの HTTP 振り分け」を、
+[internal/handler/helpers.go](../backend/internal/handler/helpers.go) の共通関数に集約した。
+
+## actorFromContext
+
+```go
+func actorFromContext(c *gin.Context) (userID, companyID uint64, role string, ok bool)
+```
+
+middleware が注入した current user（[CurrentUserFromContext](../backend/internal/handler/middleware/current_user.go)）から
+`userID / companyID / role` を取り出す。未認証なら 401(`unauthorized`) を書いて `ok=false` を返すので、
+呼び出し側は `if !ok { return }` で早期 return する。
+
+以前は各 handler が `actorContext` メソッドを個別に実装していた（teaching_material / course で完全重複）。
+これを撤去し共通関数へ統一した。
+
+## respondEntityErr
+
+```go
+func respondEntityErr(c *gin.Context, err error, notFoundMsg, fallback string)
+```
+
+usecase が返したエラーを HTTP ステータスへ振り分ける:
+
+- `gorm.ErrRecordNotFound` → 404（`notFoundMsg`）
+- `forbidden*` で始まる / `actor must belong to a company` → 403（`操作権限がありません`）
+- それ以外 → 500（`fallback`）
+
+エンティティ固有の文言は `notFoundMsg` / `fallback` で渡す（例: 「教材が見つかりません」/「教材の取得に失敗しました」）。
+以前は `respondTeachingMaterialErr` / `respondCourseErr` がほぼ同一実装で重複していた。
+
+> 注: 認可エラーを文字列（`forbidden...`）で判定しているのは既存挙動の踏襲。将来的には usecase 側で
+> sentinel error（`var ErrForbidden = errors.New(...)`）を定義し `errors.Is` で判定するのが望ましい（別 PR）。
+
+## domain.User.CompanyIDValue()
+
+```go
+func (u User) CompanyIDValue() uint64 // CompanyID が nil なら 0
+```
+
+`companyID := uint64(0); if user.CompanyID != nil { companyID = *user.CompanyID }` の展開を 1 行にする
+domain の小道具（純粋関数・副作用なし）。actorFromContext や chapter_view / lesson_progress handler で利用。


### PR DESCRIPTION
## 概要

コードベース全体のリファクタリングの一環。backend handler 層で繰り返されていた「認証 actor の取り出し」と「usecase エラーの HTTP 振り分け」の重複を共通ヘルパーへ集約した。

## 変更内容

- `internal/handler/helpers.go`（新規）に共通関数を追加:
  - `actorFromContext(c)` — current user から `userID/companyID/role` を取得、未認証は 401 を書いて `ok=false`
  - `respondEntityErr(c, err, notFoundMsg, fallback)` — `NotFound`→404 / `forbidden*`・会社未所属→403 / その他→500
- `teaching_material_handler.go` / `course_handler.go` の **完全重複していた** `actorContext` メソッドと `respondXxxErr` 関数を撤去し共通ヘルパーに置換
- `domain.User.CompanyIDValue()`（純粋メソッド・副作用なし）を追加し、`companyID(nil→0)` の展開を 1 行化。`chapter_view` / `lesson_progress` handler の重複展開も置換
- `helpers_test.go` で新ヘルパーを単体テスト（actor 取得 3 ケース / エラー振り分け 5 ケース / CompanyIDValue）

## 挙動の不変性

- 既存テストは全て green（`go test ./...`）
- `teaching_material` の `Get` は 403 文言が「閲覧権限がありません」と異なるため、意図的に inline のまま温存（挙動を変えない）
- 認可エラーの文字列判定は既存挙動を踏襲（将来 usecase の sentinel error 化は別 PR）

## テスト

- `go build ./...` / `go vet ./...` / `go test ./...` すべて pass
- 変更ファイルは gofumpt 整形済み

## 関連

リファクタリング（全体）の PR-1。docs/backend-handler-helpers.md を追加。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>