### PR TITLE
refactor: 章テーブルを teaching_materials → course_chapters に改名 (FRESTYLE-184)

### DIFF
--- a/backend/internal/adapter/persistence/lesson_progress_repository.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository.go
@@ -50,7 +50,7 @@ func (r *lessonProgressRepository) CountCompletedByUserGroupedByCourse(ctx conte
 	const q = `
 SELECT tm.course_id, COUNT(*) AS cnt
 FROM user_lesson_progress ulp
-JOIN teaching_materials tm ON tm.id = ulp.teaching_material_id
+JOIN course_chapters tm ON tm.id = ulp.teaching_material_id
 WHERE ulp.user_id = ? AND tm.is_published = TRUE
 GROUP BY tm.course_id`
 	var rows []struct {

--- a/backend/internal/adapter/persistence/lesson_progress_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository_integration_test.go
@@ -76,7 +76,7 @@ func TestLessonProgressRepository_CountCompletedByUserGroupedByCourse_Integratio
 	ctx := context.Background()
 
 	testsupport.TruncateAll(t, db, "user_lesson_progress")
-	testsupport.TruncateAll(t, db, "teaching_materials")
+	testsupport.TruncateAll(t, db, "course_chapters")
 
 	mk := func(courseID uint64, title string, published bool) *domain.TeachingMaterial {
 		m := &domain.TeachingMaterial{

--- a/backend/internal/adapter/persistence/teaching_material_repository.go
+++ b/backend/internal/adapter/persistence/teaching_material_repository.go
@@ -21,7 +21,7 @@ func NewTeachingMaterialRepository(db *gorm.DB) repository.TeachingMaterialRepos
 // ListByCompany は backward-compat 用（コース対応完了後に削除予定）。
 func (r *teachingMaterialRepository) ListByCompany(ctx context.Context, companyID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
 	const q = `
-SELECT * FROM teaching_materials
+SELECT * FROM course_chapters
 WHERE company_id = ? AND (? OR is_published = TRUE)
 ORDER BY updated_at DESC, id DESC`
 	var rows []domain.TeachingMaterial
@@ -31,15 +31,15 @@ ORDER BY updated_at DESC, id DESC`
 	return rows, nil
 }
 
-// ListByCourse はコース内の教材を order_in_course 昇順で返す。
+// ListByCourse はコース内の章を sort_order 昇順で返す。
 func (r *teachingMaterialRepository) ListByCourse(ctx context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
 	// 一覧は content(本文 markdown)を返さない（章ごとに重く、 全章を先読みすると非効率）。
 	// 本文は選択時に GetByID で都度取得する。Content は空文字のままになる。
 	const q = `
-SELECT id, company_id, course_id, created_by_user_id, title, order_in_course, is_published, created_at, updated_at
-FROM teaching_materials
+SELECT id, company_id, course_id, created_by_user_id, title, sort_order, is_published, created_at, updated_at
+FROM course_chapters
 WHERE course_id = ? AND (? OR is_published = TRUE)
-ORDER BY order_in_course ASC, id ASC`
+ORDER BY sort_order ASC, id ASC`
 	var rows []domain.TeachingMaterial
 	if err := r.db.WithContext(ctx).Raw(q, courseID, includeUnpublished).Scan(&rows).Error; err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ ORDER BY order_in_course ASC, id ASC`
 // GetByID は単一教材を返す。未存在は gorm.ErrRecordNotFound（handler が 404 に分岐）。
 func (r *teachingMaterialRepository) GetByID(ctx context.Context, id uint64) (*domain.TeachingMaterial, error) {
 	var m domain.TeachingMaterial
-	res := r.db.WithContext(ctx).Raw(`SELECT * FROM teaching_materials WHERE id = ?`, id).Scan(&m)
+	res := r.db.WithContext(ctx).Raw(`SELECT * FROM course_chapters WHERE id = ?`, id).Scan(&m)
 	if res.Error != nil {
 		return nil, res.Error
 	}
@@ -64,7 +64,7 @@ func (r *teachingMaterialRepository) GetByID(ctx context.Context, id uint64) (*d
 // trainee 向け(includeUnpublished=false)は published のみ数え、コース詳細の進捗分母と一致させる。
 func (r *teachingMaterialRepository) CountByCourseForCompany(ctx context.Context, companyID uint64, includeUnpublished bool) (map[uint64]int, error) {
 	const q = `
-SELECT course_id, COUNT(*) AS cnt FROM teaching_materials
+SELECT course_id, COUNT(*) AS cnt FROM course_chapters
 WHERE company_id = ? AND (? OR is_published = TRUE)
 GROUP BY course_id`
 	var rows []struct {
@@ -88,10 +88,10 @@ func (r *teachingMaterialRepository) Create(ctx context.Context, m *domain.Teach
 func (r *teachingMaterialRepository) Update(ctx context.Context, m *domain.TeachingMaterial) error {
 	// CreatedBy / CompanyID / CourseID は不変なので更新対象から外す。
 	return r.db.WithContext(ctx).Model(m).Updates(map[string]any{
-		"title":           m.Title,
-		"content":         m.Content,
-		"order_in_course": m.OrderInCourse,
-		"is_published":    m.IsPublished,
+		"title":        m.Title,
+		"content":      m.Content,
+		"sort_order":   m.OrderInCourse,
+		"is_published": m.IsPublished,
 	}).Error
 }
 

--- a/backend/internal/adapter/persistence/teaching_material_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/teaching_material_repository_integration_test.go
@@ -26,7 +26,7 @@ func TestTeachingMaterialRepository_CountByCourseForCompany_Integration(t *testi
 		}
 	}
 
-	testsupport.TruncateAll(t, db, "teaching_materials")
+	testsupport.TruncateAll(t, db, "course_chapters")
 
 	// company 1: course 10 に published 2 + draft 1、course 20 に published 1
 	require.NoError(t, repo.Create(ctx, mk(1, 10, "c10-pub-1", true)))

--- a/backend/internal/domain/teaching_material.go
+++ b/backend/internal/domain/teaching_material.go
@@ -2,8 +2,9 @@ package domain
 
 import "time"
 
-// TeachingMaterial は company_admin が自社 trainee 向けに作る教材。必ず 1 つの Course に所属する。
-// 本文は raw Markdown 文字列。コース内の並び順は OrderInCourse（同値時 ID 昇順）。
+// TeachingMaterial はコースを構成する「章」。必ず 1 つの Course に所属する（course 1 : N chapter）。
+// テーブルは course_chapters（FRESTYLE-184 で teaching_materials から改名）。
+// 本文は raw Markdown 文字列。コース内の並び順は sort_order 列（同値時 ID 昇順）。
 type TeachingMaterial struct {
 	ID        uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
 	CompanyID uint64 `gorm:"column:company_id;not null;index" json:"companyId"`
@@ -12,10 +13,10 @@ type TeachingMaterial struct {
 	CreatedByUserID uint64    `gorm:"column:created_by_user_id;not null" json:"createdByUserId"`
 	Title           string    `gorm:"column:title;not null;default:''" json:"title"`
 	Content         string    `gorm:"column:content;type:text;not null;default:''" json:"content"`
-	OrderInCourse   int       `gorm:"column:order_in_course;not null;default:100" json:"orderInCourse"`
+	OrderInCourse   int       `gorm:"column:sort_order;not null;default:100" json:"orderInCourse"`
 	IsPublished     bool      `gorm:"column:is_published;not null;default:false" json:"isPublished"`
 	CreatedAt       time.Time `gorm:"column:created_at" json:"createdAt"`
 	UpdatedAt       time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
-func (TeachingMaterial) TableName() string { return "teaching_materials" }
+func (TeachingMaterial) TableName() string { return "course_chapters" }

--- a/backend/migrations/0013_rename_teaching_materials_to_course_chapters.sql
+++ b/backend/migrations/0013_rename_teaching_materials_to_course_chapters.sql
@@ -1,0 +1,56 @@
+-- 0013: teaching_materials → course_chapters / order_in_course → sort_order（互換 VIEW 付き）
+--
+-- FRESTYLE-184（親 FRESTYLE-181）。章を表すテーブルの語彙を chapter に統一する。
+-- 命名規約: 子エンティティ(1:N) は親を接頭辞にして所有と 1:N を名前で示す → course_chapters
+-- （course 1 : N chapter）。並び順は courses.sort_order と揃えて sort_order に統一。
+--
+-- 【無停止のための互換 VIEW】
+-- テーブル改名は後方互換でなく、ECS ローリングデプロイ中は新旧タスクが同時に稼働する。そこで
+-- 改名後に旧名 teaching_materials を VIEW として作り直し、旧コードの SELECT/INSERT/UPDATE/DELETE
+-- をそのまま通す（PostgreSQL の自動更新可能ビュー: 単一テーブル・単純列参照・列別名は可）。
+-- 新コードをデプロイし切ったあと 0014 でこの VIEW を DROP する。
+--
+-- 冪等: 実テーブルが旧名のときだけ改名し、列も未改名のときだけ改名する。VIEW は CREATE OR REPLACE。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0013_rename_teaching_materials_to_course_chapters.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+DO $$
+BEGIN
+    -- 1) テーブル改名（実テーブルが旧名で、新名がまだ無いときだけ）
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'teaching_materials' AND table_type = 'BASE TABLE'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'course_chapters'
+    ) THEN
+        ALTER TABLE teaching_materials RENAME TO course_chapters;
+    END IF;
+
+    -- 2) 並び順カラム改名（未改名のときだけ）
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'course_chapters' AND column_name = 'order_in_course'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'course_chapters' AND column_name = 'sort_order'
+    ) THEN
+        ALTER TABLE course_chapters RENAME COLUMN order_in_course TO sort_order;
+    END IF;
+END $$;
+
+-- 3) 旧名の互換 VIEW（デプロイ完了後に 0014 で DROP する）
+CREATE OR REPLACE VIEW teaching_materials AS
+SELECT id,
+       company_id,
+       created_by_user_id,
+       title,
+       content,
+       is_published,
+       created_at,
+       updated_at,
+       course_id,
+       sort_order AS order_in_course
+FROM course_chapters;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 4a。承認済み決定「章の正式名 = `course_chapters`」の中核。

## なぜ（語彙の不統一というアンチパターン）

同一概念「章」が **teaching_material / chapter / lesson の3名**で呼ばれており、初見の人が別物と誤読する。命名規約では**子エンティティ(1:N)は親を接頭辞にして所有と 1:N を名前で示す**ため `course_chapters`（course 1 : N chapter）とする。並び順も `courses.sort_order` と揃える。

## 変更内容

- `domain.TeachingMaterial.TableName()` → `course_chapters`、並び順の gorm 列 → `sort_order`
  - **Go フィールド名 `OrderInCourse` と JSON `orderInCourse` は維持** → API・フロント・OpenAPI 不変（`make openapi` 差分なし）
- repository の生 SQL（`FROM teaching_materials` ×4）/ `JOIN` / `Updates` を新名に
- 統合テストの truncate 対象を `course_chapters` に
- `migration 0013`: テーブル改名 + `order_in_course`→`sort_order` + **旧名の互換 VIEW 作成**

## 無停止手法（互換 VIEW）

テーブル改名は後方互換でなく、ローリングデプロイ中は新旧タスクが同時稼働する。改名後に旧名 `teaching_materials` を **VIEW**（`sort_order AS order_in_course` を含む）として作り直すことで、旧タスクの SELECT/INSERT/UPDATE/DELETE がそのまま通る（PostgreSQL の自動更新可能ビュー）。

**順序**: このPRマージ → migration 0013 適用 → backend デプロイ → 教材リポ seed-courses.py 更新 → migration 0014 で VIEW を DROP。

## テスト

`go build` / `go vet` / `go test ./...`（exit 0・12 pkg）/ `gofmt` clean / `make openapi` 差分なし。

## 関連チケット
FRESTYLE-184（親 FRESTYLE-181）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * コース内の章一覧が正しい順序で表示されるようになりました。
  * 公開済みの章に基づく学習完了数の集計精度を改善しました。
  * 章の追加・更新やコース別の集計が、新しい章管理方式に対応しました。
* **移行**
  * 既存の教材・章データを維持したまま、新しい管理方式へ移行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->