### PR TITLE
fix: フロントの公開 URL(API/リダイレクト先)を workflow に直接記載 (FRESTYLE-225)

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -55,12 +55,14 @@ jobs:
         working-directory: ./frontend
 
     env:
-      VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+      # 公開 URL(公開 JS に焼き込まれる値)は Secret にする必要がないため直接記載する。
+      # frestyle.jp 移行(FRESTYLE-225)で Secrets 更新に依存しない構成に変更。
+      VITE_API_BASE_URL: https://api.frestyle.jp
+      VITE_REDIRECT_URI: https://frestyle.jp/login/callback
       VITE_WEB_SOCKET_URL_AI_CHAT: ${{ secrets.VITE_WEB_SOCKET_URL_AI_CHAT }}
       VITE_WEB_SOCKET_URL_CHAT: ${{ secrets.VITE_WEB_SOCKET_URL_CHAT }}
       VITE_COGNITO_DOMAIN: ${{ secrets.VITE_COGNITO_DOMAIN }}
       VITE_CLIENT_ID: ${{ secrets.VITE_CLIENT_ID }}
-      VITE_REDIRECT_URI: ${{ secrets.VITE_REDIRECT_URI }}
       VITE_RESPONSE_TYPE: ${{ secrets.VITE_RESPONSE_TYPE }}
       VITE_SCOPE: ${{ secrets.VITE_SCOPE }}
 


### PR DESCRIPTION
## 概要

frestyle.jp 切替で必要な `VITE_API_BASE_URL` / `VITE_REDIRECT_URI` は**公開 JS に焼き込まれる公開値**であり Secret にする意味がないため、cd-frontend.yml に直接記載する。Secrets の手動更新に依存しない構成になる。

## 緊急性

ECS 側の COGNITO_REDIRECT_URI は frestyle.jp に切替済みだが、フロントが旧 Secrets 値でビルドされたため**現在ログインが一時的に失敗する状態**。本 PR のマージ + 再デプロイで復旧する。

## 変更内容

- cd-frontend.yml: 2 変数を Secrets 参照から直接値へ(他の Secrets 参照は変更なし)

## テスト

- workflow ファイルのみの変更(アプリコード無変更)。デプロイ後に本番 JS へ api.frestyle.jp が焼き込まれていることを確認する

## 関連チケット

- FRESTYLE-225 https://frestyle.atlassian.net/browse/FRESTYLE-225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * フロントエンドのデプロイ設定を更新し、公開環境で使用するAPI接続先とリダイレクト先を固定の公開URLに変更しました。
  * その他の環境設定は従来どおり安全に管理されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->