### PR TITLE
feat: コース一覧を「学習領域を選ぶ → その領域のコース一覧」の2段構成に作り直す (FRESTYLE-177)

### DIFF
--- a/frontend/e2e/local/authenticated.spec.ts
+++ b/frontend/e2e/local/authenticated.spec.ts
@@ -67,15 +67,21 @@ test.describe('認証ガード', () => {
 });
 
 test.describe('主要画面（認証済み）', () => {
-  test('コース一覧でモックしたコースが描画される', async ({ page }) => {
+  test('コース一覧でモックしたコースの学習領域カードが描画される', async ({ page }) => {
+    // /courses は「学習領域の選択カード」になった(FRESTYLE-177)。
+    // モックコースのカテゴリ(database)の領域カードが出ることを確認する。
     const course = {
       id: 1,
       companyId: 1,
       createdByUserId: 1,
       title: 'E2E モックコース',
       description: 'Playwright によるモックコース',
+      category: 'database',
+      language: 'postgresql',
       sortOrder: 10,
       isPublished: true,
+      materialCount: 0,
+      completedCount: 0,
       createdAt: '2026-01-01T00:00:00Z',
       updatedAt: '2026-01-01T00:00:00Z',
     };
@@ -84,7 +90,7 @@ test.describe('主要画面（認証済み）', () => {
     await page.goto('/courses');
 
     await expect(page).not.toHaveURL(/\/login/);
-    await expect(page.getByText('E2E モックコース')).toBeVisible();
+    await expect(page.getByRole('link', { name: /データベース のコース一覧へ/ })).toBeVisible();
   });
 });
 

--- a/frontend/e2e/local/user-flows.spec.ts
+++ b/frontend/e2e/local/user-flows.spec.ts
@@ -40,8 +40,12 @@ const course = {
   createdByUserId: 1,
   title: 'E2E 学習コース',
   description: 'Playwright によるフロー検証用コース',
+  category: 'database',
+  language: 'postgresql',
   sortOrder: 10,
   isPublished: true,
+  materialCount: 1,
+  completedCount: 0,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
 };
@@ -88,7 +92,10 @@ test.describe('コース学習フロー', () => {
       '**/api/v2/teaching-materials/11': material,
     });
 
+    // コースは「学習領域の選択 → その領域の一覧 → 詳細」の 3 段(FRESTYLE-177)。
     await page.goto('/courses');
+    await page.getByRole('link', { name: /データベース のコース一覧へ/ }).click();
+    await expect(page).toHaveURL(/\/courses\/category\/database/);
     await expect(page.getByText('E2E 学習コース')).toBeVisible();
 
     // カード（div の onClick で navigate）を開く。

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -40,6 +40,7 @@ const AdminAuditLogPage = lazyWithReload(() => import('@/pages/admin-audit-log')
 const ExerciseLanguageSelectPage = lazyWithReload(() => import('@/pages/exercise-languages').then((m) => ({ default: m.ExerciseLanguageSelectPage })), 'ExerciseLanguageSelectPage');
 const ExerciseListPage = lazyWithReload(() => import('@/pages/exercises').then((m) => ({ default: m.ExerciseListPage })), 'ExerciseListPage');
 const ExerciseDetailPage = lazyWithReload(() => import('@/pages/exercise-detail').then((m) => ({ default: m.ExerciseDetailPage })), 'ExerciseDetailPage');
+const CourseCategorySelectPage = lazyWithReload(() => import('@/pages/courses').then((m) => ({ default: m.CourseCategorySelectPage })), 'CourseCategorySelectPage');
 const CoursesListPage = lazyWithReload(() => import('@/pages/courses').then((m) => ({ default: m.CoursesListPage })), 'CoursesListPage');
 const CourseDetailPage = lazyWithReload(() => import('@/pages/course-detail').then((m) => ({ default: m.CourseDetailPage })), 'CourseDetailPage');
 const MarkdownSyntaxHelpPage = lazyWithReload(() => import('@/pages/markdown-syntax-help').then((m) => ({ default: m.MarkdownSyntaxHelpPage })), 'MarkdownSyntaxHelpPage');
@@ -123,10 +124,13 @@ export default function App() {
         <Route path="/code-editor" element={<ExerciseLanguageSelectPage />} />
         <Route path="/code-editor/lang/:language" element={<ExerciseListPage />} />
         <Route path="/code-editor/:slug" element={<ExerciseDetailPage />} />
-        <Route path="/courses" element={<CoursesListPage />} />
+        {/* コースは「学習領域の選択 → その領域の一覧 → 詳細」の 3 段(FRESTYLE-177)。
+            /category/:category は 2 セグメントなので 1 セグメントの :id とは衝突しない。 */}
+        <Route path="/courses" element={<CourseCategorySelectPage />} />
+        <Route path="/courses/category/:category" element={<CoursesListPage />} />
         <Route path="/courses/:id" element={<CourseDetailPage />} />
         {/* 旧 /teaching-materials へのアクセスは /courses に redirect */}
-        <Route path="/teaching-materials" element={<CoursesListPage />} />
+        <Route path="/teaching-materials" element={<CourseCategorySelectPage />} />
         {/* Admin 専用（コンポーネント側で isAdmin チェック → 非 admin は / にリダイレクト） */}
         <Route path="/admin/dashboard" element={<AdminDashboardPage />} />
         <Route path="/admin/companies" element={<AdminCompaniesPage />} />

--- a/frontend/src/entities/course/config/courseCategories.ts
+++ b/frontend/src/entities/course/config/courseCategories.ts
@@ -15,6 +15,8 @@ export interface CourseCategoryDef {
   badgeClass: string;
   /** カード左端の色帯（border-l-4 と併用） */
   barClass: string;
+  /** アイコンなどのアクセント色（text-* のみ）。領域選択カードのアイコン用（FRESTYLE-177）。 */
+  accentClass: string;
 }
 
 export const COURSE_CATEGORIES: CourseCategoryDef[] = [
@@ -23,48 +25,56 @@ export const COURSE_CATEGORIES: CourseCategoryDef[] = [
     label: '開発基礎',
     badgeClass: 'bg-amber-500/15 text-amber-700 border border-amber-500/30',
     barClass: 'border-l-amber-500',
+    accentClass: 'text-amber-600',
   },
   {
     key: 'backend',
     label: 'バックエンド開発',
     badgeClass: 'bg-blue-500/15 text-blue-700 border border-blue-500/30',
     barClass: 'border-l-blue-500',
+    accentClass: 'text-blue-600',
   },
   {
     key: 'architecture',
     label: '設計・アーキテクチャ',
     badgeClass: 'bg-violet-500/15 text-violet-700 border border-violet-500/30',
     barClass: 'border-l-violet-500',
+    accentClass: 'text-violet-600',
   },
   {
     key: 'database',
     label: 'データベース',
     badgeClass: 'bg-emerald-500/15 text-emerald-700 border border-emerald-500/30',
     barClass: 'border-l-emerald-500',
+    accentClass: 'text-emerald-600',
   },
   {
     key: 'infra',
     label: 'インフラ・クラウド',
     badgeClass: 'bg-orange-500/15 text-orange-700 border border-orange-500/30',
     barClass: 'border-l-orange-500',
+    accentClass: 'text-orange-600',
   },
   {
     key: 'security',
     label: 'セキュリティ',
     badgeClass: 'bg-rose-500/15 text-rose-700 border border-rose-500/30',
     barClass: 'border-l-rose-500',
+    accentClass: 'text-rose-600',
   },
   {
     key: 'product',
     label: 'プロダクト・仕様',
     badgeClass: 'bg-cyan-500/15 text-cyan-700 border border-cyan-500/30',
     barClass: 'border-l-cyan-500',
+    accentClass: 'text-cyan-600',
   },
   {
     key: 'design',
     label: 'デザインパターン',
     badgeClass: 'bg-pink-500/15 text-pink-700 border border-pink-500/30',
     barClass: 'border-l-pink-500',
+    accentClass: 'text-pink-600',
   },
 ];
 

--- a/frontend/src/pages/courses/__tests__/CourseCategorySelectPage.test.tsx
+++ b/frontend/src/pages/courses/__tests__/CourseCategorySelectPage.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import CourseCategorySelectPage from '../ui/CourseCategorySelectPage';
+import { ToastProvider } from '@/app/providers/ToastProvider';
+import authReducer from '@/entities/user/model/authSlice';
+import { CourseRepository } from '@/entities/course';
+import type { CourseWithProgress } from '@/entities/course';
+
+vi.mock('@/entities/course/api/courseRepository', () => ({
+  default: { list: vi.fn(), create: vi.fn(), update: vi.fn(), remove: vi.fn() },
+}));
+
+const mockList = vi.mocked(CourseRepository.list);
+
+function makeCourse(overrides: Partial<CourseWithProgress> = {}): CourseWithProgress {
+  return {
+    id: 1,
+    companyId: 10,
+    createdByUserId: 1,
+    title: 'コース',
+    description: '',
+    category: 'database',
+    language: '',
+    sortOrder: 100,
+    isPublished: true,
+    materialCount: 0,
+    completedCount: 0,
+    createdAt: '2026-07-01T00:00:00Z',
+    updatedAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderPage(role = 'trainee') {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: { auth: { role } as never },
+  });
+  return render(
+    <Provider store={store}>
+      <ToastProvider>
+        <MemoryRouter>
+          <CourseCategorySelectPage />
+        </MemoryRouter>
+      </ToastProvider>
+    </Provider>,
+  );
+}
+
+describe('CourseCategorySelectPage (FRESTYLE-177)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('コースがある領域だけカードを出し、コース数とリンクを表示する', async () => {
+    mockList.mockResolvedValue([
+      makeCourse({ id: 1, category: 'database' }),
+      makeCourse({ id: 2, category: 'database' }),
+      makeCourse({ id: 3, category: 'infra' }),
+    ]);
+    renderPage('trainee');
+
+    const dbLink = await screen.findByRole('link', { name: /データベース のコース一覧へ/ });
+    expect(dbLink).toHaveAttribute('href', '/courses/category/database');
+    expect(dbLink).toHaveTextContent('2 コース');
+
+    const infraLink = screen.getByRole('link', { name: /インフラ・クラウド のコース一覧へ/ });
+    expect(infraLink).toHaveAttribute('href', '/courses/category/infra');
+
+    // コースが無い領域（セキュリティ等）はカードを出さない。
+    expect(screen.queryByRole('link', { name: /セキュリティ のコース一覧へ/ })).not.toBeInTheDocument();
+  });
+
+  it('未分類コースは uncategorized カードに集約する', async () => {
+    mockList.mockResolvedValue([makeCourse({ id: 1, category: '' })]);
+    renderPage('trainee');
+    const link = await screen.findByRole('link', { name: /未分類 のコース一覧へ/ });
+    expect(link).toHaveAttribute('href', '/courses/category/uncategorized');
+  });
+
+  it('受講者にはその領域の学習進捗（章単位の集計）を出す', async () => {
+    mockList.mockResolvedValue([
+      makeCourse({ id: 1, category: 'database', materialCount: 4, completedCount: 1 }),
+      makeCourse({ id: 2, category: 'database', materialCount: 4, completedCount: 2 }),
+    ]);
+    renderPage('trainee');
+    await screen.findByRole('link', { name: /データベース のコース一覧へ/ });
+    // 合計 3/8 章完了
+    expect(screen.getByText('3/8 章完了')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: /データベース の進捗/ })).toHaveAttribute(
+      'aria-valuenow',
+      '38',
+    );
+  });
+
+  it('管理ロールには進捗を出さない（進捗は受講者個人のもの）', async () => {
+    mockList.mockResolvedValue([
+      makeCourse({ id: 1, category: 'database', materialCount: 4, completedCount: 2 }),
+    ]);
+    renderPage('company_admin');
+    await screen.findByRole('link', { name: /データベース のコース一覧へ/ });
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('管理ロールは「新しいコース」ボタンから作成フォームを開ける', async () => {
+    mockList.mockResolvedValue([makeCourse({ id: 1, category: 'database' })]);
+    renderPage('company_admin');
+    const btn = await screen.findByRole('button', { name: /新しいコース/ });
+    fireEvent.click(btn);
+    expect(screen.getByRole('combobox', { name: /カテゴリ（学習領域）/ })).toBeInTheDocument();
+  });
+
+  it('trainee には「新しいコース」ボタンを出さない', async () => {
+    mockList.mockResolvedValue([makeCourse({ id: 1, category: 'database' })]);
+    renderPage('trainee');
+    await screen.findByRole('link', { name: /データベース のコース一覧へ/ });
+    expect(screen.queryByRole('button', { name: /新しいコース/ })).not.toBeInTheDocument();
+  });
+
+  it('コースが無いときは EmptyState を出す', async () => {
+    mockList.mockResolvedValue([]);
+    renderPage('trainee');
+    await waitFor(() => expect(screen.getByText('コースがありません')).toBeInTheDocument());
+  });
+
+  it('API が null を返してもクラッシュせず EmptyState を出す (FRESTYLE-70)', async () => {
+    mockList.mockResolvedValue(null as unknown as CourseWithProgress[]);
+    renderPage('trainee');
+    await waitFor(() => expect(screen.getByText('コースがありません')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/courses/__tests__/CoursesListPage.test.tsx
+++ b/frontend/src/pages/courses/__tests__/CoursesListPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import CoursesListPage from '../ui/CoursesListPage';
 import { ToastProvider } from '@/app/providers/ToastProvider';
 import authReducer from '@/entities/user/model/authSlice';
@@ -41,125 +41,74 @@ function makeCourse(overrides: Partial<CourseWithProgress> = {}): CourseWithProg
   };
 }
 
-function renderPage(role = 'trainee') {
+// CoursesListPage は /courses/category/:category にマウントされる。
+// slug の領域だけに絞って表示するので、テストは対象コースと同じ slug で描画する。
+function renderPage(role = 'trainee', slug = 'database') {
   const store = configureStore({
     reducer: { auth: authReducer },
-    preloadedState: {
-      auth: { role } as never,
-    },
+    preloadedState: { auth: { role } as never },
   });
   return render(
     <Provider store={store}>
       <ToastProvider>
-        <MemoryRouter>
-          <CoursesListPage />
+        <MemoryRouter initialEntries={[`/courses/category/${slug}`]}>
+          <Routes>
+            <Route path="/courses/category/:category" element={<CoursesListPage />} />
+          </Routes>
         </MemoryRouter>
       </ToastProvider>
     </Provider>,
   );
 }
 
-describe('CoursesListPage カテゴリ色分け (FRESTYLE-67)', () => {
+describe('CoursesListPage 領域スコープ (FRESTYLE-177)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('カテゴリ付きコースはセクション見出し(バッジ + 件数)の下に表示される', async () => {
+  it('URL の領域名を見出しに出し、その領域のコースを表示する', async () => {
     mockList.mockResolvedValue([makeCourse({ category: 'database' })]);
-    renderPage();
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
-    // セクション見出し = 「データベース 1 件」の折りたたみボタン
-    expect(screen.getByRole('button', { name: /データベース\s*1 件/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'データベース', level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /コース一覧に戻る/ })).toHaveAttribute('href', '/courses');
   });
 
-  it('未分類コースは「未分類」セクションに入り、カテゴリ名は表示されない', async () => {
-    mockList.mockResolvedValue([makeCourse({ category: '' })]);
-    renderPage();
-    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: /未分類\s*1 件/ })).toBeInTheDocument();
-    for (const c of COURSE_CATEGORIES) {
-      expect(screen.queryByText(c.label)).not.toBeInTheDocument();
-    }
-  });
-
-  it('セクション見出しクリックで閉じ開きできる', async () => {
-    mockList.mockResolvedValue([makeCourse({ category: 'database' })]);
-    renderPage();
-    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
-    const header = screen.getByRole('button', { name: /データベース\s*1 件/ });
-    expect(header).toHaveAttribute('aria-expanded', 'true');
-
-    fireEvent.click(header);
-    expect(header).toHaveAttribute('aria-expanded', 'false');
-    expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument();
-
-    fireEvent.click(header);
-    expect(header).toHaveAttribute('aria-expanded', 'true');
-    expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument();
-  });
-
-  it('カテゴリチップで絞り込み・再クリックで解除できる', async () => {
+  it('別領域のコースは表示しない（URL の領域だけに絞る）', async () => {
     mockList.mockResolvedValue([
       makeCourse({ id: 1, title: 'PostgreSQL 徹底入門', category: 'database' }),
       makeCourse({ id: 2, title: 'Terraform 入門', category: 'infra' }),
     ]);
-    renderPage();
-    await waitFor(() => expect(screen.getByText('Terraform 入門')).toBeInTheDocument());
-
-    const chip = screen.getByRole('button', { name: 'データベース' });
-    fireEvent.click(chip);
-    expect(chip).toHaveAttribute('aria-pressed', 'true');
-    expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument();
+    renderPage('trainee', 'database');
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     expect(screen.queryByText('Terraform 入門')).not.toBeInTheDocument();
-
-    fireEvent.click(chip);
-    expect(chip).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByText('Terraform 入門')).toBeInTheDocument();
   });
 
-  it('絞り込みで 0 件になったら該当なしの EmptyState を出す', async () => {
+  it('uncategorized は「未分類」見出しで未分類コースを表示する', async () => {
+    mockList.mockResolvedValue([makeCourse({ category: '' })]);
+    renderPage('trainee', 'uncategorized');
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
+    expect(screen.getByRole('heading', { name: '未分類', level: 1 })).toBeInTheDocument();
+  });
+
+  it('領域内検索でタイトルを絞り込める', async () => {
     mockList.mockResolvedValue([
       makeCourse({ id: 1, title: 'PostgreSQL 徹底入門', category: 'database' }),
-      makeCourse({ id: 2, title: 'Terraform 入門', category: 'infra' }),
+      makeCourse({ id: 2, title: 'MySQL 入門', category: 'database' }),
     ]);
-    renderPage();
-    await waitFor(() => expect(screen.getByText('Terraform 入門')).toBeInTheDocument());
+    renderPage('trainee', 'database');
+    await waitFor(() => expect(screen.getByText('MySQL 入門')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('コースを検索'), { target: { value: 'mysql' } });
+    expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument();
+    expect(screen.getByText('MySQL 入門')).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: 'データベース' }));
+  it('検索で 0 件になったら該当なしの EmptyState を出す', async () => {
+    mockList.mockResolvedValue([makeCourse({ id: 1, title: 'PostgreSQL 徹底入門', category: 'database' })]);
+    renderPage('trainee', 'database');
+    await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     fireEvent.change(screen.getByLabelText('コースを検索'), { target: { value: 'terraform' } });
     expect(screen.getByText('該当するコースがありません')).toBeInTheDocument();
-  });
-
-  it('管理者の作成フォームにカテゴリ選択（未分類 + 全カテゴリ）が表示される', async () => {
-    mockList.mockResolvedValue([]);
-    renderPage('company_admin');
-    // 空一覧時はヘッダーと EmptyState の 2 箇所に「新しいコース」が出るため getAllByRole で扱う
-    await waitFor(() =>
-      expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0),
-    );
-    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
-    const select = screen.getByRole('combobox', { name: /カテゴリ（学習領域）/ });
-    expect(select).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: '未分類' })).toBeInTheDocument();
-    for (const c of COURSE_CATEGORIES) {
-      expect(screen.getByRole('option', { name: c.label })).toBeInTheDocument();
-    }
-  });
-
-  it('管理者の作成フォームに言語選択（未設定 + 言語一覧）が表示される', async () => {
-    mockList.mockResolvedValue([]);
-    renderPage('company_admin');
-    await waitFor(() =>
-      expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0),
-    );
-    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
-    expect(screen.getByRole('combobox', { name: /主に扱う言語・技術/ })).toBeInTheDocument();
-    expect(
-      screen.getByRole('option', { name: '未設定（言語が主題でないコース）' }),
-    ).toBeInTheDocument();
-    for (const l of COURSE_LANGUAGES) {
-      expect(screen.getByRole('option', { name: l.label })).toBeInTheDocument();
-    }
   });
 });
 
@@ -170,40 +119,64 @@ describe('CoursesListPage CRUD フロー', () => {
 
   it('trainee には「新しいコース」ボタンを表示しない', async () => {
     mockList.mockResolvedValue([makeCourse()]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: /新しいコース/ })).not.toBeInTheDocument();
   });
 
   it('取得失敗時はエラーメッセージを表示する', async () => {
     mockList.mockRejectedValue(new Error('network'));
-    renderPage();
-    await waitFor(() =>
-      expect(screen.getByText('コースの取得に失敗しました')).toBeInTheDocument(),
-    );
+    renderPage('trainee', 'database');
+    await waitFor(() => expect(screen.getByText('コースの取得に失敗しました')).toBeInTheDocument());
   });
 
-  it('検索でタイトルを絞り込める', async () => {
-    mockList.mockResolvedValue([
-      makeCourse({ id: 1, title: 'PostgreSQL 徹底入門' }),
-      makeCourse({ id: 2, title: 'Terraform 入門', category: 'infra' }),
-    ]);
-    renderPage();
-    await waitFor(() => expect(screen.getByText('Terraform 入門')).toBeInTheDocument());
-    fireEvent.change(screen.getByLabelText('コースを検索'), { target: { value: 'terraform' } });
-    expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument();
-    expect(screen.getByText('Terraform 入門')).toBeInTheDocument();
+  it('管理者の作成フォームにカテゴリ選択（未分類 + 全カテゴリ）が表示される', async () => {
+    mockList.mockResolvedValue([]);
+    renderPage('company_admin', 'database');
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0),
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
+    expect(screen.getByRole('combobox', { name: /カテゴリ（学習領域）/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '未分類' })).toBeInTheDocument();
+    for (const c of COURSE_CATEGORIES) {
+      expect(screen.getByRole('option', { name: c.label })).toBeInTheDocument();
+    }
+  });
+
+  it('管理者の作成フォームは現在の領域を初期選択にする', async () => {
+    mockList.mockResolvedValue([]);
+    renderPage('company_admin', 'security');
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0),
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
+    const select = screen.getByRole('combobox', { name: /カテゴリ（学習領域）/ }) as HTMLSelectElement;
+    expect(select.value).toBe('security');
+  });
+
+  it('管理者の作成フォームに言語選択（未設定 + 言語一覧）が表示される', async () => {
+    mockList.mockResolvedValue([]);
+    renderPage('company_admin', 'database');
+    await waitFor(() =>
+      expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0),
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
+    expect(screen.getByRole('combobox', { name: /主に扱う言語・技術/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '未設定（言語が主題でないコース）' })).toBeInTheDocument();
+    for (const l of COURSE_LANGUAGES) {
+      expect(screen.getByRole('option', { name: l.label })).toBeInTheDocument();
+    }
   });
 
   it('作成フォームの送信でカテゴリ込みの payload が送られる', async () => {
     const mockCreate = vi.mocked(CourseRepository.create);
     mockList.mockResolvedValue([]);
     mockCreate.mockResolvedValue(makeCourse({ id: 99, title: '新コース', category: 'security' }));
-    renderPage('company_admin');
+    renderPage('company_admin', 'database');
     await waitFor(() => expect(screen.getAllByRole('button', { name: /新しいコース/ }).length).toBeGreaterThan(0));
     fireEvent.click(screen.getAllByRole('button', { name: /新しいコース/ })[0]);
 
-    // モーダル内のタイトル入力 = 検索ボックス以外の <input type="text">。
     const titleInput = screen
       .getAllByRole('textbox')
       .find((el) => el.tagName === 'INPUT' && el.getAttribute('aria-label') !== 'コースを検索');
@@ -227,7 +200,7 @@ describe('CoursesListPage CRUD フロー', () => {
     const mockUpdate = vi.mocked(CourseRepository.update);
     mockList.mockResolvedValue([makeCourse({ id: 5, category: 'database', language: 'postgresql' })]);
     mockUpdate.mockResolvedValue(makeCourse({ id: 5, category: 'infra', language: 'terraform' }));
-    renderPage('company_admin');
+    renderPage('company_admin', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'コースを編集' }));
@@ -250,7 +223,7 @@ describe('CoursesListPage CRUD フロー', () => {
     const mockRemove = vi.mocked(CourseRepository.remove);
     mockList.mockResolvedValue([makeCourse({ id: 7 })]);
     mockRemove.mockResolvedValue(undefined);
-    renderPage('company_admin');
+    renderPage('company_admin', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'コースを削除' }));
@@ -258,10 +231,7 @@ describe('CoursesListPage CRUD フロー', () => {
     fireEvent.click(screen.getByRole('button', { name: '削除' }));
 
     await waitFor(() => expect(mockRemove).toHaveBeenCalledWith(7));
-    // 削除後は一覧から消える
-    await waitFor(() =>
-      expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.queryByText('PostgreSQL 徹底入門')).not.toBeInTheDocument());
   });
 });
 
@@ -283,18 +253,6 @@ describe('findCourseCategory', () => {
   });
 });
 
-describe('API が null を返す場合の防御 (FRESTYLE-70)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('コース一覧 API が null でもクラッシュせず EmptyState を表示する', async () => {
-    mockList.mockResolvedValue(null as unknown as CourseWithProgress[]);
-    renderPage();
-    await waitFor(() => expect(screen.getByText('コースがありません')).toBeInTheDocument());
-  });
-});
-
 describe('CoursesListPage カード進捗表示 (FRESTYLE-98)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -302,51 +260,48 @@ describe('CoursesListPage カード進捗表示 (FRESTYLE-98)', () => {
 
   it('受講者のカードに完了章数/全章数・残り章数と進捗バーが表示される', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 8, completedCount: 2 })]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('2/8（25%・残り 6 章）')).toBeInTheDocument());
-    expect(screen.getByRole('progressbar', { name: '学習の進捗' })).toHaveAttribute(
-      'aria-valuenow',
-      '25',
-    );
+    expect(screen.getByRole('progressbar', { name: '学習の進捗' })).toHaveAttribute('aria-valuenow', '25');
   });
 
   it('完了記録が無いコースは 0/N と表示される', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 8, completedCount: 0 })]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('0/8（0%・残り 8 章）')).toBeInTheDocument());
   });
 
   it('管理ロールには進捗バーを表示しない', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 8, completedCount: 3 })]);
-    renderPage('company_admin');
+    renderPage('company_admin', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('章が 0 件のコースには進捗バーを出さない', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 0 })]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('全章完了は「すべて完了」+ 完了バッジ + 完了デザインで表示される (FRESTYLE-114)', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 5, completedCount: 5 })]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('すべて完了（5 章）')).toBeInTheDocument());
     expect(screen.getByText('完了')).toBeInTheDocument();
   });
 
   it('未完了のコースには完了バッジを出さない', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 5, completedCount: 4 })]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('4/5（80%・残り 1 章）')).toBeInTheDocument());
     expect(screen.queryByText('完了')).not.toBeInTheDocument();
   });
 
   it('管理ロールには完了バッジを出さない（進捗は受講者個人のもの）', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, materialCount: 5, completedCount: 5 })]);
-    renderPage('company_admin');
+    renderPage('company_admin', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     expect(screen.queryByText('完了')).not.toBeInTheDocument();
   });
@@ -358,15 +313,15 @@ describe('CoursesListPage 言語バッジ (FRESTYLE-114)', () => {
   });
 
   it('language が設定されたコースは言語バッジを表示する', async () => {
-    mockList.mockResolvedValue([makeCourse({ id: 1, language: 'go', title: 'Go 言語徹底攻略' })]);
-    renderPage('trainee');
+    mockList.mockResolvedValue([makeCourse({ id: 1, language: 'go', title: 'Go 言語徹底攻略', category: 'backend' })]);
+    renderPage('trainee', 'backend');
     await waitFor(() => expect(screen.getByText('Go 言語徹底攻略')).toBeInTheDocument());
     expect(screen.getByText('Go')).toBeInTheDocument();
   });
 
   it('language が空のコースはバッジを出さない', async () => {
     mockList.mockResolvedValue([makeCourse({ id: 1, language: '' })]);
-    renderPage('trainee');
+    renderPage('trainee', 'database');
     await waitFor(() => expect(screen.getByText('PostgreSQL 徹底入門')).toBeInTheDocument());
     expect(screen.queryByText('Go')).not.toBeInTheDocument();
   });

--- a/frontend/src/pages/courses/index.ts
+++ b/frontend/src/pages/courses/index.ts
@@ -1,1 +1,2 @@
+export { default as CourseCategorySelectPage } from './ui/CourseCategorySelectPage';
 export { default as CoursesListPage } from './ui/CoursesListPage';

--- a/frontend/src/pages/courses/model/categorySlug.ts
+++ b/frontend/src/pages/courses/model/categorySlug.ts
@@ -1,0 +1,15 @@
+import { findCourseCategory } from '@/entities/course';
+
+/**
+ * コース領域の URL slug と内部 key の相互変換（FRESTYLE-177）。
+ *
+ * 選択画面（CourseCategorySelectPage）と領域一覧（CoursesListPage）で共有する。
+ */
+
+/** URL で未分類を表す予約語。内部 key の ''（空）はパスに使えないため。 */
+export const UNCATEGORIZED_SLUG = 'uncategorized';
+
+/** 未分類('')や未知のカテゴリ値を未分類バケットの key('') に正規化する。 */
+export function normalizeCategoryKey(category: string): string {
+  return findCourseCategory(category) ? category : '';
+}

--- a/frontend/src/pages/courses/ui/CategoryIcon.tsx
+++ b/frontend/src/pages/courses/ui/CategoryIcon.tsx
@@ -1,0 +1,41 @@
+import {
+  CommandLineIcon,
+  ServerStackIcon,
+  CubeTransparentIcon,
+  CircleStackIcon,
+  CloudIcon,
+  ShieldCheckIcon,
+  ClipboardDocumentListIcon,
+  PuzzlePieceIcon,
+  Squares2X2Icon,
+} from '@heroicons/react/24/outline';
+import type { ComponentType, SVGProps } from 'react';
+
+/**
+ * CategoryIcon — 学習領域の代表アイコン（FRESTYLE-177）。
+ *
+ * 領域選択カードで使う。カテゴリは単一技術に対応しないため Devicon のロゴではなく
+ * 概念を表す Heroicons を使い、色はカテゴリ色（accentClass）で塗る。
+ * 未知 / 未分類（key = ''）は汎用のタイルアイコンにフォールバックする。
+ */
+const ICONS: Record<string, ComponentType<SVGProps<SVGSVGElement>>> = {
+  'dev-basics': CommandLineIcon,
+  backend: ServerStackIcon,
+  architecture: CubeTransparentIcon,
+  database: CircleStackIcon,
+  infra: CloudIcon,
+  security: ShieldCheckIcon,
+  product: ClipboardDocumentListIcon,
+  design: PuzzlePieceIcon,
+};
+
+export default function CategoryIcon({
+  categoryKey,
+  className = 'w-6 h-6',
+}: {
+  categoryKey: string;
+  className?: string;
+}) {
+  const Icon = ICONS[categoryKey] ?? Squares2X2Icon;
+  return <Icon className={className} aria-hidden="true" />;
+}

--- a/frontend/src/pages/courses/ui/CourseCard.tsx
+++ b/frontend/src/pages/courses/ui/CourseCard.tsx
@@ -1,0 +1,109 @@
+import {
+  CheckCircleIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+import { CourseProgressBar } from '@/entities/course';
+import LanguageBadge from '@/shared/ui/LanguageBadge';
+import { findCourseCategory } from '@/entities/course';
+import type { CourseWithProgress } from '@/entities/course';
+
+/**
+ * CourseCard — コース 1 件のカード。領域一覧ページ（CoursesListPage）で使う。
+ *
+ * 「色＝学習領域」の連想（FRESTYLE-67）でカードは左の色帯で領域を表す。
+ * 受講者視点で全章完了したコースは緑アクセントで一目で分かるようにする（FRESTYLE-114）。
+ */
+export default function CourseCard({
+  course,
+  canManage,
+  onOpen,
+  onEdit,
+  onDelete,
+}: {
+  course: CourseWithProgress;
+  canManage: boolean;
+  onOpen: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const category = findCourseCategory(course.category);
+  const isCompleted =
+    !canManage && course.materialCount > 0 && course.completedCount >= course.materialCount;
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onOpen}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onOpen();
+        }
+      }}
+      className={`group border border-l-4 ${
+        category ? category.barClass : 'border-l-surface-3'
+      } ${
+        isCompleted ? 'bg-emerald-500/5 border-emerald-500/40' : 'bg-surface-1 border-surface-3'
+      } rounded-lg p-4 cursor-pointer hover:border-taupe-500/50 hover:shadow-md transition-all`}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <h2 className="text-base font-semibold text-[var(--color-text-primary)] truncate">
+            {course.title || '無題のコース'}
+          </h2>
+        </div>
+        {isCompleted && (
+          <span className="flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-600 text-white flex-shrink-0">
+            <CheckCircleIcon className="w-3.5 h-3.5" />
+            完了
+          </span>
+        )}
+        {canManage && (
+          <div className="opacity-0 group-hover:opacity-100 flex items-center gap-1 transition-opacity">
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
+              className="p-1 rounded hover:bg-surface-3 text-[var(--color-text-muted)]"
+              aria-label="コースを編集"
+            >
+              <PencilSquareIcon className="w-4 h-4" />
+            </button>
+            <button
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete();
+              }}
+              className="p-1 rounded hover:bg-red-900/30 text-[var(--color-text-muted)] hover:text-red-400"
+              aria-label="コースを削除"
+            >
+              <TrashIcon className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+      </div>
+      <p className="flex items-center gap-2 text-xs text-[var(--color-text-muted)] mb-3">
+        {course.language && <LanguageBadge language={course.language} />}
+        <span>
+          {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
+        </span>
+      </p>
+      <p className="text-sm text-[var(--color-text-secondary)] line-clamp-3 min-h-[3.6em]">
+        {course.description || 'コース説明が未設定です'}
+      </p>
+      {!canManage && course.materialCount > 0 && (
+        <div className="mt-3">
+          <CourseProgressBar completed={course.completedCount} total={course.materialCount} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/frontend/src/pages/courses/ui/CourseCategorySelectPage.tsx
+++ b/frontend/src/pages/courses/ui/CourseCategorySelectPage.tsx
@@ -5,20 +5,13 @@ import { useAppSelector } from '@/shared/lib/store';
 import Loading from '@/shared/ui/Loading';
 import EmptyState from '@/shared/ui/EmptyState';
 import FaviconIcon from '@/shared/ui/icons/FaviconIcon';
-import { COURSE_CATEGORIES, findCourseCategory } from '@/entities/course';
+import { COURSE_CATEGORIES } from '@/entities/course';
 import type { CourseCategoryDef, CourseWithProgress } from '@/entities/course';
 import { useToast } from '@/shared/lib/hooks/useToast';
 import { useCourses } from '../model/useCourses';
+import { UNCATEGORIZED_SLUG, normalizeCategoryKey } from '../model/categorySlug';
 import CategoryIcon from './CategoryIcon';
 import CourseFormModal from './CourseFormModal';
-
-/** 未分類('')や未知の値を未分類バケットの key('') に正規化する。 */
-function normalizeCategoryKey(category: string): string {
-  return findCourseCategory(category) ? category : '';
-}
-
-/** URL で未分類を表す予約語。'' はパスに使えないため。 */
-const UNCATEGORIZED_SLUG = 'uncategorized';
 
 interface CategoryBucket {
   /** COURSE_CATEGORIES の定義。未分類は null。 */

--- a/frontend/src/pages/courses/ui/CourseCategorySelectPage.tsx
+++ b/frontend/src/pages/courses/ui/CourseCategorySelectPage.tsx
@@ -1,0 +1,194 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { AcademicCapIcon, PlusIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { useAppSelector } from '@/shared/lib/store';
+import Loading from '@/shared/ui/Loading';
+import EmptyState from '@/shared/ui/EmptyState';
+import FaviconIcon from '@/shared/ui/icons/FaviconIcon';
+import { COURSE_CATEGORIES, findCourseCategory } from '@/entities/course';
+import type { CourseCategoryDef, CourseWithProgress } from '@/entities/course';
+import { useToast } from '@/shared/lib/hooks/useToast';
+import { useCourses } from '../model/useCourses';
+import CategoryIcon from './CategoryIcon';
+import CourseFormModal from './CourseFormModal';
+
+/** 未分類('')や未知の値を未分類バケットの key('') に正規化する。 */
+function normalizeCategoryKey(category: string): string {
+  return findCourseCategory(category) ? category : '';
+}
+
+/** URL で未分類を表す予約語。'' はパスに使えないため。 */
+const UNCATEGORIZED_SLUG = 'uncategorized';
+
+interface CategoryBucket {
+  /** COURSE_CATEGORIES の定義。未分類は null。 */
+  def: CourseCategoryDef | null;
+  /** 遷移先の :category（未分類は 'uncategorized'）。 */
+  slug: string;
+  label: string;
+  total: number;
+  /** 受講者の進捗集計（章単位）。管理者は使わない。 */
+  materials: number;
+  completed: number;
+}
+
+/**
+ * CourseCategorySelectPage — `/courses` の入口（FRESTYLE-177）。
+ *
+ * 演習（`/code-editor`）と同じく「まず学習領域を選ぶ → その領域のコース一覧へ」の
+ * 2 段構成にする。全コースを 1 画面に縦積みしていたのを、領域の選択カードにした。
+ * コースが 1 件でもある領域だけカードを出す（死んだ領域カードを出さない）。
+ */
+export default function CourseCategorySelectPage() {
+  const role = useAppSelector((s) => s.auth.role);
+  const canManage = role === 'company_admin' || role === 'super_admin';
+  const { showToast } = useToast();
+  const { courses, loading, error, create } = useCourses();
+  const [creating, setCreating] = useState(false);
+
+  const buckets = useMemo<CategoryBucket[]>(() => {
+    const order: { def: CourseCategoryDef | null; key: string; slug: string; label: string }[] = [
+      ...COURSE_CATEGORIES.map((def) => ({ def, key: def.key, slug: def.key, label: def.label })),
+      { def: null, key: '', slug: UNCATEGORIZED_SLUG, label: '未分類' },
+    ];
+    return order
+      .map(({ def, key, slug, label }) => {
+        const inCat = courses.filter((c) => normalizeCategoryKey(c.category) === key);
+        return {
+          def,
+          slug,
+          label,
+          total: inCat.length,
+          materials: inCat.reduce((s, c) => s + c.materialCount, 0),
+          completed: inCat.reduce((s, c) => s + c.completedCount, 0),
+        };
+      })
+      .filter((b) => b.total > 0);
+  }, [courses]);
+
+  return (
+    <div className="px-4 sm:px-6 pt-6 pb-24 max-w-5xl mx-auto space-y-6">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-[var(--color-text-muted)]">
+            <AcademicCapIcon className="w-5 h-5" />
+            <span className="text-xs uppercase tracking-wider">Courses</span>
+          </div>
+          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">コース</h1>
+          <p className="text-sm text-[var(--color-text-tertiary)]">
+            学びたい学習領域を選んでください。各コースを開くと配下の教材を閲覧できます。
+          </p>
+        </div>
+        {canManage && (
+          <button
+            onClick={() => setCreating(true)}
+            className="bg-brand-500 text-white py-2 px-4 rounded-lg text-sm font-medium hover:bg-brand-600 transition-colors flex items-center gap-2"
+          >
+            <PlusIcon className="w-4 h-4" />
+            新しいコース
+          </button>
+        )}
+      </header>
+
+      {error && <p className="text-sm text-red-500">{error}</p>}
+
+      {loading && courses.length === 0 ? (
+        <Loading className="py-12" />
+      ) : buckets.length === 0 ? (
+        <EmptyState
+          icon={FaviconIcon}
+          title="コースがありません"
+          description={
+            canManage
+              ? '最初のコースを作成しましょう'
+              : '管理者がコースを公開すると、 ここに表示されます'
+          }
+          action={canManage ? { label: '新しいコース', onClick: () => setCreating(true) } : undefined}
+        />
+      ) : (
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {buckets.map((b) => (
+            <li key={b.slug}>
+              <CategorySelectCard bucket={b} showProgress={!canManage} />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {creating && (
+        <CourseFormModal
+          initial={null}
+          onClose={() => setCreating(false)}
+          onSubmit={async (payload) => {
+            const created = await create(payload);
+            if (created) {
+              showToast('success', 'コースを作成しました');
+              setCreating(false);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function CategorySelectCard({
+  bucket,
+  showProgress,
+}: {
+  bucket: CategoryBucket;
+  showProgress: boolean;
+}) {
+  const { def, slug, label, total, materials, completed } = bucket;
+  const accent = def ? def.accentClass : 'text-[var(--color-text-muted)]';
+  const percent = materials > 0 ? Math.round((completed / materials) * 100) : 0;
+  const allDone = showProgress && materials > 0 && completed >= materials;
+
+  return (
+    <Link
+      to={`/courses/category/${slug}`}
+      aria-label={`${label} のコース一覧へ（${total} コース）`}
+      className="group flex h-full flex-col gap-4 rounded-lg border border-surface-3 bg-surface-1 p-5 shadow-sm transition-colors hover:border-taupe-500/50 hover:bg-surface-2"
+    >
+      <div className="flex items-center gap-3">
+        <span className={`flex-shrink-0 ${accent}`}>
+          <CategoryIcon categoryKey={def ? def.key : ''} className="w-9 h-9" />
+        </span>
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-[var(--color-text-primary)] truncate">
+            {label}
+          </h2>
+          <p className="text-xs text-[var(--color-text-muted)]">{total} コース</p>
+        </div>
+        <ChevronRightIcon className="ml-auto w-5 h-5 text-[var(--color-text-muted)] transition-transform group-hover:translate-x-0.5" />
+      </div>
+
+      {/* 受講者のみ、その領域全体の学習進捗（章単位の集計）を出す。 */}
+      {showProgress && materials > 0 && (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-[var(--color-text-muted)]">
+              {completed}/{materials} 章完了
+            </span>
+            {allDone && <span className="font-semibold text-emerald-600">すべて完了</span>}
+          </div>
+          <div
+            className="h-1.5 w-full overflow-hidden rounded-full bg-surface-3"
+            role="progressbar"
+            aria-valuenow={percent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`${label} の進捗`}
+          >
+            <div
+              className={`h-full rounded-full transition-[width] ${
+                allDone ? 'bg-emerald-500' : 'bg-brand-500'
+              }`}
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </Link>
+  );
+}

--- a/frontend/src/pages/courses/ui/CourseFormModal.tsx
+++ b/frontend/src/pages/courses/ui/CourseFormModal.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { COURSE_CATEGORIES, COURSE_LANGUAGES } from '@/entities/course';
+import type { Course } from '@/entities/course';
+
+export interface CourseFormPayload {
+  title: string;
+  description: string;
+  category: string;
+  language: string;
+  sortOrder: number;
+  isPublished: boolean;
+}
+
+/**
+ * CourseFormModal — コースの作成 / 編集フォーム（管理者用）。
+ *
+ * 新規作成時は `defaultCategory` を初期選択にする（領域一覧ページから作ると、
+ * その領域が初期値になる。FRESTYLE-177）。
+ */
+export default function CourseFormModal({
+  initial,
+  defaultCategory = '',
+  onClose,
+  onSubmit,
+}: {
+  initial: Course | null;
+  defaultCategory?: string;
+  onClose: () => void;
+  onSubmit: (payload: CourseFormPayload) => Promise<void>;
+}) {
+  const [title, setTitle] = useState(initial?.title ?? '');
+  const [description, setDescription] = useState(initial?.description ?? '');
+  const [category, setCategory] = useState(initial?.category ?? defaultCategory);
+  const [language, setLanguage] = useState(initial?.language ?? '');
+  const [sortOrder, setSortOrder] = useState(initial?.sortOrder ?? 100);
+  const [isPublished, setIsPublished] = useState(initial?.isPublished ?? false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        description: description.trim(),
+        category,
+        language,
+        sortOrder,
+        isPublished,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface-1 rounded-lg shadow-xl border border-surface-3 max-w-lg w-full p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
+          {initial ? 'コースを編集' : '新しいコース'}
+        </h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">タイトル *</span>
+            <input
+              required
+              maxLength={200}
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">説明</span>
+            <textarea
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="このコースで学べる内容の概要"
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400 resize-y"
+            />
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">カテゴリ（学習領域）</span>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value)}
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
+            >
+              <option value="">未分類</option>
+              {COURSE_CATEGORIES.map((c) => (
+                <option key={c.key} value={c.key}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
+              一覧カードの色分け・領域選択に使われます（色＝学習領域）
+            </span>
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">主に扱う言語・技術</span>
+            <select
+              value={language}
+              onChange={(e) => setLanguage(e.target.value)}
+              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
+            >
+              <option value="">未設定（言語が主題でないコース）</option>
+              {COURSE_LANGUAGES.map((l) => (
+                <option key={l.key} value={l.key}>
+                  {l.label}
+                </option>
+              ))}
+            </select>
+            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
+              一覧カードに言語バッジとして表示されます
+            </span>
+          </label>
+          <label className="block">
+            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">並び順 (昇順)</span>
+            <input
+              type="number"
+              value={sortOrder}
+              onChange={(e) => setSortOrder(Number(e.target.value) || 0)}
+              className="w-32 px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
+            />
+            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
+              小さい値が上に来ます。 既定: 100
+            </span>
+          </label>
+          <label className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+            <input
+              type="checkbox"
+              checked={isPublished}
+              onChange={(e) => setIsPublished(e.target.checked)}
+            />
+            trainee に公開
+          </label>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm text-[var(--color-text-muted)] hover:bg-surface-2 rounded"
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={!title.trim() || submitting}
+              className="bg-brand-500 text-white px-4 py-1.5 rounded text-sm font-medium hover:bg-brand-600 transition-colors disabled:opacity-50"
+            >
+              {submitting ? '保存中...' : initial ? '更新' : '作成'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/courses/ui/CoursesListPage.tsx
+++ b/frontend/src/pages/courses/ui/CoursesListPage.tsx
@@ -1,41 +1,33 @@
 import { useMemo, useState } from 'react';
 import { useAppSelector } from '@/shared/lib/store';
-
-import { useNavigate } from 'react-router-dom';
-import {
-  CheckCircleIcon,
-  ChevronDownIcon,
-  PlusIcon,
-  PencilSquareIcon,
-  TrashIcon,
-} from '@heroicons/react/24/outline';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { PlusIcon, ArrowLeftIcon } from '@heroicons/react/24/outline';
 import EmptyState from '@/shared/ui/EmptyState';
 import FaviconIcon from '@/shared/ui/icons/FaviconIcon';
 import Loading from '@/shared/ui/Loading';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
-import { CourseProgressBar } from '@/entities/course';
-import LanguageBadge from '@/shared/ui/LanguageBadge';
-import { FilterChip } from '@/shared/ui';
+import { COURSE_CATEGORIES, findCourseCategory } from '@/entities/course';
+import type { Course } from '@/entities/course';
 import { useCourses } from '../model/useCourses';
 import { useToast } from '@/shared/lib/hooks/useToast';
-import { COURSE_CATEGORIES, findCourseCategory } from '@/entities/course';
-import { COURSE_LANGUAGES } from '@/entities/course';
-
-import type { Course, CourseWithProgress } from '@/entities/course';
+import CourseCard from './CourseCard';
+import CourseFormModal from './CourseFormModal';
+import CategoryIcon from './CategoryIcon';
 
 /** 未分類('')や未知の値を未分類バケットの key('') に正規化する。 */
 function normalizeCategoryKey(category: string): string {
   return findCourseCategory(category) ? category : '';
 }
 
+/** URL の :category（'uncategorized' は未分類の '' に対応）。 */
+const UNCATEGORIZED_SLUG = 'uncategorized';
+
 /**
- * CoursesListPage — `/courses` コース一覧ページ。
+ * CoursesListPage — `/courses/category/:category` の領域スコープ一覧（FRESTYLE-177）。
  *
- * - company_admin / super_admin: コースを作成 / 編集 / 削除可
- * - trainee: published コースを閲覧のみ（クリックすると `/courses/:id` 詳細へ）
- *
- * カテゴリ（学習領域 = 色）ごとのセクションでカードグリッドを表示する(FRESTYLE-68)。
- * セクションは閉じ開きでき、上部のチップでカテゴリ絞り込みができる。
+ * 入口は CourseCategorySelectPage（`/courses`）で、そこで選んだ 1 領域のコースだけを
+ * カードグリッドで出す。以前は全領域を 1 画面に縦積みしていた。
+ * company_admin / super_admin は作成 / 編集 / 削除でき、作成時はこの領域を初期選択にする。
  */
 export default function CoursesListPage() {
   const role = useAppSelector((s) => s.auth.role);
@@ -43,45 +35,33 @@ export default function CoursesListPage() {
 
   const { showToast } = useToast();
   const navigate = useNavigate();
+  const { category: categoryParam } = useParams<{ category: string }>();
 
-  const { filtered, courses, loading, error, searchQuery, setSearchQuery, create, update, remove } =
+  // URL の :category を内部 key に正規化。'uncategorized' → ''、未知の値も '' 扱い。
+  const categoryKey =
+    categoryParam === UNCATEGORIZED_SLUG
+      ? ''
+      : COURSE_CATEGORIES.some((c) => c.key === categoryParam)
+        ? (categoryParam as string)
+        : '';
+  const categoryDef = findCourseCategory(categoryKey);
+  const categoryLabel = categoryDef ? categoryDef.label : '未分類';
+
+  const { courses, loading, error, searchQuery, setSearchQuery, create, update, remove } =
     useCourses();
 
   const [editTarget, setEditTarget] = useState<Course | 'new' | null>(null);
   const [deleteTargetId, setDeleteTargetId] = useState<number | null>(null);
-  // カテゴリ絞り込み(null = すべて)と、セクションごとの折りたたみ状態。
-  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
 
-  const toggleGroup = (key: string) =>
-    setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }));
-
-  // 絞り込みチップに出すカテゴリ = 実際にコースが存在するものだけ(死にチップを出さない)。
-  const chipCategories = useMemo(() => {
-    const present = new Set(courses.map((c) => normalizeCategoryKey(c.category)));
-    return {
-      cats: COURSE_CATEGORIES.filter((c) => present.has(c.key)),
-      hasUncategorized: present.has(''),
-    };
-  }, [courses]);
-
-  // 検索(filtered) → カテゴリ絞り込み → 定義順のセクションにグルーピング。
-  const visible = useMemo(
-    () =>
-      categoryFilter === null
-        ? filtered
-        : filtered.filter((c) => normalizeCategoryKey(c.category) === categoryFilter),
-    [filtered, categoryFilter],
-  );
-  const groups = useMemo(() => {
-    const order = [...COURSE_CATEGORIES.map((c) => c.key), ''];
-    return order
-      .map((key) => ({
-        key,
-        courses: visible.filter((c) => normalizeCategoryKey(c.category) === key),
-      }))
-      .filter((g) => g.courses.length > 0);
-  }, [visible]);
+  // この領域のコースだけに絞り、検索(タイトル/説明)を掛ける。
+  const visible = useMemo(() => {
+    const inCat = courses.filter((c) => normalizeCategoryKey(c.category) === categoryKey);
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return inCat;
+    return inCat.filter(
+      (c) => c.title.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
+    );
+  }, [courses, categoryKey, searchQuery]);
 
   const handleConfirmDelete = async () => {
     if (deleteTargetId == null) return;
@@ -92,12 +72,27 @@ export default function CoursesListPage() {
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-6xl mx-auto space-y-6">
+      <div>
+        <Link
+          to="/courses"
+          className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+        >
+          <ArrowLeftIcon className="w-3.5 h-3.5" />
+          コース一覧に戻る
+        </Link>
+      </div>
+
       <header className="flex items-start justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">コース</h1>
-          <p className="text-sm text-[var(--color-text-tertiary)] mt-1">
-            学習コースの一覧。 各コースをクリックすると配下の教材を閲覧できます。
-          </p>
+        <div className="flex items-center gap-3 min-w-0">
+          <span className={`flex-shrink-0 ${categoryDef ? categoryDef.accentClass : 'text-[var(--color-text-muted)]'}`}>
+            <CategoryIcon categoryKey={categoryKey} className="w-8 h-8" />
+          </span>
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">{categoryLabel}</h1>
+            <p className="text-sm text-[var(--color-text-tertiary)] mt-0.5">
+              この学習領域のコース一覧。 各コースをクリックすると配下の教材を閲覧できます。
+            </p>
+          </div>
         </div>
         {canManage && (
           <button
@@ -113,40 +108,13 @@ export default function CoursesListPage() {
       <div className="relative max-w-md">
         <input
           type="text"
-          placeholder="コースを検索..."
+          placeholder="この領域のコースを検索..."
           aria-label="コースを検索"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-brand-400 transition-colors"
         />
       </div>
-
-      {/* カテゴリ絞り込みチップ(色＝学習領域で分別できるように。メンター/trainee 共通) */}
-      {courses.length > 0 && (chipCategories.cats.length > 0 || chipCategories.hasUncategorized) && (
-        <div className="flex items-center gap-2 flex-wrap" role="group" aria-label="カテゴリで絞り込み">
-          <FilterChip
-            label="すべて"
-            active={categoryFilter === null}
-            onClick={() => setCategoryFilter(null)}
-          />
-          {chipCategories.cats.map((c) => (
-            <FilterChip
-              key={c.key}
-              label={c.label}
-              active={categoryFilter === c.key}
-              activeClass={c.badgeClass}
-              onClick={() => setCategoryFilter((prev) => (prev === c.key ? null : c.key))}
-            />
-          ))}
-          {chipCategories.hasUncategorized && (
-            <FilterChip
-              label="未分類"
-              active={categoryFilter === ''}
-              onClick={() => setCategoryFilter((prev) => (prev === '' ? null : ''))}
-            />
-          )}
-        </div>
-      )}
 
       {error && <p className="text-sm text-red-500">{error}</p>}
 
@@ -155,73 +123,39 @@ export default function CoursesListPage() {
       ) : visible.length === 0 ? (
         <EmptyState
           icon={FaviconIcon}
-          title={searchQuery || categoryFilter !== null ? '該当するコースがありません' : 'コースがありません'}
+          title={searchQuery ? '該当するコースがありません' : 'この領域のコースはまだありません'}
           description={
-            searchQuery || categoryFilter !== null
-              ? '検索条件やカテゴリの絞り込みを変更してみてください'
+            searchQuery
+              ? '検索条件を変えてみてください'
               : canManage
-                ? '最初のコースを作成しましょう'
+                ? 'この領域に最初のコースを作成しましょう'
                 : '管理者がコースを公開すると、 ここに表示されます'
           }
           action={
-            canManage && !searchQuery && categoryFilter === null
+            canManage && !searchQuery
               ? { label: '新しいコース', onClick: () => setEditTarget('new') }
               : undefined
           }
         />
       ) : (
-        <div className="space-y-6">
-          {groups.map((g) => {
-            const def = findCourseCategory(g.key);
-            const isCollapsed = !!collapsed[g.key];
-            return (
-              <section key={g.key || 'uncategorized'} aria-label={def ? def.label : '未分類'}>
-                <button
-                  type="button"
-                  onClick={() => toggleGroup(g.key)}
-                  aria-expanded={!isCollapsed}
-                  className="flex items-center gap-2 mb-3 rounded-md px-1 py-0.5 hover:bg-surface-2 transition-colors"
-                >
-                  <ChevronDownIcon
-                    aria-hidden="true"
-                    className={`w-4 h-4 text-[var(--color-text-muted)] transition-transform ${
-                      isCollapsed ? '-rotate-90' : ''
-                    }`}
-                  />
-                  {def ? (
-                    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${def.badgeClass}`}>
-                      {def.label}
-                    </span>
-                  ) : (
-                    <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-surface-3 text-[var(--color-text-muted)]">
-                      未分類
-                    </span>
-                  )}
-                  <span className="text-xs text-[var(--color-text-muted)]">{g.courses.length} 件</span>
-                </button>
-                {!isCollapsed && (
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {g.courses.map((c) => (
-                      <CourseCard
-                        key={c.id}
-                        course={c}
-                        canManage={canManage}
-                        onOpen={() => navigate(`/courses/${c.id}`)}
-                        onEdit={() => setEditTarget(c)}
-                        onDelete={() => setDeleteTargetId(c.id)}
-                      />
-                    ))}
-                  </div>
-                )}
-              </section>
-            );
-          })}
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {visible.map((c) => (
+            <CourseCard
+              key={c.id}
+              course={c}
+              canManage={canManage}
+              onOpen={() => navigate(`/courses/${c.id}`)}
+              onEdit={() => setEditTarget(c)}
+              onDelete={() => setDeleteTargetId(c.id)}
+            />
+          ))}
         </div>
       )}
 
       {editTarget !== null && (
         <CourseFormModal
           initial={editTarget === 'new' ? null : editTarget}
+          defaultCategory={editTarget === 'new' ? categoryKey : ''}
           onClose={() => setEditTarget(null)}
           onSubmit={async (payload) => {
             if (editTarget === 'new') {
@@ -250,255 +184,4 @@ export default function CoursesListPage() {
       />
     </div>
   );
-}
-
-function CourseCard({
-  course,
-  canManage,
-  onOpen,
-  onEdit,
-  onDelete,
-}: {
-  course: CourseWithProgress;
-  canManage: boolean;
-  onOpen: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
-}) {
-  // 「色＝学習領域」の連想(FRESTYLE-67)。カードは左の色帯のみで表現し、
-  // カテゴリ名ラベルはセクション見出しが担う(同一セクション内での繰り返しを避ける。FRESTYLE-68)。
-  const category = findCourseCategory(course.category);
-  // 受講者視点で全章完了したコースは一目で分かる見た目にする(FRESTYLE-114)。
-  const isCompleted = !canManage && course.materialCount > 0 && course.completedCount >= course.materialCount;
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={onOpen}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onOpen();
-        }
-      }}
-      className={`group border border-l-4 ${
-        category ? category.barClass : 'border-l-surface-3'
-      } ${
-        isCompleted
-          ? 'bg-emerald-500/5 border-emerald-500/40'
-          : 'bg-surface-1 border-surface-3'
-      } rounded-lg p-4 cursor-pointer hover:border-taupe-500/50 hover:shadow-md transition-all`}
-    >
-      <div className="flex items-start justify-between gap-2 mb-2">
-        <div className="flex items-center gap-2 min-w-0">
-          <h2 className="text-base font-semibold text-[var(--color-text-primary)] truncate">
-            {course.title || '無題のコース'}
-          </h2>
-        </div>
-        {isCompleted && (
-          <span className="flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-600 text-white flex-shrink-0">
-            <CheckCircleIcon className="w-3.5 h-3.5" />
-            完了
-          </span>
-        )}
-        {canManage && (
-          <div className="opacity-0 group-hover:opacity-100 flex items-center gap-1 transition-opacity">
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onEdit();
-              }}
-              className="p-1 rounded hover:bg-surface-3 text-[var(--color-text-muted)]"
-              aria-label="コースを編集"
-            >
-              <PencilSquareIcon className="w-4 h-4" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
-              className="p-1 rounded hover:bg-red-900/30 text-[var(--color-text-muted)] hover:text-red-400"
-              aria-label="コースを削除"
-            >
-              <TrashIcon className="w-4 h-4" />
-            </button>
-          </div>
-        )}
-      </div>
-      <p className="flex items-center gap-2 text-xs text-[var(--color-text-muted)] mb-3">
-        {/* パッと見てどんな言語のコースか分かるように言語バッジを出す(FRESTYLE-114)。 */}
-        {course.language && <LanguageBadge language={course.language} />}
-        <span>
-          {course.isPublished ? '公開中' : '下書き'} ・ 更新 {formatDate(course.updatedAt)}
-        </span>
-      </p>
-      <p className="text-sm text-[var(--color-text-secondary)] line-clamp-3 min-h-[3.6em]">
-        {course.description || 'コース説明が未設定です'}
-      </p>
-      {/* 受講者のみ進捗を表示(FRESTYLE-98)。0 章のコースはバーを出さない。 */}
-      {!canManage && course.materialCount > 0 && (
-        <div className="mt-3">
-          <CourseProgressBar completed={course.completedCount} total={course.materialCount} />
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface CourseFormProps {
-  initial: Course | null;
-  onClose: () => void;
-  onSubmit: (payload: {
-    title: string;
-    description: string;
-    category: string;
-    language: string;
-    sortOrder: number;
-    isPublished: boolean;
-  }) => Promise<void>;
-}
-
-function CourseFormModal({ initial, onClose, onSubmit }: CourseFormProps) {
-  const [title, setTitle] = useState(initial?.title ?? '');
-  const [description, setDescription] = useState(initial?.description ?? '');
-  const [category, setCategory] = useState(initial?.category ?? '');
-  const [language, setLanguage] = useState(initial?.language ?? '');
-  const [sortOrder, setSortOrder] = useState(initial?.sortOrder ?? 100);
-  const [isPublished, setIsPublished] = useState(initial?.isPublished ?? false);
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim()) return;
-    setSubmitting(true);
-    try {
-      await onSubmit({
-        title: title.trim(),
-        description: description.trim(),
-        category,
-        language,
-        sortOrder,
-        isPublished,
-      });
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-      onClick={onClose}
-    >
-      <div
-        className="bg-surface-1 rounded-lg shadow-xl border border-surface-3 max-w-lg w-full p-6 space-y-4"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <h2 className="text-lg font-bold text-[var(--color-text-primary)]">
-          {initial ? 'コースを編集' : '新しいコース'}
-        </h2>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <label className="block">
-            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">タイトル *</span>
-            <input
-              required
-              maxLength={200}
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
-            />
-          </label>
-          <label className="block">
-            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">説明</span>
-            <textarea
-              rows={3}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder="このコースで学べる内容の概要"
-              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400 resize-y"
-            />
-          </label>
-          <label className="block">
-            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">カテゴリ（学習領域）</span>
-            <select
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
-            >
-              <option value="">未分類</option>
-              {COURSE_CATEGORIES.map((c) => (
-                <option key={c.key} value={c.key}>
-                  {c.label}
-                </option>
-              ))}
-            </select>
-            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
-              一覧カードの色分けに使われます（色＝学習領域）
-            </span>
-          </label>
-          <label className="block">
-            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">主に扱う言語・技術</span>
-            <select
-              value={language}
-              onChange={(e) => setLanguage(e.target.value)}
-              className="w-full px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
-            >
-              <option value="">未設定（言語が主題でないコース）</option>
-              {COURSE_LANGUAGES.map((l) => (
-                <option key={l.key} value={l.key}>
-                  {l.label}
-                </option>
-              ))}
-            </select>
-            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
-              一覧カードに言語バッジとして表示されます
-            </span>
-          </label>
-          <label className="block">
-            <span className="block text-sm text-[var(--color-text-secondary)] mb-1">並び順 (昇順)</span>
-            <input
-              type="number"
-              value={sortOrder}
-              onChange={(e) => setSortOrder(Number(e.target.value) || 0)}
-              className="w-32 px-3 py-1.5 bg-surface-2 border border-surface-3 rounded-lg text-sm focus:outline-none focus:border-brand-400"
-            />
-            <span className="block text-xs text-[var(--color-text-muted)] mt-1">
-              小さい値が上に来ます。 既定: 100
-            </span>
-          </label>
-          <label className="flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-            <input
-              type="checkbox"
-              checked={isPublished}
-              onChange={(e) => setIsPublished(e.target.checked)}
-            />
-            trainee に公開
-          </label>
-          <div className="flex justify-end gap-2 pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="px-3 py-1.5 text-sm text-[var(--color-text-muted)] hover:bg-surface-2 rounded"
-            >
-              キャンセル
-            </button>
-            <button
-              type="submit"
-              disabled={!title.trim() || submitting}
-              className="bg-brand-500 text-white px-4 py-1.5 rounded text-sm font-medium hover:bg-brand-600 transition-colors disabled:opacity-50"
-            >
-              {submitting ? '保存中...' : initial ? '更新' : '作成'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-function formatDate(iso: string): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}`;
 }

--- a/frontend/src/pages/courses/ui/CoursesListPage.tsx
+++ b/frontend/src/pages/courses/ui/CoursesListPage.tsx
@@ -9,18 +9,11 @@ import ConfirmModal from '@/shared/ui/ConfirmModal';
 import { COURSE_CATEGORIES, findCourseCategory } from '@/entities/course';
 import type { Course } from '@/entities/course';
 import { useCourses } from '../model/useCourses';
+import { UNCATEGORIZED_SLUG, normalizeCategoryKey } from '../model/categorySlug';
 import { useToast } from '@/shared/lib/hooks/useToast';
 import CourseCard from './CourseCard';
 import CourseFormModal from './CourseFormModal';
 import CategoryIcon from './CategoryIcon';
-
-/** 未分類('')や未知の値を未分類バケットの key('') に正規化する。 */
-function normalizeCategoryKey(category: string): string {
-  return findCourseCategory(category) ? category : '';
-}
-
-/** URL の :category（'uncategorized' は未分類の '' に対応）。 */
-const UNCATEGORIZED_SLUG = 'uncategorized';
 
 /**
  * CoursesListPage — `/courses/category/:category` の領域スコープ一覧（FRESTYLE-177）。


### PR DESCRIPTION
## 概要

`/courses` を、演習（`/code-editor`）と同じ「まず選ぶ → その配下の一覧」の 2 段構成に作り直しました。全コースを 1 画面に縦積みしていたのを、**学習領域の選択カード画面**を入口にします。

**バックエンド（Go）には一切変更を加えていません。**

## 画面

| ルート | 画面 |
|---|---|
| `/courses` | **CourseCategorySelectPage** — 学習領域（8 カテゴリ）の選択カード。各カードに領域アイコン + コース数 +（受講者）進捗。コースが 1 件でもある領域だけ表示 |
| `/courses/category/:category` | **CoursesListPage**（領域スコープに作り直し）— その領域のコース一覧。見出し + 「← コース一覧に戻る」+ 領域内検索 + 管理者の作成/編集/削除 |
| `/courses/:id` | CourseDetailPage（従来どおり） |

`/courses/category/:category` は 2 セグメントなので `/courses/:id` と衝突しません（演習の `/code-editor/lang/:language` と同じ回避）。未分類は `/courses/category/uncategorized` に集約します。

## 設計判断

- **選択軸は「学習領域」**（技術ではなく）。事前にユーザー確認して決定しました。技術（言語）軸は演習が担っており、コースは領域で分けるのが自然です。
- **アイコンは Heroicons をカテゴリ色で**。カテゴリは単一技術に対応しない（設計・アーキテクチャ / セキュリティ 等にロゴは無い）ため Devicon ロゴは使わず、概念アイコン（データベース＝スタック / インフラ＝クラウド / セキュリティ＝盾 …）を領域色で塗りました。
- 管理者の作成フォームは、領域ページから開くと**その領域を初期選択**にします。

## リファクタ

`CourseCard` / `CourseFormModal` を `CoursesListPage` から独立ファイルに抽出し、選択画面と一覧画面で共用。`courseCategories` に `accentClass`（アイコン色）を追加しました。

## テスト

- `CoursesListPage` のテストを領域スコープ版に更新（カテゴリチップ・セクション折りたたみは廃止したので該当テストを削除、`:category` ルートで描画）
- `CourseCategorySelectPage` のテストを追加（領域カード・コース数・リンク・受講者進捗集計・管理者ボタン・空/null 防御）
- E2E のコースフローを「領域選択 → 一覧 → 詳細」に更新（`authenticated.spec` / `user-flows.spec` 両方）

検証: `tsc --noEmit` / `eslint --max-warnings 0`（境界違反 0）/ `vitest run --coverage`（**152 ファイル / 1191 件緑**、Stmts 85.5%）/ `npm run build` / `playwright`（**12 件緑**）。

## 関連チケット

FRESTYLE-177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コースを「学習領域」ごとに選択し、領域別のコース一覧を表示できるようになりました。
  - 学習領域カードにコース数や受講者の進捗を表示します。
  - コースカードで言語、公開状態、更新日、説明、完了状況を確認できます。
  - 管理者はコースの作成・編集・削除を行えます。
  - 未分類コースも専用の一覧で確認できます。

- **改善**
  - 学習領域内でコースを検索できるようになりました。
  - コースがない場合やデータ取得時の問題でも、適切な空状態を表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->