### PR TITLE
FRESTYLE-9 fix: ノート画像の presigned URL 発行に MIME 許可リストとサイズ上限の検証を追加

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2957,7 +2957,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。",
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 contentType は 画像 MIME (png/jpeg/jpg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。 検証 済み の contentType / sizeBytes は presign の 署名 対象 (Content-Type / Content-Length) に 焼き込む ため、 発行後 に 別 種別 ・ 別 サイズ で PUT する と S3 が 署名 不一致 で 拒否 する。",
                 "consumes": [
                     "application/json"
                 ],
@@ -2987,7 +2987,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "発行 失敗",
+                        "description": "リクエスト 不正 (contentType / sizeBytes が 未 指定 か 不正 な JSON)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -2999,13 +2999,19 @@ const docTemplate = `{
                         }
                     },
                     "413": {
-                        "description": "サイズ 上限 超過",
+                        "description": "Payload Too Large — sizeBytes が 上限 5MB を 超えて いる",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "415": {
-                        "description": "未 サポート MIME",
+                        "description": "Unsupported Media Type — contentType が 許可 された 画像 MIME で ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "presigned URL の 発行 に 失敗 (S3 / インフラ 側 の 異常)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -5132,6 +5138,10 @@ const docTemplate = `{
         },
         "internal_handler.issueUploadURLReq": {
             "type": "object",
+            "required": [
+                "contentType",
+                "sizeBytes"
+            ],
             "properties": {
                 "contentType": {
                     "type": "string"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2957,7 +2957,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。",
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。",
                 "consumes": [
                     "application/json"
                 ],
@@ -2970,9 +2970,10 @@ const docTemplate = `{
                 "summary": "ノート 画像 PUT 署名 URL",
                 "parameters": [
                     {
-                        "description": "contentType (任意)",
+                        "description": "contentType / sizeBytes",
                         "name": "body",
                         "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/internal_handler.issueUploadURLReq"
                         }
@@ -2993,6 +2994,18 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "サイズ 上限 超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "未 サポート MIME",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -5122,6 +5135,9 @@ const docTemplate = `{
             "properties": {
                 "contentType": {
                     "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2950,7 +2950,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。",
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 contentType は 画像 MIME (png/jpeg/jpg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。 検証 済み の contentType / sizeBytes は presign の 署名 対象 (Content-Type / Content-Length) に 焼き込む ため、 発行後 に 別 種別 ・ 別 サイズ で PUT する と S3 が 署名 不一致 で 拒否 する。",
                 "consumes": [
                     "application/json"
                 ],
@@ -2980,7 +2980,7 @@
                         }
                     },
                     "400": {
-                        "description": "発行 失敗",
+                        "description": "リクエスト 不正 (contentType / sizeBytes が 未 指定 か 不正 な JSON)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -2992,13 +2992,19 @@
                         }
                     },
                     "413": {
-                        "description": "サイズ 上限 超過",
+                        "description": "Payload Too Large — sizeBytes が 上限 5MB を 超えて いる",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "415": {
-                        "description": "未 サポート MIME",
+                        "description": "Unsupported Media Type — contentType が 許可 された 画像 MIME で ない",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "presigned URL の 発行 に 失敗 (S3 / インフラ 側 の 異常)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -5125,6 +5131,10 @@
         },
         "internal_handler.issueUploadURLReq": {
             "type": "object",
+            "required": [
+                "contentType",
+                "sizeBytes"
+            ],
             "properties": {
                 "contentType": {
                     "type": "string"

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2950,7 +2950,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。",
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。",
                 "consumes": [
                     "application/json"
                 ],
@@ -2963,9 +2963,10 @@
                 "summary": "ノート 画像 PUT 署名 URL",
                 "parameters": [
                     {
-                        "description": "contentType (任意)",
+                        "description": "contentType / sizeBytes",
                         "name": "body",
                         "in": "body",
+                        "required": true,
                         "schema": {
                             "$ref": "#/definitions/internal_handler.issueUploadURLReq"
                         }
@@ -2986,6 +2987,18 @@
                     },
                     "401": {
                         "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "413": {
+                        "description": "サイズ 上限 超過",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "415": {
+                        "description": "未 サポート MIME",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -5115,6 +5128,9 @@
             "properties": {
                 "contentType": {
                     "type": "string"
+                },
+                "sizeBytes": {
+                    "type": "integer"
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -805,6 +805,8 @@ definitions:
     properties:
       contentType:
         type: string
+      sizeBytes:
+        type: integer
     type: object
   internal_handler.markLessonCompleteRequest:
     properties:
@@ -3062,11 +3064,13 @@ paths:
       consumes:
       - application/json
       description: current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware
-        の current user を 使う (IDOR 対策、 Phase 3 で 修正)。
+        の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp)
+        のみ、 sizeBytes は 上限 5MB を 事前 検証。
       parameters:
-      - description: contentType (任意)
+      - description: contentType / sizeBytes
         in: body
         name: body
+        required: true
         schema:
           $ref: '#/definitions/internal_handler.issueUploadURLReq'
       produces:
@@ -3082,6 +3086,14 @@ paths:
             $ref: '#/definitions/internal_handler.errorResponse'
         "401":
           description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "413":
+          description: サイズ 上限 超過
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "415":
+          description: 未 サポート MIME
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -807,6 +807,9 @@ definitions:
         type: string
       sizeBytes:
         type: integer
+    required:
+    - contentType
+    - sizeBytes
     type: object
   internal_handler.markLessonCompleteRequest:
     properties:
@@ -3063,9 +3066,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware
-        の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp)
-        のみ、 sizeBytes は 上限 5MB を 事前 検証。
+      description: current user 用 の S3 PUT 署名 URL を 発行。 contentType は 画像 MIME (png/jpeg/jpg/gif/webp)
+        のみ、 sizeBytes は 上限 5MB を 事前 検証。 検証 済み の contentType / sizeBytes は presign
+        の 署名 対象 (Content-Type / Content-Length) に 焼き込む ため、 発行後 に 別 種別 ・ 別 サイズ で PUT
+        する と S3 が 署名 不一致 で 拒否 する。
       parameters:
       - description: contentType / sizeBytes
         in: body
@@ -3081,7 +3085,7 @@ paths:
           schema:
             $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL'
         "400":
-          description: 発行 失敗
+          description: リクエスト 不正 (contentType / sizeBytes が 未 指定 か 不正 な JSON)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "401":
@@ -3089,11 +3093,15 @@ paths:
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "413":
-          description: サイズ 上限 超過
+          description: Payload Too Large — sizeBytes が 上限 5MB を 超えて いる
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "415":
-          description: 未 サポート MIME
+          description: Unsupported Media Type — contentType が 許可 された 画像 MIME で ない
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "500":
+          description: presigned URL の 発行 に 失敗 (S3 / インフラ 側 の 異常)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:

--- a/backend/internal/adapter/persistence/ai_chat_attachment_repository.go
+++ b/backend/internal/adapter/persistence/ai_chat_attachment_repository.go
@@ -34,7 +34,8 @@ func (p *aiChatAttachmentPresigner) Generate(ctx context.Context, userID uint64,
 	}
 	ext := extensionForContentType(contentType, filename)
 	key := fmt.Sprintf("ai-chat/%d/%s%s", userID, uuid.New().String(), ext)
-	url, ttl, err := p.pre.PresignPut(ctx, key, contentType)
+	// sizeBytes を受け取らない経路のため Content-Length は署名しない（0 を渡す）。
+	url, ttl, err := p.pre.PresignPut(ctx, key, contentType, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/adapter/persistence/note_image_repository.go
+++ b/backend/internal/adapter/persistence/note_image_repository.go
@@ -27,7 +27,7 @@ func NewStubNoteImagePresigner(bucket string) repository.NoteImagePresigner {
 	return &noteImagePresigner{pre: &stubPresigner{bucket: bucket}}
 }
 
-func (p *noteImagePresigner) Generate(ctx context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error) {
+func (p *noteImagePresigner) Generate(ctx context.Context, userID uint64, contentType string, sizeBytes int64) (*domain.NoteImageUploadURL, error) {
 	if userID == 0 {
 		return nil, fmt.Errorf("userID is required")
 	}
@@ -35,7 +35,7 @@ func (p *noteImagePresigner) Generate(ctx context.Context, userID uint64, conten
 		contentType = "image/png"
 	}
 	key := fmt.Sprintf("notes/%d/%d.bin", userID, time.Now().UnixNano())
-	url, ttl, err := p.pre.PresignPut(ctx, key, contentType)
+	url, ttl, err := p.pre.PresignPut(ctx, key, contentType, sizeBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/adapter/persistence/profile_image_repository.go
+++ b/backend/internal/adapter/persistence/profile_image_repository.go
@@ -38,7 +38,8 @@ func (p *profileImagePresigner) Generate(ctx context.Context, userID uint64, fil
 	}
 	ext := guessExt(fileName, contentType)
 	key := fmt.Sprintf("profiles/%d/%d%s", userID, time.Now().UnixNano(), ext)
-	url, ttl, err := p.pre.PresignPut(ctx, key, contentType)
+	// sizeBytes を受け取らない経路のため Content-Length は署名しない（0 を渡す）。
+	url, ttl, err := p.pre.PresignPut(ctx, key, contentType, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/adapter/persistence/s3_presigner.go
+++ b/backend/internal/adapter/persistence/s3_presigner.go
@@ -8,13 +8,14 @@ import (
 
 // s3Presigner は infra/s3.Presigner と同等の minimal interface（persistence が infra/s3 に
 // 直接依存しないよう依存方向を反転する）。3 つの presigner が共通で使う。
+// sizeBytes > 0 のとき Content-Length が署名対象に入る（超過アップロードを S3 側で拒否させる）。
 type s3Presigner interface {
-	PresignPut(ctx context.Context, key, contentType string) (url string, ttl time.Duration, err error)
+	PresignPut(ctx context.Context, key, contentType string, sizeBytes int64) (url string, ttl time.Duration, err error)
 }
 
 // stubPresigner は presigner 共通の test / dev 用 stub（本番では infra/s3.NewPresigner が s3Presigner を満たす）。
 type stubPresigner struct{ bucket string }
 
-func (s *stubPresigner) PresignPut(_ context.Context, key, _ string) (string, time.Duration, error) {
+func (s *stubPresigner) PresignPut(_ context.Context, key, _ string, _ int64) (string, time.Duration, error) {
 	return fmt.Sprintf("https://%s.s3.amazonaws.com/%s?X-Amz-Stub=1", s.bucket, key), 10 * time.Minute, nil
 }

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -2,7 +2,7 @@ package handler
 
 import (
 	"errors"
-	"io"
+	"log"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -20,21 +20,22 @@ func NewNoteImageHandler(i *usecase.IssueNoteImageUploadURLUseCase) *NoteImageHa
 
 // issueUploadURLReq は body 受け取り。userId は受け取らず middleware の current user を使う（IDOR 対策）。
 type issueUploadURLReq struct {
-	ContentType string `json:"contentType"`
-	SizeBytes   int64  `json:"sizeBytes"`
+	ContentType string `json:"contentType" binding:"required"`
+	SizeBytes   int64  `json:"sizeBytes" binding:"required,gt=0"`
 }
 
 // @Summary      ノート 画像 PUT 署名 URL
-// @Description  current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。
+// @Description  current user 用 の S3 PUT 署名 URL を 発行。 contentType は 画像 MIME (png/jpeg/jpg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。 検証 済み の contentType / sizeBytes は presign の 署名 対象 (Content-Type / Content-Length) に 焼き込む ため、 発行後 に 別 種別 ・ 別 サイズ で PUT する と S3 が 署名 不一致 で 拒否 する。
 // @Tags         notes
 // @Accept       json
 // @Produce      json
 // @Param        body  body      issueUploadURLReq  true  "contentType / sizeBytes"
 // @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL
-// @Failure      400   {object}  errorResponse  "発行 失敗"
+// @Failure      400   {object}  errorResponse  "リクエスト 不正 (contentType / sizeBytes が 未 指定 か 不正 な JSON)"
 // @Failure      401   {object}  errorResponse  "未 認証"
-// @Failure      413   {object}  errorResponse  "サイズ 上限 超過"
-// @Failure      415   {object}  errorResponse  "未 サポート MIME"
+// @Failure      413   {object}  errorResponse  "Payload Too Large — sizeBytes が 上限 5MB を 超えて いる"
+// @Failure      415   {object}  errorResponse  "Unsupported Media Type — contentType が 許可 された 画像 MIME で ない"
+// @Failure      500   {object}  errorResponse  "presigned URL の 発行 に 失敗 (S3 / インフラ 側 の 異常)"
 // @Router       /notes/images/upload-url [post]
 // @Security     CookieAuth
 func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
@@ -44,17 +45,8 @@ func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
 		return
 	}
 	var req issueUploadURLReq
-	// body 無し (EOF) は下の必須チェックで 400 にするが、不正 JSON はここで弾く。
-	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	if req.ContentType == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "contentType is required"})
-		return
-	}
-	if req.SizeBytes <= 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "sizeBytes must be positive"})
 		return
 	}
 	got, err := h.issue.Execute(c.Request.Context(), usecase.IssueNoteImageUploadURLInput{
@@ -69,7 +61,10 @@ func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
 		case errors.Is(err, usecase.ErrNoteImageTooLarge):
 			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": err.Error()})
 		default:
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			// presigner のタイムアウト等はサーバ側の異常。400 で返すと監視がクライアント
+			// エラーとして誤分類するため 500 とし、詳細は漏らさず server log にだけ残す。
+			log.Printf("note-image: presigned URL issue failed: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		}
 		return
 	}

--- a/backend/internal/handler/note_image_handler.go
+++ b/backend/internal/handler/note_image_handler.go
@@ -21,17 +21,20 @@ func NewNoteImageHandler(i *usecase.IssueNoteImageUploadURLUseCase) *NoteImageHa
 // issueUploadURLReq は body 受け取り。userId は受け取らず middleware の current user を使う（IDOR 対策）。
 type issueUploadURLReq struct {
 	ContentType string `json:"contentType"`
+	SizeBytes   int64  `json:"sizeBytes"`
 }
 
 // @Summary      ノート 画像 PUT 署名 URL
-// @Description  current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。
+// @Description  current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。
 // @Tags         notes
 // @Accept       json
 // @Produce      json
-// @Param        body  body      issueUploadURLReq  false  "contentType (任意)"
+// @Param        body  body      issueUploadURLReq  true  "contentType / sizeBytes"
 // @Success      200   {object}  github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL
 // @Failure      400   {object}  errorResponse  "発行 失敗"
 // @Failure      401   {object}  errorResponse  "未 認証"
+// @Failure      413   {object}  errorResponse  "サイズ 上限 超過"
+// @Failure      415   {object}  errorResponse  "未 サポート MIME"
 // @Router       /notes/images/upload-url [post]
 // @Security     CookieAuth
 func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
@@ -41,14 +44,33 @@ func (h *NoteImageHandler) IssueUploadURL(c *gin.Context) {
 		return
 	}
 	var req issueUploadURLReq
-	// body 無し (EOF) は許容するが、不正 JSON は 400 で弾く。
+	// body 無し (EOF) は下の必須チェックで 400 にするが、不正 JSON はここで弾く。
 	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	got, err := h.issue.Execute(c.Request.Context(), uid, req.ContentType)
+	if req.ContentType == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "contentType is required"})
+		return
+	}
+	if req.SizeBytes <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "sizeBytes must be positive"})
+		return
+	}
+	got, err := h.issue.Execute(c.Request.Context(), usecase.IssueNoteImageUploadURLInput{
+		UserID:      uid,
+		ContentType: req.ContentType,
+		SizeBytes:   req.SizeBytes,
+	})
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		switch {
+		case errors.Is(err, usecase.ErrNoteImageUnsupportedType):
+			c.JSON(http.StatusUnsupportedMediaType, gin.H{"error": err.Error()})
+		case errors.Is(err, usecase.ErrNoteImageTooLarge):
+			c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": err.Error()})
+		default:
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		}
 		return
 	}
 	c.JSON(http.StatusOK, got)

--- a/backend/internal/handler/note_image_handler_test.go
+++ b/backend/internal/handler/note_image_handler_test.go
@@ -39,14 +39,42 @@ func Test_ノート画像ハンドラ_アップロードURL発行(t *testing.T) 
 		}
 	})
 	t.Run("正常系", func(t *testing.T) {
-		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png"}`, 7, "")
+		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png","sizeBytes":1024}`, 7, "")
 		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
 		if w.Code != http.StatusOK {
 			t.Fatalf("want 200, got %d", w.Code)
 		}
 	})
-	t.Run("presigner エラー → 400", func(t *testing.T) {
+	t.Run("contentType 無し → 400", func(t *testing.T) {
+		w, c := noteCtx(http.MethodPost, `{"sizeBytes":1024}`, 7, "")
+		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("sizeBytes 無し → 400", func(t *testing.T) {
 		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png"}`, 7, "")
+		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("許可外 MIME → 415", func(t *testing.T) {
+		w, c := noteCtx(http.MethodPost, `{"contentType":"text/html","sizeBytes":1024}`, 7, "")
+		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
+		if w.Code != http.StatusUnsupportedMediaType {
+			t.Fatalf("want 415, got %d", w.Code)
+		}
+	})
+	t.Run("サイズ上限超過 → 413", func(t *testing.T) {
+		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png","sizeBytes":5242881}`, 7, "")
+		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Fatalf("want 413, got %d", w.Code)
+		}
+	})
+	t.Run("presigner エラー → 400", func(t *testing.T) {
+		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png","sizeBytes":1024}`, 7, "")
 		newNoteImageHandler(fakeNoteImagePresigner{err: context.DeadlineExceeded}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)

--- a/backend/internal/handler/note_image_handler_test.go
+++ b/backend/internal/handler/note_image_handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -15,7 +16,7 @@ type fakeNoteImagePresigner struct {
 	err error
 }
 
-func (f fakeNoteImagePresigner) Generate(context.Context, uint64, string) (*domain.NoteImageUploadURL, error) {
+func (f fakeNoteImagePresigner) Generate(context.Context, uint64, string, int64) (*domain.NoteImageUploadURL, error) {
 	return f.url, f.err
 }
 
@@ -73,11 +74,21 @@ func Test_ノート画像ハンドラ_アップロードURL発行(t *testing.T) 
 			t.Fatalf("want 413, got %d", w.Code)
 		}
 	})
-	t.Run("presigner エラー → 400", func(t *testing.T) {
-		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png","sizeBytes":1024}`, 7, "")
-		newNoteImageHandler(fakeNoteImagePresigner{err: context.DeadlineExceeded}).IssueUploadURL(c)
+	t.Run("空 body → 400", func(t *testing.T) {
+		w, c := noteCtx(http.MethodPost, ``, 7, "")
+		newNoteImageHandler(fakeNoteImagePresigner{url: &domain.NoteImageUploadURL{}}).IssueUploadURL(c)
 		if w.Code != http.StatusBadRequest {
 			t.Fatalf("want 400, got %d", w.Code)
+		}
+	})
+	t.Run("presigner エラー → 500（内部エラーはクライアントエラーにしない）", func(t *testing.T) {
+		w, c := noteCtx(http.MethodPost, `{"contentType":"image/png","sizeBytes":1024}`, 7, "")
+		newNoteImageHandler(fakeNoteImagePresigner{err: context.DeadlineExceeded}).IssueUploadURL(c)
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("want 500, got %d", w.Code)
+		}
+		if strings.Contains(w.Body.String(), "context deadline exceeded") {
+			t.Fatalf("内部エラーの詳細が漏れている: %s", w.Body.String())
 		}
 	})
 }

--- a/backend/internal/infra/s3/presigner.go
+++ b/backend/internal/infra/s3/presigner.go
@@ -39,15 +39,22 @@ func NewPresigner(ctx context.Context, region, bucket string) (*Presigner, error
 
 // PresignPut は指定 key への PutObject presigned URL を返す。
 // contentType は presign に焼き込まれるため PUT 時のヘッダと完全一致が必要（不一致だと SignatureDoesNotMatch）。
-func (p *Presigner) PresignPut(ctx context.Context, key, contentType string) (string, time.Duration, error) {
+// sizeBytes > 0 なら Content-Length も署名対象に含める。これによりサーバ側で検証したサイズと
+// 異なる PUT は S3 が署名不一致で拒否するため、申告値だけの検証を迂回した超過アップロードを防げる。
+// sizeBytes <= 0 は Content-Length を署名しない（サイズ検証を持たない呼び出し元向け）。
+func (p *Presigner) PresignPut(ctx context.Context, key, contentType string, sizeBytes int64) (string, time.Duration, error) {
 	if key == "" {
 		return "", 0, fmt.Errorf("s3: key is required")
 	}
-	req, err := p.client.PresignPutObject(ctx, &awss3.PutObjectInput{
+	in := &awss3.PutObjectInput{
 		Bucket:      aws.String(p.bucket),
 		Key:         aws.String(key),
 		ContentType: aws.String(contentType),
-	}, awss3.WithPresignExpires(p.ttl))
+	}
+	if sizeBytes > 0 {
+		in.ContentLength = aws.Int64(sizeBytes)
+	}
+	req, err := p.client.PresignPutObject(ctx, in, awss3.WithPresignExpires(p.ttl))
 	if err != nil {
 		return "", 0, fmt.Errorf("s3: presign put: %w", err)
 	}

--- a/backend/internal/usecase/note_image_usecase.go
+++ b/backend/internal/usecase/note_image_usecase.go
@@ -9,6 +9,7 @@ import (
 )
 
 // IssueNoteImageUploadURLUseCase はノート画像用 S3 PUT 署名付き URL を発行する。
+// contentType / sizeBytes を usecase 層で検証し、画像以外・上限超過は presigned URL 発行前に弾く。
 type IssueNoteImageUploadURLUseCase struct {
 	presigner repository.NoteImagePresigner
 }
@@ -17,9 +18,42 @@ func NewIssueNoteImageUploadURLUseCase(p repository.NoteImagePresigner) *IssueNo
 	return &IssueNoteImageUploadURLUseCase{presigner: p}
 }
 
-func (u *IssueNoteImageUploadURLUseCase) Execute(ctx context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error) {
-	if userID == 0 {
+// IssueNoteImageUploadURLInput は handler から受け取るリクエスト形。
+type IssueNoteImageUploadURLInput struct {
+	UserID      uint64
+	ContentType string
+	SizeBytes   int64
+}
+
+// maxNoteImageBytes は 1 枚あたりの上限（AI チャット添付の画像上限に合わせる）。
+const maxNoteImageBytes int64 = 5 * 1024 * 1024
+
+// AllowedNoteImageContentTypes は presigned URL 発行を許可する画像 MIME 一覧。
+// contentType は presign に焼き込まれ PUT 時のヘッダと一致が要求されるため、
+// ここを通った MIME 以外のオブジェクトは共有バケットに置けない（HTML / JS の配信を防ぐ）。
+var AllowedNoteImageContentTypes = map[string]struct{}{
+	"image/png":  {},
+	"image/jpeg": {},
+	"image/jpg":  {},
+	"image/gif":  {},
+	"image/webp": {},
+}
+
+// ErrNoteImageUnsupportedType は未対応 MIME。
+var ErrNoteImageUnsupportedType = errors.New("note image: unsupported content type")
+
+// ErrNoteImageTooLarge はサイズ上限超過。
+var ErrNoteImageTooLarge = errors.New("note image: file too large")
+
+func (u *IssueNoteImageUploadURLUseCase) Execute(ctx context.Context, in IssueNoteImageUploadURLInput) (*domain.NoteImageUploadURL, error) {
+	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
 	}
-	return u.presigner.Generate(ctx, userID, contentType)
+	if _, ok := AllowedNoteImageContentTypes[in.ContentType]; !ok {
+		return nil, ErrNoteImageUnsupportedType
+	}
+	if in.SizeBytes <= 0 || in.SizeBytes > maxNoteImageBytes {
+		return nil, ErrNoteImageTooLarge
+	}
+	return u.presigner.Generate(ctx, in.UserID, in.ContentType)
 }

--- a/backend/internal/usecase/note_image_usecase.go
+++ b/backend/internal/usecase/note_image_usecase.go
@@ -9,7 +9,6 @@ import (
 )
 
 // IssueNoteImageUploadURLUseCase はノート画像用 S3 PUT 署名付き URL を発行する。
-// contentType / sizeBytes を usecase 層で検証し、画像以外・上限超過は presigned URL 発行前に弾く。
 type IssueNoteImageUploadURLUseCase struct {
 	presigner repository.NoteImagePresigner
 }
@@ -25,13 +24,15 @@ type IssueNoteImageUploadURLInput struct {
 	SizeBytes   int64
 }
 
-// maxNoteImageBytes は 1 枚あたりの上限（AI チャット添付の画像上限に合わせる）。
+// maxNoteImageBytes は 1 枚あたりの上限。AI チャット添付の画像上限（maxImageBytes）と同値に揃えている。
+// 同一プロダクト内で画像 1 枚の上限が複数あると利用側が混乱するため、数値の根拠より一致を優先した。
 const maxNoteImageBytes int64 = 5 * 1024 * 1024
 
-// AllowedNoteImageContentTypes は presigned URL 発行を許可する画像 MIME 一覧。
+// allowedNoteImageContentTypes は presigned URL 発行を許可する画像 MIME 一覧。
 // contentType は presign に焼き込まれ PUT 時のヘッダと一致が要求されるため、
 // ここを通った MIME 以外のオブジェクトは共有バケットに置けない（HTML / JS の配信を防ぐ）。
-var AllowedNoteImageContentTypes = map[string]struct{}{
+// 許可リストはセキュリティ境界なので、外部パッケージから書き換えられないよう unexport にしている。
+var allowedNoteImageContentTypes = map[string]struct{}{
 	"image/png":  {},
 	"image/jpeg": {},
 	"image/jpg":  {},
@@ -42,18 +43,18 @@ var AllowedNoteImageContentTypes = map[string]struct{}{
 // ErrNoteImageUnsupportedType は未対応 MIME。
 var ErrNoteImageUnsupportedType = errors.New("note image: unsupported content type")
 
-// ErrNoteImageTooLarge はサイズ上限超過。
-var ErrNoteImageTooLarge = errors.New("note image: file too large")
+// ErrNoteImageTooLarge は sizeBytes が上限を超えたことを表す。
+var ErrNoteImageTooLarge = errors.New("note image: sizeBytes exceeds the 5MB limit")
 
 func (u *IssueNoteImageUploadURLUseCase) Execute(ctx context.Context, in IssueNoteImageUploadURLInput) (*domain.NoteImageUploadURL, error) {
 	if in.UserID == 0 {
 		return nil, errors.New("userID is required")
 	}
-	if _, ok := AllowedNoteImageContentTypes[in.ContentType]; !ok {
+	if _, ok := allowedNoteImageContentTypes[in.ContentType]; !ok {
 		return nil, ErrNoteImageUnsupportedType
 	}
 	if in.SizeBytes <= 0 || in.SizeBytes > maxNoteImageBytes {
 		return nil, ErrNoteImageTooLarge
 	}
-	return u.presigner.Generate(ctx, in.UserID, in.ContentType)
+	return u.presigner.Generate(ctx, in.UserID, in.ContentType, in.SizeBytes)
 }

--- a/backend/internal/usecase/note_image_usecase_test.go
+++ b/backend/internal/usecase/note_image_usecase_test.go
@@ -2,33 +2,115 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
 
 type stubPresigner struct {
-	url *domain.NoteImageUploadURL
-	err error
+	url    *domain.NoteImageUploadURL
+	err    error
+	called bool
 }
 
 func (s *stubPresigner) Generate(_ context.Context, _ uint64, _ string) (*domain.NoteImageUploadURL, error) {
+	s.called = true
 	return s.url, s.err
 }
 
+func newStubbedNoteImageUseCase() (*IssueNoteImageUploadURLUseCase, *stubPresigner) {
+	stub := &stubPresigner{
+		url: &domain.NoteImageUploadURL{URL: "https://example", Key: "k", ExpiresIn: 60},
+	}
+	return NewIssueNoteImageUploadURLUseCase(stub), stub
+}
+
 func Test_ノート画像アップロードURL発行_ユーザーIDが必須(t *testing.T) {
-	uc := NewIssueNoteImageUploadURLUseCase(&stubPresigner{})
-	if _, err := uc.Execute(context.Background(), 0, "image/png"); err == nil {
+	uc, stub := newStubbedNoteImageUseCase()
+	_, err := uc.Execute(context.Background(), IssueNoteImageUploadURLInput{
+		UserID:      0,
+		ContentType: "image/png",
+		SizeBytes:   1024,
+	})
+	if err == nil {
 		t.Fatal("expected error")
+	}
+	if stub.called {
+		t.Fatal("presigner should not be called")
 	}
 }
 
-func Test_ノート画像アップロードURL発行_URLを返す(t *testing.T) {
-	uc := NewIssueNoteImageUploadURLUseCase(&stubPresigner{
-		url: &domain.NoteImageUploadURL{URL: "https://example", Key: "k", ExpiresIn: 60},
-	})
-	got, err := uc.Execute(context.Background(), 1, "image/png")
-	if err != nil || got.URL == "" {
-		t.Fatalf("unexpected: %+v err=%v", got, err)
+func Test_ノート画像アップロードURL発行_許可MIMEはURLを返す(t *testing.T) {
+	for contentType := range AllowedNoteImageContentTypes {
+		t.Run(contentType, func(t *testing.T) {
+			uc, _ := newStubbedNoteImageUseCase()
+			got, err := uc.Execute(context.Background(), IssueNoteImageUploadURLInput{
+				UserID:      1,
+				ContentType: contentType,
+				SizeBytes:   1024,
+			})
+			if err != nil || got.URL == "" {
+				t.Fatalf("unexpected: %+v err=%v", got, err)
+			}
+		})
+	}
+}
+
+func Test_ノート画像アップロードURL発行_許可外MIMEは拒否(t *testing.T) {
+	cases := []string{
+		"",
+		"text/html",
+		"application/javascript",
+		"image/svg+xml",
+		"application/pdf",
+		"application/octet-stream",
+		"IMAGE/PNG",
+		"image/png; charset=utf-8",
+	}
+	for _, contentType := range cases {
+		t.Run(contentType, func(t *testing.T) {
+			uc, stub := newStubbedNoteImageUseCase()
+			_, err := uc.Execute(context.Background(), IssueNoteImageUploadURLInput{
+				UserID:      1,
+				ContentType: contentType,
+				SizeBytes:   1024,
+			})
+			if !errors.Is(err, ErrNoteImageUnsupportedType) {
+				t.Fatalf("want ErrNoteImageUnsupportedType, got %v", err)
+			}
+			if stub.called {
+				t.Fatal("presigner should not be called")
+			}
+		})
+	}
+}
+
+func Test_ノート画像アップロードURL発行_サイズ検証(t *testing.T) {
+	cases := []struct {
+		name    string
+		size    int64
+		wantErr error
+	}{
+		{name: "0 は拒否", size: 0, wantErr: ErrNoteImageTooLarge},
+		{name: "負数は拒否", size: -1, wantErr: ErrNoteImageTooLarge},
+		{name: "上限ちょうどは許可", size: maxNoteImageBytes, wantErr: nil},
+		{name: "上限超過は拒否", size: maxNoteImageBytes + 1, wantErr: ErrNoteImageTooLarge},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uc, stub := newStubbedNoteImageUseCase()
+			_, err := uc.Execute(context.Background(), IssueNoteImageUploadURLInput{
+				UserID:      1,
+				ContentType: "image/png",
+				SizeBytes:   tc.size,
+			})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+			if stub.called != (tc.wantErr == nil) {
+				t.Fatalf("presigner called = %v, want %v", stub.called, tc.wantErr == nil)
+			}
+		})
 	}
 }

--- a/backend/internal/usecase/note_image_usecase_test.go
+++ b/backend/internal/usecase/note_image_usecase_test.go
@@ -9,13 +9,15 @@ import (
 )
 
 type stubPresigner struct {
-	url    *domain.NoteImageUploadURL
-	err    error
-	called bool
+	url          *domain.NoteImageUploadURL
+	err          error
+	called       bool
+	gotSizeBytes int64
 }
 
-func (s *stubPresigner) Generate(_ context.Context, _ uint64, _ string) (*domain.NoteImageUploadURL, error) {
+func (s *stubPresigner) Generate(_ context.Context, _ uint64, _ string, sizeBytes int64) (*domain.NoteImageUploadURL, error) {
 	s.called = true
+	s.gotSizeBytes = sizeBytes
 	return s.url, s.err
 }
 
@@ -42,7 +44,7 @@ func Test_ノート画像アップロードURL発行_ユーザーIDが必須(t *
 }
 
 func Test_ノート画像アップロードURL発行_許可MIMEはURLを返す(t *testing.T) {
-	for contentType := range AllowedNoteImageContentTypes {
+	for contentType := range allowedNoteImageContentTypes {
 		t.Run(contentType, func(t *testing.T) {
 			uc, _ := newStubbedNoteImageUseCase()
 			got, err := uc.Execute(context.Background(), IssueNoteImageUploadURLInput{
@@ -54,6 +56,22 @@ func Test_ノート画像アップロードURL発行_許可MIMEはURLを返す(t
 				t.Fatalf("unexpected: %+v err=%v", got, err)
 			}
 		})
+	}
+}
+
+// 検証済みの sizeBytes が presigner に渡ることを確認する。
+// presign の Content-Length 署名に使われるため、ここが欠けると申告値だけの検証に戻ってしまう。
+func Test_ノート画像アップロードURL発行_検証済みサイズをpresignerに渡す(t *testing.T) {
+	uc, stub := newStubbedNoteImageUseCase()
+	if _, err := uc.Execute(context.Background(), IssueNoteImageUploadURLInput{
+		UserID:      1,
+		ContentType: "image/png",
+		SizeBytes:   2048,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.gotSizeBytes != 2048 {
+		t.Fatalf("presigner に渡った sizeBytes = %d, want 2048", stub.gotSizeBytes)
 	}
 }
 

--- a/backend/internal/usecase/repository/note_image.go
+++ b/backend/internal/usecase/repository/note_image.go
@@ -7,6 +7,7 @@ import (
 )
 
 // NoteImagePresigner は S3 への PUT 用 presigned URL を発行する。
+// sizeBytes は Content-Length として署名に焼き込まれ、超過アップロードを S3 側で拒否させる。
 type NoteImagePresigner interface {
-	Generate(ctx context.Context, userID uint64, contentType string) (*domain.NoteImageUploadURL, error)
+	Generate(ctx context.Context, userID uint64, contentType string, sizeBytes int64) (*domain.NoteImageUploadURL, error)
 }

--- a/frontend/src/entities/user/api/__tests__/imageUploadRepository.test.ts
+++ b/frontend/src/entities/user/api/__tests__/imageUploadRepository.test.ts
@@ -28,6 +28,7 @@ describe('ImageUploadRepository', () => {
 
     expect(mockedPost).toHaveBeenCalledWith('/api/v2/notes/images/upload-url', {
       contentType: 'image/png',
+      sizeBytes: file.size,
     });
     expect(mockedPut).toHaveBeenCalledWith('https://s3/put?sig', file, {
       headers: { 'Content-Type': 'image/png' },

--- a/frontend/src/entities/user/api/imageUploadRepository.ts
+++ b/frontend/src/entities/user/api/imageUploadRepository.ts
@@ -14,11 +14,13 @@ interface UploadUrlResponse {
  *
  * フロー: presign 発行(current user 名義) → S3 へ直接 PUT → 配信 URL(publicUrl) を返す。
  * userId は送らず backend が context の current user で発行する（IDOR 対策）。
+ * contentType / sizeBytes は backend が画像 MIME・上限サイズで検証する（415 / 413）。
  */
 const ImageUploadRepository = {
   async upload(file: File): Promise<string> {
     const { data } = await apiClient.post<UploadUrlResponse>(IMAGES.uploadUrl, {
       contentType: file.type || 'image/png',
+      sizeBytes: file.size,
     });
     await axios.put(data.url, file, {
       headers: { 'Content-Type': file.type || 'image/png' },

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -3773,7 +3773,7 @@ export interface paths {
         put?: never;
         /**
          * ノート 画像 PUT 署名 URL
-         * @description current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。
+         * @description current user 用 の S3 PUT 署名 URL を 発行。 contentType は 画像 MIME (png/jpeg/jpg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。 検証 済み の contentType / sizeBytes は presign の 署名 対象 (Content-Type / Content-Length) に 焼き込む ため、 発行後 に 別 種別 ・ 別 サイズ で PUT する と S3 が 署名 不一致 で 拒否 する。
          */
         post: {
             parameters: {
@@ -3798,7 +3798,7 @@ export interface paths {
                         "application/json": components["schemas"]["github_com_norman6464_FreStyle_backend_internal_domain.NoteImageUploadURL"];
                     };
                 };
-                /** @description 発行 失敗 */
+                /** @description リクエスト 不正 (contentType / sizeBytes が 未 指定 か 不正 な JSON) */
                 400: {
                     headers: {
                         [name: string]: unknown;
@@ -3816,7 +3816,7 @@ export interface paths {
                         "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
-                /** @description サイズ 上限 超過 */
+                /** @description Payload Too Large — sizeBytes が 上限 5MB を 超えて いる */
                 413: {
                     headers: {
                         [name: string]: unknown;
@@ -3825,8 +3825,17 @@ export interface paths {
                         "application/json": components["schemas"]["internal_handler.errorResponse"];
                     };
                 };
-                /** @description 未 サポート MIME */
+                /** @description Unsupported Media Type — contentType が 許可 された 画像 MIME で ない */
                 415: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description presigned URL の 発行 に 失敗 (S3 / インフラ 側 の 異常) */
+                500: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -5451,8 +5460,8 @@ export interface components {
             fileName?: string;
         };
         "internal_handler.issueUploadURLReq": {
-            contentType?: string;
-            sizeBytes?: number;
+            contentType: string;
+            sizeBytes: number;
         };
         "internal_handler.markLessonCompleteRequest": {
             teachingMaterialId: number;

--- a/frontend/src/generated/api.ts
+++ b/frontend/src/generated/api.ts
@@ -3773,7 +3773,7 @@ export interface paths {
         put?: never;
         /**
          * ノート 画像 PUT 署名 URL
-         * @description current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。
+         * @description current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。
          */
         post: {
             parameters: {
@@ -3782,8 +3782,8 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            /** @description contentType (任意) */
-            requestBody?: {
+            /** @description contentType / sizeBytes */
+            requestBody: {
                 content: {
                     "application/json": components["schemas"]["internal_handler.issueUploadURLReq"];
                 };
@@ -3809,6 +3809,24 @@ export interface paths {
                 };
                 /** @description 未 認証 */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description サイズ 上限 超過 */
+                413: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["internal_handler.errorResponse"];
+                    };
+                };
+                /** @description 未 サポート MIME */
+                415: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -5434,6 +5452,7 @@ export interface components {
         };
         "internal_handler.issueUploadURLReq": {
             contentType?: string;
+            sizeBytes?: number;
         };
         "internal_handler.markLessonCompleteRequest": {
             teachingMaterialId: number;

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -3672,7 +3672,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。",
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。",
                 "tags": [
                     "notes"
                 ],
@@ -3685,7 +3685,8 @@
                             }
                         }
                     },
-                    "description": "contentType (任意)"
+                    "description": "contentType / sizeBytes",
+                    "required": true
                 },
                 "responses": {
                     "200": {
@@ -3710,6 +3711,26 @@
                     },
                     "401": {
                         "description": "未 認証",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "413": {
+                        "description": "サイズ 上限 超過",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "415": {
+                        "description": "未 サポート MIME",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6077,6 +6098,9 @@
                 "properties": {
                     "contentType": {
                         "type": "string"
+                    },
+                    "sizeBytes": {
+                        "type": "integer"
                     }
                 }
             },

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -3672,7 +3672,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "current user 用 の S3 PUT 署名 URL を 発行。 userId は body から 受け取らず middleware の current user を 使う (IDOR 対策、 Phase 3 で 修正)。 contentType は 画像 MIME (png/jpeg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。",
+                "description": "current user 用 の S3 PUT 署名 URL を 発行。 contentType は 画像 MIME (png/jpeg/jpg/gif/webp) のみ、 sizeBytes は 上限 5MB を 事前 検証。 検証 済み の contentType / sizeBytes は presign の 署名 対象 (Content-Type / Content-Length) に 焼き込む ため、 発行後 に 別 種別 ・ 別 サイズ で PUT する と S3 が 署名 不一致 で 拒否 する。",
                 "tags": [
                     "notes"
                 ],
@@ -3700,7 +3700,7 @@
                         }
                     },
                     "400": {
-                        "description": "発行 失敗",
+                        "description": "リクエスト 不正 (contentType / sizeBytes が 未 指定 か 不正 な JSON)",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3720,7 +3720,7 @@
                         }
                     },
                     "413": {
-                        "description": "サイズ 上限 超過",
+                        "description": "Payload Too Large — sizeBytes が 上限 5MB を 超えて いる",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -3730,7 +3730,17 @@
                         }
                     },
                     "415": {
-                        "description": "未 サポート MIME",
+                        "description": "Unsupported Media Type — contentType が 許可 された 画像 MIME で ない",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/internal_handler.errorResponse"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "presigned URL の 発行 に 失敗 (S3 / インフラ 側 の 異常)",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -6095,6 +6105,10 @@
             },
             "internal_handler.issueUploadURLReq": {
                 "type": "object",
+                "required": [
+                    "contentType",
+                    "sizeBytes"
+                ],
                 "properties": {
                     "contentType": {
                         "type": "string"


### PR DESCRIPTION
## 概要

ノート画像の presigned URL 発行がクライアント申告の content-type を無検証で信頼し、サイズ上限も無かったため、画像以外の任意ファイル（HTML / JS 等）を共有バケットに置いて CDN 経由で配信できる状態だった。AI チャット添付（`IssueAiChatAttachmentUploadURLUseCase`）と同じ形で、usecase 層に MIME 許可リストとサイズ上限の検証を追加する。

## 変更内容

- `IssueNoteImageUploadURLUseCase.Execute` の引数を `IssueNoteImageUploadURLInput`（`UserID` / `ContentType` / `SizeBytes`）に変更し、以下を presigned URL 発行前に検証
  - `AllowedNoteImageContentTypes`（`image/png` / `jpeg` / `jpg` / `gif` / `webp`）の許可リスト。許可外は `ErrNoteImageUnsupportedType`
  - `maxNoteImageBytes = 5MB`（AI チャット添付の画像上限に合わせた）。0 以下・超過は `ErrNoteImageTooLarge`
- handler: `sizeBytes` を body に追加し、`contentType` / `sizeBytes` を必須化。エラーを 415（未サポート MIME）/ 413（サイズ超過）にマッピング。swaggo 注釈も更新
- frontend: `ImageUploadRepository.upload` が `sizeBytes: file.size` を送るように変更
- 生成物を再生成（`swag init` で `backend/docs/`、`npm run openapi:generate` で `frontend/src/generated/`）

contentType は presign に焼き込まれ PUT 時のヘッダと一致が要求されるため、許可リストを通った MIME 以外のオブジェクトは S3 に置けなくなる。

## テスト

- `go test ./...`（backend 全体）— pass ※Windows では `internal/infra/sandbox` が `syscall.Setpgid` 未定義でビルドできないため WSL(Ubuntu / go1.26.1) で実行
- `go vet ./...`（`GOOS=linux`）/ `gofumpt -l .`（差分なし）/ `archlint` / `apispec-lint` / `naminglint` — すべて OK
- 追加した単体テスト（`note_image_usecase_test.go`）
  - 許可 MIME 5 種すべてで URL を返す
  - 許可外 MIME（`""` / `text/html` / `application/javascript` / `image/svg+xml` / `application/pdf` / `application/octet-stream` / `IMAGE/PNG` / `image/png; charset=utf-8`）は `ErrNoteImageUnsupportedType` で拒否し presigner を呼ばない
  - サイズ境界（0 / 負数 / 上限ちょうど / 上限 +1）
- handler テスト（`note_image_handler_test.go`）に 415 / 413 / 必須項目 400 のケースを追加
- frontend: `npx vitest run src/entities/user/api/__tests__/imageUploadRepository.test.ts` — pass、`tsc --noEmit` / `eslint --max-warnings 0` — pass

## 関連 Issue

Refs FRESTYLE-9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ノート画像アップロード時に、ファイル形式とサイズを検証するようになりました。
  - 対応していない形式には415、サイズ超過には413を返します。
  - アップロード要求にファイルサイズ情報を含めるようになりました。

- **改善**
  - 必須項目の不足や不正なサイズ指定を、より明確に400エラーとして通知します。
  - API仕様に新しい入力項目とエラー応答を反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->