### PR TITLE
fix: 演習フロー e2e のモックをページネーション形に修正

### DIFF
--- a/frontend/e2e/local/user-flows.spec.ts
+++ b/frontend/e2e/local/user-flows.spec.ts
@@ -108,8 +108,10 @@ test.describe('演習フロー', () => {
   test('演習一覧 → リンクで詳細に遷移し演習が描画される', async ({ page }) => {
     // 一覧は ?language=php クエリ付きで叩くため glob は ** で末尾も許容する。
     // 詳細/submissions の専用パターンは後勝ちで優先される。
+    // 一覧はスクロール型ページネーション化（ExercisePage = { items, hasNext, offset, limit }）
+    // されたので、配列直返しではなくページオブジェクトでモックする。
     await mockAuthed(page, {
-      '**/api/v2/exercises**': [exercise],
+      '**/api/v2/exercises**': { items: [exercise], hasNext: false, offset: 0, limit: 20 },
       '**/api/v2/exercises/e2e-fizzbuzz': { exercise, examples: [] },
       '**/api/v2/exercises/e2e-fizzbuzz/submissions': [],
     });


### PR DESCRIPTION
## 概要

`Playwright Local (mocked API)` が**全 PR で恒常的に赤**だった原因を修正する。演習一覧 API がスクロール型ページネーション化（#2023、`ExercisePage = { items, hasNext, offset, limit }`）された後も、e2e のモックが配列を直返ししていたため `useExerciseList` が `items` を取得できず、一覧リンクが描画されず失敗していた。

## 根本原因

- 一覧 API は現在 `{ items, hasNext, offset, limit }` を返す（#2025 で `items` の null 安全化も実施済み）
- e2e モックは旧仕様の `[exercise]`（配列）を返していた → `page.items` が undefined → 一覧が空 → リンク `E2E FizzBuzz 演習` が出ず `toBeVisible()` が失敗

## 変更内容

- `e2e/local/user-flows.spec.ts` の一覧モックを `{ items: [exercise], hasNext: false, offset: 0, limit: 20 }` に修正

## テスト

- `npx playwright test --config=playwright.local.config.ts` ローカル全 **12 件 pass**（当該テスト含む）
- これにより `Playwright Local (mocked API)` ゲートが green になる

## 関連

リファクタリング（全体）の PR-6（恒常赤だった e2e ゲートの修復）。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * APIレスポンス形式をページネーション対応に更新しました。スクロール型ページネーション機能に対応するため、モック形状を調整し、詳細遷移までのテストフローを整備しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->