### PR TITLE
fix: 実行プレビューの不一致表示を明確化 — 断定形の文言 + 最初に異なる行の提示 (FRESTYLE-113)

### DIFF
--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -20,6 +20,31 @@ function normalizeOutput(s: string): string {
     .replace(/[ \t\n]+$/, '');
 }
 
+interface DiffLine {
+  /** 1 始まりの行番号。 */
+  line: number;
+  /** 該当行。片方に行が存在しない（行数が違う）場合は undefined。 */
+  actual?: string;
+  expected?: string;
+}
+
+/**
+ * 正規化済みの出力と期待出力を行単位で比較し、最初に異なる行を返す（一致なら null）。
+ * 「どこが違うのか」を学習者が自力で見つけなくて済むようにするための情報(FRESTYLE-113)。
+ */
+function firstDiffLine(normalizedActual: string, normalizedExpected: string): DiffLine | null {
+  if (normalizedActual === normalizedExpected) return null;
+  const actualLines = normalizedActual.split('\n');
+  const expectedLines = normalizedExpected.split('\n');
+  const max = Math.max(actualLines.length, expectedLines.length);
+  for (let i = 0; i < max; i++) {
+    if (actualLines[i] !== expectedLines[i]) {
+      return { line: i + 1, actual: actualLines[i], expected: expectedLines[i] };
+    }
+  }
+  return null;
+}
+
 /**
  * 提出前 動作 確認 (= 単発 実行) の 結果 を テーブル 形式 で 表示。
  * stdout / stderr / 期待 出力 を 並列 で 見せる。
@@ -28,7 +53,8 @@ function normalizeOutput(s: string): string {
  * exit 0 なら 常に 緑 だと 「エラー なく 動いた ＝ 正解」 と 色 の 印象 で 誤解 され やすい ため
  * (FRESTYLE-111)。 正誤 の 確定 は 従来 どおり 提出 時 の サーバ 側 採点 (複数 テストケース):
  *   - exit 0 + 出力 一致   → 緑 + ✓ 「実行 成功・期待 する 出力 と 一致」
- *   - exit 0 + 出力 不一致 → 琥珀 + ⚠ 「実行 成功 (エラー なし)・期待 する 出力 とは まだ 一致 して いません」
+ *   - exit 0 + 出力 不一致 → 琥珀 + ⚠ 「実行 成功 (エラー なし)・期待 する 出力 と 不一致」
+ *                            + 最初 に 異なる 行 の 提示 (どこ が 違う か を 自力 で 探さ せ ない / FRESTYLE-113)
  *   - exit != 0            → 赤 + ✗ 「実行 エラー (exit N)」
  * 期待 出力 が 空 の 演習 は 比較 でき ない ので 従来 の 中立 表示 に フォールバック。
  * さらに exit 0 でも stdout が 空 の とき は 「まだ 出力 が ない」 ヒント を 出す。
@@ -45,9 +71,11 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
 
   const isSuccess = result.exitCode === 0;
   const hasNoOutput = isSuccess && !result.stdout;
+  const normalizedStdout = normalizeOutput(result.stdout);
   const normalizedExpected = normalizeOutput(expected);
   const comparable = normalizedExpected !== '';
-  const matches = comparable && normalizeOutput(result.stdout) === normalizedExpected;
+  const matches = comparable && normalizedStdout === normalizedExpected;
+  const diff = comparable && !matches ? firstDiffLine(normalizedStdout, normalizedExpected) : null;
 
   return (
     <div className="rounded-lg border border-surface-3 bg-surface-1 overflow-hidden">
@@ -74,10 +102,28 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
                   実行成功・期待する出力と一致
                 </span>
               ) : (
-                <span className="inline-flex items-center gap-1 font-semibold text-amber-500">
-                  <ExclamationTriangleIcon className="w-4 h-4" />
-                  実行成功（エラーなし）・期待する出力とはまだ一致していません
-                </span>
+                <>
+                  <span className="inline-flex items-center gap-1 font-semibold text-amber-500">
+                    <ExclamationTriangleIcon className="w-4 h-4" />
+                    実行成功（エラーなし）・期待する出力と不一致
+                  </span>
+                  {diff && (
+                    <p className="mt-1.5 text-amber-600">
+                      {diff.line} 行目が異なります — あなたの出力:{' '}
+                      {diff.actual !== undefined ? (
+                        <code className="font-mono">「{diff.actual}」</code>
+                      ) : (
+                        '(この行がありません)'
+                      )}{' '}
+                      / 期待:{' '}
+                      {diff.expected !== undefined ? (
+                        <code className="font-mono">「{diff.expected}」</code>
+                      ) : (
+                        '(この行がありません)'
+                      )}
+                    </p>
+                  )}
+                </>
               )}
             </td>
           </tr>

--- a/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
+++ b/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
@@ -37,7 +37,7 @@ describe('ExecutionResultTable', () => {
     expect(status).toHaveClass('text-green-400');
   });
 
-  it('exit 0 でも出力が期待と不一致なら緑にせず、琥珀色の「まだ一致していません」を表示する', () => {
+  it('exit 0 でも出力が期待と不一致なら緑にせず、琥珀色の断定形「期待する出力と不一致」を表示する', () => {
     render(
       <ExecutionResultTable
         result={result({ stdout: '{"id":2}', exitCode: 0 })}
@@ -45,10 +45,64 @@ describe('ExecutionResultTable', () => {
         submitError={null}
       />,
     );
-    const status = screen.getByText(/実行成功（エラーなし）・期待する出力とはまだ一致していません/);
+    const status = screen.getByText(/実行成功（エラーなし）・期待する出力と不一致/);
     expect(status).toBeInTheDocument();
     expect(status).toHaveClass('text-amber-500');
     expect(status).not.toHaveClass('text-green-400');
+  });
+
+  it('不一致のとき、最初に異なる行の行番号と両方の行を表示する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({
+          stdout: '✓ testIsEven\n✓ testFindUserMissing\n\nOK (2 tests, 0 assertions)\n',
+          exitCode: 0,
+        })}
+        expected={'✓ testIsEven\n✓ testFindUserMissing\n\nOK (2 tests, 3 assertions)'}
+        submitError={null}
+      />,
+    );
+    const hint = screen.getByText(/4 行目が異なります/);
+    expect(hint).toBeInTheDocument();
+    expect(hint.textContent).toContain('OK (2 tests, 0 assertions)');
+    expect(hint.textContent).toContain('OK (2 tests, 3 assertions)');
+  });
+
+  it('出力の行数が足りないときは「この行がありません」と表示する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: 'Hello, World!', exitCode: 0 })}
+        expected={'Hello, World!\nHello, FreStyle!'}
+        submitError={null}
+      />,
+    );
+    const hint = screen.getByText(/2 行目が異なります/);
+    expect(hint.textContent).toContain('この行がありません');
+    expect(hint.textContent).toContain('Hello, FreStyle!');
+  });
+
+  it('出力に余分な行があるときも行番号を特定して表示する', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: 'Hello, World!\nextra line', exitCode: 0 })}
+        expected={'Hello, World!'}
+        submitError={null}
+      />,
+    );
+    const hint = screen.getByText(/2 行目が異なります/);
+    expect(hint.textContent).toContain('extra line');
+    expect(hint.textContent).toContain('この行がありません');
+  });
+
+  it('一致しているときは差分ヒントを表示しない', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '{"id":1}', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.queryByText(/行目が異なります/)).not.toBeInTheDocument();
   });
 
   it('末尾改行や行末スペースの差だけなら一致として扱う（サーバ採点の正規化と同じ）', () => {


### PR DESCRIPTION
## 概要

FRESTYLE-111 の実行プレビュー判定について、不一致時の「期待する出力とはまだ一致していません」が実行時に判定した結果に見えづらく、どこが違うのかも分からない（ユーザー報告: php-29 で最終行の assertion 数だけが違うケース）。判定であることが伝わる表示に改善する。

## 変更内容

- 不一致時の文言を断定形「実行成功（エラーなし）・**期待する出力と不一致**」に変更
- **最初に異なる行**を具体的に表示: 「N 行目が異なります — あなたの出力:「…」/ 期待:「…」」
  - 行数が違う場合は無い側を「(この行がありません)」と表示
  - 比較はサーバ採点と同じ正規化後の行単位（FRESTYLE-111 と同一ロジック）
- 一致時の緑表示・期待出力が空の演習のフォールバックは変更なし

## テスト

- vitest: 断定形文言 / 途中行・最終行の差分特定 / 行数不足（両方向）/ 一致時はヒント非表示 — 計 14 ケース green
- `tsc --noEmit` / `eslint --max-warnings 0` / `vitest run --coverage`（85%・1287 件）/ `npm run build` すべて成功

## 関連チケット

- https://frestyle.atlassian.net/browse/FRESTYLE-113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 実行結果が期待出力と異なる場合、最初に異なる行番号と実際・期待それぞれの内容を表示するようになりました。
  * 不足している行は「この行がありません」と表示され、差分を確認しやすくなりました。
  * 出力が一致している場合は、不要な差分ヒントを表示しません。
  * 不一致時のステータス表示を、警告状態であることが分かりやすい内容に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->