### PR TITLE
feat: 技術的負債 TODO の期限を見張る自作リンター debtlint を追加

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -82,6 +82,10 @@ jobs:
       - name: naminglint (usecase naming)
         run: go run ./cmd/naminglint .
 
+      # 期限付き技術的負債コメント TODO(debt: YYYY-MM-DD) の期限切れ / 期限未設定を検出する自作 linter。
+      - name: debtlint (technical-debt TODO deadlines)
+        run: go run ./cmd/debtlint .
+
       # govulncheck は Go 公式の脆弱性スキャナ。実際に呼んでいるコードパスに該当する
       # 既知 CVE だけを報告する。stdlib の CVE は Go パッチ追随次第で頻出するため、
       # CI を止めずに「可視化」目的の非ブロッキング（continue-on-error）にする。

--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -34,9 +34,10 @@ linters:
         linters:
           - gosec
         text: 'G204'
-      # 自作 lint ツール(archlint/apispec-lint/naminglint)は自分のソースツリーを
-      # WalkDir / os.Open するため Path traversal(G304/G703)は誤検知。
-      - path: cmd/(archlint|apispec-lint|naminglint)/
+      # 自作開発ツール(archlint/apispec-lint/naminglint/fakegen/debtlint)は自分のソースツリーを
+      # WalkDir / os.ReadFile / os.WriteFile するため Path traversal(G304/G703) や生成物の
+      # ディレクトリ/ファイル権限(G301/G306)は誤検知。CLI 開発ツールなので gosec を除外する。
+      - path: cmd/(archlint|apispec-lint|naminglint|fakegen|debtlint)/
         linters:
           - gosec
       # persistence の id 境界は DB が bigint(int64)、domain が uint64。値は採番シーケンス

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -3,10 +3,11 @@
 # 主要 target:
 #   make openapi      … swag init で OpenAPI spec を 再 生成 (docs/swagger.{json,yaml})
 #   make fmt          … gofumpt -w でコードを自動整形（commit 前に実行）
-#   make verify       … gofumpt / vet / build / test / archlint / apispec-lint / naminglint を 一括 実行
+#   make verify       … gofumpt / vet / build / test / archlint / apispec-lint / naminglint / debtlint を 一括 実行
 #   make archlint     … クリーンアーキテクチャ依存方向ルール (CLAUDE.md §2) を 静的 検証
 #   make apispec-lint … Gin ルート ↔ swaggo @Router 注釈 の 整合 (CLAUDE.md §2.7) を 検証
 #   make naminglint   … usecase 命名・構造規約 (CLAUDE.md §2.3) を 検証
+#   make debtlint     … TODO(debt: YYYY-MM-DD) の 期限切れ / 期限未設定 を 検出
 #   make test-integration … docker-compose で PostgreSQL を起動し -tags=integration の結合テストを実行
 #   make run          … go run ./cmd/server で ローカル サーバ 起動
 #
@@ -73,6 +74,7 @@ verify:
 	$(MAKE) archlint
 	$(MAKE) apispec-lint
 	$(MAKE) naminglint
+	$(MAKE) debtlint
 
 # クリーンアーキテクチャ依存方向ルール（CLAUDE.md §2）を静的に検証する。
 .PHONY: archlint
@@ -91,6 +93,12 @@ apispec-lint:
 naminglint:
 	@echo ">>> naminglint: usecase 命名規約チェック"
 	@go run ./cmd/naminglint .
+
+# 期限付き技術的負債コメント TODO(debt: YYYY-MM-DD) の期限切れ / 期限未設定を検出する。
+.PHONY: debtlint
+debtlint:
+	@echo ">>> debtlint: 技術的負債コメントの期限チェック"
+	@go run ./cmd/debtlint .
 
 # 結合テスト: docker-compose で本物の PostgreSQL を起動し、-tags=integration のテストを回す。
 # 終了時は必ずコンテナを破棄する（テスト失敗でも teardown する）。

--- a/backend/cmd/debtlint/main.go
+++ b/backend/cmd/debtlint/main.go
@@ -1,0 +1,179 @@
+// Command debtlint は「期限付きで明示された技術的負債」を CI で見張る自作リンター。
+// コード中の `TODO(debt: YYYY-MM-DD)` コメントを集め、(1) 期限切れ (2) 期限未設定 を検出する。
+// クリーンコース「技術的負債」の『負債は自覚して・期限を切って借りる』を機械化したもの。
+// archlint / naminglint / apispec-lint と同じ枠組み（go/ast のみ・外部依存なし）。
+//
+// 検出ルール:
+//   - `// TODO(debt: 2026-09-01): ...` で 期限が過去 → 期限切れの負債（返済すべき）として違反
+//   - `// TODO(debt): ...` のように 期限が無い → 期限未設定の負債として違反（負債には締切を）
+//   - `// TODO(debt: 2099-01-01): ...` のように 期限が未来 → OK（自覚され・期限が切られた負債）
+//
+// 検査対象は internal/ と cmd/ 配下の .go（コメントのみを見るので文字列リテラルは対象外）。
+//
+// 使い方:
+//
+//	go run ./cmd/debtlint            # backend/ 直下で実行
+//	go run ./cmd/debtlint <root>    # 別ディレクトリを指定
+//
+// 違反は `path:line: メッセージ` 形式で出力し exit 1。
+//
+// 抑制（正当に期限を延ばす / 例外扱いする場合）:
+//   - 同じコメント行に `//debtlint:allow <理由>` を併記するとその 1 件を無視
+//   - ファイル先頭コメントに `//debtlint:ignore-file <理由>` でファイル全体を無視
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// debtRe は `TODO(debt)` / `TODO(debt: 2026-09-01)` を捉える。日付は任意。
+var debtRe = regexp.MustCompile(`TODO\(debt(?::?\s*(\d{4}-\d{2}-\d{2}))?`)
+
+const dateLayout = "2006-01-02"
+
+// violation は 1 件の負債コメント違反。
+type violation struct {
+	file string
+	line int
+	msg  string
+}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Stdout, os.Stderr, time.Now()))
+}
+
+// runCLI は CLI 本体。now を引数で受けることで「期限切れ判定」をテスト可能にする。
+// exit code: 0=OK / 1=違反あり / 2=実行エラー。
+func runCLI(args []string, stdout, stderr io.Writer, now time.Time) int {
+	root := "."
+	if len(args) > 0 {
+		root = args[0]
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	var violations []violation
+	for _, sub := range []string{"internal", "cmd"} {
+		dir := filepath.Join(root, sub)
+		if _, err := os.Stat(dir); err != nil {
+			continue // そのディレクトリが無ければスキップ
+		}
+		vs, err := scanDir(dir, today)
+		if err != nil {
+			fmt.Fprintf(stderr, "debtlint: %v\n", err)
+			return 2
+		}
+		violations = append(violations, vs...)
+	}
+
+	if len(violations) == 0 {
+		fmt.Fprintln(stdout, "debtlint: OK — 期限切れ / 期限未設定の技術的負債コメントはありません")
+		return 0
+	}
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].file != violations[j].file {
+			return violations[i].file < violations[j].file
+		}
+		return violations[i].line < violations[j].line
+	})
+	for _, v := range violations {
+		fmt.Fprintf(stdout, "%s:%d: %s\n", v.file, v.line, v.msg)
+	}
+	fmt.Fprintf(stderr, "\ndebtlint: %d 件の要返済 / 要期限設定の技術的負債が見つかりました\n", len(violations))
+	return 1
+}
+
+// scanDir は dir 配下の .go を再帰的に走査し、負債コメント違反を集める。
+func scanDir(dir string, today time.Time) ([]violation, error) {
+	var violations []violation
+	fset := token.NewFileSet()
+
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if perr != nil {
+			return fmt.Errorf("%s の parse に失敗: %w", path, perr)
+		}
+		violations = append(violations, scanFile(fset, f, today)...)
+		return nil
+	})
+	return violations, err
+}
+
+// scanFile は 1 ファイルのコメントから負債違反を集める（純粋関数: テスト容易）。
+func scanFile(fset *token.FileSet, f *ast.File, today time.Time) []violation {
+	// ファイル全体抑制。CommentGroup.Text() はディレクティブ風コメントを落とすため、
+	// 生の *ast.Comment.Text を直接見る。
+	for _, cg := range f.Comments {
+		for _, c := range cg.List {
+			if strings.Contains(c.Text, "debtlint:ignore-file") {
+				return nil
+			}
+		}
+	}
+
+	var violations []violation
+	for _, cg := range f.Comments {
+		for _, c := range cg.List {
+			text := c.Text
+			m := debtRe.FindStringSubmatch(text)
+			if m == nil {
+				continue
+			}
+			if strings.Contains(text, "debtlint:allow") {
+				continue // 行内抑制
+			}
+			pos := fset.Position(c.Slash)
+			file := relpath(pos.Filename)
+
+			if m[1] == "" {
+				violations = append(violations, violation{
+					file: file, line: pos.Line,
+					msg: "技術的負債 TODO に期限がありません。`TODO(debt: YYYY-MM-DD)` で締切を付けてください（クリーンコース『技術的負債』）",
+				})
+				continue
+			}
+			deadline, err := time.Parse(dateLayout, m[1])
+			if err != nil {
+				violations = append(violations, violation{
+					file: file, line: pos.Line,
+					msg: fmt.Sprintf("技術的負債 TODO の期限 %q が不正です（YYYY-MM-DD 形式で書いてください）", m[1]),
+				})
+				continue
+			}
+			if deadline.Before(today) {
+				overdue := int(today.Sub(deadline).Hours() / 24)
+				violations = append(violations, violation{
+					file: file, line: pos.Line,
+					msg: fmt.Sprintf("期限切れの技術的負債です（期限 %s・%d 日超過）。返済するか期限を更新してください", m[1], overdue),
+				})
+			}
+		}
+	}
+	return violations
+}
+
+// relpath は出力用に絶対パスを相対パスへ寄せる（カレント基準。失敗時は元のまま）。
+func relpath(p string) string {
+	if wd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(wd, p); err == nil && !strings.HasPrefix(rel, "..") {
+			return rel
+		}
+	}
+	return p
+}

--- a/backend/cmd/debtlint/main_test.go
+++ b/backend/cmd/debtlint/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+	"time"
+)
+
+// scanFile の各ケースを検証する（now を固定して期限判定を決定的にする）。
+func Test_scanFile(t *testing.T) {
+	today := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+
+	src := `package x
+
+// TODO(debt: 2026-01-01): これは期限切れ
+func A() {}
+
+// TODO(debt: 2099-01-01): これは未来なのでOK
+func B() {}
+
+// TODO(debt): 期限が無い
+func C() {}
+
+// TODO(debt: 2026-01-01): これは抑制 //debtlint:allow 来週やる
+func D() {}
+
+// ただの TODO: これは負債ではない
+func E() {}
+`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "sample.go", src, parser.ParseComments)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := scanFile(fset, f, today)
+
+	if len(got) != 2 {
+		t.Fatalf("違反は 2 件のはず（期限切れ + 期限未設定）、got %d 件: %+v", len(got), got)
+	}
+	joined := got[0].msg + " | " + got[1].msg
+	if !strings.Contains(joined, "期限切れ") {
+		t.Errorf("期限切れの違反が含まれていません: %v", got)
+	}
+	if !strings.Contains(joined, "期限がありません") {
+		t.Errorf("期限未設定の違反が含まれていません: %v", got)
+	}
+}
+
+// ignore-file でファイル全体が無視されること。
+func Test_scanFile_ignoreFile(t *testing.T) {
+	today := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	src := `//debtlint:ignore-file 生成ファイルのため
+package x
+
+// TODO(debt: 2020-01-01): 期限切れだが ignore-file で無視される
+func A() {}
+`
+	fset := token.NewFileSet()
+	f, _ := parser.ParseFile(fset, "gen.go", src, parser.ParseComments)
+	if got := scanFile(fset, f, today); len(got) != 0 {
+		t.Errorf("ignore-file なので 0 件のはず、got %v", got)
+	}
+}
+
+// runCLI の OK パス（負債コメントが無いツリー）。
+func Test_runCLI_ok(t *testing.T) {
+	root := t.TempDir()
+	var out, errb strings.Builder
+	code := runCLI([]string{root}, &out, &errb, time.Now())
+	if code != 0 {
+		t.Fatalf("空ツリーは exit 0 のはず、got %d (%s)", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "OK") {
+		t.Errorf("OK メッセージが出ていません: %s", out.String())
+	}
+}


### PR DESCRIPTION
## 概要

クリーンコード教材『技術的負債』の **「負債は自覚して・期限を切って借りる」** を機械化する自作リンター `cmd/debtlint` を追加する。コード中の `TODO(debt: YYYY-MM-DD)` コメントを集め、**期限切れ / 期限未設定**を CI で検出する。既存の archlint / naminglint / apispec-lint と同じ枠組み（go/ast のみ・外部依存なし）。

## 検出ルール

| コメント | 判定 |
|---|---|
| `// TODO(debt: 2026-01-01): ...`（期限が過去） | ❌ **期限切れ**（返済 or 期限更新せよ・超過日数も表示） |
| `// TODO(debt): ...`（期限なし） | ❌ **期限未設定**（負債には締切を） |
| `// TODO(debt: 2099-01-01): ...`（期限が未来） | ⭕ OK（自覚され期限が切られた負債） |

## 変更内容

- **`cmd/debtlint/main.go`**: `internal/` と `cmd/` のコメントを go/ast で走査（文字列リテラルは対象外）。`runCLI` が `now` を引数で受け、期限判定をテスト可能に。抑制 `//debtlint:allow`（行）/ `//debtlint:ignore-file`（ファイル）
- **`make debtlint`** + `make verify` への組み込み + **CI（ci-backend-go.yml）に step 追加**
- **`cmd/debtlint/main_test.go`**: 期限切れ / 未設定 / 行内抑制 / ignore-file / OK パスのテスト

## CI への影響

現状コードに `TODO(debt)` コメントは無いため、**CI は green のまま**。将来 `// TODO(debt: 2026-01-01)` のような期限切れ負債を書くと CI が落ちて気づける。

## テスト

- `go test ./cmd/debtlint/...` ✅ / `make debtlint` → OK ✅
- `go build ./...` ✅ / `gofumpt -l .` 空 ✅ / archlint・naminglint・apispec-lint ✅

## 関連 Issue

なし