### PR TITLE
feat: inkwell にアニメーション系プリミティブを追加（ローディングボタン・進捗・スケルトン）(FRESTYLE-107)

### DIFF
--- a/docs/inkwell-ui-primitives.md
+++ b/docs/inkwell-ui-primitives.md
@@ -52,13 +52,25 @@ function Example() {
 | `InkwellCard` + `InkwellCardContent` / `InkwellCardActions` | `elevation`(0/1/2/3/4/8) | 標高シャドウ。0 は影の代わりに枠線 |
 | `InkwellCheckbox` | `label` / 標準 input 属性 | チェックで塗り＋レ点・押下波紋・ホバー円 |
 | `InkwellSwitch` | `label` / 標準 input 属性 | トラック上をサムが滑る・ON で色付き |
+| `InkwellLoadingButton` | `onAction`(Promise) / `variant` `color` `size` / `loadingLabel` `successLabel` `errorLabel` | 押下でラベル→スピナー→（成功でチェック / 失敗で×）。状態機械で二重送信防止・幅固定 |
+| `InkwellCircularProgress` | `value?`(0-100) / `size` `thickness` | value 省略で回転スピナー、指定で確定リング |
+| `InkwellLinearProgress` | `value?`(0-100) | value 省略で流れる帯、指定で確定バー（transform 伸縮） |
+| `InkwellSkeleton` | `variant`(text/rect/circle) / `width` `height` | 読み込み中の光沢プレースホルダ |
+| `useAsyncAction(fn)` | — | idle → loading →（success/error）→ idle の状態機械 hook（LoadingButton の中核） |
 
 ## デザイントークン（`tailwind.config.js`、名前空間 `inkwell-*`）
 
 - 色: `inkwell-primary`(#1976d2) / `-secondary`(#9c27b0) / `-error`(#d32f2f) と各 dark、`inkwell-text-*`、`inkwell-outline` / `-divider`
 - フォント: `font-roboto`（`@fontsource/roboto` を自己ホスト。CSP `font-src 'self'` 準拠。付けた要素だけに適用）
 - 影: `shadow-inkwell-1|2|3|4|8`（3 層合成の標高）
-- アニメ: `animate-inkwell-ripple`（押下波紋）
+- アニメ: `animate-inkwell-ripple`（押下波紋）/ `animate-inkwell-draw`（成功チェックの線描き）/ `animate-inkwell-bar`（線形プログレスの不確定帯）
+- イージング: `ease-inkwell-standard|decelerate|accelerate|sharp`（往復 / 出現 / 退場 / 即戻り）
+
+## アニメーションの方針
+
+- **transform / opacity のみ**をアニメートしてレイアウトシフトと再レイアウトを避ける（線形プログレスは幅ではなく `scaleX`、円形は `rotate` + `stroke-dashoffset`）。
+- **`prefers-reduced-motion` を尊重**: 各アニメに `motion-reduce:animate-none` を併用し、動きは止めてもフィードバック（状態テキスト・確定表示）は残す。
+- **ローディングボタンは状態機械**（`useAsyncAction`）で idle 以外からの実行を弾き二重送信を防ぐ。native `disabled` ではなく `aria-disabled` + クリックガードでフォーカスを保ち、状態は `role="status"` の sr-only テキストで支援技術に伝える。スピナー / チェック / × は `aria-hidden`。
 
 いずれも名前空間付きで、既存の `brand-*` / `taupe-*` / `surface-*` には影響しない。
 

--- a/frontend/src/components/inkwell/InkwellCircularProgress.tsx
+++ b/frontend/src/components/inkwell/InkwellCircularProgress.tsx
@@ -1,0 +1,57 @@
+export interface InkwellCircularProgressProps {
+  /** 0〜100。省略で indeterminate（回り続けるスピナー）。 */
+  value?: number;
+  /** 直径 px。 */
+  size?: number;
+  /** 線の太さ px。 */
+  thickness?: number;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * 円形プログレス。value 省略で回転スピナー（indeterminate）、指定で確定リング。
+ * 回転は transform なので合成層で軽い。reduced-motion では回転を止める。
+ */
+export default function InkwellCircularProgress({
+  value,
+  size = 40,
+  thickness = 4,
+  className = '',
+  'aria-label': ariaLabel,
+}: InkwellCircularProgressProps) {
+  const indeterminate = value == null;
+  const clamped = indeterminate ? 0 : Math.max(0, Math.min(100, value));
+  const r = (size - thickness) / 2;
+  const circumference = 2 * Math.PI * r;
+  // indeterminate は 3/4 欠けの弧を回す。determinate は value 分だけ描く。
+  const dash = indeterminate ? circumference * 0.75 : circumference * (1 - clamped / 100);
+
+  return (
+    <span
+      role="progressbar"
+      aria-label={ariaLabel ?? (indeterminate ? '読み込み中' : undefined)}
+      aria-valuenow={indeterminate ? undefined : clamped}
+      aria-valuemin={indeterminate ? undefined : 0}
+      aria-valuemax={indeterminate ? undefined : 100}
+      className={`inline-block ${indeterminate ? 'animate-spin motion-reduce:animate-none' : ''} ${className}`}
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="-rotate-90">
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="currentColor" strokeWidth={thickness} className="text-inkwell-divider" />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={thickness}
+          strokeLinecap="round"
+          className="text-inkwell-primary transition-[stroke-dashoffset] duration-300 ease-inkwell-standard"
+          strokeDasharray={circumference}
+          strokeDashoffset={dash}
+        />
+      </svg>
+    </span>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellLinearProgress.tsx
+++ b/frontend/src/components/inkwell/InkwellLinearProgress.tsx
@@ -1,0 +1,39 @@
+export interface InkwellLinearProgressProps {
+  /** 0〜100。省略で indeterminate（流れ続ける帯）。 */
+  value?: number;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * 線形プログレス。value 指定で確定バー（transform で伸縮＝reflow なし）、省略で indeterminate。
+ * indeterminate は帯が左から右へ流れる。reduced-motion では流れを止める。
+ */
+export default function InkwellLinearProgress({
+  value,
+  className = '',
+  'aria-label': ariaLabel,
+}: InkwellLinearProgressProps) {
+  const indeterminate = value == null;
+  const clamped = indeterminate ? 0 : Math.max(0, Math.min(100, value));
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={ariaLabel ?? (indeterminate ? '読み込み中' : undefined)}
+      aria-valuenow={indeterminate ? undefined : clamped}
+      aria-valuemin={indeterminate ? undefined : 0}
+      aria-valuemax={indeterminate ? undefined : 100}
+      className={`relative h-1 w-full overflow-hidden rounded-full bg-inkwell-primary/20 ${className}`}
+    >
+      {indeterminate ? (
+        <span className="absolute inset-y-0 left-0 w-full origin-left rounded-full bg-inkwell-primary animate-inkwell-bar motion-reduce:animate-none motion-reduce:w-1/3" />
+      ) : (
+        <span
+          className="absolute inset-y-0 left-0 w-full origin-left rounded-full bg-inkwell-primary transition-transform duration-300 ease-inkwell-standard"
+          style={{ transform: `scaleX(${clamped / 100})` }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellLoadingButton.tsx
+++ b/frontend/src/components/inkwell/InkwellLoadingButton.tsx
@@ -1,0 +1,113 @@
+import { ReactNode } from 'react';
+import InkwellButton, { type InkwellButtonProps } from './InkwellButton';
+import { useAsyncAction, type AsyncStatus } from './useAsyncAction';
+
+export interface InkwellLoadingButtonProps
+  extends Omit<InkwellButtonProps, 'onClick' | 'children'> {
+  children: ReactNode;
+  /** 押下で走らせる非同期処理。解決で成功、reject で失敗表示になる。 */
+  onAction: () => Promise<void>;
+  /** loading 中に読み上げる文言。 */
+  loadingLabel?: string;
+  /** 成功時に読み上げる文言。 */
+  successLabel?: string;
+  /** 失敗時に読み上げる文言。 */
+  errorLabel?: string;
+}
+
+/**
+ * 押下でラベルがスピナー→（成功でチェック / 失敗で×）に切り替わる送信ボタン。
+ * 状態機械で二重送信を防ぎ、幅は固定してレイアウトが揺れない。動きは prefers-reduced-motion を尊重する。
+ */
+export default function InkwellLoadingButton({
+  children,
+  onAction,
+  loadingLabel = '送信中',
+  successLabel = '完了しました',
+  errorLabel = '失敗しました',
+  className = '',
+  ...buttonProps
+}: InkwellLoadingButtonProps) {
+  const { status, run } = useAsyncAction(onAction);
+  const busy = status !== 'idle';
+
+  return (
+    <InkwellButton
+      {...buttonProps}
+      // native disabled は使わずフォーカスを保持（状態変化を読み上げ可能に）。二重送信は状態機械で防ぐ。
+      aria-disabled={busy || undefined}
+      onClick={(e) => {
+        if (busy) {
+          e.preventDefault();
+          return;
+        }
+        void run();
+      }}
+      className={`relative min-w-[8rem] ${className}`}
+    >
+      {/* ラベル層: loading 以降は透明化して幅だけ維持 */}
+      <span className={status === 'idle' ? '' : 'invisible'}>{children}</span>
+
+      {busy && (
+        <span className="absolute inset-0 grid place-items-center">
+          {status === 'loading' && (
+            <span
+              aria-hidden="true"
+              className="h-5 w-5 rounded-full border-2 border-current border-t-transparent opacity-90 animate-spin motion-reduce:animate-none"
+            />
+          )}
+          {status === 'success' && <CheckDraw />}
+          {status === 'error' && <CrossMark />}
+        </span>
+      )}
+
+      {/* 状態は見た目アイコンではなくテキストで支援技術へ伝える */}
+      <span className="sr-only" role="status">
+        {statusText(status, { loadingLabel, successLabel, errorLabel })}
+      </span>
+    </InkwellButton>
+  );
+}
+
+function statusText(
+  status: AsyncStatus,
+  labels: { loadingLabel: string; successLabel: string; errorLabel: string },
+): string {
+  if (status === 'loading') return labels.loadingLabel;
+  if (status === 'success') return labels.successLabel;
+  if (status === 'error') return labels.errorLabel;
+  return '';
+}
+
+/** 成功チェック。線を描く（reduced-motion では即表示）。 */
+function CheckDraw() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+      <path
+        d="M4 12.5l5 5 11-11"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        pathLength={1}
+        className="[stroke-dasharray:1] [stroke-dashoffset:1] animate-inkwell-draw motion-reduce:animate-none motion-reduce:[stroke-dashoffset:0]"
+      />
+    </svg>
+  );
+}
+
+/** 失敗マーク。 */
+function CrossMark() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+      <path
+        d="M6 6l12 12M18 6L6 18"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/inkwell/InkwellSkeleton.tsx
+++ b/frontend/src/components/inkwell/InkwellSkeleton.tsx
@@ -1,0 +1,32 @@
+export interface InkwellSkeletonProps {
+  /** 形状。text=丸角の行 / rect=矩形 / circle=円。 */
+  variant?: 'text' | 'rect' | 'circle';
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+}
+
+/**
+ * 読み込み中のプレースホルダ。左右に光沢が流れる（背景 position のみ＝layout に触れない）。
+ * reduced-motion では流れを止め、静的な淡色ブロックにする。
+ */
+export default function InkwellSkeleton({
+  variant = 'text',
+  width,
+  height,
+  className = '',
+}: InkwellSkeletonProps) {
+  const shape =
+    variant === 'circle' ? 'rounded-full' : variant === 'rect' ? 'rounded' : 'rounded';
+  const defaultSize =
+    variant === 'text' ? 'h-4 w-full' : variant === 'circle' ? 'h-10 w-10' : 'h-24 w-full';
+
+  return (
+    <span
+      role="status"
+      aria-label="読み込み中"
+      style={{ width, height }}
+      className={`block ${defaultSize} ${shape} bg-[linear-gradient(90deg,rgba(0,0,0,0.06)_25%,rgba(0,0,0,0.12)_37%,rgba(0,0,0,0.06)_63%)] bg-[length:400%_100%] animate-skeleton motion-reduce:animate-none ${className}`}
+    />
+  );
+}

--- a/frontend/src/components/inkwell/__tests__/InkwellLoadingButton.test.tsx
+++ b/frontend/src/components/inkwell/__tests__/InkwellLoadingButton.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import InkwellLoadingButton from '../InkwellLoadingButton';
+
+describe('InkwellLoadingButton', () => {
+  it('押下で onAction が走り、完了後に成功文言を読み上げる', async () => {
+    const action = vi.fn().mockResolvedValue(undefined);
+    render(
+      <InkwellLoadingButton onAction={action} successLabel="保存しました">
+        保存
+      </InkwellLoadingButton>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /保存/ }));
+    expect(action).toHaveBeenCalledTimes(1);
+    // loading 中は aria-disabled
+    await waitFor(() => expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true'));
+    // 解決後に success 文言
+    await waitFor(() => expect(screen.getByText('保存しました')).toBeInTheDocument());
+  });
+
+  it('loading 中の再クリックは二重送信されない', async () => {
+    let resolveFn: () => void = () => {};
+    const action = vi.fn(() => new Promise<void>((r) => (resolveFn = r)));
+    render(<InkwellLoadingButton onAction={action}>送信</InkwellLoadingButton>);
+    const btn = screen.getByRole('button');
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(action).toHaveBeenCalledTimes(1);
+    resolveFn();
+    // success 表示(約1.2s)を経て idle に戻るまで待つ。
+    await waitFor(() => expect(btn).not.toHaveAttribute('aria-disabled'), { timeout: 3000 });
+  });
+
+  it('reject で失敗文言を読み上げる', async () => {
+    const action = vi.fn().mockRejectedValue(new Error('ng'));
+    render(
+      <InkwellLoadingButton onAction={action} errorLabel="失敗しました">
+        削除
+      </InkwellLoadingButton>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByText('失敗しました')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/inkwell/__tests__/InkwellProgress.test.tsx
+++ b/frontend/src/components/inkwell/__tests__/InkwellProgress.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import InkwellCircularProgress from '../InkwellCircularProgress';
+import InkwellLinearProgress from '../InkwellLinearProgress';
+import InkwellSkeleton from '../InkwellSkeleton';
+
+describe('InkwellCircularProgress', () => {
+  it('determinate は progressbar として value を持つ', () => {
+    render(<InkwellCircularProgress value={40} />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '40');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('indeterminate は value を持たず「読み込み中」ラベル + spin', () => {
+    render(<InkwellCircularProgress />);
+    const bar = screen.getByRole('progressbar', { name: '読み込み中' });
+    expect(bar).not.toHaveAttribute('aria-valuenow');
+    expect(bar.className).toContain('animate-spin');
+  });
+
+  it('value は 0〜100 にクランプされる', () => {
+    render(<InkwellCircularProgress value={150} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+});
+
+describe('InkwellLinearProgress', () => {
+  it('determinate は value を持つ', () => {
+    render(<InkwellLinearProgress value={25} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '25');
+  });
+
+  it('indeterminate は流れる帯（animate-inkwell-bar）', () => {
+    const { container } = render(<InkwellLinearProgress />);
+    expect(container.querySelector('.animate-inkwell-bar')).not.toBeNull();
+  });
+});
+
+describe('InkwellSkeleton', () => {
+  it('status ロールと読み込み中ラベルを持つ', () => {
+    render(<InkwellSkeleton />);
+    expect(screen.getByRole('status', { name: '読み込み中' })).toBeInTheDocument();
+  });
+
+  it('circle バリアントは丸角', () => {
+    render(<InkwellSkeleton variant="circle" />);
+    expect(screen.getByRole('status').className).toContain('rounded-full');
+  });
+});

--- a/frontend/src/components/inkwell/index.ts
+++ b/frontend/src/components/inkwell/index.ts
@@ -19,3 +19,18 @@ export type { InkwellCheckboxProps } from './InkwellCheckbox';
 
 export { default as InkwellSwitch } from './InkwellSwitch';
 export type { InkwellSwitchProps } from './InkwellSwitch';
+
+export { default as InkwellLoadingButton } from './InkwellLoadingButton';
+export type { InkwellLoadingButtonProps } from './InkwellLoadingButton';
+
+export { default as InkwellCircularProgress } from './InkwellCircularProgress';
+export type { InkwellCircularProgressProps } from './InkwellCircularProgress';
+
+export { default as InkwellLinearProgress } from './InkwellLinearProgress';
+export type { InkwellLinearProgressProps } from './InkwellLinearProgress';
+
+export { default as InkwellSkeleton } from './InkwellSkeleton';
+export type { InkwellSkeletonProps } from './InkwellSkeleton';
+
+export { useAsyncAction } from './useAsyncAction';
+export type { AsyncStatus } from './useAsyncAction';

--- a/frontend/src/components/inkwell/useAsyncAction.ts
+++ b/frontend/src/components/inkwell/useAsyncAction.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useReducer } from 'react';
+
+export type AsyncStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type Event = { type: 'SUBMIT' } | { type: 'RESOLVE' } | { type: 'REJECT' } | { type: 'RESET' };
+
+// 相互排他な状態機械。idle 以外からの SUBMIT は無視され二重送信できない。
+function reducer(status: AsyncStatus, event: Event): AsyncStatus {
+  switch (status) {
+    case 'idle':
+      return event.type === 'SUBMIT' ? 'loading' : status;
+    case 'loading':
+      return event.type === 'RESOLVE' ? 'success' : event.type === 'REJECT' ? 'error' : status;
+    case 'success':
+    case 'error':
+      return event.type === 'RESET' ? 'idle' : status;
+    default:
+      return status;
+  }
+}
+
+interface Options {
+  /** success を表示してから idle に戻すまでの ms。 */
+  successResetMs?: number;
+  /** error を表示してから idle に戻すまでの ms。 */
+  errorResetMs?: number;
+}
+
+/**
+ * 非同期アクションを idle → loading →（success | error）→ idle の状態機械で扱う。
+ * loading 中の再実行は状態機械が弾く（二重送信防止）。success/error は自動で idle へ戻す。
+ */
+export function useAsyncAction(action: () => Promise<void>, options: Options = {}) {
+  const { successResetMs = 1200, errorResetMs = 2000 } = options;
+  const [status, dispatch] = useReducer(reducer, 'idle');
+
+  const run = useCallback(async () => {
+    if (status !== 'idle') return; // 副作用も含めて再入を防ぐ
+    dispatch({ type: 'SUBMIT' });
+    try {
+      await action();
+      dispatch({ type: 'RESOLVE' });
+    } catch {
+      dispatch({ type: 'REJECT' });
+    }
+  }, [status, action]);
+
+  useEffect(() => {
+    if (status === 'success') {
+      const t = setTimeout(() => dispatch({ type: 'RESET' }), successResetMs);
+      return () => clearTimeout(t);
+    }
+    if (status === 'error') {
+      const t = setTimeout(() => dispatch({ type: 'RESET' }), errorResetMs);
+      return () => clearTimeout(t);
+    }
+  }, [status, successResetMs, errorResetMs]);
+
+  return { status, run };
+}

--- a/frontend/src/pages/InkwellShowcasePage.tsx
+++ b/frontend/src/pages/InkwellShowcasePage.tsx
@@ -7,7 +7,15 @@ import {
   InkwellCardActions,
   InkwellCheckbox,
   InkwellSwitch,
+  InkwellLoadingButton,
+  InkwellCircularProgress,
+  InkwellLinearProgress,
+  InkwellSkeleton,
 } from '../components/inkwell';
+
+/** デモ用: n ミリ秒後に解決/reject する擬似非同期処理。 */
+const wait = (ms: number, fail = false) =>
+  new Promise<void>((resolve, reject) => setTimeout(() => (fail ? reject() : resolve()), ms));
 
 /**
  * inkwell プリミティブの見た目確認用カタログ（開発・レビュー用）。
@@ -16,6 +24,7 @@ import {
 export default function InkwellShowcasePage() {
   const [checked, setChecked] = useState(true);
   const [on, setOn] = useState(true);
+  const [progress, setProgress] = useState(50);
 
   return (
     <div className="min-h-screen bg-[#f5f5f5] font-roboto text-inkwell-text-primary">
@@ -79,6 +88,49 @@ export default function InkwellShowcasePage() {
             <InkwellCheckbox label="無効" disabled />
             <InkwellSwitch label="通知" checked={on} onChange={(e) => setOn(e.target.checked)} />
             <InkwellSwitch label="無効" disabled />
+          </div>
+        </Section>
+
+        <Section title="LoadingButton — 押下で送信中→完了/失敗">
+          <InkwellLoadingButton onAction={() => wait(1400)} successLabel="保存しました">
+            保存する
+          </InkwellLoadingButton>
+          <InkwellLoadingButton
+            color="error"
+            onAction={() => wait(1400, true)}
+            errorLabel="削除に失敗しました"
+          >
+            削除する
+          </InkwellLoadingButton>
+          <InkwellLoadingButton variant="outlined" onAction={() => wait(1400)}>
+            送信する
+          </InkwellLoadingButton>
+        </Section>
+
+        <Section title="Progress — 円形 / 線形（確定・不確定）">
+          <div className="flex w-full flex-col gap-5">
+            <div className="flex items-center gap-6 text-inkwell-primary">
+              <InkwellCircularProgress />
+              <InkwellCircularProgress value={progress} />
+              <InkwellCircularProgress value={progress} size={28} thickness={3} />
+              <InkwellButton size="small" variant="outlined" onClick={() => setProgress((p) => (p >= 100 ? 0 : p + 25))}>
+                進める（{progress}%）
+              </InkwellButton>
+            </div>
+            <div className="space-y-3">
+              <InkwellLinearProgress />
+              <InkwellLinearProgress value={progress} />
+            </div>
+          </div>
+        </Section>
+
+        <Section title="Skeleton — 読み込み中プレースホルダ">
+          <div className="flex w-full max-w-sm items-center gap-3">
+            <InkwellSkeleton variant="circle" />
+            <div className="flex-1 space-y-2">
+              <InkwellSkeleton variant="text" className="w-2/3" />
+              <InkwellSkeleton variant="text" />
+            </div>
           </div>
         </Section>
       </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -77,6 +77,13 @@ export default {
         // font-roboto を付けた要素だけに適用（アプリ全体の既定フォントは変えない）。
         roboto: ['Roboto', 'Helvetica', 'Arial', 'sans-serif'],
       },
+      transitionTimingFunction: {
+        // 名前付きイージング。standard=往復 / decelerate=出現 / accelerate=退場 / sharp=即戻り。
+        'inkwell-standard': 'cubic-bezier(0.4, 0, 0.2, 1)',
+        'inkwell-decelerate': 'cubic-bezier(0, 0, 0.2, 1)',
+        'inkwell-accelerate': 'cubic-bezier(0.4, 0, 1, 1)',
+        'inkwell-sharp': 'cubic-bezier(0.4, 0, 0.6, 1)',
+      },
       boxShadow: {
         // 標高シャドウ: 数字が大きいほど浮いて見える（3 層合成）。
         'inkwell-1': '0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12)',
@@ -93,6 +100,10 @@ export default {
         'toast-drop': 'toastDrop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1)',
         // 押した位置から広がりながら消える波紋。
         'inkwell-ripple': 'inkwellRipple 0.55s linear',
+        // 成功チェックの線を描く。
+        'inkwell-draw': 'inkwellDraw 0.22s ease-out forwards',
+        // 線形プログレスの indeterminate 帯（左から右へ流れる）。
+        'inkwell-bar': 'inkwellBar 1.4s ease-in-out infinite',
       },
       keyframes: {
         fadeIn: {
@@ -116,6 +127,14 @@ export default {
         inkwellRipple: {
           '0%': { transform: 'scale(0)', opacity: '0.3' },
           '100%': { transform: 'scale(1)', opacity: '0' },
+        },
+        inkwellDraw: {
+          to: { strokeDashoffset: '0' },
+        },
+        inkwellBar: {
+          '0%': { transform: 'translateX(-100%) scaleX(0.3)' },
+          '50%': { transform: 'translateX(0%) scaleX(0.6)' },
+          '100%': { transform: 'translateX(100%) scaleX(0.3)' },
         },
       },
     },


### PR DESCRIPTION
## 概要

触感的コンポーネント群 inkwell（FRESTYLE-104）に、アニメーション/マイクロインタラクションが豊かなプリミティブを追加する。目玉は**ローディングボタン**（押下でスピナー → 成功でチェック / 失敗で×）。

## 追加内容（frontend のみ・Tailwind のみ）

- **InkwellLoadingButton** + **useAsyncAction**: `idle → loading →（success/error）→ idle` の状態機械で **二重送信を防止**。幅固定でレイアウトが揺れない。native `disabled` ではなく `aria-disabled` + クリックガードでフォーカスを保ち、状態は `role="status"` の sr-only テキストで支援技術に伝える（スピナー/チェック/× は `aria-hidden`）
- **InkwellCircularProgress**: value 省略で回転スピナー、指定で確定リング（`rotate` + `stroke-dashoffset`）
- **InkwellLinearProgress**: 確定バー（`scaleX` 伸縮＝reflow なし）/ 不確定は流れる帯
- **InkwellSkeleton**: 光沢が流れる読み込みプレースホルダ（`background-position` のみ）
- **tailwind**: 名前付きイージング `ease-inkwell-standard/decelerate/accelerate/sharp`、`animate-inkwell-draw`（チェック線描き）、`animate-inkwell-bar`（不確定帯）

## 方針

- **transform / opacity のみ**をアニメートして CLS・reflow を回避
- **`prefers-reduced-motion` を尊重**（`motion-reduce:animate-none` を併用。動きは止めてもフィードバックは残す）
- 既存 inkwell・アプリ本体テーマは不変（名前空間トークンのみ追加）

## テスト

- `tsc --noEmit` / `vitest run`（158 files, 1268 tests）/ `eslint --max-warnings 0` / `npm run build` すべて成功
- inkwell テスト 10 件追加（LoadingButton の成功/失敗/二重送信防止/aria、Progress の確定・不確定・クランプ、Skeleton の role）
- カタログ `/dev/inkwell` を Playwright でスクショし、ローディングボタン・円形/線形プログレス・スケルトンの表示を確認

## 参照 / 設計理由

品質・アクセシビリティの裏取りに評価の高い OSS・記事（状態機械での非同期扱い、ローディングボタンの aria 作法、reduced-motion、GPU 合成）を広く参照（ライブラリは未導入・作法のみ）。設計理由は private リポ `frestyle-pdm` の inkwell 設計理由ドキュメントに追記予定。

## 関連チケット

- FRESTYLE-107: https://frestyle.atlassian.net/browse/FRESTYLE-107