### PR TITLE
feat: 演習の言語バッジを言語ごとの色に（docker 等の灰色を識別しやすく）(FRESTYLE-109)

### DIFF
--- a/frontend/src/components/LanguageBadge.tsx
+++ b/frontend/src/components/LanguageBadge.tsx
@@ -1,0 +1,26 @@
+import { findExerciseLanguage } from '../constants/exerciseLanguages';
+
+interface LanguageBadgeProps {
+  /** 演習の言語値（例: 'docker' / 'go'）。 */
+  language: string;
+  /** 等幅フォントで表示する（詳細ヘッダ用）。 */
+  mono?: boolean;
+  className?: string;
+}
+
+// 未知の言語は従来どおり無彩色にフォールバックする。
+const FALLBACK = 'bg-surface-3 text-[var(--color-text-muted)] border-transparent';
+
+/** 演習の言語を、言語ごとの識別色を付けたバッジで表示する。 */
+export default function LanguageBadge({ language, mono = false, className = '' }: LanguageBadgeProps) {
+  const def = findExerciseLanguage(language);
+  return (
+    <span
+      className={`inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-medium uppercase tracking-wide ${
+        mono ? 'font-mono' : ''
+      } ${def?.badgeClass ?? FALLBACK} ${className}`}
+    >
+      {language}
+    </span>
+  );
+}

--- a/frontend/src/components/__tests__/LanguageBadge.test.tsx
+++ b/frontend/src/components/__tests__/LanguageBadge.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import LanguageBadge from '../LanguageBadge';
+
+describe('LanguageBadge', () => {
+  it('docker は青系(sky)の色クラスになる', () => {
+    render(<LanguageBadge language="docker" />);
+    const badge = screen.getByText('docker');
+    expect(badge.className).toContain('bg-sky-500/15');
+    expect(badge.className).toContain('text-sky-700');
+  });
+
+  it('言語ごとに異なる色になる（go=cyan / php=indigo / git=orange / bash=slate）', () => {
+    const cases: Array<[string, string]> = [
+      ['go', 'bg-cyan-500/15'],
+      ['php', 'bg-indigo-500/15'],
+      ['git', 'bg-orange-500/15'],
+      ['bash', 'bg-slate-500/15'],
+    ];
+    for (const [lang, cls] of cases) {
+      const { unmount } = render(<LanguageBadge language={lang} />);
+      expect(screen.getByText(lang).className).toContain(cls);
+      unmount();
+    }
+  });
+
+  it('大文字小文字を無視して色を引く', () => {
+    render(<LanguageBadge language="Docker" />);
+    expect(screen.getByText('Docker').className).toContain('bg-sky-500/15');
+  });
+
+  it('未知の言語は無彩色（surface-3）にフォールバックする', () => {
+    render(<LanguageBadge language="rust" />);
+    const badge = screen.getByText('rust');
+    expect(badge.className).toContain('bg-surface-3');
+    expect(badge.className).not.toContain('bg-sky-500/15');
+  });
+
+  it('mono 指定で等幅フォントになる', () => {
+    render(<LanguageBadge language="go" mono />);
+    expect(screen.getByText('go').className).toContain('font-mono');
+  });
+});

--- a/frontend/src/constants/exerciseLanguages.ts
+++ b/frontend/src/constants/exerciseLanguages.ts
@@ -9,12 +9,21 @@
 export interface ExerciseLanguageDef {
   key: string;
   label: string;
+  /** 言語バッジの配色。淡色背景 + 濃色文字 + 枠でライトテーマでも読める。 */
+  badgeClass: string;
 }
 
+// 各言語の一般的なイメージカラーに寄せる（Docker=青 / Go=シアン / PHP=藍紫 / Git=橙 / Bash・Linux=スレート）。
 export const EXERCISE_LANGUAGES: ExerciseLanguageDef[] = [
-  { key: 'php', label: 'PHP' },
-  { key: 'go', label: 'Go' },
-  { key: 'git', label: 'Git' },
-  { key: 'bash', label: 'Bash / Linux' },
-  { key: 'docker', label: 'Docker' },
+  { key: 'php', label: 'PHP', badgeClass: 'bg-indigo-500/15 text-indigo-700 border-indigo-500/30' },
+  { key: 'go', label: 'Go', badgeClass: 'bg-cyan-500/15 text-cyan-700 border-cyan-500/30' },
+  { key: 'git', label: 'Git', badgeClass: 'bg-orange-500/15 text-orange-700 border-orange-500/30' },
+  { key: 'bash', label: 'Bash / Linux', badgeClass: 'bg-slate-500/15 text-slate-700 border-slate-500/30' },
+  { key: 'docker', label: 'Docker', badgeClass: 'bg-sky-500/15 text-sky-700 border-sky-500/30' },
 ];
+
+/** language 値（大文字小文字を無視）から定義を引く。未知は undefined。 */
+export function findExerciseLanguage(language: string): ExerciseLanguageDef | undefined {
+  const key = language.toLowerCase();
+  return EXERCISE_LANGUAGES.find((l) => l.key === key);
+}

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -11,6 +11,7 @@ import SubmissionRow from '../components/exercise/SubmissionRow';
 import QaExerciseView from '../components/exercise/QaExerciseView';
 import MarkdownView from '../components/message/MarkdownView';
 import { useExerciseDetail } from '../hooks/useExerciseDetail';
+import LanguageBadge from '../components/LanguageBadge';
 import { lazyWithReload } from '../utils/lazyWithReload';
 import { monacoLanguageOf } from '../utils/exerciseFormat';
 
@@ -173,9 +174,8 @@ export default function ExerciseDetailPage() {
             >
               リセット
             </button>
-            <span className="text-xs px-2 py-0.5 rounded bg-surface-3 text-[var(--color-text-muted)] font-mono uppercase">
-              {ex.language}
-            </span>
+            <LanguageBadge language={ex.language} mono />
+
             {warmupReady && (
               <span className="text-xs px-2 py-0.5 rounded bg-emerald-500/15 text-emerald-400 inline-flex items-center gap-1">
                 <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" aria-hidden />

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { CheckCircleIcon, ClockIcon, CodeBracketIcon } from '@heroicons/react/24/outline';
 import { FilterChip } from '../components/ui';
 import { EXERCISE_LANGUAGES } from '../constants/exerciseLanguages';
+import LanguageBadge from '../components/LanguageBadge';
 import { useExerciseList } from '../hooks/useExerciseList';
 import { MasterExerciseWithStatus } from '../types';
 
@@ -101,9 +102,7 @@ function ExerciseCard({ ex }: { ex: MasterExerciseWithStatus }) {
         <div className="min-w-0">
           <div className="flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
             <span className="font-mono">#{ex.orderIndex}</span>
-            <span className="px-1.5 py-0.5 rounded bg-surface-3 uppercase tracking-wide">
-              {ex.language}
-            </span>
+            <LanguageBadge language={ex.language} />
             <DifficultyBadge level={ex.difficulty} />
           </div>
           <h3 className="mt-1 text-base font-semibold text-[var(--color-text-primary)] group-hover:text-taupe-400 transition-colors truncate">


### PR DESCRIPTION
## 概要

演習の一覧カードと詳細ヘッダで、言語（docker / go / php / git / bash）のバッジが灰色（`bg-surface-3`）固定で見分けにくかった。言語ごとのイメージ色を付けて一目で分かるようにする。

## 変更内容

- `constants/exerciseLanguages.ts`: 各言語に `badgeClass` を追加（Docker=青(sky) / Go=シアン / PHP=藍紫(indigo) / Git=橙(orange) / Bash・Linux=スレート）。`findExerciseLanguage`（大文字小文字を無視）を追加
- 共有 `LanguageBadge` コンポーネントを新設し、`ExerciseListPage` / `ExerciseDetailPage` の灰色 span を置き換え。**未知の言語は従来どおり無彩色にフォールバック**
- 淡色背景 + 濃色文字 + 枠でライトテーマでも読める（既存のカテゴリバッジと同じトーン）

## テスト

- `tsc` / `eslint` / `LanguageBadge` テスト（各言語の色・大文字小文字無視・未知フォールバック・mono）green
- Playwright で実物 CSS の各言語バッジを描画し、docker=青ほか色分けを確認

## 関連

- FRESTYLE-109（※ Jira コネクタ一時障害のためチケットは復旧後に起票しリンクします）