### PR TITLE
style: グローバルヘッダーの縦幅を拡大 (h-14 → h-16) (FRESTYLE-148)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -139,7 +139,7 @@ export default function Header() {
   return (
     <>
       {loggingOut && <Loading fullscreen message="ログアウト中..." />}
-      <header className="flex-shrink-0 h-14 bg-[var(--color-nav)] border-b border-surface-3 flex items-center gap-2 px-3">
+      <header className="flex-shrink-0 h-16 bg-[var(--color-nav)] border-b border-surface-3 flex items-center gap-2 px-3">
         {/* ロゴ（PNG と同じ二色の飛翔マーク = brand-mark.svg。色付き箱で囲うとロゴ自体が青いため埋もれる）。 */}
         <Link to="/" className="flex items-center gap-2 flex-shrink-0 mr-2" aria-label="FreStyle ホーム">
           <img src="/brand-mark.svg" alt="" className="w-7 h-7 flex-shrink-0" />

--- a/frontend/src/pages/AskAiPage.tsx
+++ b/frontend/src/pages/AskAiPage.tsx
@@ -186,7 +186,7 @@ export default function AskAiPage() {
   };
 
   if (loading && sessions.length === 0) {
-    return <Loading message="読み込み中..." className="min-h-[calc(100vh-3.5rem)]" />;
+    return <Loading message="読み込み中..." className="min-h-[calc(100vh-4rem)]" />;
   }
 
   return (


### PR DESCRIPTION
## 概要

グローバルヘッダーの縦幅が窮屈という指摘。記事投稿サイト（Zenn）のヘッダーを参考に、高さを `h-14`（56px）→ `h-16`（64px）に広げた。

## 変更内容

- `Header.tsx`: ヘッダー root の `h-14` → `h-16`。中身（ロゴ / ナビ / ユーザーメニュー）は `items-center` で縦中央のまま。
- `AskAiPage.tsx`: ヘッダー高さに依存する Loading の `min-h-[calc(100vh-3.5rem)]` → `calc(100vh-4rem)`。

## テスト

- `tsc --noEmit` / `eslint --max-warnings 0`: 成功
- `vitest run --coverage`（全体）: 163 ファイル / 1339 件緑
- `npm run build`: 成功

ロジックを含まないレイアウトのみのデザイン専用変更。

## 関連チケット

FRESTYLE-148