### PR TITLE
fix: 設定画面の学習統計 404 を解消 — GET /daily-goals/streak を backend に実装 (FRESTYLE-199)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2132,6 +2132,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/daily-goals/streak": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "現在 の 連続 学習 日数 / 最長 連続 日数 / 累計 学習 日数 を 返す。 設定 画面 の プロフィール 統計 用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "daily-goals"
+                ],
+                "summary": "連続 学習 日数 統計 取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "集計失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/embeds/oembed": {
             "get": {
                 "security": [
@@ -4695,6 +4732,20 @@ const docTemplate = `{
                 },
                 "updatedAt": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput": {
+            "type": "object",
+            "properties": {
+                "currentStreak": {
+                    "type": "integer"
+                },
+                "longestStreak": {
+                    "type": "integer"
+                },
+                "totalAchievedDays": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2125,6 +2125,43 @@
                 }
             }
         },
+        "/daily-goals/streak": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "現在 の 連続 学習 日数 / 最長 連続 日数 / 累計 学習 日数 を 返す。 設定 画面 の プロフィール 統計 用。",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "daily-goals"
+                ],
+                "summary": "連続 学習 日数 統計 取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput"
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "集計失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/embeds/oembed": {
             "get": {
                 "security": [
@@ -4688,6 +4725,20 @@
                 },
                 "updatedAt": {
                     "type": "string"
+                }
+            }
+        },
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput": {
+            "type": "object",
+            "properties": {
+                "currentStreak": {
+                    "type": "integer"
+                },
+                "longestStreak": {
+                    "type": "integer"
+                },
+                "totalAchievedDays": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -543,6 +543,15 @@ definitions:
       updatedAt:
         type: string
     type: object
+  github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput:
+    properties:
+      currentStreak:
+        type: integer
+      longestStreak:
+        type: integer
+      totalAchievedDays:
+        type: integer
+    type: object
   github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput:
     properties:
       examples:
@@ -2451,6 +2460,29 @@ paths:
       summary: コース内 教材 一覧
       tags:
       - teaching-materials
+  /daily-goals/streak:
+    get:
+      description: 現在 の 連続 学習 日数 / 最長 連続 日数 / 累計 学習 日数 を 返す。 設定 画面 の プロフィール 統計 用。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput'
+        "401":
+          description: 未認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: 集計失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+      security:
+      - CookieAuth: []
+      summary: 連続 学習 日数 統計 取得
+      tags:
+      - daily-goals
   /embeds/oembed:
     get:
       description: ?url= で 指定 した URL の OGP / oEmbed を 解決 し card 形式 で 返す。 allow-list

--- a/backend/internal/handler/daily_goals_handler.go
+++ b/backend/internal/handler/daily_goals_handler.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// DailyGoalsHandler は日次学習目標まわりの API を提供する。
+type DailyGoalsHandler struct {
+	getStreak *usecase.GetDailyStreakUseCase
+}
+
+func NewDailyGoalsHandler(s *usecase.GetDailyStreakUseCase) *DailyGoalsHandler {
+	return &DailyGoalsHandler{getStreak: s}
+}
+
+// GetStreak はログイン中ユーザーの連続学習日数の統計を返す。
+//
+//	@Summary      連続 学習 日数 統計 取得
+//	@Description  現在 の 連続 学習 日数 / 最長 連続 日数 / 累計 学習 日数 を 返す。 設定 画面 の プロフィール 統計 用。
+//	@Tags         daily-goals
+//	@Produce      json
+//	@Success      200  {object}  usecase.GetDailyStreakOutput
+//	@Failure      401  {object}  errorResponse  "未認証"
+//	@Failure      500  {object}  errorResponse  "集計失敗"
+//	@Router       /daily-goals/streak [get]
+//	@Security     CookieAuth
+func (h *DailyGoalsHandler) GetStreak(c *gin.Context) {
+	userID := middleware.CurrentUserIDOrZero(c)
+	if userID == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	out, err := h.getStreak.Execute(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "学習統計の取得に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -94,6 +94,7 @@ func NewRouter(db *gorm.DB, cfg *config.Config) *gin.Engine {
 	registerCompanySettingsRoutes(authed, deps)
 	registerCompanyApplicationAdminRoutes(authed, companyAppHandler, audit)
 	registerDashboardRoutes(authed, deps)
+	registerDailyGoalsRoutes(authed, deps)
 	// WebSocket (/ws/ai-chat) は SSE (/ai-chat/stream) への置換で廃止 (PR-D)。
 	return r
 }

--- a/backend/internal/handler/routes_daily_goals.go
+++ b/backend/internal/handler/routes_daily_goals.go
@@ -1,0 +1,14 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+)
+
+// registerDailyGoalsRoutes は日次学習目標の API を登録する。
+func registerDailyGoalsRoutes(g *gin.RouterGroup, deps *routeDeps) {
+	activityRepo := persistence.NewUserDailyActivityRepository(deps.db)
+	h := NewDailyGoalsHandler(usecase.NewGetDailyStreakUseCase(activityRepo))
+	g.GET("/daily-goals/streak", h.GetStreak)
+}

--- a/backend/internal/usecase/get_daily_streak_usecase.go
+++ b/backend/internal/usecase/get_daily_streak_usecase.go
@@ -1,0 +1,76 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// GetDailyStreakUseCase は user_daily_activities から連続学習日数の統計を算出する。
+// 設定画面のプロフィール統計 (GET /daily-goals/streak) 用。判定条件（学習あり =
+// いずれかのカウンタが 1 以上）と現在の連続日数はダッシュボードの computeStreak と同一。
+type GetDailyStreakUseCase struct {
+	activity repository.UserDailyActivityRepository
+}
+
+func NewGetDailyStreakUseCase(a repository.UserDailyActivityRepository) *GetDailyStreakUseCase {
+	return &GetDailyStreakUseCase{activity: a}
+}
+
+// GetDailyStreakOutput は streak API のレスポンス型。JSON キーはフロント
+// (entities/user の ProfileStats) の契約に合わせる。
+type GetDailyStreakOutput struct {
+	CurrentStreak     int `json:"currentStreak"`
+	LongestStreak     int `json:"longestStreak"`
+	TotalAchievedDays int `json:"totalAchievedDays"`
+}
+
+// dailyActivityEpoch は全期間集計の下限。サービス開始 (2026-04) より十分過去に置く。
+var dailyActivityEpoch = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+func (u *GetDailyStreakUseCase) Execute(ctx context.Context, userID uint64) (*GetDailyStreakOutput, error) {
+	if userID == 0 {
+		return nil, errors.New("userID is required")
+	}
+	now := time.Now().UTC()
+	// 最長連続・累計は全履歴が必要なため全期間を取得する（1 user 1 日 1 行なので高々数百行）。
+	activities, err := u.activity.ListByUser(ctx, userID, dailyActivityEpoch, now)
+	if err != nil {
+		return nil, err
+	}
+
+	// 学習ありの日を日単位で集める（判定条件は computeStreak と同じ）。
+	daySet := make(map[string]time.Time, len(activities))
+	for _, a := range activities {
+		if a.ExerciseCount+a.LessonCount+a.AiChatCount+a.NoteCount > 0 {
+			d := a.ActivityDate.UTC().Truncate(24 * time.Hour)
+			daySet[d.Format("2006-01-02")] = d
+		}
+	}
+	days := make([]time.Time, 0, len(daySet))
+	for _, d := range daySet {
+		days = append(days, d)
+	}
+	sort.Slice(days, func(i, j int) bool { return days[i].Before(days[j]) })
+
+	longest, run := 0, 0
+	for i, d := range days {
+		if i > 0 && days[i-1].AddDate(0, 0, 1).Equal(d) {
+			run++
+		} else {
+			run = 1
+		}
+		if run > longest {
+			longest = run
+		}
+	}
+
+	return &GetDailyStreakOutput{
+		CurrentStreak:     computeStreak(activities, now),
+		LongestStreak:     longest,
+		TotalAchievedDays: len(days),
+	}, nil
+}

--- a/backend/internal/usecase/get_daily_streak_usecase_test.go
+++ b/backend/internal/usecase/get_daily_streak_usecase_test.go
@@ -1,0 +1,81 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeDailyActivityRepo は UserDailyActivityRepository の in-memory fake。
+type fakeDailyActivityRepo struct {
+	activities []domain.UserDailyActivity
+}
+
+func (f *fakeDailyActivityRepo) Increment(_ context.Context, _ uint64, _ time.Time, _ repository.UserDailyActivityIncrement) error {
+	return nil
+}
+
+func (f *fakeDailyActivityRepo) ListByUser(_ context.Context, _ uint64, _, _ time.Time) ([]domain.UserDailyActivity, error) {
+	return f.activities, nil
+}
+
+func day(offset int) time.Time {
+	return time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, offset)
+}
+
+func act(offset, exercises int) domain.UserDailyActivity {
+	return domain.UserDailyActivity{ActivityDate: day(offset), ExerciseCount: exercises}
+}
+
+func Test_連続学習統計_今日まで連続していればcurrentStreakに数える(t *testing.T) {
+	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{activities: []domain.UserDailyActivity{
+		act(-2, 1), act(-1, 1), act(0, 1),
+	}})
+	out, err := uc.Execute(context.Background(), 7)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, out.CurrentStreak)
+	assert.Equal(t, 3, out.LongestStreak)
+	assert.Equal(t, 3, out.TotalAchievedDays)
+}
+
+func Test_連続学習統計_途切れた過去の連続はlongestStreakにだけ残る(t *testing.T) {
+	// 5 日前〜3 日前の 3 連続 + 今日のみ → current=1, longest=3, total=4
+	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{activities: []domain.UserDailyActivity{
+		act(-5, 1), act(-4, 1), act(-3, 1), act(0, 1),
+	}})
+	out, err := uc.Execute(context.Background(), 7)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, out.CurrentStreak)
+	assert.Equal(t, 3, out.LongestStreak)
+	assert.Equal(t, 4, out.TotalAchievedDays)
+}
+
+func Test_連続学習統計_全カウンタ0の行は学習日に数えない(t *testing.T) {
+	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{activities: []domain.UserDailyActivity{
+		act(-1, 0), act(0, 1),
+	}})
+	out, err := uc.Execute(context.Background(), 7)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, out.CurrentStreak)
+	assert.Equal(t, 1, out.LongestStreak)
+	assert.Equal(t, 1, out.TotalAchievedDays)
+}
+
+func Test_連続学習統計_活動なしは全て0(t *testing.T) {
+	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{})
+	out, err := uc.Execute(context.Background(), 7)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, out.CurrentStreak)
+	assert.Equal(t, 0, out.LongestStreak)
+	assert.Equal(t, 0, out.TotalAchievedDays)
+}
+
+func Test_連続学習統計_userID必須(t *testing.T) {
+	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{})
+	_, err := uc.Execute(context.Background(), 0)
+	assert.Error(t, err)
+}

--- a/backend/internal/usecase/get_daily_streak_usecase_test.go
+++ b/backend/internal/usecase/get_daily_streak_usecase_test.go
@@ -24,7 +24,7 @@ func (f *fakeDailyActivityRepo) ListByUser(_ context.Context, _ uint64, _, _ tim
 }
 
 func day(offset int) time.Time {
-	return time.Now().UTC().Truncate(24 * time.Hour).AddDate(0, 0, offset)
+	return time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, offset)
 }
 
 func act(offset, exercises int) domain.UserDailyActivity {

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -2692,6 +2692,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/daily-goals/streak": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 連続 学習 日数 統計 取得
+         * @description 現在 の 連続 学習 日数 / 最長 連続 日数 / 累計 学習 日数 を 返す。 設定 画面 の プロフィール 統計 用。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 集計失敗 */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/embeds/oembed": {
         parameters: {
             query?: never;
@@ -5241,6 +5298,11 @@ export interface components {
             sortOrder?: number;
             title?: string;
             updatedAt?: string;
+        };
+        "github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput": {
+            currentStreak?: number;
+            longestStreak?: number;
+            totalAchievedDays?: number;
         };
         "github_com_norman6464_FreStyle_backend_internal_usecase.GetMasterExerciseDetailOutput": {
             examples?: components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.MasterExerciseExample"][];

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -2652,6 +2652,52 @@
                 }
             }
         },
+        "/daily-goals/streak": {
+            "get": {
+                "security": [
+                    {
+                        "CookieAuth": []
+                    }
+                ],
+                "description": "現在 の 連続 学習 日数 / 最長 連続 日数 / 累計 学習 日数 を 返す。 設定 画面 の プロフィール 統計 用。",
+                "tags": [
+                    "daily-goals"
+                ],
+                "summary": "連続 学習 日数 統計 取得",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "未認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "集計失敗",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/embeds/oembed": {
             "get": {
                 "security": [
@@ -5641,6 +5687,20 @@
                     },
                     "updatedAt": {
                         "type": "string"
+                    }
+                }
+            },
+            "github_com_norman6464_FreStyle_backend_internal_usecase.GetDailyStreakOutput": {
+                "type": "object",
+                "properties": {
+                    "currentStreak": {
+                        "type": "integer"
+                    },
+                    "longestStreak": {
+                        "type": "integer"
+                    },
+                    "totalAchievedDays": {
+                        "type": "integer"
                     }
                 }
             },


### PR DESCRIPTION
## 概要
設定画面のプロフィール統計セクションで `GET /api/v2/daily-goals/streak` が 404 になり、フロントは統計 2 API を `Promise.all` で取得しているため統計 6 項目すべてが表示できない不具合の修正です（コンソールの 404 はユーザー報告のスクリーンショットで確認）。

## 変更内容
- 原因: フロント（`entities/user/api/profileStatsRepository.ts`）は `/daily-goals/streak` から `currentStreak / longestStreak / totalAchievedDays` を取得する契約だが、backend に daily-goals 系ルートが未実装だった
- 集計はバックエンドに置く方針（規約 §3.6）に沿い、フロントの既存契約どおり backend 側を実装（**フロント変更なし**）
  - `GetDailyStreakUseCase` 新設: user_daily_activities を全期間取得し、現在の連続学習日数（dashboard の `computeStreak` を再利用・「学習あり」判定も同一）/ 最長連続日数 / 累計学習日数を算出
  - `DailyGoalsHandler.GetStreak` 新設（swaggo annotation 付き）+ `registerDailyGoalsRoutes` で認証必須グループに `GET /daily-goals/streak` を登録
- `make openapi` + `npm run openapi:generate` 再生成

## テスト
- usecase テスト 5 本（今日まで連続 / 途切れた過去は longest のみ / 全カウンタ 0 の行は数えない / 活動なしは全て 0 / userID 必須）すべて PASS
- `go build ./... && go test ./...` green / `tsc --noEmit` OK

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 連続学習日数を確認できるAPIを追加しました。
  - 現在の連続日数、最長連続日数、累計学習日数を取得できます。
  - 認証済みユーザーのみ利用できます。

- **テスト**
  - 連続学習、学習の中断、未学習日、活動なしなどの集計ケースを検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->