### PR TITLE
fix: 演習の実行結果ステータスが緑一色で正解と誤解される UX を修正 (FRESTYLE-111)

### DIFF
--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -13,8 +13,7 @@ interface Props {
  */
 function normalizeOutput(s: string): string {
   return s
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
+    .replace(/\r\n?/g, '\n')
     .split('\n')
     .map((line) => line.replace(/[ \t]+$/, ''))
     .join('\n')

--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon, ExclamationTriangleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import { CodeExecutionResult } from '../../types';
 
 interface Props {
@@ -8,16 +8,31 @@ interface Props {
 }
 
 /**
+ * サーバ採点の normalizeOutput と同じ正規化（改行コード統一・各行の末尾空白除去・
+ * 末尾の空行除去）。末尾改行の有無だけでプレビュー比較が不一致にならないようにする。
+ */
+function normalizeOutput(s: string): string {
+  return s
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .split('\n')
+    .map((line) => line.replace(/[ \t]+$/, ''))
+    .join('\n')
+    .replace(/[ \t\n]+$/, '');
+}
+
+/**
  * 提出前 動作 確認 (= 単発 実行) の 結果 を テーブル 形式 で 表示。
- * stdout / stderr / 期待 出力 を 並列 で 見せる。 採点 (正誤) は 行わ ず、 末尾 で
- * 「ここ は 実行 プレビュー」 と 明示 する (正誤 は サーバ 側 採点)。
+ * stdout / stderr / 期待 出力 を 並列 で 見せる。
  *
- * 「実行 ステータス」 は exit code に 応じた 「実行 が 通った / エラー」 を 表す だけ で、
- * 「答え が 正しい か どうか」 とは 無関係 (= ここ を 正誤 と 誤解 され ない 文言 に する):
- *   - exit 0 → 緑 + ✓ 「実行 成功 (エラー なし)」
- *   - exit != 0 → 赤 + ✗ 「実行 エラー (exit N)」
- * さらに exit 0 でも stdout が 空 の とき は 「まだ 出力 が ない」 ヒント を 出し、
- * 「出力 ゼロ なのに Success」 で 正解 と 誤解 され る の を 防ぐ。
+ * 「実行 ステータス」 は 3 状態 に 分け、 緑 は 「期待 出力 と 一致 した とき だけ」 に 予約 する。
+ * exit 0 なら 常に 緑 だと 「エラー なく 動いた ＝ 正解」 と 色 の 印象 で 誤解 され やすい ため
+ * (FRESTYLE-111)。 正誤 の 確定 は 従来 どおり 提出 時 の サーバ 側 採点 (複数 テストケース):
+ *   - exit 0 + 出力 一致   → 緑 + ✓ 「実行 成功・期待 する 出力 と 一致」
+ *   - exit 0 + 出力 不一致 → 琥珀 + ⚠ 「実行 成功 (エラー なし)・期待 する 出力 とは まだ 一致 して いません」
+ *   - exit != 0            → 赤 + ✗ 「実行 エラー (exit N)」
+ * 期待 出力 が 空 の 演習 は 比較 でき ない ので 従来 の 中立 表示 に フォールバック。
+ * さらに exit 0 でも stdout が 空 の とき は 「まだ 出力 が ない」 ヒント を 出す。
  */
 export default function ExecutionResultTable({ result, expected, submitError }: Props) {
   if (submitError) {
@@ -31,6 +46,9 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
 
   const isSuccess = result.exitCode === 0;
   const hasNoOutput = isSuccess && !result.stdout;
+  const normalizedExpected = normalizeOutput(expected);
+  const comparable = normalizedExpected !== '';
+  const matches = comparable && normalizeOutput(result.stdout) === normalizedExpected;
 
   return (
     <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
@@ -41,15 +59,25 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
               実行結果ステータス
             </th>
             <td className="px-4 py-2">
-              {isSuccess ? (
+              {!isSuccess ? (
+                <span className="inline-flex items-center gap-1 font-semibold text-red-400">
+                  <XCircleIcon className="w-4 h-4" />
+                  実行エラー（exit {result.exitCode}）
+                </span>
+              ) : !comparable ? (
                 <span className="inline-flex items-center gap-1 font-semibold text-green-400">
                   <CheckCircleIcon className="w-4 h-4" />
                   実行成功（エラーなし）
                 </span>
+              ) : matches ? (
+                <span className="inline-flex items-center gap-1 font-semibold text-green-400">
+                  <CheckCircleIcon className="w-4 h-4" />
+                  実行成功・期待する出力と一致
+                </span>
               ) : (
-                <span className="inline-flex items-center gap-1 font-semibold text-red-400">
-                  <XCircleIcon className="w-4 h-4" />
-                  実行エラー（exit {result.exitCode}）
+                <span className="inline-flex items-center gap-1 font-semibold text-amber-500">
+                  <ExclamationTriangleIcon className="w-4 h-4" />
+                  実行成功（エラーなし）・期待する出力とはまだ一致していません
                 </span>
               )}
             </td>
@@ -84,9 +112,9 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
           </tr>
         </tbody>
       </table>
-      {/* 採点はサーバ側で行う(フロントでローカル判定しない)。ここは実行結果のプレビューのみ。 */}
+      {/* 一致判定はこの画面の期待出力 1 件とのプレビュー比較。正誤の確定はサーバ側採点。 */}
       <div className="px-4 py-2 text-xs text-[var(--color-text-muted)] border-t border-surface-3">
-        「実行成功」はコードがエラーなく動いたという意味で、正誤の判定ではありません。正誤は「提出する」で複数のテストケースによりサーバ側採点されます。
+        「一致」はこの画面に表示中の期待出力とのプレビュー比較です。正誤は「提出する」で複数のテストケースによりサーバ側採点されます。
       </div>
     </div>
   );

--- a/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
+++ b/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
@@ -34,7 +34,7 @@ describe('ExecutionResultTable', () => {
     );
     const status = screen.getByText('実行成功・期待する出力と一致');
     expect(status).toBeInTheDocument();
-    expect(status.className).toContain('text-green-400');
+    expect(status).toHaveClass('text-green-400');
   });
 
   it('exit 0 でも出力が期待と不一致なら緑にせず、琥珀色の「まだ一致していません」を表示する', () => {
@@ -47,8 +47,8 @@ describe('ExecutionResultTable', () => {
     );
     const status = screen.getByText(/実行成功（エラーなし）・期待する出力とはまだ一致していません/);
     expect(status).toBeInTheDocument();
-    expect(status.className).toContain('text-amber-500');
-    expect(status.className).not.toContain('text-green-400');
+    expect(status).toHaveClass('text-amber-500');
+    expect(status).not.toHaveClass('text-green-400');
   });
 
   it('末尾改行や行末スペースの差だけなら一致として扱う（サーバ採点の正規化と同じ）', () => {

--- a/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
+++ b/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
@@ -24,7 +24,7 @@ describe('ExecutionResultTable', () => {
     expect(screen.getByText('実行に失敗しました')).toBeInTheDocument();
   });
 
-  it('exit 0 は「実行成功（エラーなし）」と表示し、正誤ではないことを明記する', () => {
+  it('exit 0 で出力が期待と一致したときだけ緑の「実行成功・期待する出力と一致」を表示する', () => {
     render(
       <ExecutionResultTable
         result={result({ stdout: '{"id":1}', exitCode: 0 })}
@@ -32,10 +32,46 @@ describe('ExecutionResultTable', () => {
         submitError={null}
       />,
     );
+    const status = screen.getByText('実行成功・期待する出力と一致');
+    expect(status).toBeInTheDocument();
+    expect(status.className).toContain('text-green-400');
+  });
+
+  it('exit 0 でも出力が期待と不一致なら緑にせず、琥珀色の「まだ一致していません」を表示する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '{"id":2}', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    const status = screen.getByText(/実行成功（エラーなし）・期待する出力とはまだ一致していません/);
+    expect(status).toBeInTheDocument();
+    expect(status.className).toContain('text-amber-500');
+    expect(status.className).not.toContain('text-green-400');
+  });
+
+  it('末尾改行や行末スペースの差だけなら一致として扱う（サーバ採点の正規化と同じ）', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: 'Hello, World!  \nHello, FreStyle!\n', exitCode: 0 })}
+        expected={'Hello, World!\nHello, FreStyle!'}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByText('実行成功・期待する出力と一致')).toBeInTheDocument();
+  });
+
+  it('期待出力が空の演習では比較せず、従来の「実行成功（エラーなし）」を表示する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: 'something', exitCode: 0 })}
+        expected=""
+        submitError={null}
+      />,
+    );
     expect(screen.getByText('実行成功（エラーなし）')).toBeInTheDocument();
-    // 「Success」単独で正誤と誤解させる旧文言は使わない
-    expect(screen.queryByText('Success')).not.toBeInTheDocument();
-    expect(screen.getByText(/正誤の判定ではありません/)).toBeInTheDocument();
+    expect(screen.queryByText(/まだ一致していません/)).not.toBeInTheDocument();
   });
 
   it('exit が 0 以外なら「実行エラー（exit N）」を表示する', () => {
@@ -70,5 +106,16 @@ describe('ExecutionResultTable', () => {
       />,
     );
     expect(screen.queryByText(/まだ出力がありません/)).not.toBeInTheDocument();
+  });
+
+  it('注記でプレビュー比較であること・正誤の確定は提出時であることを明記する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '{"id":1}', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByText(/サーバ側採点/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要

演習の「コード実行」の結果表示が、コードがエラーなく動きさえすれば緑の「実行成功（エラーなし）」になり、出力が期待する出力と一致していなくても「正解した」と誤解されやすい（ユーザー報告。ts-1 で 1 行だけの出力でも緑になっていた）。緑を「期待出力と一致したとき」だけに予約する。

## 変更内容

- `ExecutionResultTable`: 実行プレビューの stdout を「期待する出力」とフロント側で比較し、ステータスを 3 状態に分割
  - **一致**（exit 0 + 出力一致）→ 緑 ✓「実行成功・期待する出力と一致」
  - **不一致**（exit 0 + 出力不一致）→ 琥珀 ⚠「実行成功（エラーなし）・期待する出力とはまだ一致していません」
  - **実行エラー**（exit != 0）→ 赤 ✗（従来どおり）
- 比較はサーバ採点の `normalizeOutput` と同じ正規化（改行コード統一・各行の行末空白除去・末尾改行除去）で、末尾改行の差だけでは不一致にしない
- 期待出力が空の演習（比較不能）は従来の中立表示にフォールバック
- 注記を「『一致』はこの画面に表示中の期待出力とのプレビュー比較。正誤は提出時のサーバ側採点」に更新
- 出力が空のときの「まだ出力がありません」ヒントは維持

## テスト

- vitest: 3 状態 / 正規化（末尾改行・行末スペース差の吸収）/ 期待出力空のフォールバック / 既存ヒント維持 / 注記文言 の 10 ケース green
- `tsc --noEmit` / `eslint --max-warnings 0` / `vitest run --coverage`（85%）/ `npm run build` すべて成功

## 関連チケット

- https://frestyle.atlassian.net/browse/FRESTYLE-111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 実行結果と期待出力を比較し、一致・不一致を明確に表示するようになりました。
  * 改行コードや行末の空白などの違いを吸収し、実質的に同じ出力を正しく一致扱いします。
  * 実行エラー、不一致、一致の状態を色やアイコンで判別できます。
  * 期待出力のプレビュー比較であり、最終的な正誤判定は提出後のサーバー採点で行われる旨を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->