### PR TITLE
refactor: 章 FK/カウンタ列の追加と dual-write(Expand) (FRESTYLE-185)

### DIFF
--- a/backend/internal/adapter/persistence/lesson_progress_repository.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository.go
@@ -20,9 +20,11 @@ func NewLessonProgressRepository(db *gorm.DB) repository.LessonProgressRepositor
 }
 
 func (r *lessonProgressRepository) MarkCompleted(ctx context.Context, userID, materialID, courseID uint64) (bool, error) {
+	// Expand フェーズ: 旧 teaching_material_id と新 chapter_id の両方へ同値を書く(dual-write)。
 	row := &domain.UserLessonProgress{
 		UserID:             userID,
 		TeachingMaterialID: materialID,
+		ChapterID:          materialID,
 		CourseID:           courseID,
 		CompletedAt:        time.Now(),
 	}

--- a/backend/internal/adapter/persistence/user_chapter_views_repository.go
+++ b/backend/internal/adapter/persistence/user_chapter_views_repository.go
@@ -22,17 +22,20 @@ func (r *userChapterViewRepository) UpsertView(
 	ctx context.Context,
 	userID, teachingMaterialID, courseID uint64,
 ) error {
+	// Expand フェーズ: 旧 teaching_material_id と新 chapter_id の両方へ同値を書く(dual-write)。
+	// 読みと ON CONFLICT は当面旧列。Contract で新列へ切り替えて旧列を削除する。
 	sql := `
 INSERT INTO user_chapter_views
-  (user_id, teaching_material_id, course_id, first_viewed_at, last_viewed_at, view_count)
+  (user_id, teaching_material_id, chapter_id, course_id, first_viewed_at, last_viewed_at, view_count)
 VALUES
-  (?, ?, ?, NOW(), NOW(), 1)
+  (?, ?, ?, ?, NOW(), NOW(), 1)
 ON CONFLICT (user_id, teaching_material_id) DO UPDATE SET
+  chapter_id     = EXCLUDED.chapter_id,
   course_id      = EXCLUDED.course_id,
   last_viewed_at = NOW(),
   view_count     = user_chapter_views.view_count + 1
 `
-	return r.db.WithContext(ctx).Exec(sql, userID, teachingMaterialID, courseID).Error
+	return r.db.WithContext(ctx).Exec(sql, userID, teachingMaterialID, teachingMaterialID, courseID).Error
 }
 
 func (r *userChapterViewRepository) ListRecentByUser(

--- a/backend/internal/adapter/persistence/user_daily_activity_repository.go
+++ b/backend/internal/adapter/persistence/user_daily_activity_repository.go
@@ -28,15 +28,18 @@ func (r *userDailyActivityRepository) Increment(
 ) error {
 	// date を DATE 型へ切り詰め（時刻成分を捨てる）。
 	d := date.UTC().Truncate(24 * time.Hour)
+	// Expand フェーズ: 旧 lesson_count と新 chapter_count の両方へ同じ増分を加算する(dual-write)。
+	// 読みは当面 lesson_count。Contract で chapter_count へ切り替えて旧列を削除する。
 	sql := `
 INSERT INTO user_daily_activities
-  (user_id, activity_date, exercise_count, correct_count, lesson_count, ai_chat_count, note_count)
+  (user_id, activity_date, exercise_count, correct_count, lesson_count, chapter_count, ai_chat_count, note_count)
 VALUES
-  (?, ?, ?, ?, ?, ?, ?)
+  (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (user_id, activity_date) DO UPDATE SET
   exercise_count = user_daily_activities.exercise_count + EXCLUDED.exercise_count,
   correct_count  = user_daily_activities.correct_count  + EXCLUDED.correct_count,
   lesson_count   = user_daily_activities.lesson_count   + EXCLUDED.lesson_count,
+  chapter_count  = user_daily_activities.chapter_count  + EXCLUDED.chapter_count,
   ai_chat_count  = user_daily_activities.ai_chat_count  + EXCLUDED.ai_chat_count,
   note_count     = user_daily_activities.note_count     + EXCLUDED.note_count
 `
@@ -45,6 +48,7 @@ ON CONFLICT (user_id, activity_date) DO UPDATE SET
 		userID, d,
 		delta.ExerciseCount,
 		delta.CorrectCount,
+		delta.LessonCount,
 		delta.LessonCount,
 		delta.AiChatCount,
 		delta.NoteCount,

--- a/backend/internal/domain/user_chapter_views.go
+++ b/backend/internal/domain/user_chapter_views.go
@@ -8,12 +8,15 @@ import "time"
 // (省略すると AutoMigrate が bigint への ALTER を発行してしまう)。
 // フィールド個別のコメントは swaggo が API description に取り込むためここに書く。
 type UserChapterView struct {
-	UserID             uint64    `gorm:"column:user_id;primaryKey"              json:"userId"`
-	TeachingMaterialID uint64    `gorm:"column:teaching_material_id;primaryKey" json:"teachingMaterialId"`
-	CourseID           uint64    `gorm:"column:course_id"                       json:"courseId"`
-	FirstViewedAt      time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
-	LastViewedAt       time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
-	ViewCount          int       `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
+	UserID             uint64 `gorm:"column:user_id;primaryKey"              json:"userId"`
+	TeachingMaterialID uint64 `gorm:"column:teaching_material_id;primaryKey" json:"teachingMaterialId"`
+	// ChapterID は teaching_material_id の後継(参照先 course_chapters に合わせた FK 名)。
+	// Expand フェーズでは dual-write で両列を同値に保つ。Contract で旧列を削除する。
+	ChapterID     uint64    `gorm:"column:chapter_id" json:"-"`
+	CourseID      uint64    `gorm:"column:course_id"                       json:"courseId"`
+	FirstViewedAt time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
+	LastViewedAt  time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
+	ViewCount     int       `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
 }
 
 func (UserChapterView) TableName() string { return "user_chapter_views" }

--- a/backend/internal/domain/user_daily_activity.go
+++ b/backend/internal/domain/user_daily_activity.go
@@ -12,8 +12,10 @@ type UserDailyActivity struct {
 	ExerciseCount int       `gorm:"column:exercise_count;default:0;type:integer" json:"exerciseCount"`
 	CorrectCount  int       `gorm:"column:correct_count;default:0;type:integer"  json:"correctCount"`
 	LessonCount   int       `gorm:"column:lesson_count;default:0;type:integer"   json:"lessonCount"`
-	AiChatCount   int       `gorm:"column:ai_chat_count;default:0;type:integer"  json:"aiChatCount"`
-	NoteCount     int       `gorm:"column:note_count;default:0;type:integer"     json:"noteCount"`
+	// ChapterCount は lesson_count の後継(章を数えるカウンタ)。Expand では dual-write で同値に保つ。
+	ChapterCount int `gorm:"column:chapter_count;default:0;type:integer" json:"-"`
+	AiChatCount  int `gorm:"column:ai_chat_count;default:0;type:integer"  json:"aiChatCount"`
+	NoteCount    int `gorm:"column:note_count;default:0;type:integer"     json:"noteCount"`
 }
 
 func (UserDailyActivity) TableName() string { return "user_daily_activities" }

--- a/backend/internal/domain/user_lesson_progress.go
+++ b/backend/internal/domain/user_lesson_progress.go
@@ -6,12 +6,15 @@ import "time"
 // 1 行 = その (user, teaching_material) が完了済み。未完了に戻すときは行を削除する。
 // (user_id, teaching_material_id) は複合ユニーク（同じ教材の二重記録を防ぐ）。
 type UserLessonProgress struct {
-	ID                 uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
-	UserID             uint64    `gorm:"column:user_id;not null;uniqueIndex:ux_user_lesson" json:"userId"`
-	TeachingMaterialID uint64    `gorm:"column:teaching_material_id;not null;uniqueIndex:ux_user_lesson" json:"teachingMaterialId"`
-	CourseID           uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
-	CompletedAt        time.Time `gorm:"column:completed_at;not null" json:"completedAt"`
-	CreatedAt          time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID                 uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID             uint64 `gorm:"column:user_id;not null;uniqueIndex:ux_user_lesson" json:"userId"`
+	TeachingMaterialID uint64 `gorm:"column:teaching_material_id;not null;uniqueIndex:ux_user_lesson" json:"teachingMaterialId"`
+	// ChapterID は teaching_material_id の後継(参照先 course_chapters に合わせた FK 名)。
+	// Expand フェーズでは dual-write で両列を同値に保つ。Contract で旧列を削除する。
+	ChapterID   uint64    `gorm:"column:chapter_id" json:"-"`
+	CourseID    uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
+	CompletedAt time.Time `gorm:"column:completed_at;not null" json:"completedAt"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (UserLessonProgress) TableName() string { return "user_lesson_progress" }

--- a/backend/migrations/0015_expand_chapter_fk_and_count.sql
+++ b/backend/migrations/0015_expand_chapter_fk_and_count.sql
@@ -1,0 +1,42 @@
+-- 0015 (Expand): 章 FK / カウンタ列を chapter 語彙へ移行するための追加 + backfill。旧列は残す。
+--
+-- FRESTYLE-185（親 FRESTYLE-181）。Phase 4a で参照先が course_chapters（実体 = chapter）に
+-- なったため、FK を chapter_id に、日次カウンタを chapter_count に統一する。
+-- additive なので稼働中の旧 backend（旧列を参照）には無影響。
+--
+-- 新列側の UNIQUE index も同時に作る。Contract で upsert の ON CONFLICT を新列へ
+-- 切り替えるには、先に新列側の一意制約が存在している必要があるため。
+--
+-- 冪等: 列・index は存在チェック付き。backfill は未設定行のみ更新する。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0015_expand_chapter_fk_and_count.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+-- 1) user_chapter_views.teaching_material_id → chapter_id
+ALTER TABLE user_chapter_views ADD COLUMN IF NOT EXISTS chapter_id bigint;
+UPDATE user_chapter_views SET chapter_id = teaching_material_id WHERE chapter_id IS NULL;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM user_chapter_views WHERE chapter_id IS NULL) THEN
+        ALTER TABLE user_chapter_views ALTER COLUMN chapter_id SET NOT NULL;
+    END IF;
+END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_user_chapter_views_user_chapter
+    ON user_chapter_views (user_id, chapter_id);
+
+-- 2) user_lesson_progress.teaching_material_id → chapter_id
+ALTER TABLE user_lesson_progress ADD COLUMN IF NOT EXISTS chapter_id bigint;
+UPDATE user_lesson_progress SET chapter_id = teaching_material_id WHERE chapter_id IS NULL;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM user_lesson_progress WHERE chapter_id IS NULL) THEN
+        ALTER TABLE user_lesson_progress ALTER COLUMN chapter_id SET NOT NULL;
+    END IF;
+END $$;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_user_chapter_progress_user_chapter
+    ON user_lesson_progress (user_id, chapter_id);
+
+-- 3) user_daily_activities.lesson_count → chapter_count
+ALTER TABLE user_daily_activities ADD COLUMN IF NOT EXISTS chapter_count integer NOT NULL DEFAULT 0;
+UPDATE user_daily_activities SET chapter_count = lesson_count WHERE chapter_count = 0 AND lesson_count <> 0;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 4b の **Expand フェーズ**。

## なぜ

Phase 4a で章テーブルが `course_chapters`（実体 = chapter）になったため、それを参照する **FK は `chapter_id`** が正（規約: FK は参照先の実体名）。同じ「章」を数える `lesson_count` も `chapter_count` に統一する。これで DB 上の「章」語彙が chapter に一本化される。

| テーブル | before | after |
|---|---|---|
| `user_chapter_views` | `teaching_material_id` | `chapter_id` |
| `user_lesson_progress` | `teaching_material_id` | `chapter_id` |
| `user_daily_activities` | `lesson_count` | `chapter_count` |

## このPR（Expand・additive）

- `migration 0015`: 3 列を追加し旧列から backfill（**旧列は維持**）。あわせて **新列側の UNIQUE index**（`(user_id, chapter_id)`）を作成 — Contract で upsert の `ON CONFLICT` を新列へ切り替えるには先に一意制約が必要なため
- `domain` に `ChapterID` / `ChapterCount` を追加（`json:"-"` なので **API・OpenAPI 不変**）
- 3 つの upsert を **dual-write** 化（新旧両列へ同値／同増分）。読みと `ON CONFLICT` は当面**旧列**のまま

additive なので、稼働中の旧 backend（旧列を参照）に無影響。

## 次（Contract・別PR）

読み書きを新列へ、`ON CONFLICT` を新 UNIQUE index へ切替 → デプロイ → `migration 0016` で `user_chapter_views` の PK を `(user_id, chapter_id)` へ張り替え＋旧列 DROP、`user_lesson_progress` の旧 UNIQUE index 破棄＋旧列 DROP、`lesson_count` DROP。

## テスト

`go build` / `go vet` / `go test ./...`（exit 0・12 pkg）/ `gofmt` clean / `make openapi` 差分なし。

## 関連チケット
FRESTYLE-185（親 FRESTYLE-181）