### PR TITLE
feat: 実行エラーの行マーカー表示 + 結果テーブルのエラーメッセージ行分離 (FRESTYLE-117)

### DIFF
--- a/docs/code-exercises.md
+++ b/docs/code-exercises.md
@@ -117,6 +117,21 @@ Node.js による `javascript` / `typescript` 実行を追加した（[`executeN
 
 正誤の**確定**は従来どおり提出時のサーバ側採点（複数テストケース）で、この比較は画面に表示中の期待出力 1 件とのプレビュー。
 
+## 実行エラーの行マーカーとエラーメッセージ行（FRESTYLE-117）
+
+エラーになったとき「どの行が原因か」を自力で stderr から読み解かなくて済むようにする。
+
+- [`utils/executionErrors.ts`](../frontend/src/utils/executionErrors.ts) が stderr から行番号を言語別に抽出する
+  （go: `main.go:N` / javascript・typescript: `main.js|ts:N` / php: `on line N` / bash: `script.sh: line N`。
+  実行系が内部パスを `./main.go` 等に整形しているため行番号はエディタとそのまま一致する）。
+  node のスタックトレース形式は例外行（`SyntaxError: ...`）をホバー用メッセージに添える
+- `CodeEditor` の `errorMarkers` prop が monaco の `setModelMarkers`（赤波線 + ホバーでメッセージ）と
+  `createDecorationsCollection`（ガターの赤丸 ✕ + 行の薄い赤ハイライト。スタイルは index.css）を適用。
+  ガター余白はマーカーがあるときだけ確保する。行番号は 1〜行数にクランプ
+- `ExecutionResultTable` は stderr を「エラーメッセージ」行に分離（Go のコンパイル失敗 =
+  stderr に `main.go:N` があるときはラベルを「コンパイル時エラーメッセージ」に）。
+  テーブルは「実行結果ステータス / エラーメッセージ / 提出コードのアウトプット / 期待する出力」の構成
+
 ## 演習一覧の視認性（FRESTYLE-112）
 
 いずれも「バッジ類が淡くて見えにくい」というユーザー要望への対応:

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -30,6 +30,11 @@ interface CodeEditorProps {
   maxHeight?: number;
   /** Ctrl+Enter / Cmd+Enter で呼ばれる実行ハンドラ（コード実行ショートカット）。 */
   onRun?: () => void;
+  /**
+   * 実行エラーの行マーカー(FRESTYLE-117)。該当行のガターに ✕ グリフ + 行の薄い赤
+   * ハイライト + ホバーでエラーメッセージを表示する。空なら何も出さない。
+   */
+  errorMarkers?: { line: number; message: string }[];
 }
 
 // Monaco の setValue / create({value}) は引数が string でない場合 "Illegal argument" を throw する。
@@ -50,9 +55,12 @@ export default function CodeEditor({
   minHeight = 240,
   maxHeight = 2000,
   onRun,
+  errorMarkers = [],
 }: CodeEditorProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+  // エラー行のガター装飾。マーカー更新時に前回分をまとめて差し替えるためコレクションで保持する。
+  const decorationsRef = useRef<monaco.editor.IEditorDecorationsCollection | null>(null);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
   // 最新の onRun を ref で保持し、エディタ再生成なしにショートカットから呼べるようにする。
@@ -142,6 +150,49 @@ export default function CodeEditor({
   useEffect(() => {
     editorRef.current?.updateOptions({ readOnly });
   }, [readOnly]);
+
+  // 実行エラーの行マーカー(FRESTYLE-117)。
+  // - setModelMarkers: 赤波線 + ホバーでエラーメッセージ
+  // - decorations: ガターの ✕ グリフ + 行の薄い赤ハイライト(スタイルは index.css)
+  // ガター余白(glyphMargin)はマーカーがあるときだけ確保し、普段の見た目を変えない。
+  useEffect(() => {
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (!editor || !model || model.isDisposed()) return;
+
+    const lineCount = model.getLineCount();
+    const valid = errorMarkers
+      .map((m) => ({ ...m, line: Math.min(Math.max(1, m.line), lineCount) }))
+      .filter((m, i, arr) => arr.findIndex((x) => x.line === m.line) === i);
+
+    editor.updateOptions({ glyphMargin: valid.length > 0 });
+    monaco.editor.setModelMarkers(
+      model,
+      'frestyle-exec',
+      valid.map((m) => ({
+        severity: monaco.MarkerSeverity.Error,
+        message: m.message,
+        startLineNumber: m.line,
+        startColumn: 1,
+        endLineNumber: m.line,
+        endColumn: model.getLineMaxColumn(m.line),
+      })),
+    );
+    decorationsRef.current?.clear();
+    if (valid.length > 0) {
+      decorationsRef.current = editor.createDecorationsCollection(
+        valid.map((m) => ({
+          range: new monaco.Range(m.line, 1, m.line, 1),
+          options: {
+            isWholeLine: true,
+            className: 'exec-error-line',
+            glyphMarginClassName: 'exec-error-glyph',
+            glyphMarginHoverMessage: { value: m.message },
+          },
+        })),
+      );
+    }
+  }, [errorMarkers]);
 
   useEffect(() => {
     const editor = editorRef.current;

--- a/frontend/src/components/__tests__/CodeEditor.test.tsx
+++ b/frontend/src/components/__tests__/CodeEditor.test.tsx
@@ -3,6 +3,14 @@ import { render } from '@testing-library/react';
 
 // monaco は jsdom で動かないため最小モックに差し替える。
 // 目的は「Ctrl/Cmd+Enter のアクションが onRun を呼ぶ」配線の検証。
+const modelMock = {
+  isDisposed: () => false,
+  getLineCount: vi.fn(() => 10),
+  getLineMaxColumn: vi.fn(() => 20),
+};
+
+const decorationsMock = { clear: vi.fn(), set: vi.fn() };
+
 const editorMock = {
   addAction: vi.fn(),
   addCommand: vi.fn(),
@@ -11,11 +19,14 @@ const editorMock = {
   getContentHeight: vi.fn(() => 200),
   getValue: vi.fn(() => ''),
   setValue: vi.fn(),
-  getModel: vi.fn(() => ({ isDisposed: () => false })),
+  getModel: vi.fn(() => modelMock),
   layout: vi.fn(),
   updateOptions: vi.fn(),
+  createDecorationsCollection: vi.fn(() => decorationsMock),
   dispose: vi.fn(),
 };
+
+const setModelMarkersMock = vi.fn();
 
 vi.mock('monaco-editor/esm/vs/editor/editor.worker?worker', () => ({
   default: class {},
@@ -25,6 +36,16 @@ vi.mock('monaco-editor', () => ({
   editor: {
     create: vi.fn(() => editorMock),
     setModelLanguage: vi.fn(),
+    setModelMarkers: (...args: unknown[]) => setModelMarkersMock(...args),
+  },
+  MarkerSeverity: { Error: 8 },
+  Range: class {
+    constructor(
+      public startLineNumber: number,
+      public startColumn: number,
+      public endLineNumber: number,
+      public endColumn: number,
+    ) {}
   },
   KeyMod: { CtrlCmd: 2048 },
   KeyCode: { Enter: 3 },
@@ -55,5 +76,50 @@ describe('CodeEditor の実行ショートカット', () => {
     render(<CodeEditor value="x" onChange={() => {}} />);
     const action = editorMock.addAction.mock.calls[0][0];
     expect(() => action.run()).not.toThrow();
+  });
+});
+
+describe('CodeEditor のエラー行マーカー (FRESTYLE-117)', () => {
+  beforeEach(() => {
+    setModelMarkersMock.mockClear();
+    editorMock.createDecorationsCollection.mockClear();
+    editorMock.updateOptions.mockClear();
+  });
+
+  it('errorMarkers を渡すと monaco マーカーとガター装飾が設定され、glyphMargin が有効になる', () => {
+    render(
+      <CodeEditor
+        value="x"
+        onChange={() => {}}
+        errorMarkers={[{ line: 3, message: 'undefined: foo' }]}
+      />,
+    );
+    expect(setModelMarkersMock).toHaveBeenCalled();
+    const markers = setModelMarkersMock.mock.calls.at(-1)![2];
+    expect(markers).toHaveLength(1);
+    expect(markers[0].startLineNumber).toBe(3);
+    expect(markers[0].message).toBe('undefined: foo');
+    expect(editorMock.createDecorationsCollection).toHaveBeenCalledTimes(1);
+    expect(editorMock.updateOptions).toHaveBeenCalledWith({ glyphMargin: true });
+  });
+
+  it('行番号は 1〜行数の範囲にクランプされる', () => {
+    render(
+      <CodeEditor
+        value="x"
+        onChange={() => {}}
+        errorMarkers={[{ line: 999, message: 'too far' }]}
+      />,
+    );
+    const markers = setModelMarkersMock.mock.calls.at(-1)![2];
+    expect(markers[0].startLineNumber).toBe(10); // modelMock.getLineCount() = 10
+  });
+
+  it('errorMarkers が空ならマーカーは空で glyphMargin も無効', () => {
+    render(<CodeEditor value="x" onChange={() => {}} errorMarkers={[]} />);
+    const markers = setModelMarkersMock.mock.calls.at(-1)![2];
+    expect(markers).toHaveLength(0);
+    expect(editorMock.createDecorationsCollection).not.toHaveBeenCalled();
+    expect(editorMock.updateOptions).toHaveBeenCalledWith({ glyphMargin: false });
   });
 });

--- a/frontend/src/components/exercise/ExecutionResultTable.tsx
+++ b/frontend/src/components/exercise/ExecutionResultTable.tsx
@@ -5,6 +5,8 @@ interface Props {
   result: CodeExecutionResult | null;
   expected: string;
   submitError: string | null;
+  /** 演習の言語(エラーメッセージ行のラベル判定に使用。省略時は汎用ラベル)。 */
+  language?: string;
 }
 
 /**
@@ -59,7 +61,7 @@ function firstDiffLine(normalizedActual: string, normalizedExpected: string): Di
  * 期待 出力 が 空 の 演習 は 比較 でき ない ので 従来 の 中立 表示 に フォールバック。
  * さらに exit 0 でも stdout が 空 の とき は 「まだ 出力 が ない」 ヒント を 出す。
  */
-export default function ExecutionResultTable({ result, expected, submitError }: Props) {
+export default function ExecutionResultTable({ result, expected, submitError, language }: Props) {
   if (submitError) {
     return (
       <div className="rounded-md border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-400">
@@ -71,6 +73,12 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
 
   const isSuccess = result.exitCode === 0;
   const hasNoOutput = isSuccess && !result.stdout;
+  // Go の実行失敗で stderr に main.go:N が出ているのはコンパイル段階のエラー
+  // (コンパイルが通れば stdout が出得る)。ラベルを具体的にして原因の区別を助ける。
+  const errorLabel =
+    language === 'go' && !isSuccess && /main\.go:\d+/.test(result.stderr)
+      ? 'コンパイル時エラーメッセージ'
+      : 'エラーメッセージ';
   const normalizedStdout = normalizeOutput(result.stdout);
   const normalizedExpected = normalizeOutput(expected);
   const comparable = normalizedExpected !== '';
@@ -127,6 +135,20 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
               )}
             </td>
           </tr>
+          {/* stderr は stdout と混ぜず専用の行に分ける(FRESTYLE-117)。
+              エラーの本文を探す場所が一定になり、エディタの行マーカーと突き合わせやすい。 */}
+          {result.stderr && (
+            <tr className="border-b border-surface-3">
+              <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">
+                {errorLabel}
+              </th>
+              <td className="px-4 py-2">
+                <pre className="whitespace-pre-wrap break-words font-mono text-red-500 bg-red-500/5 border border-red-500/20 rounded-md p-3">
+                  {result.stderr}
+                </pre>
+              </td>
+            </tr>
+          )}
           <tr className="border-b border-surface-3">
             <th className="text-left px-4 py-2 font-medium text-[var(--color-text-muted)] bg-surface-2 align-top">
               提出コードのアウトプット
@@ -135,11 +157,6 @@ export default function ExecutionResultTable({ result, expected, submitError }: 
               <pre className="whitespace-pre-wrap break-words font-mono text-[var(--color-text-primary)]">
                 {result.stdout || '(なし)'}
               </pre>
-              {result.stderr && (
-                <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-red-400">
-                  {result.stderr}
-                </pre>
-              )}
               {hasNoOutput && (
                 <p className="mt-2 text-amber-500">
                   まだ出力がありません。<code>echo</code> や <code>print</code> などで結果を出力すると、ここに表示されます。

--- a/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
+++ b/frontend/src/components/exercise/__tests__/ExecutionResultTable.test.tsx
@@ -140,6 +140,56 @@ describe('ExecutionResultTable', () => {
     expect(screen.getByText('Parse error')).toBeInTheDocument();
   });
 
+  it('stderr は専用の「エラーメッセージ」行に表示され、アウトプット行は stdout のみになる', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: 'partial', stderr: 'boom', exitCode: 1 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.getByText('エラーメッセージ')).toBeInTheDocument();
+    const errorCell = screen.getByText('boom');
+    const outputCell = screen.getByText('partial');
+    expect(errorCell.closest('tr')).not.toBe(outputCell.closest('tr'));
+  });
+
+  it('go のコンパイル失敗（stderr に main.go:N）は「コンパイル時エラーメッセージ」ラベルになる', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stderr: './main.go:7:9: undefined: foo', exitCode: 1 })}
+        expected={expected}
+        submitError={null}
+        language="go"
+      />,
+    );
+    expect(screen.getByText('コンパイル時エラーメッセージ')).toBeInTheDocument();
+  });
+
+  it('go 以外の言語のエラーは汎用の「エラーメッセージ」ラベルのまま', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stderr: './main.js:3\nSyntaxError: bad', exitCode: 1 })}
+        expected={expected}
+        submitError={null}
+        language="javascript"
+      />,
+    );
+    expect(screen.getByText('エラーメッセージ')).toBeInTheDocument();
+    expect(screen.queryByText('コンパイル時エラーメッセージ')).not.toBeInTheDocument();
+  });
+
+  it('stderr が空ならエラーメッセージ行を出さない', () => {
+    render(
+      <ExecutionResultTable
+        result={result({ stdout: '{"id":1}', exitCode: 0 })}
+        expected={expected}
+        submitError={null}
+      />,
+    );
+    expect(screen.queryByText(/エラーメッセージ/)).not.toBeInTheDocument();
+  });
+
   it('エラーなしでも出力が空なら「まだ出力がありません」ヒントを出す（空っぽで成功＝正解と誤解させない）', () => {
     render(
       <ExecutionResultTable

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -226,3 +226,27 @@
     @apply w-full border border-surface-3 rounded-lg px-4 py-2.5 bg-surface-2 text-[var(--color-text-primary)] focus:border-brand-400 focus:ring-1 focus:ring-brand-400 focus:outline-none transition-colors duration-150 placeholder:text-[var(--color-text-faint)];
   }
 }
+
+/*
+ * 実行エラーの行マーカー(FRESTYLE-117)。CodeEditor(Monaco) の decoration から参照する。
+ * ガターに赤丸 + 白 ✕、該当行はダークテーマ上で薄い赤のハイライト。
+ */
+.exec-error-glyph::after {
+  content: '✕';
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-top: 2px;
+  margin-left: 2px;
+  border-radius: 9999px;
+  background: #dc2626;
+  color: #ffffff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+.exec-error-line {
+  background: rgba(220, 38, 38, 0.12);
+}

--- a/frontend/src/pages/ExerciseDetailPage.tsx
+++ b/frontend/src/pages/ExerciseDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { CheckCircleIcon, ChevronDownIcon, ChevronUpIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 import Loading from '../components/Loading';
@@ -14,6 +14,7 @@ import { useExerciseDetail } from '../hooks/useExerciseDetail';
 import LanguageBadge from '../components/LanguageBadge';
 import { lazyWithReload } from '../utils/lazyWithReload';
 import { monacoLanguageOf } from '../utils/exerciseFormat';
+import { parseErrorLines } from '../utils/executionErrors';
 
 const CodeEditor = lazyWithReload(() => import('../components/CodeEditor'), 'CodeEditor');
 
@@ -53,6 +54,15 @@ export default function ExerciseDetailPage() {
   } = useExerciseDetail(slug);
 
   const [showHint, setShowHint] = useState(false);
+
+  // 実行エラー時は stderr から行番号を抽出し、エディタのガターに ✕ マーカーを出す(FRESTYLE-117)。
+  const errorMarkers = useMemo(
+    () =>
+      executionResult && executionResult.exitCode !== 0 && detail
+        ? parseErrorLines(executionResult.stderr, detail.exercise.language)
+        : [],
+    [executionResult, detail],
+  );
 
   if (loading) {
     return <Loading message="読み込み中..." className="min-h-[50vh]" />;
@@ -194,6 +204,7 @@ export default function ExerciseDetailPage() {
               language={monacoLanguageOf(ex.language)}
               minHeight={260}
               onRun={runCode}
+              errorMarkers={errorMarkers}
             />
           </Suspense>
         </div>
@@ -220,6 +231,7 @@ export default function ExerciseDetailPage() {
           // 提出時のバックエンド側 fallback と齟齬が出る。
           expected={detail.examples[0]?.expectedOutput ?? ex.expectedOutput ?? ''}
           submitError={submitError}
+          language={ex.language}
         />
       )}
 

--- a/frontend/src/utils/__tests__/executionErrors.test.ts
+++ b/frontend/src/utils/__tests__/executionErrors.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { parseErrorLines } from '../executionErrors';
+
+describe('parseErrorLines', () => {
+  it('go のコンパイルエラーから行番号を抽出する', () => {
+    const stderr = `# command-line-arguments
+./main.go:7:9: undefined: undefinedFn
+./main.go:10:2: missing return`;
+    const markers = parseErrorLines(stderr, 'go');
+    expect(markers.map((m) => m.line)).toEqual([7, 10]);
+    expect(markers[0].message).toContain('undefined: undefinedFn');
+  });
+
+  it('go の同一行の重複は最初のメッセージにまとめる', () => {
+    const stderr = `./main.go:5:1: first
+./main.go:5:9: second`;
+    const markers = parseErrorLines(stderr, 'go');
+    expect(markers).toHaveLength(1);
+    expect(markers[0].line).toBe(5);
+    expect(markers[0].message).toContain('first');
+  });
+
+  it('javascript の構文エラー(スタックトレース形式)から行番号と例外を抽出する', () => {
+    const stderr = `./main.js:3
+console.log("unclosed
+            ^^^^^^^^^
+
+SyntaxError: Invalid or unexpected token
+    at wrapSafe (node:internal/modules/cjs/loader:1385:18)`;
+    const markers = parseErrorLines(stderr, 'javascript');
+    expect(markers.map((m) => m.line)).toEqual([3]);
+    expect(markers[0].message).toContain('SyntaxError: Invalid or unexpected token');
+  });
+
+  it('typescript の実行エラーから行番号を抽出する', () => {
+    const stderr = `./main.ts:5
+throw new Error("boom");
+^
+
+Error: boom
+    at Object.<anonymous> (./main.ts:5:7)`;
+    const markers = parseErrorLines(stderr, 'typescript');
+    expect(markers.map((m) => m.line)).toEqual([5]);
+    expect(markers[0].message).toContain('Error: boom');
+  });
+
+  it('php の parse error から行番号を抽出する', () => {
+    const stderr =
+      'PHP Parse error:  syntax error, unexpected end of file in /tmp/code_abc.php on line 4';
+    const markers = parseErrorLines(stderr, 'php');
+    expect(markers.map((m) => m.line)).toEqual([4]);
+    expect(markers[0].message).toContain('syntax error');
+  });
+
+  it('bash のエラーから行番号を抽出する', () => {
+    const stderr = '/tmp/bash-exec-1/script.sh: line 3: foo: command not found';
+    const markers = parseErrorLines(stderr, 'bash');
+    expect(markers.map((m) => m.line)).toEqual([3]);
+    expect(markers[0].message).toContain('command not found');
+  });
+
+  it('行番号を含まない stderr や未対応言語は空配列', () => {
+    expect(parseErrorLines('some generic failure', 'go')).toEqual([]);
+    expect(parseErrorLines('./main.go:7:9: x', 'docker')).toEqual([]);
+    expect(parseErrorLines('', 'go')).toEqual([]);
+  });
+
+  it('行番号は昇順に整列される', () => {
+    const stderr = `./main.go:9:1: b
+./main.go:2:1: a`;
+    expect(parseErrorLines(stderr, 'go').map((m) => m.line)).toEqual([2, 9]);
+  });
+});

--- a/frontend/src/utils/executionErrors.ts
+++ b/frontend/src/utils/executionErrors.ts
@@ -1,0 +1,51 @@
+/**
+ * 実行エラー(stderr)から「何行目のエラーか」を言語別に抽出する(FRESTYLE-117)。
+ * 実行系(backend sandbox)は内部パスを ./main.go 等に整形して返すため、
+ * stderr の行番号はエディタの行番号とそのまま一致する。
+ */
+export interface ExecutionErrorMarker {
+  /** 1 始まりの行番号。 */
+  line: number;
+  /** その行に紐づくエラーメッセージ(ホバー表示用)。 */
+  message: string;
+}
+
+// 言語ごとの「行番号つきエラー行」のパターン。1 番目のキャプチャが行番号。
+const LINE_PATTERNS: Record<string, RegExp> = {
+  go: /main\.go:(\d+)(?::\d+)?:/,
+  javascript: /main\.js:(\d+)(?::\d+)?/,
+  typescript: /main\.ts:(\d+)(?::\d+)?/,
+  php: /on line (\d+)/,
+  bash: /script\.sh: (?:line )?(\d+):/,
+};
+
+/**
+ * stderr を行単位に走査し、行番号を含む行をマーカーに変換する。
+ * 同じ行番号が複数回出る場合は最初のメッセージを採用する。
+ */
+export function parseErrorLines(stderr: string, language: string): ExecutionErrorMarker[] {
+  const pattern = LINE_PATTERNS[language.toLowerCase()];
+  if (!pattern || !stderr) return [];
+
+  const byLine = new Map<number, string>();
+  for (const raw of stderr.split('\n')) {
+    const m = raw.match(pattern);
+    if (!m) continue;
+    const line = Number(m[1]);
+    if (!Number.isInteger(line) || line < 1) continue;
+    if (!byLine.has(line)) {
+      byLine.set(line, raw.trim());
+    }
+  }
+
+  // node のスタックトレースのように「行番号の行」と「例外メッセージの行」が分かれる形式では、
+  // 例外メッセージ(例: SyntaxError: ...)をホバーに添える方が原因が分かりやすい。
+  const exception = stderr.split('\n').find((l) => /^[A-Za-z]*(?:Error|Exception): /.test(l.trim()));
+  const result = [...byLine.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([line, message]) => ({
+      line,
+      message: exception && !message.includes(exception.trim()) ? `${message}\n${exception.trim()}` : message,
+    }));
+  return result;
+}

--- a/frontend/src/utils/executionErrors.ts
+++ b/frontend/src/utils/executionErrors.ts
@@ -27,8 +27,9 @@ export function parseErrorLines(stderr: string, language: string): ExecutionErro
   const pattern = LINE_PATTERNS[language.toLowerCase()];
   if (!pattern || !stderr) return [];
 
+  const lines = stderr.split('\n');
   const byLine = new Map<number, string>();
-  for (const raw of stderr.split('\n')) {
+  for (const raw of lines) {
     const m = raw.match(pattern);
     if (!m) continue;
     const line = Number(m[1]);
@@ -40,7 +41,7 @@ export function parseErrorLines(stderr: string, language: string): ExecutionErro
 
   // node のスタックトレースのように「行番号の行」と「例外メッセージの行」が分かれる形式では、
   // 例外メッセージ(例: SyntaxError: ...)をホバーに添える方が原因が分かりやすい。
-  const exception = stderr.split('\n').find((l) => /^[A-Za-z]*(?:Error|Exception): /.test(l.trim()));
+  const exception = lines.find((l) => /^[A-Za-z]*(?:Error|Exception): /.test(l.trim()));
   const result = [...byLine.entries()]
     .sort((a, b) => a[0] - b[0])
     .map(([line, message]) => ({


### PR DESCRIPTION
## 概要

演習のコード実行がエラーになったとき、どの行が原因か一目で分かるようにする（学習教材サイトの参考スクリーンショット提示によるユーザー要望）。

1. **エディタの行余白（ガター）にエラー行マーカー**: 該当行に赤丸 ✕ + 行の薄い赤ハイライト + ホバーでエラー内容（赤波線も表示）
2. **実行結果テーブルを 4 行構成に**: 実行結果ステータス / **エラーメッセージ（Go のコンパイル失敗時は「コンパイル時エラーメッセージ」）** / 提出コードのアウトプット / 期待する出力

## 変更内容

- `utils/executionErrors.ts` 新設: stderr から行番号を言語別に抽出（go: `main.go:N` / js・ts: `main.js|ts:N` / php: `on line N` / bash: `script.sh: line N`）。実行系（FRESTYLE-110）が内部パスを `./main.go` 等に整形するため行番号はエディタと一致。node のスタックトレース形式は例外行（SyntaxError 等）をホバー用に添える
- `CodeEditor` に `errorMarkers` prop: monaco `setModelMarkers` + `createDecorationsCollection`。マーカーが無いときはガター余白を確保しない（普段の見た目不変）。行番号は 1〜行数にクランプ
- `ExecutionResultTable`: stderr を stdout と混ぜず専用行に分離
- `ExerciseDetailPage`: 実行結果（exit != 0）から markers を導出して配線
- docs/code-exercises.md に設計を追記

## テスト

- vitest: executionErrors 8 ケース（go 複数行・重複行の集約・js/ts スタックトレース・php・bash・非対応言語・昇順整列）+ CodeEditor マーカー 3 ケース（設定・クランプ・空で無効化）+ ExecutionResultTable 4 ケース（行分離・ラベル判定・非表示条件）
- 全 suite 1307 件 green（カバレッジ 85.8%）/ `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` 成功

## 関連チケット

- https://frestyle.atlassian.net/browse/FRESTYLE-117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline error indicators in the code editor, including red underlines, hover messages, gutter icons, and highlighted error lines.
  * Added language-aware extraction of error locations from execution output.
  * Separated error messages from standard output in execution results.
  * Added dedicated labeling for Go compilation errors.
* **Documentation**
  * Documented error markers, error message display, and execution result layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->