### PR TITLE
fix: コース切替の再取得中に前回の「次のコース」が残らないよう即クリア (FRESTYLE-102)

### DIFF
--- a/frontend/src/hooks/__tests__/useNextCourse.test.ts
+++ b/frontend/src/hooks/__tests__/useNextCourse.test.ts
@@ -75,4 +75,17 @@ describe('useNextCourse', () => {
     await waitFor(() => expect(mockList).toHaveBeenCalled());
     expect(result.current.nextCourse).toBeNull();
   });
+
+  it('コース切替の再取得中は前回の値を残さない(即クリア)', async () => {
+    mockList.mockResolvedValueOnce([course(7, 'A'), course(8, 'B')]);
+    const { result, rerender } = renderHook(({ id }: { id: number }) => useNextCourse(id, true), {
+      initialProps: { id: 7 },
+    });
+    await waitFor(() => expect(result.current.nextCourse?.id).toBe(8));
+
+    // 2 回目の取得は解決させないままにして、切替直後の状態を観察する。
+    mockList.mockReturnValue(new Promise(() => {}));
+    rerender({ id: 8 });
+    expect(result.current.nextCourse).toBeNull();
+  });
 });

--- a/frontend/src/hooks/useNextCourse.ts
+++ b/frontend/src/hooks/useNextCourse.ts
@@ -19,6 +19,8 @@ export function useNextCourse(courseId: number | null, enabled: boolean) {
       return;
     }
     let active = true;
+    // コース切替・権限切替の直後に前回の「次のコース」が一瞬残らないよう、再取得開始時にクリアする。
+    setNextCourse(null);
     CourseRepository.list()
       .then((rows) => {
         if (!active) return;


### PR DESCRIPTION
## 概要

PR #2073 への CodeRabbit 指摘（マージ後に確認）のフォローアップ。`useNextCourse` は courseId / enabled が変わってから新しい一覧取得が解決するまでの間、前回の `nextCourse` を保持し続けるため、コース切替直後に古い「次のコースへ」導線が一瞬表示され得た。

## 変更内容

- 再取得の開始時に `setNextCourse(null)` で前回値を即クリア（1 行 + コメント）
- 回帰テスト追加: 切替後の取得が未解決の間は null であることを検証

## テスト

- `vitest run`（useNextCourse 7 ケース + CourseDetailPage 12 ケース）/ `tsc --noEmit` / `eslint` すべて成功

## 関連チケット

- FRESTYLE-102: https://frestyle.atlassian.net/browse/FRESTYLE-102（PR #2073 のフォローアップ）