### PR TITLE
feat: golangci-lint に nilerr / contextcheck / wastedassign を追加 (FRESTYLE-217)

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,11 +1,18 @@
 # golangci-lint v2 設定。
 # 既存 CI の staticcheck / govet / govulncheck を補完し、以下を追加で強制する:
-#   - errorlint : errors.Is/As と %w ラップを強制（エラーの文脈喪失を防ぐ）
-#   - bodyclose : HTTP response body の Close 漏れ（リーク）検出
-#   - gosec     : セキュリティ静的解析（誤検知は下で正当に除外）
-#   - misspell  : コメント/識別子のスペルミス
-#   - unconvert : 不要な型変換
+#   - errorlint     : errors.Is/As と %w ラップを強制（エラーの文脈喪失を防ぐ）
+#   - bodyclose     : HTTP response body の Close 漏れ（リーク）検出
+#   - gosec         : セキュリティ静的解析（誤検知は下で正当に除外）
+#   - misspell      : コメント/識別子のスペルミス
+#   - unconvert     : 不要な型変換
+#   - nilerr        : err != nil なのに return nil する握り潰しバグの検出
+#   - contextcheck  : context の伝播漏れ（親 ctx を渡すべき箇所での取り違え）検出
+#   - wastedassign  : 使われないまま上書きされる代入（デッドな代入）検出
 # default で errcheck / govet / ineffassign / staticcheck / unused も走る。
+#
+# nilerr / contextcheck の現行ヒットはいずれも意図的な設計（IDOR フォールバック /
+# 後始末を別 ctx で必ず実行）で、該当箇所は理由付き nolint で明示している。
+# これらは「将来の実バグ」を検出するために有効化している（FRESTYLE-217）。
 #
 # formatters: gofumpt（gofmt の上位互換。空行・連続宣言の整列など追加ルールを強制）。
 #   `make fmt`（= golangci-lint fmt / gofumpt -w）で自動整形、CI は未整形を fail にする。
@@ -25,6 +32,9 @@ linters:
     - gosec
     - misspell
     - unconvert
+    - nilerr
+    - contextcheck
+    - wastedassign
   exclusions:
     rules:
       # サンドボックス(infra/sandbox)はユーザコードを意図的に exec する。

--- a/backend/internal/handler/profile_handler.go
+++ b/backend/internal/handler/profile_handler.go
@@ -46,6 +46,7 @@ func (h *ProfileHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	}
 	uid, err := strconv.ParseUint(param, 10, 64)
 	if err != nil {
+		//nolint:nilerr // 数字以外の userId は current user にフォールバックする設計（err は握り潰さず意図的に無視）
 		return cur, nil
 	}
 	if uid == 0 || uid != cur {

--- a/backend/internal/handler/profile_image_handler.go
+++ b/backend/internal/handler/profile_image_handler.go
@@ -41,6 +41,7 @@ func (h *ProfileImageHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	}
 	uid, err := strconv.ParseUint(param, 10, 64)
 	if err != nil {
+		//nolint:nilerr // 数字以外の userId は current user にフォールバックする設計（err は握り潰さず意図的に無視）
 		return cur, nil
 	}
 	if uid == 0 || uid != cur {

--- a/backend/internal/handler/user_stats_handler.go
+++ b/backend/internal/handler/user_stats_handler.go
@@ -35,6 +35,7 @@ func (h *UserStatsHandler) resolveUserID(c *gin.Context) (uint64, error) {
 	}
 	uid, err := strconv.ParseUint(param, 10, 64)
 	if err != nil {
+		//nolint:nilerr // 数字以外の userId は current user にフォールバックする設計（err は握り潰さず意図的に無視）
 		return cur, nil
 	}
 	if uid == 0 || uid != cur {

--- a/backend/internal/infra/sandbox/runner.go
+++ b/backend/internal/infra/sandbox/runner.go
@@ -562,6 +562,7 @@ func (r *Runner) executeSQL(ctx context.Context, input domain.CodeExecutionInput
 		return nil, fmt.Errorf("sql sandbox の準備に失敗: %w", err)
 	}
 	// 後始末は必ず実行する（ctx が timeout していても別 ctx で DROP する）。
+	//nolint:contextcheck // 親 ctx が timeout 済みでも DROP DATABASE を確実に実行するため、意図的に context.Background() を使う
 	defer func() {
 		dctx, dcancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer dcancel()


### PR DESCRIPTION
## 概要
バックエンドの `.golangci.yml`（v2）に、**誤検知が少なく実バグを拾う高シグナルな linter を 2〜3 個ずつ段階的に**追加していく方針の第 1 弾（CI 品質向上策 ①〜⑤ の ③）。今回は **nilerr / contextcheck / wastedassign** を有効化。

## 追加 linter と現行ヒットへの対応
候補 linter を実測したヒット数: nilerr=3 / contextcheck=1 / wastedassign=0（noctx=56・perfsprint=39・unparam=5 は多数のため別バッチ）。

- **nilerr**（`err != nil` なのに `return nil` する握り潰しバグ検出）
  現行 3 ヒットは全て **意図的な IDOR フォールバック**（`resolveUserID`: 数字でない `userId` は current user にフォールバックする設計）。該当 3 箇所（`profile_handler.go` / `profile_image_handler.go` / `user_stats_handler.go`）に理由付き `//nolint:nilerr` を付与。将来の実バグは検出を維持。
- **contextcheck**（context 伝播漏れ検出）
  現行 1 ヒットは `infra/sandbox/runner.go` の SQL サンドボックス後始末。**親 ctx が timeout 済みでも `DROP DATABASE` を必ず実行するため意図的に `context.Background()` を使う**（親 ctx を渡すと後始末が走らず一時 DB が残る）。理由付き `//nolint:contextcheck` を付与。
- **wastedassign**（デッドな代入検出）
  現行ヒット 0。将来の防止のため有効化。

## テスト
- `golangci-lint run ./...` → **0 issues**（意図的箇所は理由付き nolint で明示）
- `golangci-lint fmt --diff` → 差分なし（gofumpt OK）
- `go build ./...` / `go vet ./...` → OK
- `go test ./internal/handler/... ./internal/infra/sandbox/...` → 全 pass（挙動不変）

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-217