### PR TITLE
fix: 公開LPのスクロール不能・CTA不可視を修正しデザインを刷新 (FRESTYLE-223)

### DIFF
--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -90,8 +90,8 @@ const FAQS: { q: string; a: string }[] = [
  * ログイン済みで来た場合はダッシュボードへ送る（クライアント遷移時のみ。初回ロードは
  * 認証状態未確定なので LP を表示する = プリレンダーも LP になる）。
  *
- * 配色は tailwind.config.js 定義済みの brand / stone のみを使う（テーマ CSS 変数のうち
- * accent 系は未定義で、参照すると透明背景になる事故が起きた — FRESTYLE-223）。
+ * 配色は Tailwind パレット（brand / stone、正解表示のみ既存画面と同じ emerald）を使う。
+ * テーマ CSS 変数のうち accent 系は未定義で、参照すると透明背景になる事故が起きた（FRESTYLE-223）。
  */
 export default function LandingPage() {
   const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -1,43 +1,68 @@
 import { useEffect } from 'react';
 import { Link, Navigate } from 'react-router-dom';
+import {
+  ArrowRightIcon,
+  BookOpenIcon,
+  ChartBarIcon,
+  ChatBubbleLeftRightIcon,
+  CheckCircleIcon,
+  ChevronDownIcon,
+  CodeBracketIcon,
+  MapIcon,
+  UserGroupIcon,
+} from '@heroicons/react/24/outline';
 import PublicHeader from '@/shared/ui/PublicHeader';
 import { useAppSelector } from '@/shared/lib/store';
 import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 
 const SITE_URL = 'https://normanblog.com/';
 
-const FEATURES: { title: string; body: string }[] = [
+const LANGUAGES = ['PHP', 'Java', 'JavaScript', 'TypeScript', 'Go', 'Ruby', 'C', 'C++', 'SQL'];
+
+const FEATURES: { icon: typeof BookOpenIcon; title: string; body: string }[] = [
   {
+    icon: BookOpenIcon,
     title: 'コース学習',
     body: 'Git・Docker・Linux・Go・PostgreSQL からクリーンアーキテクチャまで、実務直結のコースを章立てで学べる。進捗はコースごとに記録され、続きから再開できる。',
   },
   {
+    icon: CodeBracketIcon,
     title: 'コーディング演習',
     body: 'ブラウザ上のエディタで書いて即採点。PHP・Java・JavaScript・TypeScript・Go・Ruby・C・C++・SQL など多言語に対応し、手を動かして身につける。',
   },
   {
+    icon: ChatBubbleLeftRightIcon,
     title: 'AI チャットで質問',
     body: '詰まったところを AI にその場で相談。学習の流れを止めずに、疑問を解消しながら進められる。',
   },
   {
+    icon: ChartBarIcon,
     title: '学習レポート',
     body: '取り組んだ量や進み具合をレポートで可視化。受講者は自分の伸びを、研修担当はチームの状況を把握できる。',
   },
   {
+    icon: UserGroupIcon,
     title: 'メンバーの学習状況（管理者）',
     body: '企業の研修担当は、メンバーごとの進捗・つまずきを一覧で確認。招待もマジックリンクで簡単に行える。',
   },
   {
+    icon: MapIcon,
     title: '迷わない導線',
     body: '「何を学ぶか」で迷わないよう、学習領域→コース→章の順に整理。初学者がひとりでも進められる設計。',
   },
 ];
 
+const STRENGTHS: string[] = [
+  '読むだけで終わらない — 書いて即採点する演習までが研修',
+  '受講者の伸びと研修担当の把握を、同じ場所で',
+  '初学者がひとりでも迷わず進める学習導線',
+];
+
 const STEPS: { title: string; body: string }[] = [
-  { title: '1. 利用申請', body: '企業の研修担当が利用申請を送信。折り返しご案内します。' },
-  { title: '2. メンバー招待', body: '受講者をマジックリンクで招待。受け取ったリンクから参加できます。' },
-  { title: '3. 学習開始', body: 'コース学習とコーディング演習で、手を動かしながら研修を進めます。' },
-  { title: '4. 進捗の確認', body: '学習レポートで、受講者・研修担当の双方が伸びを確認できます。' },
+  { title: '利用申請', body: '企業の研修担当が利用申請を送信。折り返しご案内します。' },
+  { title: 'メンバー招待', body: '受講者をマジックリンクで招待。受け取ったリンクから参加できます。' },
+  { title: '学習開始', body: 'コース学習とコーディング演習で、手を動かしながら研修を進めます。' },
+  { title: '進捗の確認', body: '学習レポートで、受講者・研修担当の双方が伸びを確認できます。' },
 ];
 
 const FAQS: { q: string; a: string }[] = [
@@ -64,6 +89,9 @@ const FAQS: { q: string; a: string }[] = [
  * API は叩かず純静的に描画し、ビルド時プリレンダー(Playwright)で中身入り HTML を配信する。
  * ログイン済みで来た場合はダッシュボードへ送る（クライアント遷移時のみ。初回ロードは
  * 認証状態未確定なので LP を表示する = プリレンダーも LP になる）。
+ *
+ * 配色は tailwind.config.js 定義済みの brand / stone のみを使う（テーマ CSS 変数のうち
+ * accent 系は未定義で、参照すると透明背景になる事故が起きた — FRESTYLE-223）。
  */
 export default function LandingPage() {
   const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);
@@ -86,80 +114,143 @@ export default function LandingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-[var(--color-surface)] text-[var(--color-text-primary)]">
-      <PublicHeader />
+    // body は overflow:hidden(AppShell の二重スクロールバー対策)のため、
+    // LP 自身がスクロールコンテナを持つ(h-full + overflow-y-auto)。
+    <div className="h-full overflow-y-auto bg-white text-stone-900">
+      <div className="sticky top-0 z-30">
+        <PublicHeader />
+      </div>
 
       <main>
         {/* ヒーロー */}
-        <section className="mx-auto max-w-5xl px-6 pt-16 pb-14 text-center">
-          <h1 className="text-3xl sm:text-5xl font-bold leading-tight">
-            FreStyle — 新卒ITエンジニア向け研修プラットフォーム
-          </h1>
-          <p className="mt-6 text-lg sm:text-xl text-[var(--color-text-secondary)] max-w-3xl mx-auto">
-            コース学習・多言語のコーディング演習・AI チャット・学習レポートを1つに。
-            手を動かして学び、研修の進捗をまとめて管理できます。
-          </p>
-          <div className="mt-9 flex flex-col sm:flex-row gap-3 justify-center">
-            <Link
-              to="/company-application"
-              className="inline-flex items-center justify-center rounded-lg bg-[var(--color-accent)] px-6 py-3 font-semibold text-white shadow-sm hover:opacity-90 transition"
-            >
-              企業の方：導入・利用申請
-            </Link>
-            <Link
-              to="/login"
-              className="inline-flex items-center justify-center rounded-lg border border-[var(--color-border-hover)] px-6 py-3 font-semibold text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] transition"
-            >
-              受講者の方：ログイン
-            </Link>
+        <section className="relative overflow-hidden bg-gradient-to-b from-brand-50 via-white to-white">
+          <div className="mx-auto max-w-6xl px-6 pt-16 pb-20 sm:pt-24">
+            <div className="grid items-center gap-12 lg:grid-cols-2">
+              <div className="text-center lg:text-left">
+                <p className="inline-flex items-center gap-1.5 rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-xs font-semibold text-brand-700">
+                  企業向け・新卒エンジニア研修 SaaS
+                </p>
+                <h1 className="mt-5 text-3xl font-bold leading-tight tracking-tight sm:text-4xl lg:text-[2.6rem]">
+                  「わかる」で終わらせない、
+                  <br />
+                  <span className="text-brand-600">新卒ITエンジニア向け研修プラットフォーム</span>
+                </h1>
+                <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-stone-600 sm:text-lg lg:mx-0">
+                  コース学習・多言語のコーディング演習・AI チャット・学習レポートを1つに。
+                  手を動かして学び、研修の進捗をまとめて管理できます。
+                </p>
+                <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row lg:justify-start">
+                  <Link
+                    to="/company-application"
+                    className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-600 px-6 py-3 font-semibold text-white shadow-sm transition hover:bg-brand-700"
+                  >
+                    企業の方：導入・利用申請
+                    <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                  <Link
+                    to="/login"
+                    className="inline-flex items-center justify-center rounded-lg border border-stone-300 bg-white px-6 py-3 font-semibold text-stone-800 transition hover:bg-stone-50"
+                  >
+                    受講者の方：ログイン
+                  </Link>
+                </div>
+                <ul className="mt-8 flex flex-wrap justify-center gap-1.5 lg:justify-start" aria-label="演習対応言語">
+                  {LANGUAGES.map((lang) => (
+                    <li
+                      key={lang}
+                      className="rounded-md border border-stone-200 bg-white px-2 py-0.5 font-mono text-xs text-stone-600"
+                    >
+                      {lang}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {/* プロダクトの体験を伝えるエディタ風モック(装飾・CSS のみ) */}
+              <div aria-hidden="true" className="hidden lg:block">
+                <div className="rounded-xl border border-stone-200 bg-white shadow-xl shadow-brand-100/60">
+                  <div className="flex items-center gap-1.5 border-b border-stone-200 px-4 py-3">
+                    <span className="h-2.5 w-2.5 rounded-full bg-stone-300" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-stone-300" />
+                    <span className="h-2.5 w-2.5 rounded-full bg-stone-300" />
+                    <span className="ml-3 text-xs font-medium text-stone-500">コーディング演習 — greet.js</span>
+                  </div>
+                  <pre className="overflow-hidden px-5 py-4 font-mono text-[13px] leading-6 text-stone-700">
+                    <code>
+                      {'function greet(name) {\n'}
+                      {"  return 'こんにちは、' + name + ' さん';\n"}
+                      {'}\n'}
+                    </code>
+                  </pre>
+                  <div className="mx-5 mb-5 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                    <p className="flex items-center gap-1.5 text-sm font-semibold text-emerald-700">
+                      <CheckCircleIcon className="h-5 w-5" aria-hidden="true" />
+                      正解 — 実行結果が期待出力と一致しました
+                    </p>
+                    <p className="mt-1 pl-6 font-mono text-xs text-emerald-800">こんにちは、FreStyle さん</p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </section>
 
         {/* FreStyle とは */}
-        <section className="bg-[var(--color-surface-1)] border-y border-[var(--color-surface-3)]">
-          <div className="mx-auto max-w-4xl px-6 py-14">
-            <h2 className="text-2xl font-bold">FreStyle とは</h2>
-            <p className="mt-4 text-[var(--color-text-secondary)] leading-relaxed">
-              FreStyle は、新卒・若手 IT エンジニアの研修を一気通貫で支える統合プラットフォームです。
-              読むだけの座学で終わらせず、ブラウザ上のエディタで書いて即採点する演習まで含めることで、
-              「わかる」だけでなく「できる」に届く研修を実現します。受講者は自分の伸びを、
-              企業の研修担当はメンバーの学習状況を、それぞれ同じ場所で把握できます。
-            </p>
+        <section className="border-y border-stone-200 bg-stone-50">
+          <div className="mx-auto grid max-w-6xl gap-10 px-6 py-16 lg:grid-cols-2 lg:gap-16">
+            <div>
+              <h2 className="text-2xl font-bold">FreStyle とは</h2>
+              <p className="mt-4 leading-relaxed text-stone-600">
+                FreStyle は、新卒・若手 IT エンジニアの研修を一気通貫で支える統合プラットフォームです。
+                読むだけの座学で終わらせず、ブラウザ上のエディタで書いて即採点する演習まで含めることで、
+                「わかる」だけでなく「できる」に届く研修を実現します。受講者は自分の伸びを、
+                企業の研修担当はメンバーの学習状況を、それぞれ同じ場所で把握できます。
+              </p>
+            </div>
+            <ul className="space-y-4 self-center">
+              {STRENGTHS.map((strength) => (
+                <li key={strength} className="flex items-start gap-3">
+                  <CheckCircleIcon className="mt-0.5 h-6 w-6 shrink-0 text-brand-600" aria-hidden="true" />
+                  <span className="font-medium text-stone-800">{strength}</span>
+                </li>
+              ))}
+            </ul>
           </div>
         </section>
 
         {/* 主な機能 */}
-        <section className="mx-auto max-w-6xl px-6 py-16">
-          <h2 className="text-2xl font-bold text-center">主な機能</h2>
-          <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        <section className="mx-auto max-w-6xl px-6 py-20">
+          <h2 className="text-center text-2xl font-bold sm:text-3xl">主な機能</h2>
+          <p className="mt-3 text-center text-stone-600">研修の実施から進捗管理まで、必要なものを1つに。</p>
+          <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             {FEATURES.map((feature) => (
               <div
                 key={feature.title}
-                className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-6"
+                className="rounded-xl border border-stone-200 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
               >
-                <h3 className="text-lg font-semibold">{feature.title}</h3>
-                <p className="mt-3 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-                  {feature.body}
-                </p>
+                <span className="inline-flex h-11 w-11 items-center justify-center rounded-lg bg-brand-50">
+                  <feature.icon className="h-6 w-6 text-brand-600" aria-hidden="true" />
+                </span>
+                <h3 className="mt-4 text-lg font-semibold">{feature.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-stone-600">{feature.body}</p>
               </div>
             ))}
           </div>
         </section>
 
         {/* 導入の流れ */}
-        <section className="bg-[var(--color-surface-1)] border-y border-[var(--color-surface-3)]">
-          <div className="mx-auto max-w-6xl px-6 py-16">
-            <h2 className="text-2xl font-bold text-center">導入の流れ</h2>
-            <ol className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-              {STEPS.map((step) => (
-                <li
-                  key={step.title}
-                  className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface)] p-6"
-                >
-                  <h3 className="text-base font-semibold text-[var(--color-accent)]">{step.title}</h3>
-                  <p className="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-                    {step.body}
-                  </p>
+        <section className="border-y border-stone-200 bg-stone-50">
+          <div className="mx-auto max-w-6xl px-6 py-20">
+            <h2 className="text-center text-2xl font-bold sm:text-3xl">導入の流れ</h2>
+            <p className="mt-3 text-center text-stone-600">申請から研修開始まで、4 ステップで始められます。</p>
+            <ol className="mt-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+              {STEPS.map((step, index) => (
+                <li key={step.title} className="relative">
+                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-600 text-base font-bold text-white">
+                    {index + 1}
+                  </span>
+                  <h3 className="mt-4 text-base font-semibold">{step.title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-stone-600">{step.body}</p>
                 </li>
               ))}
             </ol>
@@ -167,56 +258,67 @@ export default function LandingPage() {
         </section>
 
         {/* FAQ */}
-        <section className="mx-auto max-w-4xl px-6 py-16">
-          <h2 className="text-2xl font-bold text-center">よくある質問</h2>
-          <dl className="mt-10 space-y-6">
-            {FAQS.map((item) => (
-              <div
-                key={item.q}
-                className="rounded-xl border border-[var(--color-surface-3)] bg-[var(--color-surface-1)] p-6"
+        <section className="mx-auto max-w-3xl px-6 py-20">
+          <h2 className="text-center text-2xl font-bold sm:text-3xl">よくある質問</h2>
+          <div className="mt-10 space-y-3">
+            {FAQS.map((faq) => (
+              <details
+                key={faq.q}
+                className="group rounded-xl border border-stone-200 bg-white open:shadow-sm"
               >
-                <dt className="font-semibold">{item.q}</dt>
-                <dd className="mt-2 text-sm text-[var(--color-text-secondary)] leading-relaxed">
-                  {item.a}
-                </dd>
-              </div>
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4 font-semibold [&::-webkit-details-marker]:hidden">
+                  {faq.q}
+                  <ChevronDownIcon
+                    className="h-5 w-5 shrink-0 text-stone-400 transition-transform group-open:rotate-180"
+                    aria-hidden="true"
+                  />
+                </summary>
+                <p className="px-5 pb-5 text-sm leading-relaxed text-stone-600">{faq.a}</p>
+              </details>
             ))}
-          </dl>
+          </div>
         </section>
 
-        {/* 末尾 CTA */}
-        <section className="bg-[var(--color-surface-1)] border-t border-[var(--color-surface-3)]">
-          <div className="mx-auto max-w-4xl px-6 py-14 text-center">
-            <h2 className="text-2xl font-bold">研修の実施と管理を、FreStyle で。</h2>
-            <p className="mt-4 text-[var(--color-text-secondary)]">
+        {/* CTA バンド */}
+        <section className="bg-brand-600">
+          <div className="mx-auto max-w-4xl px-6 py-16 text-center">
+            <h2 className="text-2xl font-bold text-white sm:text-3xl">研修の実施と管理を、FreStyle で。</h2>
+            <p className="mt-3 text-brand-100">
               まずは企業の利用申請から。受講者の方は招待リンクからログインできます。
             </p>
-            <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+            <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
               <Link
                 to="/company-application"
-                className="inline-flex items-center justify-center rounded-lg bg-[var(--color-accent)] px-6 py-3 font-semibold text-white shadow-sm hover:opacity-90 transition"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-semibold text-brand-700 shadow-sm transition hover:bg-brand-50"
               >
-                利用申請する
+                企業の方：導入・利用申請
+                <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
               </Link>
               <Link
                 to="/login"
-                className="inline-flex items-center justify-center rounded-lg border border-[var(--color-border-hover)] px-6 py-3 font-semibold text-[var(--color-text-primary)] hover:bg-[var(--color-surface-2)] transition"
+                className="inline-flex items-center justify-center rounded-lg border border-brand-300 px-6 py-3 font-semibold text-white transition hover:bg-brand-700"
               >
-                ログイン
+                受講者の方：ログイン
               </Link>
             </div>
           </div>
         </section>
       </main>
 
-      <footer className="border-t border-[var(--color-surface-3)]">
-        <div className="mx-auto max-w-6xl px-6 py-8 text-sm text-[var(--color-text-muted)] flex flex-col sm:flex-row items-center justify-between gap-3">
-          <p>FreStyle — 新卒ITエンジニア向け研修プラットフォーム</p>
-          <nav className="flex gap-5">
-            <Link to="/login" className="hover:text-[var(--color-text-primary)]">
+      {/* フッター */}
+      <footer className="bg-stone-900">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-6 px-6 py-10 sm:flex-row">
+          <div className="flex items-center gap-2">
+            <img src="/favicon.svg" alt="" aria-hidden="true" className="h-6 w-6" />
+            <span className="text-sm font-semibold text-white">
+              FreStyle — 新卒ITエンジニア向け研修プラットフォーム
+            </span>
+          </div>
+          <nav className="flex items-center gap-6 text-sm text-stone-400" aria-label="フッター">
+            <Link to="/login" className="transition hover:text-white">
               ログイン
             </Link>
-            <Link to="/company-application" className="hover:text-[var(--color-text-primary)]">
+            <Link to="/company-application" className="transition hover:text-white">
               利用申請
             </Link>
           </nav>

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -54,4 +54,9 @@ describe('LandingPage', () => {
     renderLanding(true);
     expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
   });
+
+  it('LP 自身がスクロールコンテナを持つ（body overflow hidden 下でスクロール不能になった回帰: FRESTYLE-223）', () => {
+    const { container } = renderLanding(false);
+    expect(container.querySelector('.overflow-y-auto')).not.toBeNull();
+  });
 });

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -57,6 +57,7 @@ describe('LandingPage', () => {
 
   it('LP 自身がスクロールコンテナを持つ（body overflow hidden 下でスクロール不能になった回帰: FRESTYLE-223）', () => {
     const { container } = renderLanding(false);
-    expect(container.querySelector('.overflow-y-auto')).not.toBeNull();
+    // ルート要素そのものがスクロールコンテナであること（子孫のどこかでは不十分）
+    expect(container.firstElementChild).toHaveClass('h-full', 'overflow-y-auto');
   });
 });

--- a/frontend/src/widgets/auth-layout/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/widgets/auth-layout/__tests__/AuthLayout.test.tsx
@@ -30,9 +30,11 @@ describe('AuthLayout', () => {
 
   it('中央寄せレイアウトが適用される', () => {
     const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
-    // 外枠は min-h-screen の縦並び、内側に中央寄せの領域を持つ(header スロット追加に伴う構造)。
+    // 外枠は自身がスクロールコンテナ(body overflow hidden 対策: FRESTYLE-223)、
+    // 内側は min-h-full の縦並びで、短いコンテンツは中央寄せされる。
     const root = container.firstElementChild as HTMLElement;
-    expect(root.className).toContain('min-h-screen');
+    expect(root.className).toContain('overflow-y-auto');
+    expect(container.querySelector('.min-h-full')).not.toBeNull();
     const centered = container.querySelector('.items-center.justify-center') as HTMLElement;
     expect(centered).not.toBeNull();
   });

--- a/frontend/src/widgets/auth-layout/__tests__/AuthLayout.test.tsx
+++ b/frontend/src/widgets/auth-layout/__tests__/AuthLayout.test.tsx
@@ -31,10 +31,10 @@ describe('AuthLayout', () => {
   it('中央寄せレイアウトが適用される', () => {
     const { container } = render(<AuthLayout><div>テスト</div></AuthLayout>);
     // 外枠は自身がスクロールコンテナ(body overflow hidden 対策: FRESTYLE-223)、
-    // 内側は min-h-full の縦並びで、短いコンテンツは中央寄せされる。
+    // 直下の内側要素は min-h-full の縦並びで、短いコンテンツは中央寄せされる。
     const root = container.firstElementChild as HTMLElement;
-    expect(root.className).toContain('overflow-y-auto');
-    expect(container.querySelector('.min-h-full')).not.toBeNull();
+    expect(root).toHaveClass('h-full', 'overflow-y-auto');
+    expect(root.firstElementChild).toHaveClass('min-h-full', 'flex', 'flex-col');
     const centered = container.querySelector('.items-center.justify-center') as HTMLElement;
     expect(centered).not.toBeNull();
   });

--- a/frontend/src/widgets/auth-layout/ui/AuthLayout.tsx
+++ b/frontend/src/widgets/auth-layout/ui/AuthLayout.tsx
@@ -14,10 +14,13 @@ export default function AuthLayout({ children, title, footer, header }: AuthLayo
   useDocumentMeta({ robots: 'noindex, nofollow' });
 
   return (
-    <div className="min-h-screen flex flex-col bg-surface">
-      {header}
+    // body は overflow:hidden(AppShell の二重スクロールバー対策)のため、公開ページは
+    // 自身がスクロールコンテナを持つ。内側の min-h-full で短いコンテンツは従来どおり中央寄せ。
+    <div className="h-full overflow-y-auto bg-surface">
+      <div className="min-h-full flex flex-col">
+        {header}
 
-      <div className="flex flex-1 flex-col items-center justify-center px-4 py-12">
+        <div className="flex flex-1 flex-col items-center justify-center px-4 py-12">
         <div className="mb-6 flex flex-col items-center">
           <img
             src="/favicon.svg"
@@ -36,11 +39,12 @@ export default function AuthLayout({ children, title, footer, header }: AuthLayo
           {children}
         </div>
 
-        {footer && (
-          <div className="w-full max-w-sm bg-surface-1 rounded-xl border border-surface-3 p-4 text-center mt-4">
-            {footer}
-          </div>
-        )}
+          {footer && (
+            <div className="w-full max-w-sm bg-surface-1 rounded-xl border border-surface-3 p-4 text-center mt-4">
+              {footer}
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要

FRESTYLE-222 で公開した LP に本番で 2 つの不具合(スクロール不能・メイン CTA ボタン不可視)があり、あわせてデザインを刷新する。

## 変更内容

### 不具合修正
- **スクロール不能**: グローバル CSS の `body { overflow: hidden }`(AppShell の二重スクロールバー対策)により、内側スクロールコンテナを持たない LP が一切スクロールできなかった。LP と AuthLayout(ログイン/利用申請等の公開ページ共通)に `h-full + overflow-y-auto` のスクロールコンテナを追加。グローバル CSS は変更しない
- **CTA 不可視**: LP が参照していた CSS 変数 `--color-accent` が index.css に未定義(定義は surface/nav/text 系のみ)で、背景透明+白文字になり「企業の利用申請」ボタンが見えなかった。tailwind.config.js 定義済みの brand パレットに置き換え

### デザイン刷新
- グラデーションヒーロー + バッジ + 見出しのブランドカラーアクセント + 対応言語チップ
- エディタ風モック(CSS のみ・コーディング演習の体験を可視化)
- アイコン付き機能カード(hover でリフト) / ステップ番号付き導入フロー
- FAQ を details/summary のアコーディオンに(JS 不要・プリレンダー適合)
- ブランドカラーの CTA バンド + ダークフッター

## テスト

- vitest 1227 passed(カバレッジ 85.86%)。LP・AuthLayout にスクロールコンテナの回帰テストを追加
- tsc / eslint --max-warnings 0 / build + prerender すべて成功
- プリレンダー出力を Playwright で開き、スクロール実動作(scrollTop 反映)・CTA 表示・FAQ 開閉をスクリーンショットで目視確認

## 関連チケット

- FRESTYLE-223 https://frestyle.atlassian.net/browse/FRESTYLE-223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ランディングページを全面刷新し、ヒーロー、機能紹介、対応言語、導入手順、FAQ、CTA、フッターを追加・改善しました。
  * 機能項目にアイコンを追加し、ブランドカラーを基調としたデザインに更新しました。
  * FAQを開閉式に変更しました。
* **改善**
  * ランディングページと認証画面で、ページ全体をスクロールできるレイアウトに変更しました。
  * コンテンツの中央寄せとヘッダー・フッターの配置を維持しつつ、長いページでも閲覧しやすくしました。
* **テスト**
  * スクロールレイアウトに関する回帰テストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->