### PR TITLE
feat: 公開ランディングページ新設 + ビルド時プリレンダー (FRESTYLE-222)

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -45,7 +45,7 @@ jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     needs: [guard]
     if: always() && (github.event_name == 'push' || needs.guard.result == 'success')
     # 本番反映ジョブは production Environment に紐付け、required reviewers の承認待ちで止める。
@@ -79,6 +79,15 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      # 公開ページを Playwright(headless Chromium)でプリレンダーし、dist/index.html に
+      # 中身入り HTML を焼き込む。検索ボットの初回取得で本文がクロールできるようにする
+      # (CSR の空シェル対策 / FRESTYLE-222)。prerender スクリプトは空シェル/本文欠落を
+      # 検知すると fail するため、壊れた場合は deploy されない(回帰ガード)。
+      - name: Prerender public pages
+        run: |
+          npx playwright install --with-deps chromium
+          npm run prerender
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6

--- a/frontend/e2e/local/authenticated.spec.ts
+++ b/frontend/e2e/local/authenticated.spec.ts
@@ -60,7 +60,8 @@ test.describe('認証ガード', () => {
   test('認証済みなら保護ルートはログインに飛ばされない', async ({ page }) => {
     await mockAuthenticated(page);
 
-    await page.goto('/');
+    // "/" は公開 LP に変わったため、保護ルート(ダッシュボード)で検証する。
+    await page.goto('/dashboard');
 
     await expect(page).not.toHaveURL(/\/login/);
   });

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -15,15 +15,15 @@ import { test, expect } from '@playwright/test';
 const API_BASE = 'https://api.normanblog.com';
 
 test.describe('FreStyle smoke', () => {
-  test('SPA がロードされ FreStyle ロゴ / ログイン誘導が見える', async ({ page }) => {
+  test('SPA がロードされ FreStyle ブランドが見える', async ({ page }) => {
     // networkidle は SPA のヘルスポーリング等で「無通信」に到達せず timeout して flake るため使わない。
-    // domcontentloaded で遷移し、描画要素（ログインフォーム）の出現を明示的に待つ。
+    // domcontentloaded で遷移し、描画要素の出現を明示的に待つ。
     await page.goto('/', { waitUntil: 'domcontentloaded' });
     await expect(page).toHaveTitle(/FreStyle/);
-    // 未認証アクセスは /login にリダイレクトされ、ログインフォームが描画される。
-    // 本番のコールドロード + 認証チェックを見込んで余裕を持った timeout で待つ。
+    // 公開ヘッダー(PublicHeader)の FreStyle ブランドは、公開トップ(LP)でもログインページでも
+    // 常に描画される。本番のコールドロードを見込んで余裕を持った timeout で待つ。
     await expect(
-      page.getByRole('form', { name: 'ログインフォーム' })
+      page.getByRole('link', { name: 'FreStyle ホーム' })
     ).toBeVisible({ timeout: 20_000 });
   });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "tailwind:init": "tailwindcss init -p",
     "openapi:generate": "swagger2openapi ../backend/docs/swagger.json --outfile src/generated/openapi.json && openapi-typescript src/generated/openapi.json --output src/generated/api.ts",
     "knip": "knip",
-    "size": "npm run build && size-limit"
+    "size": "npm run build && size-limit",
+    "prerender": "node scripts/prerender.mjs"
   },
   "overrides": {
     "form-data": "^4.0.6"

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -1,0 +1,128 @@
+/**
+ * ビルド時プリレンダー。
+ *
+ * vite build 後の dist/ を SPA フォールバック付きの静的サーバで配信し、Playwright(既存の
+ * devDependency)の headless Chromium で公開ルートを実際に描画してから DOM をスナップショットし、
+ * 「中身入りの HTML」を dist/<route>/index.html に書き戻す。これにより検索ボットの初回取得で
+ * 本文がクロールできる状態にする(CSR の空シェル対策)。
+ *
+ * 対象は Phase 1 では公開トップ "/" のみ(dist/index.html を上書き = CloudFront/S3 の
+ * デフォルトルートオブジェクトがそのまま返るためインフラ変更不要)。追加ルートは Phase 2 で
+ * CloudFront Function を入れてから対象に加える。
+ *
+ * 使い方: npm run build && node scripts/prerender.mjs
+ */
+import { createServer } from 'node:http';
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { join, extname, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from '@playwright/test';
+
+const ROUTES = ['/']; // Phase 1: 公開トップのみ
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DIST = join(HERE, '..', 'dist');
+const READY_SELECTOR = 'html[data-prerender-ready]';
+const NAV_TIMEOUT_MS = 20000;
+
+const CONTENT_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+};
+
+async function fileExists(p) {
+  try {
+    return (await stat(p)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** dist/ を配信する静的サーバ。存在しないパスは index.html にフォールバック(SPA)。 */
+function startServer() {
+  const server = createServer(async (req, res) => {
+    try {
+      // ヘルスチェックはローカルでは常に OK を返し、メンテナンス表示への誤遷移を防ぐ。
+      if (req.url && req.url.startsWith('/api/v2/health')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{"status":"ok"}');
+        return;
+      }
+      const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+      const candidate = join(DIST, urlPath);
+      const filePath = urlPath !== '/' && (await fileExists(candidate)) ? candidate : join(DIST, 'index.html');
+      const body = await readFile(filePath);
+      res.writeHead(200, { 'content-type': CONTENT_TYPES[extname(filePath)] || 'application/octet-stream' });
+      res.end(body);
+    } catch (err) {
+      res.writeHead(500);
+      res.end(String(err));
+    }
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function main() {
+  if (!(await fileExists(join(DIST, 'index.html')))) {
+    throw new Error('dist/index.html が無い。先に `npm run build` を実行してください。');
+  }
+
+  const { server, port } = await startServer();
+  const base = `http://127.0.0.1:${port}`;
+  const browser = await chromium.launch();
+  const snapshots = [];
+
+  try {
+    for (const route of ROUTES) {
+      const page = await browser.newPage();
+      await page.goto(`${base}${route}`, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
+      // LP がマウント完了で付ける目印を待ってからスナップショット(ローディング途中を撮らない)。
+      await page.waitForSelector(READY_SELECTOR, { timeout: NAV_TIMEOUT_MS });
+      const html = await page.content();
+      await page.close();
+
+      // 回帰ガード: 空シェルや本文欠落なら fail させ、空シェルへの逆戻りを防ぐ。
+      if (/<div id="root">\s*<\/div>/.test(html)) {
+        throw new Error(`prerender: ${route} が空シェルのまま(#root が空)。`);
+      }
+      if (!html.includes('新卒ITエンジニア向け研修プラットフォーム')) {
+        throw new Error(`prerender: ${route} に想定コンテンツ(ヒーロー文言)が含まれていない。`);
+      }
+      snapshots.push({ route, html });
+      console.log(`prerendered: ${route} (${html.length} bytes)`);
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  // すべて撮り終えてから書き出す(途中で index.html を上書きしてフォールバックが変わるのを防ぐ)。
+  for (const { route, html } of snapshots) {
+    const outPath = route === '/' ? join(DIST, 'index.html') : join(DIST, route, 'index.html');
+    await mkdir(dirname(outPath), { recursive: true });
+    await writeFile(outPath, html, 'utf-8');
+    console.log(`wrote: ${outPath.replace(DIST, 'dist')}`);
+  }
+  console.log(`\nprerender 完了: ${snapshots.length} ルート`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -13,8 +13,8 @@
  * 使い方: npm run build && node scripts/prerender.mjs
  */
 import { createServer } from 'node:http';
-import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
-import { join, extname, dirname, resolve, sep } from 'node:path';
+import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
+import { join, extname, dirname, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
 
@@ -52,8 +52,26 @@ async function fileExists(p) {
   }
 }
 
-/** dist/ を配信する静的サーバ。存在しないパスは index.html にフォールバック(SPA)。 */
-function startServer() {
+/**
+ * dist/ 配下の全ファイルを列挙し「URL パス → 絶対パス」の対応表を作る。
+ * リクエスト由来の文字列は fs API に渡さず、この表の値(readdir 由来)だけを使うことで
+ * path traversal を構造的に不可能にする(CodeQL js/path-injection 対策)。
+ */
+async function buildFileMap() {
+  const entries = await readdir(DIST, { recursive: true, withFileTypes: true });
+  const map = new Map();
+  for (const e of entries) {
+    if (!e.isFile()) continue;
+    const abs = join(e.parentPath ?? e.path, e.name);
+    map.set('/' + relative(DIST, abs).split(sep).join('/'), abs);
+  }
+  return map;
+}
+
+/** dist/ を配信する静的サーバ。対応表にないパスは index.html にフォールバック(SPA)。 */
+async function startServer() {
+  const files = await buildFileMap();
+  const indexPath = join(DIST, 'index.html');
   const server = createServer(async (req, res) => {
     try {
       // ヘルスチェックはローカルでは常に OK を返し、メンテナンス表示への誤遷移を防ぐ。
@@ -63,17 +81,12 @@ function startServer() {
         return;
       }
       const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
-      // path traversal 対策: 解決後のパスが dist/ 配下でなければ index.html にフォールバック。
-      const candidate = resolve(DIST, `.${urlPath}`);
-      const inDist = candidate === DIST || candidate.startsWith(DIST + sep);
-      const filePath =
-        urlPath !== '/' && inDist && (await fileExists(candidate)) ? candidate : join(DIST, 'index.html');
+      const filePath = (urlPath !== '/' && files.get(urlPath)) || indexPath;
       const body = await readFile(filePath);
       res.writeHead(200, { 'content-type': CONTENT_TYPES[extname(filePath)] || 'application/octet-stream' });
       res.end(body);
     } catch {
-      // 例外の内容(スタックトレース等)はレスポンスに含めない。ローカル専用サーバだが
-      // CodeQL の stack-trace-exposure / xss-through-exception 指摘に従い固定文言のみ返す。
+      // 例外の内容(スタックトレース等)はレスポンスに含めない(CodeQL stack-trace-exposure 対策)。
       res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
       res.end('internal error');
     }

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -14,7 +14,7 @@
  */
 import { createServer } from 'node:http';
 import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
-import { join, extname, dirname } from 'node:path';
+import { join, extname, dirname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
 
@@ -63,14 +63,19 @@ function startServer() {
         return;
       }
       const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
-      const candidate = join(DIST, urlPath);
-      const filePath = urlPath !== '/' && (await fileExists(candidate)) ? candidate : join(DIST, 'index.html');
+      // path traversal 対策: 解決後のパスが dist/ 配下でなければ index.html にフォールバック。
+      const candidate = resolve(DIST, `.${urlPath}`);
+      const inDist = candidate === DIST || candidate.startsWith(DIST + sep);
+      const filePath =
+        urlPath !== '/' && inDist && (await fileExists(candidate)) ? candidate : join(DIST, 'index.html');
       const body = await readFile(filePath);
       res.writeHead(200, { 'content-type': CONTENT_TYPES[extname(filePath)] || 'application/octet-stream' });
       res.end(body);
-    } catch (err) {
-      res.writeHead(500);
-      res.end(String(err));
+    } catch {
+      // 例外の内容(スタックトレース等)はレスポンスに含めない。ローカル専用サーバだが
+      // CodeQL の stack-trace-exposure / xss-through-exception 指摘に従い固定文言のみ返す。
+      res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('internal error');
     }
   });
   return new Promise((resolve) => {

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -19,6 +19,8 @@ const ForgotPasswordPage = lazyWithReload(() => import('@/pages/forgot-password'
 const ConfirmForgotPasswordPage = lazyWithReload(() => import('@/pages/confirm-forgot-password').then((m) => ({ default: m.ConfirmForgotPasswordPage })), 'ConfirmForgotPasswordPage');
 const AcceptInvitationPage = lazyWithReload(() => import('@/pages/accept-invitation').then((m) => ({ default: m.AcceptInvitationPage })), 'AcceptInvitationPage');
 const CompanyApplicationPage = lazyWithReload(() => import('@/pages/company-application').then((m) => ({ default: m.CompanyApplicationPage })), 'CompanyApplicationPage');
+// 公開ランディング（SEO 対象・認証不要）。ログイン済みは /dashboard へ送る。
+const LandingPage = lazyWithReload(() => import('@/pages/landing').then((m) => ({ default: m.LandingPage })), 'LandingPage');
 
 // 認証必要ページ
 const MenuPage = lazyWithReload(() => import('@/pages/home').then((m) => ({ default: m.MenuPage })), 'MenuPage');
@@ -85,6 +87,8 @@ export default function App() {
     <Suspense fallback={<Loading fullscreen message="読み込み中..." />}>
     <Routes>
       {/* 誰でもアクセス可能 */}
+      {/* 公開トップ（SEO 対象）。ログイン済みは LandingPage 内で /dashboard へ送る。 */}
+      <Route path="/" element={<LandingPage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/login/callback" element={<LoginCallback />} />
       <Route path="/forgot-password" element={<ForgotPasswordPage />} />
@@ -108,7 +112,8 @@ export default function App() {
           </AuthInitializer>
         }
       >
-        <Route path="/" element={<MenuPage />} />
+        {/* ログイン後のダッシュボード。旧 "/" から移設（"/" は公開 LP に）。 */}
+        <Route path="/dashboard" element={<MenuPage />} />
         <Route path="/settings" element={<SettingsPage />} />
         {/* 旧 /profile/me は /settings に統合（後方互換のため redirect 相当として SettingsPage を出す） */}
         <Route path="/profile/me" element={<SettingsPage />} />

--- a/frontend/src/pages/admin-audit-log/ui/AdminAuditLogPage.tsx
+++ b/frontend/src/pages/admin-audit-log/ui/AdminAuditLogPage.tsx
@@ -62,7 +62,7 @@ export default function AdminAuditLogPage() {
 
   if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
   // 監査ログは全テナント横断の運営機能なので super_admin 専用。
-  if (!isSuperAdmin) return <Navigate to="/" replace />;
+  if (!isSuperAdmin) return <Navigate to="/dashboard" replace />;
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">

--- a/frontend/src/pages/admin-companies/ui/AdminCompaniesPage.tsx
+++ b/frontend/src/pages/admin-companies/ui/AdminCompaniesPage.tsx
@@ -49,7 +49,7 @@ export default function AdminCompaniesPage() {
   };
 
   if (authLoading) return <Loading message="認証情報を確認中..." />;
-  if (!isSuperAdmin) return <Navigate to="/" replace />;
+  if (!isSuperAdmin) return <Navigate to="/dashboard" replace />;
 
   return (
     <div className="px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">

--- a/frontend/src/pages/admin-company-applications/ui/AdminCompanyApplicationsPage.tsx
+++ b/frontend/src/pages/admin-company-applications/ui/AdminCompanyApplicationsPage.tsx
@@ -39,7 +39,7 @@ export default function AdminCompanyApplicationsPage() {
 
   if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
   // 利用申請は全テナント横断の運営機能なので super_admin のみ。
-  if (!isAdmin || role !== 'super_admin') return <Navigate to="/" replace />;
+  if (!isAdmin || role !== 'super_admin') return <Navigate to="/dashboard" replace />;
 
   const update = async (app: CompanyApplication, status: CompanyApplicationStatus) => {
     const ok = await setStatus(app.id, status);

--- a/frontend/src/pages/admin-dashboard/ui/AdminDashboardPage.tsx
+++ b/frontend/src/pages/admin-dashboard/ui/AdminDashboardPage.tsx
@@ -50,7 +50,7 @@ export default function AdminDashboardPage() {
 
   if (authLoading) return <Loading message="認証情報を確認中..." className="min-h-[50vh]" />;
   // 運営ダッシュボードは全テナント横断の概況なので super_admin 専用。
-  if (!canView) return <Navigate to="/" replace />;
+  if (!canView) return <Navigate to="/dashboard" replace />;
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-3xl mx-auto space-y-6">

--- a/frontend/src/pages/admin-invitations/ui/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/admin-invitations/ui/AdminInvitationsPage.tsx
@@ -103,7 +103,7 @@ export default function AdminInvitationsPage() {
   }, [isAdmin, fetchAll]);
 
   if (authLoading) return <Loading message="認証情報を確認中..." />;
-  if (!isAdmin) return <Navigate to="/" replace />;
+  if (!isAdmin) return <Navigate to="/dashboard" replace />;
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/frontend/src/pages/admin-members/ui/AdminMembersPage.tsx
+++ b/frontend/src/pages/admin-members/ui/AdminMembersPage.tsx
@@ -51,7 +51,7 @@ export default function AdminMembersPage() {
   }, [members, query]);
 
   if (authLoading) return <Loading message="読み込み中..." className="min-h-[50vh]" />;
-  if (!isAdmin) return <Navigate to="/" replace />;
+  if (!isAdmin) return <Navigate to="/dashboard" replace />;
 
   return (
     <div className="px-4 sm:px-6 pt-6 pb-24 max-w-4xl mx-auto">

--- a/frontend/src/pages/course-detail/__tests__/CourseDetailPage.test.tsx
+++ b/frontend/src/pages/course-detail/__tests__/CourseDetailPage.test.tsx
@@ -363,44 +363,41 @@ describe('CourseDetailPage 画像のモーダル拡大表示 (FRESTYLE-191)', ()
     mockRecordView.mockResolvedValue(undefined);
   });
 
+  // モーダルを開く。初期ロード後の再レンダーで取得済みボタンが差し替わると click が
+  // 空振りする(stale node)ため、「click → dialog 出現」を waitFor で丸ごとリトライする。
+  // recordView 待ちだけでは CI の遅い環境で後続の再レンダーと競合してフレークした。
+  async function openImageModal() {
+    await waitFor(() => expect(mockRecordView).toHaveBeenCalled());
+    await waitFor(() => {
+      fireEvent.click(screen.getByRole('button', { name: '構成図を拡大表示' }));
+      expect(screen.getByRole('dialog', { name: '構成図' })).toBeInTheDocument();
+    });
+  }
+
   it('画像クリックでモーダルが開き、拡大画像と alt が引き継がれる', async () => {
     renderPage('trainee');
-    // 初期ロード(閲覧記録まで)が済んでからクリックする。途中の再レンダーで
-    // 取得済みノードが差し替わると click が空振りするため(stale node)。
-    await waitFor(() => expect(mockRecordView).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole('button', { name: '構成図を拡大表示' }));
-    const dialog = screen.getByRole('dialog', { name: '構成図' });
-    expect(dialog).toBeInTheDocument();
+    await openImageModal();
     // モーダル内にも同じ src の img が出る（本文内 + モーダルで 2 枚）
     expect(screen.getAllByRole('img', { name: '構成図' })).toHaveLength(2);
   });
 
   it('閉じるボタンで閉じられる', async () => {
     renderPage('trainee');
-    // 初期ロード(閲覧記録まで)が済んでからクリックする。途中の再レンダーで
-    // 取得済みノードが差し替わると click が空振りするため(stale node)。
-    await waitFor(() => expect(mockRecordView).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole('button', { name: '構成図を拡大表示' }));
+    await openImageModal();
     fireEvent.click(screen.getByRole('button', { name: '閉じる' }));
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('Esc キーで閉じられる', async () => {
     renderPage('trainee');
-    // 初期ロード(閲覧記録まで)が済んでからクリックする。途中の再レンダーで
-    // 取得済みノードが差し替わると click が空振りするため(stale node)。
-    await waitFor(() => expect(mockRecordView).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole('button', { name: '構成図を拡大表示' }));
+    await openImageModal();
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
   it('背景クリックで閉じるが、拡大画像自体のクリックでは閉じない', async () => {
     renderPage('trainee');
-    // 初期ロード(閲覧記録まで)が済んでからクリックする。途中の再レンダーで
-    // 取得済みノードが差し替わると click が空振りするため(stale node)。
-    await waitFor(() => expect(mockRecordView).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole('button', { name: '構成図を拡大表示' }));
+    await openImageModal();
     const dialog = screen.getByRole('dialog', { name: '構成図' });
     // 画像クリック → 閉じない（誤タップ防止）
     const [, modalImg] = screen.getAllByRole('img', { name: '構成図' });

--- a/frontend/src/pages/help/__tests__/HelpPage.test.tsx
+++ b/frontend/src/pages/help/__tests__/HelpPage.test.tsx
@@ -64,7 +64,7 @@ describe('HelpPage', () => {
 
   it('末尾の CTA がホームに戻るリンクになっている', () => {
     renderHelp();
-    expect(screen.getByRole('link', { name: /ホームに戻って練習を始める/ })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: /ホームに戻って練習を始める/ })).toHaveAttribute('href', '/dashboard');
   });
 
   it('5軸評価の 5 つの評価項目が dt として全て描画される', () => {

--- a/frontend/src/pages/help/ui/HelpPage.tsx
+++ b/frontend/src/pages/help/ui/HelpPage.tsx
@@ -322,7 +322,7 @@ export default function HelpPage() {
       {/* CTA: ホームへ戻る */}
       <section aria-label="次のアクション">
         <ActionCard
-          to="/"
+          to="/dashboard"
           title="ホームに戻って練習を始める"
           description="読み終わったら、まずは 1 セッション体験してみましょう。"
           icon={<RocketLaunchIcon className="h-5 w-5" />}

--- a/frontend/src/pages/landing/index.ts
+++ b/frontend/src/pages/landing/index.ts
@@ -1,0 +1,1 @@
+export { default as LandingPage } from './ui/LandingPage';

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -1,0 +1,227 @@
+import { useEffect } from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import PublicHeader from '@/shared/ui/PublicHeader';
+import { useAppSelector } from '@/shared/lib/store';
+import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
+
+const SITE_URL = 'https://normanblog.com/';
+
+const FEATURES: { title: string; body: string }[] = [
+  {
+    title: 'コース学習',
+    body: 'Git・Docker・Linux・Go・PostgreSQL からクリーンアーキテクチャまで、実務直結のコースを章立てで学べる。進捗はコースごとに記録され、続きから再開できる。',
+  },
+  {
+    title: 'コーディング演習',
+    body: 'ブラウザ上のエディタで書いて即採点。PHP・Java・JavaScript・TypeScript・Go・Ruby・C・C++・SQL など多言語に対応し、手を動かして身につける。',
+  },
+  {
+    title: 'AI チャットで質問',
+    body: '詰まったところを AI にその場で相談。学習の流れを止めずに、疑問を解消しながら進められる。',
+  },
+  {
+    title: '学習レポート',
+    body: '取り組んだ量や進み具合をレポートで可視化。受講者は自分の伸びを、研修担当はチームの状況を把握できる。',
+  },
+  {
+    title: 'メンバーの学習状況（管理者）',
+    body: '企業の研修担当は、メンバーごとの進捗・つまずきを一覧で確認。招待もマジックリンクで簡単に行える。',
+  },
+  {
+    title: '迷わない導線',
+    body: '「何を学ぶか」で迷わないよう、学習領域→コース→章の順に整理。初学者がひとりでも進められる設計。',
+  },
+];
+
+const STEPS: { title: string; body: string }[] = [
+  { title: '1. 利用申請', body: '企業の研修担当が利用申請を送信。折り返しご案内します。' },
+  { title: '2. メンバー招待', body: '受講者をマジックリンクで招待。受け取ったリンクから参加できます。' },
+  { title: '3. 学習開始', body: 'コース学習とコーディング演習で、手を動かしながら研修を進めます。' },
+  { title: '4. 進捗の確認', body: '学習レポートで、受講者・研修担当の双方が伸びを確認できます。' },
+];
+
+const FAQS: { q: string; a: string }[] = [
+  {
+    q: 'FreStyle とは何ですか？',
+    a: 'FreStyle は、新卒 IT エンジニア向けの統合研修プラットフォームです。コース学習・多言語のコーディング演習・AI チャット・学習レポートを1つにまとめ、研修の実施と進捗管理を支援します。',
+  },
+  {
+    q: '誰が使うサービスですか？',
+    a: '新卒・若手エンジニアの受講者と、その研修を運営する企業の研修担当者が対象です。受講者は学習を、担当者はメンバーの学習状況の把握を行えます。',
+  },
+  {
+    q: 'どんな言語の演習ができますか？',
+    a: 'PHP・Java・JavaScript・TypeScript・Go・Ruby・C・C++・SQL などに対応しています。ブラウザ上で書いてそのまま採点できます。',
+  },
+  {
+    q: '利用を始めるには？',
+    a: '企業の研修担当者が利用申請を送るところから始まります。受講者は担当者からの招待リンクで参加します。',
+  },
+];
+
+/**
+ * LandingPage は未ログイン/検索ボット向けの公開トップ。SEO のインデックス対象。
+ * API は叩かず純静的に描画し、ビルド時プリレンダー(Playwright)で中身入り HTML を配信する。
+ * ログイン済みで来た場合はダッシュボードへ送る（クライアント遷移時のみ。初回ロードは
+ * 認証状態未確定なので LP を表示する = プリレンダーも LP になる）。
+ */
+export default function LandingPage() {
+  const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);
+
+  useDocumentMeta({
+    title: 'FreStyle | 新卒ITエンジニア向け研修プラットフォーム',
+    description:
+      'FreStyle は新卒・若手 IT エンジニア向けの研修プラットフォーム。コース学習・多言語のコーディング演習・AI チャット・学習レポートで、研修の実施と進捗管理を支援します。',
+    canonical: SITE_URL,
+  });
+
+  // プリレンダーが「描画完了」を検知するための目印（マウント後に付与）。
+  useEffect(() => {
+    document.documentElement.setAttribute('data-prerender-ready', 'true');
+    return () => document.documentElement.removeAttribute('data-prerender-ready');
+  }, []);
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)]">
+      <PublicHeader />
+
+      <main>
+        {/* ヒーロー */}
+        <section className="mx-auto max-w-5xl px-6 pt-16 pb-14 text-center">
+          <h1 className="text-3xl sm:text-5xl font-bold leading-tight">
+            FreStyle — 新卒ITエンジニア向け研修プラットフォーム
+          </h1>
+          <p className="mt-6 text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-3xl mx-auto">
+            コース学習・多言語のコーディング演習・AI チャット・学習レポートを1つに。
+            手を動かして学び、研修の進捗をまとめて管理できます。
+          </p>
+          <div className="mt-9 flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              to="/company-application"
+              className="inline-flex items-center justify-center rounded-lg bg-[var(--color-accent)] px-6 py-3 font-semibold text-white shadow-sm hover:opacity-90 transition"
+            >
+              企業の方：導入・利用申請
+            </Link>
+            <Link
+              to="/login"
+              className="inline-flex items-center justify-center rounded-lg border border-[var(--color-border-hover)] px-6 py-3 font-semibold text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] transition"
+            >
+              受講者の方：ログイン
+            </Link>
+          </div>
+        </section>
+
+        {/* FreStyle とは */}
+        <section className="bg-[var(--color-surface-1)] border-y border-[var(--color-surface-3)]">
+          <div className="mx-auto max-w-4xl px-6 py-14">
+            <h2 className="text-2xl font-bold">FreStyle とは</h2>
+            <p className="mt-4 text-[var(--color-text-secondary)] leading-relaxed">
+              FreStyle は、新卒・若手 IT エンジニアの研修を一気通貫で支える統合プラットフォームです。
+              読むだけの座学で終わらせず、ブラウザ上のエディタで書いて即採点する演習まで含めることで、
+              「わかる」だけでなく「できる」に届く研修を実現します。受講者は自分の伸びを、
+              企業の研修担当はメンバーの学習状況を、それぞれ同じ場所で把握できます。
+            </p>
+          </div>
+        </section>
+
+        {/* 主な機能 */}
+        <section className="mx-auto max-w-6xl px-6 py-16">
+          <h2 className="text-2xl font-bold text-center">主な機能</h2>
+          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((f) => (
+              <div
+                key={f.title}
+                className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-6"
+              >
+                <h3 className="text-lg font-semibold">{f.title}</h3>
+                <p className="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+                  {f.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* 導入の流れ */}
+        <section className="bg-[var(--color-surface-1)] border-y border-[var(--color-surface-3)]">
+          <div className="mx-auto max-w-6xl px-6 py-16">
+            <h2 className="text-2xl font-bold text-center">導入の流れ</h2>
+            <ol className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {STEPS.map((s) => (
+                <li
+                  key={s.title}
+                  className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface)] p-6"
+                >
+                  <h3 className="text-base font-semibold text-[var(--color-accent)]">{s.title}</h3>
+                  <p className="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+                    {s.body}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="mx-auto max-w-4xl px-6 py-16">
+          <h2 className="text-2xl font-bold text-center">よくある質問</h2>
+          <dl className="mt-10 space-y-6">
+            {FAQS.map((item) => (
+              <div
+                key={item.q}
+                className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-6"
+              >
+                <dt className="font-semibold">{item.q}</dt>
+                <dd className="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
+                  {item.a}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        {/* 末尾 CTA */}
+        <section className="bg-[var(--color-surface-1)] border-t border-[var(--color-surface-3)]">
+          <div className="mx-auto max-w-4xl px-6 py-14 text-center">
+            <h2 className="text-2xl font-bold">研修の実施と管理を、FreStyle で。</h2>
+            <p className="mt-4 text-[var(--color-text-secondary)]">
+              まずは企業の利用申請から。受講者の方は招待リンクからログインできます。
+            </p>
+            <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+              <Link
+                to="/company-application"
+                className="inline-flex items-center justify-center rounded-lg bg-[var(--color-accent)] px-6 py-3 font-semibold text-white shadow-sm hover:opacity-90 transition"
+              >
+                利用申請する
+              </Link>
+              <Link
+                to="/login"
+                className="inline-flex items-center justify-center rounded-lg border border-[var(--color-border-hover)] px-6 py-3 font-semibold text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] transition"
+              >
+                ログイン
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-[var(--color-surface-3)]">
+        <div className="mx-auto max-w-6xl px-6 py-8 text-sm text-[var(--color-text-muted)] flex flex-col sm:flex-row items-center justify-between gap-3">
+          <p>FreStyle — 新卒ITエンジニア向け研修プラットフォーム</p>
+          <nav className="flex gap-5">
+            <Link to="/login" className="hover:text-[var(--color-text-primary)]">
+              ログイン
+            </Link>
+            <Link to="/company-application" className="hover:text-[var(--color-text-primary)]">
+              利用申請
+            </Link>
+          </nav>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -132,14 +132,14 @@ export default function LandingPage() {
         <section className="mx-auto max-w-6xl px-6 py-16">
           <h2 className="text-2xl font-bold text-center">主な機能</h2>
           <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {FEATURES.map((f) => (
+            {FEATURES.map((feature) => (
               <div
-                key={f.title}
+                key={feature.title}
                 className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-6"
               >
-                <h3 className="text-lg font-semibold">{f.title}</h3>
+                <h3 className="text-lg font-semibold">{feature.title}</h3>
                 <p className="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-                  {f.body}
+                  {feature.body}
                 </p>
               </div>
             ))}
@@ -151,14 +151,14 @@ export default function LandingPage() {
           <div className="mx-auto max-w-6xl px-6 py-16">
             <h2 className="text-2xl font-bold text-center">導入の流れ</h2>
             <ol className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-              {STEPS.map((s) => (
+              {STEPS.map((step) => (
                 <li
-                  key={s.title}
+                  key={step.title}
                   className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface)] p-6"
                 >
-                  <h3 className="text-base font-semibold text-[var(--color-accent)]">{s.title}</h3>
+                  <h3 className="text-base font-semibold text-[var(--color-accent)]">{step.title}</h3>
                   <p className="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-                    {s.body}
+                    {step.body}
                   </p>
                 </li>
               ))}

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -37,8 +37,17 @@ describe('LandingPage', () => {
     expect(screen.getByRole('heading', { name: 'FreStyle とは' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '主な機能' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'よくある質問' })).toBeInTheDocument();
-    // CTA（複数箇所にあるので存在のみ確認）
-    expect(screen.getAllByRole('link', { name: /利用申請/ }).length).toBeGreaterThan(0);
+    // CTA は遷移先まで検証する（存在確認だけでは誤配線を検知できない）
+    const applyLinks = screen.getAllByRole('link', { name: /利用申請/ });
+    expect(applyLinks.length).toBeGreaterThan(0);
+    for (const link of applyLinks) {
+      expect(link).toHaveAttribute('href', '/company-application');
+    }
+    const loginLinks = screen.getAllByRole('link', { name: /ログイン/ });
+    expect(loginLinks.length).toBeGreaterThan(0);
+    for (const link of loginLinks) {
+      expect(link).toHaveAttribute('href', '/login');
+    }
   });
 
   it('ログイン済みなら /dashboard へリダイレクトする', () => {

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import LandingPage from '../LandingPage';
+import authReducer from '@/entities/user/model/authSlice';
+
+function renderLanding(isAuthenticated: boolean) {
+  const store = configureStore({
+    reducer: { auth: authReducer },
+    preloadedState: {
+      auth: { isAuthenticated, loading: false, isAdmin: false, role: null },
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/dashboard" element={<div>ダッシュボード</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe('LandingPage', () => {
+  it('未ログインでは公開LPのヒーロー・主要セクションを表示する', () => {
+    renderLanding(false);
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /新卒ITエンジニア向け研修プラットフォーム/,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'FreStyle とは' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '主な機能' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'よくある質問' })).toBeInTheDocument();
+    // CTA（複数箇所にあるので存在のみ確認）
+    expect(screen.getAllByRole('link', { name: /利用申請/ }).length).toBeGreaterThan(0);
+  });
+
+  it('ログイン済みなら /dashboard へリダイレクトする', () => {
+    renderLanding(true);
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/login-callback/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/login-callback/__tests__/LoginCallback.test.tsx
@@ -72,7 +72,7 @@ describe('LoginCallback', () => {
     await waitFor(() => {
       // 第 2 引数 invitationToken は sessionStorage に何も無いとき null。
       expect(authRepository.callback).toHaveBeenCalledWith('valid-code', null);
-      expect(mockNavigate).toHaveBeenCalledWith('/');
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
     });
   });
 

--- a/frontend/src/pages/login-callback/model/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/pages/login-callback/model/__tests__/useLoginCallback.test.ts
@@ -55,7 +55,7 @@ describe('useLoginCallback', () => {
     });
 
     expect(mockDispatch).toHaveBeenCalledWith({ type: 'auth/setAuthData' });
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
   });
 
   it('callback失敗時にトースト付きでログインページに遷移する', async () => {
@@ -109,7 +109,7 @@ describe('useLoginCallback', () => {
       renderHook(() => useLoginCallback());
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
   });
 
   it('callback失敗時にトースト付きで遷移しない', async () => {

--- a/frontend/src/pages/login-callback/model/useLoginCallback.ts
+++ b/frontend/src/pages/login-callback/model/useLoginCallback.ts
@@ -28,7 +28,7 @@ export function useLoginCallback() {
         .callback(code, invitationToken)
         .then(() => {
           dispatch(setAuthData());
-          navigate('/');
+          navigate('/dashboard');
         })
         .catch((err) => {
           // backend が PR-OIDC-Gate で返す 403 invitation_required を識別して

--- a/frontend/src/pages/login-callback/ui/LoginCallback.tsx
+++ b/frontend/src/pages/login-callback/ui/LoginCallback.tsx
@@ -1,7 +1,10 @@
 import Loading from '@/shared/ui/Loading';
+import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 import { useLoginCallback } from '../model/useLoginCallback';
 
 export default function LoginCallback() {
+  // OAuth コールバックの一時画面。検索エンジンに index させない。
+  useDocumentMeta({ robots: 'noindex, nofollow' });
   useLoginCallback();
 
   return <Loading fullscreen message="ログイン中..." />;

--- a/frontend/src/pages/login/model/__tests__/useLoginPage.test.ts
+++ b/frontend/src/pages/login/model/__tests__/useLoginPage.test.ts
@@ -57,7 +57,7 @@ describe('useLoginPage', () => {
     });
 
     expect(loginMock).toHaveBeenCalledWith({ email: '', password: '' });
-    expect(assignMock).toHaveBeenCalledWith('/');
+    expect(assignMock).toHaveBeenCalledWith('/dashboard');
   });
 
   it('資格情報誤り（非 403）はエラーメッセージを表示し遷移しない', async () => {

--- a/frontend/src/pages/login/model/useLoginPage.ts
+++ b/frontend/src/pages/login/model/useLoginPage.ts
@@ -32,7 +32,7 @@ export function useLoginPage() {
 
     try {
       await authRepository.login({ email: form.email, password: form.password });
-      window.location.assign('/');
+      window.location.assign('/dashboard');
     } catch (err) {
       // 招待なしの新規ユーザーは backend が 403 invitation_required を返す。専用文言を出す。
       const { status, serverMessage } = getApiError(err);

--- a/frontend/src/shared/lib/hooks/__tests__/useDocumentMeta.test.ts
+++ b/frontend/src/shared/lib/hooks/__tests__/useDocumentMeta.test.ts
@@ -30,4 +30,13 @@ describe('useDocumentMeta', () => {
     const href = document.head.querySelector('link[rel="canonical"]')?.getAttribute('href');
     expect(href).toBe(`${window.location.origin}${window.location.pathname}`);
   });
+
+  it('robots 未指定時は既存の robots メタを削除する（noindex の残留防止）', () => {
+    // 認証画面が noindex を設定した後、公開LPへ SPA 遷移するシナリオ
+    renderHook(() => useDocumentMeta({ robots: 'noindex, nofollow' }));
+    expect(document.head.querySelector('meta[name="robots"]')).not.toBeNull();
+
+    renderHook(() => useDocumentMeta({ title: '公開ページ' }));
+    expect(document.head.querySelector('meta[name="robots"]')).toBeNull();
+  });
 });

--- a/frontend/src/shared/lib/hooks/__tests__/useDocumentMeta.test.ts
+++ b/frontend/src/shared/lib/hooks/__tests__/useDocumentMeta.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDocumentMeta } from '../useDocumentMeta';
+
+describe('useDocumentMeta', () => {
+  it('title / description / canonical / robots を head に設定する', () => {
+    renderHook(() =>
+      useDocumentMeta({
+        title: 'テストタイトル',
+        description: 'テストの説明文',
+        canonical: 'https://example.com/x',
+        robots: 'noindex, nofollow',
+      }),
+    );
+
+    expect(document.title).toBe('テストタイトル');
+    expect(
+      document.head.querySelector('meta[name="description"]')?.getAttribute('content'),
+    ).toBe('テストの説明文');
+    expect(
+      document.head.querySelector('link[rel="canonical"]')?.getAttribute('href'),
+    ).toBe('https://example.com/x');
+    expect(
+      document.head.querySelector('meta[name="robots"]')?.getAttribute('content'),
+    ).toBe('noindex, nofollow');
+  });
+
+  it('canonical 省略時は現在の origin + pathname を使う', () => {
+    renderHook(() => useDocumentMeta({ title: 'x' }));
+    const href = document.head.querySelector('link[rel="canonical"]')?.getAttribute('href');
+    expect(href).toBe(`${window.location.origin}${window.location.pathname}`);
+  });
+});

--- a/frontend/src/shared/lib/hooks/useDocumentMeta.ts
+++ b/frontend/src/shared/lib/hooks/useDocumentMeta.ts
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+
+/**
+ * ページ単位で `<title>` / meta description / canonical / robots を設定する軽量フック。
+ *
+ * react-helmet を追加せず標準 DOM API で head を upsert する。ビルド時プリレンダー
+ * (Playwright スナップショット) が、描画後の head を静的 HTML に取り込めるようにするのが目的。
+ * SPA なので次ページの呼び出しで上書きされる想定（未設定項目は前ページの値が残るが、
+ * index.html に既定値があるため空にはならない）。
+ */
+export interface DocumentMeta {
+  title?: string;
+  description?: string;
+  /** 絶対 URL。省略時は現在の origin + pathname を使う。 */
+  canonical?: string;
+  /** 例: "noindex, nofollow"。認証必須ページで使う。 */
+  robots?: string;
+}
+
+function upsertMeta(attr: 'name' | 'property', key: string, content: string): void {
+  let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`);
+  if (!el) {
+    el = document.createElement('meta');
+    el.setAttribute(attr, key);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('content', content);
+}
+
+function upsertLink(rel: string, href: string): void {
+  let el = document.head.querySelector<HTMLLinkElement>(`link[rel="${rel}"]`);
+  if (!el) {
+    el = document.createElement('link');
+    el.setAttribute('rel', rel);
+    document.head.appendChild(el);
+  }
+  el.setAttribute('href', href);
+}
+
+export function useDocumentMeta({ title, description, canonical, robots }: DocumentMeta): void {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+    if (description) {
+      upsertMeta('name', 'description', description);
+    }
+    if (robots) {
+      upsertMeta('name', 'robots', robots);
+    }
+    const href = canonical ?? `${window.location.origin}${window.location.pathname}`;
+    upsertLink('canonical', href);
+  }, [title, description, canonical, robots]);
+}

--- a/frontend/src/shared/lib/hooks/useDocumentMeta.ts
+++ b/frontend/src/shared/lib/hooks/useDocumentMeta.ts
@@ -47,6 +47,10 @@ export function useDocumentMeta({ title, description, canonical, robots }: Docum
     }
     if (robots) {
       upsertMeta('name', 'robots', robots);
+    } else {
+      // 未指定時は既存タグを削除する。認証画面(noindex)から公開LPへ SPA 遷移したとき
+      // noindex が残留すると公開ページまで noindex になってしまうため。
+      document.head.querySelector('meta[name="robots"]')?.remove();
     }
     const href = canonical ?? `${window.location.origin}${window.location.pathname}`;
     upsertLink('canonical', href);

--- a/frontend/src/widgets/app-shell/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/widgets/app-shell/__tests__/CommandPalette.test.tsx
@@ -108,7 +108,7 @@ describe('CommandPalette', () => {
     const input = screen.getByPlaceholderText('コマンドを検索...');
     // 最初のアイテム（ホーム）が選択されている状態でEnter
     fireEvent.keyDown(input, { key: 'Enter' });
-    expect(mockNavigate).toHaveBeenCalledWith('/');
+    expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
 

--- a/frontend/src/widgets/app-shell/config/commandPaletteItems.ts
+++ b/frontend/src/widgets/app-shell/config/commandPaletteItems.ts
@@ -32,7 +32,7 @@ export const COMMAND_ITEMS: CommandItem[] = [
     description: 'ホーム画面に移動',
     icon: HomeIcon,
     category: 'ページ移動',
-    action: { type: 'navigate', path: '/' },
+    action: { type: 'navigate', path: '/dashboard' },
     keywords: ['home', 'メニュー', 'トップ'],
   },
   {

--- a/frontend/src/widgets/app-shell/ui/AppShell.tsx
+++ b/frontend/src/widgets/app-shell/ui/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAppSelector } from '@/shared/lib/store';
+import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import Header from './Header';
@@ -11,6 +12,9 @@ export default function AppShell() {
   const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const { pathname } = useLocation();
   const role = useAppSelector((s) => s.auth.role);
+
+  // 認証必須ページ（AppShell 配下）はログイン前提なので検索インデックス対象外にする。
+  useDocumentMeta({ robots: 'noindex, nofollow' });
 
   // 受講者の教材閲覧(/courses/:id)はヘッダーごとスクロールで画面外に流す(FRESTYLE-122)。
   // チャット / ノート / コース編集などのパネル型ページは main の固定高さに依存しているため、

--- a/frontend/src/widgets/app-shell/ui/Header.tsx
+++ b/frontend/src/widgets/app-shell/ui/Header.tsx
@@ -25,7 +25,7 @@ interface NavItem {
 // ヘッダーのメインナビ（テキストのみ。 アイコンは使わない）。
 // 通知はベル、 管理はドロップダウンに分けるため、 ここには含めない。
 const mainNavItems: NavItem[] = [
-  { id: 'home', label: 'ホーム', to: '/', matchExact: true },
+  { id: 'home', label: 'ホーム', to: '/dashboard', matchExact: true },
   { id: 'ai', label: 'AI', to: '/chat/ask-ai', matchPrefix: '/chat/ask-ai' },
   { id: 'code', label: '演習', to: '/code-editor', matchPrefix: '/code-editor' },
   { id: 'courses', label: 'コース', to: '/courses', matchPrefix: '/courses' },
@@ -141,7 +141,7 @@ export default function Header() {
       {loggingOut && <Loading fullscreen message="ログアウト中..." />}
       <header className="flex-shrink-0 h-16 bg-[var(--color-nav)] border-b border-surface-3 flex items-center gap-2 px-3">
         {/* ロゴ（PNG と同じ二色の飛翔マーク = brand-mark.svg。色付き箱で囲うとロゴ自体が青いため埋もれる）。 */}
-        <Link to="/" className="flex items-center gap-2 flex-shrink-0 mr-2" aria-label="FreStyle ホーム">
+        <Link to="/dashboard" className="flex items-center gap-2 flex-shrink-0 mr-2" aria-label="FreStyle ホーム">
           <img src="/brand-mark.svg" alt="" className="w-7 h-7 flex-shrink-0" />
           <span className="hidden sm:block text-sm font-semibold text-[var(--color-text-primary)]">FreStyle</span>
         </Link>

--- a/frontend/src/widgets/auth-layout/ui/AuthLayout.tsx
+++ b/frontend/src/widgets/auth-layout/ui/AuthLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -9,6 +10,9 @@ interface AuthLayoutProps {
 }
 
 export default function AuthLayout({ children, title, footer, header }: AuthLayoutProps) {
+  // 認証フロー画面(ログイン/パスワード再設定)は検索結果に出す価値がないため noindex。
+  useDocumentMeta({ robots: 'noindex, nofollow' });
+
   return (
     <div className="min-h-screen flex flex-col bg-surface">
       {header}


### PR DESCRIPTION
## 概要
SEO 改善 **Phase 1**（アプリのみ・インフラ変更なし）。Design Doc: **FRESTYLE-221**。

調査の結果、「FreStyle」で上位に出ない根因は **(1) 公開ランディングページ(LP)が無く、トップ `/` が認証ガードの内側にあること**（未ログイン/ボットは `/login` にリダイレクト＝マーケコンテンツ不在）、**(2) SPA の空シェル配信でクロール時に本文が無いこと**でした。本 PR は公開 LP を新設し、ビルド時プリレンダーでボットに中身入り HTML を配信します。

## 変更内容
- **ルーティング（App.tsx）**: `/` を公開 `LandingPage` に。ダッシュボード（`MenuPage`）は **`/dashboard`** へ移設（Protected 内のまま）。ログイン後の遷移・内部リンク（ロゴ / ホーム nav / コマンドパレット / help の戻る / admin 非権限フォールバック）を `/dashboard` に更新。
- **公開 LandingPage**: ヒーロー(H1) / FreStyle とは / 主な機能 / 導入の流れ / FAQ / フッター。**純静的（API 不使用）**。マウント完了で `data-prerender-ready` を付与。ログイン済み（Redux で既知）は `/dashboard` へ redirect（初回ロードは認証未確定なので LP 表示＝プリレンダーも LP）。
- **useDocumentMeta フック**: `title` / `description` / `canonical` を設定。AppShell 配下の認証ページは `noindex, nofollow`。meta description は `index.html` に既存（本 deploy で本番反映される）。
- **scripts/prerender.mjs**: `vite build` 後、`dist/` を SPA フォールバック配信し **Playwright（既存 devDep）**の headless Chromium で `/` を描画→スナップショットを `dist/index.html` に書き戻す。**空シェル/本文欠落を検知したら fail（回帰ガード）**。ヘルスチェックはローカルスタブで安定化。
- **cd-frontend.yml**: build 後に `playwright install chromium` → `npm run prerender` を実行してから S3 sync（`/` は `index.html` 上書きのみ＝インフラ変更なし）。

Phase 2（別 PR・infra）で CloudFront Function を追加し `/company-application` 等も prerender 配信予定。

## テスト
- ローカル `npm run build && npm run prerender` → `dist/index.html` の `#root` が空でなく、hero 文言・meta description・canonical・JSON-LD×2・FAQ を含む（**14KB**、従来は空シェル）。
- `npx tsc --noEmit` / `eslint --max-warnings 0` / **`vitest run`（156 files / 1225 tests pass）** / `knip`（clean）すべて成功。
- 追加テスト: `LandingPage`（未ログイン表示 / ログイン時 `/dashboard` リダイレクト）、`useDocumentMeta`。`/`→`/dashboard` 変更に伴い login/help/command-palette の既存テスト期待値も更新。

## 関連
- Design Doc: https://frestyle.atlassian.net/browse/FRESTYLE-221
- 実装: https://frestyle.atlassian.net/browse/FRESTYLE-222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 未ログインユーザー向けの公開ランディングページを追加しました。
  * 公開ページに機能紹介、導入手順、FAQ、利用申請への導線を追加しました。
  * ページタイトルや説明、検索エンジン向け情報を設定しました。
  * 公開ページを事前描画し、表示速度と初期表示の安定性を向上しました。

* **改善**
  * ログイン後のホームを `/dashboard` に統一しました。
  * 権限のない管理ページからダッシュボードへ適切に戻るよう改善しました。
  * 認証が必要なページを検索結果に表示しないようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->