### PR TITLE
fix: user_chapter_progress を AutoMigrate に登録し統合テストを修復 (FRESTYLE-186)

### DIFF
--- a/backend/internal/adapter/persistence/lesson_progress_repository.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository.go
@@ -37,11 +37,16 @@ func (r *lessonProgressRepository) MarkCompleted(ctx context.Context, userID, ma
 	}
 	// Expand フェーズ: 後継テーブル user_chapter_progress にも同じ行を upsert する(dual-write)。
 	// Contract で読み書きを新テーブルへ切り替え、旧テーブルを削除する。
-	const shadow = `
-INSERT INTO user_chapter_progress (user_id, chapter_id, course_id, completed_at, created_at)
-VALUES (?, ?, ?, ?, NOW())
-ON CONFLICT (user_id, chapter_id) DO NOTHING`
-	if err := r.db.WithContext(ctx).Exec(shadow, userID, materialID, courseID, completedAt).Error; err != nil {
+	shadow := &domain.UserChapterProgress{
+		UserID:      userID,
+		ChapterID:   materialID,
+		CourseID:    courseID,
+		CompletedAt: completedAt,
+	}
+	if err := r.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}, {Name: "chapter_id"}},
+		DoNothing: true,
+	}).Create(shadow).Error; err != nil {
 		return false, err
 	}
 	return result.RowsAffected > 0, nil
@@ -55,7 +60,8 @@ func (r *lessonProgressRepository) MarkIncomplete(ctx context.Context, userID, m
 	}
 	// Expand フェーズ: 後継テーブルからも削除する(dual-write)。
 	return r.db.WithContext(ctx).
-		Exec(`DELETE FROM user_chapter_progress WHERE user_id = ? AND chapter_id = ?`, userID, materialID).Error
+		Where("user_id = ? AND chapter_id = ?", userID, materialID).
+		Delete(&domain.UserChapterProgress{}).Error
 }
 
 // CountCompletedByUserGroupedByCourse は「現存する published 教材」の完了行のみを

--- a/backend/internal/adapter/persistence/lesson_progress_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/lesson_progress_repository_integration_test.go
@@ -20,7 +20,7 @@ func TestLessonProgressRepository_Integration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("MarkCompleted は冪等（二重実行でも 1 件）", func(t *testing.T) {
-		testsupport.TruncateAll(t, db, "user_lesson_progress")
+		testsupport.TruncateAll(t, db, "user_lesson_progress", "user_chapter_progress")
 
 		changed, err := repo.MarkCompleted(ctx, 1, 10, 100)
 		require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestLessonProgressRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("ListByUser は user で絞り込む", func(t *testing.T) {
-		testsupport.TruncateAll(t, db, "user_lesson_progress")
+		testsupport.TruncateAll(t, db, "user_lesson_progress", "user_chapter_progress")
 
 		_, err := repo.MarkCompleted(ctx, 1, 10, 100)
 		require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestLessonProgressRepository_Integration(t *testing.T) {
 	})
 
 	t.Run("MarkIncomplete は行を削除する（未記録でもエラーにしない）", func(t *testing.T) {
-		testsupport.TruncateAll(t, db, "user_lesson_progress")
+		testsupport.TruncateAll(t, db, "user_lesson_progress", "user_chapter_progress")
 
 		_, err := repo.MarkCompleted(ctx, 1, 10, 100)
 		require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestLessonProgressRepository_CountCompletedByUserGroupedByCourse_Integratio
 	materials := persistence.NewTeachingMaterialRepository(db)
 	ctx := context.Background()
 
-	testsupport.TruncateAll(t, db, "user_lesson_progress")
+	testsupport.TruncateAll(t, db, "user_lesson_progress", "user_chapter_progress")
 	testsupport.TruncateAll(t, db, "course_chapters")
 
 	mk := func(courseID uint64, title string, published bool) *domain.TeachingMaterial {

--- a/backend/internal/domain/user_chapter_progress.go
+++ b/backend/internal/domain/user_chapter_progress.go
@@ -1,0 +1,20 @@
+package domain
+
+import "time"
+
+// UserChapterProgress は trainee が章を完了したことの記録（user × chapter に 1 行）。
+// user_lesson_progress の後継テーブル（FRESTYLE-186）。移行期は両テーブルへ dual-write し、
+// Contract フェーズで読み書きを本テーブルへ寄せて旧テーブルを削除する。
+//
+// AutoMigrate に登録することで、SQL migration を流さない CI / ローカル環境でも
+// このテーブルが作られる（migration 0017 と同じ構造・同じ index 名になるようタグを揃える）。
+type UserChapterProgress struct {
+	ID          uint64    `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID      uint64    `gorm:"column:user_id;not null;uniqueIndex:ux_user_chapter_progress" json:"userId"`
+	ChapterID   uint64    `gorm:"column:chapter_id;not null;uniqueIndex:ux_user_chapter_progress" json:"chapterId"`
+	CourseID    uint64    `gorm:"column:course_id;not null;index" json:"courseId"`
+	CompletedAt time.Time `gorm:"column:completed_at;not null" json:"completedAt"`
+	CreatedAt   time.Time `gorm:"column:created_at" json:"createdAt"`
+}
+
+func (UserChapterProgress) TableName() string { return "user_chapter_progress" }

--- a/backend/internal/infra/database/migrate.go
+++ b/backend/internal/infra/database/migrate.go
@@ -30,6 +30,8 @@ func allDomainModels() []any {
 		&domain.LearningReport{},
 		&domain.AuditEvent{},
 		&domain.UserLessonProgress{},
+		// UserChapterProgress は UserLessonProgress の後継(FRESTYLE-186)。移行期は両方を管理する。
+		&domain.UserChapterProgress{},
 		// user_chapter_views / user_daily_activities の実テーブルは migration 0005 で作成済。
 		// ここに載せるのは結合テスト DB のスキーマ構築のため(タグは 0005 と一致させ、本番では no-op)。
 		&domain.UserChapterView{},


### PR DESCRIPTION
## 概要

PR #2148（Phase 4c Expand）で追加した dual-write 先の `user_chapter_progress` は **SQL migration 0017 でしか作られない**ため、GORM AutoMigrate で DB を組み立てる **CI / ローカル環境に存在せず**、統合テストが `ERROR: relation "user_chapter_progress" does not exist (SQLSTATE 42P01)` で失敗していた。

（#2148 は `vet / test / build` のみを見てマージしてしまい、`integration tests (postgres)` の FAILURE を見落とした。本番は migration 未適用・未デプロイのため**影響なし**。）

## 修正内容

- **`domain.UserChapterProgress` を新設し AutoMigrate に登録**。migration 0017 と同じ構造・同じ UNIQUE index 名（`ux_user_chapter_progress`）になるよう gorm タグを揃えた → SQL migration を流さない環境でもテーブルが作られる
- dual-write を生 SQL から **GORM（`OnConflict` / `Delete`）** に変更して型安全に
- 統合テストの `TruncateAll` に新テーブルを追加（可変長引数）

## テスト

`go build` / `go vet` / `go test ./...`（exit 0）/ `gofmt` clean。**`integration tests (postgres)` が green になることを本PRの CI で確認する**。

## 関連チケット
FRESTYLE-186（親 FRESTYLE-181）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * レッスン完了・未完了の変更が、章単位の進捗情報にも正しく反映されるようになりました。
  * ユーザーごとの章の完了状態が重複せず、安定して管理されます。
* **データベース**
  * 章単位の進捗を保存するテーブルが自動的に作成・更新されるようになりました。
* **バグ修正**
  * テスト間に残った進捗データの影響で、結果が不安定になる問題を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->