### PR TITLE
feat: コース詳細で最後に閲覧した章を自動表示（続きから再開）+ 章閲覧記録の配線 (FRESTYLE-99)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1967,6 +1967,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/courses/{id}/last-viewed": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き から 表示」 用。 履歴 なし は 204。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース内の最終閲覧章",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView"
+                        }
+                    },
+                    "204": {
+                        "description": "履歴 なし (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "閲覧 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/courses/{id}/materials": {
             "get": {
                 "security": [

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1960,6 +1960,67 @@
                 }
             }
         },
+        "/courses/{id}/last-viewed": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き から 表示」 用。 履歴 なし は 204。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース内の最終閲覧章",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView"
+                        }
+                    },
+                    "204": {
+                        "description": "履歴 なし (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "閲覧 権限 なし",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/courses/{id}/materials": {
             "get": {
                 "security": [

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2275,6 +2275,46 @@ paths:
       summary: コース 更新
       tags:
       - courses
+  /courses/{id}/last-viewed:
+    get:
+      description: current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き
+        から 表示」 用。 履歴 なし は 204。
+      parameters:
+      - description: コース ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView'
+        "204":
+          description: 履歴 なし (本文 なし)
+        "400":
+          description: id 不正
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 閲覧 権限 なし
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: コース が ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: コース内の最終閲覧章
+      tags:
+      - courses
   /courses/{id}/materials:
     get:
       description: 指定 コース 配下 の 教材 を 返す。 trainee は published のみ。

--- a/backend/internal/adapter/persistence/user_chapter_views_repository.go
+++ b/backend/internal/adapter/persistence/user_chapter_views_repository.go
@@ -48,3 +48,24 @@ func (r *userChapterViewRepository) ListRecentByUser(
 		Find(&rows).Error
 	return rows, err
 }
+
+// GetLastViewedByUserAndCourse は (user, course) の閲覧記録から last_viewed_at 最大の 1 件を返す。
+// 履歴なしはエラーではなく (nil, nil)(「初めて開くコース」は正常系のため)。
+func (r *userChapterViewRepository) GetLastViewedByUserAndCourse(
+	ctx context.Context,
+	userID, courseID uint64,
+) (*domain.UserChapterView, error) {
+	var rows []domain.UserChapterView
+	err := r.db.WithContext(ctx).
+		Where("user_id = ? AND course_id = ?", userID, courseID).
+		Order("last_viewed_at DESC").
+		Limit(1).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+	return &rows[0], nil
+}

--- a/backend/internal/adapter/persistence/user_chapter_views_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/user_chapter_views_repository_integration_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserChapterViewRepository_GetLastViewedByUserAndCourse_Integration は
+// (user, course) 内の last_viewed_at 最大 1 件の取得を実 Postgres で検証する。
+func TestUserChapterViewRepository_GetLastViewedByUserAndCourse_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewUserChapterViewRepository(db)
+	ctx := context.Background()
+
+	testsupport.TruncateAll(t, db, "user_chapter_views")
+
+	// user 1 が course 10 の章 101 → 102 の順に閲覧(102 が最後)。course 20 は章 201 のみ。
+	require.NoError(t, repo.UpsertView(ctx, 1, 101, 10))
+	require.NoError(t, repo.UpsertView(ctx, 1, 102, 10))
+	require.NoError(t, repo.UpsertView(ctx, 1, 201, 20))
+	// 別 user の閲覧は混ざらないことの確認用。
+	require.NoError(t, repo.UpsertView(ctx, 2, 101, 10))
+
+	t.Run("course 内で last_viewed_at 最大の 1 件を返す", func(t *testing.T) {
+		got, err := repo.GetLastViewedByUserAndCourse(ctx, 1, 10)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, uint64(102), got.TeachingMaterialID, "最後に閲覧した章 102 が返る")
+	})
+
+	t.Run("再閲覧で last_viewed_at が更新され最新扱いになる", func(t *testing.T) {
+		require.NoError(t, repo.UpsertView(ctx, 1, 101, 10)) // 101 を読み直す
+		got, err := repo.GetLastViewedByUserAndCourse(ctx, 1, 10)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.Equal(t, uint64(101), got.TeachingMaterialID)
+	})
+
+	t.Run("履歴の無い course は nil を返す", func(t *testing.T) {
+		got, err := repo.GetLastViewedByUserAndCourse(ctx, 1, 999)
+		require.NoError(t, err)
+		require.Nil(t, got)
+	})
+
+	t.Run("別 user の閲覧は混ざらない", func(t *testing.T) {
+		got, err := repo.GetLastViewedByUserAndCourse(ctx, 2, 20)
+		require.NoError(t, err)
+		require.Nil(t, got, "user 2 は course 20 を閲覧していない")
+	})
+}

--- a/backend/internal/domain/user_chapter_views.go
+++ b/backend/internal/domain/user_chapter_views.go
@@ -10,7 +10,9 @@ type UserChapterView struct {
 	CourseID           uint64    `gorm:"column:course_id"                       json:"courseId"`
 	FirstViewedAt      time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
 	LastViewedAt       time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
-	ViewCount          int       `gorm:"column:view_count;default:1"            json:"viewCount"`
+	// type:integer は migration 0005 の実テーブル定義に合わせるための明示
+	// (省略すると AutoMigrate が bigint への ALTER を発行してしまう)。
+	ViewCount int `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
 }
 
 func (UserChapterView) TableName() string { return "user_chapter_views" }

--- a/backend/internal/domain/user_chapter_views.go
+++ b/backend/internal/domain/user_chapter_views.go
@@ -13,7 +13,7 @@ type UserChapterView struct {
 	CourseID           uint64    `gorm:"column:course_id"                       json:"courseId"`
 	FirstViewedAt      time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
 	LastViewedAt       time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
-	ViewCount int `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
+	ViewCount          int       `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
 }
 
 func (UserChapterView) TableName() string { return "user_chapter_views" }

--- a/backend/internal/domain/user_chapter_views.go
+++ b/backend/internal/domain/user_chapter_views.go
@@ -4,14 +4,15 @@ import "time"
 
 // UserChapterView はユーザーが章（教材）を開いた記録。
 // PK = (user_id, teaching_material_id)。upsert により last_viewed_at と view_count を更新する。
+// GORM タグの type:integer は migration 0005 の実テーブル定義に合わせるための明示
+// (省略すると AutoMigrate が bigint への ALTER を発行してしまう)。
+// フィールド個別のコメントは swaggo が API description に取り込むためここに書く。
 type UserChapterView struct {
 	UserID             uint64    `gorm:"column:user_id;primaryKey"              json:"userId"`
 	TeachingMaterialID uint64    `gorm:"column:teaching_material_id;primaryKey" json:"teachingMaterialId"`
 	CourseID           uint64    `gorm:"column:course_id"                       json:"courseId"`
 	FirstViewedAt      time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
 	LastViewedAt       time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
-	// type:integer は migration 0005 の実テーブル定義に合わせるための明示
-	// (省略すると AutoMigrate が bigint への ALTER を発行してしまう)。
 	ViewCount int `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
 }
 

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -8,14 +8,19 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
-// CourseHandler はコースの CRUD API を扱う。
+// CourseHandler はコースの CRUD + 最終閲覧章 API を扱う。
 type CourseHandler struct {
 	uc               *usecase.CourseUseCase
 	listWithProgress *usecase.ListCoursesWithProgressUseCase
+	lastViewed       *usecase.GetLastViewedChapterUseCase
 }
 
-func NewCourseHandler(uc *usecase.CourseUseCase, listWithProgress *usecase.ListCoursesWithProgressUseCase) *CourseHandler {
-	return &CourseHandler{uc: uc, listWithProgress: listWithProgress}
+func NewCourseHandler(
+	uc *usecase.CourseUseCase,
+	listWithProgress *usecase.ListCoursesWithProgressUseCase,
+	lastViewed *usecase.GetLastViewedChapterUseCase,
+) *CourseHandler {
+	return &CourseHandler{uc: uc, listWithProgress: listWithProgress, lastViewed: lastViewed}
 }
 
 // @Summary      コース 一覧 (進捗付き)
@@ -72,6 +77,46 @@ func (h *CourseHandler) Get(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, course)
+}
+
+// @Summary      コース内の最終閲覧章
+// @Description  current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き から 表示」 用。 履歴 なし は 204。
+// @Tags         courses
+// @Produce      json
+// @Param        id  path      int  true  "コース ID"
+// @Success      200  {object}  github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView
+// @Success      204  "履歴 なし (本文 なし)"
+// @Failure      400  {object}  errorResponse  "id 不正"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "閲覧 権限 なし"
+// @Failure      404  {object}  errorResponse  "コース が ない"
+// @Router       /courses/{id}/last-viewed [get]
+// @Security     CookieAuth
+func (h *CourseHandler) LastViewed(c *gin.Context) {
+	uid, companyID, role, ok := actorFromContext(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	view, err := h.lastViewed.Execute(c.Request.Context(), usecase.GetLastViewedChapterInput{
+		UserID:         uid,
+		ActorCompanyID: companyID,
+		ActorRole:      role,
+		CourseID:       id,
+	})
+	if err != nil {
+		respondEntityErr(c, err, "コースが見つかりません", "閲覧履歴の取得に失敗しました")
+		return
+	}
+	if view == nil {
+		c.Status(http.StatusNoContent)
+		return
+	}
+	c.JSON(http.StatusOK, view)
 }
 
 type courseRequest struct {

--- a/backend/internal/handler/course_handler.go
+++ b/backend/internal/handler/course_handler.go
@@ -79,6 +79,8 @@ func (h *CourseHandler) Get(c *gin.Context) {
 	c.JSON(http.StatusOK, course)
 }
 
+// LastViewed は current user がコース内で最後に閲覧した章の閲覧記録を返す。
+//
 // @Summary      コース内の最終閲覧章
 // @Description  current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き から 表示」 用。 履歴 なし は 204。
 // @Tags         courses

--- a/backend/internal/handler/course_handler_test.go
+++ b/backend/internal/handler/course_handler_test.go
@@ -59,10 +59,30 @@ func (fakeMaterialRepo) Update(context.Context, *domain.TeachingMaterial) error 
 func (fakeMaterialRepo) Delete(context.Context, uint64) error                   { return nil }
 func (fakeMaterialRepo) DeleteByCourse(context.Context, uint64) error           { return nil }
 
+// fakeChapterViewRepoH は repository.UserChapterViewRepository の最小 fake。
+type fakeChapterViewRepoH struct {
+	lastViewed *domain.UserChapterView
+}
+
+func (f *fakeChapterViewRepoH) UpsertView(context.Context, uint64, uint64, uint64) error { return nil }
+
+func (f *fakeChapterViewRepoH) ListRecentByUser(context.Context, uint64, int) ([]domain.UserChapterView, error) {
+	return nil, nil
+}
+
+func (f *fakeChapterViewRepoH) GetLastViewedByUserAndCourse(context.Context, uint64, uint64) (*domain.UserChapterView, error) {
+	return f.lastViewed, nil
+}
+
 func newCourseHandler(cr repository.CourseRepository) *CourseHandler {
+	return newCourseHandlerWithViews(cr, &fakeChapterViewRepoH{})
+}
+
+func newCourseHandlerWithViews(cr repository.CourseRepository, cv repository.UserChapterViewRepository) *CourseHandler {
 	return NewCourseHandler(
 		usecase.NewCourseUseCase(cr, fakeMaterialRepo{}),
 		usecase.NewListCoursesWithProgressUseCase(cr, fakeMaterialRepo{}, &fakeProgressRepoH{}),
+		usecase.NewGetLastViewedChapterUseCase(cr, cv),
 	)
 }
 
@@ -158,6 +178,40 @@ func Test_コースハンドラ_削除(t *testing.T) {
 	t.Run("正常系 → 204", func(t *testing.T) {
 		_, c := ctxJSON(http.MethodDelete, "", idParam("5"), superAdminCo())
 		newCourseHandler(&fakeCourseRepo{one: &domain.Course{ID: 5, CompanyID: 1}}).Delete(c)
+		if c.Writer.Status() != http.StatusNoContent {
+			t.Fatalf("want 204, got %d", c.Writer.Status())
+		}
+	})
+}
+
+func Test_コースハンドラ_最終閲覧章(t *testing.T) {
+	course := &domain.Course{ID: 5, CompanyID: 1, IsPublished: true}
+
+	t.Run("不正な id → 400", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", idParam("abc"), superAdminCo())
+		newCourseHandler(&fakeCourseRepo{one: course}).LastViewed(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("未認証 → 401", func(t *testing.T) {
+		w, c := ctxJSON(http.MethodGet, "", idParam("5"), nil)
+		newCourseHandler(&fakeCourseRepo{one: course}).LastViewed(c)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("want 401, got %d", w.Code)
+		}
+	})
+	t.Run("履歴あり → 200", func(t *testing.T) {
+		view := &domain.UserChapterView{UserID: 1, TeachingMaterialID: 42, CourseID: 5}
+		w, c := ctxJSON(http.MethodGet, "", idParam("5"), superAdminCo())
+		newCourseHandlerWithViews(&fakeCourseRepo{one: course}, &fakeChapterViewRepoH{lastViewed: view}).LastViewed(c)
+		if w.Code != http.StatusOK {
+			t.Fatalf("want 200, got %d", w.Code)
+		}
+	})
+	t.Run("履歴なし → 204", func(t *testing.T) {
+		_, c := ctxJSON(http.MethodGet, "", idParam("5"), superAdminCo())
+		newCourseHandlerWithViews(&fakeCourseRepo{one: course}, &fakeChapterViewRepoH{}).LastViewed(c)
 		if c.Writer.Status() != http.StatusNoContent {
 			t.Fatalf("want 204, got %d", c.Writer.Status())
 		}

--- a/backend/internal/handler/routes_courses.go
+++ b/backend/internal/handler/routes_courses.go
@@ -12,16 +12,19 @@ func registerCourseRoutes(g *gin.RouterGroup, deps *routeDeps) {
 	courseRepo := persistence.NewCourseRepository(deps.db)
 	materialRepo := persistence.NewTeachingMaterialRepository(deps.db)
 	progressRepo := persistence.NewLessonProgressRepository(deps.db)
+	chapterViewRepo := persistence.NewUserChapterViewRepository(deps.db)
 
 	courseUC := usecase.NewCourseUseCase(courseRepo, materialRepo)
 	listWithProgressUC := usecase.NewListCoursesWithProgressUseCase(courseRepo, materialRepo, progressRepo)
-	courseHandler := NewCourseHandler(courseUC, listWithProgressUC)
+	lastViewedUC := usecase.NewGetLastViewedChapterUseCase(courseRepo, chapterViewRepo)
+	courseHandler := NewCourseHandler(courseUC, listWithProgressUC, lastViewedUC)
 
 	materialUC := usecase.NewTeachingMaterialUseCase(materialRepo, courseRepo)
 	materialHandler := NewTeachingMaterialHandler(materialUC)
 
 	g.GET("/courses", courseHandler.List)
 	g.GET("/courses/:id", courseHandler.Get)
+	g.GET("/courses/:id/last-viewed", courseHandler.LastViewed)
 	g.POST("/courses", courseHandler.Create)
 	g.PUT("/courses/:id", courseHandler.Update)
 	g.DELETE("/courses/:id", courseHandler.Delete)

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -30,6 +30,9 @@ func allDomainModels() []any {
 		&domain.LearningReport{},
 		&domain.AuditEvent{},
 		&domain.UserLessonProgress{},
+		// user_chapter_views の実テーブルは migration 0005 で作成済。ここに載せるのは
+		// 結合テスト DB のスキーマ構築のため(タグは 0005 と一致させ、本番では no-op)。
+		&domain.UserChapterView{},
 	}
 }
 

--- a/backend/internal/usecase/get_last_viewed_chapter_usecase.go
+++ b/backend/internal/usecase/get_last_viewed_chapter_usecase.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// GetLastViewedChapterUseCase はコース内で actor 自身が最後に閲覧した章の閲覧記録を返す。
+// コース詳細を開いたときの「続きから表示」(FRESTYLE-99)用。履歴が無い場合は nil を返す(エラーではない)。
+// canReadCourse で他社・未公開(trainee 不可)コースへのアクセスを防ぐ。
+type GetLastViewedChapterUseCase struct {
+	courses      repository.CourseRepository
+	chapterViews repository.UserChapterViewRepository
+}
+
+// NewGetLastViewedChapterUseCase は GetLastViewedChapterUseCase を組み立てる。
+func NewGetLastViewedChapterUseCase(
+	courses repository.CourseRepository,
+	chapterViews repository.UserChapterViewRepository,
+) *GetLastViewedChapterUseCase {
+	return &GetLastViewedChapterUseCase{courses: courses, chapterViews: chapterViews}
+}
+
+// GetLastViewedChapterInput は取得対象コースと actor 情報(認証 context 由来)。
+type GetLastViewedChapterInput struct {
+	UserID         uint64
+	ActorCompanyID uint64
+	ActorRole      string
+	CourseID       uint64
+}
+
+// Execute はコースの可視性を検証してから最終閲覧記録を返す。履歴なしは (nil, nil)。
+func (u *GetLastViewedChapterUseCase) Execute(ctx context.Context, in GetLastViewedChapterInput) (*domain.UserChapterView, error) {
+	course, err := u.courses.GetByID(ctx, in.CourseID)
+	if err != nil {
+		return nil, err
+	}
+	if !canReadCourse(course, in.ActorCompanyID, in.ActorRole) {
+		return nil, fmt.Errorf("forbidden")
+	}
+	return u.chapterViews.GetLastViewedByUserAndCourse(ctx, in.UserID, in.CourseID)
+}

--- a/backend/internal/usecase/get_last_viewed_chapter_usecase_test.go
+++ b/backend/internal/usecase/get_last_viewed_chapter_usecase_test.go
@@ -1,0 +1,88 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// fakeChapterViewRepo は UserChapterViewRepository の fake。
+type fakeChapterViewRepo struct {
+	lastViewed *domain.UserChapterView
+	getErr     error
+}
+
+func (f *fakeChapterViewRepo) UpsertView(context.Context, uint64, uint64, uint64) error { return nil }
+
+func (f *fakeChapterViewRepo) ListRecentByUser(context.Context, uint64, int) ([]domain.UserChapterView, error) {
+	return nil, nil
+}
+
+func (f *fakeChapterViewRepo) GetLastViewedByUserAndCourse(context.Context, uint64, uint64) (*domain.UserChapterView, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.lastViewed, nil
+}
+
+func Test_最終閲覧章_履歴があれば返す(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	view := &domain.UserChapterView{UserID: 7, TeachingMaterialID: 42, CourseID: 5, LastViewedAt: time.Now()}
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{lastViewed: view})
+
+	got, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
+		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, uint64(42), got.TeachingMaterialID)
+}
+
+func Test_最終閲覧章_履歴なしはnilを返す(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{lastViewed: nil})
+
+	got, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
+		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got, "初めて開くコースは履歴なし = 正常系")
+}
+
+func Test_最終閲覧章_他社コースは禁止(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{})
+
+	_, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
+		UserID: 7, ActorCompanyID: 99, ActorRole: domain.RoleTrainee, CourseID: 5,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func Test_最終閲覧章_traineeは未公開コース禁止(t *testing.T) {
+	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{})
+
+	_, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
+		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forbidden")
+}
+
+func Test_最終閲覧章_コースが無ければNotFound(t *testing.T) {
+	crepo := &fakeCourseRepo{getErr: gorm.ErrRecordNotFound}
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{})
+
+	_, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
+		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
+	})
+	require.ErrorIs(t, err, gorm.ErrRecordNotFound)
+}

--- a/backend/internal/usecase/repository/user_chapter_views.go
+++ b/backend/internal/usecase/repository/user_chapter_views.go
@@ -15,4 +15,8 @@ type UserChapterViewRepository interface {
 	// ListRecentByUser は最後に閲覧した章を新しい順で最大 limit 件返す。
 	// 「続きから」カード用。
 	ListRecentByUser(ctx context.Context, userID uint64, limit int) ([]domain.UserChapterView, error)
+
+	// GetLastViewedByUserAndCourse は user がコース内で最後に閲覧した 1 件を返す。
+	// コース詳細のレジューム(続きから表示)用。履歴が無い場合は (nil, nil)。
+	GetLastViewedByUserAndCourse(ctx context.Context, userID, courseID uint64) (*domain.UserChapterView, error)
 }

--- a/docs/course-chapter-loading.md
+++ b/docs/course-chapter-loading.md
@@ -33,3 +33,33 @@
 本文領域はローディングを抜けて上部のエラーバナーで通知する。
 
 関連テスト: [useTeachingMaterials.test.ts](../frontend/src/hooks/__tests__/useTeachingMaterials.test.ts)
+
+## 続きから表示（レジューム、FRESTYLE-99）
+
+受講者（trainee）がコース詳細を開くと、**最後に閲覧した章**（無ければ先頭の章）を自動選択して
+「教材を選択してください」の空表示を経由せず学習を再開できる。
+
+### 閲覧の記録
+
+- 受講者が章を表示したとき [CourseDetailPage](../frontend/src/pages/CourseDetailPage.tsx) が
+  `DashboardRepository.recordChapterView`（`POST /api/v2/teaching-materials/:id/view`）を呼ぶ。
+  ベストエフォート（失敗は黙殺）で、`user_chapter_views` の `last_viewed_at` / `view_count` が upsert される
+- この記録はダッシュボードの「続きから」基盤データも兼ねる。なお PR #2014 で API と repository は
+  用意されていたが frontend からの呼び出し配線が無く、FRESTYLE-99 で初めて配線された
+
+### 復元（自動選択）
+
+- backend: `GET /api/v2/courses/:id/last-viewed` が「そのコース内で last_viewed_at 最大の 1 件」を返す
+  （履歴なしは 204。usecase `GetLastViewedChapterUseCase` がコースの閲覧権限を検証）
+- frontend: [useChapterResume](../frontend/src/hooks/useChapterResume.ts) が章一覧のロード完了後に
+  一度だけ発火し、履歴の章（一覧に無ければ / 履歴なし / 取得失敗なら先頭の章）を `selectMaterial` する
+
+### ガード（重要）
+
+- **コースごとに一度だけ**発火（`resumedCourseRef`）。手動選択済みなら発火済み扱い
+- 履歴の取得中にユーザーが手動で章を選んだ場合は**上書きしない**（`selectedIdRef` で解決時に再判定）
+- コース切替直後は前コースの `materials` が残っている commit があるため、
+  `materials[0].courseId === courseId` になってから発火する
+- 管理ロール（company_admin / super_admin）は従来どおり自動選択なし（編集フローを変えない）
+
+関連テスト: [useChapterResume.test.ts](../frontend/src/hooks/__tests__/useChapterResume.test.ts)

--- a/frontend/src/constants/apiRoutes.ts
+++ b/frontend/src/constants/apiRoutes.ts
@@ -185,6 +185,8 @@ export const COURSES = {
   byId: (id: number | string) => `${API_V2}/courses/${id}`,
   /** GET /api/v2/courses/:id/materials — コース内教材一覧 */
   materials: (id: number | string) => `${API_V2}/courses/${id}/materials`,
+  /** GET /api/v2/courses/:id/last-viewed — コース内で最後に閲覧した章（履歴なしは 204）*/
+  lastViewed: (id: number | string) => `${API_V2}/courses/${id}/last-viewed`,
 } as const;
 
 /** 教材 個別 CRUD（コース配下）*/

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -2463,6 +2463,91 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/courses/{id}/last-viewed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * コース内の最終閲覧章
+         * @description current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き から 表示」 用。 履歴 なし は 204。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description コース ID */
+                    id: number;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView"];
+                    };
+                };
+                /** @description 履歴 なし (本文 なし) */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description id 不正 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 閲覧 権限 なし */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description コース が ない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/courses/{id}/materials": {
         parameters: {
             query?: never;

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2436,6 +2436,86 @@
                 }
             }
         },
+        "/courses/{id}/last-viewed": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "current user が この コース で 最後 に 閲覧 した 章 の 閲覧 記録 を 返す。 コース詳細 の 「続き から 表示」 用。 履歴 なし は 204。",
+                "tags": [
+                    "courses"
+                ],
+                "summary": "コース内の最終閲覧章",
+                "parameters": [
+                    {
+                        "description": "コース ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_domain.UserChapterView"
+                                }
+                            }
+                        }
+                    },
+                    "204": {
+                        "description": "履歴 なし (本文 なし)"
+                    },
+                    "400": {
+                        "description": "id 不正",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "閲覧 権限 なし",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "コース が ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/courses/{id}/materials": {
             "get": {
                 "security": [

--- a/frontend/src/hooks/__tests__/useChapterResume.test.ts
+++ b/frontend/src/hooks/__tests__/useChapterResume.test.ts
@@ -148,4 +148,38 @@ describe('useChapterResume', () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(mockLastViewed).not.toHaveBeenCalled();
   });
+
+  it('取得中に別コースへ切り替わったら前コースの応答では選択しない(stale ガード)', async () => {
+    let resolveCourse5: (v: UserChapterView | null) => void = () => {};
+    mockLastViewed.mockImplementationOnce(
+      () =>
+        new Promise<UserChapterView | null>((resolve) => {
+          resolveCourse5 = resolve;
+        }),
+    );
+    const selectMaterial = vi.fn();
+    const { rerender } = renderHook((p: Params) => useChapterResume(p), {
+      initialProps: baseParams({ selectMaterial }), // courseId=5
+    });
+    await waitFor(() => expect(mockLastViewed).toHaveBeenCalledWith(5));
+
+    // コース 6 へ遷移(選択リセット + 新コースの一覧ロード完了)。コース 6 の履歴は即 null。
+    mockLastViewed.mockResolvedValue(null);
+    rerender(
+      baseParams({
+        courseId: 6,
+        materials: [material(61, 6), material(62, 6)],
+        selectedId: null,
+        selectMaterial,
+      }),
+    );
+    await waitFor(() => expect(mockLastViewed).toHaveBeenCalledWith(6));
+
+    // 遅れて届いたコース 5 の応答はコース 6 の画面を上書きしない。
+    resolveCourse5(view(12, 5));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(selectMaterial).not.toHaveBeenCalledWith(12);
+    // コース 6 側のレジューム(履歴なし → 先頭章)は正常に動く。
+    await waitFor(() => expect(selectMaterial).toHaveBeenCalledWith(61));
+  });
 });

--- a/frontend/src/hooks/__tests__/useChapterResume.test.ts
+++ b/frontend/src/hooks/__tests__/useChapterResume.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useChapterResume } from '../useChapterResume';
+import CourseRepository from '../../repositories/CourseRepository';
+import type { TeachingMaterial, UserChapterView } from '../../types';
+
+vi.mock('../../repositories/CourseRepository', () => ({
+  default: {
+    lastViewed: vi.fn(),
+  },
+}));
+
+const mockLastViewed = vi.mocked(CourseRepository.lastViewed);
+
+function material(id: number, courseId = 5): TeachingMaterial {
+  return {
+    id,
+    companyId: 10,
+    courseId,
+    createdByUserId: 1,
+    title: `章 ${id}`,
+    content: '',
+    orderInCourse: id,
+    isPublished: true,
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+  };
+}
+
+function view(teachingMaterialId: number, courseId = 5): UserChapterView {
+  return {
+    userId: 7,
+    teachingMaterialId,
+    courseId,
+    firstViewedAt: '2026-07-01T00:00:00Z',
+    lastViewedAt: '2026-07-08T00:00:00Z',
+    viewCount: 3,
+  };
+}
+
+type Params = Parameters<typeof useChapterResume>[0];
+
+function baseParams(overrides: Partial<Params> = {}): Params {
+  return {
+    enabled: true,
+    courseId: 5,
+    materials: [material(11), material(12), material(13)],
+    loading: false,
+    selectedId: null,
+    selectMaterial: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('useChapterResume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('最後に閲覧した章が一覧にあればそれを自動選択する', async () => {
+    mockLastViewed.mockResolvedValue(view(12));
+    const params = baseParams();
+    renderHook(() => useChapterResume(params));
+    await waitFor(() => expect(params.selectMaterial).toHaveBeenCalledWith(12));
+    expect(params.selectMaterial).toHaveBeenCalledTimes(1);
+  });
+
+  it('履歴なし(204/null)は先頭の章を選択する', async () => {
+    mockLastViewed.mockResolvedValue(null);
+    const params = baseParams();
+    renderHook(() => useChapterResume(params));
+    await waitFor(() => expect(params.selectMaterial).toHaveBeenCalledWith(11));
+  });
+
+  it('履歴の章が一覧に無い(非公開化等)場合は先頭へフォールバック', async () => {
+    mockLastViewed.mockResolvedValue(view(999));
+    const params = baseParams();
+    renderHook(() => useChapterResume(params));
+    await waitFor(() => expect(params.selectMaterial).toHaveBeenCalledWith(11));
+  });
+
+  it('履歴の取得に失敗しても先頭の章を選択する', async () => {
+    mockLastViewed.mockRejectedValue(new Error('network'));
+    const params = baseParams();
+    renderHook(() => useChapterResume(params));
+    await waitFor(() => expect(params.selectMaterial).toHaveBeenCalledWith(11));
+  });
+
+  it('enabled=false(管理ロール)では API も自動選択もしない', async () => {
+    const params = baseParams({ enabled: false });
+    renderHook(() => useChapterResume(params));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockLastViewed).not.toHaveBeenCalled();
+    expect(params.selectMaterial).not.toHaveBeenCalled();
+  });
+
+  it('loading 中は発火せず、ロード完了後に一度だけ発火する', async () => {
+    mockLastViewed.mockResolvedValue(view(12));
+    const params = baseParams({ loading: true });
+    const { rerender } = renderHook((p: Params) => useChapterResume(p), {
+      initialProps: params,
+    });
+    expect(mockLastViewed).not.toHaveBeenCalled();
+
+    const loaded = { ...params, loading: false };
+    rerender(loaded);
+    await waitFor(() => expect(params.selectMaterial).toHaveBeenCalledWith(12));
+
+    // 再レンダーしても再発火しない(同一コースで一度だけ)。
+    rerender({ ...loaded });
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockLastViewed).toHaveBeenCalledTimes(1);
+    expect(params.selectMaterial).toHaveBeenCalledTimes(1);
+  });
+
+  it('すでに章が選択済みなら API も自動選択もしない', async () => {
+    const params = baseParams({ selectedId: 13 });
+    renderHook(() => useChapterResume(params));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockLastViewed).not.toHaveBeenCalled();
+    expect(params.selectMaterial).not.toHaveBeenCalled();
+  });
+
+  it('履歴取得中にユーザーが手動選択したら上書きしない', async () => {
+    let resolveFetch: (v: UserChapterView | null) => void = () => {};
+    mockLastViewed.mockReturnValue(
+      new Promise<UserChapterView | null>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+    const params = baseParams();
+    const { rerender } = renderHook((p: Params) => useChapterResume(p), {
+      initialProps: params,
+    });
+    await waitFor(() => expect(mockLastViewed).toHaveBeenCalledTimes(1));
+
+    // fetch 未解決のままユーザーが章 13 を手動選択した状態を再現。
+    rerender({ ...params, selectedId: 13 });
+    resolveFetch(view(12));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(params.selectMaterial).not.toHaveBeenCalled();
+  });
+
+  it('一覧がまだ前のコースのものである間は発火しない', async () => {
+    // courseId=6 に切り替わったが materials は courseId=5 のものが残っている commit。
+    const params = baseParams({ courseId: 6 });
+    renderHook(() => useChapterResume(params));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockLastViewed).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useChapterResume.ts
+++ b/frontend/src/hooks/useChapterResume.ts
@@ -19,6 +19,7 @@ interface UseChapterResumeParams {
  * 一度だけ自動選択する（FRESTYLE-99「続きから表示」）。
  *
  * - 手動で章を選択済みの場合や、取得完了前に手動選択された場合は上書きしない
+ * - 取得中に別コースへ切り替わった場合、遅れて届いた応答では選択しない（stale ガード）
  * - 履歴の取得に失敗しても先頭の章へフォールバックする（レジュームは補助機能）
  */
 export function useChapterResume({
@@ -31,45 +32,46 @@ export function useChapterResume({
 }: UseChapterResumeParams) {
   // コースごとに一度だけ発火させる。手動選択済みの場合も発火済み扱いにする。
   const resumedCourseRef = useRef<number | null>(null);
-  // 非同期解決時に「まだ未選択か」を最新値で判定するための ref。
+  // 非同期解決時に「まだ未選択か」「まだ同じコースか」を最新値で判定するための ref。
   const selectedIdRef = useRef<number | null>(selectedId);
-  // 発火判定時に最新の一覧を参照するための ref（materials の identity 変化で再発火させない）。
-  const materialsRef = useRef<TeachingMaterial[]>(materials);
+  const courseIdRef = useRef<number | null>(courseId);
 
   useEffect(() => {
     selectedIdRef.current = selectedId;
   }, [selectedId]);
 
   useEffect(() => {
-    materialsRef.current = materials;
-  }, [materials]);
+    courseIdRef.current = courseId;
+  }, [courseId]);
 
   useEffect(() => {
     if (!enabled || courseId == null || loading) return;
-    const mats = materialsRef.current;
     // コース切替直後は前コースの一覧が残っている commit があるため、
     // 一覧が「今の courseId のもの」になってから発火する。
-    if (mats.length === 0 || mats[0].courseId !== courseId) return;
+    if (materials.length === 0 || materials[0].courseId !== courseId) return;
     if (resumedCourseRef.current === courseId) return;
     resumedCourseRef.current = courseId;
     if (selectedIdRef.current != null) return; // すでに（手動）選択済み
 
-    const fallbackId = mats[0].id;
-    const selectIfStillUnselected = (id: number) => {
-      // 履歴取得中にユーザーが手動選択していたら上書きしない。
-      if (selectedIdRef.current == null) selectMaterial(id);
+    const requestedCourseId = courseId;
+    const fallbackId = materials[0].id;
+    const selectIfStillRelevant = (id: number) => {
+      // 応答待ちの間に別コースへ切り替わった / ユーザーが手動選択した場合は上書きしない。
+      if (courseIdRef.current === requestedCourseId && selectedIdRef.current == null) {
+        selectMaterial(id);
+      }
     };
-    CourseRepository.lastViewed(courseId)
+    CourseRepository.lastViewed(requestedCourseId)
       .then((view) => {
         // 履歴の章が非公開化等で一覧に無い場合も先頭へフォールバック。
         const target =
-          view && mats.some((m) => m.id === view.teachingMaterialId)
+          view && materials.some((m) => m.id === view.teachingMaterialId)
             ? view.teachingMaterialId
             : fallbackId;
-        selectIfStillUnselected(target);
+        selectIfStillRelevant(target);
       })
       .catch(() => {
-        selectIfStillUnselected(fallbackId);
+        selectIfStillRelevant(fallbackId);
       });
   }, [enabled, courseId, loading, materials, selectMaterial]);
 }

--- a/frontend/src/hooks/useChapterResume.ts
+++ b/frontend/src/hooks/useChapterResume.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from 'react';
+import CourseRepository from '../repositories/CourseRepository';
+import type { TeachingMaterial } from '../types';
+
+interface UseChapterResumeParams {
+  /** false（管理ロール等）のときは何もしない。 */
+  enabled: boolean;
+  courseId: number | null;
+  /** 章一覧（orderInCourse 順）。先頭がフォールバック先。 */
+  materials: TeachingMaterial[];
+  /** 章一覧の取得中フラグ。ロード完了後に一度だけ発火する。 */
+  loading: boolean;
+  selectedId: number | null;
+  selectMaterial: (id: number | null) => void;
+}
+
+/**
+ * useChapterResume — コース詳細を開いたとき、最後に閲覧した章（無ければ先頭の章）を
+ * 一度だけ自動選択する（FRESTYLE-99「続きから表示」）。
+ *
+ * - 手動で章を選択済みの場合や、取得完了前に手動選択された場合は上書きしない
+ * - 履歴の取得に失敗しても先頭の章へフォールバックする（レジュームは補助機能）
+ */
+export function useChapterResume({
+  enabled,
+  courseId,
+  materials,
+  loading,
+  selectedId,
+  selectMaterial,
+}: UseChapterResumeParams) {
+  // コースごとに一度だけ発火させる。手動選択済みの場合も発火済み扱いにする。
+  const resumedCourseRef = useRef<number | null>(null);
+  // 非同期解決時に「まだ未選択か」を最新値で判定するための ref。
+  const selectedIdRef = useRef<number | null>(selectedId);
+  // 発火判定時に最新の一覧を参照するための ref（materials の identity 変化で再発火させない）。
+  const materialsRef = useRef<TeachingMaterial[]>(materials);
+
+  useEffect(() => {
+    selectedIdRef.current = selectedId;
+  }, [selectedId]);
+
+  useEffect(() => {
+    materialsRef.current = materials;
+  }, [materials]);
+
+  useEffect(() => {
+    if (!enabled || courseId == null || loading) return;
+    const mats = materialsRef.current;
+    // コース切替直後は前コースの一覧が残っている commit があるため、
+    // 一覧が「今の courseId のもの」になってから発火する。
+    if (mats.length === 0 || mats[0].courseId !== courseId) return;
+    if (resumedCourseRef.current === courseId) return;
+    resumedCourseRef.current = courseId;
+    if (selectedIdRef.current != null) return; // すでに（手動）選択済み
+
+    const fallbackId = mats[0].id;
+    const selectIfStillUnselected = (id: number) => {
+      // 履歴取得中にユーザーが手動選択していたら上書きしない。
+      if (selectedIdRef.current == null) selectMaterial(id);
+    };
+    CourseRepository.lastViewed(courseId)
+      .then((view) => {
+        // 履歴の章が非公開化等で一覧に無い場合も先頭へフォールバック。
+        const target =
+          view && mats.some((m) => m.id === view.teachingMaterialId)
+            ? view.teachingMaterialId
+            : fallbackId;
+        selectIfStillUnselected(target);
+      })
+      .catch(() => {
+        selectIfStillUnselected(fallbackId);
+      });
+  }, [enabled, courseId, loading, materials, selectMaterial]);
+}

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -20,11 +20,13 @@ import NoteMarkdownEditor from '../components/NoteMarkdownEditor';
 import MarkdownTableOfContents from '../components/MarkdownTableOfContents';
 import { useTeachingMaterials } from '../hooks/useTeachingMaterials';
 import { useTeachingMaterialEditor } from '../hooks/useTeachingMaterialEditor';
+import { useChapterResume } from '../hooks/useChapterResume';
 import { useLessonProgress } from '../hooks/useLessonProgress';
 import { useMobilePanelState } from '../hooks/useMobilePanelState';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { useToast } from '../hooks/useToast';
 import CourseRepository from '../repositories/CourseRepository';
+import DashboardRepository from '../repositories/DashboardRepository';
 import ImageUploadRepository from '../repositories/ImageUploadRepository';
 import type { RootState } from '../store';
 import type { Course, TeachingMaterial } from '../types';
@@ -67,6 +69,16 @@ export default function CourseDetailPage() {
   } = useTeachingMaterials(courseId);
 
   const editor = useTeachingMaterialEditor({ selectedId, selected, update });
+
+  // 受講者がコースを開いたら「最後に閲覧した章(無ければ先頭)」を自動表示する(FRESTYLE-99)。
+  useChapterResume({ enabled: !canManage, courseId, materials, loading, selectedId, selectMaterial });
+
+  // 章を表示したら閲覧を記録する(受講者のみ・ベストエフォート)。
+  // レジュームとダッシュボード「続きから」の基盤データになる。
+  useEffect(() => {
+    if (canManage || selectedId == null) return;
+    DashboardRepository.recordChapterView(selectedId);
+  }, [canManage, selectedId]);
 
   // 進捗トラッキングは学習者（trainee）向け。 教材を管理するロールでは API を叩かない。
   const progress = useLessonProgress(!canManage);

--- a/frontend/src/repositories/CourseRepository.ts
+++ b/frontend/src/repositories/CourseRepository.ts
@@ -1,6 +1,6 @@
 import api from '../lib/axios';
 import { COURSES } from '../constants/apiRoutes';
-import type { Course, CourseWithProgress, TeachingMaterial } from '../types';
+import type { Course, CourseWithProgress, TeachingMaterial, UserChapterView } from '../types';
 
 /**
  * コース API ラッパ。
@@ -31,6 +31,12 @@ const CourseRepository = {
   async listMaterials(courseId: number): Promise<TeachingMaterial[]> {
     const res = await api.get<TeachingMaterial[]>(COURSES.materials(courseId));
     return res.data;
+  },
+
+  /** コース内で最後に閲覧した章の閲覧記録を返す。履歴なし（204）のときは null。 */
+  async lastViewed(courseId: number): Promise<UserChapterView | null> {
+    const res = await api.get<UserChapterView | undefined>(COURSES.lastViewed(courseId));
+    return res.status === 204 || !res.data ? null : res.data;
   },
 
   async create(payload: CoursePayload): Promise<Course> {


### PR DESCRIPTION
## 概要

コース詳細（/courses/:id）を開いた直後は章が未選択で「教材を選択してください」の空表示になり、受講者は毎回続きの章を探してクリックする必要があった。最後に閲覧した章（無ければ先頭の章）を自動表示して、開いてすぐ学習を再開できるようにする。

あわせて、PR #2014 で backend とリポジトリメソッドまで用意されながら **frontend からの呼び出し配線が入っていなかった章閲覧記録**（POST /api/v2/teaching-materials/:id/view）を配線する。これによりレジュームの基盤データ（user_chapter_views）とダッシュボード「続きから」のデータが実際に溜まり始める。

## 変更内容

### backend
- `UserChapterViewRepository` に `GetLastViewedByUserAndCourse`（user × course で last_viewed_at 最大の 1 件、履歴なしは nil）を追加（port + persistence の 2 ファイル規約）
- 新規 usecase `GetLastViewedChapterUseCase`（struct + New + Execute、canReadCourse で他社・未公開コースを 403）
- `GET /api/v2/courses/{id}/last-viewed` を追加（履歴なしは 204）。swaggo + `make openapi` の生成物同梱

### frontend
- 受講者が章を表示したとき `DashboardRepository.recordChapterView` を呼ぶ配線を CourseDetailPage に追加（ベストエフォート・失敗黙殺）
- 新 hook `useChapterResume`: 章一覧のロード完了後に一度だけ last-viewed の章を自動選択。ガード 3 種:
  - コースごとに一度だけ発火（手動選択済みなら発火済み扱い）
  - 履歴取得中にユーザーが手動選択したら上書きしない
  - コース切替直後に前コースの materials が残っている commit では発火しない（materials[0].courseId 照合）
- 履歴なし / 履歴の章が一覧に無い（非公開化等）/ 取得失敗はすべて先頭の章へフォールバック。管理ロールは従来どおり自動選択なし

### docs
- `docs/course-chapter-loading.md` に「続きから表示」の仕様・ガード・閲覧記録の配線を追記

## テスト

- backend: `go build` / `go vet`（integration タグ込み）/ `go test ./...` 全 green、archlint / naminglint / apispec-lint / gofumpt OK。usecase テスト 5 件（権限・履歴なし・NotFound）、handler テスト 4 件（400/401/200/204）、integration テスト（最終閲覧 1 件取得・再閲覧で最新化・user/course 絞り込み）追加
- frontend: `tsc --noEmit` / `vitest run`（1181 tests）/ `eslint --max-warnings 0` / `npm run build` 全 green。useChapterResume の 9 ケース（履歴あり/なし/一覧に無い/失敗/無効/loading 中/選択済み/手動選択との競合/前コース一覧の残存）

## 関連チケット

- FRESTYLE-99: https://frestyle.atlassian.net/browse/FRESTYLE-99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コース詳細で、最後に閲覧した章を自動で開けるようになりました。履歴がない場合は先頭章に戻ります。
  * コースの最終閲覧章を取得する新しいAPIが追加されました。

* **改善**
  * 章の閲覧状態が記録され、次回表示時の再開位置に反映されるようになりました。
  * コース切り替え時や手動選択時に、表示が意図せず上書きされないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->