### PR TITLE
perf: CI 高速化 — バックエンド test ジョブの冗長な go vet を削除 (FRESTYLE-219)

### DIFF
--- a/.github/workflows/ci-backend-go.yml
+++ b/.github/workflows/ci-backend-go.yml
@@ -53,8 +53,10 @@ jobs:
             exit 1
           fi
 
-      - name: go vet
-        run: go vet ./...
+      # 注: 独立した `go vet ./...` step は撤去(FRESTYLE-219)。下の golangci-lint が
+      # `govet` linter(go vet と同じ analyzer passes)を実行しており二重だったため。
+      # コンパイルエラーは golangci-lint / go test / go build が引き続き検出する。
+      # ジョブ名 `vet / test / build` は vet を golangci 経由で継続するため据え置き。
 
       # golangci-lint(v2) で複数 linter を一括実行する。default の
       # staticcheck / errcheck / govet / ineffassign / unused に加え、


### PR DESCRIPTION
## 概要
CI 品質向上策 ①〜⑤ の最終 ⑤（CI 高速化）。**実測に基づき**、`CI - Backend (Go)` の `vet / test / build` ジョブから**冗長な `go vet ./...` step を削除**する。同ジョブの golangci-lint が `govet`（go vet と同じ analyzer passes）を実行しており二重だった。

## 実測（直近 main 成功 run のステップ別所要）
`vet / test / build`（合計 ≈ 259s）:
- `go test (race + coverage)`: **99s**（必要）
- **`go vet`: 55s** ← 冗長（削除）
- `go build`: 53s / `govulncheck`: 16s / `golangci-lint`: 13s（← ここで govet 実行済み）

→ `go vet` 削除で **約 55s（≈20%）短縮**。

## 同等性の根拠（取りこぼしなし）
- `golangci-lint linters` の Enabled に `govet`（説明: *roughly the same as 'go vet' and uses its passes*）。
- `backend/.golangci.yml` は default linter（errcheck / **govet** / ineffassign / staticcheck / unused）を維持。
- 現状 `go vet ./...` も `golangci-lint run ./...` も **0 issues**（検出差なし）。
- コンパイルエラーは golangci-lint / `go test` / `go build` が引き続き検出。
- ジョブ名 `vet / test / build`（必須ステータスチェック）は据え置き（vet は golangci 経由で継続）。

## スコープ外（補足）
- `go test` / モジュールキャッシュは `actions/setup-go@v6` が既定で `GOCACHE`/`GOMODCACHE` をキャッシュ済（追加不要）。
- path フィルタでの差分スキップは、当ジョブが**必須チェック**（全 PR で report）の契約のため導入しない。
- ジョブ分割の並列化は runner 分数増と再コンパイルで wall-clock 改善が限定的なため見送り。

## テスト
- ローカル `golangci-lint run ./...`（govet 込み）= **0 issues**。
- YAML 検証済み（`go vet` step 消滅・golangci-lint step 存置・ジョブ名不変）。
- CI の `vet / test / build` が引き続き緑になることを本 PR の Checks で確認。

## 関連チケット
- https://frestyle.atlassian.net/browse/FRESTYLE-219