### PR TITLE
fix: AI チャットの会話履歴を時系列に整列（シャッフルで応答崩壊する潜在バグ） (FRESTYLE-195)

### DIFF
--- a/backend/internal/adapter/persistence/ai_chat_message_repository.go
+++ b/backend/internal/adapter/persistence/ai_chat_message_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -138,5 +139,24 @@ func (r *aiChatMessageRepository) ListBySessionID(ctx context.Context, sessionID
 			CreatedAt:   t,
 		})
 	}
+	// SK(messageId) はランダム UUID のため、Query の返却順(SK 辞書順)は時系列にならない。
+	// 会話履歴は「モデルへの入力」と「画面の表示順」の両方が時系列前提なので、ここで必ず整列する。
+	// 整列しないと履歴がシャッフルされたままモデルに渡り、支離滅裂な応答になる(FRESTYLE-195)。
+	sortAiChatMessages(msgs)
 	return msgs, nil
+}
+
+// sortAiChatMessages は会話履歴を時系列(created_at 昇順)に整列する。
+// created_at は秒精度(RFC3339)のため同一秒がありうる。同一秒内は user → assistant の順
+// (質問が先・応答が後)とし、それも同じなら messageId で決定的に安定させる。
+func sortAiChatMessages(msgs []domain.AiChatMessage) {
+	sort.Slice(msgs, func(i, j int) bool {
+		if !msgs[i].CreatedAt.Equal(msgs[j].CreatedAt) {
+			return msgs[i].CreatedAt.Before(msgs[j].CreatedAt)
+		}
+		if msgs[i].Role != msgs[j].Role {
+			return msgs[i].Role == domain.AiChatRoleUser
+		}
+		return msgs[i].MessageID < msgs[j].MessageID
+	})
 }

--- a/backend/internal/adapter/persistence/ai_chat_message_sort_test.go
+++ b/backend/internal/adapter/persistence/ai_chat_message_sort_test.go
@@ -1,0 +1,56 @@
+package persistence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func at(sec int) time.Time {
+	return time.Date(2026, 7, 25, 12, 0, sec, 0, time.UTC)
+}
+
+func Test_会話履歴の整列_SKのUUID順で崩れた履歴を時系列に戻す(t *testing.T) {
+	// DynamoDB Query は SK(ランダム UUID)順で返すため、時系列がシャッフルされた状態を再現する。
+	msgs := []domain.AiChatMessage{
+		{MessageID: "b", Role: domain.AiChatRoleUser, Content: "2つ目の質問", CreatedAt: at(30)},
+		{MessageID: "a", Role: domain.AiChatRoleAssistant, Content: "1つ目の応答", CreatedAt: at(20)},
+		{MessageID: "c", Role: domain.AiChatRoleUser, Content: "1つ目の質問", CreatedAt: at(10)},
+		{MessageID: "d", Role: domain.AiChatRoleAssistant, Content: "2つ目の応答", CreatedAt: at(40)},
+	}
+
+	sortAiChatMessages(msgs)
+
+	got := make([]string, len(msgs))
+	for i, m := range msgs {
+		got[i] = m.Content
+	}
+	assert.Equal(t, []string{"1つ目の質問", "1つ目の応答", "2つ目の質問", "2つ目の応答"}, got)
+}
+
+func Test_会話履歴の整列_同一秒内はuserが先(t *testing.T) {
+	// created_at は秒精度のため、短い応答では user と assistant が同一秒になりうる。
+	msgs := []domain.AiChatMessage{
+		{MessageID: "x", Role: domain.AiChatRoleAssistant, Content: "応答", CreatedAt: at(5)},
+		{MessageID: "y", Role: domain.AiChatRoleUser, Content: "質問", CreatedAt: at(5)},
+	}
+
+	sortAiChatMessages(msgs)
+
+	assert.Equal(t, "質問", msgs[0].Content)
+	assert.Equal(t, "応答", msgs[1].Content)
+}
+
+func Test_会話履歴の整列_同一秒同一ロールはmessageIdで安定(t *testing.T) {
+	msgs := []domain.AiChatMessage{
+		{MessageID: "zz", Role: domain.AiChatRoleUser, Content: "後", CreatedAt: at(5)},
+		{MessageID: "aa", Role: domain.AiChatRoleUser, Content: "先", CreatedAt: at(5)},
+	}
+
+	sortAiChatMessages(msgs)
+
+	assert.Equal(t, "先", msgs[0].Content)
+	assert.Equal(t, "後", msgs[1].Content)
+}


### PR DESCRIPTION
## 事象

AI チャットの応答が「😊」1 文字で途切れる（ユーザー報告）。画面の表示順も乱れる。

## 調査（切り分けの記録）

1. ECS 正常・エラーログなし。`POST /ai-chat/stream` が **latency 約 1.1 秒で 200**（正常生成なら数十秒）
2. 本番と同一モデル ID で Bedrock 直接呼び出し → 正常応答（モデル・権限は無罪）
3. DynamoDB 実データ確認 → assistant 応答が本当に `content="😊"` で保存、かつ **Query の返却順が時系列でない**

## 根本原因（既存の潜在バグ・直近リリースとは無関係）

DynamoDB の SK = `messageId` = **ランダム UUID**。`ListBySessionID` は `ScanIndexForward`（= SK 辞書順 ≒ ランダム）のまま返し **created_at で整列していなかった**。この関数は「モデルへの会話履歴」と「画面の一覧」の両方で使われるため、**シャッフルされた会話がモデルに渡り**当惑した最小応答になる。会話が伸びるほど悪化する時限爆弾型で、今回顕在化した。

## 修正

返却前に必ず整列する `sortAiChatMessages` を追加:
- `created_at` 昇順
- 同一秒内（RFC3339 は秒精度）は **user → assistant**（質問が先）
- 同一秒同一ロールは `messageId` で決定的に安定

## テスト

- 新規 3 本（シャッフル履歴の復元 / 同一秒の user 優先 / 安定ソート）全 PASS
- `go build` / `go vet` / `go test ./...` exit 0
- データ修正不要（保存は正しく、読み取り順だけの問題）

## 関連チケット
FRESTYLE-195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 会話履歴が取得順によって入れ替わる問題を修正しました。
  * 会話メッセージが作成時刻順に表示されるようになりました。
  * 同時刻のメッセージも一定のルールで安定して並ぶよう改善しました。

* **テスト**
  * 会話履歴の並び順に関する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->