### PR TITLE
feat: 演習一覧の言語フィルタをプルダウンからチップ型セレクタに変更 (FRESTYLE-101)

### DIFF
--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -81,3 +81,17 @@ frontend ExerciseDetailPage (Monaco / monacoLanguageOf)
 ## テスト
 - [backend/internal/infra/sandbox/runner_sql_test.go](../backend/internal/infra/sandbox/runner_sql_test.go): `initdb`+`pg_ctl` で使い捨て PG（`dbadmin`/`student` ロール）をローカル起動して executeSQL を実検証。`initdb`/`psql` が無い環境では Skip
   - `Test_ランナー_SQL_単純SELECT` / `Test_ランナー_SQL_複数文と集計` / `Test_ランナー_SQL_文タイムアウトで打ち切る` / `Test_ランナー_SQL_提出間はDBが隔離される` / `Test_ランナー_SQL_COPYPROGRAMは権限拒否` / `Test_ランナー_SQL_危険メタコマンドを拒否`（`\!` / `\c` / `\connect`）
+
+## 言語フィルタ UI（FRESTYLE-101）
+
+演習一覧（/code-editor）の言語絞り込みは、プルダウン（select）ではなく
+コース一覧のカテゴリ絞り込みと同じ**チップ型セレクタ**（常時見える一覧）で行う。
+
+- チップ本体は共有コンポーネント `src/components/ui/FilterChip.tsx`
+  （コース一覧 FRESTYLE-68 のローカル実装を昇格。`aria-pressed` + `role="group"`）
+- 選択肢と有効値の単一情報源は `src/constants/exerciseLanguages.ts`。
+  `useExerciseList` の localStorage 復元時の検証セットもここから導出する
+  （チップの選択肢と検証セットの二重管理を防ぐ。言語を増やすときはこの定数だけ触る）
+- 操作感はコース一覧と統一: 「すべて」+ 各言語、**アクティブなチップの再クリックで「すべて」に戻る**
+- 初期言語は localStorage 復元（既定 PHP）、絞り込みはサーバーサイド
+  （`GET /api/v2/exercises?language=`）という既存仕様は変更していない

--- a/frontend/src/components/__tests__/MarkdownTableOfContents.test.tsx
+++ b/frontend/src/components/__tests__/MarkdownTableOfContents.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import MarkdownTableOfContents from '../MarkdownTableOfContents';
+
+// jsdom は IntersectionObserver を実装していないためスタブする。
+// コールバックを捕捉して、任意のタイミングで交差イベントを再現できるようにする。
+type IOCallback = (entries: Array<Partial<IntersectionObserverEntry>>) => void;
+let capturedCallback: IOCallback | null = null;
+const observed: Element[] = [];
+
+class StubIntersectionObserver {
+  constructor(cb: IOCallback) {
+    capturedCallback = cb;
+  }
+  observe(el: Element) {
+    observed.push(el);
+  }
+  disconnect() {}
+  unobserve() {}
+}
+
+describe('MarkdownTableOfContents', () => {
+  beforeEach(() => {
+    capturedCallback = null;
+    observed.length = 0;
+    vi.stubGlobal('IntersectionObserver', StubIntersectionObserver);
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('h1〜h3 を抽出してレベルに応じたアンカーリンクを描画する', () => {
+    const content = ['# はじめに', '', '## セットアップ', '', '### 前提条件', '', '#### 深すぎる見出し'].join('\n');
+    render(<MarkdownTableOfContents content={content} />);
+    const nav = screen.getByRole('navigation', { name: '目次' });
+    expect(nav).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'はじめに' })).toHaveAttribute('href', '#はじめに');
+    expect(screen.getByRole('link', { name: 'セットアップ' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '前提条件' })).toBeInTheDocument();
+    // h4 以下は目次に載せない。
+    expect(screen.queryByRole('link', { name: '深すぎる見出し' })).not.toBeInTheDocument();
+  });
+
+  it('コードフェンス内の # 行は見出しとして扱わない', () => {
+    const content = ['# 本物の見出し', '```bash', '# これはコメント', '```'].join('\n');
+    render(<MarkdownTableOfContents content={content} />);
+    expect(screen.getByRole('link', { name: '本物の見出し' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'これはコメント' })).not.toBeInTheDocument();
+  });
+
+  it('インライン記法(コード/太字/リンク)を剥がして表示する', () => {
+    const content = '## `git status` と **確認** と [参考](https://example.com)';
+    render(<MarkdownTableOfContents content={content} />);
+    expect(screen.getByRole('link', { name: 'git status と 確認 と 参考' })).toBeInTheDocument();
+  });
+
+  it('見出しが無い場合は何も描画しない', () => {
+    const { container } = render(<MarkdownTableOfContents content={'本文だけ。見出しなし。'} />);
+    expect(container).toBeEmptyDOMElement();
+    const empty = render(<MarkdownTableOfContents content={''} />);
+    expect(empty.container).toBeEmptyDOMElement();
+  });
+
+  it('交差した見出しがハイライトされる(IntersectionObserver)', () => {
+    render(
+      <>
+        {/* rehype-slug が本文側に生成する id 付き見出しを再現する。 */}
+        <h2 id="setup" />
+        <h2 id="usage" />
+        <MarkdownTableOfContents content={'## Setup\n\n## Usage'} />
+      </>,
+    );
+    expect(observed).toHaveLength(2);
+
+    act(() => {
+      capturedCallback?.([
+        {
+          isIntersecting: true,
+          target: document.getElementById('usage')!,
+          boundingClientRect: { top: 10 } as DOMRectReadOnly,
+        },
+      ]);
+    });
+    expect(screen.getByRole('link', { name: 'Usage' })).toHaveClass('border-taupe-500');
+    expect(screen.getByRole('link', { name: 'Setup' })).not.toHaveClass('border-taupe-500');
+  });
+});

--- a/frontend/src/components/ui/FilterChip.tsx
+++ b/frontend/src/components/ui/FilterChip.tsx
@@ -1,0 +1,31 @@
+/**
+ * FilterChip — 一覧の絞り込みに使うピル型トグルボタン。
+ *
+ * コース一覧のカテゴリ絞り込み(FRESTYLE-68)と演習一覧の言語絞り込み(FRESTYLE-101)で共用。
+ * active 時は activeClass(カテゴリ色などの badgeClass)、未指定なら brand 色。
+ * 選択状態は aria-pressed で公開する。
+ */
+export interface FilterChipProps {
+  label: string;
+  active: boolean;
+  /** active 時に適用する色クラス(例: カテゴリの badgeClass)。未指定なら brand 色。 */
+  activeClass?: string;
+  onClick: () => void;
+}
+
+export default function FilterChip({ label, active, activeClass, onClick }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`text-xs font-medium px-3 py-1 rounded-full border transition-colors ${
+        active
+          ? (activeClass ?? 'bg-brand-500/15 text-brand-600 border-brand-500/30')
+          : 'bg-surface-1 text-[var(--color-text-muted)] border-surface-3 hover:bg-surface-2'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/__tests__/FilterChip.test.tsx
+++ b/frontend/src/components/ui/__tests__/FilterChip.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FilterChip from '../FilterChip';
+
+describe('FilterChip', () => {
+  it('label を表示し aria-pressed で選択状態を公開する', () => {
+    render(<FilterChip label="PHP" active={true} onClick={() => {}} />);
+    const chip = screen.getByRole('button', { name: 'PHP' });
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('非 active のときは aria-pressed=false', () => {
+    render(<FilterChip label="Go" active={false} onClick={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Go' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('クリックで onClick を呼ぶ', () => {
+    const onClick = vi.fn();
+    render(<FilterChip label="Docker" active={false} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Docker' }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('active 時に activeClass を適用する(カテゴリ色)', () => {
+    render(
+      <FilterChip label="データベース" active={true} activeClass="bg-emerald-500/15" onClick={() => {}} />,
+    );
+    expect(screen.getByRole('button', { name: 'データベース' })).toHaveClass('bg-emerald-500/15');
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,6 +1,8 @@
 export { default as Button } from './Button';
 export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
 export { default as ActionCard } from './ActionCard';
+export { default as FilterChip } from './FilterChip';
+export type { FilterChipProps } from './FilterChip';
 export { default as FirstTimeWelcome } from './FirstTimeWelcome';
 export { default as GlossaryTerm } from './GlossaryTerm';
 export { default as GuidedHint } from './GuidedHint';

--- a/frontend/src/constants/exerciseLanguages.ts
+++ b/frontend/src/constants/exerciseLanguages.ts
@@ -1,0 +1,20 @@
+/**
+ * 演習の言語フィルタ定義。
+ *
+ * key は backend の master_exercises.language 値、label は表示名。
+ * 選択肢(ExerciseListPage のチップ)と有効値の検証(useExerciseList の localStorage 復元)の
+ * 単一情報源にして二重管理を防ぐ(FRESTYLE-101)。
+ * 'linux' という独立値は存在せず bash に統合されている(表示名で併記)。
+ */
+export interface ExerciseLanguageDef {
+  key: string;
+  label: string;
+}
+
+export const EXERCISE_LANGUAGES: ExerciseLanguageDef[] = [
+  { key: 'php', label: 'PHP' },
+  { key: 'go', label: 'Go' },
+  { key: 'git', label: 'Git' },
+  { key: 'bash', label: 'Bash / Linux' },
+  { key: 'docker', label: 'Docker' },
+];

--- a/frontend/src/hooks/useExerciseList.ts
+++ b/frontend/src/hooks/useExerciseList.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState, useMemo } from 'react';
 import ExerciseRepository from '../repositories/ExerciseRepository';
+import { EXERCISE_LANGUAGES } from '../constants/exerciseLanguages';
 import { MasterExerciseWithStatus } from '../types';
 
 const LANGUAGE_STORAGE_KEY = 'frestyle:exercise-list:language';
-const VALID_LANGUAGES = new Set(['', 'php', 'go', 'bash', 'git', 'docker']);
+// '' = すべて。選択肢の定義(EXERCISE_LANGUAGES)から導出して二重管理を防ぐ(FRESTYLE-101)。
+const VALID_LANGUAGES = new Set(['', ...EXERCISE_LANGUAGES.map((l) => l.key)]);
 const PAGE_SIZE = 20;
 
 function loadStoredLanguage(fallback: string): string {

--- a/frontend/src/pages/CoursesListPage.tsx
+++ b/frontend/src/pages/CoursesListPage.tsx
@@ -12,6 +12,7 @@ import FaviconIcon from '../components/icons/FaviconIcon';
 import Loading from '../components/Loading';
 import ConfirmModal from '../components/ConfirmModal';
 import CourseProgressBar from '../components/CourseProgressBar';
+import { FilterChip } from '../components/ui';
 import { useCourses } from '../hooks/useCourses';
 import { useToast } from '../hooks/useToast';
 import { COURSE_CATEGORIES, findCourseCategory } from '../constants/courseCategories';
@@ -244,34 +245,6 @@ export default function CoursesListPage() {
         isDanger={true}
       />
     </div>
-  );
-}
-
-// カテゴリ絞り込みチップ。active 時はカテゴリ色(badgeClass)、それ以外は muted。
-function FilterChip({
-  label,
-  active,
-  activeClass,
-  onClick,
-}: {
-  label: string;
-  active: boolean;
-  activeClass?: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-pressed={active}
-      className={`text-xs font-medium px-3 py-1 rounded-full border transition-colors ${
-        active
-          ? (activeClass ?? 'bg-brand-500/15 text-brand-600 border-brand-500/30')
-          : 'bg-surface-1 text-[var(--color-text-muted)] border-surface-3 hover:bg-surface-2'
-      }`}
-    >
-      {label}
-    </button>
   );
 }
 

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
 import { CheckCircleIcon, ClockIcon, CodeBracketIcon } from '@heroicons/react/24/outline';
+import { FilterChip } from '../components/ui';
+import { EXERCISE_LANGUAGES } from '../constants/exerciseLanguages';
 import { useExerciseList } from '../hooks/useExerciseList';
 import { MasterExerciseWithStatus } from '../types';
 
@@ -35,20 +37,18 @@ export default function ExerciseListPage() {
         </p>
       </header>
 
-      <div className="flex items-center gap-2 text-sm">
-        <label className="text-[var(--color-text-muted)]">言語:</label>
-        <select
-          value={language}
-          onChange={(e) => setLanguage(e.target.value)}
-          className="px-2 py-1 rounded-lg bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] focus:outline-none focus:border-brand-400"
-        >
-          <option value="">すべて</option>
-          <option value="php">PHP</option>
-          <option value="go">Go</option>
-          <option value="git">Git</option>
-          <option value="bash">Bash / Linux</option>
-          <option value="docker">Docker</option>
-        </select>
+      {/* 言語の絞り込みはコース一覧のカテゴリチップと同じ操作感(常時見える一覧 +
+          アクティブチップの再クリックで「すべて」に戻る)にする(FRESTYLE-101)。 */}
+      <div className="flex items-center gap-2 flex-wrap" role="group" aria-label="言語で絞り込み">
+        <FilterChip label="すべて" active={language === ''} onClick={() => setLanguage('')} />
+        {EXERCISE_LANGUAGES.map((l) => (
+          <FilterChip
+            key={l.key}
+            label={l.label}
+            active={language === l.key}
+            onClick={() => setLanguage(language === l.key ? '' : l.key)}
+          />
+        ))}
       </div>
 
       {loading && (

--- a/frontend/src/pages/__tests__/CourseDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/CourseDetailPage.test.tsx
@@ -160,4 +160,63 @@ describe('CourseDetailPage 続きから表示 + 完了トグル (FRESTYLE-99 / F
       expect(screen.getByRole('heading', { level: 1, name: '章 11' })).toBeInTheDocument(),
     );
   });
+
+  it('管理ロールでは自動選択も閲覧記録もされない', async () => {
+    renderPage('company_admin');
+    await waitFor(() => expect(mockListMaterials).toHaveBeenCalled());
+    // 章メニューはモバイル drawer とデスクトップパネルの 2 箇所に描画される。
+    await waitFor(() => expect(screen.getAllByText('章 11').length).toBeGreaterThan(0));
+    expect(mockLastViewed).not.toHaveBeenCalled();
+    expect(mockRecordView).not.toHaveBeenCalled();
+    // 自動選択されないため本文見出しは出ない。
+    expect(screen.queryByRole('heading', { level: 1, name: /章 1[12]/ })).not.toBeInTheDocument();
+  });
+
+  it('「次の章へ」で次の教材に切り替わり、閲覧も記録される', async () => {
+    mockLastViewed.mockResolvedValue(view(11));
+    renderPage('trainee');
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1, name: '章 11' })).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /次の章へ/ }));
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { level: 1, name: '章 12' })).toBeInTheDocument(),
+    );
+    await waitFor(() => expect(mockRecordView).toHaveBeenCalledWith(12));
+  });
+
+  it('本文の取得に失敗したらエラーメッセージを表示する', async () => {
+    mockGetMaterial.mockRejectedValue(new Error('network'));
+    renderPage('trainee');
+    await waitFor(() => expect(screen.getByText('教材の取得に失敗しました')).toBeInTheDocument());
+  });
+
+  it('コースの取得に失敗したらエラー表示になる', async () => {
+    mockGetCourse.mockRejectedValue(new Error('network'));
+    renderPage('trainee');
+    await waitFor(() =>
+      expect(screen.getByText('コースの取得に失敗しました')).toBeInTheDocument(),
+    );
+  });
+
+  it('完了済みの章は「完了済み」表示になり、クリックで完了解除 API を呼ぶ', async () => {
+    const mockIncomplete = vi.mocked(LessonProgressRepository.incomplete);
+    mockIncomplete.mockResolvedValue(undefined);
+    mockProgressList.mockResolvedValue([
+      {
+        id: 1,
+        userId: 7,
+        teachingMaterialId: 12,
+        courseId: 5,
+        completedAt: '2026-07-08T00:00:00Z',
+        createdAt: '2026-07-08T00:00:00Z',
+      },
+    ]);
+    renderPage('trainee'); // lastViewed = 章 12
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: '完了済み' }).length).toBeGreaterThan(0),
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: '完了済み' })[0]);
+    await waitFor(() => expect(mockIncomplete).toHaveBeenCalledWith(12));
+  });
 });

--- a/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ExerciseListPage from '../ExerciseListPage';
 import ExerciseRepository from '../../repositories/ExerciseRepository';
+import { createMockStorage } from '../../test/mockStorage';
 import { ExercisePage } from '../../types';
 
 vi.mock('../../repositories/ExerciseRepository', () => ({
@@ -123,6 +124,54 @@ describe('ExerciseListPage', () => {
       expect(screen.getByRole('button', { name: 'すべて' })).toHaveAttribute('aria-pressed', 'true'),
     );
     expect(screen.getByRole('button', { name: 'Docker' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  describe('言語選択の localStorage 永続化 (FRESTYLE-101)', () => {
+    // jsdom 環境の localStorage は都度スタブする方針(src/test/mockStorage.ts)。
+    // スタブしないと getItem が使えず hook が常に既定値へフォールバックし、
+    // 「保存 → 復元」の経路がテストで一切実行されない。
+    beforeEach(() => {
+      vi.stubGlobal('localStorage', createMockStorage());
+    });
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('保存済みの言語で初期表示される', async () => {
+      window.localStorage.setItem('frestyle:exercise-list:language', 'go');
+      mockListExercises.mockResolvedValue(emptyPage);
+      renderPage();
+      await waitFor(() => expect(mockListExercises).toHaveBeenCalledWith('go', 0, 20));
+      expect(screen.getByRole('button', { name: 'Go' })).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('アクティブチップの再クリックで選んだ「すべて」も再マウント後に復元される', async () => {
+      window.localStorage.setItem('frestyle:exercise-list:language', 'docker');
+      mockListExercises.mockResolvedValue(emptyPage);
+      const { unmount } = renderPage();
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Docker' })).toHaveAttribute('aria-pressed', 'true'),
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Docker' })); // 再クリック → すべて('')
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'すべて' })).toHaveAttribute('aria-pressed', 'true'),
+      );
+
+      unmount();
+      renderPage();
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'すべて' })).toHaveAttribute('aria-pressed', 'true'),
+      );
+      expect(screen.getByRole('button', { name: 'Docker' })).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('不正な保存値は既定の PHP にフォールバックする', async () => {
+      window.localStorage.setItem('frestyle:exercise-list:language', 'cobol');
+      mockListExercises.mockResolvedValue(emptyPage);
+      renderPage();
+      await waitFor(() => expect(mockListExercises).toHaveBeenCalledWith('php', 0, 20));
+      expect(screen.getByRole('button', { name: 'PHP' })).toHaveAttribute('aria-pressed', 'true');
+    });
   });
 
   it('カードクリックで /code-editor/:slug へのリンクを描画する', async () => {

--- a/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
+++ b/frontend/src/pages/__tests__/ExerciseListPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ExerciseListPage from '../ExerciseListPage';
 import ExerciseRepository from '../../repositories/ExerciseRepository';
@@ -81,6 +81,48 @@ describe('ExerciseListPage', () => {
     await waitFor(() => expect(screen.getByText('変数')).toBeInTheDocument());
     // 未着手はデフォルト状態なのでバッジを出さない(視覚ノイズ削減 / FRESTYLE-64)。
     expect(screen.queryByText('未着手')).not.toBeInTheDocument();
+  });
+
+  it('言語チップが常時表示され、クリックで language 付き再取得になる (FRESTYLE-101)', async () => {
+    mockListExercises.mockResolvedValue(emptyPage);
+    renderPage();
+    // 初期言語は localStorage 復元(既定 php)なので PHP チップがアクティブ。
+    await waitFor(() => expect(mockListExercises).toHaveBeenCalledWith('php', 0, 20));
+    const group = screen.getByRole('group', { name: '言語で絞り込み' });
+    expect(group).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'PHP' })).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    await waitFor(() => expect(mockListExercises).toHaveBeenCalledWith('go', 0, 20));
+    expect(screen.getByRole('button', { name: 'Go' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'PHP' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('「すべて」チップで全言語(クエリなし)の再取得になる', async () => {
+    mockListExercises.mockResolvedValue(emptyPage);
+    renderPage();
+    await waitFor(() => expect(mockListExercises).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'すべて' }));
+    await waitFor(() => expect(mockListExercises).toHaveBeenCalledWith(undefined, 0, 20));
+    expect(screen.getByRole('button', { name: 'すべて' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('アクティブな言語チップの再クリックで「すべて」に戻る(コース一覧と同じトグル操作)', async () => {
+    mockListExercises.mockResolvedValue(emptyPage);
+    renderPage();
+    await waitFor(() => expect(mockListExercises).toHaveBeenCalled());
+
+    // Docker を選んでから再クリック → すべて('')へ。
+    fireEvent.click(screen.getByRole('button', { name: 'Docker' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Docker' })).toHaveAttribute('aria-pressed', 'true'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Docker' }));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'すべて' })).toHaveAttribute('aria-pressed', 'true'),
+    );
+    expect(screen.getByRole('button', { name: 'Docker' })).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('カードクリックで /code-editor/:slug へのリンクを描画する', async () => {


### PR DESCRIPTION
## 概要

コード演習一覧（/code-editor）の言語絞り込みは select（プルダウン）で、選択肢を見るには一度開く必要があった。コース一覧のカテゴリ絞り込みと同じ、常に選択肢が見えるチップ型セレクタに変更して見通しとクリック数を改善する。

## 変更内容

- コース一覧（FRESTYLE-68）のローカル実装だった `FilterChip` を `src/components/ui/FilterChip.tsx` へ昇格して共有化。DOM 構造・クラスは既存と同一のため、コース一覧側のテストは無修正で通る
- `constants/exerciseLanguages.ts` を新設し、チップの選択肢と `useExerciseList` の localStorage 復元検証セット（VALID_LANGUAGES）を単一情報源に統合（従来は select の選択肢と Set の二重管理）
- select をチップ行（`role="group"` + `aria-pressed`、「すべて」+ 各言語）に置換。アクティブなチップの再クリックで「すべて」に戻る操作感はコース一覧と統一
- 初期言語は localStorage 復元（既定 PHP）、絞り込みはサーバーサイド（language クエリ）という既存仕様は変更なし

## テスト

- `tsc --noEmit` / `vitest run`（148 files, 1193 tests）/ `eslint --max-warnings 0` / `npm run build` すべて成功
- 追加: FilterChip 単体 4 件（aria-pressed / onClick / activeClass）、ExerciseListPage のチップ操作 3 件（クリックで language 付き再取得 / 「すべて」/ アクティブ再クリックでトグル解除）

## 関連チケット

- FRESTYLE-101: https://frestyle.atlassian.net/browse/FRESTYLE-101