### PR TITLE
feat: 演習一覧の視認性改善 — カテゴリ見出しの色分け + ステータス/言語バッジの濃色化 (FRESTYLE-112)

### DIFF
--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -104,6 +104,30 @@ Node.js による `javascript` / `typescript` 実行を追加した（[`executeN
 - [backend/internal/infra/sandbox/runner_sql_test.go](../backend/internal/infra/sandbox/runner_sql_test.go): `initdb`+`pg_ctl` で使い捨て PG（`dbadmin`/`student` ロール）をローカル起動して executeSQL を実検証。`initdb`/`psql` が無い環境では Skip
   - `Test_ランナー_SQL_単純SELECT` / `Test_ランナー_SQL_複数文と集計` / `Test_ランナー_SQL_文タイムアウトで打ち切る` / `Test_ランナー_SQL_提出間はDBが隔離される` / `Test_ランナー_SQL_COPYPROGRAMは権限拒否` / `Test_ランナー_SQL_危険メタコマンドを拒否`（`\!` / `\c` / `\connect`）
 
+## 実行結果プレビューの 3 状態表示（FRESTYLE-111）
+
+「コード実行」の結果ステータスは、exit 0 なら常に緑だと「エラーなく動いた ＝ 正解」と色の印象で誤解されやすい。
+[`ExecutionResultTable`](../frontend/src/components/exercise/ExecutionResultTable.tsx) は stdout をサーバ採点と同じ正規化
+（改行コード統一・行末空白/末尾改行の除去）で期待出力とプレビュー比較し、**緑を「一致したときだけ」に予約**する:
+
+- exit 0 + 出力一致 → 緑 ✓「実行成功・期待する出力と一致」
+- exit 0 + 出力不一致 → 琥珀 ⚠「実行成功（エラーなし）・期待する出力とはまだ一致していません」
+- exit != 0 → 赤 ✗「実行エラー（exit N）」
+- 期待出力が空の演習は比較不能なので中立の「実行成功（エラーなし）」にフォールバック
+
+正誤の**確定**は従来どおり提出時のサーバ側採点（複数テストケース）で、この比較は画面に表示中の期待出力 1 件とのプレビュー。
+
+## 演習一覧の視認性（FRESTYLE-112）
+
+いずれも「バッジ類が淡くて見えにくい」というユーザー要望への対応:
+
+- **カテゴリ見出し**: [`CategoryBadge`](../frontend/src/components/CategoryBadge.tsx) の濃色塗り + 白文字バッジ。色は
+  [`utils/categoryColor`](../frontend/src/utils/categoryColor.ts) がカテゴリ名の決定的ハッシュで固定 10 色パレットから選ぶ
+  （カテゴリは DB の自由文字列で本番 36 種類 — 手書きの対応表は保守不能）。名前ハッシュ単体だと本番データで隣接ブロックの
+  同色が複数発生するため、`assignCategoryColors` が**直前ブロックと衝突したときだけ次の色へずらす**（それ以外は名前で安定）
+- **ステータスバッジ**: 解いた = `bg-emerald-600` / 取り組み中 = `bg-amber-600`（塗り + 白文字。淡色 /15 は白背景で薄すぎた）
+- **言語バッジ**: 背景 /15 → /25・枠 /30 → /50 にコントラスト強化（色相は FRESTYLE-109 のまま）
+
 ## 言語フィルタ UI（FRESTYLE-101）
 
 演習一覧（/code-editor）の言語絞り込みは、プルダウン（select）ではなく

--- a/frontend/src/components/CategoryBadge.tsx
+++ b/frontend/src/components/CategoryBadge.tsx
@@ -1,0 +1,24 @@
+import { categoryColorClass } from '../utils/categoryColor';
+
+interface CategoryBadgeProps {
+  /** 演習のカテゴリ名（例: '基礎' / 'コンテナ操作'）。 */
+  category: string;
+  /**
+   * 色クラスの明示指定。一覧のように複数カテゴリを並べる画面では
+   * utils/categoryColor の assignCategoryColors で隣接同色を避けた色を渡す。
+   * 未指定なら名前ハッシュの色にフォールバック。
+   */
+  colorClass?: string;
+  className?: string;
+}
+
+/** 演習のカテゴリを、カテゴリごとに安定した色のバッジで表示する。 */
+export default function CategoryBadge({ category, colorClass, className = '' }: CategoryBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-semibold ${colorClass ?? categoryColorClass(category)} ${className}`}
+    >
+      {category}
+    </span>
+  );
+}

--- a/frontend/src/components/__tests__/CategoryBadge.test.tsx
+++ b/frontend/src/components/__tests__/CategoryBadge.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CategoryBadge from '../CategoryBadge';
+import { assignCategoryColors, categoryColorClass } from '../../utils/categoryColor';
+
+describe('CategoryBadge', () => {
+  it('カテゴリ名を表示する', () => {
+    render(<CategoryBadge category="基礎" />);
+    expect(screen.getByText('基礎')).toBeInTheDocument();
+  });
+
+  it('同じカテゴリ名は常に同じ色クラスになる（決定的）', () => {
+    expect(categoryColorClass('基礎')).toBe(categoryColorClass('基礎'));
+    expect(categoryColorClass('コンテナ操作')).toBe(categoryColorClass('コンテナ操作'));
+  });
+
+  it('濃色塗り + 白文字のパレットから色を選ぶ', () => {
+    render(<CategoryBadge category="制御構文" />);
+    const badge = screen.getByText('制御構文');
+    expect(badge.className).toMatch(/bg-(rose|orange|amber|lime|emerald|teal|sky|blue|violet|fuchsia)-600/);
+    expect(badge.className).toContain('text-white');
+  });
+
+  it('colorClass の明示指定が優先される', () => {
+    render(<CategoryBadge category="基礎" colorClass="bg-violet-600 text-white" />);
+    expect(screen.getByText('基礎').className).toContain('bg-violet-600');
+  });
+});
+
+describe('assignCategoryColors', () => {
+  it('隣り合うカテゴリが同色にならない（ハッシュ衝突時は次の色へずらす）', () => {
+    // 本番 bash 演習で実際に名前ハッシュが衝突する並び。
+    const seq = ['基本操作', '入出力', 'ファイル操作', 'テキスト処理', 'プロセス'];
+    const colors = assignCategoryColors(seq);
+    for (let i = 1; i < seq.length; i++) {
+      expect(colors.get(seq[i])).not.toBe(colors.get(seq[i - 1]));
+    }
+  });
+
+  it('衝突しないカテゴリは名前ハッシュの色のまま（フィルタが変わっても安定）', () => {
+    const colors = assignCategoryColors(['基礎', '関数']);
+    expect(colors.get('基礎')).toBe(categoryColorClass('基礎'));
+    expect(colors.get('関数')).toBe(categoryColorClass('関数'));
+  });
+
+  it('本番に実在する代表的なカテゴリ群で色が分散する（全部同色にならない）', () => {
+    const categories = ['基礎', '制御構文', '配列', '関数', 'コンテナ操作', '並行処理', '型', 'ブランチ'];
+    const colors = assignCategoryColors(categories);
+    expect(new Set(colors.values()).size).toBeGreaterThan(2);
+  });
+});

--- a/frontend/src/components/__tests__/LanguageBadge.test.tsx
+++ b/frontend/src/components/__tests__/LanguageBadge.test.tsx
@@ -6,18 +6,18 @@ describe('LanguageBadge', () => {
   it('docker は青系(sky)の色クラスになる', () => {
     render(<LanguageBadge language="docker" />);
     const badge = screen.getByText('docker');
-    expect(badge.className).toContain('bg-sky-500/15');
+    expect(badge.className).toContain('bg-sky-500/25');
     expect(badge.className).toContain('text-sky-700');
   });
 
   it('言語ごとに異なる色になる（go=cyan / php=indigo / git=orange / bash=slate / javascript=yellow / typescript=blue）', () => {
     const cases: Array<[string, string]> = [
-      ['go', 'bg-cyan-500/15'],
-      ['php', 'bg-indigo-500/15'],
-      ['git', 'bg-orange-500/15'],
-      ['bash', 'bg-slate-500/15'],
-      ['javascript', 'bg-yellow-500/15'],
-      ['typescript', 'bg-blue-500/15'],
+      ['go', 'bg-cyan-500/25'],
+      ['php', 'bg-indigo-500/25'],
+      ['git', 'bg-orange-500/25'],
+      ['bash', 'bg-slate-500/25'],
+      ['javascript', 'bg-yellow-500/25'],
+      ['typescript', 'bg-blue-500/25'],
     ];
     for (const [lang, cls] of cases) {
       const { unmount } = render(<LanguageBadge language={lang} />);
@@ -28,14 +28,14 @@ describe('LanguageBadge', () => {
 
   it('大文字小文字を無視して色を引く', () => {
     render(<LanguageBadge language="Docker" />);
-    expect(screen.getByText('Docker').className).toContain('bg-sky-500/15');
+    expect(screen.getByText('Docker').className).toContain('bg-sky-500/25');
   });
 
   it('未知の言語は無彩色（surface-3）にフォールバックする', () => {
     render(<LanguageBadge language="rust" />);
     const badge = screen.getByText('rust');
     expect(badge.className).toContain('bg-surface-3');
-    expect(badge.className).not.toContain('bg-sky-500/15');
+    expect(badge.className).not.toContain('bg-sky-500/25');
   });
 
   it('mono 指定で等幅フォントになる', () => {

--- a/frontend/src/constants/exerciseLanguages.ts
+++ b/frontend/src/constants/exerciseLanguages.ts
@@ -15,14 +15,15 @@ export interface ExerciseLanguageDef {
 
 // 各言語の一般的なイメージカラーに寄せる
 // （Docker=青 / Go=シアン / PHP=藍紫 / Git=橙 / Bash・Linux=スレート / JavaScript=黄 / TypeScript=青）。
+// 背景 /25 + 枠 /50 は「淡すぎて見えにくい」というユーザー要望によるコントラスト強化(FRESTYLE-112)。
 export const EXERCISE_LANGUAGES: ExerciseLanguageDef[] = [
-  { key: 'php', label: 'PHP', badgeClass: 'bg-indigo-500/15 text-indigo-700 border-indigo-500/30' },
-  { key: 'go', label: 'Go', badgeClass: 'bg-cyan-500/15 text-cyan-700 border-cyan-500/30' },
-  { key: 'javascript', label: 'JavaScript', badgeClass: 'bg-yellow-500/15 text-yellow-700 border-yellow-500/30' },
-  { key: 'typescript', label: 'TypeScript', badgeClass: 'bg-blue-500/15 text-blue-700 border-blue-500/30' },
-  { key: 'git', label: 'Git', badgeClass: 'bg-orange-500/15 text-orange-700 border-orange-500/30' },
-  { key: 'bash', label: 'Bash / Linux', badgeClass: 'bg-slate-500/15 text-slate-700 border-slate-500/30' },
-  { key: 'docker', label: 'Docker', badgeClass: 'bg-sky-500/15 text-sky-700 border-sky-500/30' },
+  { key: 'php', label: 'PHP', badgeClass: 'bg-indigo-500/25 text-indigo-700 border-indigo-500/50' },
+  { key: 'go', label: 'Go', badgeClass: 'bg-cyan-500/25 text-cyan-700 border-cyan-500/50' },
+  { key: 'javascript', label: 'JavaScript', badgeClass: 'bg-yellow-500/25 text-yellow-700 border-yellow-500/50' },
+  { key: 'typescript', label: 'TypeScript', badgeClass: 'bg-blue-500/25 text-blue-700 border-blue-500/50' },
+  { key: 'git', label: 'Git', badgeClass: 'bg-orange-500/25 text-orange-700 border-orange-500/50' },
+  { key: 'bash', label: 'Bash / Linux', badgeClass: 'bg-slate-500/25 text-slate-700 border-slate-500/50' },
+  { key: 'docker', label: 'Docker', badgeClass: 'bg-sky-500/25 text-sky-700 border-sky-500/50' },
 ];
 
 /** language 値（大文字小文字を無視）から定義を引く。未知は undefined。 */

--- a/frontend/src/pages/ExerciseListPage.tsx
+++ b/frontend/src/pages/ExerciseListPage.tsx
@@ -1,8 +1,11 @@
+import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { CheckCircleIcon, ClockIcon, CodeBracketIcon } from '@heroicons/react/24/outline';
 import { FilterChip } from '../components/ui';
 import { EXERCISE_LANGUAGES } from '../constants/exerciseLanguages';
 import LanguageBadge from '../components/LanguageBadge';
+import CategoryBadge from '../components/CategoryBadge';
+import { assignCategoryColors } from '../utils/categoryColor';
 import { useExerciseList } from '../hooks/useExerciseList';
 import { MasterExerciseWithStatus } from '../types';
 
@@ -24,6 +27,9 @@ export default function ExerciseListPage() {
     error,
     sentinelRef,
   } = useExerciseList();
+
+  // カテゴリ色は名前ハッシュ基本 + 隣接ブロックの同色だけ回避(FRESTYLE-112)。
+  const categoryColors = useMemo(() => assignCategoryColors(categories), [categories]);
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-5xl mx-auto space-y-6">
@@ -65,8 +71,9 @@ export default function ExerciseListPage() {
 
       {!loading && !error && categories.map((cat) => (
         <section key={cat} className="space-y-3">
-          <h2 className="text-sm font-semibold text-[var(--color-text-secondary)] tracking-wide">
-            {cat}
+          {/* カテゴリブロックを色で区別できるよう、見出しは色付きバッジで出す(FRESTYLE-112)。 */}
+          <h2 className="text-sm font-semibold tracking-wide">
+            <CategoryBadge category={cat} colorClass={categoryColors.get(cat)} />
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {exercises
@@ -122,9 +129,10 @@ function ExerciseCard({ ex }: { ex: MasterExerciseWithStatus }) {
 }
 
 function StatusBadge({ status }: { status: MasterExerciseWithStatus['status'] }) {
+  // 淡色だと白背景で薄く「見えにくい」ため、濃色塗り + 白文字ではっきり区別する(FRESTYLE-112)。
   if (status === 'solved') {
     return (
-      <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-green-500/15 text-green-400 border border-green-500/30 flex-shrink-0">
+      <span className="flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-600 text-white flex-shrink-0">
         <CheckCircleIcon className="w-3.5 h-3.5" />
         解いた
       </span>
@@ -132,7 +140,7 @@ function StatusBadge({ status }: { status: MasterExerciseWithStatus['status'] })
   }
   if (status === 'in_progress') {
     return (
-      <span className="flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-yellow-500/15 text-yellow-400 border border-yellow-500/30 flex-shrink-0">
+      <span className="flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-amber-600 text-white flex-shrink-0">
         <ClockIcon className="w-3.5 h-3.5" />
         取り組み中
       </span>

--- a/frontend/src/utils/categoryColor.ts
+++ b/frontend/src/utils/categoryColor.ts
@@ -1,0 +1,55 @@
+/**
+ * カテゴリ名 → 固定パレットの色クラス。カテゴリは DB の自由文字列で種類が多く
+ * （本番 36 種類）、手書きの対応表では保守できないため、名前の決定的ハッシュで
+ * パレットから選ぶ。同じカテゴリは原則同じ色になり、新カテゴリの追加でも
+ * コード変更は不要。
+ *
+ * 濃色塗り + 白文字にしているのは、淡色バッジだと白背景で薄く見えて区別しにくい
+ * というユーザー要望のため(FRESTYLE-112)。
+ */
+const PALETTE = [
+  'bg-rose-600 text-white',
+  'bg-orange-600 text-white',
+  'bg-amber-600 text-white',
+  'bg-lime-600 text-white',
+  'bg-emerald-600 text-white',
+  'bg-teal-600 text-white',
+  'bg-sky-600 text-white',
+  'bg-blue-600 text-white',
+  'bg-violet-600 text-white',
+  'bg-fuchsia-600 text-white',
+];
+
+function paletteIndex(category: string): number {
+  let hash = 0;
+  for (let i = 0; i < category.length; i++) {
+    hash = (hash * 31 + category.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash) % PALETTE.length;
+}
+
+/** カテゴリ名から決定的にパレットの色クラスを返す。 */
+export function categoryColorClass(category: string): string {
+  return PALETTE[paletteIndex(category)];
+}
+
+/**
+ * 表示順のカテゴリ列に色を割り当てる。基本はカテゴリ名のハッシュ色（ページや
+ * フィルタが変わっても同じカテゴリは同じ色）だが、ハッシュ衝突で**隣り合う
+ * ブロックが同色になるときだけ**次の色へずらす。本番データでは名前ハッシュ
+ * 単体だと隣接同色が複数箇所発生するため（例: bash の 入出力/ファイル操作）、
+ * 「ブロックを色で区別したい」という本来の目的を隣接保証で担保する。
+ */
+export function assignCategoryColors(categories: string[]): Map<string, string> {
+  const assigned = new Map<string, string>();
+  let prev = -1;
+  for (const category of categories) {
+    let idx = paletteIndex(category);
+    if (idx === prev) {
+      idx = (idx + 1) % PALETTE.length;
+    }
+    assigned.set(category, PALETTE[idx]);
+    prev = idx;
+  }
+  return assigned;
+}


### PR DESCRIPTION
## 概要

演習一覧（/code-editor）の視認性改善のユーザー要望 3 点に対応する:

1. カテゴリ（「基礎」「コンテナ操作」等のブロック見出し）に色をつけて区別しやすくする
2. 「解いた」「取り組み中」のステータスバッジが薄いので、はっきりした濃い色にする
3. 全体的にバッジ類が淡くて見えにくいのでコントラストを上げる

## 変更内容

- **CategoryBadge 新設**: カテゴリ見出しを濃色塗り + 白文字のバッジに。色はカテゴリ名の決定的ハッシュで固定 10 色パレットから選ぶ（カテゴリは DB の自由文字列で本番 36 種類あり、手書きの対応表は保守不能。新カテゴリ追加でもコード変更不要）
  - 名前ハッシュ単体だと本番データで隣接ブロックの同色が複数発生する（実データで検証）ため、`assignCategoryColors` が**直前ブロックと衝突したときだけ次の色へずらす**。それ以外は名前で安定
- **StatusBadge 濃色化**: 解いた = `bg-emerald-600` / 取り組み中 = `bg-amber-600`（塗り + 白文字）
- **LanguageBadge コントラスト強化**: 背景 `/15` → `/25`・枠 `/30` → `/50`（色相は FRESTYLE-109 のまま）
- docs/code-exercises.md に設計判断を追記（FRESTYLE-111 の 3 状態表示の節も同時に補完）

## テスト

- vitest: CategoryBadge（表示 / 決定性 / colorClass 優先）+ assignCategoryColors（本番で実際に衝突する並びでの隣接非同色 / 非衝突時の名前安定性 / 色の分散）+ LanguageBadge 更新クラス — 全 1283 件 green（カバレッジ 85%）
- `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` すべて成功
- ビルド済み CSS で本番実データ（全 7 言語のカテゴリ並び）を描画し、隣接同色ゼロを目視確認

## 関連チケット

- https://frestyle.atlassian.net/browse/FRESTYLE-112