### PR TITLE
refactor: hooks の axios 直利用を getApiError に集約

### DIFF
--- a/frontend/src/hooks/__tests__/useLoginPage.test.ts
+++ b/frontend/src/hooks/__tests__/useLoginPage.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
 import { useLoginPage } from '../useLoginPage';
 import authRepository from '../../repositories/AuthRepository';
 
@@ -13,9 +14,16 @@ vi.mock('../../repositories/AuthRepository', () => ({
   default: { login: vi.fn() },
 }));
 
-vi.mock('axios', () => ({
-  default: { isAxiosError: (e: unknown) => !!(e as { isAxiosError?: boolean })?.isAxiosError },
-}));
+// 本物の AxiosError を組み立てる（getApiError は instanceof AxiosError で判定するため）。
+function axiosError(status: number, data: Record<string, unknown> = {}): AxiosError {
+  return new AxiosError('Request failed', 'ERR_BAD_REQUEST', undefined, undefined, {
+    status,
+    statusText: '',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+    data,
+  });
+}
 
 const loginMock = authRepository.login as ReturnType<typeof vi.fn>;
 const assignMock = vi.fn();
@@ -53,7 +61,7 @@ describe('useLoginPage', () => {
   });
 
   it('資格情報誤り（非 403）はエラーメッセージを表示し遷移しない', async () => {
-    loginMock.mockRejectedValueOnce({ response: { status: 401 } });
+    loginMock.mockRejectedValueOnce(axiosError(401));
     const { result } = renderHook(() => useLoginPage());
 
     await act(async () => {
@@ -65,10 +73,9 @@ describe('useLoginPage', () => {
   });
 
   it('招待なし（403）は招待文言を表示する', async () => {
-    loginMock.mockRejectedValueOnce({
-      isAxiosError: true,
-      response: { status: 403, data: { message: 'FreStyle のご利用には管理者からの招待が必要です。' } },
-    });
+    loginMock.mockRejectedValueOnce(
+      axiosError(403, { message: 'FreStyle のご利用には管理者からの招待が必要です。' }),
+    );
     const { result } = renderHook(() => useLoginPage());
 
     await act(async () => {

--- a/frontend/src/hooks/useAcceptInvitation.ts
+++ b/frontend/src/hooks/useAcceptInvitation.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import axios from 'axios';
 import invitationRepository, {
   ValidatedInvitation,
 } from '../repositories/InvitationRepository';
 import { saveInvitationToken, clearInvitationToken } from '../lib/invitationToken';
+import { getApiError } from '../utils/classifyApiError';
 
 export type AcceptInvitationStatus =
   | { kind: 'loading' }
@@ -49,7 +49,7 @@ export function useAcceptInvitation() {
         if (cancelled) return;
         clearInvitationToken();
         // 404 は「無効/期限切れリンク」として明示。それ以外はネットワーク等の障害扱い。
-        if (axios.isAxiosError(err) && err.response?.status === 404) {
+        if (getApiError(err).status === 404) {
           setStatus({ kind: 'invalid' });
           return;
         }

--- a/frontend/src/hooks/useAdminMembers.ts
+++ b/frontend/src/hooks/useAdminMembers.ts
@@ -1,15 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
-import axios from 'axios';
 import AdminMemberRepository, { Member } from '../repositories/AdminMemberRepository';
+import { getApiError } from '../utils/classifyApiError';
 
 // backend のエラーコードを日本語メッセージにする。cannot_manage_self は自己操作の防止。
 function messageFor(e: unknown, fallback: string): string {
-  if (axios.isAxiosError(e)) {
-    const code = (e.response?.data as { error?: string } | undefined)?.error;
-    if (code === 'cannot_manage_self') return '自分自身は無効化・削除できません';
-    if (code === 'forbidden') return 'この従業員を操作する権限がありません';
-    if (code === 'member_not_found') return '対象の従業員が見つかりません';
-  }
+  const code = getApiError(e).serverCode;
+  if (code === 'cannot_manage_self') return '自分自身は無効化・削除できません';
+  if (code === 'forbidden') return 'この従業員を操作する権限がありません';
+  if (code === 'member_not_found') return '対象の従業員が見つかりません';
   return fallback;
 }
 

--- a/frontend/src/hooks/useCompanyApplication.ts
+++ b/frontend/src/hooks/useCompanyApplication.ts
@@ -1,19 +1,16 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
-import axios from 'axios';
 import {
   CompanyApplicationForm,
   CompanyApplicationRepository,
 } from '../repositories/CompanyApplicationRepository';
+import { getApiError } from '../utils/classifyApiError';
 
 const GENERIC_ERROR = '送信に失敗しました。時間をおいて再度お試しください。';
 
-// serverErrorMessage は axios エラーから backend の {error} メッセージを取り出す（無ければ汎用文言）。
+// serverErrorMessage は backend の {message} / {error} を取り出す（無ければ汎用文言）。
 function serverErrorMessage(err: unknown): string {
-  if (axios.isAxiosError(err)) {
-    const data = err.response?.data as { error?: string; message?: string } | undefined;
-    return data?.message || data?.error || GENERIC_ERROR;
-  }
-  return GENERIC_ERROR;
+  const { serverCode, serverMessage } = getApiError(err);
+  return serverMessage || serverCode || GENERIC_ERROR;
 }
 
 const EMPTY: CompanyApplicationForm = {

--- a/frontend/src/hooks/useLoginCallback.ts
+++ b/frontend/src/hooks/useLoginCallback.ts
@@ -1,11 +1,10 @@
 import { useEffect } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import axios from 'axios';
 import { setAuthData } from '../store/authSlice';
 import authRepository from '../repositories/AuthRepository';
 import { consumeInvitationToken } from '../lib/invitationToken';
-import { classifyApiError } from '../utils/classifyApiError';
+import { classifyApiError, getApiError } from '../utils/classifyApiError';
 
 export function useLoginCallback() {
   const [searchParams] = useSearchParams();
@@ -33,18 +32,16 @@ export function useLoginCallback() {
         .catch((err) => {
           // backend が PR-OIDC-Gate で返す 403 invitation_required を識別して
           // 専用メッセージを表示する。それ以外は従来どおり「認証に失敗しました」。
-          if (axios.isAxiosError(err) && err.response?.status === 403) {
-            const data = err.response.data as { error?: string; message?: string } | undefined;
-            if (data?.error === 'invitation_required') {
-              navigate('/login', {
-                state: {
-                  toast:
-                    data.message ||
-                    'FreStyle のご利用には管理者からの招待が必要です。',
-                },
-              });
-              return;
-            }
+          const { status, serverCode, serverMessage } = getApiError(err);
+          if (status === 403 && serverCode === 'invitation_required') {
+            navigate('/login', {
+              state: {
+                toast:
+                  serverMessage ||
+                  'FreStyle のご利用には管理者からの招待が必要です。',
+              },
+            });
+            return;
           }
           navigate('/login', {
             state: { toast: classifyApiError(err, '認証に失敗しました') },

--- a/frontend/src/hooks/useLoginPage.ts
+++ b/frontend/src/hooks/useLoginPage.ts
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import axios from 'axios';
 import { useFormField } from './useFormField';
 import authRepository from '../repositories/AuthRepository';
+import { getApiError } from '../utils/classifyApiError';
 
 interface LoginMessage {
   type: 'success' | 'error';
@@ -35,11 +35,11 @@ export function useLoginPage() {
       window.location.assign('/');
     } catch (err) {
       // 招待なしの新規ユーザーは backend が 403 invitation_required を返す。専用文言を出す。
-      if (axios.isAxiosError(err) && err.response?.status === 403) {
-        const data = err.response.data as { message?: string } | undefined;
+      const { status, serverMessage } = getApiError(err);
+      if (status === 403) {
         setLoginMessage({
           type: 'error',
-          text: data?.message || 'FreStyle のご利用には管理者からの招待が必要です。',
+          text: serverMessage || 'FreStyle のご利用には管理者からの招待が必要です。',
         });
       } else {
         setLoginMessage({

--- a/frontend/src/utils/__tests__/classifyApiError.test.ts
+++ b/frontend/src/utils/__tests__/classifyApiError.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { AxiosError, AxiosHeaders } from 'axios';
-import { classifyApiError, extractServerErrorMessage } from '../classifyApiError';
+import { classifyApiError, extractServerErrorMessage, getApiError } from '../classifyApiError';
 
 function createAxiosError(status: number, message = 'Request failed', data: Record<string, unknown> = {}): AxiosError {
   const headers = new AxiosHeaders();
@@ -105,5 +105,30 @@ describe('extractServerErrorMessage', () => {
     const error = new Error('something went wrong');
     const result = extractServerErrorMessage(error, '通信エラーが発生しました。');
     expect(result).toBe('通信エラーが発生しました。');
+  });
+});
+
+describe('getApiError', () => {
+  it('axios エラーから status / serverCode / serverMessage を取り出す', () => {
+    const error = createAxiosError(403, 'Forbidden', {
+      error: 'invitation_required',
+      message: '招待が必要です',
+    });
+    expect(getApiError(error)).toEqual({
+      status: 403,
+      code: 'ERR_BAD_REQUEST',
+      serverCode: 'invitation_required',
+      serverMessage: '招待が必要です',
+    });
+  });
+
+  it('ネットワークエラーは code を返し status は undefined', () => {
+    const result = getApiError(createNetworkError());
+    expect(result.code).toBe('ERR_NETWORK');
+    expect(result.status).toBeUndefined();
+  });
+
+  it('axios 以外のエラーは空オブジェクトを返す', () => {
+    expect(getApiError(new Error('boom'))).toEqual({});
   });
 });

--- a/frontend/src/utils/classifyApiError.ts
+++ b/frontend/src/utils/classifyApiError.ts
@@ -48,3 +48,33 @@ export function extractServerErrorMessage(error: unknown, fallback: string): str
   }
   return classifyApiError(error, fallback);
 }
+
+/** API エラーから取り出した情報。axios 依存をこの module 内に閉じ込めるための型。 */
+export interface ApiErrorInfo {
+  /** HTTP ステータス（レスポンスがある場合）。 */
+  status?: number;
+  /** axios のエラーコード（ERR_NETWORK / ECONNABORTED など）。 */
+  code?: string;
+  /** backend が返す機械可読コード（{"error":"invitation_required"} の値）。 */
+  serverCode?: string;
+  /** backend が返す人間向けメッセージ（{"message":"..."} の値）。 */
+  serverMessage?: string;
+}
+
+/**
+ * getApiError は unknown なエラーから status / code / サーバ返却フィールドを取り出す。
+ * hooks / pages が `axios.isAxiosError` を直接呼ばず、この helper 経由でステータスコード
+ * 分岐できるようにする（axios への依存をこの module に集約する）。
+ */
+export function getApiError(error: unknown): ApiErrorInfo {
+  if (error instanceof AxiosError) {
+    const data = error.response?.data as { error?: string; message?: string } | undefined;
+    return {
+      status: error.response?.status,
+      code: error.code,
+      serverCode: data?.error,
+      serverMessage: data?.message,
+    };
+  }
+  return {};
+}


### PR DESCRIPTION
## 概要

フロントエンドの最大の負債だった「axios 依存の分散」を解消する。5 つの hook が個別に `axios.isAxiosError` でステータスコード/サーバ返却フィールドを読んでいた重複を、`utils/classifyApiError` の新しい `getApiError()` に一元化し、axios への依存を utils 層に閉じ込めた。

## 変更内容

- `utils/classifyApiError.ts` に `getApiError(error): ApiErrorInfo` を追加（`status / code / serverCode / serverMessage` を返す。axios 知識をこの module に集約）
- 以下の hook から `import axios` を撤去し `getApiError` に置換:
  - `useLoginCallback`（403 invitation_required 判定）
  - `useLoginPage`（403 招待要求）
  - `useAcceptInvitation`（404 無効リンク）
  - `useAdminMembers`（サーバエラーコード→日本語）
  - `useCompanyApplication`（サーバメッセージ抽出）
- `getApiError` の単体テストを追加
- `useLoginPage.test` の `vi.mock('axios')` duck-type を廃し、本物の `AxiosError` で検証（`getApiError` は `instanceof AxiosError` 判定のため）

## 挙動の不変性

- `status / serverCode / serverMessage` の参照は従来と同等。各分岐の文言・遷移は不変
- `NoteImageRepository` の生 `axios.put`（S3 presigned PUT）は app クライアントを通さない意図的実装のため対象外

## テスト

- `tsc --noEmit` / `eslint --max-warnings 0` / `vitest run`(1147 passed) / `npm run build` すべて pass
- カバレッジ statements 85.61% / branches 78.46%（閾値 85/78 を満たす）

## 関連

リファクタリング（全体）の PR-3（FE エラーハンドリング集約）。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>