### PR TITLE
feat: コース閲覧ページの背景を #f5f6f6 にし、タイトルを本文カード内へ移す (FRESTYLE-178)

### DIFF
--- a/frontend/src/app/styles/index.css
+++ b/frontend/src/app/styles/index.css
@@ -127,8 +127,9 @@
   --color-surface-1: #FFFFFF;
   --color-surface-2: #F5F5F4;
   --color-surface-3: #E7E5E4;
-  /* 教材コース閲覧 (/courses/:id) の読み物背景（灰青）。白カードとのコントラスト用。 */
-  --color-reading-surface: #F4F6F9;
+  /* 教材コース閲覧 (/courses/:id) の読み物背景（無彩色寄りグレー）。白カードとのコントラスト用。
+     この変数はコース閲覧ページでしか使わないため、他ページの白背景には影響しない（FRESTYLE-178）。 */
+  --color-reading-surface: #f5f6f6;
   /* サイドバー / ヘッダーは body と同じ白で、border 1px のみで境界を表現する */
   --color-nav: #FFFFFF;
   /* nav 上の hover / active 状態。色相を持たないニュートラル寄り暖色グレーで

--- a/frontend/src/pages/course-detail/__tests__/CourseDetailPage.test.tsx
+++ b/frontend/src/pages/course-detail/__tests__/CourseDetailPage.test.tsx
@@ -360,13 +360,13 @@ describe('CourseDetailPage タイトルのカード外配置 (FRESTYLE-131)', ()
     mockRecordView.mockResolvedValue(undefined);
   });
 
-  it('タイトル h1 は白カード(article)の外に置かれる', async () => {
+  it('タイトル h1 は本文カード(article)内の先頭ヘッダーに置かれる (FRESTYLE-178)', async () => {
     // 見出し付き本文にすると TOC の IntersectionObserver(jsdom 未実装)が動くため見出しなしにする。
     mockGetMaterial.mockImplementation(async (id: number) => material(id, '本文テキスト'));
     renderPage('trainee');
     const heading = await screen.findByRole('heading', { level: 1, name: '章 11' });
-    // h1 は article の中に入っていない(カードの外のヘッダーにある)。
-    expect(heading.closest('article')).toBeNull();
+    // h1 は本文カード(article)の中の先頭ヘッダーに入る(Qiita 風。カードを上げてタイトルを内包)。
+    expect(heading.closest('article')).not.toBeNull();
     expect(heading.closest('header')).not.toBeNull();
   });
 

--- a/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
+++ b/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
@@ -453,43 +453,42 @@ function ReadOnlyDetail({
           tocOpen ? 'lg:grid-cols-[minmax(0,1fr)_280px]' : ''
         }`}
       >
-        {/* 記事サイト風ヘッダー(Zenn 風): タイトル + メタをグリッド直下の子にして col-span-full で
-            行全体に広げる。 本文カード(左カラム)と右サイドバー(目次/章一覧)は次の行に並ぶので、
-            右の目次カードが本文カードと同じ高さから始まる(FRESTYLE-150 / 131)。
-            行間は grid の gap-8 が担うので header に mb は付けない。 */}
-        <header className="col-span-full text-center">
-          <h1 className="text-3xl sm:text-4xl font-bold text-[var(--color-text-primary)] leading-snug">
-            {material.title || '無題の教材'}
-          </h1>
-          {/* メタ(最終更新 / 目次トグル / 完了トグル)。 sticky にはしない(FRESTYLE-119)。
-              スクロール途中の完了操作は本文末尾の大きい完了ボタン(FRESTYLE-100)で行える。 */}
-          <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
-            <p className="text-xs text-[var(--color-text-muted)]">
-              最終更新: {formatDate(material.updatedAt)}
-            </p>
-            {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
-            <button
-              type="button"
-              onClick={() => setTocOpen((v) => !v)}
-              aria-pressed={tocOpen}
-              title={tocOpen ? '目次を隠す' : '目次を表示'}
-              className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                tocOpen
-                  ? 'border-taupe-500 text-taupe-400'
-                  : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
-              }`}
-            >
-              <ListBulletIcon className="w-4 h-4" />
-              目次
-            </button>
-            <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
-          </div>
-        </header>
-
         {/* 本文カラム。 サイドバーを隠したときは本文が全幅に伸びて読みにくいため、 読みやすい幅(860px)に
             収めて中央寄せする。 サイドバー表示時は 1fr カラムが既に同程度の幅になる。 */}
         <div className={`min-w-0 ${!tocOpen ? 'mx-auto w-full max-w-[860px]' : ''}`}>
           <article className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
+            {/* 記事サイト風ヘッダー(Qiita 風): タイトル + メタを本文カードの先頭に入れる。
+                以前はカード外の別ヘッダーに置いていたが、カードをタイトル位置まで上げて
+                タイトルもカード内に収めた(FRESTYLE-178)。目次サイドバーは同じグリッド行に来るので
+                カード上端と揃う(FRESTYLE-150)。本文先頭の重複 h1 は stripLeadingTitle で除去済み(FRESTYLE-131)。 */}
+            <header className="mb-6 pb-6 border-b border-surface-3">
+              <h1 className="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] leading-snug">
+                {material.title || '無題の教材'}
+              </h1>
+              {/* メタ(最終更新 / 目次トグル / 完了トグル)。 sticky にはしない(FRESTYLE-119)。
+                  スクロール途中の完了操作は本文末尾の大きい完了ボタン(FRESTYLE-100)で行える。 */}
+              <div className="mt-3 flex flex-wrap items-center gap-3">
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  最終更新: {formatDate(material.updatedAt)}
+                </p>
+                {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
+                <button
+                  type="button"
+                  onClick={() => setTocOpen((v) => !v)}
+                  aria-pressed={tocOpen}
+                  title={tocOpen ? '目次を隠す' : '目次を表示'}
+                  className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    tocOpen
+                      ? 'border-taupe-500 text-taupe-400'
+                      : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                >
+                  <ListBulletIcon className="w-4 h-4" />
+                  目次
+                </button>
+                <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
+              </div>
+            </header>
             <div className="prose prose-sm max-w-none course-prose">
               <ReadOnlyMarkdown content={bodyContent} />
             </div>
@@ -640,12 +639,12 @@ function MaterialSkeleton() {
         className="mx-auto w-full max-w-[860px] px-6 sm:px-10 py-8 sm:py-10 animate-pulse"
         aria-hidden="true"
       >
-        {/* タイトル + メタはカードの外・上(FRESTYLE-131 の実表示に合わせて跳ねを防ぐ)。 */}
-        <div className="mb-6 flex flex-col items-center gap-3">
-          <div className="h-8 w-3/4 rounded bg-surface-3" />
-          <div className="h-3 w-40 rounded bg-surface-2" />
-        </div>
         <div className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
+          {/* タイトル + メタはカードの先頭(FRESTYLE-178 の実表示に合わせて跳ねを防ぐ)。 */}
+          <div className="mb-6 pb-6 border-b border-surface-3 space-y-3">
+            <div className="h-8 w-3/4 rounded bg-surface-3" />
+            <div className="h-3 w-40 rounded bg-surface-2" />
+          </div>
           <div className="space-y-3">
             <div className="h-4 w-full rounded bg-surface-2" />
             <div className="h-4 w-11/12 rounded bg-surface-2" />


### PR DESCRIPTION
## 概要

コース閲覧ページ（`/courses/:id`）の読み物レイアウトを 2 点調整します。**他のページには影響しません。バックエンド（Go）にも変更なし。**

## 変更内容

**① 読み物背景を `#f5f6f6` に**

`--color-reading-surface` を `#F4F6F9`（灰青）→ `#f5f6f6`（無彩色寄りグレー）に変更しました。この変数はコース閲覧ページ（`/courses/:id`。AppShell の documentScroll も同ルート限定）でしか使われないため、他ページの白背景は変わりません。

**② タイトルを本文カードの中へ**

タイトル + メタ（最終更新 / 目次トグル / 完了トグル）を、本文カードの**外・上**（`col-span-full` の別ヘッダー）から**カード先頭の `<header>`** へ移しました。カードがタイトル位置まで上がり、タイトルもカード内に収まります（Qiita の記事カードのような見た目）。目次サイドバーは同じグリッド行に来るのでカード上端と揃います（FRESTYLE-150 を踏襲）。本文先頭の重複 h1 除去（FRESTYLE-131）は維持しています。

`MaterialSkeleton`（取得中の骨組み）も新レイアウト（タイトルをカード内）に合わせ、取得完了時の跳ねを防ぎました。

## テスト

- 既存テスト「タイトル h1 は白カード(article)の外に置かれる」を「カード内の先頭ヘッダーに入る」前提へ更新
- `tsc --noEmit` / `eslint src --max-warnings 0` / `vitest run`（**1191 件緑**）/ `npm run build` / `playwright`（**12 件緑**、教材見出し h1 は維持）

## 関連チケット

FRESTYLE-178