### PR TITLE
fix: トーストの成功色を黄緑にし、まとめ件数(×N)バッジを非表示に (FRESTYLE-108)

### DIFF
--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -11,8 +11,6 @@ export type ToastType = 'success' | 'error' | 'info';
 interface ToastProps {
   type: ToastType;
   message: string;
-  /** 同一メッセージのまとめ件数。2 以上で「×N」バッジを出す。 */
-  count?: number;
   onClose: () => void;
 }
 
@@ -22,9 +20,9 @@ const ICON_MAP = {
   info: InformationCircleIcon,
 };
 
-// 塗りスタイル: 濃い面 + 白文字・白アイコンで視認性を上げる。
+// 塗りスタイル: 濃い面 + 白文字・白アイコンで視認性を上げる。成功は黄緑。
 const COLOR_MAP = {
-  success: 'bg-emerald-600 text-white',
+  success: 'bg-lime-600 text-white',
   error: 'bg-rose-600 text-white',
   info: 'bg-taupe-700 text-white',
 };
@@ -35,7 +33,7 @@ const COLOR_MAP = {
  * 配置は ToastContainer 側（fixed top center）。 本コンポーネントは見た目と
  * 4 秒オートクローズ + アニメーションのみ責任を持つ。
  */
-export default function Toast({ type, message, count = 1, onClose }: ToastProps) {
+export default function Toast({ type, message, onClose }: ToastProps) {
   useEffect(() => {
     const timer = setTimeout(onClose, 4000);
     return () => clearTimeout(timer);
@@ -50,11 +48,6 @@ export default function Toast({ type, message, count = 1, onClose }: ToastProps)
     >
       <Icon className="w-6 h-6 flex-shrink-0 text-white" />
       <p className="text-sm leading-relaxed flex-1">{message}</p>
-      {count > 1 && (
-        <span className="flex-shrink-0 self-center rounded-full bg-white/25 px-2 py-0.5 text-xs font-semibold tabular-nums">
-          ×{count}
-        </span>
-      )}
       <button
         type="button"
         onClick={onClose}

--- a/frontend/src/components/ToastContainer.tsx
+++ b/frontend/src/components/ToastContainer.tsx
@@ -20,7 +20,6 @@ export default function ToastContainer() {
           key={toast.id}
           type={toast.type}
           message={toast.message}
-          count={toast.count}
           onClose={() => removeToast(toast.id)}
         />
       ))}

--- a/frontend/src/components/__tests__/Toast.test.tsx
+++ b/frontend/src/components/__tests__/Toast.test.tsx
@@ -65,19 +65,14 @@ describe('Toast', () => {
     expect(container.querySelector('svg')).toBeInTheDocument();
   });
 
-  it('count が 2 以上のとき「×N」バッジを表示する', () => {
-    render(<Toast type="success" message="作成しました" count={5} onClose={vi.fn()} />);
-    expect(screen.getByText('×5')).toBeInTheDocument();
-  });
-
-  it('count が 1（既定）のとき「×N」バッジを出さない', () => {
+  it('まとめ件数の「×N」バッジは表示しない', () => {
     render(<Toast type="success" message="作成しました" onClose={vi.fn()} />);
     expect(screen.queryByText(/^×\d/)).not.toBeInTheDocument();
   });
 
-  it('成功は塗り（濃い緑・白文字）スタイル', () => {
+  it('成功は塗り（黄緑・白文字）スタイル', () => {
     render(<Toast type="success" message="OK" onClose={vi.fn()} />);
-    expect(screen.getByRole('alert')).toHaveClass('bg-emerald-600', 'text-white');
+    expect(screen.getByRole('alert')).toHaveClass('bg-lime-600', 'text-white');
   });
 
   it('エラーは塗り（濃い赤・白文字）スタイル', () => {


### PR DESCRIPTION
## 概要

トースト（FRESTYLE-106）の見た目の微調整。

1. 成功トーストの塗り色を濃い緑（`bg-emerald-600`）から **黄緑**（`bg-lime-600`・白文字が読める深めの黄緑）に
2. 同一メッセージのまとめ件数 **`×N` バッジを非表示**に

## 変更内容

- `Toast`: success 配色を `bg-lime-600 text-white` に変更（error / info は据え置き）。`×N` バッジと `count` prop を撤去
- `ToastContainer`: `count` の伝搬を撤去
- **まとめ・総数上限の挙動は維持**（積み上がり防止は残し、数字の表示だけ消す）
- テスト更新（黄緑配色・×N 非表示・まとめ/上限は継続）

## テスト

- `tsc` / `eslint` / toast 系テスト green。Playwright で黄緑・白文字・数字なしの表示を確認

## 関連

- FRESTYLE-108（FRESTYLE-106 の見た目調整）。※ Jira コネクタ一時障害のためチケットは復旧後に起票しリンクします

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * 通知メッセージに表示されていた「×件数」バッジを削除しました。
  * 成功通知の背景色を、より明るいライム色に変更しました。
* **テスト**
  * 通知の件数バッジが表示されないこと、および新しい成功通知の色を確認するテストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->