### PR TITLE
feat: トップページをログイン済みならダッシュボードへ自動遷移 (FRESTYLE-225)

### DIFF
--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -80,6 +80,14 @@ async function startServer() {
         res.end('{"status":"ok"}');
         return;
       }
+      // その他の API は 401(未ログイン)を返す。SPA フォールバックで index.html(200)が
+      // 返ると LP の認証確認が「ログイン済み」と誤判定し、プリレンダーが
+      // ダッシュボードへのリダイレクトを撮ってしまうため。
+      if (req.url && req.url.startsWith('/api/')) {
+        res.writeHead(401, { 'content-type': 'application/json' });
+        res.end('{"error":"unauthorized"}');
+        return;
+      }
       const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
       const filePath = (urlPath !== '/' && files.get(urlPath)) || indexPath;
       const body = await readFile(filePath);

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -12,8 +12,9 @@ import {
   UserGroupIcon,
 } from '@heroicons/react/24/outline';
 import PublicHeader from '@/shared/ui/PublicHeader';
-import { useAppSelector } from '@/shared/lib/store';
+import { useAppSelector, useAppDispatch } from '@/shared/lib/store';
 import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
+import { AuthRepository, setAuthData } from '@/entities/user';
 
 const SITE_URL = 'https://frestyle.jp/';
 
@@ -95,6 +96,35 @@ const FAQS: { q: string; a: string }[] = [
  */
 export default function LandingPage() {
   const isAuthenticated = useAppSelector((state) => state.auth.isAuthenticated);
+  const dispatch = useAppDispatch();
+
+  // ログイン済みユーザーが直接 / を開いたときダッシュボードへ送るため、マウント時に
+  // 一度だけ認証状態を確認する(Cookie は HttpOnly のため API に聞くしかない)。
+  // 確認中・未ログイン(401)は LP をそのまま表示する(スピナーで隠すと SEO と初訪 UX を損なう)。
+  // プリレンダー時はローカルサーバが /auth/me に 401 を返すので必ず LP が撮れる。
+  useEffect(() => {
+    if (isAuthenticated) return;
+    let cancelled = false;
+    AuthRepository.getCurrentUser()
+      .then((me) => {
+        if (cancelled) return;
+        dispatch(
+          setAuthData({
+            isAdmin: !!me.isAdmin,
+            role: me.role ?? null,
+            aiChatEnabledForTrainees: me.aiChatEnabledForTrainees ?? true,
+          }),
+        );
+      })
+      .catch(() => {
+        // 未ログイン: LP のまま
+      });
+    return () => {
+      cancelled = true;
+    };
+    // マウント時に一度だけ確認する(isAuthenticated が true になったら <Navigate> が発火する)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useDocumentMeta({
     title: 'FreStyle | 新卒ITエンジニア向け研修プラットフォーム',

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -1,10 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import LandingPage from '../LandingPage';
 import authReducer from '@/entities/user/model/authSlice';
+import AuthRepository from '@/entities/user/api/authRepository';
+
+// マウント時の認証確認(ログイン済みなら /dashboard へ送る)をモックする。
+// 既定は 401(未ログイン)扱い。
+vi.mock('@/entities/user/api/authRepository', () => ({
+  default: { getCurrentUser: vi.fn().mockRejectedValue(new Error('unauthorized')) },
+}));
+const mockGetCurrentUser = vi.mocked(AuthRepository.getCurrentUser);
 
 function renderLanding(isAuthenticated: boolean) {
   const store = configureStore({
@@ -53,6 +61,23 @@ describe('LandingPage', () => {
   it('ログイン済みなら /dashboard へリダイレクトする', () => {
     renderLanding(true);
     expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+  });
+
+  it('初回ロードで認証確認が成功したら /dashboard へ自動遷移する(FRESTYLE-225)', async () => {
+    // Cookie でログイン済みのユーザーが直接 / を開いたケース: store は未認証で始まるが、
+    // マウント時の /auth/me 確認が成功したらダッシュボードへ送られる。
+    mockGetCurrentUser.mockResolvedValueOnce({ isAdmin: false, role: 'trainee' });
+    renderLanding(false);
+    expect(await screen.findByText('ダッシュボード')).toBeInTheDocument();
+  });
+
+  it('未ログイン(401)なら LP を表示し続ける', async () => {
+    renderLanding(false);
+    // 認証確認が reject された後も LP のまま
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /新卒ITエンジニア向け研修プラットフォーム/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('ダッシュボード')).not.toBeInTheDocument();
   });
 
   it('LP 自身がスクロールコンテナを持つ（body overflow hidden 下でスクロール不能になった回帰: FRESTYLE-223）', () => {


### PR DESCRIPTION
## 概要

frestyle.jp のトップ(/)を「未ログインなら紹介ページ(LP)、ログイン済みならダッシュボードへ遷移」にする(ユーザー要望)。これまでは初回ロードで認証状態を確認しないため、ログイン済みでも LP が表示されていた。

## 変更内容

- LandingPage: マウント時に一度だけ /auth/me で認証確認(Cookie は HttpOnly のため API に聞く)。成功したら既存の Navigate(/dashboard)が発火。確認中・401 は LP を表示し続ける
- scripts/prerender.mjs: プリレンダー用ローカルサーバで /api/(health 以外)に 401 を返す(SPA フォールバックの 200 HTML を「ログイン済み」と誤判定してダッシュボードのリダイレクトを撮る事故の防止)

## テスト

- LandingPage 5 tests(認証確認成功→/dashboard 遷移、401→LP 継続 を追加)
- tsc / eslint / build + prerender 成功(プリレンダー出力が LP 本文であることを確認)

## 関連チケット

- FRESTYLE-225 https://frestyle.atlassian.net/browse/FRESTYLE-225