### PR TITLE
refactor: profiles status 削除→status_message 一本化(Contract フェーズ) (FRESTYLE-182)

### DIFF
--- a/backend/internal/adapter/persistence/profile_repository.go
+++ b/backend/internal/adapter/persistence/profile_repository.go
@@ -39,7 +39,6 @@ func (r *profileRepository) FindByUserID(ctx context.Context, userID uint64) (*d
 		UserID:        uint64(row.UserID),
 		Bio:           row.Bio,
 		AvatarURL:     row.AvatarUrl,
-		Status:        row.Status,
 		StatusMessage: row.StatusMessage,
 		UpdatedAt:     row.UpdatedAt,
 	}, nil

--- a/backend/internal/adapter/persistence/profile_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/profile_repository_integration_test.go
@@ -21,7 +21,7 @@ func TestProfileRepository_Integration(t *testing.T) {
 	t.Run("FindByUserID は profile を返す", func(t *testing.T) {
 		testsupport.TruncateAll(t, db, "profiles")
 		require.NoError(t, db.WithContext(ctx).Create(&domain.Profile{
-			UserID: 7, Bio: "自己紹介", AvatarURL: "https://example.com/a.png", Status: "active",
+			UserID: 7, Bio: "自己紹介", AvatarURL: "https://example.com/a.png", StatusMessage: "active",
 		}).Error)
 
 		got, err := repo.FindByUserID(ctx, 7)
@@ -30,7 +30,7 @@ func TestProfileRepository_Integration(t *testing.T) {
 		require.Equal(t, uint64(7), got.UserID)
 		require.Equal(t, "自己紹介", got.Bio)
 		require.Equal(t, "https://example.com/a.png", got.AvatarURL)
-		require.Equal(t, "active", got.Status)
+		require.Equal(t, "active", got.StatusMessage)
 	})
 
 	t.Run("未作成は (nil, nil)", func(t *testing.T) {

--- a/backend/internal/adapter/persistence/queries/schema.sql
+++ b/backend/internal/adapter/persistence/queries/schema.sql
@@ -50,8 +50,6 @@ CREATE TABLE profiles (
     user_id    bigint PRIMARY KEY,
     bio            text NOT NULL DEFAULT '',
     avatar_url     text NOT NULL DEFAULT '',
-    -- status(旧) と status_message(新) は Expand-Contract 移行中の一時的な併存。Contract で status を削除する。
-    status         text NOT NULL DEFAULT '',
     status_message text NOT NULL DEFAULT '',
     updated_at     timestamptz NOT NULL
 );

--- a/backend/internal/adapter/persistence/sqlcgen/models.go
+++ b/backend/internal/adapter/persistence/sqlcgen/models.go
@@ -64,7 +64,6 @@ type Profile struct {
 	UserID        int64
 	Bio           string
 	AvatarUrl     string
-	Status        string
 	StatusMessage string
 	UpdatedAt     time.Time
 }

--- a/backend/internal/adapter/persistence/sqlcgen/profile.sql.go
+++ b/backend/internal/adapter/persistence/sqlcgen/profile.sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 const getProfileByUserID = `-- name: GetProfileByUserID :one
-SELECT user_id, bio, avatar_url, status, status_message, updated_at FROM profiles
+SELECT user_id, bio, avatar_url, status_message, updated_at FROM profiles
 WHERE user_id = $1
 `
 
@@ -22,7 +22,6 @@ func (q *Queries) GetProfileByUserID(ctx context.Context, userID int64) (Profile
 		&i.UserID,
 		&i.Bio,
 		&i.AvatarUrl,
-		&i.Status,
 		&i.StatusMessage,
 		&i.UpdatedAt,
 	)

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -7,10 +7,9 @@ type Profile struct {
 	UserID    uint64 `gorm:"primaryKey;column:user_id" json:"userId"`
 	Bio       string `gorm:"column:bio" json:"bio"`
 	AvatarURL string `gorm:"column:avatar_url" json:"avatarUrl"`
-	// Status は旧列。StatusMessage(新列・一言ステータス)へ移行中で、Expand フェーズでは
-	// dual-write により両者を同値に保つ。読みは当面 Status を使い、Contract で削除する。
-	Status        string    `gorm:"column:status;default:''" json:"status"`
-	StatusMessage string    `gorm:"column:status_message;default:''" json:"-"`
+	// StatusMessage はプロフィールの一言ステータス(自由文)。状態機械の status 列とは別物。
+	// JSON キーは互換のため status のまま(API 契約は不変)。
+	StatusMessage string    `gorm:"column:status_message;default:''" json:"status"`
 	UpdatedAt     time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
@@ -18,11 +17,11 @@ func (Profile) TableName() string { return "profiles" }
 
 // ProfileView は users.name と Profile を合成した表示用 DTO。
 type ProfileView struct {
-	UserID    uint64    `json:"userId"`
-	Name      string    `json:"name"`
-	Email     string    `json:"email"`
-	Bio       string    `json:"bio"`
-	AvatarURL string    `json:"avatarUrl"`
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	UserID        uint64    `json:"userId"`
+	Name          string    `json:"name"`
+	Email         string    `json:"email"`
+	Bio           string    `json:"bio"`
+	AvatarURL     string    `json:"avatarUrl"`
+	StatusMessage string    `json:"status"`
+	UpdatedAt     time.Time `json:"updatedAt"`
 }

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -153,7 +153,7 @@ func (h *ProfileHandler) buildView(c *gin.Context, uid uint64) (*domain.ProfileV
 	if p != nil {
 		view.Bio = p.Bio
 		view.AvatarURL = p.AvatarURL
-		view.Status = p.Status
+		view.StatusMessage = p.StatusMessage
 		view.UpdatedAt = p.UpdatedAt
 	}
 	user, _ := h.users.FindByID(c.Request.Context(), uid)

--- a/backend/internal/usecase/profile_usecase.go
+++ b/backend/internal/usecase/profile_usecase.go
@@ -44,13 +44,10 @@ func (u *UpdateProfileUseCase) Execute(ctx context.Context, in UpdateProfileInpu
 	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
 	}
-	// Expand フェーズ: 旧 status と新 status_message の両方へ同値を書く(dual-write)。
-	// これにより新旧タスクが同時稼働しても両列が有効な値を保つ。
 	p := &domain.Profile{
 		UserID:        in.UserID,
 		Bio:           in.Bio,
 		AvatarURL:     in.AvatarURL,
-		Status:        in.StatusMessage,
 		StatusMessage: in.StatusMessage,
 	}
 	if err := u.profiles.Upsert(ctx, p); err != nil {

--- a/backend/internal/usecase/profile_usecase_test.go
+++ b/backend/internal/usecase/profile_usecase_test.go
@@ -58,15 +58,14 @@ func Test_プロフィール更新_永続化する(t *testing.T) {
 	}
 }
 
-// Expand フェーズの dual-write を検証: StatusMessage の入力が status と status_message の
-// 両列(Profile の両フィールド)へ同値で書かれること。
-func Test_プロフィール更新_Expand期はstatusとstatus_messageに二重書きする(t *testing.T) {
+// Contract フェーズ: StatusMessage の入力が status_message へ書かれること(status 列は廃止)。
+func Test_プロフィール更新_status_messageに書き込む(t *testing.T) {
 	repo := &stubProfileRepo{}
 	uc := NewUpdateProfileUseCase(repo)
 	if _, err := uc.Execute(context.Background(), UpdateProfileInput{UserID: 1, StatusMessage: "元気です"}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if repo.p.Status != "元気です" || repo.p.StatusMessage != "元気です" {
-		t.Fatalf("dual-write 失敗: status=%q status_message=%q", repo.p.Status, repo.p.StatusMessage)
+	if repo.p.StatusMessage != "元気です" {
+		t.Fatalf("status_message 未書き込み: %q", repo.p.StatusMessage)
 	}
 }

--- a/backend/migrations/0010_contract_drop_profiles_status.sql
+++ b/backend/migrations/0010_contract_drop_profiles_status.sql
@@ -1,0 +1,23 @@
+-- 0010 (Contract): profiles.status を削除し status_message へ一本化する。
+--
+-- Expand-Contract の Contract フェーズ (FRESTYLE-182 / 親 FRESTYLE-181)。
+--
+-- ⚠️ 適用順序が重要: 必ず Contract 版コード(status を一切参照しない)を全タスクにデプロイし
+--    切ってから本 migration を適用する。先に DROP すると、まだ status を SELECT/更新している
+--    Expand 版タスクが存在する間、そのクエリが壊れる。expand(0009)とは逆順。
+--
+-- 冪等: status 列が存在するときだけ削除する。何度流しても同じ状態に収束する。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0010_contract_drop_profiles_status.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'profiles' AND column_name = 'status'
+    ) THEN
+        ALTER TABLE profiles DROP COLUMN status;
+    END IF;
+END $$;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 1 の **Contract フェーズ**（Expand は #2140 で本番適用済み）。

## このPR（Contract）でやること

`status` への参照を止め、`status_message` 一本にする。`status` 列は migration 0010 で削除。

- `schema.sql` から `status` 削除 + `make sqlc` 再生成（`Profile` モデルは `status_message` のみ）
- `domain.Profile` / `ProfileView` / usecase / handler / repository / テストを `status_message` のみに
- **API(JSON `status`) は不変**（`make openapi` 差分なし）
- `migration 0010_contract_drop_profiles_status.sql`: `DROP COLUMN status`（`IF EXISTS`・冪等）

## デプロイ順序（重要・expand とは逆）

1. このPRをマージ
2. **backend デプロイ**（contract コード = `status` を参照しない）
3. **全タスク入れ替え後に** migration 0010 適用（`status` を DROP）

先に DROP すると、まだ `status` を SELECT している Expand 版タスクが壊れるため、必ずデプロイ完了後に DROP する。

## テスト

- `go build` / `go vet` / `go test ./...`（exit 0・12 パッケージ ok）/ `gofmt -l` 差分なし / `make openapi` 差分なし

## 関連チケット

FRESTYLE-182（親 FRESTYLE-181）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - プロフィールのステータス表示を「ステータスメッセージ」に統一しました。
  - プロフィール更新時、入力したステータスメッセージが正しく保存・表示されるようになりました。
  - 既存のステータス情報を新しい形式へ移行しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->