### PR TITLE
fix: コース一覧 0 件時の null レスポンスでコース画面がクラッシュする問題を修正 (FRESTYLE-70)

### DIFF
--- a/backend/internal/usecase/course_usecase.go
+++ b/backend/internal/usecase/course_usecase.go
@@ -27,7 +27,16 @@ func (uc *CourseUseCase) List(ctx context.Context, actorCompanyID uint64, actorR
 		return []domain.Course{}, nil
 	}
 	includeUnpublished := canManage(actorRole)
-	return uc.courses.ListByCompany(ctx, actorCompanyID, includeUnpublished)
+	rows, err := uc.courses.ListByCompany(ctx, actorCompanyID, includeUnpublished)
+	if err != nil {
+		return nil, err
+	}
+	// GORM の Find は 0 件時に nil スライスを返し、JSON では null になって
+	// フロントがクラッシュするため空スライスへ正規化する(FRESTYLE-70)。
+	if rows == nil {
+		rows = []domain.Course{}
+	}
+	return rows, nil
 }
 
 func (uc *CourseUseCase) Get(ctx context.Context, id, actorCompanyID uint64, actorRole string) (*domain.Course, error) {

--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -194,3 +194,15 @@ func Test_コース_更新_不正なカテゴリは拒否(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid course category")
 	assert.Nil(t, crepo.updated)
 }
+
+func Test_コース_一覧_0件でもnilではなく空スライスを返す(t *testing.T) {
+	// GORM の Find は 0 件時に nil スライスを返し、handler がそのまま JSON にすると
+	// null になってフロントがクラッシュする(FRESTYLE-70)。usecase で正規化する。
+	crepo := &fakeCourseRepo{rows: nil}
+	mrepo := &fakeTeachingMaterialRepo{}
+	uc := usecase.NewCourseUseCase(crepo, mrepo)
+	out, err := uc.List(context.Background(), 10, domain.RoleTrainee)
+	require.NoError(t, err)
+	assert.NotNil(t, out)
+	assert.Empty(t, out)
+}

--- a/frontend/src/hooks/useCourses.ts
+++ b/frontend/src/hooks/useCourses.ts
@@ -21,7 +21,8 @@ export function useCourses() {
     setError(null);
     try {
       const rows = await CourseRepository.list();
-      setCourses(rows);
+      // backend が 0 件時に null を返す事故に備えた防御(FRESTYLE-70)。
+      setCourses(rows ?? []);
     } catch {
       setError('コースの取得に失敗しました');
     } finally {

--- a/frontend/src/pages/__tests__/CoursesListPage.test.tsx
+++ b/frontend/src/pages/__tests__/CoursesListPage.test.tsx
@@ -254,3 +254,15 @@ describe('findCourseCategory', () => {
     expect(new Set(keys).size).toBe(keys.length);
   });
 });
+
+describe('API が null を返す場合の防御 (FRESTYLE-70)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('コース一覧 API が null でもクラッシュせず EmptyState を表示する', async () => {
+    mockList.mockResolvedValue(null as unknown as Course[]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('コースがありません')).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
## 概要

コースが 0 件の会社でコース一覧を開くと、`GET /api/v2/courses` が JSON `null` を返し（Go の nil スライス）、フロントが `TypeError: Cannot read properties of null (reading 'map')` でクラッシュする問題の修正です。staging で発覚しましたが、**本番でもコース 0 件の新規会社で再現し得る**バグです（staging の実 API で body `null` を確認済み）。

Jira: FRESTYLE-70

## 変更内容

- **backend**: `CourseUseCase.List` で repository の nil スライスを `[]domain.Course{}` に正規化（TDD: `0件でもnilではなく空スライスを返す` を先行追加 → red → 実装 → green）
- **frontend**: `useCourses` の `setCourses(rows ?? [])` 防御 + 「API が null でもクラッシュせず EmptyState を表示する」回帰テスト

## テスト

- backend: `go test ./...` 全 12 パッケージ ok
- frontend: vitest **1162 passed**（CoursesListPage 16 テスト）/ tsc / eslint / build 全緑

## 関連 Issue

- Jira: FRESTYLE-70（発覚経緯: FRESTYLE-69）