### PR TITLE
chore: アプリから旧ドメイン normanblog.com の参照を撤去 (FRESTYLE-226 Step 5)

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -181,13 +181,13 @@ jobs:
           aws ecs wait services-stable --region "$AWS_REGION" \
             --cluster "$CLUSTER" --services "$SERVICE"
 
-      # normanblog.com/api/* は CloudFront(SPA fallback)が一律 200 を返して誤判定するため、
-      # ALB に直結する api.normanblog.com を叩く。パスは Go/Gin の /api/v2/health
+      # frestyle.jp/api/* は CloudFront(SPA fallback)が一律 200 を返して誤判定するため、
+      # ALB に直結する api.frestyle.jp を叩く。パスは Go/Gin の /api/v2/health
       # (旧 Spring の /actuator/health は撤去済)。
       - name: Verify health
         run: |
           for i in 1 2 3 4 5; do
-            if curl -fsS "https://api.normanblog.com/api/v2/health"; then
+            if curl -fsS "https://api.frestyle.jp/api/v2/health"; then
               echo "✅ Healthy"
               exit 0
             fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,6 @@
 name: E2E - Playwright Smoke
 
-# 目的: 本番 (https://normanblog.com / https://api.normanblog.com) に対する
+# 目的: 本番 (https://frestyle.jp / https://api.frestyle.jp) に対する
 # 認証前スモーク E2E を Playwright + Chromium で実行する。
 # 失敗時は html report / trace / screenshot / video を artifact に残す。
 #
@@ -30,9 +30,9 @@ on:
   workflow_dispatch:
     inputs:
       base_url:
-        description: 'PLAYWRIGHT_BASE_URL（既定 https://normanblog.com）'
+        description: 'PLAYWRIGHT_BASE_URL（既定 https://frestyle.jp）'
         required: false
-        default: 'https://normanblog.com'
+        default: 'https://frestyle.jp'
 
 permissions:
   contents: read
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run Playwright smoke
         env:
-          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url || 'https://normanblog.com' }}
+          PLAYWRIGHT_BASE_URL: ${{ inputs.base_url || 'https://frestyle.jp' }}
         run: npx playwright test --project=chromium
 
       - name: Upload Playwright HTML report

--- a/backend/internal/handler/middleware/cors.go
+++ b/backend/internal/handler/middleware/cors.go
@@ -7,14 +7,11 @@ import (
 )
 
 // allowedOrigins は CORS で許可するオリジン。
-// frestyle.jp はブランドドメイン移行後の本番(FRESTYLE-225)。normanblog.com は
-// 301 リダイレクトの安定稼働を確認するまで残す(整理は別チケット)。
+// 旧ドメイン normanblog.com は撤去済み(FRESTYLE-226)。
 var allowedOrigins = map[string]struct{}{
-	"https://frestyle.jp":                  {},
-	"https://normanblog.com":               {},
-	"http://normanblog.com":                {},
-	"http://localhost:5173":                {},
-	"https://dcd3m6lwt0z8u.cloudfront.net": {},
+	"https://frestyle.jp":                                             {},
+	"http://localhost:5173":                                           {},
+	"https://dcd3m6lwt0z8u.cloudfront.net":                            {},
 	"http://fre-style-bucket.s3-website-ap-northeast-1.amazonaws.com": {},
 }
 

--- a/backend/internal/handler/middleware/cors_test.go
+++ b/backend/internal/handler/middleware/cors_test.go
@@ -8,7 +8,8 @@ func Test_許可オリジン判定(t *testing.T) {
 		want   bool
 	}{
 		{"https://frestyle.jp", true},
-		{"https://normanblog.com", true},
+		// 旧ドメインは撤去済みのため許可しない(FRESTYLE-226)
+		{"https://normanblog.com", false},
 		{"http://localhost:5173", true},
 		{"https://evil.example.com", false},
 		{"", false},

--- a/backend/internal/handler/middleware/cors_test.go
+++ b/backend/internal/handler/middleware/cors_test.go
@@ -8,8 +8,9 @@ func Test_許可オリジン判定(t *testing.T) {
 		want   bool
 	}{
 		{"https://frestyle.jp", true},
-		// 旧ドメインは撤去済みのため許可しない(FRESTYLE-226)
+		// 旧ドメインは撤去済みのため許可しない(FRESTYLE-226)。http/https 双方を確認する。
 		{"https://normanblog.com", false},
+		{"http://normanblog.com", false},
 		{"http://localhost:5173", true},
 		{"https://evil.example.com", false},
 		{"", false},

--- a/backend/internal/infra/cognito/token_exchanger_test.go
+++ b/backend/internal/infra/cognito/token_exchanger_test.go
@@ -19,7 +19,7 @@ func newTestServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, Co
 	cfg := Config{
 		ClientID:     "client-xyz",
 		ClientSecret: "secret-abc",
-		RedirectURI:  "https://normanblog.com/auth/callback",
+		RedirectURI:  "https://frestyle.jp/auth/callback",
 		TokenURI:     srv.URL,
 	}
 	return srv, cfg

--- a/backend/internal/infra/ses/invitation_mail_test.go
+++ b/backend/internal/infra/ses/invitation_mail_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Test_招待メール構築_マジックリンクと表示名を含む(t *testing.T) {
-	link := "https://normanblog.com/invitations/accept?token=abc-123"
+	link := "https://frestyle.jp/invitations/accept?token=abc-123"
 	subject, htmlBody, textBody := BuildInvitationMail(link, "山田太郎", "株式会社FreStyle", "company_admin")
 
 	if subject == "" {
@@ -75,8 +75,8 @@ func Test_招待メール構築_生のroleを露出しない(t *testing.T) {
 }
 
 func Test_マジックリンクURL_末尾スラッシュを除去(t *testing.T) {
-	got := MagicLinkURL("https://normanblog.com/", "abc")
-	want := "https://normanblog.com/invitations/accept?token=abc"
+	got := MagicLinkURL("https://frestyle.jp/", "abc")
+	want := "https://frestyle.jp/invitations/accept?token=abc"
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
         - img-src 'self' data: https: blob:               : avatar / CDN 経由画像 / data URL /
                                                            URL.createObjectURL() プレビュー（添付チップ）
         - font-src 'self' data:                         : ローカルフォント + base64 埋め込み
-        - connect-src 'self' https://api.frestyle.jp https://api.normanblog.com https://*.amazoncognito.com wss://api.frestyle.jp wss://api.normanblog.com
+        - connect-src 'self' https://api.frestyle.jp https://*.amazoncognito.com wss://api.frestyle.jp
                        https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com
                                                          : API / WebSocket / Cognito callback /
                                                            プロフィール / Note 画像の S3 presigned PUT
@@ -29,7 +29,7 @@
       `report-uri` / `report-to` / `sandbox` も同様 meta では無視されるので、配信が必要な場合は
       CloudFront 側に追加する。
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.frestyle.jp https://api.normanblog.com https://*.amazoncognito.com wss://api.frestyle.jp wss://api.normanblog.com https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com; form-action 'self' https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://api.frestyle.jp https://*.amazoncognito.com wss://api.frestyle.jp https://*.s3.amazonaws.com https://*.s3.ap-northeast-1.amazonaws.com; form-action 'self' https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; upgrade-insecure-requests" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <!--


### PR DESCRIPTION
## 概要

normanblog.com の撤去に伴い、アプリ側に残っていた旧ドメインの許可設定を削除する。CloudFront の別名(alias)と 301 転送はすでに撤去済みで、旧ドメインからのアクセスは発生しない。

## 変更内容

- `backend/internal/handler/middleware/cors.go`: 許可オリジンから `https://normanblog.com` / `http://normanblog.com` を削除。テストは「不許可であること」を期待するよう変更(許可面を狭める方向)
- `frontend/index.html`: CSP の connect-src から `https://api.normanblog.com` / `wss://api.normanblog.com` を削除
- テスト内の例示 URL を frestyle.jp に統一

## テスト

- backend: go build + 対象パッケージの go test ok(middleware / ses / cognito)
- frontend: vitest 全件

## 関連チケット

- FRESTYLE-226 https://frestyle.atlassian.net/browse/FRESTYLE-226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * 旧ドメイン（normanblog.com）への接続許可を削除し、frestyle.jpを正式なドメインとして利用するよう更新しました。
  * API、WebSocket、認証コールバック、招待メール、マジックリンクの接続先を新ドメインに統一しました。
  * ローカル環境や既存のCloudFront・S3接続への許可は維持しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->