### PR TITLE
style: 完了ボタンと「次の章へ」を本文カードの外に出し折り返しを解消 (FRESTYLE-188)

### DIFF
--- a/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
+++ b/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
@@ -493,34 +493,36 @@ function ReadOnlyDetail({
               <ReadOnlyMarkdown content={bodyContent} />
             </div>
 
-            {/* 末尾に「完了にする」と「次の章へ」を並べ、 読み終えた位置から次へ進めるようにする。
-                最終章では代わりに「次のコースへ」を出し、 一覧に戻らず次のコースへ直行できるようにする
-                (FRESTYLE-102。 遷移先はレジュームにより 1 章目が自動表示される)。 */}
-            <div className="mt-10 pt-6 border-t border-surface-3 flex flex-col sm:flex-row items-center justify-center gap-3">
-              <CompleteToggleButton completed={completed} onToggle={onToggleComplete} large />
-              {nextMaterial && onGoNext ? (
-                <button
-                  type="button"
-                  onClick={onGoNext}
-                  title={`次の章へ: ${nextMaterial.title || '無題の教材'}`}
-                  className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors max-w-full"
-                >
-                  <span className="truncate">次の章へ: {nextMaterial.title || '無題の教材'}</span>
-                  <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
-                </button>
-              ) : nextCourse && onGoNextCourse ? (
-                <button
-                  type="button"
-                  onClick={onGoNextCourse}
-                  title={`次のコースへ: ${nextCourse.title || '無題のコース'}`}
-                  className="inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors max-w-full"
-                >
-                  <span className="truncate">次のコースへ: {nextCourse.title || '無題のコース'}</span>
-                  <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
-                </button>
-              ) : null}
-            </div>
           </article>
+
+          {/* 読み終わりのアクション(完了 / 次へ)は本文カードの外に置き、本文と操作を視覚的に分ける
+              (FRESTYLE-188。 以前はカード内の末尾にあった)。 最終章では代わりに「次のコースへ」を出し、
+              一覧に戻らず次のコースへ直行できるようにする
+              (FRESTYLE-102。 遷移先はレジュームにより 1 章目が自動表示される)。 */}
+          <div className="mt-6 flex flex-col sm:flex-row items-center justify-center gap-3">
+            <CompleteToggleButton completed={completed} onToggle={onToggleComplete} large />
+            {nextMaterial && onGoNext ? (
+              <button
+                type="button"
+                onClick={onGoNext}
+                title={`次の章へ: ${nextMaterial.title || '無題の教材'}`}
+                className="inline-flex min-w-0 items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors max-w-full"
+              >
+                <span className="truncate">次の章へ: {nextMaterial.title || '無題の教材'}</span>
+                <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
+              </button>
+            ) : nextCourse && onGoNextCourse ? (
+              <button
+                type="button"
+                onClick={onGoNextCourse}
+                title={`次のコースへ: ${nextCourse.title || '無題のコース'}`}
+                className="inline-flex min-w-0 items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors max-w-full"
+              >
+                <span className="truncate">次のコースへ: {nextCourse.title || '無題のコース'}</span>
+                <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
+              </button>
+            ) : null}
+          </div>
         </div>
 
         {tocOpen && (
@@ -680,7 +682,9 @@ function CompleteToggleButton({
       type="button"
       onClick={() => onToggle(!completed)}
       aria-pressed={completed}
-      className={`inline-flex items-center justify-center gap-1.5 rounded-lg font-medium transition-colors ${
+      // whitespace-nowrap / shrink-0: 隣に長いタイトルの「次の章へ」ボタンが並んでも縮まず、
+      // ラベルが「完了に / する」と 2 行に折り返さないようにする(FRESTYLE-188)。
+      className={`inline-flex shrink-0 whitespace-nowrap items-center justify-center gap-1.5 rounded-lg font-medium transition-colors ${
         large ? 'px-5 pt-[9px] pb-[11px] text-sm' : 'px-3 pt-[5px] pb-[7px] text-sm'
       } ${
         completed


### PR DESCRIPTION
## 概要

教材閲覧（`/courses/:id`）の読み終わりアクション（「完了にする」/「次の章へ: …」）を**本文カードの外**へ移動し、あわせて「完了にする」のラベルが 2 行に折り返して崩れる問題を直す。

## 現象と原因

「完了にする」が「完了に / する」と 2 行になっていた。原因は `CompleteToggleButton` に `whitespace-nowrap` が無く、同じ flex 行の「次の章へ: {長い章タイトル}」ボタン（`max-w-full`）に押されて縮んでいたため。

## 変更内容

- アクション行（完了トグル + 次の章へ / 次のコースへ）を `<article>`（本文カード）の**外**へ移動し、カード直下に配置
- カード内にあった区切り線 `pt-6 border-t border-surface-3` は不要になったので除去し、カード下の余白 `mt-6` でバランスを取る
- `CompleteToggleButton` に **`shrink-0` / `whitespace-nowrap`** を付与 → 隣が長くても縮まず 1 行表示
- 「次の章へ」側に `min-w-0` を追加し `truncate` が正しく効くように
- **本文カード自体のスタイル（幅・padding・角丸・境界）は変更していない**

## テスト

- `tsc --noEmit` ✅ / `eslint --max-warnings 0` ✅
- `vitest run` **152 ファイル / 1192 テスト 全通過**（course-detail の既存 51 テスト含む。「完了トグルはメタ行と本文末尾の 2 箇所」の assertion もカード外移動後に成立）
- `npm run build` ✅ / カバレッジ閾値クリア（85.5% / 80.91% / 82.18% / 87.21%）

ロジック変更なし・表示のみ。

## 関連チケット
FRESTYLE-188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * コース詳細ページの読み終わりアクションを記事の外側に配置し、区切りや余白を見直しました。
  * 「次の章へ」「次のコースへ」ボタンの配置と余白を調整しました。
  * 完了ボタンのラベルが折り返されにくくなり、隣接ボタンと並べた際の表示が安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->