### PR TITLE
fix: プロフィールの氏名が保存も表示もされない不一致を修正 (FRESTYLE-198)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -3310,7 +3310,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user の name / bio / avatarUrl / status を 更新 する。 他 user は 403。",
+                "description": "current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。",
                 "consumes": [
                     "application/json"
                 ],
@@ -4406,10 +4406,10 @@ const docTemplate = `{
                 "bio": {
                     "type": "string"
                 },
-                "email": {
+                "displayName": {
                     "type": "string"
                 },
-                "name": {
+                "email": {
                     "type": "string"
                 },
                 "status": {
@@ -5450,11 +5450,12 @@ const docTemplate = `{
                 "bio": {
                     "type": "string"
                 },
-                "iconUrl": {
-                    "description": "旧フロント互換。avatarUrl を優先。",
+                "displayName": {
+                    "description": "Name はフロントの送信キー displayName で受ける (name では常に空になり\nusers.UpdateName が呼ばれず氏名が保存されない: FRESTYLE-198)。",
                     "type": "string"
                 },
-                "name": {
+                "iconUrl": {
+                    "description": "旧フロント互換。avatarUrl を優先。",
                     "type": "string"
                 },
                 "status": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3303,7 +3303,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user の name / bio / avatarUrl / status を 更新 する。 他 user は 403。",
+                "description": "current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。",
                 "consumes": [
                     "application/json"
                 ],
@@ -4399,10 +4399,10 @@
                 "bio": {
                     "type": "string"
                 },
-                "email": {
+                "displayName": {
                     "type": "string"
                 },
-                "name": {
+                "email": {
                     "type": "string"
                 },
                 "status": {
@@ -5443,11 +5443,12 @@
                 "bio": {
                     "type": "string"
                 },
-                "iconUrl": {
-                    "description": "旧フロント互換。avatarUrl を優先。",
+                "displayName": {
+                    "description": "Name はフロントの送信キー displayName で受ける (name では常に空になり\nusers.UpdateName が呼ばれず氏名が保存されない: FRESTYLE-198)。",
                     "type": "string"
                 },
-                "name": {
+                "iconUrl": {
+                    "description": "旧フロント互換。avatarUrl を優先。",
                     "type": "string"
                 },
                 "status": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -336,9 +336,9 @@ definitions:
         type: string
       bio:
         type: string
-      email:
+      displayName:
         type: string
-      name:
+      email:
         type: string
       status:
         type: string
@@ -1048,10 +1048,13 @@ definitions:
         type: string
       bio:
         type: string
+      displayName:
+        description: |-
+          Name はフロントの送信キー displayName で受ける (name では常に空になり
+          users.UpdateName が呼ばれず氏名が保存されない: FRESTYLE-198)。
+        type: string
       iconUrl:
         description: 旧フロント互換。avatarUrl を優先。
-        type: string
-      name:
         type: string
       status:
         type: string
@@ -3188,8 +3191,8 @@ paths:
     put:
       consumes:
       - application/json
-      description: current user の name / bio / avatarUrl / status を 更新 する。 他 user
-        は 403。
+      description: current user の displayName / bio / avatarUrl / status を 更新 する。
+        他 user は 403。
       parameters:
       - description: 数字 ID または 'me'
         in: path

--- a/backend/internal/domain/profile.go
+++ b/backend/internal/domain/profile.go
@@ -16,9 +16,11 @@ type Profile struct {
 func (Profile) TableName() string { return "profiles" }
 
 // ProfileView は users.name と Profile を合成した表示用 DTO。
+// Name の JSON キーはフロント (entities/user の Profile 型) に合わせて displayName
+// (name だと取得・更新の両方向でフロントと食い違い氏名が消える: FRESTYLE-198)。
 type ProfileView struct {
 	UserID        uint64    `json:"userId"`
-	Name          string    `json:"name"`
+	Name          string    `json:"displayName"`
 	Email         string    `json:"email"`
 	Bio           string    `json:"bio"`
 	AvatarURL     string    `json:"avatarUrl"`

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -82,7 +82,9 @@ func (h *ProfileHandler) Get(c *gin.Context) {
 }
 
 type updateProfileReq struct {
-	Name      string `json:"name"`
+	// Name はフロントの送信キー displayName で受ける (name では常に空になり
+	// users.UpdateName が呼ばれず氏名が保存されない: FRESTYLE-198)。
+	Name      string `json:"displayName"`
 	Bio       string `json:"bio"`
 	AvatarURL string `json:"avatarUrl"`
 	IconURL   string `json:"iconUrl"` // 旧フロント互換。avatarUrl を優先。
@@ -92,7 +94,7 @@ type updateProfileReq struct {
 // Update は current user のプロフィールを更新する。
 //
 //	@Summary      プロフィール 更新
-//	@Description  current user の name / bio / avatarUrl / status を 更新 する。 他 user は 403。
+//	@Description  current user の displayName / bio / avatarUrl / status を 更新 する。 他 user は 403。
 //	@Tags         profile
 //	@Accept       json
 //	@Produce      json

--- a/backend/internal/handler/profile_handler_test.go
+++ b/backend/internal/handler/profile_handler_test.go
@@ -1,12 +1,18 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 func init() {
@@ -59,5 +65,107 @@ func Test_プロフィール_ユーザーID解決_カレントユーザーなし
 	h := &ProfileHandler{}
 	if _, err := h.resolveUserID(makeCtx(0, "me")); !errors.Is(err, errProfileUnauthorized) {
 		t.Fatalf("no current user should be unauthorized; got %v", err)
+	}
+}
+
+// stubProfileUserRepo は Update 経路で使うメソッドだけ実装した UserRepository スタブ。
+// 未実装メソッドは埋め込んだ nil interface 経由で panic する（呼ばれない前提の検知になる）。
+type stubProfileUserRepo struct {
+	repository.UserRepository
+	updatedName   string
+	updateCalled  bool
+	foundUserName string
+}
+
+func (s *stubProfileUserRepo) UpdateName(_ context.Context, _ uint64, name string) error {
+	s.updateCalled = true
+	s.updatedName = name
+	return nil
+}
+
+func (s *stubProfileUserRepo) FindByID(_ context.Context, id uint64) (*domain.User, error) {
+	return &domain.User{ID: id, Name: s.foundUserName}, nil
+}
+
+// stubProfileRepo は ProfileRepository の in-memory スタブ。
+type stubProfileRepo struct {
+	saved *domain.Profile
+}
+
+func (s *stubProfileRepo) FindByUserID(_ context.Context, userID uint64) (*domain.Profile, error) {
+	if s.saved != nil {
+		return s.saved, nil
+	}
+	return &domain.Profile{UserID: userID}, nil
+}
+
+func (s *stubProfileRepo) Upsert(_ context.Context, p *domain.Profile) error {
+	s.saved = p
+	return nil
+}
+
+// doProfileUpdate は PUT /profile/me を httptest で実行し recorder と stub を返す。
+func doProfileUpdate(t *testing.T, body string) (*httptest.ResponseRecorder, *stubProfileUserRepo, *stubProfileRepo) {
+	t.Helper()
+	users := &stubProfileUserRepo{foundUserName: "既存の名前"}
+	profiles := &stubProfileRepo{}
+	h := NewProfileHandler(
+		usecase.NewGetProfileUseCase(profiles),
+		usecase.NewUpdateProfileUseCase(profiles),
+		users,
+	)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Set(middleware.ContextKeyCurrentUserID, uint64(7))
+	c.Params = gin.Params{{Key: "userId", Value: "me"}}
+	c.Request = httptest.NewRequest("PUT", "/profile/me", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	h.Update(c)
+	return w, users, profiles
+}
+
+func Test_プロフィール更新_displayNameキーで氏名がUpdateNameに渡る(t *testing.T) {
+	// フロント (UpdateProfileRequest) の実送信キーは displayName。
+	// 旧タグ json:"name" ではここが常に空になり氏名が保存されなかった (FRESTYLE-198)。
+	w, users, profiles := doProfileUpdate(t, `{"displayName":"河野拓真","bio":"自己紹介","status":"勤務中"}`)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !users.updateCalled || users.updatedName != "河野拓真" {
+		t.Fatalf("UpdateName should be called with 河野拓真; called=%v name=%q", users.updateCalled, users.updatedName)
+	}
+	if profiles.saved == nil || profiles.saved.Bio != "自己紹介" || profiles.saved.StatusMessage != "勤務中" {
+		t.Fatalf("bio/status should be upserted together; got %+v", profiles.saved)
+	}
+}
+
+func Test_プロフィール更新_氏名省略時はUpdateNameを呼ばない(t *testing.T) {
+	w, users, profiles := doProfileUpdate(t, `{"bio":"自己紹介のみ"}`)
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if users.updateCalled {
+		t.Fatalf("UpdateName should not be called when displayName is omitted")
+	}
+	if profiles.saved == nil || profiles.saved.Bio != "自己紹介のみ" {
+		t.Fatalf("bio should still be upserted; got %+v", profiles.saved)
+	}
+}
+
+func Test_プロフィール表示_JSONの氏名キーはdisplayName(t *testing.T) {
+	// フロントの Profile 型は displayName を読む。name で返すと氏名欄・ヘッダーが空になる。
+	b, err := json.Marshal(domain.ProfileView{Name: "河野拓真"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["displayName"] != "河野拓真" {
+		t.Fatalf(`ProfileView JSON should expose displayName; got %v`, m)
+	}
+	if _, ok := m["name"]; ok {
+		t.Fatalf("ProfileView JSON should not expose legacy key name; got %v", m)
 	}
 }

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -1896,7 +1896,7 @@ export interface paths {
         put?: never;
         /**
          * コード サンドボックス 実行
-         * @description trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。
+         * @description trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / sql / javascript / typescript / java。
          */
         post: {
             parameters: {
@@ -1958,7 +1958,7 @@ export interface paths {
         put?: never;
         /**
          * 実行環境 ウォームアップ
-         * @description コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
+         * @description コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/sql/javascript/typescript/java は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。
          */
         post: {
             parameters: {
@@ -2816,6 +2816,54 @@ export interface paths {
                     };
                 };
                 /** @description DB / 集計 失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/exercises/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 演習の 言語別 集計 (問題数 + 正解済み 件数)
+         * @description 公開済み の 運営 マスタ 演習問題 を 言語 ごとに 集計 して 返す。 solved は current user が 正解済み の 問題数 (未 ログイン は 0)。 言語 選択 カード の 進捗 表示 に 使う。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.exerciseLanguageSummaryResponse"][];
+                    };
+                };
+                /** @description 集計 失敗 */
                 500: {
                     headers: {
                         [name: string]: unknown;
@@ -4126,7 +4174,7 @@ export interface paths {
         };
         /**
          * プロフィール 取得
-         * @description 指定 user (or current user) の displayName / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。
+         * @description 指定 user (or current user) の name / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。
          */
         get: {
             parameters: {
@@ -4970,6 +5018,11 @@ export interface components {
             description?: string;
             id?: number;
             isPublished?: boolean;
+            /**
+             * @description Language は主に扱う言語・技術（例: "go" / "docker" / "terraform"。空 = 言語が主題でない）。
+             *     演習の language と同じ自由文字列方式で、表示色は frontend のカラーマップが持つ。
+             */
+            language?: string;
             sortOrder?: number;
             title?: string;
             updatedAt?: string;
@@ -5066,8 +5119,8 @@ export interface components {
         "github_com_norman6464_FreStyle_backend_internal_domain.ProfileView": {
             avatarUrl?: string;
             bio?: string;
+            displayName?: string;
             email?: string;
-            name?: string;
             status?: string;
             updatedAt?: string;
             userId?: number;
@@ -5097,6 +5150,10 @@ export interface components {
             courseId?: number;
             firstViewedAt?: string;
             lastViewedAt?: string;
+            /**
+             * @description TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。
+             *     JSON キーは互換のため teachingMaterialId のまま。
+             */
             teachingMaterialId?: number;
             userId?: number;
             viewCount?: number;
@@ -5106,6 +5163,10 @@ export interface components {
             aiChatCount?: number;
             correctCount?: number;
             exerciseCount?: number;
+            /**
+             * @description LessonCount は完了した章の数。DB 列は chapter_count(FRESTYLE-185 で改名)。
+             *     JSON キーは互換のため lessonCount のまま。
+             */
             lessonCount?: number;
             noteCount?: number;
             userId?: number;
@@ -5115,6 +5176,10 @@ export interface components {
             courseId?: number;
             createdAt?: string;
             id?: number;
+            /**
+             * @description TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。
+             *     JSON キーは互換のため teachingMaterialId のまま。
+             */
             teachingMaterialId?: number;
             userId?: number;
         };
@@ -5139,7 +5204,10 @@ export interface components {
             activeThisWeek?: number;
             /** @description ActiveToday は今日(UTC)学習活動があった trainee 数。 */
             activeToday?: number;
-            /** @description RecentMembers は最終活動日の新しい順の直近アクティブメンバー(最大 5 名。活動が無い trainee は含めない)。 */
+            /**
+             * @description RecentMembers は最終活動日の新しい順の直近アクティブメンバー
+             *     (直近 7 日間に活動があるメンバーのみ、最大 5 名)。
+             */
             recentMembers?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.MemberLearningSummaryItem"][];
             /** @description TraineeCount は在籍 trainee 数(論理削除済みを除く)。 */
             traineeCount?: number;
@@ -5163,6 +5231,11 @@ export interface components {
             description?: string;
             id?: number;
             isPublished?: boolean;
+            /**
+             * @description Language は主に扱う言語・技術（例: "go" / "docker" / "terraform"。空 = 言語が主題でない）。
+             *     演習の language と同じ自由文字列方式で、表示色は frontend のカラーマップが持つ。
+             */
+            language?: string;
             /** @description MaterialCount はコース内の章数。trainee は published のみ、admin 系は下書き込み。 */
             materialCount?: number;
             sortOrder?: number;
@@ -5243,6 +5316,11 @@ export interface components {
             category?: "dev-basics" | "backend" | "architecture" | "database" | "infra" | "security" | "product";
             description?: string;
             isPublished?: boolean;
+            /**
+             * @description Language は主に扱う言語・技術(例: "go" / "docker"。空 = 言語が主題でない)。
+             *     演習の language と同じ自由文字列方式(表示色は frontend のカラーマップが持つ)。
+             */
+            language?: string;
             sortOrder?: number;
             title?: string;
         };
@@ -5266,6 +5344,11 @@ export interface components {
         "internal_handler.errorResponse": {
             /** @example unauthorized */
             error?: string;
+        };
+        "internal_handler.exerciseLanguageSummaryResponse": {
+            language?: string;
+            solved?: number;
+            total?: number;
         };
         "internal_handler.exercisePageResponse": {
             hasNext?: boolean;
@@ -5421,9 +5504,13 @@ export interface components {
         "internal_handler.updateProfileReq": {
             avatarUrl?: string;
             bio?: string;
+            /**
+             * @description Name はフロントの送信キー displayName で受ける (name では常に空になり
+             *     users.UpdateName が呼ばれず氏名が保存されない: FRESTYLE-198)。
+             */
+            displayName?: string;
             /** @description 旧フロント互換。avatarUrl を優先。 */
             iconUrl?: string;
-            name?: string;
             status?: string;
         };
         "internal_handler.updateSessionTitleReq": {

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -1839,7 +1839,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash。",
+                "description": "trainee が 書いた コード を サーバ 側 sandbox で 実行 し stdout/stderr/exitCode を 返す。 language は php / go / bash / sql / javascript / typescript / java。",
                 "tags": [
                     "code-execution"
                 ],
@@ -1896,7 +1896,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
+                "description": "コードエディタ 入場 時 に 呼び、 指定 言語 の 実行 環境 を 事前 に 温める（Go は コンパイル キャッシュ、 php/bash/sql/javascript/typescript/java は no-op）。 実行時 に 起動 する のではなく、 入場 時 に warm に する。",
                 "tags": [
                     "code-execution"
                 ],
@@ -2790,6 +2790,45 @@
                     },
                     "500": {
                         "description": "DB / 集計 失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/exercises/summary": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "公開済み の 運営 マスタ 演習問題 を 言語 ごとに 集計 して 返す。 solved は current user が 正解済み の 問題数 (未 ログイン は 0)。 言語 選択 カード の 進捗 表示 に 使う。",
+                "tags": [
+                    "exercises"
+                ],
+                "summary": "演習の 言語別 集計 (問題数 + 正解済み 件数)",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/internal_handler.exerciseLanguageSummaryResponse"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "集計 失敗",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3992,7 +4031,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "指定 user (or current user) の displayName / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。",
+                "description": "指定 user (or current user) の name / bio / avatarUrl / status を 返す。 IDOR 対策 で 自分 以外 は 403。",
                 "tags": [
                     "profile"
                 ],
@@ -5041,6 +5080,10 @@
                     "isPublished": {
                         "type": "boolean"
                     },
+                    "language": {
+                        "description": "Language は主に扱う言語・技術（例: \"go\" / \"docker\" / \"terraform\"。空 = 言語が主題でない）。\n演習の language と同じ自由文字列方式で、表示色は frontend のカラーマップが持つ。",
+                        "type": "string"
+                    },
                     "sortOrder": {
                         "type": "integer"
                     },
@@ -5309,10 +5352,10 @@
                     "bio": {
                         "type": "string"
                     },
-                    "email": {
+                    "displayName": {
                         "type": "string"
                     },
-                    "name": {
+                    "email": {
                         "type": "string"
                     },
                     "status": {
@@ -5398,6 +5441,7 @@
                         "type": "string"
                     },
                     "teachingMaterialId": {
+                        "description": "TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。\nJSON キーは互換のため teachingMaterialId のまま。",
                         "type": "integer"
                     },
                     "userId": {
@@ -5424,6 +5468,7 @@
                         "type": "integer"
                     },
                     "lessonCount": {
+                        "description": "LessonCount は完了した章の数。DB 列は chapter_count(FRESTYLE-185 で改名)。\nJSON キーは互換のため lessonCount のまま。",
                         "type": "integer"
                     },
                     "noteCount": {
@@ -5450,6 +5495,7 @@
                         "type": "integer"
                     },
                     "teachingMaterialId": {
+                        "description": "TeachingMaterialID は章(course_chapters)の ID。DB 列は chapter_id(FRESTYLE-185 で改名)。\nJSON キーは互換のため teachingMaterialId のまま。",
                         "type": "integer"
                     },
                     "userId": {
@@ -5513,7 +5559,7 @@
                         "type": "integer"
                     },
                     "recentMembers": {
-                        "description": "RecentMembers は最終活動日の新しい順の直近アクティブメンバー(最大 5 名。活動が無い trainee は含めない)。",
+                        "description": "RecentMembers は最終活動日の新しい順の直近アクティブメンバー\n(直近 7 日間に活動があるメンバーのみ、最大 5 名)。",
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.MemberLearningSummaryItem"
@@ -5578,6 +5624,10 @@
                     },
                     "isPublished": {
                         "type": "boolean"
+                    },
+                    "language": {
+                        "description": "Language は主に扱う言語・技術（例: \"go\" / \"docker\" / \"terraform\"。空 = 言語が主題でない）。\n演習の language と同じ自由文字列方式で、表示色は frontend のカラーマップが持つ。",
+                        "type": "string"
                     },
                     "materialCount": {
                         "description": "MaterialCount はコース内の章数。trainee は published のみ、admin 系は下書き込み。",
@@ -5813,6 +5863,11 @@
                     "isPublished": {
                         "type": "boolean"
                     },
+                    "language": {
+                        "description": "Language は主に扱う言語・技術(例: \"go\" / \"docker\"。空 = 言語が主題でない)。\n演習の language と同じ自由文字列方式(表示色は frontend のカラーマップが持つ)。",
+                        "type": "string",
+                        "maxLength": 50
+                    },
                     "sortOrder": {
                         "type": "integer"
                     },
@@ -5888,6 +5943,20 @@
                     "error": {
                         "type": "string",
                         "example": "unauthorized"
+                    }
+                }
+            },
+            "internal_handler.exerciseLanguageSummaryResponse": {
+                "type": "object",
+                "properties": {
+                    "language": {
+                        "type": "string"
+                    },
+                    "solved": {
+                        "type": "integer"
+                    },
+                    "total": {
+                        "type": "integer"
                     }
                 }
             },
@@ -6327,11 +6396,12 @@
                     "bio": {
                         "type": "string"
                     },
-                    "iconUrl": {
-                        "description": "旧フロント互換。avatarUrl を優先。",
+                    "displayName": {
+                        "description": "Name はフロントの送信キー displayName で受ける (name では常に空になり\nusers.UpdateName が呼ばれず氏名が保存されない: FRESTYLE-198)。",
                         "type": "string"
                     },
-                    "name": {
+                    "iconUrl": {
+                        "description": "旧フロント互換。avatarUrl を優先。",
                         "type": "string"
                     },
                     "status": {


### PR DESCRIPTION
## 概要
設定画面のプロフィール編集で「基本情報を保存」を押しても氏名（表示名）が保存されず、リロード後は氏名欄・ヘッダーのユーザー名も空になる不具合の hotfix です（本番でユーザー報告）。

## 変更内容
- 根本原因: フロント（`entities/user` の `Profile` / `UpdateProfileRequest`）は `displayName` キーで送受信するが、バックエンドの `updateProfileReq` と `ProfileView` が `json:"name"` だったため、**PUT では氏名が常に空文字**（`if name != ""` ガードで `users.UpdateName` が呼ばれない）、**GET では氏名がフロントに渡らない**双方向の不一致
- `backend/internal/domain/profile.go` / `backend/internal/handler/profile_handler.go` の JSON タグを `displayName` に統一（フロントのコード変更なし。`.name` 参照が無いことは grep 確認済み）
- bio / status は avatar と同一の GORM Save で従来から正常に保存されていることを本番 DB で確認済み（片方だけ落ちる分岐は存在しない）
- `make openapi` + `npm run openapi:generate` で docs / generated を再生成

## テスト
- handler に JSON バインドテスト 3 本を追加（従来この経路が未テストで不一致を取りこぼしていた）
  - displayName キーで送った氏名が UpdateName に渡る + bio/status が同時 upsert される
  - displayName 省略時は UpdateName を呼ばない
  - ProfileView の JSON 氏名キーが displayName であり旧キー name を出さない
- `go build ./... && go test ./...` green / `tsc --noEmit` / `vitest run` 1210 全通過 / `eslint --max-warnings 0` / `npm run build` すべて成功

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-198