### PR TITLE
feat: AIチャットのストリーミングを Gemini 実物仕様（句読点チャンク＋適応ペーシング）に作り直す (FRESTYLE-146)

### DIFF
--- a/docs/ai-chat-streaming.md
+++ b/docs/ai-chat-streaming.md
@@ -1,87 +1,90 @@
-# AI チャットのストリーミング表示と語単位フェードイン
+# AI チャットのストリーミング表示（Gemini 実物仕様のペーシング＋フェードイン）
 
-`/ask-ai`（[AskAiPage](../frontend/src/pages/AskAiPage.tsx)）のアシスタント応答を SSE で受けて描画する仕組みと、
-本文を Gemini 風に「新しく現れた語がふわっとフェードインする」表示にする実装（FRESTYLE-145）について。
+`/chat/ask-ai`（[AskAiPage](../frontend/src/pages/AskAiPage.tsx)）のアシスタント応答を SSE で受けて描画する仕組みと、
+本文を Gemini と同じリズム・アニメーションで表示する実装（FRESTYLE-145 → 146）について。
 
 ## ストリーミングの描画経路
 
 1. 受信: [useAiChatSse](../frontend/src/hooks/useAiChatSse.ts) が `fetch` + `ReadableStream` で SSE を読み、
    `event: token` / `data: {"delta": "..."}` をパースして `onEvent` に渡す（標準 `EventSource` は POST 不可のため使わない）。
-2. 反映: [useAskAi](../frontend/src/hooks/useAskAi.ts) が送信時に `id = "streaming-{ts}"`・`content: ""` の
-   アシスタント placeholder を 1 つ積み、`token` ごとに `content` の末尾へ `delta` を**そのまま文字連結**する。
-   `done` で `id` を backend の確定 id に、`content` を全文に差し替える。
-3. 描画: [AskAiPage](../frontend/src/pages/AskAiPage.tsx) の `messages.map` が `key={message.id}` で
-   [MessageBubble](../frontend/src/components/MessageBubble.tsx) を並べる。本文は
-   [MarkdownView](../frontend/src/components/message/MarkdownView.tsx)（react-markdown）で描画され、
-   **token 追記のたびに `content` 文字列全体が再パースされる**。
+2. 反映: [useAskAi](../frontend/src/hooks/useAskAi.ts) が送信時に `id = clientId = "streaming-{ts}"`・`content: ""` の
+   アシスタント placeholder を積み、`token` ごとに `content` へ `delta` を文字連結する。`done` で `id` を backend の
+   確定 id に、`content` を全文に差し替える（`clientId` は spread で保持される）。
+3. 描画: [AskAiPage](../frontend/src/pages/AskAiPage.tsx) の `messages.map` が **`key={message.clientId ?? message.id}`** で
+   [MessageBubble](../frontend/src/components/MessageBubble.tsx) を並べる。key を clientId で安定させるのは、
+   done の id 差し替えでバブルが remount して**ペーシングの残り放出が全文ジャンプになる**のを防ぐため（FRESTYLE-146）。
 
-`content` が空の間は「考え中...」（favicon の `animate-thinking` パルス）を出し、最初の token で本文へ切り替わる。
+## Gemini 実物の仕様（一次調査の結果）
 
-## 語単位フェードイン（FRESTYLE-145）
+FRESTYLE-146 で Gemini web 本体の配信バンドル（gemini.gstatic.com）原文と、headless ブラウザで実際に応答を
+ストリーミングさせた計測（`document.getAnimations()` サンプリング）から、実物のアルゴリズムを特定した:
 
-### 何を真似たか（Gemini 調査結果）
+- **放出単位**: 本文を句読点 regex `/[,:\.!\?、。，۔]+/`（sub-sentence 粒度 = 読点でも切る）で分割し、
+  `<span class="pending">`（display:none）として先行挿入。
+- **放出機構**: rAF ループが適応間隔 **fb = (チャンク到着間隔の逐次平均 EMA + 600) / (残チャンク数 + 1)**
+  （EMA サンプルは 1000ms キャップ・初期 3000ms）で 1 チャンクずつ `.pending`→`.animating` に付け替え。
+  遅延が fb×10 を超えたら floor(遅延/fb) 個を一括表示（catch-up）。応答完了（COMPLETE）で EMA×0.8 に加速。
+- **アニメ**: `@keyframes fade-in-text { 0%{opacity:0} to{opacity:1} }` — **opacity のみ（blur / translate 無し）**。
+  実測 400ms / ease-out / fill forwards / 1 回。
 
-Gemini の本文ストリーミングは 2 層構造:
+## FreStyle での再現実装
 
-- **バッファ＆リペース**: モデルは大小まちまちの大きい塊で返すため、UI 側で溜めて一定レートで放出する。
-- **語（word）単位のフェードイン**: 放出された各セグメントを `opacity: 0→1` を主役に、可読性のため控えめな
-  `blur(数px→0)` を併用（~200〜400ms・ease-out）。各セグメントは **mount 時に一度だけ**再生し、既表示テキストは
-  再アニメしない。日本語など空白で区切らない言語は `Intl.Segmenter`（`granularity: 'word'`）で語分節する。
+### ペーシング: [useSmoothReveal](../frontend/src/hooks/useSmoothReveal.ts)
 
-（※よく見つかる「1500ms・`background-position-x` のグラデーション横ワイプ」は Gemini の**トップ挨拶文の別アニメ**で、
-チャット本文のフェードとは別系統。）
+MessageBubble 内で `content`（真の受信全文）から「表示してよい prefix」を Gemini と同じ適応リズムで進める。
+messages state には手を入れず、**表示ポリシーだけを component 層で持つ**（done の id 差し替え・error 置換・
+streaming 中 fetchMessages skip の race guard をすべて無傷に保つため）。
 
-### 実装方式
+- 放出単位は [subSentenceSegments](../frontend/src/components/message/subSentenceSegments.ts) の句読点チャンク
+  （Gemini の regex ＋ **改行も境界に追加** — コードブロック等の句読点が無い行でも行単位で放出できるようにする独自拡張）。
+- 放出間隔・catch-up・完了時の加速は Gemini の式をそのまま実装（fb = (EMA+600)/(pending+1)、fb×10 超で一括、×0.8）。
+- **mount 時は全文即時表示**（履歴ロード・確定メッセージ・既存テストをこのルール 1 つで無変更に保つ）。
+- **未完チャンクの保留**: 句読点で終わっていない末尾は streaming 中は出さない（出すと次の delta で span テキストが
+  書き換わり、フェード無しで文字が増える）。120 文字を超えたら停滞防止のため放出。完了時は全部出し切る。
+- `content` が表示済み prefix の延長でないとき（既に一部表示済みで SSE error に全文置換された等）は**即スナップ**。
+- 完了（`active` true→false）後は残りをリズム付きで流し切り、`settled` になってから bookend favicon を出す。
 
-react-markdown の **rehype 段でテキストノードを語 `<span class="fade-seg">` に分割**し、CSS でフェードさせる
-（[rehypeFadeSegments](../frontend/src/components/message/rehypeFadeSegments.ts)）。
+**`done` 以外の終端（error / 連投 abort）の扱い**（[useAskAi](../frontend/src/hooks/useAskAi.ts)）: これらは placeholder の
+`id` を `streaming-` のままにすると `active` が永久に true に張り付き、句読点を含まないエラー文が未完チャンク保留で
+永久に非表示になる。そのため error ハンドラは `id` を `error-…` に、連投時の旧 placeholder は `aborted-…` に差し替えて
+**ストリーミング状態を閉じる**（`clientId` は保持されるので key は安定し remount しない）。id が非 streaming になると
+`active` が false になり、useSmoothReveal の drain 経路が受信済みぶん（未完チャンク含む）を流し切る。
 
-- **ストリーミング中だけ**適用する（`MarkdownView` の `isStreaming` prop。判定は `String(id).startsWith('streaming-')`
-  ＝末尾 bookend favicon の出し分けと同じ signal）。完了後・履歴・テストでは**素の Markdown（span なし）**に戻すので、
-  DOM が軽く保たれ、既存テストの `getByText` 完全一致も維持される。
-- 語分割は `Intl.Segmenter('ja', {granularity:'word'})`（無い環境は空白区切りにフォールバック）。**空白のみの
-  セグメントは span で包まず素のテキストで残す**（折り返し・レイアウトを保つ）。
-- **`pre` / `code` 配下は分割しない**（`rehype-highlight` のハイライトとコピー UI を壊さない／コードを 1 文字ずつ
-  光らせない）。`rehypePlugins` は `[rehypeHighlight, rehypeFadeSegments]` の順（highlight 済みの code は skip される）。
+### フェード: [rehypeFadeSegments](../frontend/src/components/message/rehypeFadeSegments.ts) + [index.css](../frontend/src/index.css)
 
-### 「既表示テキストを再アニメさせない」仕組み（最重要）
+- ストリーミング中だけ、react-markdown の rehype 段でテキストノードを**句読点チャンクの `<span class="fade-seg">`**
+  に分割（`pre`/`code` 配下は分割しない）。放出境界とチャンク境界が一致するので、span テキストの書き換えは起きない。
+- `.fade-seg { animation: fade-seg-in 400ms ease-out both }` — **Gemini 実測値そのまま（opacity のみ）**。
+  blur・translate は実物に存在しないため使わない（FRESTYLE-145 の blur は 146 で撤去）。
+- 既表示チャンクは React が DOM ノードを再利用するためアニメが再生し直されない。新しく mount した span だけが
+  1 回フェードする（[MarkdownView.test](../frontend/src/components/message/__tests__/MarkdownView.test.tsx) が
+  DOM ノード同一性でガード）。
+- `prefers-reduced-motion: reduce` は `animation-duration: 0.01ms`（実質即時。`animationend` を残すため 0 にしない）。
+- 完了後（settled）はプラグインを外し素の Markdown（span ゼロ）に戻す。[MarkdownView](../frontend/src/components/message/MarkdownView.tsx)
+  は memo 化してあり、再パースは「SSE token 毎」ではなく「放出毎」に抑えられる。
 
-再パースのたびに全 hast を作り直すが、**追記のみのストリーミングでは既出プレフィックスの語 span は位置（順序）が
-不変**なので、React が DOM ノードを再利用する（＝CSS アニメが再生し直されない）。新しく mount した末尾の語 span
-だけが 1 回フェードする。この「プレフィックスの span DOM が同一ノードとして再利用される」ことは
-[MarkdownView.test](../frontend/src/components/message/__tests__/MarkdownView.test.tsx) で **DOM ノードの同一性**を
-アサートして守っている（崩れると全文チラつきになるため）。
+### 自動スクロール
 
-char-offset で「既出語」を潰して `animation: none` にする方式は採らなかった。フェード途中の語が次 token で
-「既出」判定され opacity 1 へ瞬間スナップする（pop）副作用があるため、DOM 再利用に委ねる方が滑らか。
+ペーシングの放出は messages state と非同期に DOM の高さを伸ばすため、既存の `[messages]` 依存 effect に加えて
+**ResizeObserver**（jsdom には無いので存在ガード付き）でリストの高さ変化を拾い、`stickToBottomRef` が立っている
+ときだけ最下部へ追従する。ユーザーが上へスクロールしたら追従しない挙動（wheel/touchmove 検知）は従来のまま。
 
-なお、**末尾ブロックの種別が確定する瞬間**（段落→見出し/表、`**強調**` が閉じて `<strong>` になる等）だけは、
-その部分の subtree が unmount→mount され一度だけ再フェードする。影響は「今まさにストリーミング中の末尾」に限定され、
-確定済みの先行テキストは再フェードしないため、全文チラつきにはならない（許容する。char-offset skip の pop を避けた
-トレードオフ）。
+## 調整パラメータ（体感チューニングの入口）
 
-### CSS とアクセシビリティ
-
-[index.css](../frontend/src/index.css) に `@keyframes fade-seg-in` と `.fade-seg` を定義（`thinking-pulse` と同じ流儀）。
-
-- 主役は **opacity**。`.fade-seg` は inline 要素なので `transform`（translateY）は効かない／使わない。高さも変えないので
-  ストリーミング中の**自動スクロール追従**（`distanceFromBottom` 判定）を乱さない。
-- **blur は `prefers-reduced-motion: no-preference` の時だけ**上乗せ（`@keyframes` を media 内で再定義。
-  `4px→0` の 1 回きりで、毎フレーム連続 animate はしない）。GPU コストの高い blur を「動き OK」ユーザーに限定する。
-- **`prefers-reduced-motion: reduce`** では `animation-duration: 0.01ms`（実質即時。`animationend` を残すため 0 にしない）。
+| 場所 | 値 | 意味 |
+|---|---|---|
+| `useSmoothReveal.ts` `FB_BASE_MS` | 600 | fb 式の基底。大きいほどゆっくり |
+| `useSmoothReveal.ts` `EMA_INITIAL_MS` / `EMA_SAMPLE_CAP_MS` | 3000 / 1000 | 到着間隔平均の初期値・上限 |
+| `useSmoothReveal.ts` `COMPLETE_ACCEL` | 0.8 | 完了後の加速率 |
+| `useSmoothReveal.ts` `MAX_TAIL_HOLD_CHARS` | 120 | 未完チャンク保留の上限 |
+| `index.css` `.fade-seg` | 400ms ease-out | フェードの長さ（Gemini 実測値） |
 
 ## テスト
 
-- [rehypeFadeSegments.test](../frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts): 語分割・テキスト保持・
-  `pre`/`code` 非分割・空白の扱い。
-- [MarkdownView.test](../frontend/src/components/message/__tests__/MarkdownView.test.tsx): `isStreaming` の有無での分割/非分割、
-  コード非分割、**DOM ノード再利用（再フェード防止）**、見出し配下、GFM（リンク/表/太字）との共存。
-- [MessageBubble.test](../frontend/src/components/__tests__/MessageBubble.test.tsx): `id` が `streaming-` 始まりのとき
-  fade span・bookend 非表示／確定 id では素の描画・bookend 表示。
-
-## 今後の選択肢（未実装）
-
-実機で「高速モデルが 1 commit に大量語を返してもたつく」場合は、`useAskAi` の token 反映に軽い
-reveal バッファ（`requestAnimationFrame` で 1 フレーム 1 フラッシュ）を足して放出レートを分離する余地がある
-（Gemini のバッファ＆リペースに相当）。長文で jank が出る場合は、段落ブロック単位の `React.memo`（raw ソースキー）で
-末尾以外の再パースを止める最適化も可能。いずれも今回はスコープ外。
+- [useSmoothReveal.test](../frontend/src/hooks/__tests__/useSmoothReveal.test.ts): fake timers で mount 即時全文 /
+  初回チャンク即時 / タイマー放出 / 未完チャンク保留 / fast-drain / エラー時スナップ / catch-up / unmount cleanup。
+- [rehypeFadeSegments.test](../frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts):
+  句読点チャンク分割・全文保存・`pre`/`code` 非分割・空白の扱い。
+- [MessageBubble.test](../frontend/src/components/__tests__/MessageBubble.test.tsx): streaming id での span 付与・
+  ペーシングの時間経過検証・bookend の出し分け。
+- [useAskAi.test](../frontend/src/hooks/__tests__/useAskAi.test.tsx): done 後の clientId 保持（key 安定化の前提）。

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -4,6 +4,7 @@ import MessageAttachmentList, {
   MessageAttachmentView as _MessageAttachmentView,
 } from './message/MessageAttachmentList';
 import MarkdownView from './message/MarkdownView';
+import { useSmoothReveal } from '../hooks/useSmoothReveal';
 
 // `MessageAttachmentView` は MessageBubbleAi 経由で外部から import されている。
 // 互換性のため同名で re-export する。
@@ -58,6 +59,16 @@ export default memo(function MessageBubble({
   isDeleted = false,
 }: MessageBubbleProps) {
   const [showActions, setShowActions] = useState(false);
+
+  // ストリーミング中(placeholder)判定。 useAskAi が done まで id を `streaming-…` に保つので
+  // それを流用する。 数値 id(履歴/テスト)でも落ちないよう String 化。
+  const isStreaming = String(id).startsWith('streaming-');
+  // ストリーミング本文を Gemini 実物と同じリズム(句読点チャンク + 適応間隔)で放出する(FRESTYLE-146)。
+  // アシスタントのテキスト応答のみ有効。それ以外(自分の発話・画像・履歴)は全文即時表示。
+  const { text: shown, settled } = useSmoothReveal(
+    content,
+    isStreaming && !isSender && type === 'text' && !isDeleted,
+  );
 
   if (type === 'image') {
     return (
@@ -121,10 +132,9 @@ export default memo(function MessageBubble({
   // favicon をパルスさせながら "考え中..." ラベルを出す（Claude / ChatGPT 同様の UX）。
   // 最初の token が来た瞬間に上部のアバターアイコンは消し、本文と末尾の bookend マーカーで
   // 「処理中 → 応答中 → 完了」の状態遷移を視覚化する。
-  const isThinking = type === 'text' && content.trim() === '';
-  // ストリーミング中(placeholder)判定。 useAskAi が done まで id を `streaming-…` に保つので
-  // それを流用する(末尾 bookend の出し分けと同じ signal)。 数値 id(履歴/テスト)でも落ちないよう String 化。
-  const isStreaming = String(id).startsWith('streaming-');
+  // 「考え中...」はペーシング後の表示テキスト(shown)基準で判定する。 最初のチャンクが
+  // 放出されるまでインジケータを保ち、 空本文のバブルがちらつかないようにする。
+  const isThinking = type === 'text' && shown.trim() === '';
   return (
     <div
       className="my-6 group flex gap-3"
@@ -162,7 +172,9 @@ export default memo(function MessageBubble({
               {type === 'bot' ? (
                 <p className="italic opacity-80">{content}</p>
               ) : (
-                <MarkdownView content={content} isStreaming={isStreaming} />
+                // done 直後の drain 中(!settled)もフェードプラグインを維持し、 残りチャンクに
+                // フェードを効かせる。 出し切ったら素の Markdown(span なし)に戻る。
+                <MarkdownView content={shown} isStreaming={isStreaming || !settled} />
               )}
             </div>
             <MessageActionRow
@@ -177,8 +189,8 @@ export default memo(function MessageBubble({
             {/* 完了マーカー: ストリーミング placeholder ではない（= done 確定済 / 履歴ロード済）
                 AI 応答の末尾に favicon を 1 つ置いて「ここで応答が締まった」ことを視覚化する。
                 Claude 等のメジャー AI チャットで採用されている bookend 表現に倣う。
-                streaming 中(placeholder)は出さず、 done で id が確定した瞬間に出す。 */}
-            {!isStreaming && (
+                streaming 中(placeholder)は出さず、 done 後に残りを流し切って(settled)から出す。 */}
+            {!isStreaming && settled && (
               <div className="mt-8 flex" aria-hidden="true">
                 <img
                   src="/favicon.svg"

--- a/frontend/src/components/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/__tests__/MessageBubble.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import MessageBubble from '../MessageBubble';
 
 describe('MessageBubble', () => {
@@ -125,13 +125,42 @@ describe('MessageBubble', () => {
     expect(screen.getByRole('heading', { name: 'タイトル' })).toBeInTheDocument();
   });
 
-  it('ストリーミング中(id が streaming- 始まり)は本文が語単位の fade-seg span になる', () => {
+  it('ストリーミング中(id が streaming- 始まり)は本文が句読点チャンクの fade-seg span になる', () => {
     const { container } = render(
-      <MessageBubble isSender={false} content="今日は良い天気です" id="streaming-123" />,
+      <MessageBubble isSender={false} content="今日は晴れ。明日は雨。" id="streaming-123" />,
     );
+    // mount 時スナップショットは即時表示され、チャンク span が付く。
     expect(container.querySelectorAll('.fade-seg').length).toBeGreaterThan(1);
     // 末尾 bookend favicon は streaming 中は出さない。
     expect(container.querySelector('img[src="/favicon.svg"]')).toBeNull();
+  });
+
+  it('ストリーミング中の後続チャンクはペーシングされ、時間経過で現れる', () => {
+    vi.useFakeTimers();
+    try {
+      const { container, rerender } = render(
+        <MessageBubble isSender={false} content="こんにちは、" id="streaming-9" />,
+      );
+      // mount 時スナップショットは即時表示。
+      expect(container.textContent).toContain('こんにちは、');
+
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      rerender(
+        <MessageBubble isSender={false} content="こんにちは、今日は晴れ。" id="streaming-9" />,
+      );
+      // 放出タイマー前は後続チャンクはまだ見えない(Gemini 同様の溜め)。
+      expect(container.textContent).not.toContain('今日は晴れ。');
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+      // 適応間隔の tick でフェードイン用 span として現れる。
+      expect(container.textContent).toContain('今日は晴れ。');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('確定済みメッセージ(通常 id)はフェード span を作らず bookend を出す', () => {

--- a/frontend/src/components/message/MarkdownView.tsx
+++ b/frontend/src/components/message/MarkdownView.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, memo, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
@@ -10,12 +10,15 @@ import rehypeFadeSegments from './rehypeFadeSegments';
  * プロジェクトのトーンに揃える。`prose` クラス（Tailwind Typography）が当たって
  * いる前提なので、要素ごとにクラス上書きは最小限。
  *
- * `isStreaming` が true の間だけ、本文を語(word)単位の `<span class="fade-seg">` に分割する
- * rehype プラグインを差し込み、新しく現れた語を CSS でフェードインさせる(Gemini 風)。
+ * `isStreaming` が true の間だけ、本文を句読点チャンク単位の `<span class="fade-seg">` に分割する
+ * rehype プラグインを差し込み、新しく現れたチャンクを CSS でフェードインさせる(Gemini 実物仕様)。
  * 完了後・履歴・非ストリーミング時はプラグインを外し、素の Markdown(span なし)に戻すことで、
  * DOM を軽く保ち、既存テストの `getByText` 完全一致も維持する。
+ *
+ * memo 化: ストリーミング中の再パースを「SSE token 毎」ではなく「ペーシングの放出毎」に
+ * 抑えるため(props の content は useSmoothReveal の visible prefix が変わったときだけ変わる)。
  */
-export default function MarkdownView({
+export default memo(function MarkdownView({
   content,
   isStreaming = false,
 }: {
@@ -80,4 +83,4 @@ export default function MarkdownView({
       {content}
     </ReactMarkdown>
   );
-}
+});

--- a/frontend/src/components/message/__tests__/MarkdownView.test.tsx
+++ b/frontend/src/components/message/__tests__/MarkdownView.test.tsx
@@ -3,9 +3,8 @@ import { render, screen } from '@testing-library/react';
 import MarkdownView from '../MarkdownView';
 
 // jsdom は CSS アニメを実行しないため「見た目のフェード」は検証できないが、
-// このフェード方式の唯一の肝は「トークン追記のたびに既表示の語 span を再マウントしない
+// このフェード方式の唯一の肝は「表示が進んでも既表示チャンクの span を再マウントしない
 // （＝再フェードさせない）」こと。これは DOM ノードの同一性で直接検証できる。
-
 describe('MarkdownView', () => {
   it('非ストリーミング時は素の Markdown（fade-seg span を作らない）', () => {
     const { container } = render(<MarkdownView content="今日は良い天気です" />);
@@ -14,16 +13,16 @@ describe('MarkdownView', () => {
     expect(container.querySelectorAll('.fade-seg')).toHaveLength(0);
   });
 
-  it('ストリーミング時は本文を語単位の fade-seg span に分割する（テキストは保持）', () => {
-    const { container } = render(<MarkdownView content="今日は良い天気です" isStreaming />);
+  it('ストリーミング時は本文を句読点チャンクの fade-seg span に分割する（テキストは保持）', () => {
+    const { container } = render(<MarkdownView content="今日は晴れ。明日は雨。" isStreaming />);
     const spans = container.querySelectorAll('.fade-seg');
-    expect(spans.length).toBeGreaterThan(1);
+    expect(spans.length).toBe(2);
     // 分割してもレンダリング結果の全文は変わらない。
-    expect(container.textContent).toContain('今日は良い天気です');
+    expect(container.textContent).toContain('今日は晴れ。明日は雨。');
   });
 
   it('ストリーミング時でもコードブロックは分割しない（ハイライト/コピーを壊さない）', () => {
-    const md = '本文です\n\n```js\nconst a = 1;\n```';
+    const md = '本文です。\n\n```js\nconst a = 1;\n```';
     const { container } = render(<MarkdownView content={md} isStreaming />);
     // 本文側には fade-seg span がある。
     expect(container.querySelectorAll('.fade-seg').length).toBeGreaterThan(0);
@@ -33,24 +32,24 @@ describe('MarkdownView', () => {
     expect(container.querySelector('pre')?.textContent).toContain('const a = 1;');
   });
 
-  it('トークン追記で既表示の語 span は再マウントされず DOM ノードが再利用される（再フェードしない）', () => {
-    const { container, rerender } = render(<MarkdownView content="今日は" isStreaming />);
+  it('表示が進んでも既表示チャンクの span は再マウントされず DOM ノードが再利用される（再フェードしない）', () => {
+    const { container, rerender } = render(<MarkdownView content="今日は晴れ。" isStreaming />);
     const firstBefore = container.querySelector('.fade-seg');
     expect(firstBefore).not.toBeNull();
-    const textBefore = firstBefore?.textContent;
+    expect(firstBefore?.textContent).toBe('今日は晴れ。');
 
-    // 次トークンで本文が伸びる。
-    rerender(<MarkdownView content="今日は良い天気です" isStreaming />);
+    // 次のチャンクが放出されて本文が伸びる。
+    rerender(<MarkdownView content="今日は晴れ。明日は雨。" isStreaming />);
     const firstAfter = container.querySelector('.fade-seg');
 
-    // 先頭の語 span は同一 DOM ノードのまま（React が再利用＝CSS アニメが再生し直されない）。
+    // 先頭チャンクの span は同一 DOM ノードのまま（React が再利用＝CSS アニメが再生し直されない）。
     expect(firstAfter).toBe(firstBefore);
-    expect(firstAfter?.textContent).toBe(textBefore);
-    // 末尾には新しい語 span が増えている。
-    expect(container.querySelectorAll('.fade-seg').length).toBeGreaterThan(1);
+    expect(firstAfter?.textContent).toBe('今日は晴れ。');
+    // 末尾には新しいチャンク span が増えている。
+    expect(container.querySelectorAll('.fade-seg')).toHaveLength(2);
   });
 
-  it('見出しなどのブロック要素配下の語も fade-seg span になる', () => {
+  it('見出しなどのブロック要素配下のテキストも fade-seg span になる', () => {
     const { container } = render(<MarkdownView content="# タイトル見出し" isStreaming />);
     const heading = container.querySelector('h1');
     expect(heading).not.toBeNull();
@@ -58,7 +57,7 @@ describe('MarkdownView', () => {
     expect(heading?.textContent).toBe('タイトル見出し');
   });
 
-  it('ストリーミング時に GFM(リンク/表/太字)と語分割が共存しても構造が壊れない', () => {
+  it('ストリーミング時に GFM(リンク/表/太字)とチャンク分割が共存しても構造が壊れない', () => {
     const md = [
       'これは **強調** と [リンク](https://example.com) です',
       '',
@@ -78,7 +77,7 @@ describe('MarkdownView', () => {
     expect(strong).not.toBeNull();
     expect(strong?.textContent).toBe('強調');
 
-    // 表の構造(セル)が保たれ、セル内の語も fade-seg になる。
+    // 表の構造(セル)が保たれ、セル内のテキストも fade-seg になる。
     expect(container.querySelector('table')).not.toBeNull();
     const cells = container.querySelectorAll('td');
     expect(cells.length).toBeGreaterThan(0);

--- a/frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts
+++ b/frontend/src/components/message/__tests__/rehypeFadeSegments.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import rehypeFadeSegments from '../rehypeFadeSegments';
+import { splitSubSentences, endsAtBoundary } from '../subSentenceSegments';
 
 // hast を最小限に自前で組んでプラグインを直接動かす（react-markdown を介さない純粋な変換テスト）。
 interface Node {
@@ -33,23 +34,76 @@ const isFadeSpan = (n: Node) =>
   Array.isArray(n.properties?.className) &&
   (n.properties?.className as unknown[]).includes('fade-seg');
 
+describe('splitSubSentences', () => {
+  it('句読点(読点含む)で分割し、区切り文字は前のチャンク末尾に付く', () => {
+    expect(splitSubSentences('こんにちは、今日は晴れ。明日は雨。')).toEqual([
+      'こんにちは、',
+      '今日は晴れ。',
+      '明日は雨。',
+    ]);
+  });
+
+  it('句読点が無いテキストは 1 チャンクのまま', () => {
+    expect(splitSubSentences('今日は良い天気です')).toEqual(['今日は良い天気です']);
+  });
+
+  it('改行も境界になる(コードブロック等の行単位放出)', () => {
+    expect(splitSubSentences('line1\nline2')).toEqual(['line1\n', 'line2']);
+  });
+
+  it('全チャンクを連結すると元のテキストに戻る(全文保存)', () => {
+    const text = 'A, B: C. こんにちは、世界。改行\nもある！最後は未完';
+    expect(splitSubSentences(text).join('')).toBe(text);
+  });
+
+  it('endsAtBoundary は句読点/改行で終わるチャンクだけ true', () => {
+    expect(endsAtBoundary('こんにちは、')).toBe(true);
+    expect(endsAtBoundary('晴れ。')).toBe(true);
+    expect(endsAtBoundary('line\n')).toBe(true);
+    expect(endsAtBoundary('未完のまま')).toBe(false);
+  });
+});
+
 describe('rehypeFadeSegments', () => {
-  it('本文のテキストを語単位の fade-seg span に分割し、テキストは失われない', () => {
+  it('本文のテキストを句読点チャンクの fade-seg span に分割し、テキストは失われない', () => {
     const tree: Node = {
       type: 'root',
       children: [
-        { type: 'element', tagName: 'p', properties: {}, children: [{ type: 'text', value: '今日は良い天気です' }] },
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          children: [{ type: 'text', value: 'こんにちは、今日は晴れ。明日は雨。' }],
+        },
       ],
     };
     run(tree);
     const spans = collect(tree, isFadeSpan);
-    // 語分割されるので複数の span になる。
-    expect(spans.length).toBeGreaterThan(1);
+    // 読点・句点で 3 チャンクに分かれる。
+    expect(spans).toHaveLength(3);
+    expect(spans.map(textOf)).toEqual(['こんにちは、', '今日は晴れ。', '明日は雨。']);
     // 変換後も全文が保たれる。
+    expect(textOf(tree)).toBe('こんにちは、今日は晴れ。明日は雨。');
+  });
+
+  it('句読点の無いテキストは 1 つの span になる', () => {
+    const tree: Node = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          children: [{ type: 'text', value: '今日は良い天気です' }],
+        },
+      ],
+    };
+    run(tree);
+    expect(collect(tree, isFadeSpan)).toHaveLength(1);
     expect(textOf(tree)).toBe('今日は良い天気です');
   });
 
-  it('pre / code 配下のテキストは分割しない（コードを 1 文字ずつ光らせない）', () => {
+  it('pre / code 配下のテキストは分割しない（ハイライト/コピーを壊さない）', () => {
     const tree: Node = {
       type: 'root',
       children: [
@@ -69,28 +123,31 @@ describe('rehypeFadeSegments', () => {
       ],
     };
     run(tree);
-    // code 配下に fade-seg span は生成されない。
-    const spans = collect(tree, isFadeSpan);
-    expect(spans).toHaveLength(0);
-    // code の中身はそのまま。
+    expect(collect(tree, isFadeSpan)).toHaveLength(0);
     expect(textOf(tree)).toBe('const a = 1;');
   });
 
-  it('空白のみのセグメントは span で包まず素のテキストで残す（折り返しを保つ）', () => {
+  it('空白のみのセグメントは span で包まず素のテキストで残す', () => {
     const tree: Node = {
       type: 'root',
       children: [
-        { type: 'element', tagName: 'p', properties: {}, children: [{ type: 'text', value: 'hello world' }] },
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          // 先頭が句点 → 「。」で 1 チャンク、続く空白のみのチャンクは text のまま。
+          children: [{ type: 'text', value: '。 　' }],
+        },
       ],
     };
     run(tree);
     const p = tree.children![0];
-    // 語(hello / world)は span、間の空白は text ノードで残る。
-    const spanTexts = collect(tree, isFadeSpan).map(textOf);
-    expect(spanTexts).toContain('hello');
-    expect(spanTexts).toContain('world');
-    const hasWhitespaceText = (p.children ?? []).some((c) => c.type === 'text' && /^\s+$/.test(c.value ?? ''));
+    const spans = collect(tree, isFadeSpan);
+    expect(spans.map(textOf)).toEqual(['。']);
+    const hasWhitespaceText = (p.children ?? []).some(
+      (c) => c.type === 'text' && /^\s+$/.test(c.value ?? ''),
+    );
     expect(hasWhitespaceText).toBe(true);
-    expect(textOf(tree)).toBe('hello world');
+    expect(textOf(tree)).toBe('。 　');
   });
 });

--- a/frontend/src/components/message/rehypeFadeSegments.ts
+++ b/frontend/src/components/message/rehypeFadeSegments.ts
@@ -1,18 +1,27 @@
 /**
- * rehypeFadeSegments — ストリーミング中の Markdown 本文を「語(word)単位でフェードイン」させる rehype プラグイン。
+ * rehypeFadeSegments — ストリーミング中の Markdown 本文を「句読点チャンク単位でフェードイン」
+ * させる rehype プラグイン(Gemini 実物仕様の再現、FRESTYLE-145 → 146 で語単位から変更)。
  *
- * react-markdown が生成した hast のテキストノードを Intl.Segmenter で語に分割し、可視な語を
- * `<span class="fade-seg">` で包む。実際のフェードは CSS 側(.fade-seg)で mount 時に一度だけ
- * opacity(+ reduced-motion でない時のみ blur) を再生する。
+ * Gemini web の実装(配信バンドルで確認)は、本文を句読点 regex で sub-sentence チャンクに分割して
+ * span 化し、1 チャンクずつ opacity 0→1 (400ms / ease-out / 1 回) でフェードインさせる。
+ * 本プラグインは react-markdown が生成した hast のテキストノードを同じ規則
+ * (subSentenceSegments.splitSubSentences) で分割し、`<span class="fade-seg">` で包む。
+ * 実際のフェードは CSS 側(.fade-seg)が mount 時に一度だけ再生する。
  *
- * 既表示の語は再パースで位置が変わらなければ React が DOM ノードを再利用するため、アニメが
- * 再生し直されない(＝新しく mount した span だけがフェードする)。char-offset で「既出」を潰す
- * 方式を採らないのは、フェード途中の語を potenzialに opacity:1 へ瞬間スナップさせてしまう(pop)ため。
+ * 既表示のチャンクは、再パースで位置が変わらなければ React が DOM ノードを再利用するため
+ * アニメが再生し直されない(＝新しく mount した span だけがフェードする)。放出タイミングは
+ * useSmoothReveal(ペーシング)が句読点境界で visible prefix を伸ばすことで揃うので、
+ * プレーンテキスト部分ではチャンク境界がずれて span テキストが書き換わることはない。
+ * ただし markdown 構文がチャンク境界をまたいで後から確定する場合(例: `**強調、太字**` が
+ * 閉じて段落が strong 要素へ再構成される、連続句読点が delta を跨ぐ)は、その部分の hast が
+ * 作り直されて既表示 span が再マウント・再フェードすることがある(FRESTYLE-145 から続く既知の
+ * 局所アーティファクト。今まさにストリーミング中の末尾に限られ全文チラつきにはならない)。
  *
- * - pre / code 配下は分割しない(コードのハイライト・コピーを壊さない / 1 文字ずつ光らせない)。
- * - 空白のみのセグメントは span で包まず素のテキストで残す(折り返しとレイアウトを保つ)。
+ * - pre / code 配下は分割しない(コードのハイライト・コピーを壊さない)。
+ * - 空白のみのセグメントは span で包まず素のテキストで残す。
  * - 非ストリーミング時(完了・履歴・テスト)はこのプラグインを付けず、素の Markdown に戻す。
  */
+import { splitSubSentences } from './subSentenceSegments';
 
 interface HastText {
   type: 'text';
@@ -33,34 +42,8 @@ interface HastRoot {
   children: HastChild[];
 }
 
-// Intl.Segmenter は ES2020 の lib 型に含まれないため、必要な部分だけローカルに型定義する。
-interface WordSegmenter {
-  segment(input: string): Iterable<{ segment: string }>;
-}
-interface WordSegmenterCtor {
-  new (
-    locale?: string,
-    options?: { granularity?: 'grapheme' | 'word' | 'sentence' },
-  ): WordSegmenter;
-}
-
 // pre / code 配下のテキストは分割対象外。
 const SKIP_TAGS = new Set(['pre', 'code']);
-
-// 語分割器。Intl.Segmenter があれば日本語などの非空白区切り言語も語単位に分けられる。
-// 無い実行環境向けに空白区切りのフォールバックを持つ。
-const SegmenterImpl = (Intl as unknown as { Segmenter?: WordSegmenterCtor }).Segmenter;
-const segmenter: WordSegmenter | null = SegmenterImpl
-  ? new SegmenterImpl('ja', { granularity: 'word' })
-  : null;
-
-function segments(text: string): string[] {
-  if (segmenter) {
-    return Array.from(segmenter.segment(text), (s) => s.segment);
-  }
-  // フォールバック: 空白を保持したまま語と空白に分ける。
-  return text.split(/(\s+)/).filter((s) => s.length > 0);
-}
 
 function isText(node: HastChild): node is HastText {
   return node.type === 'text';
@@ -72,7 +55,7 @@ function isElement(node: HastChild): node is HastElement {
 
 function wrapText(value: string): HastChild[] {
   const out: HastChild[] = [];
-  for (const seg of segments(value)) {
+  for (const seg of splitSubSentences(value)) {
     if (!/\S/.test(seg)) {
       // 空白のみのセグメントは折り返しのためそのまま残す。
       out.push({ type: 'text', value: seg });
@@ -105,7 +88,7 @@ function transform(node: HastElement | HastRoot): void {
   node.children = next;
 }
 
-/** ストリーミング中の本文をフェードイン用の語 span に分割する rehype プラグイン。 */
+/** ストリーミング中の本文をフェードイン用の句読点チャンク span に分割する rehype プラグイン。 */
 export default function rehypeFadeSegments() {
   return (tree: HastRoot): void => {
     transform(tree);

--- a/frontend/src/components/message/subSentenceSegments.ts
+++ b/frontend/src/components/message/subSentenceSegments.ts
@@ -20,10 +20,9 @@ export function splitSubSentences(text: string): string[] {
   if (!text) return [];
   const out: string[] = [];
   let last = 0;
-  BOUNDARY_RE.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = BOUNDARY_RE.exec(text)) !== null) {
-    const end = m.index + m[0].length;
+  // matchAll でグローバル regex の lastIndex 共有状態を避ける(呼び出しが増えても安全)。
+  for (const m of text.matchAll(BOUNDARY_RE)) {
+    const end = (m.index ?? 0) + m[0].length;
     out.push(text.slice(last, end));
     last = end;
   }

--- a/frontend/src/components/message/subSentenceSegments.ts
+++ b/frontend/src/components/message/subSentenceSegments.ts
@@ -1,0 +1,37 @@
+/**
+ * subSentenceSegments — Gemini 実物と同じ「句読点区切りチャンク(sub-sentence)」分割。
+ *
+ * Gemini web の配信バンドルから確認した実装(FRESTYLE-146 調査)では、ストリーミング本文を
+ * 正規表現 /[,:\.!\?、。，۔]+/gi で分割し、各チャンクを不可視 span として先行挿入 →
+ * 一定リズムで 1 チャンクずつフェードインさせている。本モジュールはその分割部分を
+ * 表示側(rehypeFadeSegments)とペーシング側(useSmoothReveal)で共用する。
+ *
+ * - 区切り文字はチャンクの末尾に含める(「こんにちは、」で 1 チャンク)。
+ * - 改行も境界に含める(Gemini は markdown ノード単位で自然に切れるが、こちらは
+ *   生テキストの prefix を伸ばす方式のため、コードブロック等の句読点が無い行でも
+ *   行単位で放出できるようにする)。
+ */
+
+// Gemini 実物の sub-sentence 区切り(, : . ! ? 、 。 ， ۔) + 改行。
+const BOUNDARY_RE = /[,:.!?、。，۔\n]+/g;
+
+/** text を句読点チャンクに分割する(区切り文字は前のチャンク末尾に付く。全文が保存される)。 */
+export function splitSubSentences(text: string): string[] {
+  if (!text) return [];
+  const out: string[] = [];
+  let last = 0;
+  BOUNDARY_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = BOUNDARY_RE.exec(text)) !== null) {
+    const end = m.index + m[0].length;
+    out.push(text.slice(last, end));
+    last = end;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out;
+}
+
+/** チャンクが句読点(または改行)で完結しているか。未完チャンクはストリーミング中に保留する。 */
+export function endsAtBoundary(chunk: string): boolean {
+  return /[,:.!?、。，۔\n]$/.test(chunk);
+}

--- a/frontend/src/hooks/__tests__/useAskAi.test.tsx
+++ b/frontend/src/hooks/__tests__/useAskAi.test.tsx
@@ -147,4 +147,100 @@ describe('useAskAi', () => {
     });
     expect(result.current.messages).toHaveLength(2);
   });
+
+  // done で id がサーバ確定値に差し替わっても clientId は保持され、AskAiPage の
+  // key(clientId ?? id)が安定してバブルが remount しない(FRESTYLE-146)。
+  it('done イベント後も placeholder の clientId が保持される', async () => {
+    const { result } = renderHook(() => useAskAi(), {
+      wrapper: makeWrapper('/chat/ask-ai'),
+    });
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([]);
+    });
+
+    act(() => {
+      result.current.handleSend('こんにちは');
+    });
+    const placeholder = result.current.messages[1];
+    expect(placeholder.clientId).toBeDefined();
+    expect(placeholder.clientId).toBe(placeholder.id);
+
+    act(() => {
+      lastOnEvent?.({ type: 'token', delta: 'やあ。' });
+      lastOnEvent?.({
+        type: 'done',
+        sessionId: 1,
+        id: 'srv-99',
+        role: 'assistant',
+        content: 'やあ。こんにちは。',
+        createdAt: '2026-07-19T00:00:00Z',
+      });
+    });
+
+    const finalMsg = result.current.messages[1];
+    expect(finalMsg.id).toBe('srv-99');
+    expect(finalMsg.content).toBe('やあ。こんにちは。');
+    // id が差し替わっても clientId は元の placeholder のものが残る。
+    expect(finalMsg.clientId).toBe(placeholder.clientId);
+  });
+
+  // 最初の token より前に SSE error が来たケース。 error はエラー文を残しつつ id を
+  // 非 streaming 値へ差し替える。 これをしないと isStreaming が true のまま固まり、
+  // 句読点を含まないエラー文が useSmoothReveal の未完チャンク保留で永久に非表示になる
+  // (FRESTYLE-146 レビューで確定した regression)。
+  it('token 到着前の SSE error でも placeholder が非 streaming id + エラー文になる', async () => {
+    const { result } = renderHook(() => useAskAi(), {
+      wrapper: makeWrapper('/chat/ask-ai'),
+    });
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([]);
+    });
+
+    act(() => {
+      result.current.handleSend('質問です');
+    });
+    expect(result.current.messages[1].id).toMatch(/^streaming-/);
+
+    act(() => {
+      lastOnEvent?.({ type: 'error', message: 'ネットワークエラーが発生しました' });
+    });
+
+    const msg = result.current.messages[1];
+    // id は streaming- で始まらない → isStreaming=false → active が閉じてエラー文が表示される。
+    expect(msg.id.startsWith('streaming-')).toBe(false);
+    expect(msg.content).toBe('（エラー）ネットワークエラーが発生しました');
+  });
+
+  // 連投(前 stream の abort)では旧 placeholder に done/error が届かない。 新送信の前に
+  // 旧 placeholder を非 streaming id へ確定させ、 「考え中」固定・末尾欠落を防ぐ。
+  it('ストリーミング中に再送信すると旧 placeholder が非 streaming id へ確定される', async () => {
+    const { result } = renderHook(() => useAskAi(), {
+      wrapper: makeWrapper('/chat/ask-ai'),
+    });
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([]);
+    });
+
+    act(() => {
+      result.current.handleSend('1回目');
+    });
+    act(() => {
+      lastOnEvent?.({ type: 'token', delta: '途中まで、' });
+    });
+    const firstPlaceholderId = result.current.messages[1].id;
+    expect(firstPlaceholderId).toMatch(/^streaming-/);
+
+    // 応答中に 2 回目を送信 → 旧 placeholder が abort される。
+    act(() => {
+      result.current.handleSend('2回目');
+    });
+
+    // 旧 placeholder(index 1)は非 streaming id へ確定し、受信済み content は残る。
+    const oldPlaceholder = result.current.messages[1];
+    expect(oldPlaceholder.id.startsWith('streaming-')).toBe(false);
+    expect(oldPlaceholder.content).toBe('途中まで、');
+    // 新しい placeholder(末尾)は streaming- のまま。
+    const newPlaceholder = result.current.messages[result.current.messages.length - 1];
+    expect(newPlaceholder.id).toMatch(/^streaming-/);
+  });
 });

--- a/frontend/src/hooks/__tests__/useSmoothReveal.test.ts
+++ b/frontend/src/hooks/__tests__/useSmoothReveal.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSmoothReveal } from '../useSmoothReveal';
+
+// vitest の fake timers は Date も偽装するため、EMA(到着間隔)と放出タイマーの両方を
+// advanceTimersByTime で決定的に検証できる。
+describe('useSmoothReveal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup(content: string, active: boolean) {
+    return renderHook(({ c, a }: { c: string; a: boolean }) => useSmoothReveal(c, a), {
+      initialProps: { c: content, a: active },
+    });
+  }
+
+  it('mount 時は全文を即時表示する(履歴・確定メッセージ・remount)', () => {
+    const { result } = setup('こんにちは。今日は晴れです。', false);
+    expect(result.current.text).toBe('こんにちは。今日は晴れです。');
+    expect(result.current.settled).toBe(true);
+  });
+
+  it('ストリーミング中、最初のチャンクは待たずに即時放出される', () => {
+    const { result, rerender } = setup('', true);
+    expect(result.current.text).toBe('');
+    act(() => {
+      rerender({ c: 'こんにちは、', a: true });
+    });
+    // 「考え中」からの最初のチャンクは fb を待たない。
+    expect(result.current.text).toBe('こんにちは、');
+  });
+
+  it('後続のチャンクは適応間隔のタイマーで 1 つずつ放出される', () => {
+    const { result, rerender } = setup('', true);
+    act(() => {
+      rerender({ c: 'こんにちは、', a: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      rerender({ c: 'こんにちは、今日は晴れ。明日は雨。', a: true });
+    });
+    // まだタイマー前なので前回までの表示のまま。
+    expect(result.current.text).toBe('こんにちは、');
+    // fb = (EMA + 600) / (残チャンク数 + 1)。十分進めると 1 チャンクずつ増える。
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current.text).toBe('こんにちは、今日は晴れ。');
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.text).toBe('こんにちは、今日は晴れ。明日は雨。');
+    expect(result.current.settled).toBe(false); // まだ active
+  });
+
+  it('句読点で終わらない未完チャンクはストリーミング中は保留される', () => {
+    const { result, rerender } = setup('', true);
+    act(() => {
+      rerender({ c: 'こんにちは、', a: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      rerender({ c: 'こんにちは、続きがまだ途中', a: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    // 「続きがまだ途中」は境界(句読点/改行)で終わっていないため出さない。
+    expect(result.current.text).toBe('こんにちは、');
+  });
+
+  it('完了(active false)で保留分も含めて流し切り settled になる', () => {
+    const { result, rerender } = setup('', true);
+    act(() => {
+      rerender({ c: 'こんにちは、', a: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      rerender({ c: 'こんにちは、続きがまだ途中', a: true });
+    });
+    act(() => {
+      rerender({ c: 'こんにちは、続きがまだ途中', a: false });
+    });
+    expect(result.current.settled).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current.text).toBe('こんにちは、続きがまだ途中');
+    expect(result.current.settled).toBe(true);
+  });
+
+  it('最初のチャンク放出前に active=false + 句読点なしの content が来たら即時に全表示する(エラー文)', () => {
+    // useAskAi の error 修正後の状態遷移を再現: visible='' active=true から、
+    // 句読点を含まないエラー文で active=false になる。 未完チャンク保留は active 中のみなので、
+    // 完了状態では丸ごと放出される(「考え中」固定にならない)。
+    const { result, rerender } = setup('', true);
+    expect(result.current.text).toBe('');
+    act(() => {
+      rerender({ c: 'ネットワークエラーが発生しました', a: false });
+    });
+    expect(result.current.text).toBe('ネットワークエラーが発生しました');
+    expect(result.current.settled).toBe(true);
+  });
+
+  it('表示済み prefix の延長でない content(エラー置換)は即スナップする', () => {
+    const { result, rerender } = setup('', true);
+    act(() => {
+      rerender({ c: '回答の途中、', a: true });
+    });
+    expect(result.current.text).toBe('回答の途中、');
+    act(() => {
+      rerender({ c: '（エラー）ネットワークエラーが発生しました', a: true });
+    });
+    expect(result.current.text).toBe('（エラー）ネットワークエラーが発生しました');
+  });
+
+  it('長い無放出期間の後に大量の backlog が来たら catch-up でまとめて出す', () => {
+    const { result, rerender } = setup('', true);
+    act(() => {
+      rerender({ c: '一。', a: true });
+    });
+    expect(result.current.text).toBe('一。');
+    // 前回の放出から 10 秒経過してから大量のチャンクが届く(接続の停滞など)。
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+      rerender({ c: '一。二。三。四。五。六。七。八。', a: true });
+    });
+    // 最初の tick で elapsed が fb×10 を超えているため、1 個ずつではなく一括で追いつく。
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.text).toBe('一。二。三。四。五。六。七。八。');
+  });
+
+  it('unmount で進行中のタイマーが破棄される', () => {
+    const { rerender, unmount } = setup('', true);
+    act(() => {
+      rerender({ c: 'こんにちは、', a: true });
+    });
+    act(() => {
+      vi.advanceTimersByTime(100);
+      rerender({ c: 'こんにちは、今日は晴れ。', a: true });
+    });
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -122,7 +122,8 @@ export function useAskAi() {
       // ユーザー発話 + アシスタント placeholder を即座に追加
       const now = new Date().toISOString();
       const userMsg: AiMessage = {
-        id: `local-user-${Date.now()}`,
+        // Date.now() は同一ミリ秒の連投で衝突し得る（clientId=key が重複する）ため UUID を使う。
+        id: `local-user-${crypto.randomUUID()}`,
         sessionId: currentSessionId ?? 0,
         role: 'user',
         content: text,
@@ -134,7 +135,7 @@ export function useAskAi() {
       // 未完チャンク保留で欠けたり「考え中」で固まる（FRESTYLE-146 レビュー指摘）。 新 placeholder を
       // 積む前に旧 placeholder を非 streaming id へ確定させ、 受信済みぶんを流し切らせる。
       const prevStreamingId = streamingIdRef.current;
-      const placeholderId = `streaming-${Date.now()}`;
+      const placeholderId = `streaming-${crypto.randomUUID()}`;
       streamingIdRef.current = placeholderId;
       const placeholder: AiMessage = {
         id: placeholderId,

--- a/frontend/src/hooks/useAskAi.ts
+++ b/frontend/src/hooks/useAskAi.ts
@@ -86,19 +86,25 @@ export function useAskAi() {
           streamingIdRef.current = null;
           return;
         }
-        case 'error':
-          // placeholder にエラー本文を残す（ユーザーに状況を伝える）
-          if (streamingIdRef.current) {
+        case 'error': {
+          // placeholder にエラー本文を残す（ユーザーに状況を伝える）。
+          // id を非 streaming 値へ差し替えて「ストリーミング中」状態を閉じる。 これをしないと
+          // isStreaming が true のまま固まり、 句読点を含まないエラー文が useSmoothReveal の
+          // 未完チャンク保留で永久に非表示になる（FRESTYLE-146 レビュー指摘）。 clientId は
+          // spread で保持されるので key は安定し、 バブルは remount しない。
+          const errId = streamingIdRef.current;
+          if (errId) {
             setMessages((prev) =>
               prev.map((m) =>
-                m.id === streamingIdRef.current
-                  ? { ...m, content: `（エラー）${ev.message}` }
+                m.id === errId
+                  ? { ...m, id: `error-${errId}`, content: `（エラー）${ev.message}` }
                   : m
               )
             );
             streamingIdRef.current = null;
           }
           return;
+        }
       }
     },
     [handleIncomingSession, setCurrentSessionId, setMessages]
@@ -123,6 +129,11 @@ export function useAskAi() {
         attachments: attachments.length > 0 ? attachments : undefined,
         createdAt: now,
       };
+      // 連投時は useAiChatSse が前の stream を abort する（done/error は届かない）。
+      // その旧 placeholder が `streaming-` id のまま残ると active が閉じず、 受信済みの末尾が
+      // 未完チャンク保留で欠けたり「考え中」で固まる（FRESTYLE-146 レビュー指摘）。 新 placeholder を
+      // 積む前に旧 placeholder を非 streaming id へ確定させ、 受信済みぶんを流し切らせる。
+      const prevStreamingId = streamingIdRef.current;
       const placeholderId = `streaming-${Date.now()}`;
       streamingIdRef.current = placeholderId;
       const placeholder: AiMessage = {
@@ -130,9 +141,19 @@ export function useAskAi() {
         sessionId: currentSessionId ?? 0,
         role: 'assistant',
         content: '',
+        // done で id がサーバ確定値へ差し替わっても React の key を安定させるための
+        // クライアント側 ID(FRESTYLE-146)。done handler の spread で自動的に保持される。
+        clientId: placeholderId,
         createdAt: now,
       };
-      setMessages((prev) => [...prev, userMsg, placeholder]);
+      setMessages((prev) => {
+        const base = prevStreamingId
+          ? prev.map((m) =>
+              m.id === prevStreamingId ? { ...m, id: `aborted-${prevStreamingId}` } : m,
+            )
+          : prev;
+        return [...base, userMsg, placeholder];
+      });
 
       void sendSse({
         sessionId: currentSessionId,

--- a/frontend/src/hooks/useSmoothReveal.ts
+++ b/frontend/src/hooks/useSmoothReveal.ts
@@ -1,0 +1,178 @@
+import { useEffect, useRef, useState } from 'react';
+import { splitSubSentences, endsAtBoundary } from '../components/message/subSentenceSegments';
+
+/**
+ * useSmoothReveal — ストリーミング本文を Gemini 実物と同じリズムで放出するペーシングフック
+ * (FRESTYLE-146)。
+ *
+ * Gemini web の配信バンドルから確認したアルゴリズムの再現:
+ * - 本文を句読点チャンク(sub-sentence)に分割し、1 チャンクずつ表示に追加する
+ * - 放出間隔 fb = (チャンク到着間隔の累積平均 avg + 600) / (残チャンク数 + 1)
+ *   (avg は各サンプルを 1/n 重みで足す累積算術平均。 Gemini 実装と同型。 サンプルは 1000ms で
+ *    キャップ、初期値 3000ms。到着が速いほど・残りが多いほど速く出す)
+ * - 遅延が fb×10 を超えていたら floor(遅延/fb) 個をまとめて表示(catch-up)
+ * - 応答完了(active true→false)で avg×0.8 に加速し、残りをリズム付きで流し切る(fast-drain)
+ *
+ * 設計上のルール(既存挙動とテストを壊さないための急所):
+ * - mount 時は content 全文を即時表示する(履歴ロード・確定メッセージ・既存テストは無影響)
+ * - content が表示済み prefix の延長でないとき(SSE error の全文置換等)は即スナップ
+ * - streaming 中、句読点で終わっていない末尾の未完チャンクは保留する
+ *   (出してしまうと次の delta で span テキストが書き換わり、フェード無しで文字が増える)。
+ *   ただしコードブロック等で境界が来ない場合に備え、一定文字数を超えたら放出する
+ */
+
+const AVG_INITIAL_MS = 3000;
+const AVG_SAMPLE_CAP_MS = 1000;
+const FB_BASE_MS = 600;
+const COMPLETE_ACCEL = 0.8;
+const CATCHUP_FACTOR = 10;
+// 句読点境界が来ない未完チャンクを保留する上限。超えたら放出する(長い無句読点行の停滞防止)。
+const MAX_TAIL_HOLD_CHARS = 120;
+
+export interface SmoothRevealResult {
+  /** 表示してよい prefix。MarkdownView にはこれを渡す。 */
+  text: string;
+  /** backlog を出し切った(完了マーカー等の表示に使う)。 */
+  settled: boolean;
+}
+
+interface RevealState {
+  visible: string;
+  content: string;
+  active: boolean;
+  everActive: boolean;
+  avg: number;
+  samples: number;
+  lastArrival: number;
+  lastReveal: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+export function useSmoothReveal(content: string, active: boolean): SmoothRevealResult {
+  // mount 時スナップショットは即時全文表示(履歴・remount・既存テストをすべて無変更で満たす)。
+  const [visible, setVisible] = useState(content);
+
+  const stateRef = useRef<RevealState | null>(null);
+  if (stateRef.current === null) {
+    stateRef.current = {
+      visible: content,
+      content,
+      active,
+      everActive: active,
+      avg: AVG_INITIAL_MS,
+      samples: 0,
+      lastArrival: 0,
+      lastReveal: Date.now(),
+      timer: null,
+    };
+  }
+
+  useEffect(() => {
+    const s = stateRef.current as RevealState;
+
+    const revealTo = (next: string) => {
+      s.visible = next;
+      s.lastReveal = Date.now();
+      setVisible(next);
+    };
+
+    const stopTimer = () => {
+      if (s.timer !== null) {
+        clearTimeout(s.timer);
+        s.timer = null;
+      }
+    };
+
+    // 未放出 backlog を句読点チャンクに分割する。streaming 中は未完の末尾チャンクを保留。
+    const pendingChunks = (): string[] => {
+      const backlog = s.content.slice(s.visible.length);
+      if (!backlog) return [];
+      const chunks = splitSubSentences(backlog);
+      if (s.active && chunks.length > 0) {
+        const tail = chunks[chunks.length - 1];
+        if (!endsAtBoundary(tail) && tail.length <= MAX_TAIL_HOLD_CHARS) chunks.pop();
+      }
+      return chunks;
+    };
+
+    // Gemini の適応放出間隔: fb = (累積平均 + 600) / (残チャンク数 + 1)。
+    const fbMs = (pending: number) => (s.avg + FB_BASE_MS) / (pending + 1);
+
+    const tick = () => {
+      s.timer = null;
+      const chunks = pendingChunks();
+      if (chunks.length === 0) {
+        // 保留中の未完 tail だけが残った状態で完了した場合はここで出し切る。
+        if (!s.active && s.visible !== s.content) revealTo(s.content);
+        return;
+      }
+      const fb = fbMs(chunks.length);
+      const elapsed = Date.now() - s.lastReveal;
+      // catch-up: 大きく遅れていたら floor(遅延/fb) 個まとめて表示(Gemini と同じ)。
+      const take =
+        elapsed > fb * CATCHUP_FACTOR
+          ? Math.min(chunks.length, Math.max(1, Math.floor(elapsed / fb)))
+          : 1;
+      revealTo(s.visible + chunks.slice(0, take).join(''));
+      schedule();
+    };
+
+    const schedule = () => {
+      if (s.timer !== null) return;
+      const chunks = pendingChunks();
+      if (chunks.length === 0) {
+        if (!s.active && s.visible !== s.content) {
+          // 未完 tail のみ残して完了 → 一拍おいて出し切る。
+          s.timer = setTimeout(tick, fbMs(1));
+        }
+        return;
+      }
+      s.timer = setTimeout(tick, fbMs(chunks.length));
+    };
+
+    // チャンク到着間隔の累積平均(Gemini と同型。サンプルは 1000ms キャップ)。
+    if (active && content.length > s.content.length) {
+      const now = Date.now();
+      if (s.lastArrival > 0) {
+        const sample = Math.min(AVG_SAMPLE_CAP_MS, now - s.lastArrival);
+        s.samples += 1;
+        s.avg = ((s.samples - 1) / s.samples) * s.avg + sample / s.samples;
+      }
+      s.lastArrival = now;
+    }
+    s.content = content;
+
+    // 完了(active true→false)で放出を加速(Gemini は COMPLETE で ×0.8)。
+    if (s.active && !active) s.avg *= COMPLETE_ACCEL;
+    s.active = active;
+    if (active) s.everActive = true;
+
+    // 表示済み prefix の延長でない content(error の全文置換等)は即スナップ。
+    if (!content.startsWith(s.visible)) {
+      stopTimer();
+      revealTo(content);
+      return;
+    }
+    // 一度もストリーミングしていないメッセージ(履歴・確定・編集)は常に全文即時。
+    if (!active && !s.everActive) {
+      if (s.visible !== content) revealTo(content);
+      return;
+    }
+    // 「考え中」からの最初のチャンクは fb を待たず即時に出す。
+    if (s.visible === '' && content !== '' && s.timer === null) {
+      tick();
+      return;
+    }
+    schedule();
+  }, [content, active]);
+
+  // unmount で進行中のタイマーを破棄する。
+  useEffect(() => {
+    return () => {
+      const s = stateRef.current;
+      if (s?.timer != null) clearTimeout(s.timer);
+    };
+  }, []);
+
+  return { text: visible, settled: !active && visible === content };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -169,15 +169,16 @@
 }
 
 /*
- * AI チャットのストリーミング表示: 新しく現れた語(word)を 1 回だけフェードイン(Gemini 風, FRESTYLE-145)。
- * rehypeFadeSegments が本文の語を <span class="fade-seg"> に包み、mount 時にこのアニメが 1 回再生される。
- * 既表示の語は React が DOM を再利用するため再生し直されない。
+ * AI チャットのストリーミング表示: 新しく現れた句読点チャンクを 1 回だけフェードイン
+ * (FRESTYLE-145 → 146 で Gemini 実物仕様に変更)。
+ * rehypeFadeSegments が本文を句読点チャンクの <span class="fade-seg"> に包み、mount 時に
+ * このアニメが 1 回再生される。既表示のチャンクは React が DOM を再利用するため再生し直されない。
+ * 放出リズムは useSmoothReveal(適応ペーシング)が制御する。
  *
- * - 主役は opacity。inline 要素なので transform(translateY) は効かない/使わない。 高さも変えないので
- *   ストリーミング中の自動スクロール追従(distanceFromBottom 判定)を乱さない。
- * - blur(ぼかし→くっきり)は「動きOK」のユーザーにだけ上乗せ(no-preference)。 blur は毎フレーム連続で
- *   animate せず 4px→0 の 1 回きり。
- * - prefers-reduced-motion: reduce では実質即時表示にする(animationend は残すため 0 でなく 0.01ms)。
+ * 値は Gemini web の実測(配信バンドル + getAnimations 計測)に合わせる:
+ *   opacity 0→1 のみ / 400ms / ease-out / fill forwards / 1 回。blur や translate は使わない
+ *   (実物に存在しない。inline のまま高さも変えないのでスクロール追従も乱さない)。
+ * prefers-reduced-motion: reduce では実質即時表示(animationend は残すため 0 でなく 0.01ms)。
  */
 @keyframes fade-seg-in {
   from {
@@ -189,20 +190,7 @@
 }
 
 .fade-seg {
-  animation: fade-seg-in 240ms ease-out both;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  @keyframes fade-seg-in {
-    from {
-      opacity: 0;
-      filter: blur(4px);
-    }
-    to {
-      opacity: 1;
-      filter: blur(0);
-    }
-  }
+  animation: fade-seg-in 400ms ease-out both;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -63,6 +63,7 @@ export default function AskAiPage() {
   // ユーザーが手動で底まで戻したら stickToBottom を再 true に戻す（onScroll で検知）。
   // ChatGPT / Claude.ai と同じ UX。
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const messagesListRef = useRef<HTMLDivElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const [stickToBottom, setStickToBottom] = useState(true);
   // ref 版を 並行で持つ。 streaming 中は messages が ms 単位で更新されるため、
@@ -115,6 +116,24 @@ export default function AskAiPage() {
     // smooth animation は wheel と競合しやすいので auto に落として 1 frame で完了させる
     messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
   }, [messages]);
+
+  // ペーシング(useSmoothReveal)の放出は messages state と非同期に DOM の高さを伸ばすため、
+  // messages 依存の effect だけでは追従できない(特に done 後の drain 中)。リストの高さ変化を
+  // ResizeObserver で拾い、stick 中のみ最下部へ追従する(FRESTYLE-146)。jsdom には
+  // ResizeObserver が無いので存在ガードを入れる。
+  const hasMessages = messages.length > 0;
+  useEffect(() => {
+    if (!hasMessages) return;
+    const list = messagesListRef.current;
+    if (!list || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => {
+      if (stickToBottomRef.current) {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
+      }
+    });
+    observer.observe(list);
+    return () => observer.disconnect();
+  }, [hasMessages]);
 
   // セッション切替で先頭に戻ったときは強制的に底へ（履歴の最後を見せる）。
   useEffect(() => {
@@ -307,10 +326,12 @@ export default function AskAiPage() {
           {messages.length === 0 ? (
             <WelcomeGreeting />
           ) : (
-            <div className="max-w-3xl mx-auto space-y-4">
+            <div ref={messagesListRef} className="max-w-3xl mx-auto space-y-4">
               {messages.map((message) => (
                 <MessageBubbleAi
-                  key={message.id}
+                  // done で id が streaming-… → サーバ確定値に変わっても remount しないよう、
+                  // ストリーミング由来のメッセージは clientId で key を安定させる(FRESTYLE-146)。
+                  key={message.clientId ?? message.id}
                   id={message.id}
                   type="text"
                   content={message.content}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -118,6 +118,12 @@ export interface AiMessage {
   createdAt?: string;
   isSender?: boolean;
   isDeleted?: boolean;
+  /**
+   * ストリーミング placeholder 由来のクライアント側 ID(FRESTYLE-146)。
+   * done で id がサーバ確定値に差し替わっても React の key をこれで安定させ、
+   * バブルの remount(ペーシングの残り放出が全文ジャンプになる)を防ぐ。
+   */
+  clientId?: string;
 }
 
 /** フラッシュメッセージ */


### PR DESCRIPTION
## 概要

FRESTYLE-145 の「語単位フェード」では Gemini の体感に届かなかった（コードブロック等がそのまま出る）というユーザーフィードバックを受けた作り直し。**Gemini web 本体の配信バンドル（gemini.gstatic.com）原文 + headless ブラウザでの実測（`document.getAnimations()` サンプリング）** で実物のアルゴリズムを特定し、それを再現する。

### Gemini 実物の仕様（一次調査で確定）

- **放出単位**: 句読点区切りチャンク（regex `/[,:\.!\?、。，۔]+/` = 読点でも切る sub-sentence）を `<span class="pending">`（display:none）で先行挿入。
- **放出機構**: rAF ループが適応間隔 **fb = (チャンク到着間隔の累積平均 + 600) / (残チャンク数 + 1)** で 1 チャンクずつ `.pending`→`.animating` に付替え。遅延が fb×10 超で floor(遅延/fb) 個を一括表示（catch-up）。完了で平均×0.8 に加速。
- **アニメ**: `@keyframes fade-in-text`（**opacity 0→1 のみ / blur・translate 無し**）、実測 400ms / ease-out / forwards / 1 回。

## 変更内容

- **`useSmoothReveal.ts`（新規）**: `content`（真の受信全文）から表示 prefix を Gemini と同じ適応リズムで進める。mount 時全文即時 / 未完チャンク保留 / prefix 不一致スナップ / 完了後 fast-drain。
- **`subSentenceSegments.ts`（新規）**: Gemini と同じ句読点分割を表示側（rehype）とペーシング側で共用（改行も境界に追加 = 句読点の無い行でも放出できる独自拡張）。
- **`rehypeFadeSegments.ts`**: 語分割 → 句読点チャンク分割へ。
- **`index.css`**: `.fade-seg` を **400ms ease-out・opacity のみ**（実測値）に。FRESTYLE-145 の blur は撤去。
- **key 安定化**: `AiMessage.clientId` を追加し AskAiPage の `key` を `clientId ?? id` に。done の id 差し替えでバブルが remount して残り放出が全文ジャンプになるのを防ぐ。
- **`AskAiPage.tsx`**: ResizeObserver（jsdom ガード付き）で drain 中の下端追従を追加。
- **`MarkdownView.tsx`**: memo 化（再パースを SSE token 毎 → 放出毎に削減）。

### レビュー（敵対的検証）で確定した regression の同時修正

多次元レビューで実再現が確定した 2 件を修正した（いずれも「`done` 以外で終端した placeholder の id が `streaming-` のまま → active 永続」が根因）:
- **[HIGH] 最初の token 前の SSE error で「考え中」固定・エラー文が永久非表示** → error ハンドラで id を `error-…` に差し替えて active を閉じる（`clientId` で remount しない）。
- **[MEDIUM] 連投 abort で旧バブルが active 残留・末尾欠落** → handleSend で旧 placeholder を `aborted-…` に確定。

## テスト

- 新規 `useSmoothReveal.test.ts`（fake timers）: mount 即時 / 初回即時 / タイマー放出 / 未完保留 / fast-drain / エラー時スナップ / catch-up / unmount clear / **句読点なしエラー文の即時全表示**。
- 更新 `rehypeFadeSegments`（句読点分割）/ `MarkdownView`（分割・code 非分割・DOM ノード再利用・GFM 共存）/ `MessageBubble`（ペーシングの時間経過）/ `useAskAi`（clientId 保持・**error/連投で id 非 streaming 化**）。
- `tsc --noEmit` / `eslint --max-warnings 0`: 成功
- `vitest run --coverage`（全体）: 163 ファイル / **1339 件緑**、閾値クリア（Stmts 86.78% / Branch 81.5% / Funcs 84.16% / Lines 88.52%）
- `npm run build`: 成功

## 関連チケット

FRESTYLE-146（FRESTYLE-145 の作り直し）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - AIチャットのストリーミング表示を、句読点単位で段階的に表示するペーシングとフェードインに対応。
  - 応答完了時の表示を滑らかに仕上げ、エラーや連続送信時も表示状態を適切に確定。
  - 表示中のメッセージに合わせた自動スクロールを改善。

- **改善**
  - 新しいチャンクのみを一度だけフェード表示し、既存内容のちらつきを防止。
  - ストリーミング完了時のアイコン表示タイミングを調整。
  - 視覚効果を軽減する設定に対応。

- **ドキュメント**
  - ストリーミング表示仕様とテスト観点を更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->