### PR TITLE
refactor: course-detail の God コンポーネントを ui/lib へ分解し命名を可読化 (FRESTYLE-208)

### DIFF
--- a/frontend/src/pages/course-detail/lib/formatDate.ts
+++ b/frontend/src/pages/course-detail/lib/formatDate.ts
@@ -1,0 +1,11 @@
+/** ISO 8601 の日時文字列を `YYYY/MM/DD` 形式に整形する（空文字は空文字のまま返す）。 */
+export function formatDate(iso: string): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  return `${date.getFullYear()}/${padTwoDigits(date.getMonth() + 1)}/${padTwoDigits(date.getDate())}`;
+}
+
+/** 1 桁の数値を 2 桁ゼロ埋めの文字列にする（例: 3 → "03"）。 */
+function padTwoDigits(value: number): string {
+  return String(value).padStart(2, '0');
+}

--- a/frontend/src/pages/course-detail/lib/stripLeadingTitle.ts
+++ b/frontend/src/pages/course-detail/lib/stripLeadingTitle.ts
@@ -1,0 +1,18 @@
+/**
+ * 本文の先頭にある h1(章タイトル)を取り除く(FRESTYLE-131)。
+ *
+ * 教材本文は規約により `# タイトル`(= material.title と同じ)で始まる。閲覧ビューでは
+ * タイトルをカード外のヘッダーで大きく表示するため、本文側の先頭 h1 を消して二重表示を防ぐ。
+ * 「先頭の空行を飛ばした最初の非空行が h1 のときだけ」除去するので、コードブロック内の
+ * `# コメント` や 2 個目以降の見出しには一切触れない(先頭の 1 個だけが対象)。
+ */
+export function stripLeadingTitle(content: string): string {
+  if (!content) return content;
+  const lines = content.split('\n');
+  let firstNonEmptyLine = 0;
+  while (firstNonEmptyLine < lines.length && lines[firstNonEmptyLine].trim() === '') firstNonEmptyLine++;
+  if (firstNonEmptyLine >= lines.length || !/^#\s+\S/.test(lines[firstNonEmptyLine])) return content;
+  lines.splice(0, firstNonEmptyLine + 1);
+  while (lines.length && lines[0].trim() === '') lines.shift();
+  return lines.join('\n');
+}

--- a/frontend/src/pages/course-detail/ui/ChapterNav.tsx
+++ b/frontend/src/pages/course-detail/ui/ChapterNav.tsx
@@ -1,0 +1,78 @@
+import { Link } from 'react-router-dom';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon as CheckCircleSolidIcon } from '@heroicons/react/24/solid';
+import { CourseProgressBar } from '@/entities/course';
+import type { Course, TeachingMaterial } from '@/entities/course';
+
+/**
+ * 閲覧ビューの右サイドバーに出す章一覧(FRESTYLE-118)。
+ * コース一覧への戻り + コース名 + 進捗バー + 章リスト(完了はチェック・現在章はハイライト)。
+ */
+export default function ChapterNav({
+  course,
+  materials,
+  selectedId,
+  completedIds,
+  completedCount,
+  onSelect,
+}: {
+  course: Course;
+  materials: TeachingMaterial[];
+  selectedId: number;
+  completedIds: Set<number>;
+  completedCount: number;
+  onSelect: (id: number) => void;
+}) {
+  return (
+    // 親カードが高さを制限したとき、見出し(コース名・進捗)は固定して章リストだけを内側でスクロールさせる(FRESTYLE-144)。
+    <div className="flex min-h-0 flex-col">
+      <div className="flex-shrink-0">
+        <Link
+          to="/courses"
+          className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
+        >
+          <ArrowLeftIcon className="w-3.5 h-3.5" />
+          コース一覧
+        </Link>
+        <p className="mt-2 text-sm font-semibold text-[var(--color-text-primary)]">
+          {course.title || '無題のコース'}
+          <span className="ml-2 text-xs font-normal text-[var(--color-text-muted)]">
+            {materials.length} 章
+          </span>
+        </p>
+        {materials.length > 0 && (
+          <div className="mt-2">
+            <CourseProgressBar completed={completedCount} total={materials.length} />
+          </div>
+        )}
+      </div>
+      <nav aria-label="章一覧" className="mt-3 min-h-0 flex-1 space-y-0.5 overflow-y-auto pr-1">
+        {materials.map((material, index) => {
+          const isCurrent = material.id === selectedId;
+          return (
+            <button
+              key={material.id}
+              type="button"
+              onClick={() => onSelect(material.id)}
+              aria-current={isCurrent ? 'page' : undefined}
+              className={`w-full flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[13px] leading-snug transition-colors ${
+                isCurrent
+                  ? 'bg-brand-500/10 font-medium text-[var(--color-text-primary)]'
+                  : 'text-[var(--color-text-secondary)] hover:bg-surface-2'
+              }`}
+            >
+              {completedIds.has(material.id) ? (
+                <CheckCircleSolidIcon className="w-4 h-4 mt-0.5 text-emerald-500 flex-shrink-0" aria-label="完了" />
+              ) : (
+                <span className="w-4 h-4 mt-0.5 flex items-center justify-center text-[10px] rounded-full border border-surface-3 text-[var(--color-text-muted)] flex-shrink-0">
+                  {index + 1}
+                </span>
+              )}
+              <span className="line-clamp-2">{material.title || '無題の教材'}</span>
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/CompleteToggleButton.tsx
+++ b/frontend/src/pages/course-detail/ui/CompleteToggleButton.tsx
@@ -1,0 +1,32 @@
+import { CheckCircleIcon as CheckCircleSolidIcon } from '@heroicons/react/24/solid';
+
+/** 教材の完了 / 未完了を切り替えるトグルボタン。`large` で本文末尾用の大きめ表示にする。 */
+export default function CompleteToggleButton({
+  completed,
+  onToggle,
+  large = false,
+}: {
+  completed: boolean;
+  onToggle: (done: boolean) => void;
+  large?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(!completed)}
+      aria-pressed={completed}
+      // whitespace-nowrap / shrink-0: 隣に長いタイトルの「次の章へ」ボタンが並んでも縮まず、
+      // ラベルが「完了に / する」と 2 行に折り返さないようにする(FRESTYLE-188)。
+      className={`inline-flex shrink-0 whitespace-nowrap items-center justify-center gap-1.5 rounded-lg font-medium transition-colors ${
+        large ? 'px-5 pt-[9px] pb-[11px] text-sm' : 'px-3 pt-[5px] pb-[7px] text-sm'
+      } ${
+        completed
+          ? 'bg-green-500/15 text-green-500 hover:bg-green-500/25'
+          : 'bg-brand-500 text-white hover:bg-brand-600'
+      }`}
+    >
+      <CheckCircleSolidIcon className="w-4 h-4" />
+      {completed ? '完了済み' : '完了にする'}
+    </button>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
+++ b/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
@@ -236,7 +236,6 @@ export default function CourseDetailPage() {
                 isActive={selectedId === material.id}
                 onSelect={handleSelect}
                 onDelete={canManage ? (materialId) => setDeleteTargetId(materialId) : undefined}
-                completed={progress.completedIds.has(material.id)}
               />
             ))
           )}

--- a/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
+++ b/frontend/src/pages/course-detail/ui/CourseDetailPage.tsx
@@ -1,38 +1,31 @@
-import { useEffect, useState, useMemo, useRef } from 'react';
-import { useAppSelector } from '@/shared/lib/store';
-
+import { useEffect, useState, useMemo } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   PlusIcon,
   Bars3Icon,
-  TrashIcon,
   ArrowLeftIcon,
-  ArrowRightIcon,
-  ListBulletIcon,
-  XMarkIcon,
 } from '@heroicons/react/24/outline';
-import { CheckCircleIcon as CheckCircleSolidIcon } from '@heroicons/react/24/solid';
+import { useAppSelector } from '@/shared/lib/store';
 import { SecondaryPanel } from '@/widgets/secondary-panel';
-import { CourseProgressBar } from '@/entities/course';
+import { CourseProgressBar, CourseRepository } from '@/entities/course';
 import EmptyState from '@/shared/ui/EmptyState';
 import FaviconIcon from '@/shared/ui/icons/FaviconIcon';
 import ConfirmModal from '@/shared/ui/ConfirmModal';
 import Loading from '@/shared/ui/Loading';
-import { NoteMarkdownEditor } from '@/entities/note';
-import MarkdownTableOfContents from '@/shared/ui/MarkdownTableOfContents';
+import { DashboardRepository } from '@/entities/user';
+import { useMobilePanelState } from '@/shared/lib/hooks/useMobilePanelState';
+import { useLocalStorage } from '@/shared/lib/hooks/useLocalStorage';
+import { useToast } from '@/shared/lib/hooks/useToast';
 import { useTeachingMaterials } from '../model/useTeachingMaterials';
 import { useTeachingMaterialEditor } from '../model/useTeachingMaterialEditor';
 import { useChapterResume } from '../model/useChapterResume';
 import { useNextCourse } from '../model/useNextCourse';
 import { useLessonProgress } from '../model/useLessonProgress';
-import { useMobilePanelState } from '@/shared/lib/hooks/useMobilePanelState';
-import { useLocalStorage } from '@/shared/lib/hooks/useLocalStorage';
-import { useToast } from '@/shared/lib/hooks/useToast';
-import { CourseRepository } from '@/entities/course';
-import { DashboardRepository } from '@/entities/user';
-import { ImageUploadRepository } from '@/entities/user';
-
-import type { Course, CourseWithProgress, TeachingMaterial } from '@/entities/course';
+import MaterialListItem from './MaterialListItem';
+import MaterialSkeleton from './MaterialSkeleton';
+import ManagedDetail from './ManagedDetail';
+import ReadOnlyDetail from './ReadOnlyDetail';
+import type { Course } from '@/entities/course';
 
 /**
  * CourseDetailPage — `/courses/:id` 配下の教材一覧 + 編集ページ。
@@ -47,7 +40,7 @@ export default function CourseDetailPage() {
   const courseId = id ? Number(id) : null;
   const navigate = useNavigate();
 
-  const role = useAppSelector((s) => s.auth.role);
+  const role = useAppSelector((state) => state.auth.role);
   const canManage = role === 'company_admin' || role === 'super_admin';
 
   const { showToast } = useToast();
@@ -89,20 +82,22 @@ export default function CourseDetailPage() {
   // 進捗トラッキングは学習者（trainee）向け。 教材を管理するロールでは API を叩かない。
   const progress = useLessonProgress(!canManage);
   const completedCount = useMemo(
-    () => materials.filter((m) => progress.completedIds.has(m.id)).length,
+    () => materials.filter((material) => progress.completedIds.has(material.id)).length,
     [materials, progress.completedIds],
   );
 
   // 表示順で「次の章」を求める（読み終えたら順に進める導線用）。
   const nextMaterial = useMemo(() => {
     if (selectedId == null) return null;
-    const idx = materials.findIndex((m) => m.id === selectedId);
-    return idx >= 0 && idx < materials.length - 1 ? materials[idx + 1] : null;
+    const selectedIndex = materials.findIndex((material) => material.id === selectedId);
+    return selectedIndex >= 0 && selectedIndex < materials.length - 1
+      ? materials[selectedIndex + 1]
+      : null;
   }, [materials, selectedId]);
 
   const handleToggleComplete = async (materialId: number, done: boolean) => {
-    const ok = await progress.toggle(materialId, done);
-    if (!ok) {
+    const succeeded = await progress.toggle(materialId, done);
+    if (!succeeded) {
       showToast('error', '進捗の更新に失敗しました');
     } else if (done) {
       showToast('success', '完了にしました');
@@ -115,7 +110,7 @@ export default function CourseDetailPage() {
     if (!courseId) return;
     setCourseLoading(true);
     CourseRepository.get(courseId)
-      .then((c) => setCourse(c))
+      .then((fetchedCourse) => setCourse(fetchedCourse))
       .catch(() => setCourseError('コースの取得に失敗しました'))
       .finally(() => setCourseLoading(false));
   }, [courseId]);
@@ -123,7 +118,7 @@ export default function CourseDetailPage() {
   // 次の order_in_course を計算（既存の最大値 + 10）。
   const nextOrder = useMemo(() => {
     if (materials.length === 0) return 100;
-    return Math.max(...materials.map((m) => m.orderInCourse)) + 10;
+    return Math.max(...materials.map((material) => material.orderInCourse)) + 10;
   }, [materials]);
 
   const handleCreate = async () => {
@@ -141,8 +136,8 @@ export default function CourseDetailPage() {
     closeMobilePanel();
   };
 
-  const handleSelect = (mid: number) => {
-    selectMaterial(mid);
+  const handleSelect = (materialId: number) => {
+    selectMaterial(materialId);
     closeMobilePanel();
   };
 
@@ -192,7 +187,7 @@ export default function CourseDetailPage() {
         onMobileClose={closeMobilePanel}
         collapsible
         collapsed={!panelOpen}
-        onToggleCollapsed={() => setPanelOpen((v) => !v)}
+        onToggleCollapsed={() => setPanelOpen((isOpen) => !isOpen)}
         headerContent={
           <div className="space-y-2">
             <Link
@@ -234,14 +229,14 @@ export default function CourseDetailPage() {
               />
             </div>
           ) : (
-            materials.map((m) => (
+            materials.map((material) => (
               <MaterialListItem
-                key={m.id}
-                material={m}
-                isActive={selectedId === m.id}
+                key={material.id}
+                material={material}
+                isActive={selectedId === material.id}
                 onSelect={handleSelect}
-                onDelete={canManage ? (mid) => setDeleteTargetId(mid) : undefined}
-                completed={progress.completedIds.has(m.id)}
+                onDelete={canManage ? (materialId) => setDeleteTargetId(materialId) : undefined}
+                completed={progress.completedIds.has(material.id)}
               />
             ))
           )}
@@ -310,570 +305,5 @@ export default function CourseDetailPage() {
         onCancel={() => setDeleteTargetId(null)}
       />
     </div>
-  );
-}
-
-function MaterialListItem({
-  material,
-  isActive,
-  onSelect,
-  onDelete,
-  completed = false,
-}: {
-  material: TeachingMaterial;
-  isActive: boolean;
-  onSelect: (id: number) => void;
-  onDelete?: (id: number) => void;
-  completed?: boolean;
-}) {
-  return (
-    <div
-      role="button"
-      tabIndex={0}
-      onClick={() => onSelect(material.id)}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onSelect(material.id);
-        }
-      }}
-      className={`group flex items-start gap-2.5 pl-4 pr-2 py-2.5 cursor-pointer transition-colors border-l-2 ${
-        isActive
-          ? 'border-brand-500 bg-[var(--color-nav-active)]'
-          : 'border-transparent hover:bg-[var(--color-nav-hover)]'
-      }`}
-    >
-      <p className={`flex-1 min-w-0 text-[13px] leading-snug line-clamp-2 ${
-        isActive
-          ? 'font-medium text-[var(--color-text-primary)]'
-          : 'text-[var(--color-text-secondary)]'
-      }`}>
-        {material.title || '無題の教材'}
-      </p>
-
-      {onDelete && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete(material.id);
-          }}
-          className="opacity-0 group-hover:opacity-100 p-1 hover:bg-red-900/30 rounded transition-opacity flex-shrink-0"
-          aria-label="教材を削除"
-        >
-          <TrashIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)] hover:text-red-400" />
-        </button>
-      )}
-    </div>
-  );
-}
-
-function ManagedDetail({
-  editor,
-}: {
-  editor: ReturnType<typeof useTeachingMaterialEditor>;
-}) {
-  return (
-    <div className="flex-1 flex flex-col min-h-0">
-      <div className="px-6 pt-4 pb-2 flex items-center justify-end gap-2 border-b border-surface-3">
-        <label className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)] cursor-pointer">
-          <input
-            type="checkbox"
-            checked={editor.editIsPublished}
-            onChange={(e) => editor.handleIsPublishedChange(e.target.checked)}
-            className="rounded border-surface-3"
-          />
-          trainee に公開
-        </label>
-      </div>
-      <div className="flex-1 min-h-0">
-        <NoteMarkdownEditor
-          title={editor.editTitle}
-          content={editor.editContent}
-          saveStatus={editor.saveStatus}
-          onTitleChange={editor.handleTitleChange}
-          onContentChange={editor.handleContentChange}
-          onImageUpload={(file) => ImageUploadRepository.upload(file)}
-        />
-      </div>
-    </div>
-  );
-}
-
-function ReadOnlyDetail({
-  material,
-  completed,
-  onToggleComplete,
-  nextMaterial,
-  onGoNext,
-  nextCourse,
-  onGoNextCourse,
-  course,
-  materials,
-  completedIds,
-  onSelectMaterial,
-  completedCount,
-}: {
-  material: TeachingMaterial;
-  completed: boolean;
-  onToggleComplete: (done: boolean) => void;
-  nextMaterial?: TeachingMaterial | null;
-  onGoNext?: () => void;
-  nextCourse?: CourseWithProgress | null;
-  onGoNextCourse?: () => void;
-  course: Course;
-  materials: TeachingMaterial[];
-  completedIds: Set<number>;
-  onSelectMaterial: (id: number) => void;
-  completedCount: number;
-}) {
-  // 目次の表示状態は localStorage に保持し、 教材を切り替えても選択が続くようにする（既定は表示）。
-  // 横幅が狭いときに本文幅を稼げるよう trainee が出し入れできる。
-  const [tocOpen, setTocOpen] = useLocalStorage('course-toc-open', true);
-
-  // 章を切り替えたら本文の先頭までスクロールを戻す（末尾の「次の章へ」から進んでも頭から読める）。
-  // スクロールは AppShell のドキュメントスクロールコンテナ(FRESTYLE-122)側で起きるため、
-  // そちらへ遡って scrollTo する（テスト等で見つからない場合は自要素へフォールバック）。
-  const scrollRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const scroller = scrollRef.current?.closest('[data-app-scroll]') ?? scrollRef.current;
-    scroller?.scrollTo({ top: 0 });
-  }, [material.id]);
-
-  // 本文先頭の h1(= タイトル)は、下のヘッダーで material.title を大きく出すため取り除く。
-  // 残すとカードの外(ヘッダー)とカードの中(本文)でタイトルが二重に見える(FRESTYLE-131)。
-  const bodyContent = useMemo(() => stripLeadingTitle(material.content), [material.content]);
-
-  // 本文内の画像クリックでモーダル拡大表示する(FRESTYLE-191)。ページを離れずに図の細部を
-  // 確認できる(別タブで開くリンクは学習が中断されるため FRESTYLE-125 で除去済み)。
-  const [lightboxImage, setLightboxImage] = useState<{ src: string; alt: string } | null>(null);
-  useEffect(() => setLightboxImage(null), [material.id]);
-
-  return (
-    // 背景は読み物用の灰青(--color-reading-surface)、本文は白カード。背景と内容のコントラストで
-    // 読み物として視線が本文に集まるようにする(FRESTYLE-118)。body は白に戻したが、教材閲覧だけ
-    // 灰青を維持する(FRESTYLE-147)。内部スクロールは持たない(FRESTYLE-122 でページ全体スクロール)。
-    <div ref={scrollRef} className="flex-1 bg-[var(--color-reading-surface)]">
-      {/* 読み物ページなので外側の余白は広め(FRESTYLE-115)。中央寄せなので左右は自然に余白になる。 */}
-      <div
-        className={`mx-auto w-full max-w-6xl px-6 sm:px-10 py-8 sm:py-10 grid grid-cols-1 gap-8 ${
-          tocOpen ? 'lg:grid-cols-[minmax(0,1fr)_280px]' : ''
-        }`}
-      >
-        {/* 本文カラム。 サイドバーを隠したときは本文が全幅に伸びて読みにくいため、 読みやすい幅(860px)に
-            収めて中央寄せする。 サイドバー表示時は 1fr カラムが既に同程度の幅になる。 */}
-        <div className={`min-w-0 ${!tocOpen ? 'mx-auto w-full max-w-[860px]' : ''}`}>
-          <article className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
-            {/* 記事サイト風ヘッダー(Qiita 風): タイトル + メタを本文カードの先頭に入れる。
-                以前はカード外の別ヘッダーに置いていたが、カードをタイトル位置まで上げて
-                タイトルもカード内に収めた(FRESTYLE-178)。目次サイドバーは同じグリッド行に来るので
-                カード上端と揃う(FRESTYLE-150)。本文先頭の重複 h1 は stripLeadingTitle で除去済み(FRESTYLE-131)。 */}
-            <header className="mb-6 pb-6 border-b border-surface-3">
-              <h1 className="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] leading-snug">
-                {material.title || '無題の教材'}
-              </h1>
-              {/* メタ(最終更新 / 目次トグル / 完了トグル)。 sticky にはしない(FRESTYLE-119)。
-                  スクロール途中の完了操作は本文末尾の大きい完了ボタン(FRESTYLE-100)で行える。 */}
-              <div className="mt-3 flex flex-wrap items-center gap-3">
-                <p className="text-xs text-[var(--color-text-muted)]">
-                  最終更新: {formatDate(material.updatedAt)}
-                </p>
-                {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
-                <button
-                  type="button"
-                  onClick={() => setTocOpen((v) => !v)}
-                  aria-pressed={tocOpen}
-                  title={tocOpen ? '目次を隠す' : '目次を表示'}
-                  className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
-                    tocOpen
-                      ? 'border-taupe-500 text-taupe-400'
-                      : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
-                  }`}
-                >
-                  <ListBulletIcon className="w-4 h-4" />
-                  目次
-                </button>
-                <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
-              </div>
-            </header>
-            <div className="prose prose-sm max-w-none course-prose">
-              <ReadOnlyMarkdown content={bodyContent} onImageClick={setLightboxImage} />
-            </div>
-
-            {/* 末尾に「完了にする」と「次の章へ」を並べ、 読み終えた位置から次へ進めるようにする。
-                崩れ対策(FRESTYLE-189): 完了ボタンは shrink-0 / whitespace-nowrap で常に 1 行を保ち、
-                次へボタンは min-w-0 + truncate で長い章タイトルを省略しつつ、 幅を取りすぎないよう
-                上限(sm:max-w-[55%])を設けて 2 つのボタンのバランスを取る。
-                最終章では代わりに「次のコースへ」を出し、 一覧に戻らず次のコースへ直行できるようにする
-                (FRESTYLE-102。 遷移先はレジュームにより 1 章目が自動表示される)。 */}
-            <div className="mt-10 pt-6 border-t border-surface-3 flex flex-col sm:flex-row items-center justify-center gap-3">
-              <CompleteToggleButton completed={completed} onToggle={onToggleComplete} large />
-              {nextMaterial && onGoNext ? (
-                <button
-                  type="button"
-                  onClick={onGoNext}
-                  title={`次の章へ: ${nextMaterial.title || '無題の教材'}`}
-                  className="inline-flex min-w-0 max-w-full sm:max-w-[55%] items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors"
-                >
-                  <span className="truncate">次の章へ: {nextMaterial.title || '無題の教材'}</span>
-                  <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
-                </button>
-              ) : nextCourse && onGoNextCourse ? (
-                <button
-                  type="button"
-                  onClick={onGoNextCourse}
-                  title={`次のコースへ: ${nextCourse.title || '無題のコース'}`}
-                  className="inline-flex min-w-0 max-w-full sm:max-w-[55%] items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors"
-                >
-                  <span className="truncate">次のコースへ: {nextCourse.title || '無題のコース'}</span>
-                  <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
-                </button>
-              ) : null}
-            </div>
-          </article>
-
-          {lightboxImage && (
-            <ImageLightbox
-              src={lightboxImage.src}
-              alt={lightboxImage.alt}
-              onClose={() => setLightboxImage(null)}
-            />
-          )}
-        </div>
-
-        {tocOpen && (
-          <aside className="hidden lg:block">
-            {/* サイドバー全体をビューポート高さに収める(FRESTYLE-144)。目次カードと章一覧カードは
-                内容ぶんの高さを取りつつ、合計が収まらないときは flex で縮み各カードが内部スクロールする。
-                これで章が長くてもサイドバーが間延びせず、各カードに独立したスクロールバーが出る。 */}
-            <div className="sticky top-6 flex max-h-[calc(100vh-3rem)] flex-col gap-4">
-              <div className="flex min-h-0 flex-col rounded-xl border border-surface-3 bg-white p-4 shadow-sm">
-                {/* タイトルはヘッダーで大きく出すため、 目次からも先頭 h1 を除いた本文を渡す。 */}
-                <MarkdownTableOfContents content={bodyContent} />
-              </div>
-              {/* 章一覧は左パネルから右サイドバー(目次の下)へ移動(FRESTYLE-118)。 */}
-              <div className="flex min-h-0 flex-col rounded-xl border border-surface-3 bg-white p-4 shadow-sm">
-                <ChapterNav
-                  course={course}
-                  materials={materials}
-                  selectedId={material.id}
-                  completedIds={completedIds}
-                  completedCount={completedCount}
-                  onSelect={onSelectMaterial}
-                />
-              </div>
-            </div>
-          </aside>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/**
- * ChapterNav — 閲覧ビューの右サイドバーに出す章一覧(FRESTYLE-118)。
- * コース一覧への戻り + コース名 + 進捗バー + 章リスト(完了はチェック・現在章はハイライト)。
- */
-function ChapterNav({
-  course,
-  materials,
-  selectedId,
-  completedIds,
-  completedCount,
-  onSelect,
-}: {
-  course: Course;
-  materials: TeachingMaterial[];
-  selectedId: number;
-  completedIds: Set<number>;
-  completedCount: number;
-  onSelect: (id: number) => void;
-}) {
-  return (
-    // 親カードが高さを制限したとき、見出し(コース名・進捗)は固定して章リストだけを内側でスクロールさせる(FRESTYLE-144)。
-    <div className="flex min-h-0 flex-col">
-      <div className="flex-shrink-0">
-        <Link
-          to="/courses"
-          className="inline-flex items-center gap-1 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]"
-        >
-          <ArrowLeftIcon className="w-3.5 h-3.5" />
-          コース一覧
-        </Link>
-        <p className="mt-2 text-sm font-semibold text-[var(--color-text-primary)]">
-          {course.title || '無題のコース'}
-          <span className="ml-2 text-xs font-normal text-[var(--color-text-muted)]">
-            {materials.length} 章
-          </span>
-        </p>
-        {materials.length > 0 && (
-          <div className="mt-2">
-            <CourseProgressBar completed={completedCount} total={materials.length} />
-          </div>
-        )}
-      </div>
-      <nav aria-label="章一覧" className="mt-3 min-h-0 flex-1 space-y-0.5 overflow-y-auto pr-1">
-        {materials.map((m, i) => {
-          const active = m.id === selectedId;
-          return (
-            <button
-              key={m.id}
-              type="button"
-              onClick={() => onSelect(m.id)}
-              aria-current={active ? 'page' : undefined}
-              className={`w-full flex items-start gap-2 rounded-md px-2 py-1.5 text-left text-[13px] leading-snug transition-colors ${
-                active
-                  ? 'bg-brand-500/10 font-medium text-[var(--color-text-primary)]'
-                  : 'text-[var(--color-text-secondary)] hover:bg-surface-2'
-              }`}
-            >
-              {completedIds.has(m.id) ? (
-                <CheckCircleSolidIcon className="w-4 h-4 mt-0.5 text-emerald-500 flex-shrink-0" aria-label="完了" />
-              ) : (
-                <span className="w-4 h-4 mt-0.5 flex items-center justify-center text-[10px] rounded-full border border-surface-3 text-[var(--color-text-muted)] flex-shrink-0">
-                  {i + 1}
-                </span>
-              )}
-              <span className="line-clamp-2">{m.title || '無題の教材'}</span>
-            </button>
-          );
-        })}
-      </nav>
-    </div>
-  );
-}
-
-/**
- * MaterialSkeleton は章本文の取得中に出す骨組み。
- *
- * バーのスピナーではなく記事レイアウト（タイトル / メタ / 本文行 / 図ブロック）を
- * 模した pulse プレースホルダにすることで、 章切り替え時のちらつきを抑え体感速度を上げる。
- */
-function MaterialSkeleton() {
-  return (
-    // 実表示(灰青背景 + 白カード)と同じ配色にして、取得完了時の切り替わりで背景が変わらないようにする。
-    <div className="flex-1 bg-[var(--color-reading-surface)]">
-      <div
-        className="mx-auto w-full max-w-[860px] px-6 sm:px-10 py-8 sm:py-10 animate-pulse"
-        aria-hidden="true"
-      >
-        <div className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
-          {/* タイトル + メタはカードの先頭(FRESTYLE-178 の実表示に合わせて跳ねを防ぐ)。 */}
-          <div className="mb-6 pb-6 border-b border-surface-3 space-y-3">
-            <div className="h-8 w-3/4 rounded bg-surface-3" />
-            <div className="h-3 w-40 rounded bg-surface-2" />
-          </div>
-          <div className="space-y-3">
-            <div className="h-4 w-full rounded bg-surface-2" />
-            <div className="h-4 w-11/12 rounded bg-surface-2" />
-            <div className="h-4 w-4/5 rounded bg-surface-2" />
-          </div>
-          <div className="mt-6 h-40 w-full rounded-lg bg-surface-2" />
-          <div className="mt-6 space-y-3">
-            <div className="h-4 w-full rounded bg-surface-2" />
-            <div className="h-4 w-10/12 rounded bg-surface-2" />
-            <div className="h-4 w-3/4 rounded bg-surface-2" />
-          </div>
-        </div>
-      </div>
-      <span className="sr-only" role="status">
-        読み込み中
-      </span>
-    </div>
-  );
-}
-
-/** CompleteToggleButton は教材の完了 / 未完了を切り替えるトグルボタン。 */
-function CompleteToggleButton({
-  completed,
-  onToggle,
-  large = false,
-}: {
-  completed: boolean;
-  onToggle: (done: boolean) => void;
-  large?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onToggle(!completed)}
-      aria-pressed={completed}
-      // whitespace-nowrap / shrink-0: 隣に長いタイトルの「次の章へ」ボタンが並んでも縮まず、
-      // ラベルが「完了に / する」と 2 行に折り返さないようにする(FRESTYLE-188)。
-      className={`inline-flex shrink-0 whitespace-nowrap items-center justify-center gap-1.5 rounded-lg font-medium transition-colors ${
-        large ? 'px-5 pt-[9px] pb-[11px] text-sm' : 'px-3 pt-[5px] pb-[7px] text-sm'
-      } ${
-        completed
-          ? 'bg-green-500/15 text-green-500 hover:bg-green-500/25'
-          : 'bg-brand-500 text-white hover:bg-brand-600'
-      }`}
-    >
-      <CheckCircleSolidIcon className="w-4 h-4" />
-      {completed ? '完了済み' : '完了にする'}
-    </button>
-  );
-}
-
-function formatDate(iso: string): string {
-  if (!iso) return '';
-  const d = new Date(iso);
-  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())}`;
-}
-
-function pad(n: number): string {
-  return String(n).padStart(2, '0');
-}
-
-/**
- * stripLeadingTitle — 本文の先頭にある h1(章タイトル)を取り除く(FRESTYLE-131)。
- *
- * 教材本文は規約により `# タイトル`(= material.title と同じ)で始まる。閲覧ビューでは
- * タイトルをカード外のヘッダーで大きく表示するため、本文側の先頭 h1 を消して二重表示を防ぐ。
- * 「先頭の空行を飛ばした最初の非空行が h1 のときだけ」除去するので、コードブロック内の
- * `# コメント` や 2 個目以降の見出しには一切触れない(先頭の 1 個だけが対象)。
- */
-function stripLeadingTitle(content: string): string {
-  if (!content) return content;
-  const lines = content.split('\n');
-  let i = 0;
-  while (i < lines.length && lines[i].trim() === '') i++;
-  if (i >= lines.length || !/^#\s+\S/.test(lines[i])) return content;
-  lines.splice(0, i + 1);
-  while (lines.length && lines[0].trim() === '') lines.shift();
-  return lines.join('\n');
-}
-
-// trainee の閲覧用に Markdown を render するだけのコンポーネント。
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import remarkBreaks from 'remark-breaks';
-import rehypeHighlight from 'rehype-highlight';
-import rehypeSlug from 'rehype-slug';
-import type { ReactNode } from 'react';
-
-/** ImageLightbox は本文内の画像をモーダルで拡大表示する(FRESTYLE-191)。
-    背景クリック / 閉じるボタン / Esc キーで閉じる。開いたら閉じるボタンへフォーカスを移す。 */
-function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
-  const closeRef = useRef<HTMLButtonElement>(null);
-  useEffect(() => {
-    closeRef.current?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label={alt || '画像の拡大表示'}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 sm:p-10"
-      onClick={onClose}
-    >
-      <button
-        ref={closeRef}
-        type="button"
-        onClick={onClose}
-        aria-label="閉じる"
-        className="absolute top-4 right-4 rounded-full bg-white/90 p-2 text-gray-700 shadow hover:bg-white transition-colors"
-      >
-        <XMarkIcon className="w-5 h-5" />
-      </button>
-      {/* 画像自体のクリックでは閉じない(誤タップで閉じるのを防ぐ)。背景クリックのみで閉じる。 */}
-      <img
-        src={src}
-        alt={alt}
-        className="max-h-full max-w-full rounded-lg bg-white shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-      />
-    </div>
-  );
-}
-
-function ReadOnlyMarkdown({
-  content,
-  onImageClick,
-}: {
-  content: string;
-  onImageClick?: (image: { src: string; alt: string }) => void;
-}) {
-  if (!content.trim()) {
-    return <p className="text-[var(--color-text-muted)]">この教材にはまだ本文がありません。</p>;
-  }
-  return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkBreaks]}
-      rehypePlugins={[rehypeSlug, rehypeHighlight]}
-      components={{
-        a: ({ href, children }) => (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-brand-400 underline-offset-2 hover:underline"
-          >
-            {children as ReactNode}
-          </a>
-        ),
-        // 図（draw.io から書き出した PNG/SVG 等）を本文に埋め込めるようにする。
-        // 中央寄せ + 枠 + 白背景（透過 SVG が見えるよう）。リンクにはしない
-        // （クリックで画像 URL が別タブに開き学習が中断される、というユーザー要望で FRESTYLE-125 にて除去）。
-        // 代わりにクリックでモーダル拡大表示する(FRESTYLE-191。ページを離れないので中断されない)。
-        img: ({ src, alt }) => {
-          const url = typeof src === 'string' ? src : undefined;
-          const image = (
-            <img
-              src={url}
-              alt={alt ?? ''}
-              loading="lazy"
-              className="mx-auto max-w-[90%] h-auto rounded-lg border border-surface-3 bg-white"
-            />
-          );
-          return (
-            <figure className="my-5">
-              {onImageClick && url ? (
-                <button
-                  type="button"
-                  onClick={() => onImageClick({ src: url, alt: alt ?? '' })}
-                  aria-label={`${alt || '図'}を拡大表示`}
-                  className="block w-full cursor-zoom-in"
-                >
-                  {image}
-                </button>
-              ) : (
-                image
-              )}
-              {alt && (
-                <figcaption className="mt-2 text-center text-xs text-[var(--color-text-muted)]">
-                  {alt}
-                </figcaption>
-              )}
-            </figure>
-          );
-        },
-        code: ({ className, children, ...props }) => {
-          const isBlock = className?.includes('language-');
-          if (isBlock) {
-            return (
-              <code className={className} {...props}>
-                {children as ReactNode}
-              </code>
-            );
-          }
-          return (
-            <code className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[0.85em]">
-              {children as ReactNode}
-            </code>
-          );
-        },
-        table: ({ children }) => (
-          <div className="overflow-x-auto">
-            <table className="text-sm border-collapse">{children as ReactNode}</table>
-          </div>
-        ),
-      }}
-    >
-      {content}
-    </ReactMarkdown>
   );
 }

--- a/frontend/src/pages/course-detail/ui/ImageLightbox.tsx
+++ b/frontend/src/pages/course-detail/ui/ImageLightbox.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+/**
+ * 本文内の画像をモーダルで拡大表示する(FRESTYLE-191)。
+ * 背景クリック / 閉じるボタン / Esc キーで閉じる。開いたら閉じるボタンへフォーカスを移す。
+ */
+export default function ImageLightbox({
+  src,
+  alt,
+  onClose,
+}: {
+  src: string;
+  alt: string;
+  onClose: () => void;
+}) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt || '画像の拡大表示'}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4 sm:p-10"
+      onClick={onClose}
+    >
+      <button
+        ref={closeButtonRef}
+        type="button"
+        onClick={onClose}
+        aria-label="閉じる"
+        className="absolute top-4 right-4 rounded-full bg-white/90 p-2 text-gray-700 shadow hover:bg-white transition-colors"
+      >
+        <XMarkIcon className="w-5 h-5" />
+      </button>
+      {/* 画像自体のクリックでは閉じない(誤タップで閉じるのを防ぐ)。背景クリックのみで閉じる。 */}
+      <img
+        src={src}
+        alt={alt}
+        className="max-h-full max-w-full rounded-lg bg-white shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/ManagedDetail.tsx
+++ b/frontend/src/pages/course-detail/ui/ManagedDetail.tsx
@@ -1,0 +1,39 @@
+import { NoteMarkdownEditor } from '@/entities/note';
+import { ImageUploadRepository } from '@/entities/user';
+import type { useTeachingMaterialEditor } from '../model/useTeachingMaterialEditor';
+
+/**
+ * 管理ロール(company_admin / super_admin)向けの教材編集ビュー。
+ * NoteMarkdownEditor(Edit/Preview タブ)を流用し、上部に「trainee に公開」トグルを置く。
+ */
+export default function ManagedDetail({
+  editor,
+}: {
+  editor: ReturnType<typeof useTeachingMaterialEditor>;
+}) {
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <div className="px-6 pt-4 pb-2 flex items-center justify-end gap-2 border-b border-surface-3">
+        <label className="flex items-center gap-2 text-xs text-[var(--color-text-secondary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={editor.editIsPublished}
+            onChange={(event) => editor.handleIsPublishedChange(event.target.checked)}
+            className="rounded border-surface-3"
+          />
+          trainee に公開
+        </label>
+      </div>
+      <div className="flex-1 min-h-0">
+        <NoteMarkdownEditor
+          title={editor.editTitle}
+          content={editor.editContent}
+          saveStatus={editor.saveStatus}
+          onTitleChange={editor.handleTitleChange}
+          onContentChange={editor.handleContentChange}
+          onImageUpload={(file) => ImageUploadRepository.upload(file)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/MaterialListItem.tsx
+++ b/frontend/src/pages/course-detail/ui/MaterialListItem.tsx
@@ -7,13 +7,11 @@ export default function MaterialListItem({
   isActive,
   onSelect,
   onDelete,
-  completed = false,
 }: {
   material: TeachingMaterial;
   isActive: boolean;
   onSelect: (id: number) => void;
   onDelete?: (id: number) => void;
-  completed?: boolean;
 }) {
   return (
     <div

--- a/frontend/src/pages/course-detail/ui/MaterialListItem.tsx
+++ b/frontend/src/pages/course-detail/ui/MaterialListItem.tsx
@@ -1,0 +1,57 @@
+import { TrashIcon } from '@heroicons/react/24/outline';
+import type { TeachingMaterial } from '@/entities/course';
+
+/** 左パネル(教材リスト)の 1 行。クリック / Enter・Space で選択、管理ロールでは削除ボタンを出す。 */
+export default function MaterialListItem({
+  material,
+  isActive,
+  onSelect,
+  onDelete,
+  completed = false,
+}: {
+  material: TeachingMaterial;
+  isActive: boolean;
+  onSelect: (id: number) => void;
+  onDelete?: (id: number) => void;
+  completed?: boolean;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(material.id)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(material.id);
+        }
+      }}
+      className={`group flex items-start gap-2.5 pl-4 pr-2 py-2.5 cursor-pointer transition-colors border-l-2 ${
+        isActive
+          ? 'border-brand-500 bg-[var(--color-nav-active)]'
+          : 'border-transparent hover:bg-[var(--color-nav-hover)]'
+      }`}
+    >
+      <p className={`flex-1 min-w-0 text-[13px] leading-snug line-clamp-2 ${
+        isActive
+          ? 'font-medium text-[var(--color-text-primary)]'
+          : 'text-[var(--color-text-secondary)]'
+      }`}>
+        {material.title || '無題の教材'}
+      </p>
+
+      {onDelete && (
+        <button
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete(material.id);
+          }}
+          className="opacity-0 group-hover:opacity-100 p-1 hover:bg-red-900/30 rounded transition-opacity flex-shrink-0"
+          aria-label="教材を削除"
+        >
+          <TrashIcon className="w-3.5 h-3.5 text-[var(--color-text-muted)] hover:text-red-400" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/MaterialSkeleton.tsx
+++ b/frontend/src/pages/course-detail/ui/MaterialSkeleton.tsx
@@ -1,0 +1,39 @@
+/**
+ * 章本文の取得中に出す骨組み。
+ *
+ * バーのスピナーではなく記事レイアウト（タイトル / メタ / 本文行 / 図ブロック）を
+ * 模した pulse プレースホルダにすることで、 章切り替え時のちらつきを抑え体感速度を上げる。
+ */
+export default function MaterialSkeleton() {
+  return (
+    // 実表示(灰青背景 + 白カード)と同じ配色にして、取得完了時の切り替わりで背景が変わらないようにする。
+    <div className="flex-1 bg-[var(--color-reading-surface)]">
+      <div
+        className="mx-auto w-full max-w-[860px] px-6 sm:px-10 py-8 sm:py-10 animate-pulse"
+        aria-hidden="true"
+      >
+        <div className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
+          {/* タイトル + メタはカードの先頭(FRESTYLE-178 の実表示に合わせて跳ねを防ぐ)。 */}
+          <div className="mb-6 pb-6 border-b border-surface-3 space-y-3">
+            <div className="h-8 w-3/4 rounded bg-surface-3" />
+            <div className="h-3 w-40 rounded bg-surface-2" />
+          </div>
+          <div className="space-y-3">
+            <div className="h-4 w-full rounded bg-surface-2" />
+            <div className="h-4 w-11/12 rounded bg-surface-2" />
+            <div className="h-4 w-4/5 rounded bg-surface-2" />
+          </div>
+          <div className="mt-6 h-40 w-full rounded-lg bg-surface-2" />
+          <div className="mt-6 space-y-3">
+            <div className="h-4 w-full rounded bg-surface-2" />
+            <div className="h-4 w-10/12 rounded bg-surface-2" />
+            <div className="h-4 w-3/4 rounded bg-surface-2" />
+          </div>
+        </div>
+      </div>
+      <span className="sr-only" role="status">
+        読み込み中
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/ReadOnlyDetail.tsx
+++ b/frontend/src/pages/course-detail/ui/ReadOnlyDetail.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ArrowRightIcon, ListBulletIcon } from '@heroicons/react/24/outline';
+import { useLocalStorage } from '@/shared/lib/hooks/useLocalStorage';
+import MarkdownTableOfContents from '@/shared/ui/MarkdownTableOfContents';
+import type { Course, CourseWithProgress, TeachingMaterial } from '@/entities/course';
+import CompleteToggleButton from './CompleteToggleButton';
+import ChapterNav from './ChapterNav';
+import ImageLightbox from './ImageLightbox';
+import ReadOnlyMarkdown from './ReadOnlyMarkdown';
+import { formatDate } from '../lib/formatDate';
+import { stripLeadingTitle } from '../lib/stripLeadingTitle';
+
+/**
+ * trainee 向けの教材閲覧ビュー。記事風の本文カード + 右サイドバー(目次 + 章一覧)。
+ * 本文末尾に「完了にする」と「次の章へ / 次のコースへ」を並べ、読み終えた位置から先へ進める。
+ */
+export default function ReadOnlyDetail({
+  material,
+  completed,
+  onToggleComplete,
+  nextMaterial,
+  onGoNext,
+  nextCourse,
+  onGoNextCourse,
+  course,
+  materials,
+  completedIds,
+  onSelectMaterial,
+  completedCount,
+}: {
+  material: TeachingMaterial;
+  completed: boolean;
+  onToggleComplete: (done: boolean) => void;
+  nextMaterial?: TeachingMaterial | null;
+  onGoNext?: () => void;
+  nextCourse?: CourseWithProgress | null;
+  onGoNextCourse?: () => void;
+  course: Course;
+  materials: TeachingMaterial[];
+  completedIds: Set<number>;
+  onSelectMaterial: (id: number) => void;
+  completedCount: number;
+}) {
+  // 目次の表示状態は localStorage に保持し、 教材を切り替えても選択が続くようにする（既定は表示）。
+  // 横幅が狭いときに本文幅を稼げるよう trainee が出し入れできる。
+  const [tocOpen, setTocOpen] = useLocalStorage('course-toc-open', true);
+
+  // 章を切り替えたら本文の先頭までスクロールを戻す（末尾の「次の章へ」から進んでも頭から読める）。
+  // スクロールは AppShell のドキュメントスクロールコンテナ(FRESTYLE-122)側で起きるため、
+  // そちらへ遡って scrollTo する（テスト等で見つからない場合は自要素へフォールバック）。
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const scroller = scrollRef.current?.closest('[data-app-scroll]') ?? scrollRef.current;
+    scroller?.scrollTo({ top: 0 });
+  }, [material.id]);
+
+  // 本文先頭の h1(= タイトル)は、下のヘッダーで material.title を大きく出すため取り除く。
+  // 残すとカードの外(ヘッダー)とカードの中(本文)でタイトルが二重に見える(FRESTYLE-131)。
+  const bodyContent = useMemo(() => stripLeadingTitle(material.content), [material.content]);
+
+  // 本文内の画像クリックでモーダル拡大表示する(FRESTYLE-191)。ページを離れずに図の細部を
+  // 確認できる(別タブで開くリンクは学習が中断されるため FRESTYLE-125 で除去済み)。
+  const [lightboxImage, setLightboxImage] = useState<{ src: string; alt: string } | null>(null);
+  useEffect(() => setLightboxImage(null), [material.id]);
+
+  return (
+    // 背景は読み物用の灰青(--color-reading-surface)、本文は白カード。背景と内容のコントラストで
+    // 読み物として視線が本文に集まるようにする(FRESTYLE-118)。body は白に戻したが、教材閲覧だけ
+    // 灰青を維持する(FRESTYLE-147)。内部スクロールは持たない(FRESTYLE-122 でページ全体スクロール)。
+    <div ref={scrollRef} className="flex-1 bg-[var(--color-reading-surface)]">
+      {/* 読み物ページなので外側の余白は広め(FRESTYLE-115)。中央寄せなので左右は自然に余白になる。 */}
+      <div
+        className={`mx-auto w-full max-w-6xl px-6 sm:px-10 py-8 sm:py-10 grid grid-cols-1 gap-8 ${
+          tocOpen ? 'lg:grid-cols-[minmax(0,1fr)_280px]' : ''
+        }`}
+      >
+        {/* 本文カラム。 サイドバーを隠したときは本文が全幅に伸びて読みにくいため、 読みやすい幅(860px)に
+            収めて中央寄せする。 サイドバー表示時は 1fr カラムが既に同程度の幅になる。 */}
+        <div className={`min-w-0 ${!tocOpen ? 'mx-auto w-full max-w-[860px]' : ''}`}>
+          <article className="bg-white border border-surface-3 rounded-xl shadow-sm px-6 sm:px-10 py-8 sm:py-10">
+            {/* 記事サイト風ヘッダー: タイトル + メタを本文カードの先頭に入れる。
+                以前はカード外の別ヘッダーに置いていたが、カードをタイトル位置まで上げて
+                タイトルもカード内に収めた(FRESTYLE-178)。目次サイドバーは同じグリッド行に来るので
+                カード上端と揃う(FRESTYLE-150)。本文先頭の重複 h1 は stripLeadingTitle で除去済み(FRESTYLE-131)。 */}
+            <header className="mb-6 pb-6 border-b border-surface-3">
+              <h1 className="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] leading-snug">
+                {material.title || '無題の教材'}
+              </h1>
+              {/* メタ(最終更新 / 目次トグル / 完了トグル)。 sticky にはしない(FRESTYLE-119)。
+                  スクロール途中の完了操作は本文末尾の大きい完了ボタン(FRESTYLE-100)で行える。 */}
+              <div className="mt-3 flex flex-wrap items-center gap-3">
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  最終更新: {formatDate(material.updatedAt)}
+                </p>
+                {/* 目次は lg 以上でのみ表示されるため、 トグルも lg 未満では隠す。 */}
+                <button
+                  type="button"
+                  onClick={() => setTocOpen((isOpen) => !isOpen)}
+                  aria-pressed={tocOpen}
+                  title={tocOpen ? '目次を隠す' : '目次を表示'}
+                  className={`hidden lg:inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                    tocOpen
+                      ? 'border-taupe-500 text-taupe-400'
+                      : 'border-surface-3 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)]'
+                  }`}
+                >
+                  <ListBulletIcon className="w-4 h-4" />
+                  目次
+                </button>
+                <CompleteToggleButton completed={completed} onToggle={onToggleComplete} />
+              </div>
+            </header>
+            <div className="prose prose-sm max-w-none course-prose">
+              <ReadOnlyMarkdown content={bodyContent} onImageClick={setLightboxImage} />
+            </div>
+
+            {/* 末尾に「完了にする」と「次の章へ」を並べ、 読み終えた位置から次へ進めるようにする。
+                崩れ対策(FRESTYLE-189): 完了ボタンは shrink-0 / whitespace-nowrap で常に 1 行を保ち、
+                次へボタンは min-w-0 + truncate で長い章タイトルを省略しつつ、 幅を取りすぎないよう
+                上限(sm:max-w-[55%])を設けて 2 つのボタンのバランスを取る。
+                最終章では代わりに「次のコースへ」を出し、 一覧に戻らず次のコースへ直行できるようにする
+                (FRESTYLE-102。 遷移先はレジュームにより 1 章目が自動表示される)。 */}
+            <div className="mt-10 pt-6 border-t border-surface-3 flex flex-col sm:flex-row items-center justify-center gap-3">
+              <CompleteToggleButton completed={completed} onToggle={onToggleComplete} large />
+              {nextMaterial && onGoNext ? (
+                <button
+                  type="button"
+                  onClick={onGoNext}
+                  title={`次の章へ: ${nextMaterial.title || '無題の教材'}`}
+                  className="inline-flex min-w-0 max-w-full sm:max-w-[55%] items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors"
+                >
+                  <span className="truncate">次の章へ: {nextMaterial.title || '無題の教材'}</span>
+                  <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
+                </button>
+              ) : nextCourse && onGoNextCourse ? (
+                <button
+                  type="button"
+                  onClick={onGoNextCourse}
+                  title={`次のコースへ: ${nextCourse.title || '無題のコース'}`}
+                  className="inline-flex min-w-0 max-w-full sm:max-w-[55%] items-center justify-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-surface-2 border border-surface-3 text-[var(--color-text-primary)] hover:bg-surface-3 transition-colors"
+                >
+                  <span className="truncate">次のコースへ: {nextCourse.title || '無題のコース'}</span>
+                  <ArrowRightIcon className="w-4 h-4 flex-shrink-0" />
+                </button>
+              ) : null}
+            </div>
+          </article>
+
+          {lightboxImage && (
+            <ImageLightbox
+              src={lightboxImage.src}
+              alt={lightboxImage.alt}
+              onClose={() => setLightboxImage(null)}
+            />
+          )}
+        </div>
+
+        {tocOpen && (
+          <aside className="hidden lg:block">
+            {/* サイドバー全体をビューポート高さに収める(FRESTYLE-144)。目次カードと章一覧カードは
+                内容ぶんの高さを取りつつ、合計が収まらないときは flex で縮み各カードが内部スクロールする。
+                これで章が長くてもサイドバーが間延びせず、各カードに独立したスクロールバーが出る。 */}
+            <div className="sticky top-6 flex max-h-[calc(100vh-3rem)] flex-col gap-4">
+              <div className="flex min-h-0 flex-col rounded-xl border border-surface-3 bg-white p-4 shadow-sm">
+                {/* タイトルはヘッダーで大きく出すため、 目次からも先頭 h1 を除いた本文を渡す。 */}
+                <MarkdownTableOfContents content={bodyContent} />
+              </div>
+              {/* 章一覧は左パネルから右サイドバー(目次の下)へ移動(FRESTYLE-118)。 */}
+              <div className="flex min-h-0 flex-col rounded-xl border border-surface-3 bg-white p-4 shadow-sm">
+                <ChapterNav
+                  course={course}
+                  materials={materials}
+                  selectedId={material.id}
+                  completedIds={completedIds}
+                  completedCount={completedCount}
+                  onSelect={onSelectMaterial}
+                />
+              </div>
+            </div>
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/course-detail/ui/ReadOnlyMarkdown.tsx
+++ b/frontend/src/pages/course-detail/ui/ReadOnlyMarkdown.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeSlug from 'rehype-slug';
+
+/** trainee の閲覧用に Markdown を render するだけのコンポーネント（画像クリックで拡大表示できる）。 */
+export default function ReadOnlyMarkdown({
+  content,
+  onImageClick,
+}: {
+  content: string;
+  onImageClick?: (image: { src: string; alt: string }) => void;
+}) {
+  if (!content.trim()) {
+    return <p className="text-[var(--color-text-muted)]">この教材にはまだ本文がありません。</p>;
+  }
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      rehypePlugins={[rehypeSlug, rehypeHighlight]}
+      components={{
+        a: ({ href, children }) => (
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-400 underline-offset-2 hover:underline"
+          >
+            {children as ReactNode}
+          </a>
+        ),
+        // 図（draw.io から書き出した PNG/SVG 等）を本文に埋め込めるようにする。
+        // 中央寄せ + 枠 + 白背景（透過 SVG が見えるよう）。リンクにはしない
+        // （クリックで画像 URL が別タブに開き学習が中断される、というユーザー要望で FRESTYLE-125 にて除去）。
+        // 代わりにクリックでモーダル拡大表示する(FRESTYLE-191。ページを離れないので中断されない)。
+        img: ({ src, alt }) => {
+          const url = typeof src === 'string' ? src : undefined;
+          const image = (
+            <img
+              src={url}
+              alt={alt ?? ''}
+              loading="lazy"
+              className="mx-auto max-w-[90%] h-auto rounded-lg border border-surface-3 bg-white"
+            />
+          );
+          return (
+            <figure className="my-5">
+              {onImageClick && url ? (
+                <button
+                  type="button"
+                  onClick={() => onImageClick({ src: url, alt: alt ?? '' })}
+                  aria-label={`${alt || '図'}を拡大表示`}
+                  className="block w-full cursor-zoom-in"
+                >
+                  {image}
+                </button>
+              ) : (
+                image
+              )}
+              {alt && (
+                <figcaption className="mt-2 text-center text-xs text-[var(--color-text-muted)]">
+                  {alt}
+                </figcaption>
+              )}
+            </figure>
+          );
+        },
+        code: ({ className, children, ...props }) => {
+          const isBlock = className?.includes('language-');
+          if (isBlock) {
+            return (
+              <code className={className} {...props}>
+                {children as ReactNode}
+              </code>
+            );
+          }
+          return (
+            <code className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[0.85em]">
+              {children as ReactNode}
+            </code>
+          );
+        },
+        table: ({ children }) => (
+          <div className="overflow-x-auto">
+            <table className="text-sm border-collapse">{children as ReactNode}</table>
+          </div>
+        ),
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}


### PR DESCRIPTION
## 概要
FSD 移行後に残っていたフロント最大の単一ファイル `CourseDetailPage.tsx`（879 行の God コンポーネント）を、page-local な `ui/` `lib/` へ分解し、省略名を読み手に優しい名前へ書き直す純粋なリファクタです（**振る舞い不変**）。

## 変更内容
- **ui/ へ分解（1 ファイル 1 コンポーネント）**: `MaterialListItem` / `ManagedDetail` / `ReadOnlyDetail` / `ChapterNav` / `MaterialSkeleton` / `CompleteToggleButton` / `ImageLightbox` / `ReadOnlyMarkdown`
- **lib/ へ抽出**: `formatDate`(+ 内部 `padTwoDigits`) / `stripLeadingTitle`
- **ファイル途中の import 文**（`import type { ReactNode }` 等）を各ファイル先頭へ集約
- **命名の可読化**: `s`→`state` / `idx`→`selectedIndex` / `m`→`material` / `mid`→`materialId` / `ok`→`succeeded` / `e`→`event` / `i`→`index` / `v`→`isOpen` / `c`→`fetchedCourse` / `active`→`isCurrent` / `n`→`value` / `d`→`date` 等
- `CourseDetailPage` は **879 → 309 行**

## テスト（振る舞い不変の担保）
- 既存テストの **assert を一切変更せず**全通過（DOM 出力が同一である証明）。course-detail: 6 files / 55 tests、全体: **1221 tests 全通過**
- `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` green、カバレッジ **branches 80.17%（閾値 80 維持）**
- FSD 境界 lint（error）もパス（Public API `index.ts` の外部シグネチャ不変）

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コース詳細画面に章一覧、進捗バー、選択中・完了状態の表示を追加しました。
  * 教材の完了状態を切り替えられるようになりました。
  * Markdown本文、目次、コード、表、画像を読みやすく表示できます。
  * 画像をクリックすると拡大表示できます。
  * 管理者は教材タイトル・本文・公開状態を編集できます。
  * 教材の読み込み中にプレースホルダーを表示します。
* **改善**
  * 次の章やコースへ移動できるナビゲーションを追加しました。
  * 教材の更新日を見やすい形式で表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->