### PR TITLE
feat: ログイン画面のホストを auth.frestyle.jp へ切替 (FRESTYLE-226 Step 1)

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -59,9 +59,10 @@ jobs:
       # frestyle.jp 移行(FRESTYLE-225)で Secrets 更新に依存しない構成に変更。
       VITE_API_BASE_URL: https://api.frestyle.jp
       VITE_REDIRECT_URI: https://frestyle.jp/login/callback
+      # ログイン画面(Cognito ホスト UI)のホスト。auth.normanblog.com から移設(FRESTYLE-226)。
+      VITE_COGNITO_DOMAIN: auth.frestyle.jp
       VITE_WEB_SOCKET_URL_AI_CHAT: ${{ secrets.VITE_WEB_SOCKET_URL_AI_CHAT }}
       VITE_WEB_SOCKET_URL_CHAT: ${{ secrets.VITE_WEB_SOCKET_URL_CHAT }}
-      VITE_COGNITO_DOMAIN: ${{ secrets.VITE_COGNITO_DOMAIN }}
       VITE_CLIENT_ID: ${{ secrets.VITE_CLIENT_ID }}
       VITE_RESPONSE_TYPE: ${{ secrets.VITE_RESPONSE_TYPE }}
       VITE_SCOPE: ${{ secrets.VITE_SCOPE }}


### PR DESCRIPTION
## 概要

normanblog.com 撤去の第一段階。**ログイン画面(Cognito ホスト UI)のホストを auth.normanblog.com から auth.frestyle.jp へ移設**したことにフロント側を追随させる。

AWS 側は実施済み:
- auth.frestyle.jp の証明書(us-east-1)発行 → ISSUED
- Cognito カスタムドメインを張り替え(削除 → 作成。配信先 djhj9azih3imb.cloudfront.net)
- auth.frestyle.jp の A/AAAA alias を作成
- app client の許可 URL に `https://auth.frestyle.jp/oauth2/idpresponse` を追加
- Google Cloud Console 側のリダイレクト URI 追加はユーザーが実施済み

## 緊急性

旧ドメインを削除した時点から**新ビルドが出るまで Google ログインが使えない**(メール/パスワードのログインは別経路で影響なし)。マージ + デプロイで復旧する。

## 変更内容

- cd-frontend.yml: `VITE_COGNITO_DOMAIN` を Secret 参照から `auth.frestyle.jp` の直接記載へ。公開 JS に焼き込まれる公開値であり、Secrets 更新漏れによる障害(FRESTYLE-225)を繰り返さないため他の公開 URL と同じ扱いにする

## テスト

- workflow 設定のみの変更(アプリコード無変更)
- デプロイ後: frestyle.jp の「Google でログイン」で認可画面まで到達すること、メール/パスワードのログインが通ることを確認する

## 関連チケット

- FRESTYLE-226 https://frestyle.atlassian.net/browse/FRESTYLE-226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * フロントエンドの認証ドメイン設定を更新しました。
  * 認証サービスの移設に伴う設定コメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->