### PR TITLE
refactor: master_exercises sort_order 読み切替 + order_index DROP(Contract) (FRESTYLE-183)

### DIFF
--- a/backend/internal/adapter/persistence/master_exercise_repository.go
+++ b/backend/internal/adapter/persistence/master_exercise_repository.go
@@ -23,7 +23,7 @@ func (r *masterExerciseRepository) ListByLanguage(ctx context.Context, language 
 	if language != "" {
 		q = q.Where("language = ?", language)
 	}
-	if err := q.Order("order_index asc").Find(&exercises).Error; err != nil {
+	if err := q.Order("sort_order asc").Find(&exercises).Error; err != nil {
 		return nil, err
 	}
 	return exercises, nil
@@ -109,7 +109,7 @@ LEFT JOIN (
 ) usr ON usr.exercise_id = e.id
 WHERE e.is_published = TRUE
   AND (? = '' OR e.language = ?)
-ORDER BY e.order_index ASC`
+ORDER BY e.sort_order ASC`
 
 	var q string
 	var args []interface{}

--- a/backend/internal/adapter/persistence/master_exercise_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/master_exercise_repository_integration_test.go
@@ -24,10 +24,10 @@ func TestMasterExerciseRepository_ListWithStatusByLanguage_Integration(t *testin
 
 	// 問題: php-1(公開) / php-2(公開) / go-1(公開) / draft-1(非公開) を用意。
 	exercises := []domain.MasterExercise{
-		{Slug: "php-1", Language: "php", Title: "PHP1", OrderIndex: 1, IsPublished: true},
-		{Slug: "php-2", Language: "php", Title: "PHP2", OrderIndex: 2, IsPublished: true},
-		{Slug: "go-1", Language: "go", Title: "Go1", OrderIndex: 3, IsPublished: true},
-		{Slug: "draft-1", Language: "php", Title: "Draft", OrderIndex: 4, IsPublished: false},
+		{Slug: "php-1", Language: "php", Title: "PHP1", SortOrder: 1, IsPublished: true},
+		{Slug: "php-2", Language: "php", Title: "PHP2", SortOrder: 2, IsPublished: true},
+		{Slug: "go-1", Language: "go", Title: "Go1", SortOrder: 3, IsPublished: true},
+		{Slug: "draft-1", Language: "php", Title: "Draft", SortOrder: 4, IsPublished: false},
 	}
 	for i := range exercises {
 		require.NoError(t, db.WithContext(ctx).Create(&exercises[i]).Error)
@@ -52,7 +52,7 @@ func TestMasterExerciseRepository_ListWithStatusByLanguage_Integration(t *testin
 		return repository.ListWithStatusInput{UserID: userID, Language: language}
 	}
 
-	t.Run("言語フィルタ + 非公開除外 + order_index 昇順", func(t *testing.T) {
+	t.Run("言語フィルタ + 非公開除外 + sort_order 昇順", func(t *testing.T) {
 		rows, err := exRepo.ListWithStatusByLanguage(ctx, in(0, "php"))
 		require.NoError(t, err)
 		require.Len(t, rows, 2, "php の公開問題のみ（draft は除外）")

--- a/backend/internal/domain/master_exercise.go
+++ b/backend/internal/domain/master_exercise.go
@@ -7,7 +7,7 @@ type MasterExercise struct {
 	ID             uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
 	Slug           string `gorm:"size:64;not null;uniqueIndex" json:"slug"`
 	Language       string `gorm:"size:32;not null;index" json:"language"`
-	OrderIndex     int    `gorm:"not null;default:0" json:"orderIndex"`
+	SortOrder      int    `gorm:"column:sort_order;not null;default:0" json:"orderIndex"`
 	Category       string `gorm:"size:64;not null" json:"category"`
 	Title          string `gorm:"size:200;not null" json:"title"`
 	Description    string `gorm:"type:text;not null" json:"description"`

--- a/backend/internal/handler/master_exercise_handler.go
+++ b/backend/internal/handler/master_exercise_handler.go
@@ -154,7 +154,7 @@ func (h *MasterExerciseHandler) List(c *gin.Context) {
 			ID:          r.ID,
 			Slug:        r.Slug,
 			Language:    r.Language,
-			OrderIndex:  r.OrderIndex,
+			OrderIndex:  r.SortOrder,
 			Category:    r.Category,
 			Title:       r.Title,
 			Difficulty:  r.Difficulty,

--- a/backend/migrations/0012_contract_drop_master_exercises_order_index.sql
+++ b/backend/migrations/0012_contract_drop_master_exercises_order_index.sql
@@ -1,0 +1,23 @@
+-- 0012 (Contract): master_exercises.order_index を削除。sort_order へ一本化する。
+--
+-- Expand-Contract の Contract フェーズ (FRESTYLE-183 / 親 FRESTYLE-181)。
+--
+-- ⚠️ 適用順序が重要: 必ず (a) backend を sort_order 読みにデプロイし切り、(b) 教材リポ seed.py を
+--    sort_order に切り替えた後に本 migration を適用する。先に DROP すると、まだ order_index を読む
+--    旧 backend タスクや、order_index を書く旧 seed.py が壊れる。expand(0011)とは逆順。
+--
+-- 冪等: order_index 列が存在するときだけ削除する。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0012_contract_drop_master_exercises_order_index.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'master_exercises' AND column_name = 'order_index'
+    ) THEN
+        ALTER TABLE master_exercises DROP COLUMN order_index;
+    END IF;
+END $$;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 3 の **Contract フェーズ**（Expand #2142 で `sort_order` 追加+backfill 済み・本番適用済み）。

## このPR

backend を `sort_order` 読みに切替え、`order_index` を削除する。

- `domain.MasterExercise.OrderIndex` → `SortOrder`（`column:sort_order`）。**JSON は `orderIndex` 維持で API 不変**
- repository の `Order("order_index asc")` / raw `ORDER BY e.order_index` を `sort_order` に
- handler レスポンス詰め替えを `r.SortOrder` に（レスポンスの `json:"orderIndex"` は不変）
- `migration 0012_contract_drop_master_exercises_order_index.sql`: `order_index` を DROP（冪等）

## デプロイ順序（重要）

1. このPRをマージ
2. 教材リポ `seed.py` を `sort_order` に切替（別 PR）
3. **backend デプロイ**（`sort_order` 読み。`order_index` はまだ DB に在るのでローリング重複中も両タスク OK）
4. デプロイ完了 & seed.py 反映後、**migration 0012 適用**（`order_index` DROP）

## テスト

`go build`/`vet`/`test ./...`（exit 0・12 pkg）/ `gofmt` clean / `make openapi` 差分なし。

## 関連チケット
FRESTYLE-183（親 FRESTYLE-181）