### PR TITLE
refactor: 章テーブル改名の互換 VIEW を削除(Contract) (FRESTYLE-184)

### DIFF
--- a/backend/migrations/0014_drop_teaching_materials_compat_view.sql
+++ b/backend/migrations/0014_drop_teaching_materials_compat_view.sql
@@ -1,0 +1,17 @@
+-- 0014 (Contract): 互換 VIEW teaching_materials を削除する。
+--
+-- FRESTYLE-184（親 FRESTYLE-181）。0013 でテーブルを course_chapters に改名した際、
+-- ローリングデプロイ中の旧タスクを壊さないために旧名の互換 VIEW を作成した。
+--
+-- ⚠️ 適用条件: 以下がすべて完了してから適用すること。
+--   (a) backend が course_chapters / sort_order を参照するコードでデプロイ済み（全タスク入替済）
+--   (b) 教材リポ seed-courses.py が course_chapters / sort_order に切替済
+-- 先に DROP すると、まだ旧名を参照するタスク・seed が壊れる。
+--
+-- 冪等: VIEW が存在するときだけ削除する（IF EXISTS）。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0014_drop_teaching_materials_compat_view.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+DROP VIEW IF EXISTS teaching_materials;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 4a の **Contract（仕上げ）**。

## このPR

migration 0013 で `teaching_materials` → `course_chapters` に改名した際、ローリングデプロイ中の旧タスクを壊さないために作成した**旧名の互換 VIEW** を削除する。

- `migration 0014_drop_teaching_materials_compat_view.sql`: `DROP VIEW IF EXISTS teaching_materials`（冪等）

## 適用条件（いずれも完了済み）

- ✅ backend が `course_chapters` / `sort_order` 参照でデプロイ済み（run 29875788608 = success、health 200）
- ✅ 教材リポ `seed-courses.py` を `course_chapters` / `sort_order` に切替済（teaching-materials PR #27 マージ済）

旧名を参照するタスク・seed が無くなったため、VIEW を安全に削除できる。

## テスト

SQL のみ（コード変更なし）。適用後 `information_schema` で VIEW 消滅・`course_chapters` が BASE TABLE として残ることを確認する。

## 関連チケット
FRESTYLE-184（親 FRESTYLE-181）