### PR TITLE
FRESTYLE-18 refactor: 未配線の SnsPublisher interface と no-op stub を撤去

### DIFF
--- a/backend/internal/adapter/persistence/notification_repository.go
+++ b/backend/internal/adapter/persistence/notification_repository.go
@@ -74,10 +74,3 @@ func (r *notificationRepository) CountUnread(ctx context.Context, userID uint64)
 	}
 	return sqlcgen.New(sqlDB).CountUnreadNotifications(ctx, uid)
 }
-
-// stubSnsPublisher は [repository.SnsPublisher] の no-op 実装（本番の SNS 実装は別 PR）。
-type stubSnsPublisher struct{}
-
-func NewStubSnsPublisher() repository.SnsPublisher { return &stubSnsPublisher{} }
-
-func (p *stubSnsPublisher) Publish(_ context.Context, _ uint64, _, _ string) error { return nil }

--- a/backend/internal/usecase/repository/notification.go
+++ b/backend/internal/usecase/repository/notification.go
@@ -16,8 +16,3 @@ type NotificationRepository interface {
 	MarkAllRead(ctx context.Context, userID uint64) error
 	CountUnread(ctx context.Context, userID uint64) (int64, error)
 }
-
-// SnsPublisher は通知 push 用（実装は AWS SDK 連携で別 PR）。
-type SnsPublisher interface {
-	Publish(ctx context.Context, userID uint64, title, body string) error
-}


### PR DESCRIPTION
<!--
PR タイトル・本文は日本語で。タイトルは Prefix を付ける（feat / fix / refactor / docs / test / chore / perf / style）。
詳細な規約は CONTRIBUTING.md を参照。
-->

## 概要
現在、通知 Push 用の SnsPublisher は interface と no-op stub のみが存在しており、router に配線されていないため、どの usecase からも利用されていません。

本PRでは、不要なコードとして SnsPublisher 関連の実装を撤去しました。
<!-- この PR で何を・なぜやったかを 1〜3 行で -->
## 撤去理由
- SnsPublisher は router に登録されておらず、実際の処理から参照されていません。
- interface、実装（stub）、生成関数のいずれも利用箇所がなく、dead code となっていました。
- 今回のチケットでは「実装して利用する」または「不要なため撤去する」の判断が必要でしたが、現状の利用状況を踏まえ、保守性向上のため撤去を選択しました。

## 変更内容
2 ファイル、12 行削除。

- backend/internal/usecase/repository/notification.go から SnsPublisher interface を削除

- backend/internal/adapter/persistence/notification_repository.go から stubSnsPublisher と NewStubSnsPublisher を削除

NotificationRepository（一覧 / 既読 / 未読数）と通知 UI には変更ありません。
<!-- 主な変更点を箇条書きで -->
-

## テスト

<!-- どう検証したか（コマンド・結果）。新規コードには単体テストを付ける -->
**実行確認**

以下を実行し、すべて正常終了（pass）することを確認しました。

- go build ./...
- go vet ./...
- gofumpt -l .（差分なし）
- go test ./...（backend 全体）
- archlint
- apispec-lint
- naminglint

**補足**
本PRは未使用（dead code）の削除のみで、新たなロジックの追加や既存ロジックの変更はありません。そのため、単体テストの追加は行っていません。

また、チケットに記載されている「配信処理の単体テストを追加」「通知配信の構成を docs に記載」については、通知配信を実装する場合の要件であり、本PRでは削除を選択したため対象外です。

## 関連 チケット
[https://frestyle.atlassian.net/browse/FRESTYLE-18](url)
<!-- 例: Closes #123 / Refs #456 -->

---