### PR TITLE
fix: 招待取消とセッションノート取得の認可欠落を修正 (FRESTYLE-228)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -456,7 +456,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。",
+                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。\nsuper_admin は 全社、 company_admin は 自社 の 招待 のみ 取消 できる。",
                 "produces": [
                     "application/json"
                 ],
@@ -478,7 +478,25 @@ const docTemplate = `{
                         "description": "成功 (本文 なし)"
                     },
                     "400": {
-                        "description": "DB 失敗",
+                        "description": "不正 な ID / DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "招待 が 存在 し ない (他社 の 招待 を 含む)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -3474,7 +3492,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。",
+                "description": "AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。\n所有者 本人 の ノート のみ 返す。 他人 の ノート は 存在 を 漏らさ ない ため 404 と する。",
                 "produces": [
                     "application/json"
                 ],
@@ -3499,7 +3517,7 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "DB 失敗",
+                        "description": "不正 な sessionId / DB 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -449,7 +449,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。",
+                "description": "指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。\nsuper_admin は 全社、 company_admin は 自社 の 招待 のみ 取消 できる。",
                 "produces": [
                     "application/json"
                 ],
@@ -471,7 +471,25 @@
                         "description": "成功 (本文 なし)"
                     },
                     "400": {
-                        "description": "DB 失敗",
+                        "description": "不正 な ID / DB 失敗",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "管理者 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "招待 が 存在 し ない (他社 の 招待 を 含む)",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }
@@ -3467,7 +3485,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。",
+                "description": "AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。\n所有者 本人 の ノート のみ 返す。 他人 の ノート は 存在 を 漏らさ ない ため 404 と する。",
                 "produces": [
                     "application/json"
                 ],
@@ -3492,7 +3510,7 @@
                         }
                     },
                     "400": {
-                        "description": "DB 失敗",
+                        "description": "不正 な sessionId / DB 失敗",
                         "schema": {
                             "$ref": "#/definitions/internal_handler.errorResponse"
                         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1365,7 +1365,9 @@ paths:
       - admin
   /admin/invitations/{id}:
     delete:
-      description: 指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。
+      description: |-
+        指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。
+        super_admin は 全社、 company_admin は 自社 の 招待 のみ 取消 できる。
       parameters:
       - description: 招待 ID
         in: path
@@ -1378,7 +1380,19 @@ paths:
         "204":
           description: 成功 (本文 なし)
         "400":
-          description: DB 失敗
+          description: 不正 な ID / DB 失敗
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: 管理者 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "404":
+          description: 招待 が 存在 し ない (他社 の 招待 を 含む)
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
       security:
@@ -3325,8 +3339,9 @@ paths:
       - profile
   /sessions/{sessionId}/note:
     get:
-      description: AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し
-        ない 場合 は 404。
+      description: |-
+        AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。
+        所有者 本人 の ノート のみ 返す。 他人 の ノート は 存在 を 漏らさ ない ため 404 と する。
       parameters:
       - description: AI チャット セッション ID
         in: path
@@ -3341,7 +3356,7 @@ paths:
           schema:
             $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.SessionNote'
         "400":
-          description: DB 失敗
+          description: 不正 な sessionId / DB 失敗
           schema:
             $ref: '#/definitions/internal_handler.errorResponse'
         "401":

--- a/backend/internal/adapter/persistence/admin_invitation_repository.go
+++ b/backend/internal/adapter/persistence/admin_invitation_repository.go
@@ -49,6 +49,21 @@ func (r *adminInvitationRepository) FindPendingByEmail(ctx context.Context, emai
 	return &row, nil
 }
 
+func (r *adminInvitationRepository) FindByID(ctx context.Context, id uint64) (*domain.AdminInvitation, error) {
+	if id == 0 {
+		return nil, nil
+	}
+	var row domain.AdminInvitation
+	err := r.db.WithContext(ctx).Where("id = ?", id).First(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &row, nil
+}
+
 func (r *adminInvitationRepository) FindPendingByToken(ctx context.Context, token string) (*domain.AdminInvitation, error) {
 	if token == "" {
 		return nil, nil

--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -154,11 +154,15 @@ func (h *AdminInvitationHandler) Create(c *gin.Context) {
 
 // @Summary      招待 取り消し
 // @Description  指定 招待 の status を canceled に 更新。 行 は 物理 削除 せず 監査 用 に 残す。
+// @Description  super_admin は 全社、 company_admin は 自社 の 招待 のみ 取消 できる。
 // @Tags         admin
 // @Produce      json
 // @Param        id  path  int  true  "招待 ID"
 // @Success      204  "成功 (本文 なし)"
-// @Failure      400  {object}  errorResponse  "DB 失敗"
+// @Failure      400  {object}  errorResponse  "不正 な ID / DB 失敗"
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "管理者 以外"
+// @Failure      404  {object}  errorResponse  "招待 が 存在 し ない (他社 の 招待 を 含む)"
 // @Router       /admin/invitations/{id} [delete]
 // @Security     CookieAuth
 func (h *AdminInvitationHandler) Cancel(c *gin.Context) {

--- a/backend/internal/handler/admin_invitation_handler.go
+++ b/backend/internal/handler/admin_invitation_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -161,10 +162,36 @@ func (h *AdminInvitationHandler) Create(c *gin.Context) {
 // @Router       /admin/invitations/{id} [delete]
 // @Security     CookieAuth
 func (h *AdminInvitationHandler) Cancel(c *gin.Context) {
-	id, _ := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err := h.cancel.Execute(c.Request.Context(), id); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	user := middleware.CurrentUserFromContext(c)
+	if user == nil {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 		return
 	}
-	c.Status(http.StatusNoContent)
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_id"})
+		return
+	}
+
+	// CompanyID は SuperAdmin では nil になり得る（usecase 側で role により無視される）。
+	var actorCompanyID uint64
+	if user.CompanyID != nil {
+		actorCompanyID = *user.CompanyID
+	}
+
+	err = h.cancel.Execute(c.Request.Context(), usecase.CancelAdminInvitationInput{
+		ID:             id,
+		ActorRole:      user.Role,
+		ActorCompanyID: actorCompanyID,
+	})
+	switch {
+	case err == nil:
+		c.Status(http.StatusNoContent)
+	case errors.Is(err, usecase.ErrForbidden):
+		c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+	case errors.Is(err, usecase.ErrInvitationNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": "not_found"})
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	}
 }

--- a/backend/internal/handler/admin_invitation_handler_test.go
+++ b/backend/internal/handler/admin_invitation_handler_test.go
@@ -41,6 +41,15 @@ func (r *fakeAdminInvRepo) FindPendingByToken(_ context.Context, _ string) (*dom
 	return nil, nil
 }
 
+func (r *fakeAdminInvRepo) FindByID(_ context.Context, id uint64) (*domain.AdminInvitation, error) {
+	for i := range r.all {
+		if r.all[i].ID == id {
+			return &r.all[i], nil
+		}
+	}
+	return nil, nil
+}
+
 func init() {
 	gin.SetMode(gin.TestMode)
 }

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -108,6 +108,10 @@ func (r *fakeInvitationRepo) FindPendingByToken(_ context.Context, token string)
 	return nil, nil
 }
 
+func (r *fakeInvitationRepo) FindByID(_ context.Context, _ uint64) (*domain.AdminInvitation, error) {
+	return nil, nil
+}
+
 func (r *fakeInvitationRepo) Create(_ context.Context, _ *domain.AdminInvitation) error { return nil }
 
 func (r *fakeInvitationRepo) UpdateStatus(_ context.Context, id uint64, status string) error {

--- a/backend/internal/handler/session_note_handler.go
+++ b/backend/internal/handler/session_note_handler.go
@@ -22,11 +22,12 @@ func NewSessionNoteHandler(g *usecase.GetSessionNoteUseCase, u *usecase.UpsertSe
 //
 //	@Summary      セッション ノート 取得
 //	@Description  AI チャット セッション に 紐づく ノート (= 学習 者 が セッション ごと に 残した メモ) を 取得。 存在 し ない 場合 は 404。
+//	@Description  所有者 本人 の ノート のみ 返す。 他人 の ノート は 存在 を 漏らさ ない ため 404 と する。
 //	@Tags         session-notes
 //	@Produce      json
 //	@Param        sessionId  path      int  true  "AI チャット セッション ID"
 //	@Success      200        {object}  github_com_norman6464_FreStyle_backend_internal_domain.SessionNote
-//	@Failure      400        {object}  errorResponse  "DB 失敗"
+//	@Failure      400        {object}  errorResponse  "不正 な sessionId / DB 失敗"
 //	@Failure      401        {object}  errorResponse  "未 認証"
 //	@Failure      404        {object}  errorResponse  "未 作成"
 //	@Router       /sessions/{sessionId}/note [get]

--- a/backend/internal/handler/session_note_handler.go
+++ b/backend/internal/handler/session_note_handler.go
@@ -32,8 +32,17 @@ func NewSessionNoteHandler(g *usecase.GetSessionNoteUseCase, u *usecase.UpsertSe
 //	@Router       /sessions/{sessionId}/note [get]
 //	@Security     CookieAuth
 func (h *SessionNoteHandler) Get(c *gin.Context) {
-	sid, _ := strconv.ParseUint(c.Param("sessionId"), 10, 64)
-	n, err := h.get.Execute(c.Request.Context(), sid)
+	uid := middleware.CurrentUserIDOrZero(c)
+	if uid == 0 {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+	sid, err := strconv.ParseUint(c.Param("sessionId"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_session_id"})
+		return
+	}
+	n, err := h.get.Execute(c.Request.Context(), usecase.GetSessionNoteInput{SessionID: sid, UserID: uid})
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -133,9 +133,37 @@ func NewCancelAdminInvitationUseCase(r repository.AdminInvitationRepository) *Ca
 	return &CancelAdminInvitationUseCase{repo: r}
 }
 
-func (u *CancelAdminInvitationUseCase) Execute(ctx context.Context, id uint64) error {
-	if id == 0 {
+// CancelAdminInvitationInput は取消対象と、取消を要求している管理者を表す。
+type CancelAdminInvitationInput struct {
+	ID             uint64
+	ActorRole      string
+	ActorCompanyID uint64
+}
+
+// ErrInvitationNotFound は対象の招待が存在しない場合に返す。
+var ErrInvitationNotFound = errors.New("invitation not found")
+
+// Execute は招待を canceled にする。
+// super_admin は全社、company_admin は自社の招待のみ取消できる（それ以外は ErrForbidden）。
+// 他社の招待は存在を漏らさないため ErrInvitationNotFound として扱う。
+func (u *CancelAdminInvitationUseCase) Execute(ctx context.Context, in CancelAdminInvitationInput) error {
+	if in.ID == 0 {
 		return errors.New("id is required")
 	}
-	return u.repo.UpdateStatus(ctx, id, domain.InvitationStatusCanceled)
+	if in.ActorRole != domain.RoleSuperAdmin && in.ActorRole != domain.RoleCompanyAdmin {
+		return ErrForbidden
+	}
+
+	inv, err := u.repo.FindByID(ctx, in.ID)
+	if err != nil {
+		return err
+	}
+	if inv == nil {
+		return ErrInvitationNotFound
+	}
+	if in.ActorRole == domain.RoleCompanyAdmin && inv.CompanyID != in.ActorCompanyID {
+		return ErrInvitationNotFound
+	}
+
+	return u.repo.UpdateStatus(ctx, in.ID, domain.InvitationStatusCanceled)
 }

--- a/backend/internal/usecase/admin_invitation_usecase.go
+++ b/backend/internal/usecase/admin_invitation_usecase.go
@@ -156,7 +156,7 @@ func (u *CancelAdminInvitationUseCase) Execute(ctx context.Context, in CancelAdm
 
 	inv, err := u.repo.FindByID(ctx, in.ID)
 	if err != nil {
-		return err
+		return fmt.Errorf("find invitation: %w", err)
 	}
 	if inv == nil {
 		return ErrInvitationNotFound

--- a/backend/internal/usecase/admin_invitation_usecase_test.go
+++ b/backend/internal/usecase/admin_invitation_usecase_test.go
@@ -233,6 +233,19 @@ func Test_招待取消_会社管理者は自社のみ(t *testing.T) {
 	})
 }
 
+// 認可判定は FindByID の結果に依存するため、取得に失敗したら status を更新せずエラーを返す。
+func Test_招待取消_リポジトリエラーは伝播する(t *testing.T) {
+	wantErr := errors.New("db error")
+	uc := NewCancelAdminInvitationUseCase(&stubAdminInvRepo{err: wantErr})
+
+	err := uc.Execute(context.Background(), CancelAdminInvitationInput{
+		ID: 1, ActorRole: domain.RoleSuperAdmin,
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("リポジトリのエラーは伝播すべき: got %v", err)
+	}
+}
+
 func Test_招待取消_super_adminは全社取消できる(t *testing.T) {
 	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 8, CompanyID: 2}}}
 	uc := NewCancelAdminInvitationUseCase(repo)

--- a/backend/internal/usecase/admin_invitation_usecase_test.go
+++ b/backend/internal/usecase/admin_invitation_usecase_test.go
@@ -47,6 +47,18 @@ func (s *stubAdminInvRepo) FindPendingByToken(_ context.Context, _ string) (*dom
 	return nil, s.err
 }
 
+func (s *stubAdminInvRepo) FindByID(_ context.Context, id uint64) (*domain.AdminInvitation, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	for i := range s.rows {
+		if s.rows[i].ID == id {
+			return &s.rows[i], nil
+		}
+	}
+	return nil, nil
+}
+
 // stubMailSender は SES SendEmail の代わり。送信内容をフィールドに記録するだけで実際にネットワークアクセスしない。
 type stubMailSender struct {
 	err     error
@@ -175,8 +187,61 @@ func Test_招待作成_送信者nilはメールをスキップ(t *testing.T) {
 
 func Test_招待取消_IDが必須(t *testing.T) {
 	uc := NewCancelAdminInvitationUseCase(&stubAdminInvRepo{})
-	if err := uc.Execute(context.Background(), 0); err == nil {
+	err := uc.Execute(context.Background(), CancelAdminInvitationInput{
+		ID: 0, ActorRole: domain.RoleSuperAdmin,
+	})
+	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+// 招待取消は管理者専用。trainee が他人の招待を取り消せてはならない（認可欠落の回帰防止）。
+func Test_招待取消_管理者以外は拒否(t *testing.T) {
+	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 7, CompanyID: 1}}}
+	uc := NewCancelAdminInvitationUseCase(repo)
+
+	err := uc.Execute(context.Background(), CancelAdminInvitationInput{
+		ID: 7, ActorRole: domain.RoleTrainee, ActorCompanyID: 1,
+	})
+	if !errors.Is(err, ErrForbidden) {
+		t.Fatalf("trainee は拒否されるべき: got %v", err)
+	}
+}
+
+// company_admin は自社の招待だけ取り消せる。他社分は存在を漏らさず not found にする。
+func Test_招待取消_会社管理者は自社のみ(t *testing.T) {
+	rows := []domain.AdminInvitation{{ID: 7, CompanyID: 1}, {ID: 8, CompanyID: 2}}
+
+	t.Run("自社は取消できる", func(t *testing.T) {
+		uc := NewCancelAdminInvitationUseCase(&stubAdminInvRepo{rows: rows})
+		err := uc.Execute(context.Background(), CancelAdminInvitationInput{
+			ID: 7, ActorRole: domain.RoleCompanyAdmin, ActorCompanyID: 1,
+		})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+	})
+
+	t.Run("他社は not found", func(t *testing.T) {
+		uc := NewCancelAdminInvitationUseCase(&stubAdminInvRepo{rows: rows})
+		err := uc.Execute(context.Background(), CancelAdminInvitationInput{
+			ID: 8, ActorRole: domain.RoleCompanyAdmin, ActorCompanyID: 1,
+		})
+		if !errors.Is(err, ErrInvitationNotFound) {
+			t.Fatalf("他社の招待は not found であるべき: got %v", err)
+		}
+	})
+}
+
+func Test_招待取消_super_adminは全社取消できる(t *testing.T) {
+	repo := &stubAdminInvRepo{rows: []domain.AdminInvitation{{ID: 8, CompanyID: 2}}}
+	uc := NewCancelAdminInvitationUseCase(repo)
+
+	err := uc.Execute(context.Background(), CancelAdminInvitationInput{
+		ID: 8, ActorRole: domain.RoleSuperAdmin,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
 	}
 }
 

--- a/backend/internal/usecase/errors.go
+++ b/backend/internal/usecase/errors.go
@@ -1,0 +1,16 @@
+package usecase
+
+import "errors"
+
+// 層をまたいで意味が変わらない共通のエラー。
+//
+// handler はこれらを errors.Is で判定して HTTP ステータスにマップする。
+// 文字列比較（err.Error() == "forbidden" 等）はエラー文言を変えた瞬間に
+// 静かに 500 へ化けるため使わないこと。
+//
+// 個別の事情がある場合は fmt.Errorf("%w: 詳細", ErrForbidden) のようにラップして、
+// errors.Is での判定を保ったまま文脈を足す。
+var (
+	// ErrForbidden は認証は済んでいるが操作の権限がないことを表す（403）。
+	ErrForbidden = errors.New("forbidden")
+)

--- a/backend/internal/usecase/repository/admin_invitation.go
+++ b/backend/internal/usecase/repository/admin_invitation.go
@@ -16,6 +16,8 @@ type AdminInvitationRepository interface {
 	FindPendingByEmail(ctx context.Context, email string) (*domain.AdminInvitation, error)
 	// FindPendingByToken は token 一致 & pending & 未期限切れのみ返す（該当なしは nil, nil）。
 	FindPendingByToken(ctx context.Context, token string) (*domain.AdminInvitation, error)
+	// FindByID は ID 一致の招待を返す（該当なしは nil, nil）。会社スコープの認可判定に使う。
+	FindByID(ctx context.Context, id uint64) (*domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
 	UpdateStatus(ctx context.Context, id uint64, status string) error
 }

--- a/backend/internal/usecase/session_note_usecase.go
+++ b/backend/internal/usecase/session_note_usecase.go
@@ -17,11 +17,28 @@ func NewGetSessionNoteUseCase(r repository.SessionNoteRepository) *GetSessionNot
 	return &GetSessionNoteUseCase{repo: r}
 }
 
-func (u *GetSessionNoteUseCase) Execute(ctx context.Context, sessionID uint64) (*domain.SessionNote, error) {
-	if sessionID == 0 {
-		return nil, errors.New("sessionID is required")
+// GetSessionNoteInput は取得対象と、それを要求している利用者を表す。
+// UserID は所有者検証に使う（他人のノートを sessionID の総当たりで読めないようにする）。
+type GetSessionNoteInput struct {
+	SessionID uint64
+	UserID    uint64
+}
+
+// Execute は所有者本人のノートのみ返す。
+// 他人のノートは「存在しない」と同じ扱い（nil, nil）にして、
+// そのセッションにノートがあること自体を漏らさない。
+func (u *GetSessionNoteUseCase) Execute(ctx context.Context, in GetSessionNoteInput) (*domain.SessionNote, error) {
+	if in.SessionID == 0 || in.UserID == 0 {
+		return nil, errors.New("sessionID and userID are required")
 	}
-	return u.repo.FindBySessionID(ctx, sessionID)
+	n, err := u.repo.FindBySessionID(ctx, in.SessionID)
+	if err != nil || n == nil {
+		return nil, err
+	}
+	if n.UserID != in.UserID {
+		return nil, nil
+	}
+	return n, nil
 }
 
 // UpsertSessionNoteUseCase はセッションノートを upsert する。

--- a/backend/internal/usecase/session_note_usecase_test.go
+++ b/backend/internal/usecase/session_note_usecase_test.go
@@ -24,11 +24,38 @@ func (s *stubSessionNoteRepo) Upsert(_ context.Context, n *domain.SessionNote) e
 	return nil
 }
 
-func Test_セッションノート取得_セッションIDが必須(t *testing.T) {
+func Test_セッションノート取得_セッションIDとユーザーIDが必須(t *testing.T) {
 	uc := NewGetSessionNoteUseCase(&stubSessionNoteRepo{})
-	if _, err := uc.Execute(context.Background(), 0); err == nil {
-		t.Fatal("expected error")
+
+	if _, err := uc.Execute(context.Background(), GetSessionNoteInput{UserID: 2}); err == nil {
+		t.Fatal("sessionID 未指定はエラーであるべき")
 	}
+	if _, err := uc.Execute(context.Background(), GetSessionNoteInput{SessionID: 1}); err == nil {
+		t.Fatal("userID 未指定はエラーであるべき")
+	}
+}
+
+// sessionID を総当たりしても他人のノートは読めない（IDOR の回帰防止）。
+func Test_セッションノート取得_他人のノートは返さない(t *testing.T) {
+	repo := &stubSessionNoteRepo{n: &domain.SessionNote{SessionID: 1, UserID: 2, Content: "secret"}}
+	uc := NewGetSessionNoteUseCase(repo)
+
+	t.Run("所有者本人は取得できる", func(t *testing.T) {
+		got, err := uc.Execute(context.Background(), GetSessionNoteInput{SessionID: 1, UserID: 2})
+		if err != nil || got == nil || got.Content != "secret" {
+			t.Fatalf("unexpected: %+v err=%v", got, err)
+		}
+	})
+
+	t.Run("別ユーザーには存在しない扱い", func(t *testing.T) {
+		got, err := uc.Execute(context.Background(), GetSessionNoteInput{SessionID: 1, UserID: 999})
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("他人のノートが漏れている: %+v", got)
+		}
+	})
 }
 
 func Test_セッションノート保存_バリデーション(t *testing.T) {


### PR DESCRIPTION
## 概要

コード全体のリファクタリング調査の過程で見つかった、**認可(権限チェック)の抜け 2 件**を修正します。いずれも「ログインしていれば権限のない操作ができてしまう」もので、リファクタリング本体より先に単独で出します。

## 変更内容

### 1. 招待の取消に権限チェックを追加

`DELETE /admin/invitations/{id}` に role チェックが無く、作成(Create)側には実装されている認可が取消側だけ抜けていました。

- 管理者(super_admin / company_admin)のみ許可
- company_admin は自社の招待に限定。他社の招待は**存在を漏らさないため not found 扱い**
- 取消対象の会社を判定するため `AdminInvitationRepository.FindByID` を追加

### 2. セッションノート取得に所有者検証を追加

`GET /sessions/{sessionId}/note` に所有者確認が無く、保存(Upsert)側には「userId は current user 固定(IDOR 対策)」と実装されていたのに取得側だけ漏れていました。

- 所有者本人のノートのみ返す
- 他人のものは**存在しない扱い(404)**にして、そのセッションにノートがあること自体を漏らさない

### 3. 共通 sentinel `usecase.ErrForbidden` を追加

既存コードには `err.Error() == "forbidden"` のような**文字列比較で 403 を判定している箇所**があり、文言を変えた瞬間に 403 が静かに 500 に化ける状態でした。その解消の起点として共通エラーを定義します(既存の個別 sentinel は段階的に寄せます)。

## テスト

**いずれも修正前のコードでは失敗する回帰テスト**を追加しました。

- 招待取消: 受講者は拒否 / 会社管理者は自社のみ・他社は not found / 運営は全社取消可
- セッションノート: 所有者本人は取得可 / 別ユーザーには存在しない扱い

検証結果: `go build` OK / `go test ./internal/...` 全パッケージ ok / `golangci-lint` 0 issues / `archlint` OK / `make openapi` 再生成済み

## 関連チケット

- FRESTYLE-228 https://frestyle.atlassian.net/browse/FRESTYLE-228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **機能改善**
  * 招待のキャンセル時に、実行者の権限と所属会社を確認するようになりました。
  * 会社管理者は自社の招待のみ、スーパー管理者は全社の招待をキャンセルできます。
  * 権限不足、未認証、対象未存在などの状態を適切なエラーとして返します。
  * セッションノートは本人のみ閲覧でき、他ユーザーのノートは表示されません。
  * 招待IDやセッション情報の入力チェックを強化しました。

* **バグ修正**
  * 他ユーザーのセッションノートが閲覧できる可能性を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->