### PR TITLE
style: UI 監査第1弾 — 表記の日本語統一と無意味な表示のノイズ削減 (FRESTYLE-64)

### DIFF
--- a/frontend/src/components/NoteListItem.tsx
+++ b/frontend/src/components/NoteListItem.tsx
@@ -65,13 +65,23 @@ export default memo(function NoteListItem({
             {isPinned && <PinIcon className="w-3.5 h-3.5 inline mr-1 text-taupe-500" />}
             {displayTitle}
           </p>
-          {preview && (
+          {preview ? (
             <p className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">
               {preview}
             </p>
+          ) : (
+            <p className="text-xs text-[var(--color-text-faint)] truncate mt-0.5">
+              本文なし
+            </p>
           )}
           <p className="text-[11px] text-[var(--color-text-faint)] mt-1">
-            {dateStr} · <ReadingTime charCount={stats.charCount} />
+            {dateStr}
+            {stats.charCount > 0 && (
+              <>
+                {' · '}
+                <ReadingTime charCount={stats.charCount} />
+              </>
+            )}
           </p>
         </div>
         <div className="flex items-center gap-0.5">

--- a/frontend/src/components/NoteMarkdownEditor.tsx
+++ b/frontend/src/components/NoteMarkdownEditor.tsx
@@ -188,10 +188,10 @@ export default function NoteMarkdownEditor({
 
       <div className="flex items-center gap-1 mb-3">
         <TabButton active={tab === 'edit'} onClick={() => setTab('edit')}>
-          Edit
+          編集
         </TabButton>
         <TabButton active={tab === 'preview'} onClick={() => setTab('preview')}>
-          Preview
+          プレビュー
         </TabButton>
       </div>
 

--- a/frontend/src/components/ReadingTime.tsx
+++ b/frontend/src/components/ReadingTime.tsx
@@ -5,7 +5,10 @@ interface ReadingTimeProps {
 const CHARS_PER_MINUTE = 500;
 
 export default function ReadingTime({ charCount }: ReadingTimeProps) {
-  const minutes = charCount === 0 ? 0 : Math.max(1, Math.ceil(charCount / CHARS_PER_MINUTE));
+  // 「約0分」は情報量ゼロの表示になるため、本文が無いときは描画しない(FRESTYLE-64)。
+  if (charCount === 0) return null;
+
+  const minutes = Math.max(1, Math.ceil(charCount / CHARS_PER_MINUTE));
 
   return (
     <span className="text-[10px] text-[var(--color-text-faint)]">

--- a/frontend/src/components/__tests__/NoteListItem.test.tsx
+++ b/frontend/src/components/__tests__/NoteListItem.test.tsx
@@ -109,8 +109,18 @@ describe('NoteListItem', () => {
     expect(screen.getByText(/約\d+分/)).toBeInTheDocument();
   });
 
-  it('空の内容では読了時間が約0分と表示される', () => {
+  it('空の内容では読了時間を表示しない', () => {
     render(<NoteListItem {...defaultProps} content="" />);
-    expect(screen.getByText('約0分')).toBeInTheDocument();
+    expect(screen.queryByText(/約\d+分/)).not.toBeInTheDocument();
+  });
+
+  it('空の内容では「本文なし」プレースホルダを表示する', () => {
+    render(<NoteListItem {...defaultProps} content="" />);
+    expect(screen.getByText('本文なし')).toBeInTheDocument();
+  });
+
+  it('本文がある場合は「本文なし」を表示しない', () => {
+    render(<NoteListItem {...defaultProps} content="テスト内容" />);
+    expect(screen.queryByText('本文なし')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
+++ b/frontend/src/components/__tests__/NoteMarkdownEditor.test.tsx
@@ -32,7 +32,7 @@ describe('NoteMarkdownEditor', () => {
 
   it('Preview タブをクリックすると Markdown レンダリングが表示される', () => {
     renderEditor();
-    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    fireEvent.click(screen.getByRole('button', { name: 'プレビュー' }));
     // Markdown の見出しがレンダリングされ、 textarea は消える
     expect(screen.getByRole('heading', { name: '見出し' })).toBeInTheDocument();
     expect(document.querySelector('textarea')).toBeNull();
@@ -40,8 +40,8 @@ describe('NoteMarkdownEditor', () => {
 
   it('Edit タブに戻ると textarea が再表示される', () => {
     renderEditor();
-    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    fireEvent.click(screen.getByRole('button', { name: 'プレビュー' }));
+    fireEvent.click(screen.getByRole('button', { name: '編集' }));
     expect(getMarkdownTextarea().value).toBe('# 見出し\n\n本文');
   });
 
@@ -54,7 +54,7 @@ describe('NoteMarkdownEditor', () => {
 
   it('空コンテンツの Preview は案内文を出す', () => {
     renderEditor({ content: '   ' });
-    fireEvent.click(screen.getByRole('button', { name: 'Preview' }));
+    fireEvent.click(screen.getByRole('button', { name: 'プレビュー' }));
     expect(screen.getByText('プレビューするコンテンツがありません')).toBeInTheDocument();
   });
 

--- a/frontend/src/components/__tests__/ReadingTime.test.tsx
+++ b/frontend/src/components/__tests__/ReadingTime.test.tsx
@@ -3,9 +3,9 @@ import { render, screen } from '@testing-library/react';
 import ReadingTime from '../ReadingTime';
 
 describe('ReadingTime', () => {
-  it('0文字の場合「約0分」を表示する', () => {
-    render(<ReadingTime charCount={0} />);
-    expect(screen.getByText('約0分')).toBeInTheDocument();
+  it('0文字の場合は何も表示しない（「約0分」は情報量ゼロのため）', () => {
+    const { container } = render(<ReadingTime charCount={0} />);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('400文字の場合「約1分」を表示する', () => {

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -139,11 +139,9 @@ function StatusBadge({ status }: { status: MasterExerciseWithStatus['status'] })
       </span>
     );
   }
-  return (
-    <span className="text-xs px-2 py-0.5 rounded-full bg-surface-3 text-[var(--color-text-muted)] flex-shrink-0">
-      未着手
-    </span>
-  );
+  // 未着手はデフォルト状態なのでバッジを出さない。全カードに付く「未着手」チップは
+  // 視覚ノイズになり、意味のある状態(解いた/取り組み中)の視認性を下げるため(FRESTYLE-64)。
+  return null;
 }
 
 function DifficultyBadge({ level }: { level: number }) {

--- a/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
@@ -65,7 +65,7 @@ describe('ExerciseListPage', () => {
     expect(screen.getByText(/正答ユーザ 10/)).toBeInTheDocument();
   });
 
-  it('未着手のカードには未着手バッジが付く', async () => {
+  it('未着手のカードには状態バッジを表示しない', async () => {
     mockListExercises.mockResolvedValue({
       items: [{
         id: 2, slug: 'php-2', language: 'php', orderIndex: 2, category: '基礎',
@@ -79,7 +79,8 @@ describe('ExerciseListPage', () => {
     });
     renderPage();
     await waitFor(() => expect(screen.getByText('変数')).toBeInTheDocument());
-    expect(screen.getByText('未着手')).toBeInTheDocument();
+    // 未着手はデフォルト状態なのでバッジを出さない(視覚ノイズ削減 / FRESTYLE-64)。
+    expect(screen.queryByText('未着手')).not.toBeInTheDocument();
   });
 
   it('カードクリックで /code-editor/:slug へのリンクを描画する', async () => {

--- a/frontend/src/pages/__tests__/NotesPage.test.tsx
+++ b/frontend/src/pages/__tests__/NotesPage.test.tsx
@@ -111,8 +111,8 @@ describe('NotesPage', () => {
     render(<NotesPage />);
     expect(screen.getByDisplayValue('選択ノート')).toBeInTheDocument();
     // Edit / Preview タブが表示されることを確認（旧 block-editor から markdown editor へ）
-    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Preview' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'プレビュー' })).toBeInTheDocument();
   });
 
   it('新しいノートボタンでcreateNoteが呼ばれる', async () => {


### PR DESCRIPTION
## 概要

主要プラットフォームのデザインガイドラインの共通原則（一貫性 / 明瞭さ / 意味のある状態表現）に照らして現行 UI 4 画面を監査し（監査結果全体は FRESTYLE-64 に記載）、その第1弾として**表記と表示ノイズの是正（純デザイン変更）**を行います。

Jira: FRESTYLE-64（第2弾: FRESTYLE-65 ダッシュボードレイアウト / 第3弾: FRESTYLE-66 アカウント表示）

## 変更内容

1. **表記の言語混在を解消**: ノートエディタのタブ「Edit / Preview」→「編集 / プレビュー」（UI 内で唯一の英語ラベルだった）
2. **無意味なメタデータを排除**: `ReadingTime` は 0 文字のとき何も表示しない（ノート一覧の「5/29 · 約0分」が「5/29」になる）
3. **ノート一覧の識別性**: 空ノートに「本文なし」プレースホルダを表示（「無題」が並んだときに状態が伝わる）
4. **デフォルト状態チップの削減**: 演習一覧の「未着手」チップを非表示化（全カードに付く既定バッジは視覚ノイズで、「解いた / 取り組み中」の視認性を下げる）

## テスト

- 関連テスト 5 ファイルを新仕様に更新
- `tsc --noEmit` / `vitest run`（**143 files / 1146 tests 全緑**）/ `eslint --max-warnings 0`（変更ファイル）/ `npm run build`: すべて成功

## 補足

- ロジック・API 契約・状態管理の変更なし（ラベル文字列と表示条件のみ）。デザイン専用変更（CLAUDE.md §4.2）のため CodeRabbit を待たず admin merge → フロントデプロイまで実施します。

## 関連 Issue

- Jira: FRESTYLE-64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ノート編集画面のタブ表示が日本語になりました（「編集」「プレビュー」）。
* **Bug Fixes**
  * 本文が空のノートでは「本文なし」と表示し、読書時間は表示しないようになりました。
  * 0文字のときに「約0分」と出ないよう改善しました。
  * 未着手の課題カードでは状態バッジを表示しないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->