### PR TITLE
fix: コード学習の言語カードのボタン文言を「問題を見る」に統一 (FRESTYLE-161)

### DIFF
--- a/frontend/src/pages/exercise-languages/__tests__/ExerciseLanguageSelectPage.test.tsx
+++ b/frontend/src/pages/exercise-languages/__tests__/ExerciseLanguageSelectPage.test.tsx
@@ -36,7 +36,7 @@ describe('ExerciseLanguageSelectPage (FRESTYLE-152)', () => {
     expect(screen.getByText('10 問')).toBeInTheDocument();
   });
 
-  it('進捗に応じてボタン文言が変わる（未着手 / 途中 / 完了）', async () => {
+  it('ボタン文言は進捗によらず「問題を見る」で統一する（遷移先が同じため）', async () => {
     mockSummary.mockResolvedValue([
       { language: 'php', total: 20, solved: 0 },
       { language: 'go', total: 10, solved: 4 },
@@ -44,9 +44,11 @@ describe('ExerciseLanguageSelectPage (FRESTYLE-152)', () => {
     ]);
     renderPage();
 
-    await waitFor(() => expect(screen.getByText('はじめる')).toBeInTheDocument());
-    expect(screen.getByText('続きからはじめる')).toBeInTheDocument();
-    expect(screen.getByText('もう一度解く')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText('問題を見る')).toHaveLength(3));
+    // 「続きからはじめる」は未解答の問題から再開すると読めるが、実際は一覧に戻るだけだった。
+    expect(screen.queryByText('続きからはじめる')).not.toBeInTheDocument();
+    expect(screen.queryByText('もう一度解く')).not.toBeInTheDocument();
+    // 進捗の伝達は進捗バーと「すべて完了」バッジが担う。
     expect(screen.getByText('すべて完了')).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/exercise-languages/ui/ExerciseLanguageSelectPage.tsx
+++ b/frontend/src/pages/exercise-languages/ui/ExerciseLanguageSelectPage.tsx
@@ -50,8 +50,6 @@ function LanguageCard({ card }: { card: ExerciseLanguageCard }) {
   const { language, label, total, solved } = card;
   const percent = total > 0 ? Math.round((solved / total) * 100) : 0;
   const completed = total > 0 && solved >= total;
-  // 1 問でも解いていれば「続きから」。完了済みは「もう一度解く」。
-  const actionLabel = completed ? 'もう一度解く' : solved > 0 ? '続きからはじめる' : 'はじめる';
 
   return (
     <Link
@@ -96,8 +94,11 @@ function LanguageCard({ card }: { card: ExerciseLanguageCard }) {
         </div>
       </div>
 
+      {/* 遷移先はどの状態でも同じ「その言語の問題一覧」なので、ラベルも状態で出し分けない。
+          「続きからはじめる」は未解答の問題から再開すると読めてしまうが実際は一覧に戻るだけで、
+          文言が挙動を偽っていた（FRESTYLE-161）。進捗は上の進捗バーと「すべて完了」で示す。 */}
       <span className="mt-auto inline-flex items-center justify-center rounded-lg border border-surface-3 px-4 py-2 text-sm font-medium text-[var(--color-text-primary)] transition-colors group-hover:border-taupe-500/50 group-hover:bg-surface-1">
-        {actionLabel}
+        問題を見る
       </span>
     </Link>
   );


### PR DESCRIPTION
## 概要

`/code-editor`（コード学習の言語選択画面）の言語カードのボタン文言を「問題を見る」に統一します。

進捗に応じて **「はじめる」「続きからはじめる」「もう一度解く」** の 3 通りに出し分けていましたが、**どの状態でも遷移先は同じ「その言語の問題一覧」** で、文言が挙動を偽っていました。

とくに「続きからはじめる」は「前回の続き（未解答の問題）から再開する」と読めますが、実際には問題一覧に戻るだけです。

カード全体が問題一覧への `<Link>` で、ボタンに見える要素はその中の `<span>` にすぎないため、3 通りの文言はすべて同じ遷移になっていました。

## 変更内容

- 状態による出し分け（`actionLabel`）を削除し、文言を **「問題を見る」** に統一
- なぜ出し分けないのかを WHY コメントとして残す（将来また出し分けたくなったときのため）
- 進捗の伝達は **進捗バー** と **「すべて完了」バッジ** が引き続き担うので据え置き

なお「未解答の最初の問題へ直接飛ぶ」レジューム機能そのものは本 PR のスコープ外です（実装するなら別途）。

## テスト

既存テスト「進捗に応じてボタン文言が変わる（未着手 / 途中 / 完了）」を、統一されたことの検証に置き換えました。

- 3 枚のカードすべてが「問題を見る」になること
- 「続きからはじめる」「もう一度解く」が **存在しない** こと
- 「すべて完了」バッジは **残る** こと

検証結果:

- `tsc --noEmit`: 成功
- `eslint src --max-warnings 0`: 成功
- `vitest run --coverage`: **164 ファイル / 1346 件緑**（Stmts 86.78% / Branch 81.23% / Funcs 84.27% / Lines 88.47%）
- `npm run build`: 成功
- `playwright test --config=playwright.local.config.ts`: **12 件緑**（演習フローはカードの `aria-label` でリンクを取得しているためボタン文言に依存しません）

## 関連チケット

FRESTYLE-161