### PR TITLE
style: カード/ボタンのアフォーダンスを強化（押せる場所を明確に）

### DIFF
--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -12,9 +12,9 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 const VARIANT: Record<ButtonVariant, string> = {
-  primary: 'bg-brand-500 hover:bg-brand-600 active:bg-brand-700 text-white',
+  primary: 'bg-brand-500 hover:bg-brand-600 active:bg-brand-700 text-white shadow-sm hover:shadow',
   secondary:
-    'border border-surface-3 bg-surface-1 hover:bg-surface-2 active:bg-surface-3 text-[var(--color-text-secondary)]',
+    'border border-[var(--color-border-hover)] bg-surface-1 shadow-sm hover:bg-surface-2 hover:shadow active:bg-surface-3 text-[var(--color-text-secondary)]',
   ghost: 'hover:bg-surface-2 active:bg-surface-3 text-[var(--color-text-secondary)]',
   danger: 'bg-red-500 hover:bg-red-600 active:bg-red-700 text-white',
 };

--- a/frontend/src/components/ui/__tests__/Button.test.tsx
+++ b/frontend/src/components/ui/__tests__/Button.test.tsx
@@ -63,9 +63,11 @@ describe('Button', () => {
       expect(screen.getByRole('button').className).toContain('bg-brand-500');
     });
 
-    it('secondary: border border-surface-3クラスが付く', () => {
+    it('secondary: 境界線と影で輪郭が出る（白背景に埋もれない）', () => {
       render(<Button variant="secondary">テスト</Button>);
-      expect(screen.getByRole('button').className).toContain('border-surface-3');
+      const cls = screen.getByRole('button').className;
+      expect(cls).toContain('border-[var(--color-border-hover)]');
+      expect(cls).toContain('shadow-sm');
     });
 
     it('danger: bg-red-500クラスが付く', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -164,15 +164,17 @@
 
 @layer components {
   .btn-primary {
-    @apply bg-brand-500 text-white font-medium py-2.5 rounded-lg hover:bg-brand-600 active:bg-brand-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
+    @apply bg-brand-500 text-white font-medium py-2.5 rounded-lg shadow-sm hover:bg-brand-600 hover:shadow active:bg-brand-700 transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed;
   }
 
+  /* 純白の body に埋もれないよう、輪郭が見える境界色 + 影で「押せる」感を出す。 */
   .btn-secondary {
-    @apply border border-surface-3 text-[var(--color-text-tertiary)] font-medium py-2.5 rounded-lg hover:bg-surface-2 active:bg-surface-3 transition-colors duration-150;
+    @apply border border-[var(--color-border-hover)] bg-surface-1 text-[var(--color-text-tertiary)] font-medium py-2.5 rounded-lg shadow-sm hover:bg-surface-2 hover:shadow active:bg-surface-3 transition-all duration-150;
   }
 
+  /* カードは白い body から浮いて見えるよう、安静時から影を持たせ境界を明確にする。 */
   .card {
-    @apply bg-surface-1 rounded-xl shadow-sm p-6 border border-surface-3;
+    @apply bg-surface-1 rounded-xl shadow p-6 border border-surface-3;
   }
 
   .input-primary {

--- a/frontend/src/pages/MenuPage.tsx
+++ b/frontend/src/pages/MenuPage.tsx
@@ -205,7 +205,7 @@ function FeatureCard({ to, icon: Icon, title, description, color, badge }: Featu
   return (
     <Link
       to={to}
-      className="group relative flex h-full flex-col p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] hover:bg-[var(--color-surface-2)] hover:border-[var(--color-text-muted)]/40 hover:shadow-sm transition-all duration-150"
+      className="group relative flex h-full flex-col p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] shadow-sm hover:border-brand-300 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:shadow-sm transition-all duration-150"
     >
       {badge && (
         <span className="absolute top-4 right-4 text-[10px] font-semibold px-2 pt-px pb-[3px] rounded-full bg-emerald-100 text-emerald-700">


### PR DESCRIPTION
## 概要

body を純白(#FFFFFF)に統一した結果、白いカード／セカンダリボタンが**安静時に影を持たず**、薄い境界線だけで白背景に溶け込み、「**どこが押せるか・どこまでがボタンか**」が分かりにくくなっていた。触れる領域を一目で判別できるよう、アフォーダンス（押せそう感）を強化する。

## 変更内容

- **ダッシュボードの `FeatureCard`**（ホーム画面の主要カード）: 安静時 `shadow-sm` を付与し白い body から浮かせ、ホバーで `shadow-md` + `-translate-y-0.5` + brand 色の境界 → クリック可能と一目で分かる。押下時は沈む(`active:translate-y-0`)
- **`Button` secondary**: 境界色を `border-hover`(#D3D3D0) に強め `shadow-sm` 付与（白に埋もれない輪郭 + 立体感）
- **`Button` primary**: `shadow-sm` でボタンらしい立体感
- **`.card` / `.btn-*` ユーティリティ**（アプリ全体で共用）も同方針で安静時の影・境界を明確化
- Button のクラス検査テストを新しい意図（境界線+影で輪郭を出す）に更新

いずれも Tailwind クラス／CSS の見た目変更のみで、ロジック・API・状態管理への変更はなし。

## テスト

- `tsc --noEmit` ✅ / `eslint src --max-warnings 0` ✅ / `vitest run`（1144件）✅ / `npm run build` ✅

## 関連 Issue

なし（UX 改善・デザイン微修正）