### PR TITLE
feat: frestyle.jp 移行 Phase 5 — アプリ本体のドメイン切替 (FRESTYLE-225)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -4,10 +4,10 @@
 // @version         2.0
 // @description     新卒 IT エンジニア 向け 統合 研修 プラットフォーム の REST API。
 // @description     Clean Architecture (port = usecase/repository / adapter = adapter/persistence) で 構築。
-// @termsOfService  https://normanblog.com/terms
+// @termsOfService  https://frestyle.jp/terms
 //
 // @contact.name    FreStyle Engineering
-// @contact.url     https://normanblog.com
+// @contact.url     https://frestyle.jp
 //
 // @BasePath        /api/v2
 //

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -9,10 +9,10 @@ const docTemplate = `{
     "info": {
         "description": "{{escape .Description}}",
         "title": "{{.Title}}",
-        "termsOfService": "https://normanblog.com/terms",
+        "termsOfService": "https://frestyle.jp/terms",
         "contact": {
             "name": "FreStyle Engineering",
-            "url": "https://normanblog.com"
+            "url": "https://frestyle.jp"
         },
         "version": "{{.Version}}"
     },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -3,10 +3,10 @@
     "info": {
         "description": "新卒 IT エンジニア 向け 統合 研修 プラットフォーム の REST API。\nClean Architecture (port = usecase/repository / adapter = adapter/persistence) で 構築。",
         "title": "FreStyle Backend API",
-        "termsOfService": "https://normanblog.com/terms",
+        "termsOfService": "https://frestyle.jp/terms",
         "contact": {
             "name": "FreStyle Engineering",
-            "url": "https://normanblog.com"
+            "url": "https://frestyle.jp"
         },
         "version": "2.0"
     },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1078,11 +1078,11 @@ definitions:
 info:
   contact:
     name: FreStyle Engineering
-    url: https://normanblog.com
+    url: https://frestyle.jp
   description: |-
     新卒 IT エンジニア 向け 統合 研修 プラットフォーム の REST API。
     Clean Architecture (port = usecase/repository / adapter = adapter/persistence) で 構築。
-  termsOfService: https://normanblog.com/terms
+  termsOfService: https://frestyle.jp/terms
   title: FreStyle Backend API
   version: "2.0"
 paths:

--- a/backend/internal/handler/middleware/cors.go
+++ b/backend/internal/handler/middleware/cors.go
@@ -10,11 +10,11 @@ import (
 // frestyle.jp はブランドドメイン移行後の本番(FRESTYLE-225)。normanblog.com は
 // 301 リダイレクトの安定稼働を確認するまで残す(整理は別チケット)。
 var allowedOrigins = map[string]struct{}{
-	"https://frestyle.jp":                                             {},
-	"https://normanblog.com":                                          {},
-	"http://normanblog.com":                                           {},
-	"http://localhost:5173":                                           {},
-	"https://dcd3m6lwt0z8u.cloudfront.net":                            {},
+	"https://frestyle.jp":                  {},
+	"https://normanblog.com":               {},
+	"http://normanblog.com":                {},
+	"http://localhost:5173":                {},
+	"https://dcd3m6lwt0z8u.cloudfront.net": {},
 	"http://fre-style-bucket.s3-website-ap-northeast-1.amazonaws.com": {},
 }
 

--- a/backend/internal/handler/middleware/cors.go
+++ b/backend/internal/handler/middleware/cors.go
@@ -7,7 +7,10 @@ import (
 )
 
 // allowedOrigins は CORS で許可するオリジン。
+// frestyle.jp はブランドドメイン移行後の本番(FRESTYLE-225)。normanblog.com は
+// 301 リダイレクトの安定稼働を確認するまで残す(整理は別チケット)。
 var allowedOrigins = map[string]struct{}{
+	"https://frestyle.jp":                                             {},
 	"https://normanblog.com":                                          {},
 	"http://normanblog.com":                                           {},
 	"http://localhost:5173":                                           {},

--- a/backend/internal/handler/middleware/cors_test.go
+++ b/backend/internal/handler/middleware/cors_test.go
@@ -7,6 +7,7 @@ func Test_許可オリジン判定(t *testing.T) {
 		origin string
 		want   bool
 	}{
+		{"https://frestyle.jp", true},
 		{"https://normanblog.com", true},
 		{"http://localhost:5173", true},
 		{"https://evil.example.com", false},

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	DBSSLMode  string
 
 	// AppBaseURL は招待マジックリンクの組み立てに使う、フロントエンドの絶対 URL。
-	// 例: https://normanblog.com (末尾スラッシュ無し / 有り どちらも可)
+	// 例: https://frestyle.jp (末尾スラッシュ無し / 有り どちらも可)
 	AppBaseURL string
 
 	// CodeRunnerURL はコード実行サイドカー（cmd/coderunner）の baseURL。
@@ -57,7 +57,7 @@ type DynamoDBConfig struct {
 }
 
 // SESConfig は招待マジックリンクメール送信用の SES v2 設定。
-// FromAddress は SES で検証済の送信元（例: "FreStyle <noreply@normanblog.com>"）。
+// FromAddress は SES で検証済の送信元（例: "FreStyle <noreply@frestyle.jp>"）。
 // 未設定（空文字）のときは送信スキップ → token をログに残してフォールバック。
 type SESConfig struct {
 	Region      string

--- a/backend/internal/infra/embed/oembed_fetcher.go
+++ b/backend/internal/infra/embed/oembed_fetcher.go
@@ -20,7 +20,7 @@ const (
 	maxBodyBytes       = 512 * 1024 // OGP 抽出に必要なのは <head> の一部のみ
 	cacheTTL           = 30 * time.Minute
 	cacheMaxEntries    = 256
-	userAgent          = "FreStyle/1.0 (+https://normanblog.com)"
+	userAgent          = "FreStyle/1.0 (+https://frestyle.jp)"
 )
 
 // Card はフロントエンドに返す統一カード DTO。

--- a/backend/internal/infra/ses/client.go
+++ b/backend/internal/infra/ses/client.go
@@ -19,7 +19,7 @@ type Client struct {
 }
 
 // NewClient は ECS Task Role / 環境変数の認証情報チェーンで SES クライアントを組み立てる。
-// fromAddress は SES で検証済の送信元（例: "FreStyle <noreply@normanblog.com>"）を渡す。
+// fromAddress は SES で検証済の送信元（例: "FreStyle <noreply@frestyle.jp>"）を渡す。
 func NewClient(ctx context.Context, region, fromAddress string) (*Client, error) {
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -12,7 +12,7 @@ import { test, expect } from '@playwright/test';
  * 依存するため、別 spec で `storageState` 経由の事前認証パターンを使う想定。
  */
 
-const API_BASE = 'https://api.normanblog.com';
+const API_BASE = 'https://api.frestyle.jp';
 
 test.describe('FreStyle smoke', () => {
   test('SPA がロードされ FreStyle ブランドが見える', async ({ page }) => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
         - img-src 'self' data: https: blob:               : avatar / CDN 経由画像 / data URL /
                                                            URL.createObjectURL() プレビュー（添付チップ）
         - font-src 'self' data:                         : ローカルフォント + base64 埋め込み
-        - connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com
+        - connect-src 'self' https://api.frestyle.jp https://api.normanblog.com https://*.amazoncognito.com wss://api.frestyle.jp wss://api.normanblog.com
                        https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com
                                                          : API / WebSocket / Cognito callback /
                                                            プロフィール / Note 画像の S3 presigned PUT
@@ -29,7 +29,7 @@
       `report-uri` / `report-to` / `sandbox` も同様 meta では無視されるので、配信が必要な場合は
       CloudFront 側に追加する。
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.normanblog.com https://*.amazoncognito.com wss://api.normanblog.com https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com; form-action 'self' https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.frestyle.jp https://api.normanblog.com https://*.amazoncognito.com wss://api.frestyle.jp wss://api.normanblog.com https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com; form-action 'self' https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <!--
@@ -46,7 +46,7 @@
       name="description"
       content="FreStyle は新卒ITエンジニアの研修を一つにまとめた企業向け学習プラットフォームです。教材・コーディング演習・AI 学習支援・学習レポートで、新人エンジニアが即戦力になるまでを支援します。"
     />
-    <link rel="canonical" href="https://normanblog.com/" />
+    <link rel="canonical" href="https://frestyle.jp/" />
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="FreStyle" />
     <meta property="og:title" content="FreStyle | 新卒ITエンジニア向け研修プラットフォーム" />
@@ -54,8 +54,8 @@
       property="og:description"
       content="新卒ITエンジニアの研修を一つにまとめた企業向け学習プラットフォーム。教材・コーディング演習・AI 学習支援・学習レポートを提供します。"
     />
-    <meta property="og:url" content="https://normanblog.com/" />
-    <meta property="og:image" content="https://normanblog.com/ogp.png" />
+    <meta property="og:url" content="https://frestyle.jp/" />
+    <meta property="og:image" content="https://frestyle.jp/ogp.png" />
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary" />
     <script type="application/ld+json">
@@ -64,19 +64,19 @@
         "@graph": [
           {
             "@type": "Organization",
-            "@id": "https://normanblog.com/#organization",
+            "@id": "https://frestyle.jp/#organization",
             "name": "FreStyle",
-            "url": "https://normanblog.com/",
-            "logo": "https://normanblog.com/ogp.png"
+            "url": "https://frestyle.jp/",
+            "logo": "https://frestyle.jp/ogp.png"
           },
           {
             "@type": "WebSite",
-            "@id": "https://normanblog.com/#website",
-            "url": "https://normanblog.com/",
+            "@id": "https://frestyle.jp/#website",
+            "url": "https://frestyle.jp/",
             "name": "FreStyle",
             "description": "新卒ITエンジニア向け研修プラットフォーム。教材・コーディング演習・AI 学習支援・学習レポートを提供する企業向け学習サービス。",
             "inLanguage": "ja",
-            "publisher": { "@id": "https://normanblog.com/#organization" }
+            "publisher": { "@id": "https://frestyle.jp/#organization" }
           }
         ]
       }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright E2E config
  *
- * - 既定 baseURL は production (https://normanblog.com)。
+ * - 既定 baseURL は production (https://frestyle.jp)。
  *   ローカルや Preview 環境を狙うときは PLAYWRIGHT_BASE_URL を上書きする。
  * - CI では retries=2 + workers=2、ローカルは retries=0 で速く回す。
  * - 失敗時は trace + screenshot + video を artifact として残す。
@@ -27,7 +27,7 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://normanblog.com',
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://frestyle.jp',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://normanblog.com/sitemap.xml
+Sitemap: https://frestyle.jp/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -2,11 +2,11 @@
 <!-- 公開ページのみ掲載する（認証必須ページは載せない） -->
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://normanblog.com/</loc>
+    <loc>https://frestyle.jp/</loc>
     <lastmod>2026-07-25</lastmod>
   </url>
   <url>
-    <loc>https://normanblog.com/company-application</loc>
+    <loc>https://frestyle.jp/company-application</loc>
     <lastmod>2026-07-25</lastmod>
   </url>
 </urlset>

--- a/frontend/src/generated/openapi.json
+++ b/frontend/src/generated/openapi.json
@@ -3,10 +3,10 @@
     "info": {
         "description": "新卒 IT エンジニア 向け 統合 研修 プラットフォーム の REST API。\nClean Architecture (port = usecase/repository / adapter = adapter/persistence) で 構築。",
         "title": "FreStyle Backend API",
-        "termsOfService": "https://normanblog.com/terms",
+        "termsOfService": "https://frestyle.jp/terms",
         "contact": {
             "name": "FreStyle Engineering",
-            "url": "https://normanblog.com"
+            "url": "https://frestyle.jp"
         },
         "version": "2.0"
     },

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -15,7 +15,7 @@ import PublicHeader from '@/shared/ui/PublicHeader';
 import { useAppSelector } from '@/shared/lib/store';
 import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 
-const SITE_URL = 'https://normanblog.com/';
+const SITE_URL = 'https://frestyle.jp/';
 
 const LANGUAGES = ['PHP', 'Java', 'JavaScript', 'TypeScript', 'Go', 'Ruby', 'C', 'C++', 'SQL'];
 

--- a/frontend/src/pages/markdown-syntax-help/ui/MarkdownSyntaxHelpPage.tsx
+++ b/frontend/src/pages/markdown-syntax-help/ui/MarkdownSyntaxHelpPage.tsx
@@ -86,11 +86,11 @@ export default function MarkdownSyntaxHelpPage() {
 
       <Section title="リンク / 画像">
         <Row
-          code={`[FreStyle](https://normanblog.com)\n\n![代替テキスト](https://placehold.jp/120x40.png)`}
+          code={`[FreStyle](https://frestyle.jp)\n\n![代替テキスト](https://placehold.jp/120x40.png)`}
         >
           <p className="m-0">
             <a
-              href="https://normanblog.com"
+              href="https://frestyle.jp"
               target="_blank"
               rel="noopener noreferrer"
               className="text-brand-400 underline-offset-2 hover:underline"
@@ -162,15 +162,15 @@ export default function MarkdownSyntaxHelpPage() {
       </Section>
 
       <Section title="自動リンク (GFM)">
-        <Row code={`https://normanblog.com を直接書くだけでリンクになります`}>
+        <Row code={`https://frestyle.jp を直接書くだけでリンクになります`}>
           <p className="m-0 text-[var(--color-text-primary)]">
             <a
-              href="https://normanblog.com"
+              href="https://frestyle.jp"
               target="_blank"
               rel="noopener noreferrer"
               className="text-brand-400 underline-offset-2 hover:underline"
             >
-              https://normanblog.com
+              https://frestyle.jp
             </a>
             を直接書くだけでリンクになります
           </p>


### PR DESCRIPTION
## 概要

ブランドドメイン移行(FRESTYLE-225)のアプリ側切替。frestyle.jp を正式ドメイン(canonical)とし、API 通信・SEO メタ・E2E をすべて新ドメイン基準に切り替える。旧ドメインの許可(CORS/CSP)は 301 リダイレクト安定稼働の確認まで残す。

## 変更内容

### backend
- CORS(ブラウザが別ドメインの API を呼ぶときの許可リスト)に https://frestyle.jp を追加 + テスト
- oembed User-Agent / swagger annotation / コメントの例示 URL を新ドメインへ
- `make openapi` 再生成(docs/)

### frontend
- index.html: canonical(検索エンジンに伝える正式 URL)・OGP・JSON-LD を frestyle.jp へ。CSP の connect-src に api.frestyle.jp を追加(旧 API 併記)
- LandingPage の SITE_URL・sitemap.xml・robots.txt を frestyle.jp へ
- e2e: smoke の API_BASE → api.frestyle.jp、playwright baseURL → frestyle.jp
- openapi:generate 再生成(src/generated/)

## テスト

- backend: go build + go test 全 13 パッケージ ok
- frontend: tsc / vitest 1227 passed / build + prerender 成功(出力 HTML の canonical が https://frestyle.jp/ であることを確認)

## デプロイ手順(マージ後・チケットに記録)

1. バックエンドデプロイ(CORS 反映)
2. infra 側 ECS 環境変数切替(別 PR) + GitHub Secrets(VITE_API_BASE_URL / VITE_REDIRECT_URI)切替
3. フロントエンドデプロイ → frestyle.jp でログイン一連を確認
4. normanblog.com → frestyle.jp の 301(CloudFront Function)

## 関連チケット

- FRESTYLE-225 https://frestyle.atlassian.net/browse/FRESTYLE-225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * サービスの公式ドメインを `frestyle.jp` に更新しました。
  * ページの正規URL、SNS共有情報、サイトマップ、検索エンジン向け設定を新ドメインに統一しました。
  * APIおよびWebSocket接続先を新ドメインに対応しました。
  * Markdownヘルプ内のURL例を更新しました。
  * Swaggerの利用規約・連絡先情報を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->