### PR TITLE
fix: axios を 1.18.1 に上げて HIGH 脆弱性 GHSA-gcfj-64vw-6mp9 を解消 (FRESTYLE-169)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "@monaco-editor/react": "^4.7.0",
         "@reduxjs/toolkit": "^2.9.0",
         "@tanstack/react-query-devtools": "^5.101.0",
-        "axios": "^1.16.1",
+        "axios": "^1.18.1",
         "github-slugger": "^2.0.0",
         "lodash": "^4.18.1",
         "markdown-it-container": "^4.0.0",
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@reduxjs/toolkit": "^2.9.0",
     "@tanstack/react-query-devtools": "^5.101.0",
-    "axios": "^1.16.1",
+    "axios": "^1.18.1",
     "github-slugger": "^2.0.0",
     "lodash": "^4.18.1",
     "markdown-it-container": "^4.0.0",


### PR DESCRIPTION
## 概要

frontend の `axios` に新規公表された HIGH 脆弱性 **GHSA-gcfj-64vw-6mp9**（Node の HTTP adapter が継承したプロキシを誤用しうる）を、trivy が検出して CI が赤になりました。`axios ^1.16.1` → `^1.18.1` に上げて解消します。

## なぜ hotfix か

これは **main を含むすべての open PR をブロック**します。trivy の脆弱性 DB 更新で既存の `axios@1.16.1` が新たに引っかかるようになったもので、特定の PR の変更が原因ではありません。CI の必須チェック（trivy, `--exit-code 1`）が全 PR で赤になるため、先行して単独で入れます（FSD 移行の PR #2125 はこれを取り込んでから通します）。

## 変更内容

- `frontend/package.json`: `axios ^1.16.1` → `^1.18.1`
- `frontend/package-lock.json`: 追従

破壊的変更はありません（axios 1.x 内のマイナーアップグレード、API 互換）。

## テスト

- `tsc --noEmit`: 成功
- `vitest run`: **151 ファイル / 1184 件 合格**
- `npm run build`: 成功
- `trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed`: **0 件**（ローカル確認済み）

## 関連チケット

FRESTYLE-169