### PR TITLE
fix: 本番ログイン不能の修正 — CD が最新タスク定義を採用 + ログイン 401 の握り潰し解消 (FRESTYLE-226)

### DIFF
--- a/.github/workflows/cd-backend.yml
+++ b/.github/workflows/cd-backend.yml
@@ -39,6 +39,8 @@ env:
   AWS_REGION: ap-northeast-1
   CLUSTER: frestyle-prod
   SERVICE: frestyle-prod-svc
+  # ファミリー名のみ指定して最新 ACTIVE リビジョンを採用する(下の deploy ステップ参照)
+  TASK_FAMILY: frestyle-prod-task
   AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-role
 
 # OIDC(id-token: write) は AWS 認証を行うジョブ(build-and-push / deploy)だけに
@@ -167,14 +169,21 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       # タスク定義は infra リポの Terraform(ecs.tf)が :latest / :coderunner-latest を参照して
-      # 管理する。build-and-push が新イメージを push 済みなので、force-new-deployment の
-      # ローリング再起動だけで新イメージが pull される(タスク定義の再登録は不要)。
-      - name: Force new deployment (rolling restart)
+      # 管理する。build-and-push が新イメージを push 済みなので、ローリング再起動で新イメージが
+      # pull される(タスク定義の再登録は不要)。
+      #
+      # --task-definition にファミリー名だけを渡し、**最新の ACTIVE リビジョン**を必ず採用する。
+      # ECS サービスは Terraform 側で lifecycle.ignore_changes = [task_definition] のため、
+      # ecs.tf の環境変数を変えて apply しても新リビジョンが作られるだけでサービスは古い
+      # リビジョンのまま動き続ける。force-new-deployment だけだとその古い設定を再起動して
+      # しまい、環境変数の変更が永久に本番へ反映されない(FRESTYLE-226 でログイン不能の原因)。
+      - name: Deploy latest task definition (rolling restart)
         run: |
           aws ecs update-service --region "$AWS_REGION" \
             --cluster "$CLUSTER" --service "$SERVICE" \
+            --task-definition "$TASK_FAMILY" \
             --force-new-deployment \
-            --query 'service.deployments[0].status' --output text
+            --query 'service.taskDefinition' --output text
 
       - name: Wait for service to stabilize
         run: |

--- a/frontend/src/entities/user/api/__tests__/authRepository.test.ts
+++ b/frontend/src/entities/user/api/__tests__/authRepository.test.ts
@@ -17,7 +17,12 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.login({ email: 'test@example.com', password: 'password123' });
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/cognito/login', { email: 'test@example.com', password: 'password123' });
+    // 401(認証情報の誤り)でログイン画面へ強制遷移させないため skipAuthRedirect を付ける
+    expect(mockedApiClient.post).toHaveBeenCalledWith(
+      '/api/v2/auth/cognito/login',
+      { email: 'test@example.com', password: 'password123' },
+      { skipAuthRedirect: true },
+    );
     expect(result).toEqual(mockUser);
   });
 
@@ -27,7 +32,11 @@ describe('AuthRepository', () => {
 
     const result = await authRepository.callback('auth-code-123');
 
-    expect(mockedApiClient.post).toHaveBeenCalledWith('/api/v2/auth/login', { code: 'auth-code-123' });
+    expect(mockedApiClient.post).toHaveBeenCalledWith(
+      '/api/v2/auth/login',
+      { code: 'auth-code-123' },
+      { skipAuthRedirect: true },
+    );
     expect(result).toEqual(mockData);
   });
 

--- a/frontend/src/entities/user/api/authRepository.ts
+++ b/frontend/src/entities/user/api/authRepository.ts
@@ -52,9 +52,14 @@ export interface UserInfo {
 class AuthRepository {
   /**
    * ログイン
+   *
+   * 401(認証情報が違う)は正常な応答なので、共通インターセプターの
+   * 「401 → トークンリフレッシュ → 失敗ならログイン画面へ強制遷移」を無効にする。
+   * これがないと画面が再読み込みされ、呼び出し側のエラーメッセージが表示されない。
    */
   async login(request: LoginRequest): Promise<UserInfo> {
-    const response = await apiClient.post(AUTH.login, request);
+    const config: PublicSafeRequestConfig = { skipAuthRedirect: true };
+    const response = await apiClient.post(AUTH.login, request, config);
     return response.data;
   }
 
@@ -68,7 +73,9 @@ class AuthRepository {
   async callback(code: string, invitationToken?: string | null): Promise<{ success: string }> {
     const body: { code: string; invitationToken?: string } = { code };
     if (invitationToken) body.invitationToken = invitationToken;
-    const response = await apiClient.post(AUTH.callback, body);
+    // 認可コードの交換失敗(401)も正常な応答として呼び出し側で扱う(login と同じ理由)。
+    const config: PublicSafeRequestConfig = { skipAuthRedirect: true };
+    const response = await apiClient.post(AUTH.callback, body, config);
     return response.data;
   }
 


### PR DESCRIPTION
## 概要

**本番でログインできない不具合の修正。** 独立した 2 つの原因があった。

## 原因1: ECS の環境変数変更が本番に永久に反映されない(本命)

1. ECS サービスは Terraform 側で `lifecycle.ignore_changes = [task_definition]`(夜間 scale と CD の競合回避のため)
2. `ecs.tf` の環境変数を変えて apply すると**新リビジョンは作られる**が、サービスは古いリビジョンを指したまま
3. CD は `--force-new-deployment` のみ = **古い環境変数のまま再起動**

結果、ドメイン移行で `COGNITO_REDIRECT_URI` を frestyle.jp に変えたのに本番は normanblog.com のまま稼働。**認可時とコード交換時の redirect_uri が食い違い Google ログインが 401**(= ログイン後にログイン画面へ戻される症状)。`SES_FROM_ADDRESS` / `APP_BASE_URL` / `NOTE_IMAGES_CDN_URL` も旧値のままで、招待メールの送信元とリンクも壊れていた。

- 本番は先に `update-service --task-definition frestyle-prod-task:91` で復旧済み(環境変数 4 件が新値であることを確認)
- 恒久対策として CD で `--task-definition <family>` を指定し、**最新 ACTIVE リビジョン**を必ず採用させる

## 原因2: ログイン 401 が握り潰され、エラーが表示されない

`login` / `callback` は 401 が正常な応答(認証情報の誤り・コード交換失敗)なのに、共通インターセプターの「401 → リフレッシュ → 失敗ならログイン画面へ強制遷移」が発火し、**呼び出し側がエラーメッセージを出す前に画面が再読み込み**されていた。本番で実際に「パスワードを間違えても何も表示されず再読み込みされる」ことを Playwright で確認。

公開ページと同じ `skipAuthRedirect` を付けて遷移を抑止する。

## 変更内容

- `cd-backend.yml`: `--task-definition $TASK_FAMILY` を追加(ファミリー名のみ = 最新 ACTIVE リビジョン)。経緯をコメントで明記
- `authRepository.login/callback`: `skipAuthRedirect: true` を付与。テストも意図を検証する形に更新

## テスト

- vitest 1231 passed / tsc / eslint
- YAML パース確認
- 次回バックエンドデプロイで `service.taskDefinition` が最新リビジョンになることを確認する

## 関連チケット

- FRESTYLE-226 https://frestyle.atlassian.net/browse/FRESTYLE-226