### PR TITLE
feat: 演習に JavaScript / TypeScript 言語を追加 — sandbox 実行対応 (FRESTYLE-110)

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -129,11 +129,22 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ secrets.AWS_ECR_API_SERVER_REPOSITORY }}
         run: |
-          docker buildx build --platform linux/amd64 \
-            -f Dockerfile.coderunner \
-            -t "$ECR_REGISTRY/$ECR_REPOSITORY:coderunner-latest" \
-            -t "$ECR_REGISTRY/$ECR_REPOSITORY:coderunner-${{ github.sha }}" \
-            --push .
+          # Docker Hub の pull(node:24-bookworm 等)は runner 上で transient に timeout する
+          # ことがあるためリトライする(ci-backend-go.yml の integration と同じ方針)。
+          # backend :latest push 済みの後にここが失敗すると :coderunner-latest だけ旧のまま
+          # 残り「新 backend + 旧 coderunner」が生まれるため、諦める前に 3 回試す。
+          # buildx は docker-container driver でキャッシュが daemon と分離されているので、
+          # 先行 docker pull ではなく buildx build 自体をリトライで包む必要がある。
+          for i in 1 2 3; do
+            docker buildx build --platform linux/amd64 \
+              -f Dockerfile.coderunner \
+              -t "$ECR_REGISTRY/$ECR_REPOSITORY:coderunner-latest" \
+              -t "$ECR_REGISTRY/$ECR_REPOSITORY:coderunner-${{ github.sha }}" \
+              --push . && exit 0
+            echo "coderunner build failed (attempt $i/3), retrying in 10s..."
+            sleep 10
+          done
+          exit 1
 
   deploy:
     name: ECS Rolling Deploy

--- a/backend/Dockerfile.coderunner
+++ b/backend/Dockerfile.coderunner
@@ -13,8 +13,9 @@ ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 RUN go build -trimpath -ldflags="-s -w" -o /out/coderunner ./cmd/coderunner
 
 # --- Runtime stage ---
-# 学習者コード（php / go / bash / sql）をサンドボックス実行するため、PHP CLI / Go ツールチェイン /
-# 使い捨て PostgreSQL を同居させる。backend 本体（cmd/server）はこのランタイムを含まない distroless に分離する。
+# 学習者コード（php / go / bash / sql / javascript / typescript）をサンドボックス実行するため、
+# PHP CLI / Go ツールチェイン / 使い捨て PostgreSQL / Node.js を同居させる。
+# backend 本体（cmd/server）はこのランタイムを含まない distroless に分離する。
 # runner には DB / Cognito / AWS の機密 env を注入しない（ECS タスク定義で env を渡さない）。
 FROM golang:1.26-bookworm
 
@@ -23,6 +24,15 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         php-cli ca-certificates postgresql-15 postgresql-client-15 && \
     rm -rf /var/lib/apt/lists/*
+
+# Node.js: javascript / typescript 演習の実行用。公式 node イメージ（同じ bookworm 系）から
+# 実行バイナリだけを取り込む。npm 等のパッケージマネージャは同梱しない
+# （学習者コードの実行に不要で、サンドボックス内の攻撃面を増やさないため）。
+# TypeScript は Node 組み込みの型除去（+ --experimental-transform-types）で実行するため
+# tsc 等の追加ツールも不要。
+COPY --from=node:24-bookworm /usr/local/bin/node /usr/local/bin/node
+RUN node --version && \
+    node --experimental-transform-types -e 'const ok: string = "ts-ok"; console.log(ok)'
 
 # initdb / pg_ctl / postgres の server バイナリは /usr/lib/postgresql/15/bin にあり PATH 外なので通す。
 ENV PATH="/usr/lib/postgresql/15/bin:${PATH}"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1479,7 +1479,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。",
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / sql / javascript / typescript。",
                 "consumes": [
                     "application/json"
                 ],
@@ -1530,7 +1530,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -1530,7 +1530,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/sql/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1523,7 +1523,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/sql/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1472,7 +1472,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。",
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / sql / javascript / typescript。",
                 "consumes": [
                     "application/json"
                 ],
@@ -1523,7 +1523,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2025,7 +2025,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript
+      description: コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/sql/javascript/typescript
         は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
       parameters:
       - description: 言語

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1993,7 +1993,7 @@ paths:
       consumes:
       - application/json
       description: trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode
-        を 返す。 language は php / go / bash。
+        を 返す。 language は php / go / bash / sql / javascript / typescript。
       parameters:
       - description: コード + 言語
         in: body
@@ -2025,7 +2025,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash
+      description: コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript
         は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
       parameters:
       - description: 言語

--- a/backend/internal/domain/code_execution.go
+++ b/backend/internal/domain/code_execution.go
@@ -1,7 +1,8 @@
 package domain
 
 // CodeExecutionInput は学習者コードのサンドボックス実行入力。
-// Language は "php" / "go" / "bash"。Stdin はテストケース採点で標準入力として流す。
+// Language は "php" / "go" / "bash" / "sql" / "javascript" / "typescript"。
+// Stdin はテストケース採点で標準入力として流す。
 type CodeExecutionInput struct {
 	Code     string `json:"code"`
 	Language string `json:"language"`

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -26,7 +26,7 @@ type codeExecuteRequest struct {
 }
 
 // @Summary      コード サンドボックス 実行
-// @Description  trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。
+// @Description  trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / sql / javascript / typescript。
 // @Tags         code-execution
 // @Accept       json
 // @Produce      json
@@ -68,7 +68,7 @@ type codeWarmupResponse struct {
 }
 
 // @Summary      実行環境 ウォームアップ
-// @Description  コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
+// @Description  コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
 // @Tags         code-execution
 // @Accept       json
 // @Produce      json

--- a/backend/internal/handler/code_execute_handler.go
+++ b/backend/internal/handler/code_execute_handler.go
@@ -68,7 +68,7 @@ type codeWarmupResponse struct {
 }
 
 // @Summary      実行環境 ウォームアップ
-// @Description  コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
+// @Description  コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/sql/javascript/typescript は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
 // @Tags         code-execution
 // @Accept       json
 // @Produce      json

--- a/backend/internal/infra/sandbox/runner.go
+++ b/backend/internal/infra/sandbox/runner.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	maxCodeBytes = 64 * 1024 // 64 KB
-	// execTimeout は PHP / bash の上限。
+	// execTimeout は PHP / bash / javascript / typescript の上限。
 	execTimeout = 8 * time.Second
 	// goExecTimeout は Go 専用。go run はコンパイルも走るため余裕を持たせる（cold compile ~6-8s）。
 	goExecTimeout  = 15 * time.Second
@@ -279,8 +279,16 @@ func (r *Runner) executeNode(ctx context.Context, input domain.CodeExecutionInpu
 	out, runErr := runCommand(cmd, input.Stdin)
 	if out != nil {
 		// スタックトレース等に出る一時ディレクトリの絶対パスを学習者に見せない。
-		out.Stderr = strings.ReplaceAll(out.Stderr, tmpDir+string(os.PathSeparator), "./")
-		out.Stderr = strings.ReplaceAll(out.Stderr, tmpDir, ".")
+		// Node は main モジュールを realpath 解決してから出力する（macOS は /var → /private/var の
+		// symlink）ため、解決後のパスを先に置換しないと部分一致で `/private./main.js` に崩れる。
+		paths := []string{tmpDir}
+		if real, err := filepath.EvalSymlinks(tmpDir); err == nil && real != tmpDir {
+			paths = []string{real, tmpDir}
+		}
+		for _, p := range paths {
+			out.Stderr = strings.ReplaceAll(out.Stderr, p+string(os.PathSeparator), "./")
+			out.Stderr = strings.ReplaceAll(out.Stderr, p, ".")
+		}
 	}
 	return out, runErr
 }

--- a/backend/internal/infra/sandbox/runner.go
+++ b/backend/internal/infra/sandbox/runner.go
@@ -1,6 +1,6 @@
-// Package sandbox は学習者コード（php / go / bash）を os/exec でサンドボックス実行する
-// in-process 実装を提供する。backend 本体に同居させる場合（CODE_RUNNER_URL 未設定）と、
-// 別バイナリ cmd/coderunner（HTTP サーバ）の中身の双方から共有して使う。
+// Package sandbox は学習者コード（php / go / bash / sql / javascript / typescript）を
+// os/exec でサンドボックス実行する in-process 実装を提供する。backend 本体に同居させる場合
+// （CODE_RUNNER_URL 未設定）と、別バイナリ cmd/coderunner（HTTP サーバ）の中身の双方から共有して使う。
 package sandbox
 
 import (
@@ -69,8 +69,8 @@ var disableFunctions = strings.Join([]string{
 	"syslog", "openlog", "closelog",
 }, ",")
 
-// Runner は php / go / bash を os/exec でサンドボックス実行する in-process 実装。
-// 共通制約: timeout / 64 KB code-size / 64 KB output-size。
+// Runner は php / go / bash / sql / javascript / typescript を os/exec でサンドボックス実行する
+// in-process 実装。共通制約: timeout / 64 KB code-size / 64 KB output-size。
 type Runner struct{}
 
 // NewRunner は in-process サンドボックス Runner を返す。
@@ -92,13 +92,16 @@ func (r *Runner) Run(ctx context.Context, input domain.CodeExecutionInput) (*dom
 		return r.executeBash(ctx, input)
 	case "sql":
 		return r.executeSQL(ctx, input)
+	case "javascript", "typescript":
+		return r.executeNode(ctx, input)
 	default:
 		return nil, fmt.Errorf("未対応の言語: %s", input.Language)
 	}
 }
 
 // Warmup は実行環境を事前に温める。Go は go run のコンパイルキャッシュを温めるため
-// trivial なプログラムを 1 回コンパイル/実行する。php / bash は起動が軽量なので no-op。
+// trivial なプログラムを 1 回コンパイル/実行する。php / bash / javascript / typescript は
+// 起動が軽量なので no-op。
 func (r *Runner) Warmup(ctx context.Context, language string) error {
 	if language != "go" {
 		return nil
@@ -222,6 +225,64 @@ func (r *Runner) executeBash(ctx context.Context, input domain.CodeExecutionInpu
 	configureProcessGroup(cmd)
 
 	return runCommand(cmd, input.Stdin)
+}
+
+// executeNode は javascript / typescript を Node.js で実行する。TypeScript は Node 組み込みの
+// 型除去（type stripping）でそのまま実行し、別途のコンパイル工程を持たない（起動が速い）。
+// enum 等の型除去だけでは動かない構文も --experimental-transform-types で変換して通す。
+func (r *Runner) executeNode(ctx context.Context, input domain.CodeExecutionInput) (*domain.CodeExecutionResult, error) {
+	// リクエストごとに独立した temp dir を HOME / PWD に固定し、副作用を temp に閉じる。
+	tmpDir, err := os.MkdirTemp("", "node-exec-")
+	if err != nil {
+		return nil, fmt.Errorf("一時ディレクトリの作成に失敗: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// 拡張子で Node の TypeScript 処理（型除去）が切り替わるため、言語に合わせる。
+	name := "main.js"
+	args := []string{}
+	if input.Language == "typescript" {
+		name = "main.ts"
+		args = append(
+			args,
+			"--experimental-transform-types",
+			// 実験機能の警告が stderr に混ざると学習者の実行結果を汚すため抑止する。
+			"--disable-warning=ExperimentalWarning",
+		)
+	}
+	// 512MB タスクに同居する他プロセスを圧迫しないようヒープ上限を絞る（学習用途には十分）。
+	args = append(args, "--max-old-space-size=128", name)
+
+	filename := filepath.Join(tmpDir, name)
+	if err := os.WriteFile(filename, []byte(input.Code), 0o600); err != nil {
+		return nil, fmt.Errorf("一時ファイルの作成に失敗: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, execTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "node", args...)
+	cmd.Dir = tmpDir
+	// AWS credential や DB password 等を子プロセスに継承しないため、環境変数は最小限に絞る
+	// （NODE_OPTIONS 等の注入も防ぐ）。
+	cmd.Env = []string{
+		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"HOME=" + tmpDir,
+		"PWD=" + tmpDir,
+		"LANG=C.UTF-8",
+		"LC_ALL=C.UTF-8",
+	}
+
+	// child_process 等で子孫プロセスを起動しうるので、独立プロセスグループに置いて一括 kill する。
+	configureProcessGroup(cmd)
+
+	out, runErr := runCommand(cmd, input.Stdin)
+	if out != nil {
+		// スタックトレース等に出る一時ディレクトリの絶対パスを学習者に見せない。
+		out.Stderr = strings.ReplaceAll(out.Stderr, tmpDir+string(os.PathSeparator), "./")
+		out.Stderr = strings.ReplaceAll(out.Stderr, tmpDir, ".")
+	}
+	return out, runErr
 }
 
 // pgConn は psql 接続に必要な最小情報。host が "/" 始まりなら unix socket ディレクトリ。

--- a/backend/internal/infra/sandbox/runner_test.go
+++ b/backend/internal/infra/sandbox/runner_test.go
@@ -190,11 +190,13 @@ func Test_ランナー_ウォームアップ_Go(t *testing.T) {
 	require.NoError(t, r.Warmup(context.Background(), "go"))
 }
 
-// Warmup(php/bash/未対応) は no-op で常に成功する。
+// Warmup(php/bash/javascript/typescript/未対応) は no-op で常に成功する。
 func Test_ランナー_ウォームアップ_Go以外は何もしない(t *testing.T) {
 	r := sandbox.NewRunner()
 	require.NoError(t, r.Warmup(context.Background(), "php"))
 	require.NoError(t, r.Warmup(context.Background(), "bash"))
+	require.NoError(t, r.Warmup(context.Background(), "javascript"))
+	require.NoError(t, r.Warmup(context.Background(), "typescript"))
 	require.NoError(t, r.Warmup(context.Background(), "unknown"))
 }
 
@@ -273,6 +275,152 @@ func Test_ランナー_Bash_終了コードを伝播(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "before\n", out.Stdout)
 	assert.Equal(t, 7, out.ExitCode)
+}
+
+// --- JavaScript / TypeScript ---
+
+// requireNodeJS は node が PATH に無い環境（一部 CI やローカル）でテストを skip する。
+// forTS=true のときは TypeScript 実行に使う --experimental-transform-types 未対応の
+// 古い node でも skip する。
+func requireNodeJS(t *testing.T, forTS bool) {
+	t.Helper()
+	if _, err := exec.LookPath("node"); err != nil {
+		t.Skip("node not found in PATH, skipping integration test")
+	}
+	if forTS {
+		probe := exec.Command("node", "--experimental-transform-types", "-e", "")
+		if err := probe.Run(); err != nil {
+			t.Skip("node does not support --experimental-transform-types, skipping")
+		}
+	}
+}
+
+func Test_ランナー_JavaScript_HelloWorld(t *testing.T) {
+	requireNodeJS(t, false)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `console.log("Hello, World!");`,
+		Language: "javascript",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, World!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func Test_ランナー_JavaScript_構文エラーで内部パスを隠す(t *testing.T) {
+	requireNodeJS(t, false)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `console.log("unclosed`,
+		Language: "javascript",
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, 0, out.ExitCode)
+	assert.NotEmpty(t, out.Stderr)
+	// 一時ディレクトリの内部パスを露出せず、`./main.js` に整形される。
+	assert.NotContains(t, out.Stderr, "node-exec-")
+	assert.Contains(t, out.Stderr, "main.js")
+}
+
+func Test_ランナー_JavaScript_標準入力を読む(t *testing.T) {
+	requireNodeJS(t, false)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `const data = require("fs").readFileSync(0, "utf8");
+console.log("got: " + data.trim());`,
+		Language: "javascript",
+		Stdin:    "hello\n",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "got: hello\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+func Test_ランナー_JavaScript_終了コードを伝播(t *testing.T) {
+	requireNodeJS(t, false)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `console.log("before"); process.exit(7);`,
+		Language: "javascript",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "before\n", out.Stdout)
+	assert.Equal(t, 7, out.ExitCode)
+}
+
+// AWS / DB の credential が子プロセスに継承されないことを確認する（環境変数を絞っている）。
+func Test_ランナー_JavaScript_親envを落とす(t *testing.T) {
+	requireNodeJS(t, false)
+	t.Setenv("FRESTYLE_SECRET_TEST", "must-not-leak")
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `console.log("value=" + (process.env.FRESTYLE_SECRET_TEST ?? "missing"));`,
+		Language: "javascript",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "value=missing\n", out.Stdout)
+}
+
+// 無限ループも timeout でプロセスグループごと kill され、数秒以内に return する。
+func Test_ランナー_JavaScript_タイムアウトで停止(t *testing.T) {
+	requireNodeJS(t, false)
+	r := sandbox.NewRunner()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	out, err := r.Run(ctx, domain.CodeExecutionInput{
+		Code:     `while (true) {}`,
+		Language: "javascript",
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.NotZero(t, out.ExitCode, "process should be killed by timeout")
+	assert.Less(t, elapsed, 5*time.Second)
+}
+
+// TypeScript は Node 組み込みの型除去でそのまま実行できる（tsc 等の別工程を挟まない）。
+func Test_ランナー_TypeScript_型注釈つきコードを実行(t *testing.T) {
+	requireNodeJS(t, true)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `const greet = (name: string): string => "Hello, " + name + "!";
+console.log(greet("TypeScript"));`,
+		Language: "typescript",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, TypeScript!\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// enum は型除去だけでは動かず --experimental-transform-types による変換が必要。
+// フラグの付け忘れ regression を検知する。
+func Test_ランナー_TypeScript_enumを実行(t *testing.T) {
+	requireNodeJS(t, true)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code: `enum Color { Red = "red", Green = "green" }
+console.log(Color.Green);`,
+		Language: "typescript",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "green\n", out.Stdout)
+	assert.Equal(t, 0, out.ExitCode)
+}
+
+// 実験機能の警告（ExperimentalWarning）が stderr に混ざらないことを確認する。
+// 学習者の実行結果表示を警告で汚さないための regression test。
+func Test_ランナー_TypeScript_実験機能の警告を出さない(t *testing.T) {
+	requireNodeJS(t, true)
+	r := sandbox.NewRunner()
+	out, err := r.Run(context.Background(), domain.CodeExecutionInput{
+		Code:     `const n: number = 42; console.log(n);`,
+		Language: "typescript",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "42\n", out.Stdout)
+	assert.NotContains(t, out.Stderr, "ExperimentalWarning")
 }
 
 // timeout 時に bash 配下の子孫プロセスもまとめて kill されることを確認する regression test。

--- a/backend/internal/infra/sandbox/runner_test.go
+++ b/backend/internal/infra/sandbox/runner_test.go
@@ -318,8 +318,11 @@ func Test_ランナー_JavaScript_構文エラーで内部パスを隠す(t *tes
 	assert.NotEqual(t, 0, out.ExitCode)
 	assert.NotEmpty(t, out.Stderr)
 	// 一時ディレクトリの内部パスを露出せず、`./main.js` に整形される。
+	// Node は realpath 解決してから出力するため、symlink な temp dir（macOS の
+	// /var → /private/var）でも `/private./main.js` に崩れないこと。
 	assert.NotContains(t, out.Stderr, "node-exec-")
-	assert.Contains(t, out.Stderr, "main.js")
+	assert.Contains(t, out.Stderr, "./main.js")
+	assert.NotContains(t, out.Stderr, "/private.")
 }
 
 func Test_ランナー_JavaScript_標準入力を読む(t *testing.T) {

--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -30,8 +30,28 @@ frontend ExerciseDetailPage (Monaco / monacoLanguageOf)
 | `go` | `go run`（単一ファイル） | `package main` 必須。GOCACHE 共有で cold compile を短縮 |
 | `bash` | `/bin/bash` | 独立 process group で timeout 時に子孫まで kill |
 | `sql` | 同居 PostgreSQL + `psql` | **使い捨て DB を提出ごとに作成し非 superuser で実行**（下記） |
+| `javascript` | `node`（単一ファイル） | コンパイル不要で起動が速い。最小 env + 独立 process group（下記） |
+| `typescript` | `node --experimental-transform-types`（単一ファイル） | Node 組み込みの型除去で実行（tsc 等の別工程なし）。下記 |
 
 共通制約: コード 64KB / 出力 64KB 上限、言語別 timeout、`sandboxEnv` が AWS/DB/Cognito 等の機密 env を子プロセスから除去。
+
+## JavaScript / TypeScript 実行系（Node.js）— FRESTYLE-110
+
+Go 演習は `go run` のコンパイルを伴い初回実行が重い。起動が速いスクリプト言語の選択肢として
+Node.js による `javascript` / `typescript` 実行を追加した（[`executeNode`](../backend/internal/infra/sandbox/runner.go)）。
+
+- **TypeScript は Node 組み込みの型除去（type stripping）でそのまま実行**する。`main.ts` の拡張子 +
+  `--experimental-transform-types`（enum 等、型除去だけでは動かない構文も変換）で起動し、
+  **`--disable-warning=ExperimentalWarning`** で実験機能の警告が学習者の stderr に混ざるのを防ぐ
+  - 型チェックはしない（型エラーでも動く構文なら実行される）。採点は他言語と同じ stdout 比較
+- bash と同じ隔離方針: **os.Environ を継承せず最小 env のみ**（PATH/HOME/PWD/LANG。`NODE_OPTIONS`
+  注入も防げる）、HOME/PWD はリクエストごとの temp dir、独立 process group で timeout 時に
+  `child_process` の子孫ごと SIGKILL、timeout 8s
+- `--max-old-space-size=128` でヒープ上限を絞る（512MB タスクに PG 等と同居するため）
+- stderr のスタックトレースに出る temp dir の絶対パスは `./` に整形して内部パスを隠す
+- ランタイムは `Dockerfile.coderunner` が **公式 node:24-bookworm イメージから `node` バイナリだけ** を
+  取り込む。npm は同梱しない（演習実行に不要・サンドボックス内の攻撃面を増やさない）。
+  backend 本体イメージには Node を追加しない
 
 ## SQL 実行系（PostgreSQL）
 
@@ -79,6 +99,8 @@ frontend ExerciseDetailPage (Monaco / monacoLanguageOf)
 `exercises/_scripts/seed.py` が UPSERT SQL を生成 → infra リポ `make apply-migration-supabase` で Supabase に投入（詳細は CLAUDE.md §7-bis）。
 
 ## テスト
+- [backend/internal/infra/sandbox/runner_test.go](../backend/internal/infra/sandbox/runner_test.go): php / go / bash / javascript / typescript の実実行テスト。ランタイムが PATH に無い環境では Skip（TS は `--experimental-transform-types` 未対応の古い node でも Skip）
+  - JS/TS 分: HelloWorld / 構文エラーで内部パス隠蔽 / stdin / 終了コード伝播 / 親 env 遮断 / 無限ループ timeout / 型注釈 / enum（transform-types の regression）/ ExperimentalWarning 非混入
 - [backend/internal/infra/sandbox/runner_sql_test.go](../backend/internal/infra/sandbox/runner_sql_test.go): `initdb`+`pg_ctl` で使い捨て PG（`dbadmin`/`student` ロール）をローカル起動して executeSQL を実検証。`initdb`/`psql` が無い環境では Skip
   - `Test_ランナー_SQL_単純SELECT` / `Test_ランナー_SQL_複数文と集計` / `Test_ランナー_SQL_文タイムアウトで打ち切る` / `Test_ランナー_SQL_提出間はDBが隔離される` / `Test_ランナー_SQL_COPYPROGRAMは権限拒否` / `Test_ランナー_SQL_危険メタコマンドを拒否`（`\!` / `\c` / `\connect`）
 

--- a/frontend/src/components/__tests__/LanguageBadge.test.tsx
+++ b/frontend/src/components/__tests__/LanguageBadge.test.tsx
@@ -10,12 +10,14 @@ describe('LanguageBadge', () => {
     expect(badge.className).toContain('text-sky-700');
   });
 
-  it('言語ごとに異なる色になる（go=cyan / php=indigo / git=orange / bash=slate）', () => {
+  it('言語ごとに異なる色になる（go=cyan / php=indigo / git=orange / bash=slate / javascript=yellow / typescript=blue）', () => {
     const cases: Array<[string, string]> = [
       ['go', 'bg-cyan-500/15'],
       ['php', 'bg-indigo-500/15'],
       ['git', 'bg-orange-500/15'],
       ['bash', 'bg-slate-500/15'],
+      ['javascript', 'bg-yellow-500/15'],
+      ['typescript', 'bg-blue-500/15'],
     ];
     for (const [lang, cls] of cases) {
       const { unmount } = render(<LanguageBadge language={lang} />);

--- a/frontend/src/components/exercise/ExerciseHeader.tsx
+++ b/frontend/src/components/exercise/ExerciseHeader.tsx
@@ -1,6 +1,7 @@
 import { DocumentTextIcon } from '@heroicons/react/24/outline';
 import BackLink from './BackLink';
 import ResultBadge from './ResultBadge';
+import LanguageBadge from '../LanguageBadge';
 import { MasterExercise, ExerciseSubmitResult } from '../../types';
 
 interface Props {
@@ -27,7 +28,7 @@ export default function ExerciseHeader({ exercise: ex, submitResult }: Props) {
             {ex.title}
           </h1>
           <div className="mt-1 flex items-center gap-2 text-xs text-[var(--color-text-muted)]">
-            <span className="px-1.5 py-0.5 rounded bg-surface-3 uppercase">{ex.language}</span>
+            <LanguageBadge language={ex.language} />
             <span>難易度 {'★'.repeat(Math.max(1, Math.min(5, ex.difficulty)))}</span>
             <span>#{ex.orderIndex}</span>
           </div>

--- a/frontend/src/constants/exerciseLanguages.ts
+++ b/frontend/src/constants/exerciseLanguages.ts
@@ -13,10 +13,13 @@ export interface ExerciseLanguageDef {
   badgeClass: string;
 }
 
-// 各言語の一般的なイメージカラーに寄せる（Docker=青 / Go=シアン / PHP=藍紫 / Git=橙 / Bash・Linux=スレート）。
+// 各言語の一般的なイメージカラーに寄せる
+// （Docker=青 / Go=シアン / PHP=藍紫 / Git=橙 / Bash・Linux=スレート / JavaScript=黄 / TypeScript=青）。
 export const EXERCISE_LANGUAGES: ExerciseLanguageDef[] = [
   { key: 'php', label: 'PHP', badgeClass: 'bg-indigo-500/15 text-indigo-700 border-indigo-500/30' },
   { key: 'go', label: 'Go', badgeClass: 'bg-cyan-500/15 text-cyan-700 border-cyan-500/30' },
+  { key: 'javascript', label: 'JavaScript', badgeClass: 'bg-yellow-500/15 text-yellow-700 border-yellow-500/30' },
+  { key: 'typescript', label: 'TypeScript', badgeClass: 'bg-blue-500/15 text-blue-700 border-blue-500/30' },
   { key: 'git', label: 'Git', badgeClass: 'bg-orange-500/15 text-orange-700 border-orange-500/30' },
   { key: 'bash', label: 'Bash / Linux', badgeClass: 'bg-slate-500/15 text-slate-700 border-slate-500/30' },
   { key: 'docker', label: 'Docker', badgeClass: 'bg-sky-500/15 text-sky-700 border-sky-500/30' },


### PR DESCRIPTION
## 概要

演習（コード学習）で選べる言語に JavaScript / TypeScript を追加する。Go はコンパイルを伴い初回実行が遅くなりやすいため、起動が速いスクリプト言語の選択肢を増やす（FRESTYLE-110）。

問題データ本体は教材リポ（private）に別 PR で追加済みで、本 PR マージ・デプロイ後に本番 DB へ seed する。

## 変更内容

### backend
- `sandbox/runner.go`: `executeNode` を追加。`javascript` は `node main.js`、`typescript` は Node 組み込みの型除去（`--experimental-transform-types`）で `main.ts` を直接実行（tsc 等の別工程なし・起動が速い）
  - 実験機能の警告が学習者の stderr を汚さないよう `--disable-warning=ExperimentalWarning`
  - 隔離は既存 bash と同方針: **os.Environ を継承せず最小 env のみ**（`NODE_OPTIONS` 注入も防止）/ HOME・PWD はリクエストごとの temp dir / 独立プロセスグループで timeout 時に子孫ごと SIGKILL / timeout 8s / `--max-old-space-size=128`
  - stderr の temp dir 絶対パスは `./` に整形（Node は realpath 解決して出力するため symlink 解決後のパスも置換）
- `Dockerfile.coderunner`: 公式 node:24-bookworm イメージから **node バイナリのみ** 取込（npm 非同梱 = サンドボックス内の攻撃面を増やさない）。build 時に TS 実行を検証
  - linux/amd64 でローカル実ビルドし、node v24 起動・TS 実行・警告抑止を確認済
- `cd-backend.yml`: coderunner イメージビルドを 3 回リトライで包む（Docker Hub pull の transient 失敗で backend :latest だけ更新される新旧混在を防ぐ）
- swaggo 記述更新 + `make openapi` 済

### frontend
- `exerciseLanguages.ts`: JavaScript（黄）/ TypeScript（青）を追加（一覧チップ・言語バッジ・localStorage 検証セットは単一情報源から自動反映）
- `ExerciseHeader.tsx`: 詳細ヘッダに残っていた灰色 span を共通 `LanguageBadge` に統一（FRESTYLE-109 の置換漏れ）
- Monaco の構文ハイライトは `monacoLanguageOf` が js/ts 対応済のため変更なし

### docs
- `docs/code-exercises.md`: 対応言語表 + JS/TS 実行系の設計（なぜ型除去か・隔離方針・npm 非同梱の理由）を追記

## テスト

- go test: runner に JS/TS の実実行テスト 9 件を追加（HelloWorld / 構文エラーの内部パス隠蔽 / stdin / 終了コード / 親 env 遮断 / 無限ループ timeout / 型注釈 / enum / 警告非混入）。node が無い環境では Skip
- vitest: LanguageBadge に javascript/typescript の色ケースを追加。全 suite green（カバレッジ 85%）
- `go build ./... && go test ./...` / `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` すべて成功
- Dockerfile は linux/amd64 で実ビルド検証済

## 関連チケット

- https://frestyle.atlassian.net/browse/FRESTYLE-110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * JavaScript と TypeScript のコード実行に対応しました。
  * TypeScript の型注釈や enum を含むコードを実行できます。
  * JavaScript・TypeScript の言語バッジとカラー表示を追加しました。
* **改善**
  * 実行時のタイムアウト、入力処理、終了コード、エラー表示を改善しました。
  * エラーメッセージから内部パスが表示されないようにしました。
  * コード実行環境のビルド失敗時に自動リトライするようにしました。
* **ドキュメント**
  * 対応言語と JavaScript・TypeScript の実行仕様を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->