### PR TITLE
fix: 学習レポート画面のクラッシュを修正 — 型を backend の非同期 DTO に整合 (FRESTYLE-105)

### DIFF
--- a/frontend/src/components/ReportCard.tsx
+++ b/frontend/src/components/ReportCard.tsx
@@ -1,57 +1,50 @@
-import { ArrowTrendingUpIcon, ArrowTrendingDownIcon } from '@heroicons/react/24/outline';
 import type { LearningReport } from '../types';
 
 interface ReportCardProps {
   report: LearningReport;
 }
 
+// 生成状態のラベルと配色。淡色背景 + 濃色文字でライトテーマでも読める。
+const STATUS_STYLE: Record<LearningReport['status'], { label: string; className: string }> = {
+  pending: { label: '作成中', className: 'text-amber-700 bg-amber-50 border-amber-200' },
+  ready: { label: '完成', className: 'text-emerald-700 bg-emerald-50 border-emerald-200' },
+  failed: { label: '失敗', className: 'text-rose-700 bg-rose-50 border-rose-200' },
+};
+
+/** 対象月・生成状態・作成日を 1 行で示す学習レポートのカード。 */
 export default function ReportCard({ report }: ReportCardProps) {
-  const scoreChangeColor = (report.scoreChange ?? 0) >= 0 ? 'text-emerald-500' : 'text-rose-500';
-  const ScoreChangeIcon = (report.scoreChange ?? 0) >= 0 ? ArrowTrendingUpIcon : ArrowTrendingDownIcon;
+  const status = STATUS_STYLE[report.status] ?? STATUS_STYLE.pending;
 
   return (
-    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4">
-      <div className="flex items-center justify-between mb-3">
+    <div className="bg-surface-1 rounded-lg border border-surface-3 p-4 flex items-center justify-between gap-3">
+      <div className="min-w-0">
         <h3 className="text-sm font-semibold text-[var(--color-text-primary)]">
-          {report.year}年{report.month}月
+          {formatPeriod(report.periodFrom)} の学習レポート
         </h3>
-        {report.scoreChange != null && (
-          <div className={`flex items-center gap-1 text-xs font-medium ${scoreChangeColor}`}>
-            <ScoreChangeIcon className="w-3.5 h-3.5" />
-            {report.scoreChange > 0 ? '+' : ''}{report.scoreChange.toFixed(1)}
-          </div>
-        )}
+        <p className="mt-0.5 text-xs text-[var(--color-text-muted)]">
+          作成日: {formatDate(report.createdAt)}
+        </p>
       </div>
-
-      <div className="grid grid-cols-3 gap-3 mb-3">
-        <div className="text-center">
-          <p className="text-lg font-bold text-taupe-500">{report.totalSessions}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)]">セッション数</p>
-        </div>
-        <div className="text-center">
-          <p className="text-lg font-bold text-[var(--color-text-primary)]">{report.averageScore.toFixed(1)}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)]">平均スコア</p>
-        </div>
-        <div className="text-center">
-          <p className="text-lg font-bold text-[var(--color-text-secondary)]">{report.practiceDays}</p>
-          <p className="text-[10px] text-[var(--color-text-faint)]">練習日数</p>
-        </div>
-      </div>
-
-      {(report.bestAxis || report.worstAxis) && (
-        <div className="flex gap-2">
-          {report.bestAxis && (
-            <span className="text-[10px] font-medium text-emerald-400 bg-emerald-900/20 px-2 py-0.5 rounded">
-              強み: {report.bestAxis}
-            </span>
-          )}
-          {report.worstAxis && (
-            <span className="text-[10px] font-medium text-amber-400 bg-amber-900/20 px-2 py-0.5 rounded">
-              課題: {report.worstAxis}
-            </span>
-          )}
-        </div>
-      )}
+      <span
+        className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full border ${status.className}`}
+      >
+        {status.label}
+      </span>
     </div>
   );
+}
+
+/** ISO 文字列（対象期間の月初）から「YYYY年M月」を作る。不正値はそのまま返す。 */
+function formatPeriod(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso || '対象月不明';
+  return `${d.getFullYear()}年${d.getMonth() + 1}月`;
+}
+
+/** ISO 文字列から「YYYY/MM/DD」を作る。未設定・不正値は「—」。 */
+function formatDate(iso?: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
 }

--- a/frontend/src/components/ReportCard.tsx
+++ b/frontend/src/components/ReportCard.tsx
@@ -34,17 +34,18 @@ export default function ReportCard({ report }: ReportCardProps) {
   );
 }
 
-/** ISO 文字列（対象期間の月初）から「YYYY年M月」を作る。不正値はそのまま返す。 */
+/** ISO 文字列（対象期間の月初、UTC）から「YYYY年M月」を作る。不正値はそのまま返す。
+ *  期間境界は UTC 深夜のため、UTC メソッドで解釈しないと後ろの TZ で前月にずれる。 */
 function formatPeriod(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso || '対象月不明';
-  return `${d.getFullYear()}年${d.getMonth() + 1}月`;
+  return `${d.getUTCFullYear()}年${d.getUTCMonth() + 1}月`;
 }
 
-/** ISO 文字列から「YYYY/MM/DD」を作る。未設定・不正値は「—」。 */
+/** ISO 文字列（UTC）から「YYYY/MM/DD」を作る。未設定・不正値は「—」。 */
 function formatDate(iso?: string): string {
   if (!iso) return '—';
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '—';
-  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+  return `${d.getUTCFullYear()}/${String(d.getUTCMonth() + 1).padStart(2, '0')}/${String(d.getUTCDate()).padStart(2, '0')}`;
 }

--- a/frontend/src/components/__tests__/ReportCard.test.tsx
+++ b/frontend/src/components/__tests__/ReportCard.test.tsx
@@ -3,39 +3,52 @@ import { render, screen } from '@testing-library/react';
 import ReportCard from '../ReportCard';
 import type { LearningReport } from '../../types';
 
-const baseReport: LearningReport = {
-  id: 1,
-  year: 2024,
-  month: 6,
-  totalSessions: 15,
-  averageScore: 7.8,
-  practiceDays: 10,
-  scoreChange: 0.5,
-  bestAxis: '傾聴力',
-  worstAxis: '説得力',
-};
+function makeReport(overrides: Partial<LearningReport> = {}): LearningReport {
+  return {
+    id: 1,
+    userId: 7,
+    periodFrom: '2026-06-01T00:00:00Z',
+    periodTo: '2026-07-01T00:00:00Z',
+    status: 'pending',
+    createdAt: '2026-06-30T09:00:00Z',
+    ...overrides,
+  };
+}
 
 describe('ReportCard', () => {
-  it('年月が表示される', () => {
-    render(<ReportCard report={baseReport} />);
-    expect(screen.getByText('2024年6月')).toBeInTheDocument();
+  it('対象月（periodFrom 由来）を表示する', () => {
+    render(<ReportCard report={makeReport()} />);
+    expect(screen.getByText('2026年6月 の学習レポート')).toBeInTheDocument();
   });
 
-  it('統計データが表示される', () => {
-    render(<ReportCard report={baseReport} />);
-    expect(screen.getByText('15')).toBeInTheDocument();
-    expect(screen.getByText('7.8')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
+  it('作成日を表示する', () => {
+    render(<ReportCard report={makeReport()} />);
+    expect(screen.getByText(/作成日: 2026\/06\/30/)).toBeInTheDocument();
   });
 
-  it('スコア変動が表示される', () => {
-    render(<ReportCard report={baseReport} />);
-    expect(screen.getByText('+0.5')).toBeInTheDocument();
+  it('pending は「作成中」バッジ', () => {
+    render(<ReportCard report={makeReport({ status: 'pending' })} />);
+    expect(screen.getByText('作成中')).toBeInTheDocument();
   });
 
-  it('強みと課題が表示される', () => {
-    render(<ReportCard report={baseReport} />);
-    expect(screen.getByText('強み: 傾聴力')).toBeInTheDocument();
-    expect(screen.getByText('課題: 説得力')).toBeInTheDocument();
+  it('ready は「完成」バッジ', () => {
+    render(<ReportCard report={makeReport({ status: 'ready' })} />);
+    expect(screen.getByText('完成')).toBeInTheDocument();
+  });
+
+  it('failed は「失敗」バッジ', () => {
+    render(<ReportCard report={makeReport({ status: 'failed' })} />);
+    expect(screen.getByText('失敗')).toBeInTheDocument();
+  });
+
+  it('欠損データでもクラッシュしない（旧スキーマ由来の不整合耐性）', () => {
+    const broken = { id: 2, status: 'pending' } as unknown as LearningReport;
+    expect(() => render(<ReportCard report={broken} />)).not.toThrow();
+    expect(screen.getByText('作成中')).toBeInTheDocument();
+  });
+
+  it('作成日が未設定なら「—」を表示する', () => {
+    render(<ReportCard report={makeReport({ createdAt: '' })} />);
+    expect(screen.getByText(/作成日: —/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/hooks/__tests__/useLearningReport.test.ts
+++ b/frontend/src/hooks/__tests__/useLearningReport.test.ts
@@ -15,8 +15,8 @@ vi.mock('../../repositories/LearningReportRepository', () => ({
 }));
 
 const mockReports = [
-  { id: 1, year: 2026, month: 2, totalSessions: 8, averageScore: 80.0, previousAverageScore: 75.0, scoreChange: 5.0, bestAxis: '論理的構成力', worstAxis: '配慮表現', practiceDays: 5, createdAt: '2026-03-01T00:00:00' },
-  { id: 2, year: 2026, month: 1, totalSessions: 5, averageScore: 75.0, previousAverageScore: null, scoreChange: null, bestAxis: '要約力', worstAxis: '提案力', practiceDays: 3, createdAt: '2026-02-01T00:00:00' },
+  { id: 1, userId: 7, periodFrom: '2026-02-01T00:00:00Z', periodTo: '2026-03-01T00:00:00Z', status: 'pending', createdAt: '2026-02-28T00:00:00Z' },
+  { id: 2, userId: 7, periodFrom: '2026-01-01T00:00:00Z', periodTo: '2026-02-01T00:00:00Z', status: 'ready', s3Key: 'reports/2026-01.pdf', createdAt: '2026-01-31T00:00:00Z' },
 ];
 
 describe('useLearningReport', () => {

--- a/frontend/src/pages/__tests__/LearningReportPage.test.tsx
+++ b/frontend/src/pages/__tests__/LearningReportPage.test.tsx
@@ -8,16 +8,11 @@ vi.mock('../../hooks/useLearningReport');
 
 const mockReport: LearningReport = {
   id: 1,
-  year: 2026,
-  month: 2,
-  totalSessions: 5,
-  averageScore: 75.0,
-  previousAverageScore: 70.0,
-  scoreChange: 5.0,
-  bestAxis: '論理的構成力',
-  worstAxis: '配慮表現',
-  practiceDays: 3,
-  createdAt: '2026-02-01T00:00:00',
+  userId: 7,
+  periodFrom: '2026-02-01T00:00:00Z',
+  periodTo: '2026-03-01T00:00:00Z',
+  status: 'pending',
+  createdAt: '2026-02-28T00:00:00Z',
 };
 
 describe('LearningReportPage', () => {

--- a/frontend/src/repositories/__tests__/LearningReportRepository.test.ts
+++ b/frontend/src/repositories/__tests__/LearningReportRepository.test.ts
@@ -20,7 +20,7 @@ describe('LearningReportRepository', () => {
 
   it('getAll: レポート一覧を取得する', async () => {
     const reports = [
-      { id: 1, year: 2024, month: 6, totalSessions: 10, averageScore: 7.5, practiceDays: 8 },
+      { id: 1, userId: 7, periodFrom: '2024-06-01T00:00:00Z', periodTo: '2024-07-01T00:00:00Z', status: 'pending', createdAt: '2024-06-30T00:00:00Z' },
     ];
     mockedGet.mockResolvedValue({ data: reports });
 
@@ -30,7 +30,7 @@ describe('LearningReportRepository', () => {
   });
 
   it('getMonthly: 指定月のレポートを取得する', async () => {
-    const report = { id: 1, year: 2024, month: 6, totalSessions: 10, averageScore: 7.5, practiceDays: 8 };
+    const report = { id: 1, userId: 7, periodFrom: '2024-06-01T00:00:00Z', periodTo: '2024-07-01T00:00:00Z', status: 'ready', s3Key: 'reports/2024-06.pdf', createdAt: '2024-06-30T00:00:00Z' };
     mockedGet.mockResolvedValue({ data: report });
 
     const result = await LearningReportRepository.getMonthly(2024, 6);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -318,29 +318,16 @@ export interface User {
   deletedAt?: string | null;
 }
 
-/** 学習レポート（フロント表示用 view）。
- *  backend 1:1 は `LearningReportDto` を参照すること。 */
+/** 学習レポート。Go backend `domain.LearningReport` と 1:1。
+ *  非同期生成のため status (`pending` / `ready` / `failed`) と s3Key を持つ。 */
 export interface LearningReport {
   id: number;
-  year: number;
-  month: number;
-  totalSessions: number;
-  averageScore: number;
-  previousAverageScore?: number;
-  scoreChange?: number;
-  bestAxis?: string;
-  worstAxis?: string;
-  practiceDays: number;
-  createdAt?: string;
-}
-
-/** LearningReportDto は Go backend `domain.LearningReport` と 1:1。
- *  非同期生成のため status (`pending` / `ready` / `failed`) と s3Key を持つ。 */
-export interface LearningReportDto {
-  id: number;
   userId: number;
+  /** 対象期間の開始（月初、ISO 文字列）。表示の対象月はここから導出する。 */
   periodFrom: string;
+  /** 対象期間の終了（翌月初、半開区間）。 */
   periodTo: string;
+  /** 生成状態。pending = 作成中 / ready = 完成 / failed = 失敗。 */
   status: 'pending' | 'ready' | 'failed';
   s3Key?: string;
   createdAt: string;


### PR DESCRIPTION
## 概要

学習レポート画面（/reports）が `Cannot read properties of undefined (reading 'toFixed')` で必ずクラッシュし、ErrorBoundary の「エラーが発生しました」に落ちていた hotfix。

## 原因

- backend の `GET /api/v2/learning-reports` は **非同期生成 DTO**（`domain.LearningReport`: id / userId / periodFrom / periodTo / status(pending/ready/failed) / s3Key / createdAt）を返す
- 一方 frontend の `LearningReport` 型・`ReportCard` は **旧い集計形**（year / month / averageScore / scoreChange / totalSessions / practiceDays）のままで、スキーマがずれていた
- `ReportCard` の `report.averageScore.toFixed(1)` が undefined 参照 → クラッシュ（`scoreChange` はガード済みだったが `averageScore` は未ガード）
- frontend には正しい DTO 型 `LearningReportDto` が定義済みだが未使用だった

## 変更内容

- **types**: `LearningReport` を backend `domain.LearningReport` と 1:1 の DTO 形に統一（重複していた `LearningReportDto` を統合）
- **ReportCard**: 対象月（`periodFrom` 由来）+ ステータスバッジ（作成中 / 完成 / 失敗）+ 作成日を描画。`toFixed` 等の数値依存を撤去し、`periodFrom` / `createdAt` が不正・欠損でもクラッシュしない（`—` フォールバック）
- **useLearningReport / LearningReportRepository**: 型追随のみ（ポーリング挙動は不変）
- テストを DTO 形に更新（ReportCard / page / hook / repository）+ 「欠損データでもクラッシュしない」耐性テストを追加

## テスト

- `tsc --noEmit` / `vitest run`（156 files, 1251 tests）/ `eslint --max-warnings 0` / `npm run build` すべて成功

## スコープ外

- 非同期生成 worker の本実装・S3 ダウンロード導線（FRESTYLE-33 相当。今回は status 表示に留める）

## 関連チケット

- FRESTYLE-105: https://frestyle.atlassian.net/browse/FRESTYLE-105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - レポートカードの表示内容を刷新し、対象月・生成状態・作成日を確認できるようになりました。
  - 生成状態に応じて「生成待ち」「生成済み」「生成失敗」などのステータスバッジを表示します。
  - 対象月や作成日が不正・未設定の場合も、適切な代替表示を行います。
  - 旧形式のレポートデータを受け取った場合でも、画面がクラッシュしにくくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->