### PR TITLE
refactor: profiles status→status_message 移行(Expand フェーズ) (FRESTYLE-182)

### DIFF
--- a/backend/internal/adapter/persistence/profile_repository.go
+++ b/backend/internal/adapter/persistence/profile_repository.go
@@ -36,11 +36,12 @@ func (r *profileRepository) FindByUserID(ctx context.Context, userID uint64) (*d
 		return nil, err
 	}
 	return &domain.Profile{
-		UserID:    uint64(row.UserID),
-		Bio:       row.Bio,
-		AvatarURL: row.AvatarUrl,
-		Status:    row.Status,
-		UpdatedAt: row.UpdatedAt,
+		UserID:        uint64(row.UserID),
+		Bio:           row.Bio,
+		AvatarURL:     row.AvatarUrl,
+		Status:        row.Status,
+		StatusMessage: row.StatusMessage,
+		UpdatedAt:     row.UpdatedAt,
 	}, nil
 }
 

--- a/backend/internal/adapter/persistence/queries/schema.sql
+++ b/backend/internal/adapter/persistence/queries/schema.sql
@@ -14,14 +14,14 @@ CREATE TABLE master_exercise_examples (
     updated_at      timestamptz NOT NULL
 );
 
--- cognito_sub / email / display_name / role はアプリが必ず値を入れるため NOT NULL とみなす
+-- cognito_sub / email / name / role はアプリが必ず値を入れるため NOT NULL とみなす
 -- （sqlc が string を生成し domain への詰め替えが綺麗になる）。company_id / onboarded_at /
 -- deleted_at は実際に NULL になり得る（SuperAdmin は company 無し等）ので nullable のまま。
 CREATE TABLE users (
     id           bigint PRIMARY KEY,
     cognito_sub  text NOT NULL,
     email        text NOT NULL DEFAULT '',
-    display_name text NOT NULL DEFAULT '',
+    name       text NOT NULL DEFAULT '',
     company_id   bigint,
     role         text NOT NULL,
     ai_chat_enabled boolean,
@@ -48,10 +48,12 @@ CREATE TABLE notes (
 -- users とは別管理のプロフィール拡張（user_id が PK）。全列 domain.Profile と 1:1。
 CREATE TABLE profiles (
     user_id    bigint PRIMARY KEY,
-    bio        text NOT NULL DEFAULT '',
-    avatar_url text NOT NULL DEFAULT '',
-    status     text NOT NULL DEFAULT '',
-    updated_at timestamptz NOT NULL
+    bio            text NOT NULL DEFAULT '',
+    avatar_url     text NOT NULL DEFAULT '',
+    -- status(旧) と status_message(新) は Expand-Contract 移行中の一時的な併存。Contract で status を削除する。
+    status         text NOT NULL DEFAULT '',
+    status_message text NOT NULL DEFAULT '',
+    updated_at     timestamptz NOT NULL
 );
 
 -- アプリ内通知。全列 domain.Notification と 1:1。

--- a/backend/internal/adapter/persistence/sqlcgen/models.go
+++ b/backend/internal/adapter/persistence/sqlcgen/models.go
@@ -61,11 +61,12 @@ type Notification struct {
 }
 
 type Profile struct {
-	UserID    int64
-	Bio       string
-	AvatarUrl string
-	Status    string
-	UpdatedAt time.Time
+	UserID        int64
+	Bio           string
+	AvatarUrl     string
+	Status        string
+	StatusMessage string
+	UpdatedAt     time.Time
 }
 
 type SessionNote struct {

--- a/backend/internal/adapter/persistence/sqlcgen/profile.sql.go
+++ b/backend/internal/adapter/persistence/sqlcgen/profile.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getProfileByUserID = `-- name: GetProfileByUserID :one
-SELECT user_id, bio, avatar_url, status, updated_at FROM profiles
+SELECT user_id, bio, avatar_url, status, status_message, updated_at FROM profiles
 WHERE user_id = $1
 `
 
@@ -23,6 +23,7 @@ func (q *Queries) GetProfileByUserID(ctx context.Context, userID int64) (Profile
 		&i.Bio,
 		&i.AvatarUrl,
 		&i.Status,
+		&i.StatusMessage,
 		&i.UpdatedAt,
 	)
 	return i, err

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -4,11 +4,14 @@ import "time"
 
 // Profile は users とは別管理のプロフィール拡張情報。
 type Profile struct {
-	UserID    uint64    `gorm:"primaryKey;column:user_id" json:"userId"`
-	Bio       string    `gorm:"column:bio" json:"bio"`
-	AvatarURL string    `gorm:"column:avatar_url" json:"avatarUrl"`
-	Status    string    `gorm:"column:status;default:''" json:"status"`
-	UpdatedAt time.Time `gorm:"column:updated_at" json:"updatedAt"`
+	UserID    uint64 `gorm:"primaryKey;column:user_id" json:"userId"`
+	Bio       string `gorm:"column:bio" json:"bio"`
+	AvatarURL string `gorm:"column:avatar_url" json:"avatarUrl"`
+	// Status は旧列。StatusMessage(新列・一言ステータス)へ移行中で、Expand フェーズでは
+	// dual-write により両者を同値に保つ。読みは当面 Status を使い、Contract で削除する。
+	Status        string    `gorm:"column:status;default:''" json:"status"`
+	StatusMessage string    `gorm:"column:status_message;default:''" json:"-"`
+	UpdatedAt     time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
 func (Profile) TableName() string { return "profiles" }

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -127,10 +127,10 @@ func (h *ProfileHandler) Update(c *gin.Context) {
 		}
 	}
 	if _, err := h.update.Execute(c.Request.Context(), usecase.UpdateProfileInput{
-		UserID:    uid,
-		Bio:       req.Bio,
-		AvatarURL: avatarURL,
-		Status:    req.Status,
+		UserID:        uid,
+		Bio:           req.Bio,
+		AvatarURL:     avatarURL,
+		StatusMessage: req.Status,
 	}); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -34,21 +34,24 @@ func NewUpdateProfileUseCase(p repository.ProfileRepository) *UpdateProfileUseCa
 }
 
 type UpdateProfileInput struct {
-	UserID    uint64
-	Bio       string
-	AvatarURL string
-	Status    string
+	UserID        uint64
+	Bio           string
+	AvatarURL     string
+	StatusMessage string
 }
 
 func (u *UpdateProfileUseCase) Execute(ctx context.Context, in UpdateProfileInput) (*domain.Profile, error) {
 	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
 	}
+	// Expand フェーズ: 旧 status と新 status_message の両方へ同値を書く(dual-write)。
+	// これにより新旧タスクが同時稼働しても両列が有効な値を保つ。
 	p := &domain.Profile{
-		UserID:    in.UserID,
-		Bio:       in.Bio,
-		AvatarURL: in.AvatarURL,
-		Status:    in.Status,
+		UserID:        in.UserID,
+		Bio:           in.Bio,
+		AvatarURL:     in.AvatarURL,
+		Status:        in.StatusMessage,
+		StatusMessage: in.StatusMessage,
 	}
 	if err := u.profiles.Upsert(ctx, p); err != nil {
 		return nil, err

--- a/backend/internal/usecase/profile_usecase_test.go
+++ b/backend/internal/usecase/profile_usecase_test.go
@@ -57,3 +57,16 @@ func Test_プロフィール更新_永続化する(t *testing.T) {
 		t.Fatalf("expected bio=hi, got %q", got.Bio)
 	}
 }
+
+// Expand フェーズの dual-write を検証: StatusMessage の入力が status と status_message の
+// 両列(Profile の両フィールド)へ同値で書かれること。
+func Test_プロフィール更新_Expand期はstatusとstatus_messageに二重書きする(t *testing.T) {
+	repo := &stubProfileRepo{}
+	uc := NewUpdateProfileUseCase(repo)
+	if _, err := uc.Execute(context.Background(), UpdateProfileInput{UserID: 1, StatusMessage: "元気です"}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if repo.p.Status != "元気です" || repo.p.StatusMessage != "元気です" {
+		t.Fatalf("dual-write 失敗: status=%q status_message=%q", repo.p.Status, repo.p.StatusMessage)
+	}
+}

--- a/backend/migrations/0009_expand_profiles_status_message.sql
+++ b/backend/migrations/0009_expand_profiles_status_message.sql
@@ -1,0 +1,27 @@
+-- 0009 (Expand): profiles に status_message を追加し status から backfill。status は残す。
+--
+-- Expand-Contract の Expand フェーズ (FRESTYLE-182 / 親 FRESTYLE-181)。列リネームは後方互換で
+-- ないため、まず新列を追加して両立させる。additive なので、稼働中の旧 backend(status を明示列で
+-- SELECT / 更新している)には無影響。次にコードを dual-write(status と status_message の両方に書く)
+-- にデプロイし、最後の Contract フェーズ(0010)で status を削除する。
+--
+-- 冪等: 列が無ければ追加し、backfill は status_message が空で status が非空の行だけ更新する。
+-- 何度流しても同じ状態に収束する。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0009_expand_profiles_status_message.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'profiles' AND column_name = 'status_message'
+    ) THEN
+        ALTER TABLE profiles ADD COLUMN status_message text NOT NULL DEFAULT '';
+    END IF;
+END $$;
+
+UPDATE profiles
+SET status_message = status
+WHERE status_message = '' AND status <> '';


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 1 を **Expand-Contract** でやり直す **Expand フェーズ**（#2138 revert 後の再実装）。

## 背景

列リネームは後方互換ではない。ECS ローリングデプロイで新旧タスクが同時稼働するため、単純な rename は必ず壊れる瞬間が出る（前回 #2138 で本番 `/profile` を一時ダウンさせた）。無停止のため Expand-Contract で段階移行する。

## このPR（Expand）でやること

新列 `status_message` を追加し、旧 `status` は残したまま、コードを **dual-write**（両列へ同値を書く）にする。**additive なので、稼働中の旧 backend（`status` を明示列で SELECT / 更新）に無影響**。

- `migration 0009_expand_profiles_status_message.sql`: `status_message` を追加（`IF NOT EXISTS`）し、`status` から backfill（`status_message` が空の行のみ）。冪等。
- `schema.sql` に `status_message` を追加し `make sqlc` 再生成 → `Profile` モデルに `StatusMessage` 追加
- `domain.Profile` に `StatusMessage` フィールド追加（`Status` は残す）
- `usecase` が `status` と `status_message` の両方へ dual-write（dual-write 検証テストを追加）
- 読みは当面 `status`（全タスクが更新し続けるので常に最新）
- **API(JSON `status`)・OpenAPI は不変**（`make openapi` 差分なし）
- ついでに `schema.sql` の `users` 列 drift（migration 0006 以降 `display_name` 残置）を `name` に再是正

## デプロイ順序（このPRマージ後）

1. **migration 0009 を Supabase に適用**（additive・旧 backend に無影響）
2. **backend デプロイ**（dual-write 開始）

その後、別の **Contract PR** で `status` を削除し `status_message` 一本にする（コード先行デプロイ → 列 DROP の順）。

## テスト

- `go build` / `go vet` / `go test ./...`（exit 0・12 パッケージ ok、dual-write テスト含む）/ `gofmt -l` 差分なし / `make openapi` 差分なし

## 関連チケット

FRESTYLE-182（親 FRESTYLE-181）