### PR TITLE
chore: backend 全体を gofumpt 整形して CI ゲートを green 化

### DIFF
--- a/backend/internal/adapter/persistence/user_daily_activity_repository.go
+++ b/backend/internal/adapter/persistence/user_daily_activity_repository.go
@@ -40,7 +40,8 @@ ON CONFLICT (user_id, activity_date) DO UPDATE SET
   ai_chat_count  = user_daily_activities.ai_chat_count  + EXCLUDED.ai_chat_count,
   note_count     = user_daily_activities.note_count     + EXCLUDED.note_count
 `
-	return r.db.WithContext(ctx).Exec(sql,
+	return r.db.WithContext(ctx).Exec(
+		sql,
 		userID, d,
 		delta.ExerciseCount,
 		delta.CorrectCount,

--- a/backend/internal/adapter/persistence/user_repository.go
+++ b/backend/internal/adapter/persistence/user_repository.go
@@ -35,9 +35,9 @@ func toDomainUser(row sqlcgen.User) *domain.User {
 		Email:      row.Email,
 		Name:       row.Name,
 		Role:       row.Role,
-		IsActive:    row.IsActive,
-		CreatedAt:   row.CreatedAt,
-		UpdatedAt:   row.UpdatedAt,
+		IsActive:   row.IsActive,
+		CreatedAt:  row.CreatedAt,
+		UpdatedAt:  row.UpdatedAt,
 	}
 	if row.CompanyID.Valid {
 		cid := uint64(row.CompanyID.Int64)

--- a/backend/internal/domain/admin_invitation.go
+++ b/backend/internal/domain/admin_invitation.go
@@ -3,12 +3,12 @@ package domain
 import "time"
 
 type AdminInvitation struct {
-	ID          uint64 `gorm:"primaryKey" json:"id"`
-	CompanyID   uint64 `gorm:"column:company_id;index" json:"companyId"`
-	Email       string `gorm:"column:email" json:"email"`
-	Role        string `gorm:"column:role" json:"role"`
-	Name string `gorm:"column:name" json:"name"`
-	Status      string `gorm:"column:status" json:"status"`
+	ID        uint64 `gorm:"primaryKey" json:"id"`
+	CompanyID uint64 `gorm:"column:company_id;index" json:"companyId"`
+	Email     string `gorm:"column:email" json:"email"`
+	Role      string `gorm:"column:role" json:"role"`
+	Name      string `gorm:"column:name" json:"name"`
+	Status    string `gorm:"column:status" json:"status"`
 	// Token はマジックリンク用の不透明 UUID（秘匿値なので json では返さない）。
 	// 未設定値を NULL にして UNIQUE 制約に引っかけないため *string にしている。
 	Token     *string   `gorm:"column:token;uniqueIndex;size:64" json:"-"`

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -13,15 +13,15 @@ import (
 
 // fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
 type fakeUserRepo struct {
-	existingBySub        map[string]*domain.User
-	created              *domain.User
-	createErr            error
-	updateRoleID         uint64
-	updateRoleVal        string
-	updateCompanyID      uint64
-	updateCompanyVal     uint64
-	updateNameID  uint64
-	updateNameVal string
+	existingBySub    map[string]*domain.User
+	created          *domain.User
+	createErr        error
+	updateRoleID     uint64
+	updateRoleVal    string
+	updateCompanyID  uint64
+	updateCompanyVal uint64
+	updateNameID     uint64
+	updateNameVal    string
 }
 
 func (r *fakeUserRepo) FindByCognitoSub(_ context.Context, sub string) (*domain.User, error) {

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
-	repository "github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	repository "github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 	"gorm.io/gorm"
 )
 

--- a/backend/internal/handler/middleware/current_user_test.go
+++ b/backend/internal/handler/middleware/current_user_test.go
@@ -25,7 +25,7 @@ func (s *stubUsers) ListByRole(context.Context, string) ([]domain.User, error) {
 func (s *stubUsers) ListByCompanyID(context.Context, uint64) ([]domain.User, error) { return nil, nil }
 func (s *stubUsers) Create(context.Context, *domain.User) error                     { return nil }
 func (s *stubUsers) UpdateAiChatEnabled(context.Context, uint64, *bool) error       { return nil }
-func (s *stubUsers) UpdateName(context.Context, uint64, string) error        { return nil }
+func (s *stubUsers) UpdateName(context.Context, uint64, string) error               { return nil }
 func (s *stubUsers) UpdateRole(context.Context, uint64, string) error               { return nil }
 func (s *stubUsers) UpdateCompanyID(context.Context, uint64, uint64) error          { return nil }
 func (s *stubUsers) UpdateActive(context.Context, uint64, bool) error               { return nil }

--- a/backend/internal/handler/public_invitation_handler.go
+++ b/backend/internal/handler/public_invitation_handler.go
@@ -44,7 +44,7 @@ func (h *PublicInvitationHandler) Validate(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"role":        got.Role,
-		"name": got.Name,
+		"name":        got.Name,
 		"companyId":   got.CompanyID,
 		"companyName": got.CompanyName,
 	})

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -96,8 +96,8 @@ func (u *CreateAdminInvitationUseCase) Execute(ctx context.Context, in CreateAdm
 		Role:      in.Role,
 		Name:      in.Name,
 		Status:    domain.InvitationStatusPending,
-		Token:       &token,
-		ExpiresAt:   time.Now().UTC().Add(u.expiresIn),
+		Token:     &token,
+		ExpiresAt: time.Now().UTC().Add(u.expiresIn),
 	}
 	if err := u.repo.Create(ctx, inv); err != nil {
 		log.Printf("CreateAdminInvitation: repo.Create failed email=%s role=%s companyID=%d: %v",

--- a/backend/internal/usecase/ai_chat_usecase_test.go
+++ b/backend/internal/usecase/ai_chat_usecase_test.go
@@ -15,6 +15,7 @@ type nopActivityRepo struct{}
 func (n *nopActivityRepo) Increment(_ context.Context, _ uint64, _ time.Time, _ repository.UserDailyActivityIncrement) error {
 	return nil
 }
+
 func (n *nopActivityRepo) ListByUser(_ context.Context, _ uint64, _, _ time.Time) ([]domain.UserDailyActivity, error) {
 	return nil, nil
 }

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -41,13 +41,13 @@ func (f *fakeUsersForApp) ListByRole(_ context.Context, role string) ([]domain.U
 	}
 	return nil, nil
 }
-func (f *fakeUsersForApp) Create(context.Context, *domain.User) error              { return nil }
-func (f *fakeUsersForApp) UpdateName(context.Context, uint64, string) error { return nil }
-func (f *fakeUsersForApp) UpdateRole(context.Context, uint64, string) error        { return nil }
-func (f *fakeUsersForApp) UpdateCompanyID(context.Context, uint64, uint64) error   { return nil }
-func (f *fakeUsersForApp) UpdateActive(context.Context, uint64, bool) error        { return nil }
-func (f *fakeUsersForApp) SoftDelete(context.Context, uint64) error                { return nil }
-func (f *fakeUsersForApp) MarkOnboarded(context.Context, uint64) error             { return nil }
+func (f *fakeUsersForApp) Create(context.Context, *domain.User) error            { return nil }
+func (f *fakeUsersForApp) UpdateName(context.Context, uint64, string) error      { return nil }
+func (f *fakeUsersForApp) UpdateRole(context.Context, uint64, string) error      { return nil }
+func (f *fakeUsersForApp) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
+func (f *fakeUsersForApp) UpdateActive(context.Context, uint64, bool) error      { return nil }
+func (f *fakeUsersForApp) SoftDelete(context.Context, uint64) error              { return nil }
+func (f *fakeUsersForApp) MarkOnboarded(context.Context, uint64) error           { return nil }
 func (f *fakeUsersForApp) ListByCompanyID(context.Context, uint64) ([]domain.User, error) {
 	return nil, nil
 }

--- a/backend/internal/usecase/send_ai_message_stream_usecase_test.go
+++ b/backend/internal/usecase/send_ai_message_stream_usecase_test.go
@@ -21,6 +21,7 @@ type nopActivityRepo struct{}
 func (n *nopActivityRepo) Increment(_ context.Context, _ uint64, _ time.Time, _ repository.UserDailyActivityIncrement) error {
 	return nil
 }
+
 func (n *nopActivityRepo) ListByUser(_ context.Context, _ uint64, _, _ time.Time) ([]domain.UserDailyActivity, error) {
 	return nil, nil
 }

--- a/backend/internal/usecase/validate_invitation_token_usecase.go
+++ b/backend/internal/usecase/validate_invitation_token_usecase.go
@@ -25,7 +25,7 @@ func NewValidateInvitationTokenUseCase(
 // ValidatedInvitation は受諾画面に表示する最低限の情報。
 type ValidatedInvitation struct {
 	Role        string
-	Name string
+	Name        string
 	CompanyID   uint64
 	CompanyName string
 }
@@ -52,7 +52,7 @@ func (u *ValidateInvitationTokenUseCase) Execute(ctx context.Context, token stri
 
 	return &ValidatedInvitation{
 		Role:        normalizeInvitationRole(inv.Role),
-		Name: inv.Name,
+		Name:        inv.Name,
 		CompanyID:   inv.CompanyID,
 		CompanyName: companyName,
 	}, nil


### PR DESCRIPTION
## 概要

CI の `vet / test / build` ジョブが参照する `gofumpt -l` で未整形だった 12 ファイルを `gofumpt -w` で整形する。リファクタリングの一環で、**main / 各 PR で恒常的に赤だった Go フォーマットゲートを green 化**し、以降の PR でフォーマット起因の偽陽性 fail を防ぐ。

## 変更内容

`gofumpt -w` による整形のみ（struct フィールド整列・タグ整列）。**ロジック変更なし**:

- internal/adapter/persistence/{user_daily_activity_repository, user_repository}.go
- internal/domain/admin_invitation.go
- internal/handler/{auth_handler_test, master_exercise_handler, public_invitation_handler}.go
- internal/handler/middleware/current_user_test.go
- internal/usecase/{admin_invitation_usecase, ai_chat_usecase_test, create_company_application_usecase_test, send_ai_message_stream_usecase_test, validate_invitation_token_usecase}.go

## テスト

- `gofumpt -l .` が空（全ファイル整形済み）
- `go build ./...` / `go test ./...` すべて pass
- `go mod tidy` 差分なし（既に tidy）

## 関連

リファクタリング（全体）の一環。Go CI ゲートの green 化。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>