### PR TITLE
feat: 教材の完了トグルをスクロールしても押せるようメタ行を sticky 化 (FRESTYLE-100)

### DIFF
--- a/docs/course-chapter-loading.md
+++ b/docs/course-chapter-loading.md
@@ -63,3 +63,15 @@
 - 管理ロール（company_admin / super_admin）は従来どおり自動選択なし（編集フローを変えない）
 
 関連テスト: [useChapterResume.test.ts](../frontend/src/hooks/__tests__/useChapterResume.test.ts)
+
+## 完了トグルの固定表示（FRESTYLE-100）
+
+受講者向け本文（ReadOnlyDetail）のメタ行（最終更新日・目次トグル・完了トグル）は
+`sticky top-0` + ページ背景色（`bg-surface`）+ 下ボーダーで、スクロールコンテナの
+上部に常時残る。本文を読み進めている途中でも、先頭へ戻らずに「完了にする」を押せる。
+
+- sticky の基準はウィンドウではなく ReadOnlyDetail の `overflow-y-auto` コンテナ
+  （body は overflow:hidden。目次 aside の `sticky top-6` と同じ仕組み）
+- z-index は 10（ツールチップ z-30 / モーダル z-50 の下）
+- 本文末尾の大きい完了ボタン + 「次の章へ」は読了導線としてそのまま残している
+- 連打の二重送信は useLessonProgress の in-flight ガードで防止済み

--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -417,7 +417,10 @@ function ReadOnlyDetail({
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)] mb-2">
             {material.title || '無題の教材'}
           </h1>
-          <div className="flex items-center justify-between gap-3 mb-6">
+          {/* 完了トグルを含むメタ行は sticky でスクロールコンテナ上部に残し、
+              本文の途中でも完了操作できるようにする(FRESTYLE-100)。
+              bg はページ背景(surface=白)と同じにして、通過する本文が透けないようにする。 */}
+          <div className="sticky top-0 z-10 bg-surface py-2 border-b border-surface-3 flex items-center justify-between gap-3 mb-6">
             <p className="text-xs text-[var(--color-text-muted)]">
               最終更新: {formatDate(material.updatedAt)}
             </p>

--- a/frontend/src/pages/__tests__/CourseDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/CourseDetailPage.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import CourseDetailPage from '../CourseDetailPage';
+import { ToastProvider } from '../../components/ToastProvider';
+import authReducer from '../../store/authSlice';
+import CourseRepository from '../../repositories/CourseRepository';
+import TeachingMaterialRepository from '../../repositories/TeachingMaterialRepository';
+import LessonProgressRepository from '../../repositories/LessonProgressRepository';
+import DashboardRepository from '../../repositories/DashboardRepository';
+import type { Course, TeachingMaterial, UserChapterView } from '../../types';
+
+vi.mock('../../repositories/CourseRepository', () => ({
+  default: {
+    get: vi.fn(),
+    listMaterials: vi.fn(),
+    lastViewed: vi.fn(),
+  },
+}));
+
+vi.mock('../../repositories/TeachingMaterialRepository', () => ({
+  default: {
+    get: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('../../repositories/LessonProgressRepository', () => ({
+  default: {
+    list: vi.fn(),
+    complete: vi.fn(),
+    incomplete: vi.fn(),
+  },
+}));
+
+vi.mock('../../repositories/DashboardRepository', () => ({
+  default: {
+    get: vi.fn(),
+    recordChapterView: vi.fn(),
+  },
+}));
+
+const mockGetCourse = vi.mocked(CourseRepository.get);
+const mockListMaterials = vi.mocked(CourseRepository.listMaterials);
+const mockLastViewed = vi.mocked(CourseRepository.lastViewed);
+const mockGetMaterial = vi.mocked(TeachingMaterialRepository.get);
+const mockProgressList = vi.mocked(LessonProgressRepository.list);
+const mockComplete = vi.mocked(LessonProgressRepository.complete);
+const mockRecordView = vi.mocked(DashboardRepository.recordChapterView);
+
+function course(): Course {
+  return {
+    id: 5,
+    companyId: 10,
+    createdByUserId: 1,
+    title: 'Git 入門',
+    description: '',
+    category: 'dev-basics',
+    sortOrder: 20,
+    isPublished: true,
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+  };
+}
+
+function material(id: number, content = ''): TeachingMaterial {
+  return {
+    id,
+    companyId: 10,
+    courseId: 5,
+    createdByUserId: 1,
+    title: `章 ${id}`,
+    content,
+    orderInCourse: id,
+    isPublished: true,
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+  };
+}
+
+function view(teachingMaterialId: number): UserChapterView {
+  return {
+    userId: 7,
+    teachingMaterialId,
+    courseId: 5,
+    firstViewedAt: '2026-07-01T00:00:00Z',
+    lastViewedAt: '2026-07-08T00:00:00Z',
+    viewCount: 2,
+  };
+}
+
+function renderPage(role = 'trainee') {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: { role } as never,
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/courses/5']}>
+          <Routes>
+            <Route path="/courses/:id" element={<CourseDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>
+    </Provider>,
+  );
+}
+
+describe('CourseDetailPage 続きから表示 + 完了トグル (FRESTYLE-99 / FRESTYLE-100)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCourse.mockResolvedValue(course());
+    mockListMaterials.mockResolvedValue([material(11), material(12)]);
+    mockLastViewed.mockResolvedValue(view(12));
+    mockGetMaterial.mockImplementation(async (id: number) => material(id, '本文テキスト'));
+    mockProgressList.mockResolvedValue([]);
+    mockComplete.mockResolvedValue(undefined);
+    mockRecordView.mockResolvedValue(undefined);
+  });
+
+  it('受講者が開くと最後に閲覧した章が自動表示され、閲覧が記録される', async () => {
+    renderPage('trainee');
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1, name: '章 12' })).toBeInTheDocument(),
+    );
+    expect(mockLastViewed).toHaveBeenCalledWith(5);
+    await waitFor(() => expect(mockRecordView).toHaveBeenCalledWith(12));
+  });
+
+  it('完了トグルは sticky なメタ行と本文末尾の 2 箇所に表示される', async () => {
+    renderPage('trainee');
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '完了にする' })).toHaveLength(2),
+    );
+    // 先頭(メタ行)のトグルはスクロールしても画面に残るよう sticky な行に入っている(FRESTYLE-100)。
+    const [metaToggle] = screen.getAllByRole('button', { name: '完了にする' });
+    expect(metaToggle.closest('.sticky')).not.toBeNull();
+  });
+
+  it('メタ行の完了トグルをクリックすると完了 API を呼ぶ', async () => {
+    renderPage('trainee');
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '完了にする' })).toHaveLength(2),
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: '完了にする' })[0]);
+    await waitFor(() => expect(mockComplete).toHaveBeenCalledWith(12));
+  });
+
+  it('閲覧履歴が無い場合は先頭の章が表示される', async () => {
+    mockLastViewed.mockResolvedValue(null);
+    renderPage('trainee');
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1, name: '章 11' })).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## 概要

教材本文の「完了にする」ボタンは本文先頭のメタ行と本文末尾の 2 箇所にあるが、どちらもスクロールコンテナの内側にあり、読み進めると画面外に消える。メタ行を sticky 化して、スクロール位置に関係なく完了操作できるようにする（クリック / スクロールの手数削減）。

## 変更内容

- `CourseDetailPage` の受講者向け本文（ReadOnlyDetail）のメタ行（最終更新日・目次トグル・完了トグル）を `sticky top-0 z-10 bg-surface` + 下ボーダーに変更。スクロールコンテナ（overflow-y-auto、目次の sticky と同じ基準）上部に常時残る
- 本文末尾の大きい完了ボタン + 「次の章へ」は読了導線としてそのまま
- ロジック・API 契約の変更なし（連打の二重送信は既存の in-flight ガードで防止済み）
- `CourseDetailPage` の初のページテストを新設: レジューム自動表示（FRESTYLE-99 の統合確認）/ 閲覧記録の送信 / 完了トグル 2 箇所と sticky 配置 / 完了 API 呼び出し / 履歴なしフォールバック
- `docs/course-chapter-loading.md` に固定表示の仕様を追記

## テスト

- `tsc --noEmit` / `vitest run`（全件、新規 4 ケース含む）/ `eslint --max-warnings 0` / `npm run build` すべて成功
- 見た目のみの変更のため、CLAUDE.md §4.2「デザイン専用変更の特例」の条件（ロジック非変更 + 上記 4 チェック成功)を満たす

## 関連チケット

- FRESTYLE-100: https://frestyle.atlassian.net/browse/FRESTYLE-100