### PR TITLE
fix: 公開ページの認証確認でログイン画面へ強制遷移する回帰を修正 (FRESTYLE-225)

### DIFF
--- a/frontend/e2e/local/public-pages.spec.ts
+++ b/frontend/e2e/local/public-pages.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 公開ページ（未ログインの訪問者・検索エンジンのクローラ向け）の E2E。
+ *
+ * FRESTYLE-225 の本番回帰の再発防止:
+ * 公開トップは「ログイン済みならダッシュボードへ送る」ために /auth/me を呼ぶが、
+ * 未ログインの 401 でトークンリフレッシュが走り、その失敗で axios interceptor が
+ * /login へ強制遷移していた。結果、公開 LP が誰にも（Googlebot にも）見えなくなっていた。
+ */
+
+test.describe('公開トップ（未ログイン）', () => {
+  test('未ログインでもログイン画面へ飛ばされず LP を表示し続ける', async ({ page }) => {
+    // 認証系を含むすべての API を 401 にする（未ログイン状態の再現）。
+    await page.route('**/api/v2/**', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: '{"error":"unauthorized"}',
+      })
+    );
+    // ヘルスチェックだけは 200。ここを 401 にするとバックエンド障害と判定され
+    // メンテナンス画面になり、「未ログイン訪問者」の検証にならないため
+    // （後から登録した route が優先される）。
+    await page.route('**/api/v2/health', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '{"status":"ok"}' })
+    );
+
+    await page.goto('/');
+
+    // ヒーロー見出しが出ていること（LP が描画されている）。
+    await expect(
+      page.getByRole('heading', { level: 1, name: /新卒ITエンジニア向け研修プラットフォーム/ })
+    ).toBeVisible();
+
+    // リダイレクトは非同期に起きるため、猶予を置いてから URL を確認する。
+    await page.waitForTimeout(2000);
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(
+      page.getByRole('heading', { level: 1, name: /新卒ITエンジニア向け研修プラットフォーム/ })
+    ).toBeVisible();
+  });
+
+  test('ログイン済みならダッシュボードへ送られる', async ({ page }) => {
+    await page.route('**/api/v2/**', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    );
+    await page.route('**/api/v2/auth/me', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ isAdmin: false, role: 'trainee' }),
+      })
+    );
+
+    await page.goto('/');
+
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+});

--- a/frontend/src/entities/user/api/authRepository.ts
+++ b/frontend/src/entities/user/api/authRepository.ts
@@ -1,4 +1,4 @@
-import apiClient from '@/shared/api/axios';
+import apiClient, { type PublicSafeRequestConfig } from '@/shared/api/axios';
 import { AUTH } from '@/shared/config/apiRoutes';
 
 /**
@@ -100,6 +100,19 @@ class AuthRepository {
    */
   async getCurrentUser(): Promise<UserInfo> {
     const response = await apiClient.get(AUTH.me);
+    return response.data;
+  }
+
+  /**
+   * 公開ページ用の認証確認。
+   *
+   * getCurrentUser との違いは「未ログインでも /login へ飛ばさない」ことだけ。
+   * 公開ページでは 401 が正常な答えなので、訪問者や検索エンジンのクローラを
+   * ログイン画面へ追い出さないためにこちらを使う（FRESTYLE-225）。
+   */
+  async probeCurrentUser(): Promise<UserInfo> {
+    const config: PublicSafeRequestConfig = { skipAuthRedirect: true };
+    const response = await apiClient.get(AUTH.me, config);
     return response.data;
   }
 

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -105,7 +105,7 @@ export default function LandingPage() {
   useEffect(() => {
     if (isAuthenticated) return;
     let cancelled = false;
-    AuthRepository.getCurrentUser()
+    AuthRepository.probeCurrentUser()
       .then((me) => {
         if (cancelled) return;
         dispatch(

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -8,11 +8,11 @@ import authReducer from '@/entities/user/model/authSlice';
 import AuthRepository from '@/entities/user/api/authRepository';
 
 // マウント時の認証確認(ログイン済みなら /dashboard へ送る)をモックする。
-// 既定は 401(未ログイン)扱い。
+// 既定は 401(未ログイン)扱い。公開ページなので probeCurrentUser を使う(FRESTYLE-225)。
 vi.mock('@/entities/user/api/authRepository', () => ({
-  default: { getCurrentUser: vi.fn().mockRejectedValue(new Error('unauthorized')) },
+  default: { probeCurrentUser: vi.fn().mockRejectedValue(new Error('unauthorized')) },
 }));
-const mockGetCurrentUser = vi.mocked(AuthRepository.getCurrentUser);
+const mockGetCurrentUser = vi.mocked(AuthRepository.probeCurrentUser);
 
 function renderLanding(isAuthenticated: boolean) {
   const store = configureStore({

--- a/frontend/src/shared/api/__tests__/axios.test.ts
+++ b/frontend/src/shared/api/__tests__/axios.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import axios from 'axios';
+import apiClient from '../axios';
+
+/**
+ * 401 レスポンス時の挙動（トークンリフレッシュ → 失敗時のログイン画面遷移）の検証。
+ *
+ * 公開ページの認証確認（skipAuthRedirect）で遷移してしまうと、LP の訪問者や
+ * 検索エンジンのクローラがログイン画面に飛ばされる（FRESTYLE-225 の本番回帰）。
+ */
+
+// 401 を返すアダプタ。引数の config は interceptor が受け取る config と同一なので、
+// skipAuthRedirect の伝播もそのまま検証できる。
+const reject401 = (config: unknown) =>
+  Promise.reject({ isAxiosError: true, response: { status: 401 }, config });
+
+let hrefSetter: ReturnType<typeof vi.fn>;
+let originalLocation: Location;
+
+beforeEach(() => {
+  originalLocation = window.location;
+  hrefSetter = vi.fn();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      set href(value: string) {
+        hrefSetter(value);
+      },
+      get href() {
+        return 'http://localhost/';
+      },
+    },
+  });
+  // リフレッシュは常に失敗させる（未ログイン状態の再現）。
+  vi.spyOn(axios, 'post').mockRejectedValue(new Error('refresh failed'));
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: originalLocation,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('apiClient の 401 ハンドリング', () => {
+  it('通常の呼び出しはリフレッシュ失敗でログイン画面へ遷移する', async () => {
+    await expect(apiClient.get('/protected', { adapter: reject401 })).rejects.toThrow();
+    expect(hrefSetter).toHaveBeenCalledWith('/login');
+  });
+
+  it('skipAuthRedirect の呼び出しはリフレッシュ失敗でも遷移しない（公開ページ用）', async () => {
+    await expect(
+      apiClient.get('/auth/me', { adapter: reject401, skipAuthRedirect: true }),
+    ).rejects.toThrow();
+    expect(hrefSetter).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/shared/api/axios.ts
+++ b/frontend/src/shared/api/axios.ts
@@ -28,6 +28,18 @@ const apiClient = axios.create({
 });
 
 /**
+ * 公開ページから呼ぶときのリクエスト設定。
+ *
+ * `skipAuthRedirect: true` を付けた呼び出しは、401（かつリフレッシュ失敗）でも
+ * /login へ強制遷移しない。「ログイン済みか確かめる」用途では 401 は正常な答えであり、
+ * 公開ページの訪問者や検索エンジンのクローラをログイン画面へ追い出してはいけないため
+ * （公開 LP の全訪問者が /login に飛ばされた回帰: FRESTYLE-225）。
+ */
+export interface PublicSafeRequestConfig extends AxiosRequestConfig {
+  skipAuthRedirect?: boolean;
+}
+
+/**
  * トークンリフレッシュ中フラグ
  * 複数のリクエストが同時に401を受けた場合、リフレッシュは1回だけ実行
  */
@@ -63,7 +75,10 @@ const processQueue = (error: AxiosError | null = null) => {
 apiClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
-    const originalRequest = error.config as InternalAxiosRequestConfig & { _retry?: boolean };
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retry?: boolean;
+      skipAuthRedirect?: boolean;
+    };
 
     // 401エラーかつ、まだリトライしていない場合
     if (error.response?.status === 401 && !originalRequest._retry) {
@@ -100,8 +115,9 @@ apiClient.interceptors.response.use(
         processQueue(error);
         isRefreshing = false;
 
-        // リフレッシュ失敗 → ログインページへ
-        if (typeof window !== 'undefined') {
+        // リフレッシュ失敗 → ログインページへ。
+        // ただし公開ページの認証確認（skipAuthRedirect）では遷移しない。
+        if (!originalRequest.skipAuthRedirect && typeof window !== 'undefined') {
           window.location.href = '/login';
         }
 


### PR DESCRIPTION
## 概要

**本番障害の修正。** 匿名の訪問者が https://frestyle.jp/ を開くと自動的に /login に飛ばされ、**公開 LP が誰にも(Googlebot にも)見えない**状態でした。SEO 施策の前提が崩れるため緊急度が高い変更です。

## 原因

昨日の PR #2192 で、公開トップに「ログイン済みならダッシュボードへ送る」ための `/auth/me` 呼び出しを追加しました。未ログインではこれが 401 になり、axios の共通インターセプターが

1. 401 → トークンリフレッシュを試行 → それも 401
2. リフレッシュ失敗のフォールバックで `window.location.href = '/login'`

と動きます。保護ページでは正しい挙動ですが、**401 が正常な答えである公開ページでは訪問者を追い出してしまう**のが誤りでした。

本番で再現確認済み(Playwright):

```
→ GET  /api/v2/auth/me      ← 401
→ POST /api/v2/auth/refresh ← 401
## NAV https://frestyle.jp/login   ← 強制遷移
```

## 変更内容

- `shared/api/axios.ts`: `skipAuthRedirect` を付けた呼び出しはリフレッシュ失敗でも遷移しない(型 `PublicSafeRequestConfig` を export)
- `entities/user/api/authRepository.ts`: 公開ページ用の `probeCurrentUser()` を追加(`getCurrentUser()` との差分は「遷移しない」ことだけ)
- `pages/landing`: `probeCurrentUser()` を使用

## テスト

- **e2e 回帰(新規)**: 未ログインで `/` を開いて LP に留まること / ログイン済みで `/dashboard` へ送られること。**旧コードなら確実に落ちる**テストです
- **interceptor 単体(新規)**: 通常呼び出しは /login へ遷移する・skipAuthRedirect では遷移しない
- 既存: vitest 1231 passed(カバレッジ 86.19%) / tsc / eslint / e2e local 14 passed / build + prerender 成功(出力が LP であることを確認)

## 副次効果

プリレンダーも安定化します。スナップショット取得中に同じ強制遷移が起き得たため、ログイン画面が焼き込まれる潜在的な事故を防ぎます。

## 関連チケット

- FRESTYLE-225 https://frestyle.atlassian.net/browse/FRESTYLE-225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 未ログイン状態でも、公開ランディングページがログイン画面へリダイレクトされず表示されるよう改善しました。
  - 公開ページでの認証確認に失敗した場合も、ページ表示が継続されます。
  - ログイン済みの場合は、従来どおりダッシュボードへ遷移します。

- **テスト**
  - 未ログイン・ログイン済みの公開ページ表示と、認証エラー時の遷移動作を自動検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->