### PR TITLE
feat: 触感的 UI プリミティブ群 inkwell を Tailwind のみで新設 (FRESTYLE-104)

### DIFF
--- a/docs/inkwell-ui-primitives.md
+++ b/docs/inkwell-ui-primitives.md
@@ -14,14 +14,33 @@
 - アプリ本体のテーマ（`brand-*` / `taupe-*` のモノクロ最小構成）とは**分離**。既存 `components/ui/` は不変。
 
 ```tsx
-import { InkwellButton, InkwellTextField, InkwellCard, InkwellCheckbox, InkwellSwitch } from '../components/inkwell';
+import { useState } from 'react';
+import {
+  InkwellButton,
+  InkwellTextField,
+  InkwellCard,
+  InkwellCardContent,
+  InkwellCheckbox,
+  InkwellSwitch,
+} from '../components/inkwell';
 
-<InkwellButton color="primary">保存</InkwellButton>
-<InkwellButton variant="outlined">キャンセル</InkwellButton>
-<InkwellTextField label="メール" helperText="社内アドレス" error={hasError} />
-<InkwellCard elevation={2}><InkwellCardContent>...</InkwellCardContent></InkwellCard>
-<InkwellCheckbox label="同意する" checked={ok} onChange={e => setOk(e.target.checked)} />
-<InkwellSwitch label="通知" checked={on} onChange={e => setOn(e.target.checked)} />
+function Example() {
+  const [ok, setOk] = useState(false);
+  const [on, setOn] = useState(true);
+  const hasError = false;
+  return (
+    <>
+      <InkwellButton color="primary">保存</InkwellButton>
+      <InkwellButton variant="outlined">キャンセル</InkwellButton>
+      <InkwellTextField label="メール" helperText="社内アドレス" error={hasError} />
+      <InkwellCard elevation={2}>
+        <InkwellCardContent>本文</InkwellCardContent>
+      </InkwellCard>
+      <InkwellCheckbox label="同意する" checked={ok} onChange={(e) => setOk(e.target.checked)} />
+      <InkwellSwitch label="通知" checked={on} onChange={(e) => setOn(e.target.checked)} />
+    </>
+  );
+}
 ```
 
 ## コンポーネント

--- a/docs/inkwell-ui-primitives.md
+++ b/docs/inkwell-ui-primitives.md
@@ -1,0 +1,65 @@
+# inkwell UI プリミティブ（触感的コンポーネント群）
+
+押下時の波紋・標高シャドウ・浮き上がるラベルを持つ触感的な UI プリミティブを、外部 UI ライブラリを使わず
+**Tailwind CSS だけ**で実装したもの。青系プライマリ（#1976d2）・Roboto・角丸 4px・大文字ボタンといった
+定番の Material 風ルックを、バンドルを増やさずに提供する。
+
+> 「なぜこの見た目にするのか」という設計判断・採用理由は private リポ `frestyle-pdm` の
+> `docs/architecture/inkwell-ui-primitives.md` に記載（本リポは使い方に集中する）。
+
+## 置き場所と使い方
+
+- 実装: `frontend/src/components/inkwell/`
+- カタログ（見た目確認）: `/dev/inkwell`（認証不要ルート）
+- アプリ本体のテーマ（`brand-*` / `taupe-*` のモノクロ最小構成）とは**分離**。既存 `components/ui/` は不変。
+
+```tsx
+import { InkwellButton, InkwellTextField, InkwellCard, InkwellCheckbox, InkwellSwitch } from '../components/inkwell';
+
+<InkwellButton color="primary">保存</InkwellButton>
+<InkwellButton variant="outlined">キャンセル</InkwellButton>
+<InkwellTextField label="メール" helperText="社内アドレス" error={hasError} />
+<InkwellCard elevation={2}><InkwellCardContent>...</InkwellCardContent></InkwellCard>
+<InkwellCheckbox label="同意する" checked={ok} onChange={e => setOk(e.target.checked)} />
+<InkwellSwitch label="通知" checked={on} onChange={e => setOn(e.target.checked)} />
+```
+
+## コンポーネント
+
+| コンポーネント | 主な props | 見た目 |
+|---|---|---|
+| `InkwellButton` | `variant`(contained/outlined/text) / `color`(primary/secondary/error) / `size` / `startIcon` `endIcon` | 大文字ラベル・押下波紋・contained は標高が上がる |
+| `InkwellTextField` | `label`(必須) / `helperText` / `error` / `fullWidth` | 枠線 + 浮き上がるラベル（枠を背景色で切り欠く）・エラー色 |
+| `InkwellCard` + `InkwellCardContent` / `InkwellCardActions` | `elevation`(0/1/2/3/4/8) | 標高シャドウ。0 は影の代わりに枠線 |
+| `InkwellCheckbox` | `label` / 標準 input 属性 | チェックで塗り＋レ点・押下波紋・ホバー円 |
+| `InkwellSwitch` | `label` / 標準 input 属性 | トラック上をサムが滑る・ON で色付き |
+
+## デザイントークン（`tailwind.config.js`、名前空間 `inkwell-*`）
+
+- 色: `inkwell-primary`(#1976d2) / `-secondary`(#9c27b0) / `-error`(#d32f2f) と各 dark、`inkwell-text-*`、`inkwell-outline` / `-divider`
+- フォント: `font-roboto`（`@fontsource/roboto` を自己ホスト。CSP `font-src 'self'` 準拠。付けた要素だけに適用）
+- 影: `shadow-inkwell-1|2|3|4|8`（3 層合成の標高）
+- アニメ: `animate-inkwell-ripple`（押下波紋）
+
+いずれも名前空間付きで、既存の `brand-*` / `taupe-*` / `surface-*` には影響しない。
+
+## 実装ノート（品質のための定番パターン）
+
+- **波紋**: `useRipple` が pointerdown 座標に円を置き、`animate-inkwell-ripple` でスケール＋フェード。
+  `onAnimationEnd` で DOM から除去してリークを防ぐ。
+- **浮き上がるラベル**: ラベルを input の**後ろ**に置き `peer` で連動。既定を「浮いた状態」にして
+  `peer-placeholder-shown:` で未入力時のみプレースホルダ位置へ戻す（入力後にラベルが本文へ落ちるバグの回避）。
+  空白 placeholder（`' '`）で `:placeholder-shown` を機能させ、ラベル背景色で枠線を切り欠く。
+- **アクセシビリティ**: Checkbox / Switch は実 `<input>`（`sr-only` の peer）+ `<label>` で構成し、
+  role・checked・disabled がそのまま働く。Button は `focus-visible` リング、TextField は
+  `aria-invalid` / `aria-describedby` を付与。
+
+## テスト
+
+`frontend/src/components/inkwell/__tests__/`（vitest + RTL、24 ケース）。role/aria・variant クラス・
+クリック/トグル・波紋要素の生成を検証。
+
+## 関連
+
+- Jira: FRESTYLE-104
+- 設計理由（why）: `frestyle-pdm` `docs/architecture/inkwell-ui-primitives.md`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,8 @@ const ExerciseDetailPage = lazyWithReload(() => import('./pages/ExerciseDetailPa
 const CoursesListPage = lazyWithReload(() => import('./pages/CoursesListPage'), 'CoursesListPage');
 const CourseDetailPage = lazyWithReload(() => import('./pages/CourseDetailPage'), 'CourseDetailPage');
 const MarkdownSyntaxHelpPage = lazyWithReload(() => import('./pages/MarkdownSyntaxHelpPage'), 'MarkdownSyntaxHelpPage');
+// inkwell プリミティブの見た目確認用カタログ（認証不要・削除可）。
+const InkwellShowcasePage = lazyWithReload(() => import('./pages/InkwellShowcasePage'), 'InkwellShowcasePage');
 
 function NavigationToast() {
   const location = useLocation();
@@ -91,6 +93,8 @@ export default function App() {
       {/* 招待マジックリンクの受諾画面（認証不要・SES メールから踏まれる） */}
       <Route path="/invitations/accept" element={<AcceptInvitationPage />} />
       <Route path="/company-application" element={<CompanyApplicationPage />} />
+      {/* inkwell UI カタログ（見た目確認用・認証不要） */}
+      <Route path="/dev/inkwell" element={<InkwellShowcasePage />} />
 
       {/* 認証が必要（AppShell レイアウト内） */}
       <Route

--- a/frontend/src/components/inkwell/InkwellButton.tsx
+++ b/frontend/src/components/inkwell/InkwellButton.tsx
@@ -1,0 +1,91 @@
+import { ReactNode } from 'react';
+import { useRipple } from './useRipple';
+
+export type InkwellButtonVariant = 'contained' | 'outlined' | 'text';
+export type InkwellButtonColor = 'primary' | 'secondary' | 'error';
+export type InkwellButtonSize = 'small' | 'medium' | 'large';
+
+export interface InkwellButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: InkwellButtonVariant;
+  color?: InkwellButtonColor;
+  size?: InkwellButtonSize;
+  fullWidth?: boolean;
+  startIcon?: ReactNode;
+  endIcon?: ReactNode;
+  children: ReactNode;
+}
+
+// 塗り: 面を色で埋め、押下で標高が上がる。
+const CONTAINED: Record<InkwellButtonColor, string> = {
+  primary: 'bg-inkwell-primary hover:bg-inkwell-primary-dark text-white shadow-inkwell-2 hover:shadow-inkwell-4',
+  secondary: 'bg-inkwell-secondary hover:bg-inkwell-secondary-dark text-white shadow-inkwell-2 hover:shadow-inkwell-4',
+  error: 'bg-inkwell-error hover:bg-inkwell-error-dark text-white shadow-inkwell-2 hover:shadow-inkwell-4',
+};
+
+// 枠線: 縁取りのみ。ホバーで薄い面のオーバーレイ。
+const OUTLINED: Record<InkwellButtonColor, string> = {
+  primary: 'border border-inkwell-primary/50 hover:border-inkwell-primary text-inkwell-primary hover:bg-inkwell-primary/[0.04]',
+  secondary: 'border border-inkwell-secondary/50 hover:border-inkwell-secondary text-inkwell-secondary hover:bg-inkwell-secondary/[0.04]',
+  error: 'border border-inkwell-error/50 hover:border-inkwell-error text-inkwell-error hover:bg-inkwell-error/[0.04]',
+};
+
+// 文字のみ: 面も枠も無し。ホバーで薄い面のオーバーレイ。
+const TEXT: Record<InkwellButtonColor, string> = {
+  primary: 'text-inkwell-primary hover:bg-inkwell-primary/[0.04]',
+  secondary: 'text-inkwell-secondary hover:bg-inkwell-secondary/[0.04]',
+  error: 'text-inkwell-error hover:bg-inkwell-error/[0.04]',
+};
+
+// text/outlined は左右パディングを詰める。
+const SIZE: Record<InkwellButtonSize, string> = {
+  small: 'text-[0.8125rem] px-[10px] py-1',
+  medium: 'text-sm px-4 py-1.5',
+  large: 'text-[0.9375rem] px-[22px] py-2',
+};
+
+const rippleColor: Record<InkwellButtonVariant, string> = {
+  contained: 'rgba(255,255,255,0.5)',
+  outlined: 'currentColor',
+  text: 'currentColor',
+};
+
+/** 押下波紋・標高・大文字ラベルを持つボタン。塗り / 枠線 / 文字のみの 3 バリアント。 */
+export default function InkwellButton({
+  variant = 'contained',
+  color = 'primary',
+  size = 'medium',
+  fullWidth = false,
+  startIcon,
+  endIcon,
+  children,
+  className = '',
+  type = 'button',
+  disabled,
+  onPointerDown,
+  ...props
+}: InkwellButtonProps) {
+  const { addRipple, rippleOverlay } = useRipple(rippleColor[variant]);
+  const VARIANT = variant === 'contained' ? CONTAINED : variant === 'outlined' ? OUTLINED : TEXT;
+
+  return (
+    <button
+      type={type}
+      disabled={disabled}
+      onPointerDown={(e) => {
+        if (!disabled) addRipple(e);
+        onPointerDown?.(e);
+      }}
+      className={`relative inline-flex items-center justify-center gap-2 overflow-hidden rounded font-roboto font-medium uppercase leading-[1.75] tracking-[0.02857em] transition-[background-color,box-shadow,border-color] duration-200 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inkwell-primary/50 disabled:pointer-events-none disabled:text-inkwell-text-disabled ${
+        disabled && variant === 'contained' ? 'bg-black/[0.12] shadow-none' : VARIANT[color]
+      } ${disabled && variant === 'outlined' ? 'border-black/[0.12]' : ''} ${SIZE[size]} ${
+        fullWidth ? 'w-full' : ''
+      } ${className}`}
+      {...props}
+    >
+      {startIcon && <span className="inline-flex shrink-0 [&>svg]:h-[1.125em] [&>svg]:w-[1.125em]">{startIcon}</span>}
+      {children}
+      {endIcon && <span className="inline-flex shrink-0 [&>svg]:h-[1.125em] [&>svg]:w-[1.125em]">{endIcon}</span>}
+      {rippleOverlay}
+    </button>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellButton.tsx
+++ b/frontend/src/components/inkwell/InkwellButton.tsx
@@ -67,6 +67,16 @@ export default function InkwellButton({
   const { addRipple, rippleOverlay } = useRipple(rippleColor[variant]);
   const VARIANT = variant === 'contained' ? CONTAINED : variant === 'outlined' ? OUTLINED : TEXT;
 
+  // disabled のときは配色クラスを丸ごと差し替える（配色クラスの枠線・背景が残って
+  // 定義順依存で勝敗が変わるのを避ける）。
+  const stateClass = disabled
+    ? variant === 'contained'
+      ? 'bg-black/[0.12] shadow-none'
+      : variant === 'outlined'
+        ? 'border border-black/[0.12]'
+        : ''
+    : VARIANT[color];
+
   return (
     <button
       type={type}
@@ -75,9 +85,7 @@ export default function InkwellButton({
         if (!disabled) addRipple(e);
         onPointerDown?.(e);
       }}
-      className={`relative inline-flex items-center justify-center gap-2 overflow-hidden rounded font-roboto font-medium uppercase leading-[1.75] tracking-[0.02857em] transition-[background-color,box-shadow,border-color] duration-200 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inkwell-primary/50 disabled:pointer-events-none disabled:text-inkwell-text-disabled ${
-        disabled && variant === 'contained' ? 'bg-black/[0.12] shadow-none' : VARIANT[color]
-      } ${disabled && variant === 'outlined' ? 'border-black/[0.12]' : ''} ${SIZE[size]} ${
+      className={`relative inline-flex items-center justify-center gap-2 overflow-hidden rounded font-roboto font-medium uppercase leading-[1.75] tracking-[0.02857em] transition-[background-color,box-shadow,border-color] duration-200 select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inkwell-primary/50 disabled:pointer-events-none disabled:text-inkwell-text-disabled ${stateClass} ${SIZE[size]} ${
         fullWidth ? 'w-full' : ''
       } ${className}`}
       {...props}

--- a/frontend/src/components/inkwell/InkwellCard.tsx
+++ b/frontend/src/components/inkwell/InkwellCard.tsx
@@ -1,0 +1,47 @@
+import { ReactNode } from 'react';
+
+export type InkwellElevation = 0 | 1 | 2 | 3 | 4 | 8;
+
+export interface InkwellCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  elevation?: InkwellElevation;
+  children: ReactNode;
+}
+
+const ELEVATION: Record<InkwellElevation, string> = {
+  0: 'border border-inkwell-divider',
+  1: 'shadow-inkwell-1',
+  2: 'shadow-inkwell-2',
+  3: 'shadow-inkwell-3',
+  4: 'shadow-inkwell-4',
+  8: 'shadow-inkwell-8',
+};
+
+/** 標高シャドウで浮遊感を出す面。elevation=0 は影の代わりに枠線。 */
+export default function InkwellCard({ elevation = 1, children, className = '', ...props }: InkwellCardProps) {
+  return (
+    <div
+      className={`overflow-hidden rounded bg-white font-roboto text-inkwell-text-primary ${ELEVATION[elevation]} ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** カード本文の内側余白。 */
+export function InkwellCardContent({ children, className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`p-4 ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}
+
+/** カード下部のアクション行（ボタンを右寄せ等）。 */
+export function InkwellCardActions({ children, className = '', ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`flex items-center gap-2 p-2 ${className}`} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellCheckbox.tsx
+++ b/frontend/src/components/inkwell/InkwellCheckbox.tsx
@@ -1,0 +1,56 @@
+import { useId } from 'react';
+import { useRipple } from './useRipple';
+
+export interface InkwellCheckboxProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> {
+  label?: string;
+}
+
+/** チェックで塗り＋レ点、周囲に押下波紋とホバーの淡い円。 */
+export default function InkwellCheckbox({
+  label,
+  className = '',
+  id,
+  checked,
+  disabled,
+  ...props
+}: InkwellCheckboxProps) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+  const { addRipple, rippleOverlay } = useRipple('rgba(25,118,210,0.3)');
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={`inline-flex cursor-pointer items-center font-roboto text-inkwell-text-primary ${
+        disabled ? 'cursor-not-allowed opacity-60' : ''
+      } ${className}`}
+    >
+      <span
+        onPointerDown={(e) => {
+          if (!disabled) addRipple(e);
+        }}
+        className="relative flex h-[38px] w-[38px] items-center justify-center rounded-full transition-colors hover:bg-inkwell-primary/[0.04]"
+      >
+        <input
+          id={inputId}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          className="peer sr-only"
+          {...props}
+        />
+        {/* 枠（未チェック時のみ表示） */}
+        <span className="pointer-events-none absolute h-[18px] w-[18px] rounded-[2px] border-2 border-inkwell-text-secondary transition-opacity peer-checked:opacity-0 peer-disabled:border-inkwell-text-disabled" />
+        {/* 塗り + レ点（チェック時に表示） */}
+        <span className="pointer-events-none absolute flex h-[18px] w-[18px] items-center justify-center rounded-[2px] bg-inkwell-primary opacity-0 transition-opacity peer-checked:opacity-100 peer-disabled:bg-inkwell-text-disabled">
+          <svg viewBox="0 0 24 24" className="h-[18px] w-[18px] text-white" aria-hidden="true">
+            <path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z" />
+          </svg>
+        </span>
+        {rippleOverlay}
+      </span>
+      {label && <span className="pl-1 pr-2 text-base">{label}</span>}
+    </label>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellSwitch.tsx
+++ b/frontend/src/components/inkwell/InkwellSwitch.tsx
@@ -1,0 +1,37 @@
+import { useId } from 'react';
+
+export interface InkwellSwitchProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'size'> {
+  label?: string;
+}
+
+/** トラック上をサム（つまみ）が滑るトグル。ON でトラック・サムが色付き、サムは標高シャドウ付き。 */
+export default function InkwellSwitch({ label, className = '', id, checked, disabled, ...props }: InkwellSwitchProps) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+
+  return (
+    <label
+      htmlFor={inputId}
+      className={`inline-flex items-center font-roboto text-inkwell-text-primary ${
+        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+      } ${className}`}
+    >
+      <span className="relative inline-flex h-[38px] w-[58px] shrink-0 items-center px-[12px]">
+        <input
+          id={inputId}
+          type="checkbox"
+          checked={checked}
+          disabled={disabled}
+          className="peer sr-only"
+          {...props}
+        />
+        {/* トラック */}
+        <span className="h-[14px] w-[34px] rounded-full bg-black/[0.38] transition-colors peer-checked:bg-inkwell-primary/50 peer-disabled:bg-black/[0.12]" />
+        {/* サム（トラックの兄弟。ON で右へ移動＋色変化） */}
+        <span className="pointer-events-none absolute left-[10px] top-1/2 h-5 w-5 -translate-y-1/2 rounded-full bg-white shadow-inkwell-1 transition-transform duration-200 peer-checked:translate-x-4 peer-checked:bg-inkwell-primary" />
+      </span>
+      {label && <span className="pl-1 pr-2 text-base">{label}</span>}
+    </label>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellTextField.tsx
+++ b/frontend/src/components/inkwell/InkwellTextField.tsx
@@ -1,0 +1,69 @@
+import { useId } from 'react';
+
+export interface InkwellTextFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  label: string;
+  helperText?: string;
+  error?: boolean;
+  fullWidth?: boolean;
+}
+
+/**
+ * 枠線 + 浮き上がるラベルの入力欄。
+ * ラベルは未入力時は枠内に、フォーカス／入力ありで枠線上へ縮小移動し、背景色で枠線を切り欠く。
+ */
+export default function InkwellTextField({
+  label,
+  helperText,
+  error = false,
+  fullWidth = false,
+  className = '',
+  id,
+  disabled,
+  placeholder,
+  ...props
+}: InkwellTextFieldProps) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+  const helperId = helperText ? `${inputId}-helper` : undefined;
+
+  // placeholder があると :placeholder-shown が常に false になり未入力でもラベルが浮くため、
+  // フォーカス時のみ placeholder を出す想定で peer 状態と併用する。
+  return (
+    <div className={`font-roboto ${fullWidth ? 'w-full' : 'w-auto'} ${className}`}>
+      <div className="relative">
+        <input
+          id={inputId}
+          disabled={disabled}
+          placeholder={placeholder ?? ' '}
+          aria-invalid={error || undefined}
+          aria-describedby={helperId}
+          className={`peer block w-full rounded border bg-transparent px-3 py-4 text-base text-inkwell-text-primary outline-none transition-colors placeholder:text-transparent disabled:text-inkwell-text-disabled ${
+            error
+              ? 'border-inkwell-error focus:border-inkwell-error focus:ring-1 focus:ring-inkwell-error'
+              : 'border-inkwell-outline hover:border-inkwell-text-primary focus:border-inkwell-primary focus:ring-1 focus:ring-inkwell-primary disabled:border-inkwell-divider'
+          }`}
+          {...props}
+        />
+        <label
+          htmlFor={inputId}
+          className={`pointer-events-none absolute left-2 top-4 origin-[0] -translate-y-[1.65rem] scale-75 cursor-text bg-white px-1 text-base transition-all duration-150 peer-placeholder-shown:translate-y-0 peer-placeholder-shown:scale-100 peer-focus:-translate-y-[1.65rem] peer-focus:scale-75 ${
+            error
+              ? 'text-inkwell-error'
+              : 'text-inkwell-text-secondary peer-focus:text-inkwell-primary peer-disabled:text-inkwell-text-disabled'
+          }`}
+        >
+          {label}
+        </label>
+      </div>
+      {helperText && (
+        <p
+          id={helperId}
+          className={`mt-1 px-3 text-xs ${error ? 'text-inkwell-error' : 'text-inkwell-text-secondary'}`}
+        >
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/inkwell/__tests__/InkwellButton.test.tsx
+++ b/frontend/src/components/inkwell/__tests__/InkwellButton.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InkwellButton from '../InkwellButton';
+
+describe('InkwellButton', () => {
+  it('ラベルを描画しクリックで onClick が呼ばれる', () => {
+    const onClick = vi.fn();
+    render(<InkwellButton onClick={onClick}>保存</InkwellButton>);
+    const btn = screen.getByRole('button', { name: '保存' });
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('contained/primary は塗りの背景クラスを持つ', () => {
+    render(<InkwellButton>OK</InkwellButton>);
+    expect(screen.getByRole('button')).toHaveClass('bg-inkwell-primary');
+  });
+
+  it('outlined は枠線クラスを持ち塗り背景は持たない', () => {
+    render(<InkwellButton variant="outlined">OK</InkwellButton>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('border-inkwell-primary/50');
+    expect(btn).not.toHaveClass('bg-inkwell-primary');
+  });
+
+  it('color=error で error 系クラスに切り替わる', () => {
+    render(<InkwellButton color="error">削除</InkwellButton>);
+    expect(screen.getByRole('button')).toHaveClass('bg-inkwell-error');
+  });
+
+  it('disabled ではクリックが発火しない', () => {
+    const onClick = vi.fn();
+    render(
+      <InkwellButton disabled onClick={onClick}>
+        無効
+      </InkwellButton>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('押下で波紋要素が追加される', () => {
+    const { container } = render(<InkwellButton>波紋</InkwellButton>);
+    const btn = screen.getByRole('button');
+    expect(container.querySelector('.animate-inkwell-ripple')).toBeNull();
+    fireEvent.pointerDown(btn);
+    expect(container.querySelector('.animate-inkwell-ripple')).not.toBeNull();
+  });
+
+  it('startIcon / endIcon を描画する', () => {
+    render(
+      <InkwellButton startIcon={<svg data-testid="start" />} endIcon={<svg data-testid="end" />}>
+        送信
+      </InkwellButton>,
+    );
+    expect(screen.getByTestId('start')).toBeInTheDocument();
+    expect(screen.getByTestId('end')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/inkwell/__tests__/InkwellCard.test.tsx
+++ b/frontend/src/components/inkwell/__tests__/InkwellCard.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import InkwellCard, { InkwellCardContent, InkwellCardActions } from '../InkwellCard';
+
+describe('InkwellCard', () => {
+  it('既定 elevation=1 は shadow クラスを持つ', () => {
+    render(<InkwellCard>本文</InkwellCard>);
+    expect(screen.getByText('本文')).toHaveClass('shadow-inkwell-1');
+  });
+
+  it('elevation=0 は影ではなく枠線', () => {
+    render(<InkwellCard elevation={0}>枠</InkwellCard>);
+    const card = screen.getByText('枠');
+    expect(card).toHaveClass('border', 'border-inkwell-divider');
+    expect(card).not.toHaveClass('shadow-inkwell-1');
+  });
+
+  it('elevation=8 は最も強い影クラス', () => {
+    render(<InkwellCard elevation={8}>浮遊</InkwellCard>);
+    expect(screen.getByText('浮遊')).toHaveClass('shadow-inkwell-8');
+  });
+
+  it('Content と Actions を内包できる', () => {
+    render(
+      <InkwellCard>
+        <InkwellCardContent>コンテンツ</InkwellCardContent>
+        <InkwellCardActions>
+          <button>操作</button>
+        </InkwellCardActions>
+      </InkwellCard>,
+    );
+    expect(screen.getByText('コンテンツ')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '操作' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/inkwell/__tests__/InkwellTextField.test.tsx
+++ b/frontend/src/components/inkwell/__tests__/InkwellTextField.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import InkwellTextField from '../InkwellTextField';
+
+describe('InkwellTextField', () => {
+  it('ラベルと入力が紐づく（label クリックで input にフォーカスできる関連）', () => {
+    render(<InkwellTextField label="お名前" />);
+    const input = screen.getByLabelText('お名前');
+    expect(input).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('helperText を表示し aria-describedby で結びつく', () => {
+    render(<InkwellTextField label="メール" helperText="社内アドレス" />);
+    const input = screen.getByLabelText('メール');
+    const helper = screen.getByText('社内アドレス');
+    expect(input.getAttribute('aria-describedby')).toBe(helper.id);
+  });
+
+  it('error のとき aria-invalid とエラー色クラスになる', () => {
+    render(<InkwellTextField label="パスワード" error helperText="不正" />);
+    const input = screen.getByLabelText('パスワード');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).toHaveClass('border-inkwell-error');
+  });
+
+  it('未入力でも placeholder-shown 判定用に空白 placeholder が入る', () => {
+    render(<InkwellTextField label="検索" />);
+    expect(screen.getByLabelText('検索')).toHaveAttribute('placeholder', ' ');
+  });
+
+  it('disabled を渡せる', () => {
+    render(<InkwellTextField label="無効" disabled />);
+    expect(screen.getByLabelText('無効')).toBeDisabled();
+  });
+});

--- a/frontend/src/components/inkwell/__tests__/InkwellToggles.test.tsx
+++ b/frontend/src/components/inkwell/__tests__/InkwellToggles.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InkwellCheckbox from '../InkwellCheckbox';
+import InkwellSwitch from '../InkwellSwitch';
+
+describe('InkwellCheckbox', () => {
+  it('checkbox ロールとラベルを持つ', () => {
+    render(<InkwellCheckbox label="同意" />);
+    expect(screen.getByRole('checkbox', { name: '同意' })).toBeInTheDocument();
+  });
+
+  it('クリックで onChange が発火する', () => {
+    const onChange = vi.fn();
+    render(<InkwellCheckbox label="同意" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('checked を反映する', () => {
+    render(<InkwellCheckbox label="既定 ON" checked readOnly />);
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('disabled を反映する', () => {
+    render(<InkwellCheckbox label="無効" disabled />);
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('押下で波紋が追加される', () => {
+    const { container } = render(<InkwellCheckbox label="波紋" />);
+    fireEvent.pointerDown(container.querySelector('span')!);
+    expect(container.querySelector('.animate-inkwell-ripple')).not.toBeNull();
+  });
+});
+
+describe('InkwellSwitch', () => {
+  it('checkbox ロール（トグル）とラベルを持つ', () => {
+    render(<InkwellSwitch label="通知" />);
+    expect(screen.getByRole('checkbox', { name: '通知' })).toBeInTheDocument();
+  });
+
+  it('クリックで onChange が発火する', () => {
+    const onChange = vi.fn();
+    render(<InkwellSwitch label="通知" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('checked / disabled を反映する', () => {
+    render(<InkwellSwitch label="ON 無効" checked disabled readOnly />);
+    const el = screen.getByRole('checkbox');
+    expect(el).toBeChecked();
+    expect(el).toBeDisabled();
+  });
+});

--- a/frontend/src/components/inkwell/index.ts
+++ b/frontend/src/components/inkwell/index.ts
@@ -1,0 +1,21 @@
+// inkwell — 押下波紋 + 標高シャドウの触感的 UI プリミティブ群。
+// Roboto を自己ホストで読み込む（font-roboto を付けた要素のみに適用。全体フォントは不変）。
+import '@fontsource/roboto/300.css';
+import '@fontsource/roboto/400.css';
+import '@fontsource/roboto/500.css';
+import '@fontsource/roboto/700.css';
+
+export { default as InkwellButton } from './InkwellButton';
+export type { InkwellButtonProps, InkwellButtonVariant, InkwellButtonColor, InkwellButtonSize } from './InkwellButton';
+
+export { default as InkwellTextField } from './InkwellTextField';
+export type { InkwellTextFieldProps } from './InkwellTextField';
+
+export { default as InkwellCard, InkwellCardContent, InkwellCardActions } from './InkwellCard';
+export type { InkwellCardProps, InkwellElevation } from './InkwellCard';
+
+export { default as InkwellCheckbox } from './InkwellCheckbox';
+export type { InkwellCheckboxProps } from './InkwellCheckbox';
+
+export { default as InkwellSwitch } from './InkwellSwitch';
+export type { InkwellSwitchProps } from './InkwellSwitch';

--- a/frontend/src/components/inkwell/useRipple.tsx
+++ b/frontend/src/components/inkwell/useRipple.tsx
@@ -15,12 +15,14 @@ export function useRipple(color = 'currentColor') {
   const [ripples, setRipples] = useState<RippleItem[]>([]);
 
   const addRipple = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    const el = e.currentTarget;
-    const rect = el.getBoundingClientRect();
-    // クリック点を覆いきる直径 = 点から最遠角までの距離 × 2。
-    const size = Math.max(rect.width, rect.height) * 2;
-    const x = e.clientX - rect.left - size / 2;
-    const y = e.clientY - rect.top - size / 2;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    const py = e.clientY - rect.top;
+    // クリック点から最遠角までの距離を半径にして要素を覆いきる。
+    const radius = Math.hypot(Math.max(px, rect.width - px), Math.max(py, rect.height - py));
+    const size = radius * 2;
+    const x = px - radius;
+    const y = py - radius;
     setRipples((prev) => [...prev, { key: prev.length ? prev[prev.length - 1].key + 1 : 0, x, y, size }]);
   }, []);
 

--- a/frontend/src/components/inkwell/useRipple.tsx
+++ b/frontend/src/components/inkwell/useRipple.tsx
@@ -1,0 +1,45 @@
+import { useCallback, useState } from 'react';
+
+interface RippleItem {
+  key: number;
+  x: number;
+  y: number;
+  size: number;
+}
+
+/**
+ * 押した位置から波紋を広げる触感エフェクト。
+ * pointer down の座標を中心に、要素を覆う円をスケール＋フェードで消す。
+ */
+export function useRipple(color = 'currentColor') {
+  const [ripples, setRipples] = useState<RippleItem[]>([]);
+
+  const addRipple = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    const el = e.currentTarget;
+    const rect = el.getBoundingClientRect();
+    // クリック点を覆いきる直径 = 点から最遠角までの距離 × 2。
+    const size = Math.max(rect.width, rect.height) * 2;
+    const x = e.clientX - rect.left - size / 2;
+    const y = e.clientY - rect.top - size / 2;
+    setRipples((prev) => [...prev, { key: prev.length ? prev[prev.length - 1].key + 1 : 0, x, y, size }]);
+  }, []);
+
+  const clear = useCallback((key: number) => {
+    setRipples((prev) => prev.filter((r) => r.key !== key));
+  }, []);
+
+  const rippleOverlay = (
+    <span aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]">
+      {ripples.map((r) => (
+        <span
+          key={r.key}
+          onAnimationEnd={() => clear(r.key)}
+          className="absolute rounded-full animate-inkwell-ripple"
+          style={{ left: r.x, top: r.y, width: r.size, height: r.size, backgroundColor: color }}
+        />
+      ))}
+    </span>
+  );
+
+  return { addRipple, rippleOverlay };
+}

--- a/frontend/src/pages/InkwellShowcasePage.tsx
+++ b/frontend/src/pages/InkwellShowcasePage.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import {
+  InkwellButton,
+  InkwellTextField,
+  InkwellCard,
+  InkwellCardContent,
+  InkwellCardActions,
+  InkwellCheckbox,
+  InkwellSwitch,
+} from '../components/inkwell';
+
+/**
+ * inkwell プリミティブの見た目確認用カタログ（開発・レビュー用）。
+ * アプリ本体のテーマとは独立した触感的コンポーネント群を一覧する。
+ */
+export default function InkwellShowcasePage() {
+  const [checked, setChecked] = useState(true);
+  const [on, setOn] = useState(true);
+
+  return (
+    <div className="min-h-screen bg-[#f5f5f5] font-roboto text-inkwell-text-primary">
+      <div className="mx-auto max-w-4xl px-6 py-10 space-y-10">
+        <header>
+          <h1 className="text-3xl font-medium">inkwell UI カタログ</h1>
+          <p className="mt-1 text-inkwell-text-secondary">押下波紋・標高シャドウ・浮き上がるラベルを Tailwind だけで実装した触感的プリミティブ。</p>
+        </header>
+
+        <Section title="Button — 塗り (contained)">
+          <InkwellButton>Primary</InkwellButton>
+          <InkwellButton color="secondary">Secondary</InkwellButton>
+          <InkwellButton color="error">Error</InkwellButton>
+          <InkwellButton disabled>Disabled</InkwellButton>
+        </Section>
+
+        <Section title="Button — 枠線 (outlined) / 文字のみ (text)">
+          <InkwellButton variant="outlined">Outlined</InkwellButton>
+          <InkwellButton variant="outlined" color="secondary">Outlined</InkwellButton>
+          <InkwellButton variant="text">Text</InkwellButton>
+          <InkwellButton variant="text" color="error">Text</InkwellButton>
+        </Section>
+
+        <Section title="Button — サイズ">
+          <InkwellButton size="small">Small</InkwellButton>
+          <InkwellButton size="medium">Medium</InkwellButton>
+          <InkwellButton size="large">Large</InkwellButton>
+        </Section>
+
+        <Section title="TextField — 枠線 + 浮き上がるラベル">
+          <div className="flex flex-wrap gap-6">
+            <InkwellTextField label="お名前" />
+            <InkwellTextField label="メール" helperText="社内アドレスを入力" defaultValue="taro@example.jp" />
+            <InkwellTextField label="パスワード" type="password" error helperText="8 文字以上にしてください" />
+            <InkwellTextField label="無効" disabled />
+          </div>
+        </Section>
+
+        <Section title="Card — 標高">
+          <div className="flex flex-wrap gap-4">
+            {([0, 1, 2, 4, 8] as const).map((e) => (
+              <InkwellCard key={e} elevation={e} className="w-44">
+                <InkwellCardContent>
+                  <p className="text-sm font-medium">elevation {e}</p>
+                  <p className="mt-1 text-xs text-inkwell-text-secondary">数字が大きいほど浮いて見える</p>
+                </InkwellCardContent>
+                <InkwellCardActions className="justify-end">
+                  <InkwellButton variant="text" size="small">
+                    詳細
+                  </InkwellButton>
+                </InkwellCardActions>
+              </InkwellCard>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="Checkbox / Switch">
+          <div className="flex flex-wrap items-center gap-6">
+            <InkwellCheckbox label="同意する" checked={checked} onChange={(e) => setChecked(e.target.checked)} />
+            <InkwellCheckbox label="未チェック" checked={false} readOnly />
+            <InkwellCheckbox label="無効" disabled />
+            <InkwellSwitch label="通知" checked={on} onChange={(e) => setOn(e.target.checked)} />
+            <InkwellSwitch label="無効" disabled />
+          </div>
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h2 className="mb-3 text-xs font-semibold uppercase tracking-widest text-inkwell-text-secondary">{title}</h2>
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </section>
+  );
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -45,6 +45,24 @@ export default {
         'surface-1': 'var(--color-surface-1)',
         'surface-2': 'var(--color-surface-2)',
         'surface-3': 'var(--color-surface-3)',
+        // inkwell: 押下波紋 + 標高シャドウの触感的コンポーネント群専用パレット。
+        inkwell: {
+          primary: '#1976d2',
+          'primary-dark': '#1565c0',
+          'primary-light': '#42a5f5',
+          secondary: '#9c27b0',
+          'secondary-dark': '#7b1fa2',
+          'secondary-light': '#ba68c8',
+          error: '#d32f2f',
+          'error-dark': '#c62828',
+          // テキスト（黒に対する不透明度で階調を作る）
+          'text-primary': 'rgba(0,0,0,0.87)',
+          'text-secondary': 'rgba(0,0,0,0.6)',
+          'text-disabled': 'rgba(0,0,0,0.38)',
+          // アウトライン / 区切り線
+          outline: 'rgba(0,0,0,0.23)',
+          divider: 'rgba(0,0,0,0.12)',
+        },
       },
       // 角丸ルール:
       //   rounded-xl  → カード / パネル / モーダル / フローティングメニュー
@@ -55,12 +73,26 @@ export default {
         xl: '1rem',
         '2xl': '1.5rem',
       },
+      fontFamily: {
+        // font-roboto を付けた要素だけに適用（アプリ全体の既定フォントは変えない）。
+        roboto: ['Roboto', 'Helvetica', 'Arial', 'sans-serif'],
+      },
+      boxShadow: {
+        // 標高シャドウ: 数字が大きいほど浮いて見える（3 層合成）。
+        'inkwell-1': '0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12)',
+        'inkwell-2': '0px 3px 1px -2px rgba(0,0,0,0.2), 0px 2px 2px 0px rgba(0,0,0,0.14), 0px 1px 5px 0px rgba(0,0,0,0.12)',
+        'inkwell-3': '0px 3px 3px -2px rgba(0,0,0,0.2), 0px 3px 4px 0px rgba(0,0,0,0.14), 0px 1px 8px 0px rgba(0,0,0,0.12)',
+        'inkwell-4': '0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12)',
+        'inkwell-8': '0px 5px 5px -3px rgba(0,0,0,0.2), 0px 8px 10px 1px rgba(0,0,0,0.14), 0px 3px 14px 2px rgba(0,0,0,0.12)',
+      },
       animation: {
         'fade-in': 'fadeIn 0.15s ease-in',
         'scale-in': 'scaleIn 0.2s ease-out',
         'skeleton': 'skeleton 1.5s ease-in-out infinite',
         // Toast 用: 上から落ちてバウンドする 0.6s のアニメーション。
         'toast-drop': 'toastDrop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
+        // 押した位置から広がりながら消える波紋。
+        'inkwell-ripple': 'inkwellRipple 0.55s linear',
       },
       keyframes: {
         fadeIn: {
@@ -80,6 +112,10 @@ export default {
           '60%': { transform: 'translateY(12px)', opacity: '1' },
           '80%': { transform: 'translateY(-6px)' },
           '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
+        inkwellRipple: {
+          '0%': { transform: 'scale(0)', opacity: '0.3' },
+          '100%': { transform: 'scale(1)', opacity: '0' },
         },
       },
     },


### PR DESCRIPTION
## 概要

外部 UI ライブラリを一切使わず、押下時の波紋・標高シャドウ・浮き上がるラベルを持つ触感的な UI プリミティブ（`InkwellButton` / `InkwellTextField` / `InkwellCard` / `InkwellCheckbox` / `InkwellSwitch`）を **Tailwind CSS だけ** で新設する。青系プライマリ（#1976d2）・Roboto・角丸 4px・大文字ボタンといった定番ルックを、ランタイム依存もバンドル増も無しで提供する。

アプリ本体の「ライトテーマ単一・モノクロ最小主義」は変えず、名前空間で分離した別系統として共存させる。

## 変更内容

- **tailwind.config.js**: 名前空間トークンを追加（`inkwell-*` 配色 / `font-roboto` / `shadow-inkwell-1..8` 標高 / `animate-inkwell-ripple` 波紋 + keyframe）。**既存の brand/taupe/surface トークンには一切触れない**
- **src/components/inkwell/**: `useRipple`（押下座標に波紋、`onAnimationEnd` で DOM 除去）+ 5 プリミティブ + barrel（`@fontsource/roboto` を自己ホストで読込、CSP `font-src 'self'` 準拠）
- フローティングラベルは `peer-placeholder-shown` 方式で「入力後にラベルが本文へ落ちる」定番バグを回避し、背景色で枠線を切り欠く。Checkbox / Switch は実 `<input>`（sr-only peer）+ `<label>` で role・checked・disabled を標準に委ね a11y 準拠
- **/dev/inkwell**: 見た目確認用カタログ（認証不要ルート・削除可）
- **docs/inkwell-ui-primitives.md**（使い方）。設計理由（なぜこの見た目・作り方か）は private リポ `frestyle-pdm` の `docs/architecture/inkwell-ui-primitives.md`（PR #22）に記載

## テスト

- `tsc --noEmit` / `vitest run --coverage`（156 files, 1248 tests、statements 85.33% / branches 79.12%）/ `eslint --max-warnings 0` / `npm run build` すべて成功
- inkwell の単体テスト 24 ケース（role/aria・variant クラス・クリック/トグル・波紋要素の生成）
- `/dev/inkwell` を Playwright でスクリーンショットし、塗り/枠線/文字のみボタン・切り欠きラベル入力（充填/エラー/無効）・標高カード・チェックボックス・スイッチが標準テーマに忠実であることを目視確認

## 参照

品質・アクセシビリティの裏取りに評価の高い OSS（shadcn/ui・Radix / Headless UI・Park UI・daisyUI・Flowbite の floating label 等）と実装解説を参照（ライブラリとしては未導入、作法のみ反映）。詳細は pdm の設計理由ドキュメント参照。

## 関連チケット

- FRESTYLE-104: https://frestyle.atlassian.net/browse/FRESTYLE-104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 波紋エフェクトや標高シャドウに対応した Inkwell UI プリミティブを追加しました。
  * ボタン、テキストフィールド、カード、チェックボックス、スイッチを提供します。
  * `/dev/inkwell` で各コンポーネントの表示を確認できます。
  * フローティングラベル、エラー表示、無効状態、アクセシビリティに対応しました。

* **ドキュメント**
  * Inkwell UI の利用方法、デザイントークン、テスト方針を追加しました。

* **テスト**
  * 各コンポーネントの操作、状態、アクセシビリティ、表示を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->