### PR TITLE
refactor: profiles.status → status_message（スキーマ命名統一 Phase 1）(FRESTYLE-182)

### DIFF
--- a/backend/internal/adapter/persistence/profile_repository.go
+++ b/backend/internal/adapter/persistence/profile_repository.go
@@ -36,11 +36,11 @@ func (r *profileRepository) FindByUserID(ctx context.Context, userID uint64) (*d
 		return nil, err
 	}
 	return &domain.Profile{
-		UserID:    uint64(row.UserID),
-		Bio:       row.Bio,
-		AvatarURL: row.AvatarUrl,
-		Status:    row.Status,
-		UpdatedAt: row.UpdatedAt,
+		UserID:        uint64(row.UserID),
+		Bio:           row.Bio,
+		AvatarURL:     row.AvatarUrl,
+		StatusMessage: row.StatusMessage,
+		UpdatedAt:     row.UpdatedAt,
 	}, nil
 }
 

--- a/backend/internal/adapter/persistence/profile_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/profile_repository_integration_test.go
@@ -21,7 +21,7 @@ func TestProfileRepository_Integration(t *testing.T) {
 	t.Run("FindByUserID は profile を返す", func(t *testing.T) {
 		testsupport.TruncateAll(t, db, "profiles")
 		require.NoError(t, db.WithContext(ctx).Create(&domain.Profile{
-			UserID: 7, Bio: "自己紹介", AvatarURL: "https://example.com/a.png", Status: "active",
+			UserID: 7, Bio: "自己紹介", AvatarURL: "https://example.com/a.png", StatusMessage: "active",
 		}).Error)
 
 		got, err := repo.FindByUserID(ctx, 7)
@@ -30,7 +30,7 @@ func TestProfileRepository_Integration(t *testing.T) {
 		require.Equal(t, uint64(7), got.UserID)
 		require.Equal(t, "自己紹介", got.Bio)
 		require.Equal(t, "https://example.com/a.png", got.AvatarURL)
-		require.Equal(t, "active", got.Status)
+		require.Equal(t, "active", got.StatusMessage)
 	})
 
 	t.Run("未作成は (nil, nil)", func(t *testing.T) {

--- a/backend/internal/adapter/persistence/queries/schema.sql
+++ b/backend/internal/adapter/persistence/queries/schema.sql
@@ -14,14 +14,14 @@ CREATE TABLE master_exercise_examples (
     updated_at      timestamptz NOT NULL
 );
 
--- cognito_sub / email / display_name / role はアプリが必ず値を入れるため NOT NULL とみなす
+-- cognito_sub / email / name / role はアプリが必ず値を入れるため NOT NULL とみなす
 -- （sqlc が string を生成し domain への詰め替えが綺麗になる）。company_id / onboarded_at /
 -- deleted_at は実際に NULL になり得る（SuperAdmin は company 無し等）ので nullable のまま。
 CREATE TABLE users (
     id           bigint PRIMARY KEY,
     cognito_sub  text NOT NULL,
     email        text NOT NULL DEFAULT '',
-    display_name text NOT NULL DEFAULT '',
+    name       text NOT NULL DEFAULT '',
     company_id   bigint,
     role         text NOT NULL,
     ai_chat_enabled boolean,
@@ -48,10 +48,10 @@ CREATE TABLE notes (
 -- users とは別管理のプロフィール拡張（user_id が PK）。全列 domain.Profile と 1:1。
 CREATE TABLE profiles (
     user_id    bigint PRIMARY KEY,
-    bio        text NOT NULL DEFAULT '',
-    avatar_url text NOT NULL DEFAULT '',
-    status     text NOT NULL DEFAULT '',
-    updated_at timestamptz NOT NULL
+    bio            text NOT NULL DEFAULT '',
+    avatar_url     text NOT NULL DEFAULT '',
+    status_message text NOT NULL DEFAULT '',
+    updated_at     timestamptz NOT NULL
 );
 
 -- アプリ内通知。全列 domain.Notification と 1:1。

--- a/backend/internal/adapter/persistence/sqlcgen/models.go
+++ b/backend/internal/adapter/persistence/sqlcgen/models.go
@@ -61,11 +61,11 @@ type Notification struct {
 }
 
 type Profile struct {
-	UserID    int64
-	Bio       string
-	AvatarUrl string
-	Status    string
-	UpdatedAt time.Time
+	UserID        int64
+	Bio           string
+	AvatarUrl     string
+	StatusMessage string
+	UpdatedAt     time.Time
 }
 
 type SessionNote struct {

--- a/backend/internal/adapter/persistence/sqlcgen/profile.sql.go
+++ b/backend/internal/adapter/persistence/sqlcgen/profile.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getProfileByUserID = `-- name: GetProfileByUserID :one
-SELECT user_id, bio, avatar_url, status, updated_at FROM profiles
+SELECT user_id, bio, avatar_url, status_message, updated_at FROM profiles
 WHERE user_id = $1
 `
 
@@ -22,7 +22,7 @@ func (q *Queries) GetProfileByUserID(ctx context.Context, userID int64) (Profile
 		&i.UserID,
 		&i.Bio,
 		&i.AvatarUrl,
-		&i.Status,
+		&i.StatusMessage,
 		&i.UpdatedAt,
 	)
 	return i, err

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -4,22 +4,24 @@ import "time"
 
 // Profile は users とは別管理のプロフィール拡張情報。
 type Profile struct {
-	UserID    uint64    `gorm:"primaryKey;column:user_id" json:"userId"`
-	Bio       string    `gorm:"column:bio" json:"bio"`
-	AvatarURL string    `gorm:"column:avatar_url" json:"avatarUrl"`
-	Status    string    `gorm:"column:status;default:''" json:"status"`
-	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
+	UserID    uint64 `gorm:"primaryKey;column:user_id" json:"userId"`
+	Bio       string `gorm:"column:bio" json:"bio"`
+	AvatarURL string `gorm:"column:avatar_url" json:"avatarUrl"`
+	// StatusMessage はプロフィールの一言ステータス(自由文)。状態機械の status 列とは別物。
+	// JSON キーは互換のため status のまま(API 契約は不変)。
+	StatusMessage string    `gorm:"column:status_message;default:''" json:"status"`
+	UpdatedAt     time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
 func (Profile) TableName() string { return "profiles" }
 
 // ProfileView は users.name と Profile を合成した表示用 DTO。
 type ProfileView struct {
-	UserID    uint64    `json:"userId"`
-	Name      string    `json:"name"`
-	Email     string    `json:"email"`
-	Bio       string    `json:"bio"`
-	AvatarURL string    `json:"avatarUrl"`
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	UserID        uint64    `json:"userId"`
+	Name          string    `json:"name"`
+	Email         string    `json:"email"`
+	Bio           string    `json:"bio"`
+	AvatarURL     string    `json:"avatarUrl"`
+	StatusMessage string    `json:"status"`
+	UpdatedAt     time.Time `json:"updatedAt"`
 }

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -127,10 +127,10 @@ func (h *ProfileHandler) Update(c *gin.Context) {
 		}
 	}
 	if _, err := h.update.Execute(c.Request.Context(), usecase.UpdateProfileInput{
-		UserID:    uid,
-		Bio:       req.Bio,
-		AvatarURL: avatarURL,
-		Status:    req.Status,
+		UserID:        uid,
+		Bio:           req.Bio,
+		AvatarURL:     avatarURL,
+		StatusMessage: req.Status,
 	}); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
@@ -153,7 +153,7 @@ func (h *ProfileHandler) buildView(c *gin.Context, uid uint64) (*domain.ProfileV
 	if p != nil {
 		view.Bio = p.Bio
 		view.AvatarURL = p.AvatarURL
-		view.Status = p.Status
+		view.StatusMessage = p.StatusMessage
 		view.UpdatedAt = p.UpdatedAt
 	}
 	user, _ := h.users.FindByID(c.Request.Context(), uid)

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -34,10 +34,10 @@ func NewUpdateProfileUseCase(p repository.ProfileRepository) *UpdateProfileUseCa
 }
 
 type UpdateProfileInput struct {
-	UserID    uint64
-	Bio       string
-	AvatarURL string
-	Status    string
+	UserID        uint64
+	Bio           string
+	AvatarURL     string
+	StatusMessage string
 }
 
 func (u *UpdateProfileUseCase) Execute(ctx context.Context, in UpdateProfileInput) (*domain.Profile, error) {
@@ -45,10 +45,10 @@ func (u *UpdateProfileUseCase) Execute(ctx context.Context, in UpdateProfileInpu
 		return nil, errors.New("userID is required")
 	}
 	p := &domain.Profile{
-		UserID:    in.UserID,
-		Bio:       in.Bio,
-		AvatarURL: in.AvatarURL,
-		Status:    in.Status,
+		UserID:        in.UserID,
+		Bio:           in.Bio,
+		AvatarURL:     in.AvatarURL,
+		StatusMessage: in.StatusMessage,
 	}
 	if err := u.profiles.Upsert(ctx, p); err != nil {
 		return nil, err

--- a/backend/migrations/0009_rename_profiles_status_to_status_message.sql
+++ b/backend/migrations/0009_rename_profiles_status_to_status_message.sql
@@ -1,0 +1,24 @@
+-- 0009: profiles.status を status_message に改名 (FRESTYLE-182 / 親 FRESTYLE-181)
+--
+-- profiles.status は「一言ステータス(自由文)」を表す列だが、状態機械(決まった状態を遷移する
+-- 列挙)である invitations.status / company_applications.status / learning_reports.status と
+-- 同じ名前で役割を誤解しやすい。命名規約(FRESTYLE-181)に沿い status_message に改名する。
+-- GORM AutoMigrate は列リネームを追従しない(新列を足すだけ)ため本 SQL で明示的に改名する。
+-- 冪等: 旧列があり新列が無いときだけ実行。何度流しても同じ状態に収束する。対象が無ければ no-op。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0009_rename_profiles_status_to_status_message.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'profiles' AND column_name = 'status'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'profiles' AND column_name = 'status_message'
+    ) THEN
+        ALTER TABLE profiles RENAME COLUMN status TO status_message;
+    END IF;
+END $$;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 1。

## 概要

`profiles.status` を `status_message` に改名する。プロフィールの「一言ステータス（自由文）」を表す列だが、状態機械（決まった状態を遷移する列挙）である `invitations.status` / `company_applications.status` / `learning_reports.status` と同じ名前で役割を誤解しやすい（曖昧・過負荷な命名）。命名規約（FRESTYLE-181）に沿い、状態機械の列挙にのみ `status` を使い、自由文には `status_message` を使う。

**JSON キーは `status` のまま維持**（`json:"status"`）。API 契約・フロント・OpenAPI は不変（`make openapi` 差分なしを確認）。今回はスキーマ（DB 列・Go フィールド）の明確化に限定。

## 変更内容

- `backend/migrations/0009_rename_profiles_status_to_status_message.sql`: `ALTER TABLE profiles RENAME COLUMN status TO status_message`。`information_schema` ガードで冪等。適用は infra リポ `make apply-migration-supabase`（§5）
- `queries/schema.sql` の profiles を `status_message` に更新し `make sqlc` 再生成（`sqlcgen/models.go`・`profile.sql.go`）
- `domain.Profile` / `domain.ProfileView` の `Status` → `StatusMessage`（gorm 列 `status_message`、JSON は `status` 維持）
- `usecase.UpdateProfileInput` / `handler` の詰め替え / `profile_repository` を `StatusMessage` に
- 統合テストを新フィールド名に更新

## ついでに是正した潜在バグ（schema.sql の drift）

`make sqlc` 再生成時に、`queries/schema.sql` の `users` 列が **migration 0006（`display_name`→`name`）以降 `display_name` のまま取り残されていた** ことが判明。実 DB・`domain.User`（`column:name`）・従来の生成コードはすべて `name` で、schema.sql だけがズレていた。次に誰かが `make sqlc` を回すと users クエリが存在しない列 `display_name` を参照して壊れる潜在バグ。この機会に schema.sql を実 DB に一致（`name`）させた。

## テスト

- `go build ./...` / `go vet` / `go test ./...`（exit 0・12 パッケージ ok）
- `gofmt -l` 差分なし
- `make openapi` 差分なし（JSON 契約不変の確認）
- マイグレーション適用後、`information_schema.columns` で `profiles.status_message` の存在と `profiles.status` の消滅を確認（ステージング/本番適用時）

## 関連チケット

FRESTYLE-182（親 FRESTYLE-181）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - プロフィールのステータスメッセージを、保存・取得・表示の各処理で一貫して扱えるようになりました。
  - APIのJSON項目名は従来どおり `status` のまま維持されます。

- **データ移行**
  - 既存プロフィールのステータス情報を新しいステータスメッセージ項目へ移行する処理を追加しました。

- **不具合修正**
  - プロフィール更新後にステータスメッセージが正しく保存・表示されない問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->