### PR TITLE
fix(ui): ヘッダーロゴを二色の飛翔マークに修正（青い四角を解消）

### DIFF
--- a/frontend/public/brand-mark.svg
+++ b/frontend/public/brand-mark.svg
@@ -1,0 +1,6 @@
+<svg width="120" height="120" viewBox="0 0 120 120" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="FreStyle">
+  <!-- google-oauth-logo-120.png と同じ「鋭角な3枚の飛翔マーク」を二色ブルーで再現（透過背景） -->
+  <path d="M8,52 L52,72 L8,92 Z" fill="#7fb0f9"/>
+  <path d="M30,40 L74,60 L30,80 Z" fill="#4a8bf6"/>
+  <path d="M52,28 L96,48 L52,68 Z" fill="#2e7df6"/>
+</svg>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -140,9 +140,9 @@ export default function Header() {
     <>
       {loggingOut && <Loading fullscreen message="ログアウト中..." />}
       <header className="flex-shrink-0 h-14 bg-[var(--color-nav)] border-b border-surface-3 flex items-center gap-2 px-3">
-        {/* ロゴ（いつもの favicon をそのまま + サービス名）。色付き箱で囲うとロゴ自体が青いため埋もれる。 */}
+        {/* ロゴ（PNG と同じ二色の飛翔マーク = brand-mark.svg。色付き箱で囲うとロゴ自体が青いため埋もれる）。 */}
         <Link to="/" className="flex items-center gap-2 flex-shrink-0 mr-2" aria-label="FreStyle ホーム">
-          <img src="/favicon.svg" alt="" className="w-7 h-7 flex-shrink-0" />
+          <img src="/brand-mark.svg" alt="" className="w-7 h-7 flex-shrink-0" />
           <span className="hidden sm:block text-sm font-semibold text-[var(--color-text-primary)]">FreStyle</span>
         </Link>
 


### PR DESCRIPTION
## 概要

ヘッダー左上のロゴが青い四角に見える問題を修正します。`frontend/public/google-oauth-logo-120.png` と同じ**二色ブルーの飛翔マーク**を新規 SVG で再現し、ヘッダーをそれに差し替えました。

## 変更内容

- 新規 `frontend/public/brand-mark.svg`（鋭角な3枚の飛翔マークを二色ブルーで再現・透過背景・正方形 viewBox）
- `Header.tsx` のロゴ `img` を `/favicon.svg` → `/brand-mark.svg` に変更
- **新ファイル名**にすることで、古い `favicon.svg` の CDN/ブラウザキャッシュも回避

## テスト

- `tsc --noEmit` ✅ / Header 関連テスト 25件 ✅ / `eslint --max-warnings 0` ✅ / `npm run build` ✅（`brand-mark.svg` が dist に同梱）

## 補足

見た目のみの変更（ロジック・API・状態管理の変更なし）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ヘッダー左側のロゴ表示を更新し、ブランドマークが表示されるようになりました。
  * ロゴに関する説明文も新しい表記に統一されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->