### PR TITLE
feat: コースに学習領域カテゴリを追加し一覧を色分け表示 (FRESTYLE-67)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3975,6 +3975,9 @@ const docTemplate = `{
         "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
             "type": "object",
             "properties": {
+                "category": {
+                    "type": "string"
+                },
                 "companyId": {
                     "type": "integer"
                 },
@@ -4660,6 +4663,19 @@ const docTemplate = `{
         "internal_handler.courseRequest": {
             "type": "object",
             "properties": {
+                "category": {
+                    "description": "Category は定義済みの学習領域のみ許可(空 = 未分類)。値の正本は domain.ValidCourseCategories。\noneof で宣言的に 400 を返し、usecase 側でも防衛的に検証する。",
+                    "type": "string",
+                    "enum": [
+                        "dev-basics",
+                        "backend",
+                        "architecture",
+                        "database",
+                        "infra",
+                        "security",
+                        "product"
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3968,6 +3968,9 @@
         "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
             "type": "object",
             "properties": {
+                "category": {
+                    "type": "string"
+                },
                 "companyId": {
                     "type": "integer"
                 },
@@ -4653,6 +4656,19 @@
         "internal_handler.courseRequest": {
             "type": "object",
             "properties": {
+                "category": {
+                    "description": "Category は定義済みの学習領域のみ許可(空 = 未分類)。値の正本は domain.ValidCourseCategories。\noneof で宣言的に 400 を返し、usecase 側でも防衛的に検証する。",
+                    "type": "string",
+                    "enum": [
+                        "dev-basics",
+                        "backend",
+                        "architecture",
+                        "database",
+                        "infra",
+                        "security",
+                        "product"
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -138,6 +138,8 @@ definitions:
     type: object
   github_com_norman6464_FreStyle_backend_internal_domain.Course:
     properties:
+      category:
+        type: string
       companyId:
         type: integer
       createdAt:
@@ -590,6 +592,19 @@ definitions:
     type: object
   internal_handler.courseRequest:
     properties:
+      category:
+        description: |-
+          Category は定義済みの学習領域のみ許可(空 = 未分類)。値の正本は domain.ValidCourseCategories。
+          oneof で宣言的に 400 を返し、usecase 側でも防衛的に検証する。
+        enum:
+        - dev-basics
+        - backend
+        - architecture
+        - database
+        - infra
+        - security
+        - product
+        type: string
       description:
         type: string
       isPublished:

--- a/backend/internal/domain/course.go
+++ b/backend/internal/domain/course.go
@@ -2,6 +2,43 @@ package domain
 
 import "time"
 
+// CourseCategory は「色＝学習領域」の連想を支える定義済み分類（FRESTYLE-67）。
+// 自由入力にすると色の一貫性が崩れるため選択式とし、表示色は frontend の
+// カラーマップが持つ。backend は値の正当性のみ保証する。
+const (
+	CourseCategoryDevBasics    = "dev-basics"   // 開発基礎
+	CourseCategoryBackend      = "backend"      // バックエンド開発
+	CourseCategoryArchitecture = "architecture" // 設計・アーキテクチャ
+	CourseCategoryDatabase     = "database"     // データベース
+	CourseCategoryInfra        = "infra"        // インフラ・クラウド
+	CourseCategorySecurity     = "security"     // セキュリティ
+	CourseCategoryProduct      = "product"      // プロダクト・仕様
+)
+
+// ValidCourseCategories は選択可能なカテゴリの一覧（未分類 = 空文字は含まない）。
+var ValidCourseCategories = []string{
+	CourseCategoryDevBasics,
+	CourseCategoryBackend,
+	CourseCategoryArchitecture,
+	CourseCategoryDatabase,
+	CourseCategoryInfra,
+	CourseCategorySecurity,
+	CourseCategoryProduct,
+}
+
+// IsValidCourseCategory は c が未分類("")または定義済みカテゴリかを返す。
+func IsValidCourseCategory(c string) bool {
+	if c == "" {
+		return true
+	}
+	for _, v := range ValidCourseCategories {
+		if v == c {
+			return true
+		}
+	}
+	return false
+}
+
 // Course は教材を束ねるコース。階層は Company 1 ── * Course 1 ── * TeachingMaterial。
 // trainee は自社の is_published=true のみ閲覧可。並び順は SortOrder（同値時 ID 昇順）。
 type Course struct {
@@ -10,6 +47,7 @@ type Course struct {
 	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
 	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
 	Description     string    `gorm:"column:description;type:text;not null;default:''" json:"description"`
+	Category        string    `gorm:"column:category;not null;default:''" json:"category"`
 	SortOrder       int       `gorm:"column:sort_order;not null;default:100" json:"sortOrder"`
 	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
 	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -72,6 +72,9 @@ func (h *CourseHandler) Get(c *gin.Context) {
 type courseRequest struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
+	// Category は定義済みの学習領域のみ許可(空 = 未分類)。値の正本は domain.ValidCourseCategories。
+	// oneof で宣言的に 400 を返し、usecase 側でも防衛的に検証する。
+	Category    string `json:"category" binding:"omitempty,oneof=dev-basics backend architecture database infra security product"`
 	SortOrder   int    `json:"sortOrder"`
 	IsPublished bool   `json:"isPublished"`
 }
@@ -104,6 +107,7 @@ func (h *CourseHandler) Create(c *gin.Context) {
 		ActorRole:      role,
 		Title:          req.Title,
 		Description:    req.Description,
+		Category:       req.Category,
 		SortOrder:      req.SortOrder,
 		IsPublished:    req.IsPublished,
 	})
@@ -149,6 +153,7 @@ func (h *CourseHandler) Update(c *gin.Context) {
 		ActorRole:      role,
 		Title:          req.Title,
 		Description:    req.Description,
+		Category:       req.Category,
 		SortOrder:      req.SortOrder,
 		IsPublished:    req.IsPublished,
 	})

--- a/backend/internal/handler/course_handler_test.go
+++ b/backend/internal/handler/course_handler_test.go
@@ -156,3 +156,20 @@ func Test_コースハンドラ_削除(t *testing.T) {
 		}
 	})
 }
+
+func Test_コースハンドラ_作成_カテゴリ(t *testing.T) {
+	t.Run("不正なカテゴリ → 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodPost, `{"title":"X","category":"not-a-category"}`, nil, superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Create(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("定義済みカテゴリ → 201", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodPost, `{"title":"PostgreSQL","category":"database"}`, nil, superAdminCo())
+		newCourseHandler(&fakeCourseRepo{}).Create(c)
+		if w.Code != http.StatusCreated {
+			t.Fatalf("want 201, got %d", w.Code)
+		}
+	})
+}

--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -60,6 +60,7 @@ type CreateCourseInput struct {
 	ActorRole      string
 	Title          string
 	Description    string
+	Category       string
 	SortOrder      int
 	IsPublished    bool
 }
@@ -71,11 +72,15 @@ func (uc *CourseUseCase) Create(ctx context.Context, in CreateCourseInput) (*dom
 	if in.ActorCompanyID == 0 {
 		return nil, fmt.Errorf("actor must belong to a company")
 	}
+	if !domain.IsValidCourseCategory(in.Category) {
+		return nil, fmt.Errorf("invalid course category: %s", in.Category)
+	}
 	c := &domain.Course{
 		CompanyID:       in.ActorCompanyID,
 		CreatedByUserID: in.ActorUserID,
 		Title:           in.Title,
 		Description:     in.Description,
+		Category:        in.Category,
 		SortOrder:       in.SortOrder,
 		IsPublished:     in.IsPublished,
 	}
@@ -91,6 +96,7 @@ type UpdateCourseInput struct {
 	ActorRole      string
 	Title          string
 	Description    string
+	Category       string
 	SortOrder      int
 	IsPublished    bool
 }
@@ -106,8 +112,12 @@ func (uc *CourseUseCase) Update(ctx context.Context, in UpdateCourseInput) (*dom
 	if in.ActorRole != domain.RoleSuperAdmin && existing.CompanyID != in.ActorCompanyID {
 		return nil, fmt.Errorf("forbidden")
 	}
+	if !domain.IsValidCourseCategory(in.Category) {
+		return nil, fmt.Errorf("invalid course category: %s", in.Category)
+	}
 	existing.Title = in.Title
 	existing.Description = in.Description
+	existing.Category = in.Category
 	existing.SortOrder = in.SortOrder
 	existing.IsPublished = in.IsPublished
 	if err := uc.courses.Update(ctx, existing); err != nil {

--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -132,3 +132,65 @@ func Test_コース_削除_自社管理者は教材も連鎖削除(t *testing.T)
 	assert.Equal(t, uint64(1), crepo.deleted)
 	assert.Equal(t, uint64(1), mrepo.deletedByCo, "コース配下の教材も cascade で削除される")
 }
+
+func Test_コース_作成_カテゴリ付きで成功(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "PostgreSQL 徹底入門", Category: domain.CourseCategoryDatabase,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.CourseCategoryDatabase, got.Category)
+}
+
+func Test_コース_作成_不正なカテゴリは拒否(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X", Category: "unknown-category",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid course category")
+	assert.Nil(t, crepo.created)
+}
+
+func Test_コース_作成_カテゴリ未分類は許可(t *testing.T) {
+	crepo := &fakeCourseRepo{}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
+		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X", Category: "",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "", got.Category)
+}
+
+func Test_コース_更新_カテゴリを変更できる(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Category: domain.CourseCategoryDevBasics}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
+		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "Terraform 入門", Category: domain.CourseCategoryInfra,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.CourseCategoryInfra, got.Category)
+}
+
+func Test_コース_更新_不正なカテゴリは拒否(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	_, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
+		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
+		Title: "X", Category: "nope",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid course category")
+	assert.Nil(t, crepo.updated)
+}

--- a/docs/course-categories.md
+++ b/docs/course-categories.md
@@ -1,0 +1,51 @@
+# コースのカテゴリ（学習領域）と色分け
+
+コース一覧で「色＝学習領域」の連想を作るためのカテゴリ機構（FRESTYLE-67 / Design Doc 承認済）。
+コースをグループ単位で色分けし、繰り返し利用で説明なしでも学習者が領域を識別できる UI を目指す。
+
+## 仕組み
+
+- `courses.category`（string / 既定 `''` = 未分類）に**定義済みカテゴリ key** を保存する
+- カテゴリは自由入力ではなく**選択式**。自由入力にすると「色＝領域」の一貫性が崩れるため
+- 値の正本は backend の [`domain.ValidCourseCategories`](../backend/internal/domain/course.go)。
+  frontend の [`constants/courseCategories.ts`](../frontend/src/constants/courseCategories.ts) が
+  同じ key に対して表示名（日本語）と色（Tailwind クラス）を持つ
+
+## カテゴリ一覧（7 分類）
+
+| key | 表示名 | 色 |
+|---|---|---|
+| `dev-basics` | 開発基礎 | 黄 (amber) |
+| `backend` | バックエンド開発 | 青 (blue) |
+| `architecture` | 設計・アーキテクチャ | 紫 (violet) |
+| `database` | データベース | 緑 (emerald) |
+| `infra` | インフラ・クラウド | 橙 (orange) |
+| `security` | セキュリティ | 赤 (rose) |
+| `product` | プロダクト・仕様 | 水色 (cyan) |
+
+未分類（`''`）は無色 = 従来表示のまま。
+
+## 表示（frontend）
+
+- コース一覧カード: 左端の**色帯**（`border-l-4`）+ **カテゴリ名バッジ**
+  - 色だけに依存しない（色覚特性・スクリーンリーダー対応のため必ず文字ラベルを併記）
+- コース作成 / 編集フォーム: カテゴリの select（未分類 + 7 分類）
+
+## バリデーション（backend）
+
+- handler: `courseRequest.Category` の `binding:"omitempty,oneof=..."` で宣言的に 400
+- usecase: `domain.IsValidCourseCategory` で防衛的に再検証（HTTP 以外の呼び出し元対策）
+
+## カテゴリを増やす / 変えるとき
+
+1. `backend/internal/domain/course.go` の定数 + `ValidCourseCategories` に追加
+2. `backend/internal/handler/course_handler.go` の `oneof` リストを同期
+3. `frontend/src/constants/courseCategories.ts` に key / label / 色を追加
+4. `make openapi`（backend）→ `npm run openapi:generate`（frontend）で spec / 生成型を更新
+5. 本ドキュメントの表を更新
+
+## DB への反映
+
+- 列追加は GORM AutoMigrate が ECS 起動時に自動適用（破壊なし）
+- 既存コースへのカテゴリ割当は UPDATE SQL を `make apply-migration-supabase` で適用する
+- 教材リポ（frestyle-teaching-materials）の `course.yaml` にも `category` を追記して正本の整合を保つ

--- a/frontend/src/constants/courseCategories.ts
+++ b/frontend/src/constants/courseCategories.ts
@@ -1,0 +1,69 @@
+/**
+ * コースの学習領域カテゴリと表示色の対応（FRESTYLE-67）。
+ *
+ * 「色＝学習領域」の連想を一貫させるため、カテゴリは backend の
+ * domain.ValidCourseCategories と 1:1 の固定リストで、色もここで固定する。
+ * アクセシビリティ配慮のため色だけに依存せず、必ず label をバッジ文字列として
+ * 併記して使うこと（色覚特性・スクリーンリーダー対応）。
+ */
+export interface CourseCategoryDef {
+  /** backend に保存される値（domain.CourseCategory* と一致） */
+  key: string;
+  /** バッジに表示する日本語名 */
+  label: string;
+  /** カテゴリバッジの配色 */
+  badgeClass: string;
+  /** カード左端の色帯（border-l-4 と併用） */
+  barClass: string;
+}
+
+export const COURSE_CATEGORIES: CourseCategoryDef[] = [
+  {
+    key: 'dev-basics',
+    label: '開発基礎',
+    badgeClass: 'bg-amber-500/15 text-amber-700 border border-amber-500/30',
+    barClass: 'border-l-amber-500',
+  },
+  {
+    key: 'backend',
+    label: 'バックエンド開発',
+    badgeClass: 'bg-blue-500/15 text-blue-700 border border-blue-500/30',
+    barClass: 'border-l-blue-500',
+  },
+  {
+    key: 'architecture',
+    label: '設計・アーキテクチャ',
+    badgeClass: 'bg-violet-500/15 text-violet-700 border border-violet-500/30',
+    barClass: 'border-l-violet-500',
+  },
+  {
+    key: 'database',
+    label: 'データベース',
+    badgeClass: 'bg-emerald-500/15 text-emerald-700 border border-emerald-500/30',
+    barClass: 'border-l-emerald-500',
+  },
+  {
+    key: 'infra',
+    label: 'インフラ・クラウド',
+    badgeClass: 'bg-orange-500/15 text-orange-700 border border-orange-500/30',
+    barClass: 'border-l-orange-500',
+  },
+  {
+    key: 'security',
+    label: 'セキュリティ',
+    badgeClass: 'bg-rose-500/15 text-rose-700 border border-rose-500/30',
+    barClass: 'border-l-rose-500',
+  },
+  {
+    key: 'product',
+    label: 'プロダクト・仕様',
+    badgeClass: 'bg-cyan-500/15 text-cyan-700 border border-cyan-500/30',
+    barClass: 'border-l-cyan-500',
+  },
+];
+
+/** key からカテゴリ定義を引く。未分類('')や未知の値は undefined（無色表示）。 */
+export function findCourseCategory(key: string | undefined): CourseCategoryDef | undefined {
+  if (!key) return undefined;
+  return COURSE_CATEGORIES.find((c) => c.key === key);
+}

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -4,6 +4,72 @@
  */
 
 export interface paths {
+    "/admin/audit-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 監査ログ一覧（super_admin）
+         * @description 管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で最大 200 件返す。super_admin 専用。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent"][];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description super_admin 以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/companies": {
         parameters: {
             query?: never;
@@ -50,6 +116,164 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/admin/companies/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 会社横断ビュー（メンバー集計・super_admin）
+         * @description 全 company に、各社の在籍メンバー数（総数 / 有効 / trainee）を付けて返す。super_admin 専用画面用。認可は middleware で別途担保。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat"][];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description super_admin 以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/companies/{id}/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 会社アカウントの有効/無効を切り替え（super_admin 専用）
+         * @description 会社を無効化すると、その会社の全ユーザーがログイン/利用不可になる（middleware で弾く）。super_admin のみ。
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 会社 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            /** @description active=false で無効化 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.setCompanyActiveRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.messageResponse"];
+                    };
+                };
+                /** @description 不正な ID / body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description super_admin 以外 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 会社が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 更新失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/admin/company-applications": {
@@ -445,6 +669,181 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/admin/members/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * 従業員を論理削除
+         * @description 従業員を一覧から退会させる（論理削除）。以後ログイン/利用不可。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 従業員の数値 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正な ID / 自分自身 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 管理者以外 / 別会社の従業員 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 従業員が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部エラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/members/{userId}/active": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * 従業員アカウントの有効/無効を切り替え
+         * @description 無効化すると、その従業員はログイン/利用不可になる（middleware で弾く）。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 従業員の数値 ID */
+                    userId: string;
+                };
+                cookie?: never;
+            };
+            /** @description active=false で無効化 */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.setMemberActiveRequest"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正な ID / body / 自分自身 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 管理者以外 / 別会社の従業員 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 従業員が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 内部エラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/admin/members/{userId}/ai-access": {
@@ -2237,14 +2636,18 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * 演習問題 一覧 (status + stats 付き)
-         * @description 運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。
+         * 演習問題 一覧 (status + stats + ページネーション付き)
+         * @description 運営 マスタ 演習問題 を 取得。 query language で 絞り込み。 limit/offset で ページネーション。 current user の 提出 状況 と 全 user 集計 を 返す。
          */
         get: {
             parameters: {
                 query?: {
-                    /** @description 言語 フィルタ (例: php, go, javascript) */
+                    /** @description 言語 フィルタ (例: php, go, bash, git) */
                     language?: string;
+                    /** @description 1 ページの 件数 (デフォルト 20、最大 100) */
+                    limit?: number;
+                    /** @description 取得 開始 位置 (デフォルト 0) */
+                    offset?: number;
                 };
                 header?: never;
                 path?: never;
@@ -2258,7 +2661,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"][];
+                        "application/json": components["schemas"]["internal_handler.exercisePageResponse"];
                     };
                 };
                 /** @description DB / 集計 失敗 */
@@ -2742,6 +3145,258 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/lesson-progress": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 自分の学習進捗（完了レッスン一覧）
+         * @description current user が完了した教材（レッスン）の一覧を返す。進捗バー / 完了チェック表示用。userId は受け取らない（current user 固定）。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserLessonProgress"][];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * レッスンを完了にする
+         * @description current user 名義で教材（レッスン）を完了として記録する。冪等（二重実行しても 1 件）。course は教材から解決する。自社かつ閲覧可能な教材のみ完了にできる。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description 完了する教材 ID */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["internal_handler.markLessonCompleteRequest"];
+                };
+            };
+            responses: {
+                /** @description 成功（本文なし） */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正な body */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 他社 / 閲覧不可な教材 */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 教材が存在しない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/lesson-progress/{teachingMaterialId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * レッスンの完了を取り消す
+         * @description current user の当該教材の完了記録を取り消す（未記録でも 204）。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 教材 ID */
+                    teachingMaterialId: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 成功（本文なし） */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正な ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description DB 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/me/dashboard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ダッシュボード データ 取得
+         * @description 過去 90 日間の日次活動サマリー・連続学習日数・直近の閲覧章を返す。 カレンダーヒートマップ や 「続きから」 カード の 描画 に 使う。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.GetUserDashboardOutput"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 集計失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -3948,6 +4603,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/teaching-materials/{id}/view": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 章の閲覧を記録する
+         * @description ユーザーが教材（章）を開いたときに呼び出す。user_chapter_views を upsert し「続きから」カードの基盤データを更新する。 エラーは握り潰し 204 を返す（ベストエフォート）。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description 教材 ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 記録成功（本文なし） */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description 不正な ID */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/{userId}/stats": {
         parameters: {
             query?: never;
@@ -4024,10 +4737,10 @@ export interface components {
         "github_com_norman6464_FreStyle_backend_internal_domain.AdminInvitation": {
             companyId?: number;
             createdAt?: string;
-            displayName?: string;
             email?: string;
             expiresAt?: string;
             id?: number;
+            name?: string;
             role?: string;
             status?: string;
         };
@@ -4056,6 +4769,17 @@ export interface components {
             kind?: string;
             sizeBytes?: number;
         };
+        "github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent": {
+            /** @description Action は「METHOD ルートパターン」（例: "PATCH /api/v2/admin/companies/:id/active"）。 */
+            action?: string;
+            actorEmail?: string;
+            actorId?: number;
+            actorRole?: string;
+            createdAt?: string;
+            id?: number;
+            /** @description TargetID は操作対象の ID（会社 ID / ユーザー ID など。取得できないときは 0）。 */
+            targetId?: number;
+        };
         "github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult": {
             exitCode?: number;
             stderr?: string;
@@ -4069,6 +4793,11 @@ export interface components {
             aiChatEnabledForTrainees?: boolean;
             createdAt?: string;
             id?: number;
+            /**
+             * @description IsActive は会社アカウントの有効/無効。false（無効）にすると、その会社の全ユーザーが
+             *     ログイン/利用不可になる（middleware で弾く）。super_admin が会社一覧から切り替える。
+             */
+            isActive?: boolean;
             name?: string;
             updatedAt?: string;
         };
@@ -4083,6 +4812,7 @@ export interface components {
             updatedAt?: string;
         };
         "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
+            category?: string;
             companyId?: number;
             createdAt?: string;
             createdByUserId?: number;
@@ -4163,6 +4893,8 @@ export interface components {
         "github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL": {
             expiresIn?: number;
             key?: string;
+            /** @description PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。 */
+            publicUrl?: string;
             url?: string;
         };
         "github_com_norman6464_FreStyle_backend_internal_domain.Notification": {
@@ -4183,8 +4915,8 @@ export interface components {
         "github_com_norman6464_FreStyle_backend_internal_domain.ProfileView": {
             avatarUrl?: string;
             bio?: string;
-            displayName?: string;
             email?: string;
+            name?: string;
             status?: string;
             updatedAt?: string;
             userId?: number;
@@ -4210,6 +4942,31 @@ export interface components {
             title?: string;
             updatedAt?: string;
         };
+        "github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView": {
+            courseId?: number;
+            firstViewedAt?: string;
+            lastViewedAt?: string;
+            teachingMaterialId?: number;
+            userId?: number;
+            viewCount?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.UserDailyActivity": {
+            activityDate?: string;
+            aiChatCount?: number;
+            correctCount?: number;
+            exerciseCount?: number;
+            lessonCount?: number;
+            noteCount?: number;
+            userId?: number;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_domain.UserLessonProgress": {
+            completedAt?: string;
+            courseId?: number;
+            createdAt?: string;
+            id?: number;
+            teachingMaterialId?: number;
+            userId?: number;
+        };
         "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
             averageScore?: number;
             longestStreak?: number;
@@ -4226,32 +4983,26 @@ export interface components {
             title?: string;
             url?: string;
         };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat": {
+            activeMembers?: number;
+            createdAt?: string;
+            id?: number;
+            isActive?: boolean;
+            memberTotal?: number;
+            name?: string;
+            traineeCount?: number;
+        };
         "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
             examples?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"][];
             exercise?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExercise"];
         };
-        "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
-            category?: string;
-            chapterId?: number;
-            createdAt?: string;
-            description?: string;
-            difficulty?: number;
-            expectedOutput?: string;
-            /** @description Explanation は qa モードで正解後に表示する markdown 解説。 */
-            explanation?: string;
-            hintText?: string;
-            id?: number;
-            isPublished?: boolean;
-            language?: string;
-            /** @description Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。 */
-            mode?: string;
-            orderIndex?: number;
-            slug?: string;
-            starterCode?: string;
-            stats?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"];
-            status?: string;
-            title?: string;
-            updatedAt?: string;
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetUserDashboardOutput": {
+            recentActivity?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserDailyActivity"][];
+            recentChapterViews?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView"][];
+            streak?: number;
+            totalCorrect?: number;
+            totalExercises?: number;
+            totalLessons?: number;
         };
         "github_com_norman6464_FreStyle_backend_internal_usecase.SubmitMasterExerciseOutput": {
             isCorrect?: boolean;
@@ -4299,6 +5050,12 @@ export interface components {
             aiChatEnabledForTrainees?: boolean;
         };
         "internal_handler.courseRequest": {
+            /**
+             * @description Category は定義済みの学習領域のみ許可(空 = 未分類)。値の正本は domain.ValidCourseCategories。
+             *     oneof で宣言的に 400 を返し、usecase 側でも防衛的に検証する。
+             * @enum {string}
+             */
+            category?: "dev-basics" | "backend" | "architecture" | "database" | "infra" | "security" | "product";
             description?: string;
             isPublished?: boolean;
             sortOrder?: number;
@@ -4306,8 +5063,8 @@ export interface components {
         };
         "internal_handler.createAdminInvReq": {
             companyId: number;
-            displayName?: string;
             email: string;
+            name?: string;
             role: string;
         };
         "internal_handler.createCompanyApplicationReq": {
@@ -4325,13 +5082,19 @@ export interface components {
             /** @example unauthorized */
             error?: string;
         };
+        "internal_handler.exercisePageResponse": {
+            hasNext?: boolean;
+            items?: components["schemas"]["internal_handler.masterExerciseListItemResponse"][];
+            limit?: number;
+            offset?: number;
+        };
         "internal_handler.invitationValidateResponse": {
             /** @example 1 */
             companyId?: number;
             /** @example Example Corp */
             companyName?: string;
             /** @example 山田 太郎 */
-            displayName?: string;
+            name?: string;
             /** @example trainee */
             role?: string;
         };
@@ -4342,14 +5105,29 @@ export interface components {
         "internal_handler.issueUploadURLReq": {
             contentType?: string;
         };
+        "internal_handler.markLessonCompleteRequest": {
+            teachingMaterialId: number;
+        };
+        "internal_handler.masterExerciseListItemResponse": {
+            category?: string;
+            difficulty?: number;
+            id?: number;
+            isPublished?: boolean;
+            language?: string;
+            mode?: string;
+            orderIndex?: number;
+            slug?: string;
+            stats?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"];
+            /** @description Status は current user の提出状況。"solved" / "in_progress" / ""（未提出）。 */
+            status?: string;
+            title?: string;
+        };
         "internal_handler.meResponse": {
             /** @example abc-123-uuid */
             cognitoSub?: string;
             /** @example 1 */
             companyId?: number;
             createdAt?: string;
-            /** @example 山田 太郎 */
-            displayName?: string;
             /** @example user@example.com */
             email?: string;
             /**
@@ -4362,6 +5140,8 @@ export interface components {
             id?: number;
             /** @example false */
             isAdmin?: boolean;
+            /** @example 山田 太郎 */
+            name?: string;
             /** @example true */
             onboarded?: boolean;
             /** @example trainee */
@@ -4371,9 +5151,11 @@ export interface components {
         "internal_handler.memberResponse": {
             /** @description AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。 */
             aiChatEnabled?: boolean;
-            displayName?: string;
             email?: string;
             id?: number;
+            /** @description IsActive はアカウントの有効/無効。false = 無効（ログイン/利用不可）。 */
+            isActive?: boolean;
+            name?: string;
             role?: string;
         };
         "internal_handler.messageResponse": {
@@ -4403,6 +5185,12 @@ export interface components {
         };
         "internal_handler.sessionNoteUpsertReq": {
             content?: string;
+        };
+        "internal_handler.setCompanyActiveRequest": {
+            active: boolean;
+        };
+        "internal_handler.setMemberActiveRequest": {
+            active: boolean;
         };
         "internal_handler.sseAttachmentRequest": {
             contentType?: string;
@@ -4448,10 +5236,8 @@ export interface components {
         "internal_handler.updateProfileReq": {
             avatarUrl?: string;
             bio?: string;
-            displayName?: string;
             /** @description 旧フロント互換。avatarUrl を優先。 */
             iconUrl?: string;
-            /** @description 旧フロント互換。displayName を優先。 */
             name?: string;
             status?: string;
         };

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -11,6 +11,65 @@
         "version": "2.0"
     },
     "paths": {
+        "/admin/audit-events": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "管理者の重要操作（会社の有効/無効・従業員の停止/削除・招待など）の監査記録を新しい順で最大 200 件返す。super_admin 専用。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "監査ログ一覧（super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/admin/companies": {
             "get": {
                 "security": [
@@ -39,6 +98,163 @@
                     },
                     "500": {
                         "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/companies/stats": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "全 company に、各社の在籍メンバー数（総数 / 有効 / trainee）を付けて返す。super_admin 専用画面用。認可は middleware で別途担保。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社横断ビュー（メンバー集計・super_admin）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/companies/{id}/active": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "会社を無効化すると、その会社の全ユーザーがログイン/利用不可になる（middleware で弾く）。super_admin のみ。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "会社アカウントの有効/無効を切り替え（super_admin 専用）",
+                "parameters": [
+                    {
+                        "description": "会社 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.setCompanyActiveRequest"
+                            }
+                        }
+                    },
+                    "description": "active=false で無効化",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.messageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正な ID / body",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "会社が存在しない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "更新失敗",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -412,6 +628,177 @@
                     },
                     "403": {
                         "description": "管理者以外",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "従業員を一覧から退会させる（論理削除）。以後ログイン/利用不可。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員を論理削除",
+                "parameters": [
+                    {
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "不正な ID / 自分自身",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "従業員が存在しない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "内部エラー",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/admin/members/{userId}/active": {
+            "patch": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "無効化すると、その従業員はログイン/利用不可になる（middleware で弾く）。super_admin は全社、company_admin は自社の従業員のみ。自分自身は不可。",
+                "tags": [
+                    "admin"
+                ],
+                "summary": "従業員アカウントの有効/無効を切り替え",
+                "parameters": [
+                    {
+                        "description": "従業員の数値 ID",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.setMemberActiveRequest"
+                            }
+                        }
+                    },
+                    "description": "active=false で無効化",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "不正な ID / body / 自分自身",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "管理者以外 / 別会社の従業員",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "従業員が存在しない",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2223,18 +2610,34 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み (例: php / go)。 current user の 提出 状況 と 全 user 集計 を 同時 に 返す。 未 ログイン 時 は status 空。",
+                "description": "運営 マスタ 演習問題 を 取得。 query language で 絞り込み。 limit/offset で ページネーション。 current user の 提出 状況 と 全 user 集計 を 返す。",
                 "tags": [
                     "exercises"
                 ],
-                "summary": "演習問題 一覧 (status + stats 付き)",
+                "summary": "演習問題 一覧 (status + stats + ページネーション付き)",
                 "parameters": [
                     {
-                        "description": "言語 フィルタ (例: php, go, javascript)",
+                        "description": "言語 フィルタ (例: php, go, bash, git)",
                         "name": "language",
                         "in": "query",
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    {
+                        "description": "1 ページの 件数 (デフォルト 20、最大 100)",
+                        "name": "limit",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "取得 開始 位置 (デフォルト 0)",
+                        "name": "offset",
+                        "in": "query",
+                        "schema": {
+                            "type": "integer"
                         }
                     }
                 ],
@@ -2244,10 +2647,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus"
-                                    }
+                                    "$ref": "#/components/schemas/internal_handler.exercisePageResponse"
                                 }
                             }
                         }
@@ -2696,6 +3096,239 @@
                     },
                     "401": {
                         "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/lesson-progress": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user が完了した教材（レッスン）の一覧を返す。進捗バー / 完了チェック表示用。userId は受け取らない（current user 固定）。",
+                "tags": [
+                    "lesson-progress"
+                ],
+                "summary": "自分の学習進捗（完了レッスン一覧）",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserLessonProgress"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user 名義で教材（レッスン）を完了として記録する。冪等（二重実行しても 1 件）。course は教材から解決する。自社かつ閲覧可能な教材のみ完了にできる。",
+                "tags": [
+                    "lesson-progress"
+                ],
+                "summary": "レッスンを完了にする",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/internal_handler.markLessonCompleteRequest"
+                            }
+                        }
+                    },
+                    "description": "完了する教材 ID",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "成功（本文なし）"
+                    },
+                    "400": {
+                        "description": "不正な body",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "他社 / 閲覧不可な教材",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "教材が存在しない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/lesson-progress/{teachingMaterialId}": {
+            "delete": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user の当該教材の完了記録を取り消す（未記録でも 204）。",
+                "tags": [
+                    "lesson-progress"
+                ],
+                "summary": "レッスンの完了を取り消す",
+                "parameters": [
+                    {
+                        "description": "教材 ID",
+                        "name": "teachingMaterialId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "成功（本文なし）"
+                    },
+                    "400": {
+                        "description": "不正な ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "DB 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/me/dashboard": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "過去 90 日間の日次活動サマリー・連続学習日数・直近の閲覧章を返す。 カレンダーヒートマップ や 「続きから」 カード の 描画 に 使う。",
+                "tags": [
+                    "dashboard"
+                ],
+                "summary": "ダッシュボード データ 取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.GetUserDashboardOutput"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "集計失敗",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3915,6 +4548,56 @@
                 }
             }
         },
+        "/teaching-materials/{id}/view": {
+            "post": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "ユーザーが教材（章）を開いたときに呼び出す。user_chapter_views を upsert し「続きから」カードの基盤データを更新する。 エラーは握り潰し 204 を返す（ベストエフォート）。",
+                "tags": [
+                    "teaching-materials"
+                ],
+                "summary": "章の閲覧を記録する",
+                "parameters": [
+                    {
+                        "description": "教材 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "記録成功（本文なし）"
+                    },
+                    "400": {
+                        "description": "不正な ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/users/{userId}/stats": {
             "get": {
                 "security": [
@@ -4007,9 +4690,6 @@
                     "createdAt": {
                         "type": "string"
                     },
-                    "displayName": {
-                        "type": "string"
-                    },
                     "email": {
                         "type": "string"
                     },
@@ -4018,6 +4698,9 @@
                     },
                     "id": {
                         "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
                     },
                     "role": {
                         "type": "string"
@@ -4102,6 +4785,34 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_domain.AuditEvent": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "description": "Action は「METHOD ルートパターン」（例: \"PATCH /api/v2/admin/companies/:id/active\"）。",
+                        "type": "string"
+                    },
+                    "actorEmail": {
+                        "type": "string"
+                    },
+                    "actorId": {
+                        "type": "integer"
+                    },
+                    "actorRole": {
+                        "type": "string"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "targetId": {
+                        "description": "TargetID は操作対象の ID（会社 ID / ユーザー ID など。取得できないときは 0）。",
+                        "type": "integer"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_domain.CodeExecutionResult": {
                 "type": "object",
                 "properties": {
@@ -4128,6 +4839,10 @@
                     },
                     "id": {
                         "type": "integer"
+                    },
+                    "isActive": {
+                        "description": "IsActive は会社アカウントの有効/無効。false（無効）にすると、その会社の全ユーザーが\nログイン/利用不可になる（middleware で弾く）。super_admin が会社一覧から切り替える。",
+                        "type": "boolean"
                     },
                     "name": {
                         "type": "string"
@@ -4169,6 +4884,9 @@
             "github_com_norman6464_FreStyle_backend_internal_domain.Course": {
                 "type": "object",
                 "properties": {
+                    "category": {
+                        "type": "string"
+                    },
                     "companyId": {
                         "type": "integer"
                     },
@@ -4394,6 +5112,10 @@
                     "key": {
                         "type": "string"
                     },
+                    "publicUrl": {
+                        "description": "PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。",
+                        "type": "string"
+                    },
                     "url": {
                         "type": "string"
                     }
@@ -4451,10 +5173,10 @@
                     "bio": {
                         "type": "string"
                     },
-                    "displayName": {
+                    "email": {
                         "type": "string"
                     },
-                    "email": {
+                    "name": {
                         "type": "string"
                     },
                     "status": {
@@ -4527,6 +5249,78 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView": {
+                "type": "object",
+                "properties": {
+                    "courseId": {
+                        "type": "integer"
+                    },
+                    "firstViewedAt": {
+                        "type": "string"
+                    },
+                    "lastViewedAt": {
+                        "type": "string"
+                    },
+                    "teachingMaterialId": {
+                        "type": "integer"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    },
+                    "viewCount": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.UserDailyActivity": {
+                "type": "object",
+                "properties": {
+                    "activityDate": {
+                        "type": "string"
+                    },
+                    "aiChatCount": {
+                        "type": "integer"
+                    },
+                    "correctCount": {
+                        "type": "integer"
+                    },
+                    "exerciseCount": {
+                        "type": "integer"
+                    },
+                    "lessonCount": {
+                        "type": "integer"
+                    },
+                    "noteCount": {
+                        "type": "integer"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_domain.UserLessonProgress": {
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string"
+                    },
+                    "courseId": {
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "teachingMaterialId": {
+                        "type": "integer"
+                    },
+                    "userId": {
+                        "type": "integer"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_domain.UserStats": {
                 "type": "object",
                 "properties": {
@@ -4571,6 +5365,32 @@
                     }
                 }
             },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.CompanyStat": {
+                "type": "object",
+                "properties": {
+                    "activeMembers": {
+                        "type": "integer"
+                    },
+                    "createdAt": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isActive": {
+                        "type": "boolean"
+                    },
+                    "memberTotal": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "traineeCount": {
+                        "type": "integer"
+                    }
+                }
+            },
             "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
                 "type": "object",
                 "properties": {
@@ -4585,67 +5405,32 @@
                     }
                 }
             },
-            "github_com_norman6464_FreStyle_backend_internal_usecase.MasterExerciseWithStatus": {
+            "github_com_norman6464_FreStyle_backend_internal_usecase.GetUserDashboardOutput": {
                 "type": "object",
                 "properties": {
-                    "category": {
-                        "type": "string"
+                    "recentActivity": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserDailyActivity"
+                        }
                     },
-                    "chapterId": {
+                    "recentChapterViews": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView"
+                        }
+                    },
+                    "streak": {
                         "type": "integer"
                     },
-                    "createdAt": {
-                        "type": "string"
-                    },
-                    "description": {
-                        "type": "string"
-                    },
-                    "difficulty": {
+                    "totalCorrect": {
                         "type": "integer"
                     },
-                    "expectedOutput": {
-                        "type": "string"
-                    },
-                    "explanation": {
-                        "description": "Explanation は qa モードで正解後に表示する markdown 解説。",
-                        "type": "string"
-                    },
-                    "hintText": {
-                        "type": "string"
-                    },
-                    "id": {
+                    "totalExercises": {
                         "type": "integer"
                     },
-                    "isPublished": {
-                        "type": "boolean"
-                    },
-                    "language": {
-                        "type": "string"
-                    },
-                    "mode": {
-                        "description": "Mode は採点モード。execute は実行して stdout 比較、qa は提出文字列と ExpectedOutput を trim 比較。",
-                        "type": "string"
-                    },
-                    "orderIndex": {
+                    "totalLessons": {
                         "type": "integer"
-                    },
-                    "slug": {
-                        "type": "string"
-                    },
-                    "starterCode": {
-                        "type": "string"
-                    },
-                    "stats": {
-                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
-                    },
-                    "status": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "updatedAt": {
-                        "type": "string"
                     }
                 }
             },
@@ -4787,6 +5572,19 @@
             "internal_handler.courseRequest": {
                 "type": "object",
                 "properties": {
+                    "category": {
+                        "description": "Category は定義済みの学習領域のみ許可(空 = 未分類)。値の正本は domain.ValidCourseCategories。\noneof で宣言的に 400 を返し、usecase 側でも防衛的に検証する。",
+                        "type": "string",
+                        "enum": [
+                            "dev-basics",
+                            "backend",
+                            "architecture",
+                            "database",
+                            "infra",
+                            "security",
+                            "product"
+                        ]
+                    },
                     "description": {
                         "type": "string"
                     },
@@ -4812,10 +5610,10 @@
                     "companyId": {
                         "type": "integer"
                     },
-                    "displayName": {
+                    "email": {
                         "type": "string"
                     },
-                    "email": {
+                    "name": {
                         "type": "string"
                     },
                     "role": {
@@ -4871,6 +5669,26 @@
                     }
                 }
             },
+            "internal_handler.exercisePageResponse": {
+                "type": "object",
+                "properties": {
+                    "hasNext": {
+                        "type": "boolean"
+                    },
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/internal_handler.masterExerciseListItemResponse"
+                        }
+                    },
+                    "limit": {
+                        "type": "integer"
+                    },
+                    "offset": {
+                        "type": "integer"
+                    }
+                }
+            },
             "internal_handler.invitationValidateResponse": {
                 "type": "object",
                 "properties": {
@@ -4882,7 +5700,7 @@
                         "type": "string",
                         "example": "Example Corp"
                     },
-                    "displayName": {
+                    "name": {
                         "type": "string",
                         "example": "山田 太郎"
                     },
@@ -4911,6 +5729,56 @@
                     }
                 }
             },
+            "internal_handler.markLessonCompleteRequest": {
+                "type": "object",
+                "required": [
+                    "teachingMaterialId"
+                ],
+                "properties": {
+                    "teachingMaterialId": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "internal_handler.masterExerciseListItemResponse": {
+                "type": "object",
+                "properties": {
+                    "category": {
+                        "type": "string"
+                    },
+                    "difficulty": {
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "integer"
+                    },
+                    "isPublished": {
+                        "type": "boolean"
+                    },
+                    "language": {
+                        "type": "string"
+                    },
+                    "mode": {
+                        "type": "string"
+                    },
+                    "orderIndex": {
+                        "type": "integer"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "stats": {
+                        "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase_repository.ExerciseSubmissionStats"
+                    },
+                    "status": {
+                        "description": "Status は current user の提出状況。\"solved\" / \"in_progress\" / \"\"（未提出）。",
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    }
+                }
+            },
             "internal_handler.meResponse": {
                 "type": "object",
                 "properties": {
@@ -4924,10 +5792,6 @@
                     },
                     "createdAt": {
                         "type": "string"
-                    },
-                    "displayName": {
-                        "type": "string",
-                        "example": "山田 太郎"
                     },
                     "email": {
                         "type": "string",
@@ -4950,6 +5814,10 @@
                         "type": "boolean",
                         "example": false
                     },
+                    "name": {
+                        "type": "string",
+                        "example": "山田 太郎"
+                    },
                     "onboarded": {
                         "type": "boolean",
                         "example": true
@@ -4970,14 +5838,18 @@
                         "description": "AiChatEnabled は AI 利用可否の個別上書き。null = 会社設定に従う。",
                         "type": "boolean"
                     },
-                    "displayName": {
-                        "type": "string"
-                    },
                     "email": {
                         "type": "string"
                     },
                     "id": {
                         "type": "integer"
+                    },
+                    "isActive": {
+                        "description": "IsActive はアカウントの有効/無効。false = 無効（ログイン/利用不可）。",
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
                     },
                     "role": {
                         "type": "string"
@@ -5073,6 +5945,28 @@
                 "properties": {
                     "content": {
                         "type": "string"
+                    }
+                }
+            },
+            "internal_handler.setCompanyActiveRequest": {
+                "type": "object",
+                "required": [
+                    "active"
+                ],
+                "properties": {
+                    "active": {
+                        "type": "boolean"
+                    }
+                }
+            },
+            "internal_handler.setMemberActiveRequest": {
+                "type": "object",
+                "required": [
+                    "active"
+                ],
+                "properties": {
+                    "active": {
+                        "type": "boolean"
                     }
                 }
             },
@@ -5211,15 +6105,11 @@
                     "bio": {
                         "type": "string"
                     },
-                    "displayName": {
-                        "type": "string"
-                    },
                     "iconUrl": {
                         "description": "旧フロント互換。avatarUrl を優先。",
                         "type": "string"
                     },
                     "name": {
-                        "description": "旧フロント互換。displayName を優先。",
                         "type": "string"
                     },
                     "status": {

--- a/frontend/src/pages/CoursesListPage.tsx
+++ b/frontend/src/pages/CoursesListPage.tsx
@@ -12,6 +12,7 @@ import Loading from '../components/Loading';
 import ConfirmModal from '../components/ConfirmModal';
 import { useCourses } from '../hooks/useCourses';
 import { useToast } from '../hooks/useToast';
+import { COURSE_CATEGORIES, findCourseCategory } from '../constants/courseCategories';
 import type { RootState } from '../store';
 import type { Course } from '../types';
 
@@ -156,6 +157,9 @@ function CourseCard({
   onEdit: () => void;
   onDelete: () => void;
 }) {
+  // 「色＝学習領域」の連想(FRESTYLE-67)。左の色帯 + カテゴリ名バッジで表現し、
+  // 色のみに依存しない(未分類は無色 = 従来表示)。
+  const category = findCourseCategory(course.category);
   return (
     <div
       role="button"
@@ -167,7 +171,9 @@ function CourseCard({
           onOpen();
         }
       }}
-      className="group bg-surface-1 border border-surface-3 rounded-lg p-4 cursor-pointer hover:border-taupe-500/50 hover:shadow-md transition-all"
+      className={`group bg-surface-1 border border-surface-3 border-l-4 ${
+        category ? category.barClass : 'border-l-surface-3'
+      } rounded-lg p-4 cursor-pointer hover:border-taupe-500/50 hover:shadow-md transition-all`}
     >
       <div className="flex items-start justify-between gap-2 mb-2">
         <div className="flex items-center gap-2 min-w-0">
@@ -200,9 +206,16 @@ function CourseCard({
           </div>
         )}
       </div>
-      <p className="text-xs text-[var(--color-text-muted)] mb-3">
-        {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
-      </p>
+      <div className="flex items-center gap-2 mb-3">
+        {category && (
+          <span className={`text-[11px] px-2 py-0.5 rounded-full flex-shrink-0 ${category.badgeClass}`}>
+            {category.label}
+          </span>
+        )}
+        <p className="text-xs text-[var(--color-text-muted)]">
+          {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
+        </p>
+      </div>
       <p className="text-sm text-[var(--color-text-secondary)] line-clamp-3 min-h-[3.6em]">
         {course.description || 'コース説明が未設定です'}
       </p>
@@ -216,6 +229,7 @@ interface CourseFormProps {
   onSubmit: (payload: {
     title: string;
     description: string;
+    category: string;
     sortOrder: number;
     isPublished: boolean;
   }) => Promise<void>;
@@ -224,6 +238,7 @@ interface CourseFormProps {
 function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
   const [title, setTitle] = useState(initial?.title ?? '');
   const [description, setDescription] = useState(initial?.description ?? '');
+  const [category, setCategory] = useState(initial?.category ?? '');
   const [sortOrder, setSortOrder] = useState(initial?.sortOrder ?? 100);
   const [isPublished, setIsPublished] = useState(initial?.isPublished ?? false);
   const [submitting, setSubmitting] = useState(false);
@@ -233,7 +248,7 @@ function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
     if (!title.trim()) return;
     setSubmitting(true);
     try {
-      await onSubmit({ title: title.trim(), description: description.trim(), sortOrder, isPublished });
+      await onSubmit({ title: title.trim(), description: description.trim(), category, sortOrder, isPublished });
     } finally {
       setSubmitting(false);
     }
@@ -271,6 +286,24 @@ function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
               placeholder="このコースで学べる内容の概要"
               className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400 resize-y"
             />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">カテゴリ（学習領域）</span>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
+            >
+              <option value="">未分類</option>
+              {COURSE_CATEGORIES.map((c) => (
+                <option key={c.key} value={c.key}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
+              一覧カードの色分けに使われます（色＝学習領域）
+            </span>
           </label>
           <label className="block">
             <span className="block text-sm text-[var(--color-text-secondary)] mb-1">並び順 (昇順)</span>

--- a/frontend/src/pages/__tests__/CoursesListPage.test.tsx
+++ b/frontend/src/pages/__tests__/CoursesListPage.test.tsx
@@ -79,7 +79,10 @@ describe('CoursesListPage カテゴリ色分け (FRESTYLE-67)', () => {
   it('管理者の作成フォームにカテゴリ選択（未分類 + 全カテゴリ）が表示される', async () => {
     mockList.mockResolvedValue([]);
     renderPage('company_admin');
-    await waitFor(() => expect(screen.getByRole('button', { name: /新しいコース/ })).toBeInTheDocument());
+    // 空一覧時はヘッダーと EmptyState の 2 箇所に「新しいコース」が出るため getAllByRole で扱う
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0),
+    );
     fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
     const select = screen.getByRole('combobox');
     expect(select).toBeInTheDocument();

--- a/frontend/src/pages/__tests__/CoursesListPage.test.tsx
+++ b/frontend/src/pages/__tests__/CoursesListPage.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import CoursesListPage from '../CoursesListPage';
+import { ToastProvider } from '../../components/ToastProvider';
+import authReducer from '../../store/authSlice';
+import CourseRepository from '../../repositories/CourseRepository';
+import { COURSE_CATEGORIES, findCourseCategory } from '../../constants/courseCategories';
+import type { Course } from '../../types';
+
+vi.mock('../../repositories/CourseRepository', () => ({
+  default: {
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const mockList = vi.mocked(CourseRepository.list);
+
+function makeCourse(overrides: Partial<Course> = {}): Course {
+  return {
+    id: 1,
+    companyId: 10,
+    createdByUserId: 1,
+    title: 'PostgreSQL 徹底入門',
+    description: 'DB の基礎',
+    category: 'database',
+    sortOrder: 100,
+    isPublished: true,
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderPage(role = 'trainee') {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: { role } as never,
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <ToastProvider>
+        <MemoryRouter>
+          <CoursesListPage />
+        </MemoryRouter>
+      </ToastProvider>
+    </Provider>,
+  );
+}
+
+describe('CoursesListPage カテゴリ色分け (FRESTYLE-67)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('カテゴリ付きコースはカテゴリ名バッジを表示する', async () => {
+    mockList.mockResolvedValue([makeCourse({ category: 'database' })]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+    expect(screen.getByText('データベース')).toBeInTheDocument();
+  });
+
+  it('未分類コースはカテゴリバッジを表示しない', async () => {
+    mockList.mockResolvedValue([makeCourse({ category: '' })]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+    for (const c of COURSE_CATEGORIES) {
+      expect(screen.queryByText(c.label)).not.toBeInTheDocument();
+    }
+  });
+
+  it('管理者の作成フォームにカテゴリ選択（未分類 + 全カテゴリ）が表示される', async () => {
+    mockList.mockResolvedValue([]);
+    renderPage('company_admin');
+    await waitFor(() => expect(screen.getByRole('button', { name: /新しいコース/ })).toBeInTheDocument());
+    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
+    const select = screen.getByRole('combobox');
+    expect(select).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '未分類' })).toBeInTheDocument();
+    for (const c of COURSE_CATEGORIES) {
+      expect(screen.getByRole('option', { name: c.label })).toBeInTheDocument();
+    }
+  });
+});
+
+describe('findCourseCategory', () => {
+  it('定義済み key は定義を返す', () => {
+    expect(findCourseCategory('database')?.label).toBe('データベース');
+    expect(findCourseCategory('dev-basics')?.label).toBe('開発基礎');
+  });
+
+  it('空文字・未知の key は undefined（無色 = 従来表示）', () => {
+    expect(findCourseCategory('')).toBeUndefined();
+    expect(findCourseCategory(undefined)).toBeUndefined();
+    expect(findCourseCategory('unknown')).toBeUndefined();
+  });
+
+  it('カテゴリ key に重複がない', () => {
+    const keys = COURSE_CATEGORIES.map((c) => c.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/frontend/src/pages/__tests__/CoursesListPage.test.tsx
+++ b/frontend/src/pages/__tests__/CoursesListPage.test.tsx
@@ -90,6 +90,100 @@ describe('CoursesListPage カテゴリ色分け (FRESTYLE-67)', () => {
   });
 });
 
+describe('CoursesListPage CRUD フロー', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('trainee には「新しいコース」ボタンを表示しない', async () => {
+    mockList.mockResolvedValue([makeCourse()]);
+    renderPage('trainee');
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /新しいコース/ })).not.toBeInTheDocument();
+  });
+
+  it('取得失敗時はエラーメッセージを表示する', async () => {
+    mockList.mockRejectedValue(new Error('network'));
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText('コースの取得に失敗しました')).toBeInTheDocument(),
+    );
+  });
+
+  it('検索でタイトルを絞り込める', async () => {
+    mockList.mockResolvedValue([
+      makeCourse({ id: 1, title: 'PostgreSQL 徹底入門' }),
+      makeCourse({ id: 2, title: 'Terraform 入門', category: 'infra' }),
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Terraform 入門')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('コースを検索'), { target: { value: 'terraform' } });
+    expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument();
+    expect(screen.getByText('Terraform 入門')).toBeInTheDocument();
+  });
+
+  it('作成フォームの送信でカテゴリ込みの payload が送られる', async () => {
+    const mockCreate = vi.mocked(CourseRepository.create);
+    mockList.mockResolvedValue([]);
+    mockCreate.mockResolvedValue(makeCourse({ id: 99, title: '新コース', category: 'security' }));
+    renderPage('company_admin');
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0));
+    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
+
+    // モーダル内のタイトル入力 = 検索ボックス以外の <input type="text">。
+    const titleInput = screen
+      .getAllByRole('textbox')
+      .find((el) => el.tagName === 'INPUT' && el.getAttribute('aria-label') !== 'コースを検索');
+    expect(titleInput).toBeDefined();
+    fireEvent.change(titleInput!, { target: { value: '新コース' } });
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'security' } });
+    fireEvent.click(screen.getByRole('button', { name: '作成' }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ title: '新コース', category: 'security' }),
+    );
+  });
+
+  it('編集フォームは既存カテゴリが初期選択され、更新 payload に含まれる', async () => {
+    const mockUpdate = vi.mocked(CourseRepository.update);
+    mockList.mockResolvedValue([makeCourse({ id: 5, category: 'database' })]);
+    mockUpdate.mockResolvedValue(makeCourse({ id: 5, category: 'infra' }));
+    renderPage('company_admin');
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'コースを編集' }));
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    expect(select.value).toBe('database');
+    fireEvent.change(select, { target: { value: 'infra' } });
+    fireEvent.click(screen.getByRole('button', { name: '更新' }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(
+      5,
+      expect.objectContaining({ category: 'infra' }),
+    );
+  });
+
+  it('削除は確認モーダル経由で remove を呼ぶ', async () => {
+    const mockRemove = vi.mocked(CourseRepository.remove);
+    mockList.mockResolvedValue([makeCourse({ id: 7 })]);
+    mockRemove.mockResolvedValue(undefined);
+    renderPage('company_admin');
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'コースを削除' }));
+    expect(screen.getByText(/このコースを削除しますか/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '削除' }));
+
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith(7));
+    // 削除後は一覧から消える
+    await waitFor(() =>
+      expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument(),
+    );
+  });
+});
+
 describe('findCourseCategory', () => {
   it('定義済み key は定義を返す', () => {
     expect(findCourseCategory('database')?.label).toBe('データベース');

--- a/frontend/src/repositories/CourseRepository.ts
+++ b/frontend/src/repositories/CourseRepository.ts
@@ -11,6 +11,8 @@ import type { Course, TeachingMaterial } from '../types';
 export interface CoursePayload {
   title: string;
   description: string;
+  /** 学習領域カテゴリ（空 = 未分類） */
+  category: string;
   sortOrder: number;
   isPublished: boolean;
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -545,6 +545,8 @@ export interface Course {
   createdByUserId: number;
   title: string;
   description: string;
+  /** 学習領域カテゴリ（空 = 未分類。constants/courseCategories の key と対応） */
+  category: string;
   sortOrder: number;
   isPublished: boolean;
   createdAt: string;


### PR DESCRIPTION
## 概要

会議決定「コース分類の色分け（色＝学習領域の連想促進）」の実装です。Design Doc（FRESTYLE-67）で承認済みの**案 A: 定義済み 7 カテゴリ + 固定カラーマップ**を実装します。コースをグループ単位で色分けし、繰り返し利用で説明なしでも学習者が領域を識別できる UI を目指します。

Jira: FRESTYLE-67（Design Doc・承認記録あり）

## 変更内容

**backend**
- `domain.Course` に `Category string`（既定 `''` = 未分類）を追加 — **GORM AutoMigrate の列追加のみ・非破壊**（migration SQL 不要）
- 定義済みカテゴリ定数（dev-basics / backend / architecture / database / infra / security / product）+ `ValidCourseCategories` + `IsValidCourseCategory`
- Create / Update usecase でカテゴリ検証（TDD で 5 テスト先行 → 実装。不正値は拒否）
- handler `courseRequest` に `binding:"omitempty,oneof=..."` で宣言的に 400（+ handler テスト 2 件）
- `make openapi` で spec 再生成

**frontend**
- `constants/courseCategories.ts`: 7 カテゴリの表示名（日本語）+ 色（バッジ / 左色帯）。backend の値と 1:1
- コース一覧カード: 左端の色帯（`border-l-4`）+ **カテゴリ名バッジ**（色のみに依存しない: 色覚特性・スクリーンリーダー対応でラベル併記）。未分類は無色 = 従来表示
- 作成 / 編集フォームにカテゴリ select（未分類 + 7 分類）
- `Course` 型 / `CoursePayload` に category、`openapi:generate` で生成型更新
- `CoursesListPage` テスト新設（バッジ表示 / 未分類 / フォーム選択 / カラーマップ単体、6 テスト）

**docs**
- `docs/course-categories.md` 新設（仕組み・カテゴリ一覧・拡張手順・DB 反映手順）

## テスト

- backend: `go test ./...` 全 12 パッケージ ok / archlint / naminglint / apispec-lint すべて OK
- frontend: `vitest run` **1152 passed** / `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` すべて成功

## マージ後の手順（FRESTYLE-67 で継続）

1. backend デプロイ（AutoMigrate で `category` 列追加）+ フロントデプロイ
2. 既存 22 コースへのカテゴリ割当 UPDATE SQL を `make apply-migration-supabase` で適用
3. 教材リポの course.yaml / seed-courses.py にカテゴリを同期（正本の整合）

## 関連 Issue

- Jira: FRESTYLE-67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Courses now support a category/learning-domain field.
  * The course list shows category badges and color accents when set.
  * Create/edit course forms include a category selector, with “Unclassified” as an option.

* **Bug Fixes**
  * Category values are now validated consistently, preventing invalid selections from being saved.
  * Course details and list views now stay in sync with the selected category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->