### PR TITLE
feat: コースカテゴリに design（デザインパターン・桃色）を追加 (FRESTYLE-127)

### DIFF
--- a/backend/internal/domain/course.go
+++ b/backend/internal/domain/course.go
@@ -13,6 +13,7 @@ const (
 	CourseCategoryInfra        = "infra"        // インフラ・クラウド
 	CourseCategorySecurity     = "security"     // セキュリティ
 	CourseCategoryProduct      = "product"      // プロダクト・仕様
+	CourseCategoryDesign       = "design"       // 設計・デザインパターン
 )
 
 // ValidCourseCategories は選択可能なカテゴリの一覧（未分類 = 空文字は含まない）。
@@ -24,6 +25,7 @@ var ValidCourseCategories = []string{
 	CourseCategoryInfra,
 	CourseCategorySecurity,
 	CourseCategoryProduct,
+	CourseCategoryDesign,
 }
 
 // IsValidCourseCategory は c が未分類("")または定義済みカテゴリかを返す。

--- a/docs/course-categories.md
+++ b/docs/course-categories.md
@@ -11,7 +11,7 @@
   frontend の [`constants/courseCategories.ts`](../frontend/src/constants/courseCategories.ts) が
   同じ key に対して表示名（日本語）と色（Tailwind クラス）を持つ
 
-## カテゴリ一覧（7 分類）
+## カテゴリ一覧（8 分類）
 
 | key | 表示名 | 色 |
 |---|---|---|
@@ -22,6 +22,7 @@
 | `infra` | インフラ・クラウド | 橙 (orange) |
 | `security` | セキュリティ | 赤 (rose) |
 | `product` | プロダクト・仕様 | 水色 (cyan) |
+| `design` | デザインパターン | 桃 (pink)。コース「デザインパターン入門 (PHP)」向けに FRESTYLE-127 で追加 |
 
 未分類（`''`）は無色 = 従来表示のまま。
 

--- a/frontend/src/constants/courseCategories.ts
+++ b/frontend/src/constants/courseCategories.ts
@@ -60,6 +60,12 @@ export const COURSE_CATEGORIES: CourseCategoryDef[] = [
     badgeClass: 'bg-cyan-500/15 text-cyan-700 border border-cyan-500/30',
     barClass: 'border-l-cyan-500',
   },
+  {
+    key: 'design',
+    label: 'デザインパターン',
+    badgeClass: 'bg-pink-500/15 text-pink-700 border border-pink-500/30',
+    barClass: 'border-l-pink-500',
+  },
 ];
 
 /** key からカテゴリ定義を引く。未分類('')や未知の値は undefined（無色表示）。 */


### PR DESCRIPTION
## 概要
新コース「デザインパターン入門 (PHP)」（教材リポで追加・本番 id 23）が使う新カテゴリ design への対応（FRESTYLE-127）。

## 変更内容
- backend domain.ValidCourseCategories に design を追加（バリデーション）
- frontend courseCategories.ts に design（label: デザインパターン、pink 系バッジ/色帯）を追加
- docs/course-categories.md の一覧を 8 分類に更新
- 教材リポ側の seed 許可リストにも追加済み

## テスト
- go build / go test（handler・domain）pass、tsc / eslint / vitest 1307 tests / build すべて成功
- 未知カテゴリは従来どおり無色フォールバックのため後方互換

## 関連チケット
FRESTYLE-127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コースカテゴリに「デザインパターン」を追加しました。
  * コース一覧で新しいカテゴリとして表示・識別できるようになりました。

* **ドキュメント**
  * コースカテゴリ一覧を8分類に更新しました。
  * 「デザインパターン入門 (PHP)」のカテゴリ情報を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->