### PR TITLE
refactor: 章 FK/カウンタを新列へ切替え旧列を削除(Contract) (FRESTYLE-185)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -4495,6 +4495,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "teachingMaterialId": {
+                    "description": "TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。\nJSON キーは互換のため teachingMaterialId のまま。",
                     "type": "integer"
                 },
                 "userId": {
@@ -4521,6 +4522,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "lessonCount": {
+                    "description": "LessonCount は完了した章の数。DB 列は chapter_count(FRESTYLE-185 で改名)。\nJSON キーは互換のため lessonCount のまま。",
                     "type": "integer"
                 },
                 "noteCount": {
@@ -4547,6 +4549,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "teachingMaterialId": {
+                    "description": "TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。\nJSON キーは互換のため teachingMaterialId のまま。",
                     "type": "integer"
                 },
                 "userId": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4488,6 +4488,7 @@
                     "type": "string"
                 },
                 "teachingMaterialId": {
+                    "description": "TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。\nJSON キーは互換のため teachingMaterialId のまま。",
                     "type": "integer"
                 },
                 "userId": {
@@ -4514,6 +4515,7 @@
                     "type": "integer"
                 },
                 "lessonCount": {
+                    "description": "LessonCount は完了した章の数。DB 列は chapter_count(FRESTYLE-185 で改名)。\nJSON キーは互換のため lessonCount のまま。",
                     "type": "integer"
                 },
                 "noteCount": {
@@ -4540,6 +4542,7 @@
                     "type": "integer"
                 },
                 "teachingMaterialId": {
+                    "description": "TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。\nJSON キーは互換のため teachingMaterialId のまま。",
                     "type": "integer"
                 },
                 "userId": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -396,6 +396,9 @@ definitions:
       lastViewedAt:
         type: string
       teachingMaterialId:
+        description: |-
+          TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。
+          JSON キーは互換のため teachingMaterialId のまま。
         type: integer
       userId:
         type: integer
@@ -413,6 +416,9 @@ definitions:
       exerciseCount:
         type: integer
       lessonCount:
+        description: |-
+          LessonCount は完了した章の数。DB 列は chapter_count(FRESTYLE-185 で改名)。
+          JSON キーは互換のため lessonCount のまま。
         type: integer
       noteCount:
         type: integer
@@ -430,6 +436,9 @@ definitions:
       id:
         type: integer
       teachingMaterialId:
+        description: |-
+          TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。
+          JSON キーは互換のため teachingMaterialId のまま。
         type: integer
       userId:
         type: integer

--- a/backend/internal/adapter/persistence/company_learning_activity_repository.go
+++ b/backend/internal/adapter/persistence/company_learning_activity_repository.go
@@ -33,7 +33,7 @@ SELECT u.id AS user_id,
        MAX(a.activity_date) AS last_active_date,
        COALESCE(SUM(
          CASE WHEN a.activity_date >= ?
-              THEN a.exercise_count + a.lesson_count + a.ai_chat_count + a.note_count
+              THEN a.exercise_count + a.chapter_count + a.ai_chat_count + a.note_count
               ELSE 0 END
        ), 0) AS recent_activity_count
 FROM users u

--- a/backend/internal/adapter/persistence/lesson_progress_repository.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository.go
@@ -20,17 +20,15 @@ func NewLessonProgressRepository(db *gorm.DB) repository.LessonProgressRepositor
 }
 
 func (r *lessonProgressRepository) MarkCompleted(ctx context.Context, userID, materialID, courseID uint64) (bool, error) {
-	// Expand フェーズ: 旧 teaching_material_id と新 chapter_id の両方へ同値を書く(dual-write)。
 	row := &domain.UserLessonProgress{
 		UserID:             userID,
 		TeachingMaterialID: materialID,
-		ChapterID:          materialID,
 		CourseID:           courseID,
 		CompletedAt:        time.Now(),
 	}
-	// (user_id, teaching_material_id) が衝突したら何もしない（冪等）。RowsAffected で初回かを判定。
+	// (user_id, chapter_id) が衝突したら何もしない（冪等）。RowsAffected で初回かを判定。
 	result := r.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "user_id"}, {Name: "teaching_material_id"}},
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "chapter_id"}},
 		DoNothing: true,
 	}).Create(row)
 	if result.Error != nil {
@@ -41,7 +39,7 @@ func (r *lessonProgressRepository) MarkCompleted(ctx context.Context, userID, ma
 
 func (r *lessonProgressRepository) MarkIncomplete(ctx context.Context, userID, materialID uint64) error {
 	return r.db.WithContext(ctx).
-		Where("user_id = ? AND teaching_material_id = ?", userID, materialID).
+		Where("user_id = ? AND chapter_id = ?", userID, materialID).
 		Delete(&domain.UserLessonProgress{}).Error
 }
 
@@ -52,7 +50,7 @@ func (r *lessonProgressRepository) CountCompletedByUserGroupedByCourse(ctx conte
 	const q = `
 SELECT tm.course_id, COUNT(*) AS cnt
 FROM user_lesson_progress ulp
-JOIN course_chapters tm ON tm.id = ulp.teaching_material_id
+JOIN course_chapters tm ON tm.id = ulp.chapter_id
 WHERE ulp.user_id = ? AND tm.is_published = TRUE
 GROUP BY tm.course_id`
 	var rows []struct {

--- a/backend/internal/adapter/persistence/user_chapter_views_repository.go
+++ b/backend/internal/adapter/persistence/user_chapter_views_repository.go
@@ -22,20 +22,17 @@ func (r *userChapterViewRepository) UpsertView(
 	ctx context.Context,
 	userID, teachingMaterialID, courseID uint64,
 ) error {
-	// Expand フェーズ: 旧 teaching_material_id と新 chapter_id の両方へ同値を書く(dual-write)。
-	// 読みと ON CONFLICT は当面旧列。Contract で新列へ切り替えて旧列を削除する。
 	sql := `
 INSERT INTO user_chapter_views
-  (user_id, teaching_material_id, chapter_id, course_id, first_viewed_at, last_viewed_at, view_count)
+  (user_id, chapter_id, course_id, first_viewed_at, last_viewed_at, view_count)
 VALUES
-  (?, ?, ?, ?, NOW(), NOW(), 1)
-ON CONFLICT (user_id, teaching_material_id) DO UPDATE SET
-  chapter_id     = EXCLUDED.chapter_id,
+  (?, ?, ?, NOW(), NOW(), 1)
+ON CONFLICT (user_id, chapter_id) DO UPDATE SET
   course_id      = EXCLUDED.course_id,
   last_viewed_at = NOW(),
   view_count     = user_chapter_views.view_count + 1
 `
-	return r.db.WithContext(ctx).Exec(sql, userID, teachingMaterialID, teachingMaterialID, courseID).Error
+	return r.db.WithContext(ctx).Exec(sql, userID, teachingMaterialID, courseID).Error
 }
 
 func (r *userChapterViewRepository) ListRecentByUser(

--- a/backend/internal/adapter/persistence/user_daily_activity_repository.go
+++ b/backend/internal/adapter/persistence/user_daily_activity_repository.go
@@ -28,17 +28,14 @@ func (r *userDailyActivityRepository) Increment(
 ) error {
 	// date を DATE 型へ切り詰め（時刻成分を捨てる）。
 	d := date.UTC().Truncate(24 * time.Hour)
-	// Expand フェーズ: 旧 lesson_count と新 chapter_count の両方へ同じ増分を加算する(dual-write)。
-	// 読みは当面 lesson_count。Contract で chapter_count へ切り替えて旧列を削除する。
 	sql := `
 INSERT INTO user_daily_activities
-  (user_id, activity_date, exercise_count, correct_count, lesson_count, chapter_count, ai_chat_count, note_count)
+  (user_id, activity_date, exercise_count, correct_count, chapter_count, ai_chat_count, note_count)
 VALUES
-  (?, ?, ?, ?, ?, ?, ?, ?)
+  (?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT (user_id, activity_date) DO UPDATE SET
   exercise_count = user_daily_activities.exercise_count + EXCLUDED.exercise_count,
   correct_count  = user_daily_activities.correct_count  + EXCLUDED.correct_count,
-  lesson_count   = user_daily_activities.lesson_count   + EXCLUDED.lesson_count,
   chapter_count  = user_daily_activities.chapter_count  + EXCLUDED.chapter_count,
   ai_chat_count  = user_daily_activities.ai_chat_count  + EXCLUDED.ai_chat_count,
   note_count     = user_daily_activities.note_count     + EXCLUDED.note_count
@@ -48,7 +45,6 @@ ON CONFLICT (user_id, activity_date) DO UPDATE SET
 		userID, d,
 		delta.ExerciseCount,
 		delta.CorrectCount,
-		delta.LessonCount,
 		delta.LessonCount,
 		delta.AiChatCount,
 		delta.NoteCount,

--- a/backend/internal/domain/user_chapter_views.go
+++ b/backend/internal/domain/user_chapter_views.go
@@ -3,20 +3,19 @@ package domain
 import "time"
 
 // UserChapterView はユーザーが章（教材）を開いた記録。
-// PK = (user_id, teaching_material_id)。upsert により last_viewed_at と view_count を更新する。
+// PK = (user_id, chapter_id)。upsert により last_viewed_at と view_count を更新する。
 // GORM タグの type:integer は migration 0005 の実テーブル定義に合わせるための明示
 // (省略すると AutoMigrate が bigint への ALTER を発行してしまう)。
 // フィールド個別のコメントは swaggo が API description に取り込むためここに書く。
 type UserChapterView struct {
-	UserID             uint64 `gorm:"column:user_id;primaryKey"              json:"userId"`
-	TeachingMaterialID uint64 `gorm:"column:teaching_material_id;primaryKey" json:"teachingMaterialId"`
-	// ChapterID は teaching_material_id の後継(参照先 course_chapters に合わせた FK 名)。
-	// Expand フェーズでは dual-write で両列を同値に保つ。Contract で旧列を削除する。
-	ChapterID     uint64    `gorm:"column:chapter_id" json:"-"`
-	CourseID      uint64    `gorm:"column:course_id"                       json:"courseId"`
-	FirstViewedAt time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
-	LastViewedAt  time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
-	ViewCount     int       `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
+	UserID uint64 `gorm:"column:user_id;primaryKey"              json:"userId"`
+	// TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。
+	// JSON キーは互換のため teachingMaterialId のまま。
+	TeachingMaterialID uint64    `gorm:"column:chapter_id;primaryKey"           json:"teachingMaterialId"`
+	CourseID           uint64    `gorm:"column:course_id"                       json:"courseId"`
+	FirstViewedAt      time.Time `gorm:"column:first_viewed_at"                 json:"firstViewedAt"`
+	LastViewedAt       time.Time `gorm:"column:last_viewed_at"                  json:"lastViewedAt"`
+	ViewCount          int       `gorm:"column:view_count;default:1;type:integer" json:"viewCount"`
 }
 
 func (UserChapterView) TableName() string { return "user_chapter_views" }

--- a/backend/internal/domain/user_daily_activity.go
+++ b/backend/internal/domain/user_daily_activity.go
@@ -11,11 +11,11 @@ type UserDailyActivity struct {
 	ActivityDate  time.Time `gorm:"column:activity_date;type:date;primaryKey" json:"activityDate"`
 	ExerciseCount int       `gorm:"column:exercise_count;default:0;type:integer" json:"exerciseCount"`
 	CorrectCount  int       `gorm:"column:correct_count;default:0;type:integer"  json:"correctCount"`
-	LessonCount   int       `gorm:"column:lesson_count;default:0;type:integer"   json:"lessonCount"`
-	// ChapterCount は lesson_count の後継(章を数えるカウンタ)。Expand では dual-write で同値に保つ。
-	ChapterCount int `gorm:"column:chapter_count;default:0;type:integer" json:"-"`
-	AiChatCount  int `gorm:"column:ai_chat_count;default:0;type:integer"  json:"aiChatCount"`
-	NoteCount    int `gorm:"column:note_count;default:0;type:integer"     json:"noteCount"`
+	// LessonCount は完了した章の数。DB 列は chapter_count(FRESTYLE-185 で改名)。
+	// JSON キーは互換のため lessonCount のまま。
+	LessonCount int `gorm:"column:chapter_count;default:0;type:integer"  json:"lessonCount"`
+	AiChatCount int `gorm:"column:ai_chat_count;default:0;type:integer"  json:"aiChatCount"`
+	NoteCount   int `gorm:"column:note_count;default:0;type:integer"     json:"noteCount"`
 }
 
 func (UserDailyActivity) TableName() string { return "user_daily_activities" }

--- a/backend/internal/domain/user_lesson_progress.go
+++ b/backend/internal/domain/user_lesson_progress.go
@@ -2,19 +2,18 @@ package domain
 
 import "time"
 
-// UserLessonProgress は trainee が教材（レッスン）を完了したことの記録。
-// 1 行 = その (user, teaching_material) が完了済み。未完了に戻すときは行を削除する。
-// (user_id, teaching_material_id) は複合ユニーク（同じ教材の二重記録を防ぐ）。
+// UserLessonProgress は trainee が章を完了したことの記録。
+// 1 行 = その (user, chapter) が完了済み。未完了に戻すときは行を削除する。
+// (user_id, chapter_id) は複合ユニーク（同じ章の二重記録を防ぐ）。
 type UserLessonProgress struct {
-	ID                 uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
-	UserID             uint64 `gorm:"column:user_id;not null;uniqueIndex:ux_user_lesson" json:"userId"`
-	TeachingMaterialID uint64 `gorm:"column:teaching_material_id;not null;uniqueIndex:ux_user_lesson" json:"teachingMaterialId"`
-	// ChapterID は teaching_material_id の後継(参照先 course_chapters に合わせた FK 名)。
-	// Expand フェーズでは dual-write で両列を同値に保つ。Contract で旧列を削除する。
-	ChapterID   uint64    `gorm:"column:chapter_id" json:"-"`
-	CourseID    uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
-	CompletedAt time.Time `gorm:"column:completed_at;not null" json:"completedAt"`
-	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
+	ID     uint64 `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID uint64 `gorm:"column:user_id;not null;uniqueIndex:ux_user_chapter_progress_user_chapter" json:"userId"`
+	// TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。
+	// JSON キーは互換のため teachingMaterialId のまま。
+	TeachingMaterialID uint64    `gorm:"column:chapter_id;not null;uniqueIndex:ux_user_chapter_progress_user_chapter" json:"teachingMaterialId"`
+	CourseID           uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
+	CompletedAt        time.Time `gorm:"column:completed_at;not null" json:"completedAt"`
+	CreatedAt          time.Time `gorm:"column:created_at" json:"createdAt"`
 }
 
 func (UserLessonProgress) TableName() string { return "user_lesson_progress" }

--- a/backend/internal/usecase/repository/user_chapter_views.go
+++ b/backend/internal/usecase/repository/user_chapter_views.go
@@ -8,7 +8,7 @@ import (
 
 // UserChapterViewRepository は章閲覧記録の永続化 port。
 type UserChapterViewRepository interface {
-	// UpsertView は (user_id, teaching_material_id) の行を upsert する。
+	// UpsertView は (user_id, chapter_id) の行を upsert する。
 	// 初回: INSERT。2回目以降: last_viewed_at を現在時刻に更新し view_count を +1。
 	UpsertView(ctx context.Context, userID, teachingMaterialID, courseID uint64) error
 

--- a/backend/migrations/0016_contract_drop_old_chapter_fk_and_count.sql
+++ b/backend/migrations/0016_contract_drop_old_chapter_fk_and_count.sql
@@ -1,0 +1,46 @@
+-- 0016 (Contract): 章 FK / カウンタの旧列を削除する。
+--
+-- FRESTYLE-185（親 FRESTYLE-181）。0015 で chapter_id / chapter_count を追加し dual-write して
+-- きた。本 migration で旧列を削除し chapter 語彙へ一本化する。
+--
+-- ⚠️ 適用条件: 新列のみを読み書きする Contract 版コードを全タスクにデプロイし切ってから適用する。
+--    先に DROP すると、まだ旧列を参照する Expand 版タスクが壊れる。
+--
+-- user_chapter_views は (user_id, teaching_material_id) が複合 PK のため、旧列を落とす前に
+-- PK を張り替える。0015 で作成済みの UNIQUE index を `USING INDEX` でそのまま PK に昇格させ、
+-- 余分な index を作らない。
+--
+-- 冪等: 旧列が存在するときだけ実行する。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0016_contract_drop_old_chapter_fk_and_count.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+-- 1) user_chapter_views: PK を (user_id, chapter_id) に張り替えてから旧列を削除
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'user_chapter_views' AND column_name = 'teaching_material_id'
+    ) THEN
+        ALTER TABLE user_chapter_views DROP CONSTRAINT IF EXISTS user_chapter_views_pkey;
+        ALTER TABLE user_chapter_views
+            ADD CONSTRAINT user_chapter_views_pkey PRIMARY KEY USING INDEX ux_user_chapter_views_user_chapter;
+        ALTER TABLE user_chapter_views DROP COLUMN teaching_material_id;
+    END IF;
+END $$;
+
+-- 2) user_lesson_progress: 旧 UNIQUE index を落として旧列を削除（PK は id のまま）
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'user_lesson_progress' AND column_name = 'teaching_material_id'
+    ) THEN
+        DROP INDEX IF EXISTS ux_user_lesson;
+        ALTER TABLE user_lesson_progress DROP COLUMN teaching_material_id;
+    END IF;
+END $$;
+
+-- 3) user_daily_activities: 旧カウンタ列を削除
+ALTER TABLE user_daily_activities DROP COLUMN IF EXISTS lesson_count;


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 4b の **Contract フェーズ**（Expand #2146 は本番適用済み・dual-write 稼働中）。

## このPR

読み書きを新列（`chapter_id` / `chapter_count`）へ切り替え、旧列を削除する。

- `domain` の **gorm 列タグのみ**を `chapter_id` / `chapter_count` に変更。**Go フィールド名（`TeachingMaterialID` / `LessonCount`）と JSON キーは維持**したため、usecase / handler は無変更・**API と OpenAPI も不変**
- upsert の `ON CONFLICT` を `(user_id, chapter_id)` に（0015 で作成済みの UNIQUE index を使用）、`JOIN` / `WHERE` も新列へ
- 日次カウンタの INSERT・加算を `chapter_count` に、会社学習集計の生 SQL も `chapter_count` に
- `migration 0016`: `user_chapter_views` の PK を **`USING INDEX` で 0015 の UNIQUE index から張り替え**（余分な index を作らない）→ 旧列 DROP。`user_lesson_progress` は旧 UNIQUE index `ux_user_lesson` を落として旧列 DROP。`lesson_count` DROP

## デプロイ順序

1. このPRをマージ
2. **backend デプロイ**（新列のみ読み書き。旧列はまだ DB に在るのでローリング重複中も Expand 版タスクが動く）
3. デプロイ完了後 **migration 0016 適用**（旧列 DROP）

## テスト

`go build` / `go vet` / `go test ./...`（exit 0・12 pkg）/ `gofmt` clean / `make openapi` 差分なし。

## 関連チケット
FRESTYLE-185（親 FRESTYLE-181）