### PR TITLE
feat: ホームのコース/演習カードに学べる技術ロゴ(Devicon)を添える (FRESTYLE-179)

### DIFF
--- a/frontend/src/pages/home/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/home/__tests__/MenuPage.test.tsx
@@ -84,6 +84,16 @@ describe('MenuPage', () => {
     expect(screen.getByText('連続学習')).toBeInTheDocument();
   });
 
+  it('コース/演習カードに学べる技術ロゴ(Devicon)が出る (FRESTYLE-179)', () => {
+    mockUseUserDashboard.mockReturnValue({ dashboard: sampleDashboard, loading: false, error: null });
+    const { container } = renderMenu('trainee');
+    // LanguageIcon は /lang/<key>.svg を img で描画する。コース(git 等)・演習(go 等)のロゴが出る。
+    expect(container.querySelector('img[src="/lang/git.svg"]')).not.toBeNull();
+    expect(container.querySelector('img[src="/lang/typescript.svg"]')).not.toBeNull();
+    // go は両カードに出るため 2 つ以上。
+    expect(container.querySelectorAll('img[src="/lang/go.svg"]').length).toBeGreaterThanOrEqual(2);
+  });
+
   it('super_admin は統計を取得せず即時に管理メニューを表示する', () => {
     mockUseUserDashboard.mockReturnValue({ dashboard: null, loading: false, error: null });
     renderMenu('super_admin');

--- a/frontend/src/pages/home/ui/MenuPage.tsx
+++ b/frontend/src/pages/home/ui/MenuPage.tsx
@@ -11,6 +11,7 @@ import {
   BookOpenIcon,
   ArrowRightIcon,
 } from '@heroicons/react/24/outline';
+import LanguageIcon from '@/shared/ui/LanguageIcon';
 
 import { useUserDashboard } from '../model/useUserDashboard';
 import { useCompanyLearningSummary } from '../model/useCompanyLearningSummary';
@@ -97,6 +98,7 @@ export default function MenuPage() {
                   description="体系的なカリキュラムで段階的に学べます。"
                   color="emerald"
                   badge="おすすめ"
+                  techLogos={['git', 'go', 'docker', 'php']}
                 />
                 <FeatureCard
                   to="/code-editor"
@@ -104,6 +106,7 @@ export default function MenuPage() {
                   title="コード演習"
                   description="実際にコードを書いて手を動かしながら学べます。"
                   color="emerald"
+                  techLogos={['go', 'php', 'javascript', 'typescript']}
                 />
               </FeatureSection>
 
@@ -202,6 +205,9 @@ interface FeatureCardProps {
   description: string;
   color: CardColor;
   badge?: string;
+  /** 学べる技術のロゴ（Devicon）。指定時に説明の下へミニロゴ列を出す（FRESTYLE-179）。
+      vendoring 済みの key（public/lang/*.svg）だけ渡すこと（未 vendoring は汎用アイコンにフォールバックし列が不揃いになる）。 */
+  techLogos?: string[];
 }
 
 const iconBg: Record<CardColor, string> = {
@@ -211,7 +217,7 @@ const iconBg: Record<CardColor, string> = {
   blue:    'bg-blue-100 text-blue-600',
 };
 
-function FeatureCard({ to, icon: Icon, title, description, color, badge }: FeatureCardProps) {
+function FeatureCard({ to, icon: Icon, title, description, color, badge, techLogos }: FeatureCardProps) {
   return (
     <Link
       to={to}
@@ -235,6 +241,14 @@ function FeatureCard({ to, icon: Icon, title, description, color, badge }: Featu
       <p className="mt-3 text-xs text-[var(--color-text-muted)] leading-relaxed">
         {description}
       </p>
+      {/* 学べる技術のロゴ列（Devicon）。コース/演習カードにだけ付き、技術感を出す（FRESTYLE-179）。 */}
+      {techLogos && techLogos.length > 0 && (
+        <div className="mt-3 flex items-center gap-2" aria-hidden="true">
+          {techLogos.map((t) => (
+            <LanguageIcon key={t} language={t} className="w-5 h-5" />
+          ))}
+        </div>
+      )}
       <div className="mt-4 flex items-center gap-1 text-xs text-[var(--color-text-muted)] group-hover:text-brand-500 transition-colors">
         <span>開く</span>
         <ArrowRightIcon className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />


### PR DESCRIPTION
## 概要

学習ダッシュボード（ホーム）の「コース」「コード演習」カードに、**学べる技術のロゴ（Devicon）**をミニアイコンとして添え、技術感を出します。

**バックエンド（Go）には一切変更を加えていません。**

## 設計判断

事前にお伺いして「技術ロゴを象徴として添える」方針に決めました。

- Devicon は技術ロゴ集で、コース/演習は技術に結びつくためロゴが合います。一方 **AI チャット / ノート / レポートは抽象概念でロゴが無い**ため、従来の UI アイコン（Heroicons）のままにしています。
- ロゴは **vendoring 済みの SVG だけ**使います（`public/lang/*.svg`: bash / docker / git / go / javascript / php / typescript）。未 vendoring の技術（PostgreSQL / AWS 等）は `LanguageIcon` の汎用フォールバックになりロゴ列が不揃いになるため使いません。

## 変更内容

- `FeatureCard` に任意 prop `techLogos?: string[]` を追加。指定時、説明文の下に小さなロゴ行を出す（`LanguageIcon` を再利用）
- **コース**カード: `git / go / docker / php`
- **コード演習**カード: `go / php / javascript / typescript`

## テスト

- MenuPage テストに、コース/演習カードへ技術ロゴ（`/lang/*.svg`）が出る確認を追加（既存の text ベース assert は不変）
- `tsc --noEmit` / `eslint src --max-warnings 0` / `vitest run`（**1192 件緑**）/ `npm run build`

## 関連チケット

FRESTYLE-179