### PR TITLE
feat: AIチャットのセッション操作にトースト通知を出す (FRESTYLE-151)

### DIFF
--- a/frontend/src/hooks/__tests__/useAiSession.test.ts
+++ b/frontend/src/hooks/__tests__/useAiSession.test.ts
@@ -5,9 +5,15 @@ import { useAiSession } from '../useAiSession';
 const mockNavigate = vi.fn();
 const mockDeleteSession = vi.fn();
 const mockUpdateSessionTitle = vi.fn();
+const mockShowToast = vi.fn();
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
+}));
+
+// トースト通知(FRESTYLE-151)。 Provider を張らずに呼び出しだけ検証したいのでモックする。
+vi.mock('../useToast', () => ({
+  useToast: () => ({ showToast: mockShowToast, removeToast: vi.fn(), toasts: [] }),
 }));
 
 describe('useAiSession', () => {
@@ -45,6 +51,8 @@ describe('useAiSession', () => {
 
     expect(result.current.currentSessionId).toBeNull();
     expect(mockNavigate).toHaveBeenCalledWith('/chat/ask-ai');
+    // 新しいチャット開始をトーストで知らせる(FRESTYLE-151)。
+    expect(mockShowToast).toHaveBeenCalledWith('success', '新しいチャットを開始しました');
   });
 
   it('セッション削除確認モーダルの開閉ができる', () => {
@@ -85,6 +93,31 @@ describe('useAiSession', () => {
 
     expect(mockDeleteSession).toHaveBeenCalledWith(5);
     expect(result.current.currentSessionId).toBeNull();
+    // 削除成功をトーストで知らせる(FRESTYLE-151)。
+    expect(mockShowToast).toHaveBeenCalledWith('success', 'セッションを削除しました');
+  });
+
+  it('セッション削除に失敗したらエラートーストを出す', async () => {
+    mockDeleteSession.mockResolvedValue(false);
+    const { result } = renderHook(() =>
+      useAiSession({ deleteSession: mockDeleteSession, updateSessionTitle: mockUpdateSessionTitle })
+    );
+
+    act(() => {
+      result.current.handleSelectSession(5);
+    });
+
+    act(() => {
+      result.current.handleDeleteSession(5);
+    });
+
+    await act(async () => {
+      await result.current.confirmDeleteSession();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith('error', 'セッションの削除に失敗しました');
+    // 失敗時は選択中セッションを維持する。
+    expect(result.current.currentSessionId).toBe(5);
   });
 
   it('タイトル編集の開始・保存・キャンセルができる', async () => {
@@ -111,6 +144,8 @@ describe('useAiSession', () => {
 
     expect(mockUpdateSessionTitle).toHaveBeenCalledWith(10, { title: '新しいタイトル' });
     expect(result.current.editingSessionId).toBeNull();
+    // タイトル変更成功をトーストで知らせる(FRESTYLE-151)。
+    expect(mockShowToast).toHaveBeenCalledWith('success', 'タイトルを変更しました');
   });
 
   it('deleteModal初期値がclosed状態', () => {

--- a/frontend/src/hooks/__tests__/useAskAi.test.tsx
+++ b/frontend/src/hooks/__tests__/useAskAi.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import authReducer from '../../store/authSlice';
+import { ToastProvider } from '../../components/ToastProvider';
 import { useAskAi } from '../useAskAi';
 
 // useAskAi は useAiChatSse / AiChatRepository / fetchSessions / fetchMessages を内部で叩く。
@@ -52,14 +53,17 @@ function makeWrapper(initialPath: string) {
       auth: { isAuthenticated: true, loading: false, isAdmin: false, role: 'trainee' },
     },
   });
+  // useAiSession がセッション操作のトーストを出すため ToastProvider が必要(FRESTYLE-151)。
   return ({ children }: { children: ReactNode }) => (
     <Provider store={store}>
-      <MemoryRouter initialEntries={[initialPath]}>
-        <Routes>
-          <Route path="/chat/ask-ai" element={<>{children}</>} />
-          <Route path="/chat/ask-ai/:sessionId" element={<>{children}</>} />
-        </Routes>
-      </MemoryRouter>
+      <ToastProvider>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path="/chat/ask-ai" element={<>{children}</>} />
+            <Route path="/chat/ask-ai/:sessionId" element={<>{children}</>} />
+          </Routes>
+        </MemoryRouter>
+      </ToastProvider>
     </Provider>
   );
 }

--- a/frontend/src/hooks/useAiSession.ts
+++ b/frontend/src/hooks/useAiSession.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useToast } from './useToast';
 
 interface DeleteModal {
   isOpen: boolean;
@@ -13,6 +14,9 @@ interface UseAiSessionProps {
 
 export function useAiSession({ deleteSession, updateSessionTitle }: UseAiSessionProps) {
   const navigate = useNavigate();
+  // セッション操作(新規 / 削除 / タイトル変更)の結果をトーストで知らせる。
+  // 他画面(教材・ノート・プロフィール等)と同じ通知体験に揃える(FRESTYLE-151)。
+  const { showToast } = useToast();
   const [currentSessionId, setCurrentSessionId] = useState<number | null>(null);
   const [deleteModal, setDeleteModal] = useState<DeleteModal>({ isOpen: false, sessionId: null });
   const [editingSessionId, setEditingSessionId] = useState<number | null>(null);
@@ -21,7 +25,8 @@ export function useAiSession({ deleteSession, updateSessionTitle }: UseAiSession
   const handleNewSession = useCallback(() => {
     setCurrentSessionId(null);
     navigate('/chat/ask-ai');
-  }, [navigate]);
+    showToast('success', '新しいチャットを開始しました');
+  }, [navigate, showToast]);
 
   const handleSelectSession = useCallback((sessionId: number) => {
     setCurrentSessionId(sessionId);
@@ -38,12 +43,17 @@ export function useAiSession({ deleteSession, updateSessionTitle }: UseAiSession
 
     if (sessionId) {
       const success = await deleteSession(sessionId);
-      if (success && currentSessionId === sessionId) {
-        setCurrentSessionId(null);
-        navigate('/chat/ask-ai');
+      if (success) {
+        showToast('success', 'セッションを削除しました');
+        if (currentSessionId === sessionId) {
+          setCurrentSessionId(null);
+          navigate('/chat/ask-ai');
+        }
+      } else {
+        showToast('error', 'セッションの削除に失敗しました');
       }
     }
-  }, [deleteModal.sessionId, deleteSession, currentSessionId, navigate]);
+  }, [deleteModal.sessionId, deleteSession, currentSessionId, navigate, showToast]);
 
   const cancelDeleteSession = useCallback(() => {
     setDeleteModal({ isOpen: false, sessionId: null });
@@ -62,8 +72,11 @@ export function useAiSession({ deleteSession, updateSessionTitle }: UseAiSession
     const success = await updateSessionTitle(sessionId, { title: editingTitle.trim() });
     if (success) {
       setEditingSessionId(null);
+      showToast('success', 'タイトルを変更しました');
+    } else {
+      showToast('error', 'タイトルの変更に失敗しました');
     }
-  }, [editingTitle, updateSessionTitle]);
+  }, [editingTitle, updateSessionTitle, showToast]);
 
   const handleCancelEditTitle = useCallback(() => {
     setEditingSessionId(null);


### PR DESCRIPTION
## 概要

AI チャット画面でセッションを削除したり新しいチャットを開始しても、他画面では出るトースト通知（上から落ちてバウンドする `animate-toast-drop`）が表示されなかった。同じ通知体験に揃える。

## 原因

トーストの土台（`ToastProvider` / `ToastContainer`）は `App.tsx` で全画面共通に描画されているが、AI チャットのセッション操作を担う `useAiSession` が `showToast` を一度も呼んでいなかった（教材・ノート・プロフィール等は呼んでいる）。

## 変更内容

- `useAiSession.ts` に `useToast` を導入し、セッション操作の結果を通知：
  - 新しいチャット開始 → success「新しいチャットを開始しました」
  - セッション削除 → 成功 success「セッションを削除しました」／失敗 error「セッションの削除に失敗しました」
  - タイトル変更 → 成功 success「タイトルを変更しました」／失敗 error「タイトルの変更に失敗しました」
- 削除失敗時は選択中セッションを維持する（従来は成功時のみリセットしていた挙動を明示化）。

## テスト

- `useAiSession.test.ts`: `useToast` をモックし、新規 / 削除成功 / 削除失敗 / タイトル変更成功で `showToast` が期待の引数で呼ばれることを検証（**削除失敗ケースを新規追加**）。
- `useAskAi.test.tsx`: `useAiSession` がトーストを使うため wrapper に `ToastProvider` を追加。
- `tsc --noEmit` / `eslint --max-warnings 0`: 成功
- `vitest run --coverage`（全体）: 163 ファイル / **1340 件緑**、閾値クリア
- `npm run build`: 成功

## 関連チケット

FRESTYLE-151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AIチャットの新規開始、セッション削除、タイトル変更の結果をトースト通知で表示するようになりました。
  * セッション操作の成功・失敗に応じて、適切なメッセージを表示します。
  * セッション削除に失敗した場合も、現在のセッションを維持します。

* **テスト**
  * 各操作時のトースト通知とセッション状態を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->