### PR TITLE
refactor: home MenuPage の同居サブコンポーネントを ui/ へ分解し命名を可読化 (FRESTYLE-210)

### DIFF
--- a/frontend/src/pages/home/ui/FeatureCard.tsx
+++ b/frontend/src/pages/home/ui/FeatureCard.tsx
@@ -1,0 +1,66 @@
+import type { ComponentType, SVGProps } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import LanguageIcon from '@/shared/ui/LanguageIcon';
+
+type CardColor = 'brand' | 'emerald' | 'taupe' | 'blue';
+
+interface FeatureCardProps {
+  to: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  title: string;
+  description: string;
+  color: CardColor;
+  badge?: string;
+  /** 学べる技術のロゴ（Devicon）。指定時に説明の下へミニロゴ列を出す（FRESTYLE-179）。
+      vendoring 済みの key（public/lang/*.svg）だけ渡すこと（未 vendoring は汎用アイコンにフォールバックし列が不揃いになる）。 */
+  techLogos?: string[];
+}
+
+const iconBg: Record<CardColor, string> = {
+  brand:   'bg-brand-100 text-brand-600',
+  emerald: 'bg-emerald-100 text-emerald-700',
+  taupe:   'bg-taupe-100 text-taupe-600',
+  blue:    'bg-blue-100 text-blue-600',
+};
+
+/** ホームの機能カード 1 枚（コース / 演習 / AI チャット等へのリンク）。 */
+export default function FeatureCard({ to, icon: Icon, title, description, color, badge, techLogos }: FeatureCardProps) {
+  return (
+    <Link
+      to={to}
+      className="group relative flex h-full flex-col p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] shadow-sm hover:border-brand-300 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:shadow-sm transition-all duration-150"
+    >
+      {badge && (
+        <span className="absolute top-4 right-4 text-[10px] font-semibold px-2 pt-px pb-[3px] rounded-full bg-emerald-100 text-emerald-700">
+          {badge}
+        </span>
+      )}
+      <div className="flex items-start gap-3">
+        <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBg[color]}`}>
+          <Icon className="w-5 h-5 -translate-y-px" />
+        </div>
+        <div className="min-w-0 pt-1">
+          <h3 className="font-semibold text-[var(--color-text-primary)] text-sm group-hover:text-brand-500 transition-colors">
+            {title}
+          </h3>
+        </div>
+      </div>
+      <p className="mt-3 text-xs text-[var(--color-text-muted)] leading-relaxed">
+        {description}
+      </p>
+      {/* 学べる技術のロゴ列（Devicon）。コース/演習カードにだけ付き、技術感を出す（FRESTYLE-179）。 */}
+      {techLogos && techLogos.length > 0 && (
+        <div className="mt-3 flex items-center gap-2" aria-hidden="true">
+          {techLogos.map((tech) => (
+            <LanguageIcon key={tech} language={tech} className="w-5 h-5" />
+          ))}
+        </div>
+      )}
+      <div className="mt-4 flex items-center gap-1 text-xs text-[var(--color-text-muted)] group-hover:text-brand-500 transition-colors">
+        <span>開く</span>
+        <ArrowRightIcon className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
+      </div>
+    </Link>
+  );
+}

--- a/frontend/src/pages/home/ui/FeatureSection.tsx
+++ b/frontend/src/pages/home/ui/FeatureSection.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+interface FeatureSectionProps {
+  title: string;
+  children: ReactNode;
+}
+
+/** ホームのメニューを見出し付きのカードグリッドでまとめるセクション（「学習」「ツール」等）。 */
+export default function FeatureSection({ title, children }: FeatureSectionProps) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest">
+        {title}
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/home/ui/MenuPage.tsx
+++ b/frontend/src/pages/home/ui/MenuPage.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import { useAppSelector } from '@/shared/lib/store';
 
 import {
@@ -9,14 +8,16 @@ import {
   BuildingOffice2Icon,
   EnvelopeIcon,
   BookOpenIcon,
-  ArrowRightIcon,
 } from '@heroicons/react/24/outline';
-import LanguageIcon from '@/shared/ui/LanguageIcon';
 
 import { useUserDashboard } from '../model/useUserDashboard';
 import { useCompanyLearningSummary } from '../model/useCompanyLearningSummary';
 import DashboardStats from './DashboardStats';
 import CompanyLearningPanel from './CompanyLearningPanel';
+import FeatureSection from './FeatureSection';
+import FeatureCard from './FeatureCard';
+import MenuSkeleton from './MenuSkeleton';
+import StatsSkeleton from './StatsSkeleton';
 
 /**
  * ホーム画面（ダッシュボード）。
@@ -171,134 +172,6 @@ export default function MenuPage() {
             )}
           </div>
         )}
-      </div>
-    </div>
-  );
-}
-
-// ─── サブコンポーネント ──────────────────────────────────────────────────────
-
-interface FeatureSectionProps {
-  title: string;
-  children: React.ReactNode;
-}
-
-function FeatureSection({ title, children }: FeatureSectionProps) {
-  return (
-    <section className="space-y-3">
-      <h2 className="text-xs font-semibold text-[var(--color-text-muted)] uppercase tracking-widest">
-        {title}
-      </h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {children}
-      </div>
-    </section>
-  );
-}
-
-type CardColor = 'brand' | 'emerald' | 'taupe' | 'blue';
-
-interface FeatureCardProps {
-  to: string;
-  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-  title: string;
-  description: string;
-  color: CardColor;
-  badge?: string;
-  /** 学べる技術のロゴ（Devicon）。指定時に説明の下へミニロゴ列を出す（FRESTYLE-179）。
-      vendoring 済みの key（public/lang/*.svg）だけ渡すこと（未 vendoring は汎用アイコンにフォールバックし列が不揃いになる）。 */
-  techLogos?: string[];
-}
-
-const iconBg: Record<CardColor, string> = {
-  brand:   'bg-brand-100 text-brand-600',
-  emerald: 'bg-emerald-100 text-emerald-700',
-  taupe:   'bg-taupe-100 text-taupe-600',
-  blue:    'bg-blue-100 text-blue-600',
-};
-
-function FeatureCard({ to, icon: Icon, title, description, color, badge, techLogos }: FeatureCardProps) {
-  return (
-    <Link
-      to={to}
-      className="group relative flex h-full flex-col p-5 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] shadow-sm hover:border-brand-300 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:shadow-sm transition-all duration-150"
-    >
-      {badge && (
-        <span className="absolute top-4 right-4 text-[10px] font-semibold px-2 pt-px pb-[3px] rounded-full bg-emerald-100 text-emerald-700">
-          {badge}
-        </span>
-      )}
-      <div className="flex items-start gap-3">
-        <div className={`w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 ${iconBg[color]}`}>
-          <Icon className="w-5 h-5 -translate-y-px" />
-        </div>
-        <div className="min-w-0 pt-1">
-          <h3 className="font-semibold text-[var(--color-text-primary)] text-sm group-hover:text-brand-500 transition-colors">
-            {title}
-          </h3>
-        </div>
-      </div>
-      <p className="mt-3 text-xs text-[var(--color-text-muted)] leading-relaxed">
-        {description}
-      </p>
-      {/* 学べる技術のロゴ列（Devicon）。コース/演習カードにだけ付き、技術感を出す（FRESTYLE-179）。 */}
-      {techLogos && techLogos.length > 0 && (
-        <div className="mt-3 flex items-center gap-2" aria-hidden="true">
-          {techLogos.map((t) => (
-            <LanguageIcon key={t} language={t} className="w-5 h-5" />
-          ))}
-        </div>
-      )}
-      <div className="mt-4 flex items-center gap-1 text-xs text-[var(--color-text-muted)] group-hover:text-brand-500 transition-colors">
-        <span>開く</span>
-        <ArrowRightIcon className="w-3 h-3 group-hover:translate-x-0.5 transition-transform" />
-      </div>
-    </Link>
-  );
-}
-
-// ─── スケルトン（ロード中のプレースホルダ）─────────────────────────────────
-
-/** MenuSkeleton はメニューカード読み込み中のプレースホルダ。実レイアウトと寸法を揃える。 */
-function MenuSkeleton() {
-  return (
-    <div className="space-y-8" aria-hidden="true">
-      {[2, 3].map((count, s) => (
-        <section key={s} className="space-y-3">
-          <div className="h-3 w-16 rounded bg-[var(--color-surface-3)] animate-pulse" />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {Array.from({ length: count }).map((_, i) => (
-              <div
-                key={i}
-                className="h-[148px] rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-5"
-              >
-                <div className="w-9 h-9 rounded-lg bg-[var(--color-surface-3)] animate-pulse" />
-                <div className="mt-3 h-3.5 w-24 rounded bg-[var(--color-surface-3)] animate-pulse" />
-                <div className="mt-3 h-3 w-full rounded bg-[var(--color-surface-3)] animate-pulse" />
-              </div>
-            ))}
-          </div>
-        </section>
-      ))}
-    </div>
-  );
-}
-
-/** StatsSkeleton は右サイドバー（学習統計）読み込み中のプレースホルダ。 */
-function StatsSkeleton() {
-  return (
-    <div
-      className="space-y-4 p-4 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)]"
-      aria-hidden="true"
-    >
-      <div className="grid grid-cols-2 gap-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="h-[88px] rounded-lg bg-[var(--color-surface-2)] animate-pulse" />
-        ))}
-      </div>
-      <div className="space-y-2">
-        <div className="h-3 w-40 rounded bg-[var(--color-surface-3)] animate-pulse" />
-        <div className="h-20 w-full rounded bg-[var(--color-surface-2)] animate-pulse" />
       </div>
     </div>
   );

--- a/frontend/src/pages/home/ui/MenuSkeleton.tsx
+++ b/frontend/src/pages/home/ui/MenuSkeleton.tsx
@@ -1,0 +1,24 @@
+/** メニューカード読み込み中のプレースホルダ。実レイアウトと寸法を揃えてちらつきを防ぐ。 */
+export default function MenuSkeleton() {
+  return (
+    <div className="space-y-8" aria-hidden="true">
+      {[2, 3].map((cardCount, sectionIndex) => (
+        <section key={sectionIndex} className="space-y-3">
+          <div className="h-3 w-16 rounded bg-[var(--color-surface-3)] animate-pulse" />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {Array.from({ length: cardCount }).map((_, cardIndex) => (
+              <div
+                key={cardIndex}
+                className="h-[148px] rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-5"
+              >
+                <div className="w-9 h-9 rounded-lg bg-[var(--color-surface-3)] animate-pulse" />
+                <div className="mt-3 h-3.5 w-24 rounded bg-[var(--color-surface-3)] animate-pulse" />
+                <div className="mt-3 h-3 w-full rounded bg-[var(--color-surface-3)] animate-pulse" />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/home/ui/StatsSkeleton.tsx
+++ b/frontend/src/pages/home/ui/StatsSkeleton.tsx
@@ -1,0 +1,19 @@
+/** 右サイドバー（学習統計）読み込み中のプレースホルダ。 */
+export default function StatsSkeleton() {
+  return (
+    <div
+      className="space-y-4 p-4 rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)]"
+      aria-hidden="true"
+    >
+      <div className="grid grid-cols-2 gap-3">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="h-[88px] rounded-lg bg-[var(--color-surface-2)] animate-pulse" />
+        ))}
+      </div>
+      <div className="space-y-2">
+        <div className="h-3 w-40 rounded bg-[var(--color-surface-3)] animate-pulse" />
+        <div className="h-20 w-full rounded bg-[var(--color-surface-2)] animate-pulse" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
可読性リファクタ第 2 弾（第 1 弾 = FRESTYLE-208 course-detail）。ホーム画面 `MenuPage.tsx`（305 行）に同居していた 4 コンポーネントを page-local な `ui/` へ分解し、スケルトンの省略名を可読化する純粋なリファクタです（**振る舞い不変**）。

## 変更内容
- **ui/ へ分解**: `FeatureSection` / `FeatureCard`（+ 型 `CardColor` / 定数 `iconBg` を同梱）/ `MenuSkeleton` / `StatsSkeleton`
- **命名の可読化**: `s`→`sectionIndex` / `i`→`cardIndex`・`index` / `t`→`tech`
- 不要になった `Link` / `ArrowRightIcon` / `LanguageIcon` の import は `FeatureCard` 側へ移動
- `MenuPage` は **305 → 178 行**

## テスト（振る舞い不変の担保）
- 既存テストの **assert を一切変更せず**全通過（DOM 出力が同一である証明）。home: 6 files / 23 tests、全体: **1221 tests 全通過**
- `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` green、カバレッジ **branches 80.16%（閾値 80 維持）**、FSD 境界 lint（error）パス

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-210