### PR TITLE
refactor: authSlice の重複 reducer setAuthenticated を削除

### DIFF
--- a/frontend/src/store/__tests__/authSlice.test.ts
+++ b/frontend/src/store/__tests__/authSlice.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import authReducer, {
   setAuthData,
-  setAuthenticated,
   clearAuth,
   finishLoading,
   setAiChatEnabledForTrainees,
@@ -66,25 +65,6 @@ describe('authSlice', () => {
     expect(state.aiChatEnabledForTrainees).toBe(false);
     const back = authReducer(state, setAiChatEnabledForTrainees(true));
     expect(back.aiChatEnabledForTrainees).toBe(true);
-  });
-
-  it('setAuthenticatedでisAuthenticated=true, loading=falseになる', () => {
-    const state = authReducer(initialState, setAuthenticated());
-    expect(state.isAuthenticated).toBe(true);
-    expect(state.loading).toBe(false);
-    expect(state.isAdmin).toBe(false);
-  });
-
-  it('setAuthenticatedでpayload未指定の場合は既存のisAdminを保持する', () => {
-    const adminState = {
-      isAuthenticated: true,
-      loading: false,
-      isAdmin: true,
-      role: 'company_admin',
-    };
-    const state = authReducer(adminState, setAuthenticated());
-    expect(state.isAdmin).toBe(true);
-    expect(state.role).toBe('company_admin');
   });
 
   it('clearAuthで全フィールドが初期値にリセットされる', () => {

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -36,20 +36,6 @@ const authSlice = createSlice({
       }
     },
 
-    setAuthenticated(state, action: PayloadAction<AuthPayload | undefined>) {
-      state.isAuthenticated = true;
-      state.loading = false;
-      if (action.payload?.isAdmin !== undefined) {
-        state.isAdmin = action.payload.isAdmin;
-      }
-      if (action.payload?.role !== undefined) {
-        state.role = action.payload.role;
-      }
-      if (action.payload?.aiChatEnabledForTrainees !== undefined) {
-        state.aiChatEnabledForTrainees = action.payload.aiChatEnabledForTrainees;
-      }
-    },
-
     clearAuth(state) {
       state.isAuthenticated = false;
       state.loading = false;
@@ -71,7 +57,6 @@ const authSlice = createSlice({
 
 export const {
   setAuthData,
-  setAuthenticated,
   clearAuth,
   finishLoading,
   setAiChatEnabledForTrainees,


### PR DESCRIPTION
## 概要

リファクタリングの一環。`authSlice` の `setAuthData` と `setAuthenticated` は**実装が完全に同一**で、`setAuthenticated` は production から一度も dispatch されていない（テストのみ参照）重複 reducer だった。`setAuthData` に一本化する。

## 変更内容

- `setAuthenticated` reducer とエクスポートを削除（`setAuthData` と byte 一致の重複）
- `authSlice.test.ts` から `setAuthenticated` の import と専用テスト 2 件を削除（同一挙動は `setAuthData` のテストで担保済み）

## 挙動の不変性

- production の認証フロー（AuthInitializer / useLoginCallback / useAuth）は元々 `setAuthData` のみ使用。`setAuthenticated` は未使用だったため影響なし
- `vitest run`（authSlice 10 / 関連 20 passed）/ `eslint` / `tsc` / `npm run build` すべて pass

## 関連

リファクタリング（全体）の PR-4。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>