### PR TITLE
refactor: user_chapter_progress を新設し dual-write(Expand) (FRESTYLE-186)

### DIFF
--- a/backend/internal/adapter/persistence/lesson_progress_repository.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository.go
@@ -20,11 +20,12 @@ func NewLessonProgressRepository(db *gorm.DB) repository.LessonProgressRepositor
 }
 
 func (r *lessonProgressRepository) MarkCompleted(ctx context.Context, userID, materialID, courseID uint64) (bool, error) {
+	completedAt := time.Now()
 	row := &domain.UserLessonProgress{
 		UserID:             userID,
 		TeachingMaterialID: materialID,
 		CourseID:           courseID,
-		CompletedAt:        time.Now(),
+		CompletedAt:        completedAt,
 	}
 	// (user_id, chapter_id) が衝突したら何もしない（冪等）。RowsAffected で初回かを判定。
 	result := r.db.WithContext(ctx).Clauses(clause.OnConflict{
@@ -34,13 +35,27 @@ func (r *lessonProgressRepository) MarkCompleted(ctx context.Context, userID, ma
 	if result.Error != nil {
 		return false, result.Error
 	}
+	// Expand フェーズ: 後継テーブル user_chapter_progress にも同じ行を upsert する(dual-write)。
+	// Contract で読み書きを新テーブルへ切り替え、旧テーブルを削除する。
+	const shadow = `
+INSERT INTO user_chapter_progress (user_id, chapter_id, course_id, completed_at, created_at)
+VALUES (?, ?, ?, ?, NOW())
+ON CONFLICT (user_id, chapter_id) DO NOTHING`
+	if err := r.db.WithContext(ctx).Exec(shadow, userID, materialID, courseID, completedAt).Error; err != nil {
+		return false, err
+	}
 	return result.RowsAffected > 0, nil
 }
 
 func (r *lessonProgressRepository) MarkIncomplete(ctx context.Context, userID, materialID uint64) error {
-	return r.db.WithContext(ctx).
+	if err := r.db.WithContext(ctx).
 		Where("user_id = ? AND chapter_id = ?", userID, materialID).
-		Delete(&domain.UserLessonProgress{}).Error
+		Delete(&domain.UserLessonProgress{}).Error; err != nil {
+		return err
+	}
+	// Expand フェーズ: 後継テーブルからも削除する(dual-write)。
+	return r.db.WithContext(ctx).
+		Exec(`DELETE FROM user_chapter_progress WHERE user_id = ? AND chapter_id = ?`, userID, materialID).Error
 }
 
 // CountCompletedByUserGroupedByCourse は「現存する published 教材」の完了行のみを

--- a/backend/migrations/0017_expand_user_chapter_progress_table.sql
+++ b/backend/migrations/0017_expand_user_chapter_progress_table.sql
@@ -1,0 +1,42 @@
+-- 0017 (Expand): user_lesson_progress の後継テーブル user_chapter_progress を作成し全行コピーする。
+--
+-- FRESTYLE-186（親 FRESTYLE-181）。DB 上の「章」語彙で唯一残る "lesson" を chapter に統一する。
+--
+-- 【なぜテーブル改名(+互換 VIEW)ではないのか】
+-- このテーブルへの書き込みは GORM の upsert（INSERT ... ON CONFLICT (user_id, chapter_id)
+-- DO NOTHING）。PostgreSQL は VIEW に対する ON CONFLICT をサポートしないため、4a で使った
+-- 「改名 + 旧名の互換 VIEW」方式が使えない（INSTEAD OF トリガを付けても ON CONFLICT は不可）。
+-- そこで新テーブルを作り、移行期は 2 テーブルへ dual-write する Expand-Contract とする。
+--
+-- 冪等: テーブル・index は IF NOT EXISTS、コピーは ON CONFLICT DO NOTHING。
+--
+-- 適用: frestyle-infrastructure リポで
+--   make apply-migration-supabase FILE=../FreStyle/backend/migrations/0017_expand_user_chapter_progress_table.sql \
+--        DATABASE_URL_SECRET_NAME=frestyle-prod/database-url
+
+CREATE TABLE IF NOT EXISTS user_chapter_progress (
+    id           bigserial PRIMARY KEY,
+    user_id      bigint      NOT NULL,
+    chapter_id   bigint      NOT NULL,
+    course_id    bigint      NOT NULL,
+    completed_at timestamptz NOT NULL,
+    created_at   timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_user_chapter_progress
+    ON user_chapter_progress (user_id, chapter_id);
+CREATE INDEX IF NOT EXISTS idx_user_chapter_progress_course_id
+    ON user_chapter_progress (course_id);
+
+-- 既存の完了記録をコピー（id を保持して再適用時も重複しないようにする）
+INSERT INTO user_chapter_progress (id, user_id, chapter_id, course_id, completed_at, created_at)
+SELECT id, user_id, chapter_id, course_id, completed_at, created_at
+FROM user_lesson_progress
+WHERE chapter_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- id シーケンスをコピー済みの最大値に合わせる（以後の INSERT が衝突しないように）
+SELECT setval(
+    pg_get_serial_sequence('user_chapter_progress', 'id'),
+    GREATEST(COALESCE((SELECT MAX(id) FROM user_chapter_progress), 1), 1)
+);


### PR DESCRIPTION
親 Design Doc: FRESTYLE-181 / Phase 4c の **Expand フェーズ**。

## なぜ

4a/4b で章の語彙は `course_chapters` / `chapter_id` / `chapter_count` に統一済み。残るのは **`user_lesson_progress` というテーブル名だけ**で、現状は「テーブル名は lesson・列は chapter」という不整合になっている。

## なぜ「改名 + 互換 VIEW」ではないのか

4a のテーブル改名では旧名を VIEW で残す方式が使えたが、このテーブルの書き込みは GORM の upsert（`INSERT ... ON CONFLICT (user_id, chapter_id) DO NOTHING`）。**PostgreSQL は VIEW に対する `ON CONFLICT` を非対応**（`INSTEAD OF` トリガを付けても不可）。よって**新テーブル + 2 テーブル dual-write** で移行する。

## このPR（Expand・additive）

- `migration 0017`: `user_chapter_progress` を作成（`chapter_id` NOT NULL）、`UNIQUE(user_id, chapter_id)` と `course_id` index、既存行を **id 保持でコピー**、id シーケンスを最大値へ `setval`
- `MarkCompleted` / `MarkIncomplete` が**新旧 2 テーブルへ dual-write**。読み（集計・一覧）は当面**旧テーブル**

additive なので稼働中の backend に無影響。

## 次（Contract・別PR）

`TableName()` を新テーブルへ切替え shadow write を撤去 → デプロイ → `migration 0018` で旧テーブルを DROP。

## テスト

`go build` / `go vet` / `go test ./...`（exit 0・12 pkg）/ `gofmt` clean。

## 関連チケット
FRESTYLE-186（親 FRESTYLE-181）