### PR TITLE
style: 教材閲覧の目次カードを本文カードと同じ高さから始める (FRESTYLE-150)

### DIFF
--- a/frontend/src/pages/CourseDetailPage.tsx
+++ b/frontend/src/pages/CourseDetailPage.tsx
@@ -452,40 +452,42 @@ function ReadOnlyDetail({
           tocOpen ? 'lg:grid-cols-[minmax(0,1fr)_280px]' : ''
         }`}
       >
-        {/* サイドバーを隠したときは本文が全幅に伸びて読みにくいため、 読みやすい幅(860px)に
-            収めて中央寄せする。 サイドバー表示時は 1fr カラムが既に同程度の幅になる。
-            タイトル/メタのヘッダーはカードの外・上に置き、 本文だけを白カードに入れる(FRESTYLE-131)。 */}
-        <div className={`min-w-0 ${!tocOpen ? 'mx-auto w-full max-w-[860px]' : ''}`}>
-          {/* 記事サイト風ヘッダー: 灰青背景の上にタイトル + メタを中央寄せで置く(FRESTYLE-131)。 */}
-          <header className="mb-6 text-center">
-            <h1 className="text-3xl sm:text-4xl font-bold text-[var(--color-text-primary)] leading-snug">
-              {material.title || '無題の教材'}
-            </h1>
-            {/* メタ(最終更新 / 目次トグル / 完了トグル)。 sticky にはしない(FRESTYLE-119)。
-                スクロール途中の完了操作は本文末尾の大きい完了ボタン(FRESTYLE-100)で行える。 */}
-            <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-              <p className="text-xs text-[var(--color-text-muted)]">
-                最終更新: {formatDate(material.updatedAt)}
-              </p>
-              {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
-              <button
-                type="button"
-                onClick={() => setTocOpen((v) => !v)}
-                aria-pressed={tocOpen}
-                title={tocOpen ? '目次を隠す' : '目次を表示'}
-                className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                  tocOpen
-                    ? 'border-taupe-500 text-taupe-400'
-                    : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
-                }`}
-              >
-                <ListBulletIcon className="w-4 h-4" />
-                目次
-              </button>
-              <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
-            </div>
-          </header>
+        {/* 記事サイト風ヘッダー(Zenn 風): タイトル + メタをグリッド直下の子にして col-span-full で
+            行全体に広げる。 本文カード(左カラム)と右サイドバー(目次/章一覧)は次の行に並ぶので、
+            右の目次カードが本文カードと同じ高さから始まる(FRESTYLE-150 / 131)。
+            行間は grid の gap-8 が担うので header に mb は付けない。 */}
+        <header className="col-span-full text-center">
+          <h1 className="text-3xl sm:text-4xl font-bold text-[var(--color-text-primary)] leading-snug">
+            {material.title || '無題の教材'}
+          </h1>
+          {/* メタ(最終更新 / 目次トグル / 完了トグル)。 sticky にはしない(FRESTYLE-119)。
+              スクロール途中の完了操作は本文末尾の大きい完了ボタン(FRESTYLE-100)で行える。 */}
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+            <p className="text-xs text-[var(--color-text-muted)]">
+              最終更新: {formatDate(material.updatedAt)}
+            </p>
+            {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
+            <button
+              type="button"
+              onClick={() => setTocOpen((v) => !v)}
+              aria-pressed={tocOpen}
+              title={tocOpen ? '目次を隠す' : '目次を表示'}
+              className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                tocOpen
+                  ? 'border-taupe-500 text-taupe-400'
+                  : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
+              }`}
+            >
+              <ListBulletIcon className="w-4 h-4" />
+              目次
+            </button>
+            <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
+          </div>
+        </header>
 
+        {/* 本文カラム。 サイドバーを隠したときは本文が全幅に伸びて読みにくいため、 読みやすい幅(860px)に
+            収めて中央寄せする。 サイドバー表示時は 1fr カラムが既に同程度の幅になる。 */}
+        <div className={`min-w-0 ${!tocOpen ? 'mx-auto w-full max-w-[860px]' : ''}`}>
           <article className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
             <div className="prose prose-sm max-w-none course-prose">
               <ReadOnlyMarkdown content={bodyContent} />


### PR DESCRIPTION
## 概要

教材コース閲覧（/courses/:id）の右サイドバー（目次 / 章一覧カード）が、タイトル（ヘッダー）の高さから始まっていて本文カードより高い位置にあった。Zenn のように **目次カードを本文カードと同じ高さから** 始める。

## 原因と変更内容

タイトル + メタのヘッダーがグリッドの左カラム内に入っていたため、右サイドバーが行の先頭＝タイトルの高さから始まっていた。

- `CourseDetailPage.tsx` の `ReadOnlyDetail`: ヘッダーをグリッド直下の子にして **`col-span-full`**（行全体）に広げた。本文カード（左カラム）と右サイドバー（目次 / 章一覧）は次の行に並ぶので、**同じ高さから始まる**。行間は grid の `gap-8` が担う（header の `mb-6` は撤去）。

## テスト

- `tsc --noEmit` / `eslint --max-warnings 0`: 成功
- `vitest run --coverage`（全体）: 163 ファイル / 1339 件緑（h1 が header 内・article 外の既存テストも維持）
- `npm run build`: 成功

ロジックを含まないレイアウトのみのデザイン専用変更。

## 関連チケット

FRESTYLE-150