### PR TITLE
FRESTYLE-18 refactor: 未配線の SnsPublisher interface と no-op stub を撤去

### DIFF
--- a/backend/internal/adapter/persistence/notification_repository.go
+++ b/backend/internal/adapter/persistence/notification_repository.go
@@ -74,10 +74,3 @@ func (r *notificationRepository) CountUnread(ctx context.Context, userID uint64)
 	}
 	return sqlcgen.New(sqlDB).CountUnreadNotifications(ctx, uid)
 }
-
-// stubSnsPublisher は [repository.SnsPublisher] の no-op 実装（本番の SNS 実装は別 PR）。
-type stubSnsPublisher struct{}
-
-func NewStubSnsPublisher() repository.SnsPublisher { return &stubSnsPublisher{} }
-
-func (p *stubSnsPublisher) Publish(_ context.Context, _ uint64, _, _ string) error { return nil }

--- a/backend/internal/usecase/repository/notification.go
+++ b/backend/internal/usecase/repository/notification.go
@@ -16,8 +16,3 @@ type NotificationRepository interface {
 	MarkAllRead(ctx context.Context, userID uint64) error
 	CountUnread(ctx context.Context, userID uint64) (int64, error)
 }
-
-// SnsPublisher は通知 push 用（実装は AWS SDK 連携で別 PR）。
-type SnsPublisher interface {
-	Publish(ctx context.Context, userID uint64, title, body string) error
-}


### PR DESCRIPTION
## 概要

通知 push 用の `SnsPublisher` は interface と no-op stub だけが存在し、router に配線されず、どの usecase からも呼ばれていない dead code だった。中身が空の stub が残ると「もう動くはず」という誤解を招くため、interface ごと撤去する。

## 方針（撤去を選んだ理由）

AWS SNS の push 配信先は APNs / FCM / ADM、つまりネイティブモバイルアプリ。FreStyle のクライアントは React の Web SPA のみで（`react-native` 依存なし）、**SNS が配信できる相手が存在しない**。ブラウザへの push は Web Push（VAPID + Service Worker）で SNS では送れない。

加えて、実装するならデバイストークン（または Web Push subscription）テーブルと登録 API、SNS Platform Application の Terraform、フロントの Service Worker が必要になるが、これらのコードは backend / frontend ともに現状ゼロ。1 チケットに収まらずエピック相当のため、まず dead code を解消し、push が必要になった時点で Design Doc から設計し直す。

## 変更内容

- `repository.SnsPublisher` interface を削除（`internal/usecase/repository/notification.go`）
- `stubSnsPublisher` / `NewStubSnsPublisher` を削除（`internal/adapter/persistence/notification_repository.go`）
- 削除のみで 12 行減。`NotificationRepository`（一覧 / 既読 / 未読数）と通知 UI は変更なし

リポジトリ全体を grep して `SnsPublisher` の残存参照がゼロであることを確認済み（Go / TypeScript / docs / Terraform いずれもヒットなし）。

## テスト

- `go test ./...`（backend 全体）— pass ※Windows では `internal/infra/sandbox` が `syscall.Setpgid` 未定義でビルドできないため WSL(Ubuntu / go1.26.1) で実行
- `go build ./...` / `go vet ./...`（`GOOS=linux`）— pass
- `gofumpt -l .` — 差分なし
- `archlint` / `apispec-lint` / `naminglint` — すべて OK

dead code の削除のみで新規ロジックが無いため、単体テストの追加はなし（チケットの「配信処理の単体テスト」は実装を選んだ場合の条件）。同様に「通知配信の構成を docs に記載」も実装時の条件のため対象外。

## 関連 Issue

Refs FRESTYLE-18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 通知機能に関連する不要な内部処理を整理しました。
  * 通知の作成、一覧表示、既読化、未読件数の取得に関する既存の機能は変更ありません。
* **影響**
  * エンドユーザー向けの画面や操作に目立った変更はありません。
  * 通知機能はこれまでどおり利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->