### PR TITLE
feat: フロントのバンドルサイズを size-limit で計測する CI を非ブロッキングで追加 (FRESTYLE-218)

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -74,16 +74,17 @@ jobs:
         run: npm run build
 
   # 未使用ファイル / 未使用依存 / 未宣言(phantom)依存を knip で検出する。
-  # 非ブロッキング(continue-on-error)。必須チェック(Vitest + Build)とは独立した job にし、
-  # デッドコードの可視化に徹する。件数を使った gating はしない(数値が安定してから別途)。
+  # 必須チェック(Vitest + Build)とは独立した job にし、デッドコードの可視化に徹する。
+  # 件数を使った gating はしない(数値が安定してから別途)。
   # knip 設定は frontend/knip.json(rules で files/dependencies/unlisted に集中、
   # FSD の Public API barrel の未使用 export ノイズは当面 off)。
+  # 非ブロッキング化は「knip 実行 step だけ」continue-on-error にする(下記)。
+  # checkout / npm ci の失敗は job を赤くして可視化する(握り潰さない)。本 job は
+  # 必須チェックではないため、赤くなっても PR マージはブロックしない。
   knip:
     name: Dead code (knip)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # この job の失敗(未使用検出=exit 1)で PR をブロックしない。
-    continue-on-error: true
     defaults:
       run:
         working-directory: frontend
@@ -107,8 +108,10 @@ jobs:
       # 検出結果を PR の Job Summary に markdown で残す。knip の exit code は
       # 「dead code 検出 = 非 0」になり得るが、それを握り潰さず保持する
       # (設定エラー・起動失敗も Summary に出力してから同じ code で終了)。
-      # job は continue-on-error なので、非 0 でも PR はブロックしない。
+      # continue-on-error はこの step だけに付け、非 0 でも job を止めない
+      # (checkout / npm ci の失敗は job を赤くして可視化する)。
       - name: Run knip (report only)
+        continue-on-error: true
         run: |
           set +e
           npx knip --reporter markdown > /tmp/knip-report.md 2>&1
@@ -120,15 +123,16 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
 
-  # 本番バンドルサイズ(gzip)を size-limit で計測する。非ブロッキング(continue-on-error)。
-  # 必須チェック(Vitest + Build)とは独立した job にし、サイズの可視化と回帰検知に徹する。
-  # 上限(.size-limit.json)は現状 + ヘッドルームで、超過はシグナルとして step を赤くするが
-  # job は継続する(PR はブロックしない)。厳密な gating は数値が安定してから別途。
+  # 本番バンドルサイズ(gzip)を size-limit で計測する。必須チェック(Vitest + Build)とは
+  # 独立した job にし、サイズの可視化と回帰検知に徹する。上限(.size-limit.json)は現状 +
+  # ヘッドルームで、超過はシグナルとして扱う。厳密な gating は数値が安定してから別途。
+  # 非ブロッキング化は「size-limit 実行 step だけ」continue-on-error にする(下記)。
+  # npm ci / build の失敗は job を赤くして可視化する(握り潰さない)。本 job は必須チェック
+  # ではないため、赤くなっても PR マージはブロックしない。
   size-limit:
     name: Bundle size (size-limit)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     defaults:
       run:
         working-directory: frontend
@@ -163,8 +167,10 @@ jobs:
         run: npm run build
 
       # 計測結果を Job Summary に残す。上限超過で size-limit は非 0 を返すが、
-      # continue-on-error なので run 全体は赤くならない(失敗は握り潰さず code を保持)。
+      # continue-on-error はこの step だけに付け、非 0 でも job を止めない
+      # (build / npm ci の失敗はこの step の前段で job を赤くする)。
       - name: Run size-limit (report only)
+        continue-on-error: true
         run: |
           set +e
           npx size-limit > /tmp/size-report.txt 2>&1

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -119,3 +119,61 @@ jobs:
             cat /tmp/knip-report.md
           } >> "$GITHUB_STEP_SUMMARY"
           exit "$status"
+
+  # 本番バンドルサイズ(gzip)を size-limit で計測する。非ブロッキング(continue-on-error)。
+  # 必須チェック(Vitest + Build)とは独立した job にし、サイズの可視化と回帰検知に徹する。
+  # 上限(.size-limit.json)は現状 + ヘッドルームで、超過はシグナルとして step を赤くするが
+  # job は継続する(PR はブロックしない)。厳密な gating は数値が安定してから別途。
+  size-limit:
+    name: Bundle size (size-limit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # この job は push しないため GITHUB_TOKEN を作業ツリーに残さない。
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # size-limit は dist/assets/* の実出力を計測するため、先に本番ビルドする。
+      # VITE_* はサイズ計測が目的なのでダミーで良い(コード量は本番と同じ)。
+      - name: Build
+        env:
+          VITE_API_BASE_URL: https://example.invalid
+          VITE_WEB_SOCKET_URL_AI_CHAT: wss://example.invalid
+          VITE_WEB_SOCKET_URL_CHAT: wss://example.invalid
+          VITE_COGNITO_DOMAIN: https://example.invalid
+          VITE_CLIENT_ID: ci-dummy
+          VITE_REDIRECT_URI: https://example.invalid/callback
+          VITE_RESPONSE_TYPE: code
+          VITE_SCOPE: openid
+        run: npm run build
+
+      # 計測結果を Job Summary に残す。上限超過で size-limit は非 0 を返すが、
+      # continue-on-error なので run 全体は赤くならない(失敗は握り潰さず code を保持)。
+      - name: Run size-limit (report only)
+        run: |
+          set +e
+          npx size-limit > /tmp/size-report.txt 2>&1
+          status=$?
+          {
+            echo "## Frontend bundle size (size-limit, gzip)"
+            echo ""
+            echo '```'
+            cat /tmp/size-report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"

--- a/frontend/.size-limit.json
+++ b/frontend/.size-limit.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "初期ロード (アプリ + React/Redux, Monaco 除く)",
+    "path": [
+      "dist/assets/index-*.js",
+      "dist/assets/vendor-react-*.js",
+      "dist/assets/vendor-state-*.js",
+      "dist/assets/rolldown-runtime-*.js"
+    ],
+    "gzip": true,
+    "limit": "130 KB"
+  },
+  {
+    "name": "Monaco エディタ (vendor-monaco, modulepreload)",
+    "path": "dist/assets/vendor-monaco-*.js",
+    "gzip": true,
+    "limit": "1150 KB"
+  }
+]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@playwright/test": "^1.60.0",
+        "@size-limit/file": "~12.1.0",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@tailwindcss/typography": "^0.5.19",
@@ -45,6 +46,7 @@
         "knip": "^6.29.0",
         "openapi-typescript": "^7.13.0",
         "postcss": "^8.5.6",
+        "size-limit": "~12.1.0",
         "swagger2openapi": "^7.0.8",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.9.3",
@@ -2725,6 +2727,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4004,6 +4019,16 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -6021,13 +6046,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/js-levenshtein": {
@@ -6226,16 +6251,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/knip/node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/knip/node_modules/picomatch": {
@@ -7747,6 +7762,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -9401,6 +9426,34 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.1.tgz",
@@ -9763,6 +9816,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
       }
     },
     "node_modules/thenify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "tailwind:init": "tailwindcss init -p",
     "openapi:generate": "swagger2openapi ../backend/docs/swagger.json --outfile src/generated/openapi.json && openapi-typescript src/generated/openapi.json --output src/generated/api.ts",
     "knip": "knip",
-    "size": "size-limit"
+    "size": "npm run build && size-limit"
   },
   "overrides": {
     "form-data": "^4.0.6"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "e2e:install": "playwright install --with-deps chromium",
     "tailwind:init": "tailwindcss init -p",
     "openapi:generate": "swagger2openapi ../backend/docs/swagger.json --outfile src/generated/openapi.json && openapi-typescript src/generated/openapi.json --output src/generated/api.ts",
-    "knip": "knip"
+    "knip": "knip",
+    "size": "size-limit"
   },
   "overrides": {
     "form-data": "^4.0.6"
@@ -41,6 +42,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.60.0",
+    "@size-limit/file": "~12.1.0",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@tailwindcss/typography": "^0.5.19",
@@ -59,6 +61,7 @@
     "knip": "^6.29.0",
     "openapi-typescript": "^7.13.0",
     "postcss": "^8.5.6",
+    "size-limit": "~12.1.0",
     "swagger2openapi": "^7.0.8",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## 概要
フロントの本番バンドルサイズ（gzip）を **size-limit** で計測し、CI に**非ブロッキング**（`continue-on-error`）で追加する。サイズを可視化し、将来の肥大化を検知できるようにする（CI 品質向上策 ①〜⑤ の ④）。

## 変更内容
- `frontend` に devDep `size-limit` + `@size-limit/file`（**matched pair `~12.1.0`**）と `size` script を追加
- `frontend/.size-limit.json`: vite build の実出力（`dist/assets/*`）を 2 グループで計測
  - **初期ロード（アプリ + React/Redux, Monaco 除く）** = `index` + `vendor-react` + `vendor-state` + `rolldown-runtime` → 現状 **114.88 KB** / 上限 130 KB
  - **Monaco エディタ（vendor-monaco, modulepreload）** → 現状 **1.04 MB** / 上限 1.15 MB（固定コストをアプリ本体の増減と分けて追跡）
- `.github/workflows/ci-frontend.yml` に非ブロッキング job `Bundle size (size-limit)` を追加。build → size-limit を実行し結果を Job Summary に出力（上限超過は step を赤くするが PR はブロックしない）

## 補足
- **バージョン整合**: `@size-limit/file@13` は `size-limit@13`（node 22+ 必須）を peer に要求するため、CI の node 20 と揃う **v12.1.0 の matched pair** に `~` で固定（v13 への自動 bump を防止）。
- **将来最適化メモ（別チケット）**: `vendor-monaco`（1MB gzip）が `modulepreload` で初期ロードに乗っている。エディタ利用画面まで遅延化すれば初期表示が軽くなる。

## テスト
- `npm run build && npx size-limit` → 両グループ **pass（exit 0）**
- `npm ls size-limit @size-limit/file` → matched（`invalid` 無し）
- YAML 検証済み。既存の必須チェック（Vitest + Build）とは独立した非ブロッキング job。

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * フロントエンドのビルド成果物に対するサイズ制限チェックを追加しました。
  * 初期ロード用ファイルとエディター用ファイルに、それぞれgzip圧縮後の上限を設定しました。

* **改善**
  * サイズチェックの結果をCIの実行概要で確認できるようになりました。
  * サイズ超過時も、他のCIチェックを継続して実行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->