### PR TITLE
feat: AIチャットのストリーミングを語単位フェードイン（Gemini風）にする (FRESTYLE-145)

### DIFF
--- a/docs/ai-chat-streaming.md
+++ b/docs/ai-chat-streaming.md
@@ -1,0 +1,87 @@
+# AI チャットのストリーミング表示と語単位フェードイン
+
+`/ask-ai`（[AskAiPage](../frontend/src/pages/AskAiPage.tsx)）のアシスタント応答を SSE で受けて描画する仕組みと、
+本文を Gemini 風に「新しく現れた語がふわっとフェードインする」表示にする実装（FRESTYLE-145）について。
+
+## ストリーミングの描画経路
+
+1. 受信: [useAiChatSse](../frontend/src/hooks/useAiChatSse.ts) が `fetch` + `ReadableStream` で SSE を読み、
+   `event: token` / `data: {"delta": "..."}` をパースして `onEvent` に渡す（標準 `EventSource` は POST 不可のため使わない）。
+2. 反映: [useAskAi](../frontend/src/hooks/useAskAi.ts) が送信時に `id = "streaming-{ts}"`・`content: ""` の
+   アシスタント placeholder を 1 つ積み、`token` ごとに `content` の末尾へ `delta` を**そのまま文字連結**する。
+   `done` で `id` を backend の確定 id に、`content` を全文に差し替える。
+3. 描画: [AskAiPage](../frontend/src/pages/AskAiPage.tsx) の `messages.map` が `key={message.id}` で
+   [MessageBubble](../frontend/src/components/MessageBubble.tsx) を並べる。本文は
+   [MarkdownView](../frontend/src/components/message/MarkdownView.tsx)（react-markdown）で描画され、
+   **token 追記のたびに `content` 文字列全体が再パースされる**。
+
+`content` が空の間は「考え中...」（favicon の `animate-thinking` パルス）を出し、最初の token で本文へ切り替わる。
+
+## 語単位フェードイン（FRESTYLE-145）
+
+### 何を真似たか（Gemini 調査結果）
+
+Gemini の本文ストリーミングは 2 層構造:
+
+- **バッファ＆リペース**: モデルは大小まちまちの大きい塊で返すため、UI 側で溜めて一定レートで放出する。
+- **語（word）単位のフェードイン**: 放出された各セグメントを `opacity: 0→1` を主役に、可読性のため控えめな
+  `blur(数px→0)` を併用（~200〜400ms・ease-out）。各セグメントは **mount 時に一度だけ**再生し、既表示テキストは
+  再アニメしない。日本語など空白で区切らない言語は `Intl.Segmenter`（`granularity: 'word'`）で語分節する。
+
+（※よく見つかる「1500ms・`background-position-x` のグラデーション横ワイプ」は Gemini の**トップ挨拶文の別アニメ**で、
+チャット本文のフェードとは別系統。）
+
+### 実装方式
+
+react-markdown の **rehype 段でテキストノードを語 `<span class="fade-seg">` に分割**し、CSS でフェードさせる
+（[rehypeFadeSegments](../frontend/src/components/message/rehypeFadeSegments.ts)）。
+
+- **ストリーミング中だけ**適用する（`MarkdownView` の `isStreaming` prop。判定は `String(id).startsWith('streaming-')`
+  ＝末尾 bookend favicon の出し分けと同じ signal）。完了後・履歴・テストでは**素の Markdown（span なし）**に戻すので、
+  DOM が軽く保たれ、既存テストの `getByText` 完全一致も維持される。
+- 語分割は `Intl.Segmenter('ja', {granularity:'word'})`（無い環境は空白区切りにフォールバック）。**空白のみの
+  セグメントは span で包まず素のテキストで残す**（折り返し・レイアウトを保つ）。
+- **`pre` / `code` 配下は分割しない**（`rehype-highlight` のハイライトとコピー UI を壊さない／コードを 1 文字ずつ
+  光らせない）。`rehypePlugins` は `[rehypeHighlight, rehypeFadeSegments]` の順（highlight 済みの code は skip される）。
+
+### 「既表示テキストを再アニメさせない」仕組み（最重要）
+
+再パースのたびに全 hast を作り直すが、**追記のみのストリーミングでは既出プレフィックスの語 span は位置（順序）が
+不変**なので、React が DOM ノードを再利用する（＝CSS アニメが再生し直されない）。新しく mount した末尾の語 span
+だけが 1 回フェードする。この「プレフィックスの span DOM が同一ノードとして再利用される」ことは
+[MarkdownView.test](../frontend/src/components/message/__tests__/MarkdownView.test.tsx) で **DOM ノードの同一性**を
+アサートして守っている（崩れると全文チラつきになるため）。
+
+char-offset で「既出語」を潰して `animation: none` にする方式は採らなかった。フェード途中の語が次 token で
+「既出」判定され opacity 1 へ瞬間スナップする（pop）副作用があるため、DOM 再利用に委ねる方が滑らか。
+
+なお、**末尾ブロックの種別が確定する瞬間**（段落→見出し/表、`**強調**` が閉じて `<strong>` になる等）だけは、
+その部分の subtree が unmount→mount され一度だけ再フェードする。影響は「今まさにストリーミング中の末尾」に限定され、
+確定済みの先行テキストは再フェードしないため、全文チラつきにはならない（許容する。char-offset skip の pop を避けた
+トレードオフ）。
+
+### CSS とアクセシビリティ
+
+[index.css](../frontend/src/index.css) に `@keyframes fade-seg-in` と `.fade-seg` を定義（`thinking-pulse` と同じ流儀）。
+
+- 主役は **opacity**。`.fade-seg` は inline 要素なので `transform`（translateY）は効かない／使わない。高さも変えないので
+  ストリーミング中の**自動スクロール追従**（`distanceFromBottom` 判定）を乱さない。
+- **blur は `prefers-reduced-motion: no-preference` の時だけ**上乗せ（`@keyframes` を media 内で再定義。
+  `4px→0` の 1 回きりで、毎フレーム連続 animate はしない）。GPU コストの高い blur を「動き OK」ユーザーに限定する。
+- **`prefers-reduced-motion: reduce`** では `animation-duration: 0.01ms`（実質即時。`animationend` を残すため 0 にしない）。
+
+## テスト
+
+- [rehypeFadeSegments.test](../frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts): 語分割・テキスト保持・
+  `pre`/`code` 非分割・空白の扱い。
+- [MarkdownView.test](../frontend/src/components/message/__tests__/MarkdownView.test.tsx): `isStreaming` の有無での分割/非分割、
+  コード非分割、**DOM ノード再利用（再フェード防止）**、見出し配下、GFM（リンク/表/太字）との共存。
+- [MessageBubble.test](../frontend/src/components/__tests__/MessageBubble.test.tsx): `id` が `streaming-` 始まりのとき
+  fade span・bookend 非表示／確定 id では素の描画・bookend 表示。
+
+## 今後の選択肢（未実装）
+
+実機で「高速モデルが 1 commit に大量語を返してもたつく」場合は、`useAskAi` の token 反映に軽い
+reveal バッファ（`requestAnimationFrame` で 1 フレーム 1 フラッシュ）を足して放出レートを分離する余地がある
+（Gemini のバッファ＆リペースに相当）。長文で jank が出る場合は、段落ブロック単位の `React.memo`（raw ソースキー）で
+末尾以外の再パースを止める最適化も可能。いずれも今回はスコープ外。

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -122,6 +122,9 @@ export default memo(function MessageBubble({
   // 最初の token が来た瞬間に上部のアバターアイコンは消し、本文と末尾の bookend マーカーで
   // 「処理中 → 応答中 → 完了」の状態遷移を視覚化する。
   const isThinking = type === 'text' && content.trim() === '';
+  // ストリーミング中(placeholder)判定。 useAskAi が done まで id を `streaming-…` に保つので
+  // それを流用する(末尾 bookend の出し分けと同じ signal)。 数値 id(履歴/テスト)でも落ちないよう String 化。
+  const isStreaming = String(id).startsWith('streaming-');
   return (
     <div
       className="my-6 group flex gap-3"
@@ -159,7 +162,7 @@ export default memo(function MessageBubble({
               {type === 'bot' ? (
                 <p className="italic opacity-80">{content}</p>
               ) : (
-                <MarkdownView content={content} />
+                <MarkdownView content={content} isStreaming={isStreaming} />
               )}
             </div>
             <MessageActionRow
@@ -174,8 +177,8 @@ export default memo(function MessageBubble({
             {/* 完了マーカー: ストリーミング placeholder ではない（= done 確定済 / 履歴ロード済）
                 AI 応答の末尾に favicon を 1 つ置いて「ここで応答が締まった」ことを視覚化する。
                 Claude 等のメジャー AI チャットで採用されている bookend 表現に倣う。
-                id は型定義上 string だが、 旧テスト互換のため number が来ても動くよう String 化して判定。 */}
-            {!String(id).startsWith('streaming-') && (
+                streaming 中(placeholder)は出さず、 done で id が確定した瞬間に出す。 */}
+            {!isStreaming && (
               <div className="mt-8 flex" aria-hidden="true">
                 <img
                   src="/favicon.svg"

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -125,6 +125,25 @@ describe('MessageBubble', () => {
     expect(screen.getByRole('heading', { name: 'タイトル' })).toBeInTheDocument();
   });
 
+  it('ストリーミング中(id が streaming- 始まり)は本文が語単位の fade-seg span になる', () => {
+    const { container } = render(
+      <MessageBubble isSender={false} content="今日は良い天気です" id="streaming-123" />,
+    );
+    expect(container.querySelectorAll('.fade-seg').length).toBeGreaterThan(1);
+    // 末尾 bookend favicon は streaming 中は出さない。
+    expect(container.querySelector('img[src="/favicon.svg"]')).toBeNull();
+  });
+
+  it('確定済みメッセージ(通常 id)はフェード span を作らず bookend を出す', () => {
+    const { container } = render(
+      <MessageBubble isSender={false} content="今日は良い天気です" id="m17" />,
+    );
+    expect(container.querySelectorAll('.fade-seg')).toHaveLength(0);
+    expect(screen.getByText('今日は良い天気です')).toBeInTheDocument();
+    // done 済みは末尾 bookend favicon が出る。
+    expect(container.querySelector('img[src="/favicon.svg"]')).not.toBeNull();
+  });
+
   describe('コードブロックのコピー UI', () => {
     const writeText = vi.fn();
     beforeEach(() => {

--- a/frontend/src/components/message/MarkdownView.tsx
+++ b/frontend/src/components/message/MarkdownView.tsx
@@ -1,19 +1,36 @@
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import CodeBlock from './CodeBlock';
+import rehypeFadeSegments from './rehypeFadeSegments';
 
 /**
  * react-markdown のラッパ。コンポーネントマップで pre / code / a / table などを
  * プロジェクトのトーンに揃える。`prose` クラス（Tailwind Typography）が当たって
  * いる前提なので、要素ごとにクラス上書きは最小限。
+ *
+ * `isStreaming` が true の間だけ、本文を語(word)単位の `<span class="fade-seg">` に分割する
+ * rehype プラグインを差し込み、新しく現れた語を CSS でフェードインさせる(Gemini 風)。
+ * 完了後・履歴・非ストリーミング時はプラグインを外し、素の Markdown(span なし)に戻すことで、
+ * DOM を軽く保ち、既存テストの `getByText` 完全一致も維持する。
  */
-export default function MarkdownView({ content }: { content: string }) {
+export default function MarkdownView({
+  content,
+  isStreaming = false,
+}: {
+  content: string;
+  isStreaming?: boolean;
+}) {
+  const rehypePlugins = useMemo(
+    () => (isStreaming ? [rehypeHighlight, rehypeFadeSegments] : [rehypeHighlight]),
+    [isStreaming],
+  );
+
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeHighlight]}
+      rehypePlugins={rehypePlugins}
       components={{
         a: ({ href, children }) => (
           <a

--- a/frontend/src/components/message/__tests__/MarkdownView.test.tsx
+++ b/frontend/src/components/message/__tests__/MarkdownView.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MarkdownView from '../MarkdownView';
+
+// jsdom は CSS アニメを実行しないため「見た目のフェード」は検証できないが、
+// このフェード方式の唯一の肝は「トークン追記のたびに既表示の語 span を再マウントしない
+// （＝再フェードさせない）」こと。これは DOM ノードの同一性で直接検証できる。
+
+describe('MarkdownView', () => {
+  it('非ストリーミング時は素の Markdown（fade-seg span を作らない）', () => {
+    const { container } = render(<MarkdownView content="今日は良い天気です" />);
+    // 分割されないので getByText の完全一致が通る（既存テストの前提）。
+    expect(screen.getByText('今日は良い天気です')).toBeInTheDocument();
+    expect(container.querySelectorAll('.fade-seg')).toHaveLength(0);
+  });
+
+  it('ストリーミング時は本文を語単位の fade-seg span に分割する（テキストは保持）', () => {
+    const { container } = render(<MarkdownView content="今日は良い天気です" isStreaming />);
+    const spans = container.querySelectorAll('.fade-seg');
+    expect(spans.length).toBeGreaterThan(1);
+    // 分割してもレンダリング結果の全文は変わらない。
+    expect(container.textContent).toContain('今日は良い天気です');
+  });
+
+  it('ストリーミング時でもコードブロックは分割しない（ハイライト/コピーを壊さない）', () => {
+    const md = '本文です\n\n```js\nconst a = 1;\n```';
+    const { container } = render(<MarkdownView content={md} isStreaming />);
+    // 本文側には fade-seg span がある。
+    expect(container.querySelectorAll('.fade-seg').length).toBeGreaterThan(0);
+    // pre(コードブロック)配下には fade-seg span を作らない。
+    expect(container.querySelectorAll('pre .fade-seg')).toHaveLength(0);
+    // コードの中身は保持される。
+    expect(container.querySelector('pre')?.textContent).toContain('const a = 1;');
+  });
+
+  it('トークン追記で既表示の語 span は再マウントされず DOM ノードが再利用される（再フェードしない）', () => {
+    const { container, rerender } = render(<MarkdownView content="今日は" isStreaming />);
+    const firstBefore = container.querySelector('.fade-seg');
+    expect(firstBefore).not.toBeNull();
+    const textBefore = firstBefore?.textContent;
+
+    // 次トークンで本文が伸びる。
+    rerender(<MarkdownView content="今日は良い天気です" isStreaming />);
+    const firstAfter = container.querySelector('.fade-seg');
+
+    // 先頭の語 span は同一 DOM ノードのまま（React が再利用＝CSS アニメが再生し直されない）。
+    expect(firstAfter).toBe(firstBefore);
+    expect(firstAfter?.textContent).toBe(textBefore);
+    // 末尾には新しい語 span が増えている。
+    expect(container.querySelectorAll('.fade-seg').length).toBeGreaterThan(1);
+  });
+
+  it('見出しなどのブロック要素配下の語も fade-seg span になる', () => {
+    const { container } = render(<MarkdownView content="# タイトル見出し" isStreaming />);
+    const heading = container.querySelector('h1');
+    expect(heading).not.toBeNull();
+    expect(heading?.querySelectorAll('.fade-seg').length).toBeGreaterThan(0);
+    expect(heading?.textContent).toBe('タイトル見出し');
+  });
+
+  it('ストリーミング時に GFM(リンク/表/太字)と語分割が共存しても構造が壊れない', () => {
+    const md = [
+      'これは **強調** と [リンク](https://example.com) です',
+      '',
+      '| 名前 | 値 |',
+      '| --- | --- |',
+      '| foo | bar |',
+    ].join('\n');
+    const { container } = render(<MarkdownView content={md} isStreaming />);
+
+    // リンクは href を保持したまま、リンクテキストも fade-seg 分割される。
+    const link = container.querySelector('a[href="https://example.com"]');
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toContain('リンク');
+
+    // 太字(strong)は要素として残り、配下も分割される。
+    const strong = container.querySelector('strong');
+    expect(strong).not.toBeNull();
+    expect(strong?.textContent).toBe('強調');
+
+    // 表の構造(セル)が保たれ、セル内の語も fade-seg になる。
+    expect(container.querySelector('table')).not.toBeNull();
+    const cells = container.querySelectorAll('td');
+    expect(cells.length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('td .fade-seg, th .fade-seg').length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts
+++ b/frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import rehypeFadeSegments from '../rehypeFadeSegments';
+
+// hast を最小限に自前で組んでプラグインを直接動かす（react-markdown を介さない純粋な変換テスト）。
+interface Node {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: Node[];
+}
+
+function run(tree: Node): Node {
+  // プラグインは transformer を返す。tree を破壊的に書き換える。
+  rehypeFadeSegments()(tree as never);
+  return tree;
+}
+
+function collect(node: Node, pred: (n: Node) => boolean, acc: Node[] = []): Node[] {
+  if (pred(node)) acc.push(node);
+  node.children?.forEach((c) => collect(c, pred, acc));
+  return acc;
+}
+
+function textOf(node: Node): string {
+  if (node.type === 'text') return node.value ?? '';
+  return (node.children ?? []).map(textOf).join('');
+}
+
+const isFadeSpan = (n: Node) =>
+  n.type === 'element' &&
+  n.tagName === 'span' &&
+  Array.isArray(n.properties?.className) &&
+  (n.properties?.className as unknown[]).includes('fade-seg');
+
+describe('rehypeFadeSegments', () => {
+  it('本文のテキストを語単位の fade-seg span に分割し、テキストは失われない', () => {
+    const tree: Node = {
+      type: 'root',
+      children: [
+        { type: 'element', tagName: 'p', properties: {}, children: [{ type: 'text', value: '今日は良い天気です' }] },
+      ],
+    };
+    run(tree);
+    const spans = collect(tree, isFadeSpan);
+    // 語分割されるので複数の span になる。
+    expect(spans.length).toBeGreaterThan(1);
+    // 変換後も全文が保たれる。
+    expect(textOf(tree)).toBe('今日は良い天気です');
+  });
+
+  it('pre / code 配下のテキストは分割しない（コードを 1 文字ずつ光らせない）', () => {
+    const tree: Node = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'pre',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: {},
+              children: [{ type: 'text', value: 'const a = 1;' }],
+            },
+          ],
+        },
+      ],
+    };
+    run(tree);
+    // code 配下に fade-seg span は生成されない。
+    const spans = collect(tree, isFadeSpan);
+    expect(spans).toHaveLength(0);
+    // code の中身はそのまま。
+    expect(textOf(tree)).toBe('const a = 1;');
+  });
+
+  it('空白のみのセグメントは span で包まず素のテキストで残す（折り返しを保つ）', () => {
+    const tree: Node = {
+      type: 'root',
+      children: [
+        { type: 'element', tagName: 'p', properties: {}, children: [{ type: 'text', value: 'hello world' }] },
+      ],
+    };
+    run(tree);
+    const p = tree.children![0];
+    // 語(hello / world)は span、間の空白は text ノードで残る。
+    const spanTexts = collect(tree, isFadeSpan).map(textOf);
+    expect(spanTexts).toContain('hello');
+    expect(spanTexts).toContain('world');
+    const hasWhitespaceText = (p.children ?? []).some((c) => c.type === 'text' && /^\s+$/.test(c.value ?? ''));
+    expect(hasWhitespaceText).toBe(true);
+    expect(textOf(tree)).toBe('hello world');
+  });
+});

--- a/frontend/src/components/message/rehypeFadeSegments.ts
+++ b/frontend/src/components/message/rehypeFadeSegments.ts
@@ -1,0 +1,113 @@
+/**
+ * rehypeFadeSegments — ストリーミング中の Markdown 本文を「語(word)単位でフェードイン」させる rehype プラグイン。
+ *
+ * react-markdown が生成した hast のテキストノードを Intl.Segmenter で語に分割し、可視な語を
+ * `<span class="fade-seg">` で包む。実際のフェードは CSS 側(.fade-seg)で mount 時に一度だけ
+ * opacity(+ reduced-motion でない時のみ blur) を再生する。
+ *
+ * 既表示の語は再パースで位置が変わらなければ React が DOM ノードを再利用するため、アニメが
+ * 再生し直されない(＝新しく mount した span だけがフェードする)。char-offset で「既出」を潰す
+ * 方式を採らないのは、フェード途中の語を potenzialに opacity:1 へ瞬間スナップさせてしまう(pop)ため。
+ *
+ * - pre / code 配下は分割しない(コードのハイライト・コピーを壊さない / 1 文字ずつ光らせない)。
+ * - 空白のみのセグメントは span で包まず素のテキストで残す(折り返しとレイアウトを保つ)。
+ * - 非ストリーミング時(完了・履歴・テスト)はこのプラグインを付けず、素の Markdown に戻す。
+ */
+
+interface HastText {
+  type: 'text';
+  value: string;
+}
+
+interface HastElement {
+  type: 'element';
+  tagName: string;
+  properties?: Record<string, unknown>;
+  children: HastChild[];
+}
+
+type HastChild = HastText | HastElement | { type: string; [key: string]: unknown };
+
+interface HastRoot {
+  type: 'root';
+  children: HastChild[];
+}
+
+// Intl.Segmenter は ES2020 の lib 型に含まれないため、必要な部分だけローカルに型定義する。
+interface WordSegmenter {
+  segment(input: string): Iterable<{ segment: string }>;
+}
+interface WordSegmenterCtor {
+  new (
+    locale?: string,
+    options?: { granularity?: 'grapheme' | 'word' | 'sentence' },
+  ): WordSegmenter;
+}
+
+// pre / code 配下のテキストは分割対象外。
+const SKIP_TAGS = new Set(['pre', 'code']);
+
+// 語分割器。Intl.Segmenter があれば日本語などの非空白区切り言語も語単位に分けられる。
+// 無い実行環境向けに空白区切りのフォールバックを持つ。
+const SegmenterImpl = (Intl as unknown as { Segmenter?: WordSegmenterCtor }).Segmenter;
+const segmenter: WordSegmenter | null = SegmenterImpl
+  ? new SegmenterImpl('ja', { granularity: 'word' })
+  : null;
+
+function segments(text: string): string[] {
+  if (segmenter) {
+    return Array.from(segmenter.segment(text), (s) => s.segment);
+  }
+  // フォールバック: 空白を保持したまま語と空白に分ける。
+  return text.split(/(\s+)/).filter((s) => s.length > 0);
+}
+
+function isText(node: HastChild): node is HastText {
+  return node.type === 'text';
+}
+
+function isElement(node: HastChild): node is HastElement {
+  return node.type === 'element';
+}
+
+function wrapText(value: string): HastChild[] {
+  const out: HastChild[] = [];
+  for (const seg of segments(value)) {
+    if (!/\S/.test(seg)) {
+      // 空白のみのセグメントは折り返しのためそのまま残す。
+      out.push({ type: 'text', value: seg });
+    } else {
+      out.push({
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['fade-seg'] },
+        children: [{ type: 'text', value: seg }],
+      });
+    }
+  }
+  return out;
+}
+
+function transform(node: HastElement | HastRoot): void {
+  const next: HastChild[] = [];
+  for (const child of node.children) {
+    if (isText(child)) {
+      next.push(...wrapText(child.value));
+    } else if (isElement(child)) {
+      if (!SKIP_TAGS.has(child.tagName)) {
+        transform(child);
+      }
+      next.push(child);
+    } else {
+      next.push(child);
+    }
+  }
+  node.children = next;
+}
+
+/** ストリーミング中の本文をフェードイン用の語 span に分割する rehype プラグイン。 */
+export default function rehypeFadeSegments() {
+  return (tree: HastRoot): void => {
+    transform(tree);
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -168,6 +168,49 @@
   transform-origin: center;
 }
 
+/*
+ * AI チャットのストリーミング表示: 新しく現れた語(word)を 1 回だけフェードイン(Gemini 風, FRESTYLE-145)。
+ * rehypeFadeSegments が本文の語を <span class="fade-seg"> に包み、mount 時にこのアニメが 1 回再生される。
+ * 既表示の語は React が DOM を再利用するため再生し直されない。
+ *
+ * - 主役は opacity。inline 要素なので transform(translateY) は効かない/使わない。 高さも変えないので
+ *   ストリーミング中の自動スクロール追従(distanceFromBottom 判定)を乱さない。
+ * - blur(ぼかし→くっきり)は「動きOK」のユーザーにだけ上乗せ(no-preference)。 blur は毎フレーム連続で
+ *   animate せず 4px→0 の 1 回きり。
+ * - prefers-reduced-motion: reduce では実質即時表示にする(animationend は残すため 0 でなく 0.01ms)。
+ */
+@keyframes fade-seg-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-seg {
+  animation: fade-seg-in 240ms ease-out both;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes fade-seg-in {
+    from {
+      opacity: 0;
+      filter: blur(4px);
+    }
+    to {
+      opacity: 1;
+      filter: blur(0);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-seg {
+    animation-duration: 0.01ms;
+  }
+}
+
 @layer base {
   /*
    * 外側スクロールバー (Chrome ブラウザ標準) と内側スクロールバー (AppShell の <main>)


### PR DESCRIPTION
## 概要

AI チャットのアシスタント応答が SSE の token を `content` にそのまま追記する「即時パラパラ表示」だったのを、Gemini / ChatGPT のように**新しく現れた語がふわっとフェードインする**表示に変更した。

### Gemini のアニメ調査（結論）

Web の一次情報・OSS 分解で確認した Gemini 本文表示は 2 層:
1. **バッファ＆リペース**（大きい塊で来る応答を溜めて一定レートで放出）
2. **語（word）単位のフェードイン** — `opacity 0→1` を主役に、可読性のため控えめな `blur(数px→0)` を併用、~200〜400ms・ease-out。各セグメントは mount 時 1 回だけ再生し既表示は再アニメしない。CJK は `Intl.Segmenter(word)` で語分節。
（※「1500ms の `background-position-x` 横ワイプ」は Gemini トップ挨拶文の別アニメで本文フェードとは別系統。）

## 変更内容

- **`rehypeFadeSegments.ts`（新規）**: react-markdown の rehype 段で本文テキストを `Intl.Segmenter('ja', word)` で語分割し `<span class="fade-seg">` に包む。`pre`/`code` 配下は分割しない。空白のみのセグメントは素のテキストで残す。
- **`MarkdownView.tsx`**: `isStreaming` の間だけ `[rehypeHighlight, rehypeFadeSegments]` を適用。完了/履歴/テストでは素の markdown（span なし）に戻し DOM を軽く保つ＋既存 `getByText` 完全一致を維持。
- **再アニメ防止は char-offset skip でなく React の DOM ノード再利用に委ねる**。追記のみのストリーミングでは既出プレフィックスの語 span は位置不変なので React が再利用し、新しく mount した末尾の語だけが 1 回フェードする。skip 方式はフェード途中の語を opacity 1 へ pop させる副作用があるため不採用。
- **`index.css`**: `@keyframes fade-seg-in` + `.fade-seg`。主役は opacity。blur は `prefers-reduced-motion: no-preference` のときだけ上乗せ、`reduce` は実質即時（0.01ms）。inline 要素のため translateY は使わず、高さを変えないので自動スクロール追従を乱さない。
- **`MessageBubble.tsx`**: streaming 判定（`String(id).startsWith('streaming-')`）を bookend favicon と共通化し、`MarkdownView` に `isStreaming` を伝播。
- **docs**: `docs/ai-chat-streaming.md` を新規追加（描画経路・フェード設計・再アニメ防止の仕組み・a11y）。

## テスト

- `rehypeFadeSegments.test.ts`: 語分割・テキスト保持・`pre`/`code` 非分割・空白の扱い
- `MarkdownView.test.tsx`: isStreaming 有無での分割/非分割、コード非分割、**DOM ノード再利用（再フェード防止）を DOM 同一性でアサート**、見出し配下、GFM（リンク/表/太字）との共存
- `MessageBubble.test.tsx`: streaming id で fade span・bookend 非表示／確定 id では素の描画・bookend 表示
- `tsc --noEmit` / `eslint --max-warnings 0`: 成功
- `vitest run --coverage`（全体）: 162 ファイル / **1320 件緑**、閾値クリア（Stmts 85.99% / Branch 80.57% / Funcs 83.36% / Lines 87.66%）
- `npm run build`: 成功
- 多次元の敵対的レビュー（正当性/perf/a11y/markdown・14 エージェント）を実施し、10 指摘はすべて反証（material なバグなし。末尾ブロック確定時の局所再フェードは許容トレードオフ、O(n²) 再パースは本 PR 以前からの既存挙動）

## 関連チケット

FRESTYLE-145

## 参考（調査ソース）

LibreChat discussion #3218（buffer & re-pace）/ Vercel AI SDK `smoothStream`（chunking: word）/ prompt-kit response-stream / Vercel Streamdown / MDN prefers-reduced-motion