### PR TITLE
docs: profile handler の swaggo Description の旧語彙を修正 (FRESTYLE-190)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3260,7 +3260,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "指定 user (or current user) の displayName / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。",
+                "description": "指定 user (or current user) の name / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。",
                 "produces": [
                     "application/json"
                 ],
@@ -3310,7 +3310,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。",
+                "description": "current user の name / bio / avatarUrl / status を 更新 する。 他 user は 403。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3253,7 +3253,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "指定 user (or current user) の displayName / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。",
+                "description": "指定 user (or current user) の name / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。",
                 "produces": [
                     "application/json"
                 ],
@@ -3303,7 +3303,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。",
+                "description": "current user の name / bio / avatarUrl / status を 更新 する。 他 user は 403。",
                 "consumes": [
                     "application/json"
                 ],

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -3153,8 +3153,8 @@ paths:
       - notifications
   /profile/{userId}:
     get:
-      description: 指定 user (or current user) の displayName / bio / avatarUrl / status
-        を 返す。 IDOR 対策 で 自分 以外 は 403。
+      description: 指定 user (or current user) の name / bio / avatarUrl / status を 返す。
+        IDOR 対策 で 自分 以外 は 403。
       parameters:
       - description: 数字 ID または 'me'
         in: path
@@ -3188,8 +3188,8 @@ paths:
     put:
       consumes:
       - application/json
-      description: current user の displayName / bio / avatarUrl / status を 更新 する。
-        他 user は 403。
+      description: current user の name / bio / avatarUrl / status を 更新 する。 他 user
+        は 403。
       parameters:
       - description: 数字 ID または 'me'
         in: path

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -57,7 +57,7 @@ func (h *ProfileHandler) resolveUserID(c *gin.Context) (uint64, error) {
 // Get は指定 user のプロフィールを返す。
 //
 //	@Summary      プロフィール 取得
-//	@Description  指定 user (or current user) の displayName / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。
+//	@Description  指定 user (or current user) の name / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。
 //	@Tags         profile
 //	@Produce      json
 //	@Param        userId  path      string  true   "数字 ID または 'me'"
@@ -92,7 +92,7 @@ type updateProfileReq struct {
 // Update は current user のプロフィールを更新する。
 //
 //	@Summary      プロフィール 更新
-//	@Description  current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。
+//	@Description  current user の name / bio / avatarUrl / status を 更新 する。 他 user は 403。
 //	@Tags         profile
 //	@Accept       json
 //	@Produce      json


### PR DESCRIPTION
## 概要

`profile_handler.go` の swaggo `@Description`（Get / Update）に、`users.display_name`→`name` 改名（migration 0006）以前の旧語彙 **displayName** が残っていた。コース 05 教材刷新（FRESTYLE-190）の全章監査で発見。

## 変更内容

- `@Description` 2 行の `displayName` → `name`（実装は既に `name`。annotation のみの乖離）
- `make openapi` 再生成（`backend/docs/`）

## テスト

`go build` / handler テスト通過。annotation とコメントのみの変更でロジック不変。

## 関連チケット
FRESTYLE-190

マージ後、教材 025 章の引用へ同セッション内バックポートする（規約）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * プロフィールAPIの仕様説明を更新し、取得・更新対象の項目名を実際のフィールドに合わせて `name` と明記しました。
  * `name`、`bio`、`avatarUrl`、`status` の対象項目がより明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->