### PR TITLE
feat: トースト改善 — 同一メッセージのまとめ・総数上限・塗りスタイル化 (FRESTYLE-106)

### DIFF
--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -11,6 +11,8 @@ export type ToastType = 'success' | 'error' | 'info';
 interface ToastProps {
   type: ToastType;
   message: string;
+  /** 同一メッセージのまとめ件数。2 以上で「×N」バッジを出す。 */
+  count?: number;
   onClose: () => void;
 }
 
@@ -20,18 +22,11 @@ const ICON_MAP = {
   info: InformationCircleIcon,
 };
 
+// 塗りスタイル: 濃い面 + 白文字・白アイコンで視認性を上げる。
 const COLOR_MAP = {
-  // 既存の色設計（emerald / rose / primary）を維持しつつ、 ライトテーマでも
-  // 読めるように背景は淡色 + 文字は濃色のコントラスト。
-  success: 'border-emerald-400 bg-emerald-50 text-emerald-700',
-  error: 'border-rose-400 bg-rose-50 text-rose-700',
-  info: 'border-taupe-400 bg-taupe-50 text-taupe-700',
-};
-
-const ICON_COLOR_MAP = {
-  success: 'text-emerald-500',
-  error: 'text-rose-500',
-  info: 'text-taupe-500',
+  success: 'bg-emerald-600 text-white',
+  error: 'bg-rose-600 text-white',
+  info: 'bg-taupe-700 text-white',
 };
 
 /**
@@ -40,7 +35,7 @@ const ICON_COLOR_MAP = {
  * 配置は ToastContainer 側（fixed top center）。 本コンポーネントは見た目と
  * 4 秒オートクローズ + アニメーションのみ責任を持つ。
  */
-export default function Toast({ type, message, onClose }: ToastProps) {
+export default function Toast({ type, message, count = 1, onClose }: ToastProps) {
   useEffect(() => {
     const timer = setTimeout(onClose, 4000);
     return () => clearTimeout(timer);
@@ -51,15 +46,20 @@ export default function Toast({ type, message, onClose }: ToastProps) {
   return (
     <div
       role="alert"
-      className={`pointer-events-auto flex items-start gap-3 px-5 py-3.5 rounded-lg border shadow-xl min-w-[280px] max-w-md ${COLOR_MAP[type]} animate-toast-drop`}
+      className={`pointer-events-auto flex items-start gap-3 px-5 py-3.5 rounded-lg shadow-xl min-w-[280px] max-w-md ${COLOR_MAP[type]} animate-toast-drop`}
     >
-      <Icon className={`w-6 h-6 flex-shrink-0 ${ICON_COLOR_MAP[type]}`} />
+      <Icon className="w-6 h-6 flex-shrink-0 text-white" />
       <p className="text-sm leading-relaxed flex-1">{message}</p>
+      {count > 1 && (
+        <span className="flex-shrink-0 self-center rounded-full bg-white/25 px-2 py-0.5 text-xs font-semibold tabular-nums">
+          ×{count}
+        </span>
+      )}
       <button
         type="button"
         onClick={onClose}
         aria-label="閉じる"
-        className="-mr-1 -mt-0.5 p-1 rounded hover:bg-black/5 transition-colors"
+        className="-mr-1 -mt-0.5 p-1 rounded hover:bg-white/20 transition-colors"
       >
         <XMarkIcon className="w-4 h-4" />
       </button>

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -20,6 +20,7 @@ export default function ToastContainer() {
           key={toast.id}
           type={toast.type}
           message={toast.message}
+          count={toast.count}
           onClose={() => removeToast(toast.id)}
         />
       ))}

--- a/frontend/src/components/ToastProvider.tsx
+++ b/frontend/src/components/ToastProvider.tsx
@@ -4,6 +4,9 @@ import type { ToastType } from './Toast';
 
 let toastId = 0;
 
+// 同時表示の上限。連続操作でも画面が埋まらないよう古いものから落とす。
+const MAX_TOASTS = 3;
+
 /**
  * ToastProvider は ToastContext の React Context Provider。
  *
@@ -15,8 +18,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const showToast = useCallback((type: ToastType, message: string) => {
-    const id = String(++toastId);
-    setToasts((prev) => [...prev, { id, type, message }]);
+    setToasts((prev) => {
+      // 同一 (type, message) が表示中なら、新規追加せず件数をまとめる。
+      // id を振り直して末尾へ移すことで Toast が再マウントし、自動消滅タイマーもリフレッシュされる。
+      const existing = prev.find((t) => t.type === type && t.message === message);
+      if (existing) {
+        const rest = prev.filter((t) => t !== existing);
+        const merged: ToastItem = { ...existing, id: String(++toastId), count: existing.count + 1 };
+        return [...rest, merged].slice(-MAX_TOASTS);
+      }
+      const next: ToastItem = { id: String(++toastId), type, message, count: 1 };
+      return [...prev, next].slice(-MAX_TOASTS);
+    });
   }, []);
 
   const removeToast = useCallback((id: string) => {

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -64,4 +64,24 @@ describe('Toast', () => {
     const { container } = render(<Toast type="info" message="情報" onClose={vi.fn()} />);
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
+
+  it('count が 2 以上のとき「×N」バッジを表示する', () => {
+    render(<Toast type="success" message="作成しました" count={5} onClose={vi.fn()} />);
+    expect(screen.getByText('×5')).toBeInTheDocument();
+  });
+
+  it('count が 1（既定）のとき「×N」バッジを出さない', () => {
+    render(<Toast type="success" message="作成しました" onClose={vi.fn()} />);
+    expect(screen.queryByText(/^×\d/)).not.toBeInTheDocument();
+  });
+
+  it('成功は塗り（濃い緑・白文字）スタイル', () => {
+    render(<Toast type="success" message="OK" onClose={vi.fn()} />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-emerald-600', 'text-white');
+  });
+
+  it('エラーは塗り（濃い赤・白文字）スタイル', () => {
+    render(<Toast type="error" message="NG" onClose={vi.fn()} />);
+    expect(screen.getByRole('alert')).toHaveClass('bg-rose-600', 'text-white');
+  });
 });

--- a/frontend/src/hooks/__tests__/useToast.test.tsx
+++ b/frontend/src/hooks/__tests__/useToast.test.tsx
@@ -52,4 +52,36 @@ describe('useToast', () => {
     });
     expect(result.current.toasts).toHaveLength(2);
   });
+
+  it('同一メッセージを連続で出すと 1 枚にまとまり count が増える', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.showToast('success', 'ノートを作成しました');
+      result.current.showToast('success', 'ノートを作成しました');
+      result.current.showToast('success', 'ノートを作成しました');
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0].count).toBe(3);
+  });
+
+  it('type が違えば同じ文言でも別枠になる', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.showToast('success', '完了');
+      result.current.showToast('error', '完了');
+    });
+    expect(result.current.toasts).toHaveLength(2);
+  });
+
+  it('総数は上限(3)でクランプされ古いものから落ちる', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.showToast('info', 'A');
+      result.current.showToast('info', 'B');
+      result.current.showToast('info', 'C');
+      result.current.showToast('info', 'D');
+    });
+    expect(result.current.toasts).toHaveLength(3);
+    expect(result.current.toasts.map((t) => t.message)).toEqual(['B', 'C', 'D']);
+  });
 });

--- a/frontend/src/hooks/useToastContext.ts
+++ b/frontend/src/hooks/useToastContext.ts
@@ -5,6 +5,8 @@ export interface ToastItem {
   id: string;
   type: ToastType;
   message: string;
+  /** 同一メッセージが連続したときのまとめ件数（1 のときは無表示）。 */
+  count: number;
 }
 
 export interface ToastContextValue {


### PR DESCRIPTION
## 概要

トースト通知に 2 つの改善を入れる。

1. **積み上がりの解消**: ノートを短時間に大量作成すると「ノートを作成しました」が画面いっぱいに積み上がっていた（自動消滅 4 秒以内の連続操作で溜まる）
2. **視認性の改善**: 成功トーストが薄い緑で目立たなかったのを、濃い緑・白文字の「塗り」スタイルに

## 変更内容

- **ToastProvider**: 同一 `(type, message)` が表示中なら新規追加せず **1 枚にまとめて `×N`** にし、id を振り直して末尾へ移す（Toast が再マウントして自動消滅タイマーもリフレッシュ）。総数は **上限 3 でクランプ**し古いものから落とす
- **Toast**: `count` を受け取り `count >= 2` で `×N` バッジを表示。配色を**塗り**に変更（success = `bg-emerald-600 text-white` / error = `bg-rose-600` / info = `bg-taupe-700`）、アイコン・閉じるボタンも白基調
- **useToastContext**: `ToastItem` に `count` を追加。**ToastContainer**: `count` を伝搬
- `aria-live`（polite）と `role="alert"` は維持

## テスト

- `tsc --noEmit` / `eslint --max-warnings 0` 成功、toast 系テスト 24 件（まとめ / type 別枠 / 上限クランプ / count 表示 / 塗り配色）green
- Playwright で塗りスタイル + `×9` まとめの見た目を確認

## スコープ外

- トーストの位置・アニメーション自体の変更（上部中央 + drop を維持）

## 関連チケット

- FRESTYLE-106: https://frestyle.atlassian.net/browse/FRESTYLE-106