### PR TITLE
feat: 既存コースへの学習領域カテゴリ割当 migration (FRESTYLE-67)

### DIFF
--- a/backend/migrations/0007_course_categories_backfill.sql
+++ b/backend/migrations/0007_course_categories_backfill.sql
@@ -1,0 +1,34 @@
+-- 0007: 既存コースへの学習領域カテゴリ割当 (FRESTYLE-67)
+--
+-- courses.category 列は GORM AutoMigrate が追加済み(既定 '')。本 SQL は既存 22 コースに
+-- 定義済みカテゴリ(domain.ValidCourseCategories / docs/course-categories.md)を割り当てる。
+-- 冪等: 同じ値への UPDATE は何度流しても同じ状態に収束する。対象 id が無ければ no-op。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0007_course_categories_backfill.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+BEGIN;
+
+-- 開発基礎(黄): Web 基礎 / Git / Docker / Linux
+UPDATE courses SET category = 'dev-basics'   WHERE id IN (1, 2, 3, 4);
+
+-- バックエンド開発(青): FreStyle バックエンド入門 / Go / テスト / Go API 設計 / コードリーディング / 自作リンター
+UPDATE courses SET category = 'backend'      WHERE id IN (5, 6, 15, 16, 18, 22);
+
+-- 設計・アーキテクチャ(紫): クリーンアーキ / ヘキサゴナル / レイヤード / Design Doc / クリーンコード
+UPDATE courses SET category = 'architecture' WHERE id IN (7, 8, 9, 14, 21);
+
+-- データベース(緑): PostgreSQL
+UPDATE courses SET category = 'database'     WHERE id = 10;
+
+-- プロダクト・仕様(水色): FreStyle プロダクト / OpenAPI
+UPDATE courses SET category = 'product'      WHERE id IN (11, 12);
+
+-- インフラ・クラウド(橙): ステージング検証 / Terraform / AWS
+UPDATE courses SET category = 'infra'        WHERE id IN (13, 17, 19);
+
+-- セキュリティ(赤): Web セキュリティ
+UPDATE courses SET category = 'security'     WHERE id = 20;
+
+COMMIT;

--- a/docs/course-categories.md
+++ b/docs/course-categories.md
@@ -47,5 +47,19 @@
 ## DB への反映
 
 - 列追加は GORM AutoMigrate が ECS 起動時に自動適用（破壊なし）
-- 既存コースへのカテゴリ割当は UPDATE SQL を `make apply-migration-supabase` で適用する
+- 既存 22 コースへのカテゴリ割当は
+  [`backend/migrations/0007_course_categories_backfill.sql`](../backend/migrations/0007_course_categories_backfill.sql)
+  を `make apply-migration-supabase` で適用済（2026-07-03）
 - 教材リポ（frestyle-teaching-materials）の `course.yaml` にも `category` を追記して正本の整合を保つ
+
+### 既存コースの割当
+
+| カテゴリ | コース id |
+|---|---|
+| dev-basics | 1, 2, 3, 4 |
+| backend | 5, 6, 15, 16, 18, 22 |
+| architecture | 7, 8, 9, 14, 21 |
+| database | 10 |
+| product | 11, 12 |
+| infra | 13, 17, 19 |
+| security | 20 |


### PR DESCRIPTION
## 概要

FRESTYLE-67（コース色分け）の段階2です。PR #2062 で追加した `courses.category`（AutoMigrate 適用済・現在全件 `''`）に対し、既存 22 コースへ定義済みカテゴリを割り当てる migration SQL を追加します。

## 変更内容

- `backend/migrations/0007_course_categories_backfill.sql`（新規・冪等 UPDATE のみ）
  - dev-basics: 1-4 / backend: 5,6,15,16,18,22 / architecture: 7,8,9,14,21 / database: 10 / product: 11,12 / infra: 13,17,19 / security: 20
- `docs/course-categories.md` に割当表を追記

## テスト

- 本番 DB の `SELECT id, title FROM courses` と突き合わせて id を確認済み
- マージ後に `make apply-migration-supabase` で適用し、`/courses` の色分け表示を確認（結果は Jira FRESTYLE-67 に記録）

## 関連 Issue

- Jira: FRESTYLE-67