### PR TITLE
feat: コース一覧をカテゴリ(色)ごとの折りたたみセクション + 絞り込みチップに (FRESTYLE-68)

### DIFF
--- a/frontend/src/pages/CoursesListPage.tsx
+++ b/frontend/src/pages/CoursesListPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
+  ChevronDownIcon,
   PlusIcon,
   PencilSquareIcon,
   TrashIcon,
@@ -16,13 +17,19 @@ import { COURSE_CATEGORIES, findCourseCategory } from '../constants/courseCatego
 import type { RootState } from '../store';
 import type { Course } from '../types';
 
+/** 未分類('')や未知の値を未分類バケットの key('') に正規化する。 */
+function normalizeCategoryKey(category: string): string {
+  return findCourseCategory(category) ? category : '';
+}
+
 /**
  * CoursesListPage — `/courses` コース一覧ページ。
  *
  * - company_admin / super_admin: コースを作成 / 編集 / 削除可
  * - trainee: published コースを閲覧のみ（クリックすると `/courses/:id` 詳細へ）
  *
- * カードグリッドで表示し、 各カードに教材数 / 公開状態 / 説明文を出す。
+ * カテゴリ（学習領域 = 色）ごとのセクションでカードグリッドを表示する(FRESTYLE-68)。
+ * セクションは閉じ開きでき、上部のチップでカテゴリ絞り込みができる。
  */
 export default function CoursesListPage() {
   const role = useSelector((s: RootState) => s.auth.role);
@@ -36,6 +43,39 @@ export default function CoursesListPage() {
 
   const [editTarget, setEditTarget] = useState<Course | 'new' | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
+  // カテゴリ絞り込み(null = すべて)と、セクションごとの折りたたみ状態。
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  const toggleGroup = (key: string) =>
+    setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
+
+  // 絞り込みチップに出すカテゴリ = 実際にコースが存在するものだけ(死にチップを出さない)。
+  const chipCategories = useMemo(() => {
+    const present = new Set(courses.map((c) => normalizeCategoryKey(c.category)));
+    return {
+      cats: COURSE_CATEGORIES.filter((c) => present.has(c.key)),
+      hasUncategorized: present.has(''),
+    };
+  }, [courses]);
+
+  // 検索(filtered) → カテゴリ絞り込み → 定義順のセクションにグルーピング。
+  const visible = useMemo(
+    () =>
+      categoryFilter === null
+        ? filtered
+        : filtered.filter((c) => normalizeCategoryKey(c.category) === categoryFilter),
+    [filtered, categoryFilter],
+  );
+  const groups = useMemo(() => {
+    const order = [...COURSE_CATEGORIES.map((c) => c.key), ''];
+    return order
+      .map((key) => ({
+        key,
+        courses: visible.filter((c) => normalizeCategoryKey(c.category) === key),
+      }))
+      .filter((g) => g.courses.length > 0);
+  }, [visible]);
 
   const handleConfirmDelete = async () => {
     if (deleteTargetId == null) return;
@@ -75,39 +115,101 @@ export default function CoursesListPage() {
         />
       </div>
 
+      {/* カテゴリ絞り込みチップ(色＝学習領域で分別できるように。メンター/trainee 共通) */}
+      {courses.length > 0 && (chipCategories.cats.length > 0 || chipCategories.hasUncategorized) && (
+        <div className="flex items-center gap-2 flex-wrap" role="group" aria-label="カテゴリで絞り込み">
+          <FilterChip
+            label="すべて"
+            active={categoryFilter === null}
+            onClick={() => setCategoryFilter(null)}
+          />
+          {chipCategories.cats.map((c) => (
+            <FilterChip
+              key={c.key}
+              label={c.label}
+              active={categoryFilter === c.key}
+              activeClass={c.badgeClass}
+              onClick={() => setCategoryFilter((prev) => (prev === c.key ? null : c.key))}
+            />
+          ))}
+          {chipCategories.hasUncategorized && (
+            <FilterChip
+              label="未分類"
+              active={categoryFilter === ''}
+              onClick={() => setCategoryFilter((prev) => (prev === '' ? null : ''))}
+            />
+          )}
+        </div>
+      )}
+
       {error && <p className="text-sm text-red-500">{error}</p>}
 
       {loading && courses.length === 0 ? (
         <Loading className="py-12" />
-      ) : filtered.length === 0 ? (
+      ) : visible.length === 0 ? (
         <EmptyState
           icon={FaviconIcon}
-          title={searchQuery ? '該当するコースがありません' : 'コースがありません'}
+          title={searchQuery || categoryFilter !== null ? '該当するコースがありません' : 'コースがありません'}
           description={
-            searchQuery
-              ? '検索条件を変更してみてください'
+            searchQuery || categoryFilter !== null
+              ? '検索条件やカテゴリの絞り込みを変更してみてください'
               : canManage
                 ? '最初のコースを作成しましょう'
                 : '管理者がコースを公開すると、 ここに表示されます'
           }
           action={
-            canManage && !searchQuery
+            canManage && !searchQuery && categoryFilter === null
               ? { label: '新しいコース', onClick: () => setEditTarget('new') }
               : undefined
           }
         />
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map((c) => (
-            <CourseCard
-              key={c.id}
-              course={c}
-              canManage={canManage}
-              onOpen={() => navigate(`/courses/${c.id}`)}
-              onEdit={() => setEditTarget(c)}
-              onDelete={() => setDeleteTargetId(c.id)}
-            />
-          ))}
+        <div className="space-y-6">
+          {groups.map((g) => {
+            const def = findCourseCategory(g.key);
+            const isCollapsed = !!collapsed[g.key];
+            return (
+              <section key={g.key || 'uncategorized'} aria-label={def ? def.label : '未分類'}>
+                <button
+                  type="button"
+                  onClick={() => toggleGroup(g.key)}
+                  aria-expanded={!isCollapsed}
+                  className="flex items-center gap-2 mb-3 rounded-md px-1 py-0.5 hover:bg-surface-2 transition-colors"
+                >
+                  <ChevronDownIcon
+                    aria-hidden="true"
+                    className={`w-4 h-4 text-[var(--color-text-muted)] transition-transform ${
+                      isCollapsed ? '-rotate-90' : ''
+                    }`}
+                  />
+                  {def ? (
+                    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${def.badgeClass}`}>
+                      {def.label}
+                    </span>
+                  ) : (
+                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-surface-3 text-[var(--color-text-muted)]">
+                      未分類
+                    </span>
+                  )}
+                  <span className="text-xs text-[var(--color-text-muted)]">{g.courses.length} 件</span>
+                </button>
+                {!isCollapsed && (
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {g.courses.map((c) => (
+                      <CourseCard
+                        key={c.id}
+                        course={c}
+                        canManage={canManage}
+                        onOpen={() => navigate(`/courses/${c.id}`)}
+                        onEdit={() => setEditTarget(c)}
+                        onDelete={() => setDeleteTargetId(c.id)}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            );
+          })}
         </div>
       )}
 
@@ -144,6 +246,34 @@ export default function CoursesListPage() {
   );
 }
 
+// カテゴリ絞り込みチップ。active 時はカテゴリ色(badgeClass)、それ以外は muted。
+function FilterChip({
+  label,
+  active,
+  activeClass,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  activeClass?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`text-xs font-medium px-3 py-1 rounded-full border transition-colors ${
+        active
+          ? (activeClass ?? 'bg-brand-500/15 text-brand-600 border-brand-500/30')
+          : 'bg-surface-1 text-[var(--color-text-muted)] border-surface-3 hover:bg-surface-2'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
 function CourseCard({
   course,
   canManage,
@@ -157,8 +287,8 @@ function CourseCard({
   onEdit: () => void;
   onDelete: () => void;
 }) {
-  // 「色＝学習領域」の連想(FRESTYLE-67)。左の色帯 + カテゴリ名バッジで表現し、
-  // 色のみに依存しない(未分類は無色 = 従来表示)。
+  // 「色＝学習領域」の連想(FRESTYLE-67)。カードは左の色帯のみで表現し、
+  // カテゴリ名ラベルはセクション見出しが担う(同一セクション内での繰り返しを避ける。FRESTYLE-68)。
   const category = findCourseCategory(course.category);
   return (
     <div
@@ -206,16 +336,9 @@ function CourseCard({
           </div>
         )}
       </div>
-      <div className="flex items-center gap-2 mb-3">
-        {category && (
-          <span className={`text-[11px] px-2 py-0.5 rounded-full flex-shrink-0 ${category.badgeClass}`}>
-            {category.label}
-          </span>
-        )}
-        <p className="text-xs text-[var(--color-text-muted)]">
-          {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
-        </p>
-      </div>
+      <p className="text-xs text-[var(--color-text-muted)] mb-3">
+        {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
+      </p>
       <p className="text-sm text-[var(--color-text-secondary)] line-clamp-3 min-h-[3.6em]">
         {course.description || 'コース説明が未設定です'}
       </p>

--- a/frontend/src/pages/__tests__/CoursesListPage.test.tsx
+++ b/frontend/src/pages/__tests__/CoursesListPage.test.tsx
@@ -60,20 +60,70 @@ describe('CoursesListPage カテゴリ色分け (FRESTYLE-67)', () => {
     vi.clearAllMocks();
   });
 
-  it('カテゴリ付きコースはカテゴリ名バッジを表示する', async () => {
+  it('カテゴリ付きコースはセクション見出し(バッジ + 件数)の下に表示される', async () => {
     mockList.mockResolvedValue([makeCourse({ category: 'database' })]);
     renderPage();
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
-    expect(screen.getByText('データベース')).toBeInTheDocument();
+    // セクション見出し = 「データベース 1 件」の折りたたみボタン
+    expect(screen.getByRole('button', { name: /データベース\s*1 件/ })).toBeInTheDocument();
   });
 
-  it('未分類コースはカテゴリバッジを表示しない', async () => {
+  it('未分類コースは「未分類」セクションに入り、カテゴリ名は表示されない', async () => {
     mockList.mockResolvedValue([makeCourse({ category: '' })]);
     renderPage();
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /未分類\s*1 件/ })).toBeInTheDocument();
     for (const c of COURSE_CATEGORIES) {
       expect(screen.queryByText(c.label)).not.toBeInTheDocument();
     }
+  });
+
+  it('セクション見出しクリックで閉じ開きできる', async () => {
+    mockList.mockResolvedValue([makeCourse({ category: 'database' })]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+    const header = screen.getByRole('button', { name: /データベース\s*1 件/ });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument();
+
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument();
+  });
+
+  it('カテゴリチップで絞り込み・再クリックで解除できる', async () => {
+    mockList.mockResolvedValue([
+      makeCourse({ id: 1, title: 'PostgreSQL 徹底入門', category: 'database' }),
+      makeCourse({ id: 2, title: 'Terraform 入門', category: 'infra' }),
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Terraform 入門')).toBeInTheDocument());
+
+    const chip = screen.getByRole('button', { name: 'データベース' });
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument();
+    expect(screen.queryByText('Terraform 入門')).not.toBeInTheDocument();
+
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText('Terraform 入門')).toBeInTheDocument();
+  });
+
+  it('絞り込みで 0 件になったら該当なしの EmptyState を出す', async () => {
+    mockList.mockResolvedValue([
+      makeCourse({ id: 1, title: 'PostgreSQL 徹底入門', category: 'database' }),
+      makeCourse({ id: 2, title: 'Terraform 入門', category: 'infra' }),
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Terraform 入門')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'データベース' }));
+    fireEvent.change(screen.getByLabelText('コースを検索'), { target: { value: 'terraform' } });
+    expect(screen.getByText('該当するコースがありません')).toBeInTheDocument();
   });
 
   it('管理者の作成フォームにカテゴリ選択（未分類 + 全カテゴリ）が表示される', async () => {


### PR DESCRIPTION
## 概要

FRESTYLE-67（コース色分け）の発展として、要望「色ごとにまとめる」「色ごとに閉じ開きできるように」「メンター側が色で分別できるように」を実装します。frontend のみの変更です（category は導入済み）。

Jira: FRESTYLE-68

## 変更内容

- **カテゴリごとのセクション表示**: 定義順（開発基礎 → バックエンド → 設計 → DB → インフラ → セキュリティ → プロダクト → 未分類）にグルーピング。見出しはカテゴリバッジ + 件数 + シェブロン
- **閉じ開き**: 見出しクリックで折りたたみ（`aria-expanded` 付与）
- **カテゴリ絞り込みチップ**: 「すべて」+ 実在するカテゴリ + 未分類（`aria-pressed`、再クリックで解除）。メンター / trainee 共通で利用可能
- **カード側のバッジをセクション見出しへ昇格**: 同一セクション内でカテゴリ名が繰り返される視覚ノイズを排除（カードは左の色帯のみ維持）
- 検索・絞り込みで 0 件時の EmptyState 文言を統合。未知カテゴリ値は未分類バケットに防衛的に正規化

## テスト

- CoursesListPage テスト 15 件（グルーピング / 閉じ開き / チップ絞り込み・解除 / 0 件 EmptyState / 既存 CRUD フロー）
- `tsc` / `vitest run --coverage`（**statements 85.6% / branches 78.92%** — 閾値 85/78 クリア）/ `eslint` / `build` すべて成功

## 関連 Issue

- Jira: FRESTYLE-68（前提: FRESTYLE-67）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コース一覧にカテゴリごとの絞り込みチップを追加しました。
  * カテゴリ別にセクション表示され、各セクションを折りたたみ/展開できるようになりました。
  * 未分類のコースも専用セクションにまとめて表示されます。

* **テスト**
  * カテゴリ絞り込み、セクションの開閉、空結果表示の挙動を確認するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->