### PR TITLE
fix: 会社一覧の認可欠落を修正し admin ルート全体を多層防御する (FRESTYLE-76)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -72,7 +72,7 @@ const docTemplate = `{
                         "CookieAuth": []
                     }
                 ],
-                "description": "全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。",
+                "description": "全 company を 返す。 super_admin 専用。 顧客 企業 の 一覧 な ので 他 role に は 出さ ない。",
                 "produces": [
                     "application/json"
                 ],
@@ -88,6 +88,18 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Company"
                             }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "500": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -65,7 +65,7 @@
                         "CookieAuth": []
                     }
                 ],
-                "description": "全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。",
+                "description": "全 company を 返す。 super_admin 専用。 顧客 企業 の 一覧 な ので 他 role に は 出さ ない。",
                 "produces": [
                     "application/json"
                 ],
@@ -81,6 +81,18 @@
                             "items": {
                                 "$ref": "#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Company"
                             }
+                        }
+                    },
+                    "401": {
+                        "description": "未 認証",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "super_admin 以外",
+                        "schema": {
+                            "$ref": "#/definitions/internal_handler.errorResponse"
                         }
                     },
                     "500": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1118,7 +1118,7 @@ paths:
       - admin
   /admin/companies:
     get:
-      description: 全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。
+      description: 全 company を 返す。 super_admin 専用。 顧客 企業 の 一覧 な ので 他 role に は 出さ ない。
       produces:
       - application/json
       responses:
@@ -1128,6 +1128,14 @@ paths:
             items:
               $ref: '#/definitions/github_com_norman6464_FreStyle_backend_internal_domain.Company'
             type: array
+        "401":
+          description: 未 認証
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
+        "403":
+          description: super_admin 以外
+          schema:
+            $ref: '#/definitions/internal_handler.errorResponse'
         "500":
           description: DB 失敗
           schema:

--- a/backend/internal/handler/admin_company_handler.go
+++ b/backend/internal/handler/admin_company_handler.go
@@ -34,14 +34,20 @@ func NewAdminCompanyHandler(
 }
 
 // @Summary      会社 一覧 (SuperAdmin)
-// @Description  全 company を 返す。 super_admin 専用 画面 用。 認可 は middleware で 別途 担保。
+// @Description  全 company を 返す。 super_admin 専用。 顧客 企業 の 一覧 な ので 他 role に は 出さ ない。
 // @Tags         admin
 // @Produce      json
 // @Success      200  {array}   github_com_norman6464_FreStyle_backend_internal_domain.Company
+// @Failure      401  {object}  errorResponse  "未 認証"
+// @Failure      403  {object}  errorResponse  "super_admin 以外"
 // @Failure      500  {object}  errorResponse  "DB 失敗"
 // @Router       /admin/companies [get]
 // @Security     CookieAuth
 func (h *AdminCompanyHandler) List(c *gin.Context) {
+	if !isSuperAdmin(middleware.CurrentUserFromContext(c)) {
+		c.JSON(http.StatusForbidden, errorResponse{Error: "forbidden"})
+		return
+	}
 	companies, err := h.list.Execute(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})

--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -77,21 +77,62 @@ func Test_会社管理ハンドラ_横断ビュー_super_admin以外は禁止(t 
 	}
 }
 
-func Test_会社管理ハンドラ_一覧_正常系(t *testing.T) {
+// listCompaniesAs は指定 actor で会社一覧を叩く。actor が nil のときは未認証扱い。
+func listCompaniesAs(t *testing.T, actor *domain.User, repo *fakeCompanyRepo) *httptest.ResponseRecorder {
+	t.Helper()
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/admin/companies", nil)
-	newAdminCompanyHandler(&fakeCompanyRepo{rows: []domain.Company{{ID: 1, Name: "Co"}}}).List(c)
+	if actor != nil {
+		c.Set(middleware.ContextKeyCurrentUser, actor)
+	}
+	newAdminCompanyHandler(repo).List(c)
+	return w
+}
+
+func Test_会社管理ハンドラ_一覧_正常系(t *testing.T) {
+	w := listCompaniesAs(
+		t,
+		&domain.User{ID: 1, Role: domain.RoleSuperAdmin},
+		&fakeCompanyRepo{rows: []domain.Company{{ID: 1, Name: "Co"}}},
+	)
 	if w.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", w.Code)
 	}
 }
 
+// 顧客企業の一覧は super_admin 専用。trainee / company_admin / 未認証には出さない
+// （認可が抜けており全認証ユーザーが列挙できた回帰の防止: FRESTYLE-76）。
+func Test_会社管理ハンドラ_一覧_super_admin以外は禁止(t *testing.T) {
+	cases := []struct {
+		name  string
+		actor *domain.User
+		want  int
+	}{
+		{"trainee", &domain.User{ID: 2, Role: domain.RoleTrainee}, http.StatusForbidden},
+		{"company_admin", &domain.User{ID: 3, Role: domain.RoleCompanyAdmin}, http.StatusForbidden},
+		{"未認証", nil, http.StatusForbidden},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeCompanyRepo{rows: []domain.Company{{ID: 1, Name: "Secret Co"}}}
+			w := listCompaniesAs(t, tc.actor, repo)
+			if w.Code != tc.want {
+				t.Fatalf("want %d, got %d", tc.want, w.Code)
+			}
+			if strings.Contains(w.Body.String(), "Secret Co") {
+				t.Fatalf("会社名が漏れている: %s", w.Body.String())
+			}
+		})
+	}
+}
+
 func Test_会社管理ハンドラ_一覧_エラー(t *testing.T) {
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodGet, "/admin/companies", nil)
-	newAdminCompanyHandler(&fakeCompanyRepo{err: context.DeadlineExceeded}).List(c)
+	w := listCompaniesAs(
+		t,
+		&domain.User{ID: 1, Role: domain.RoleSuperAdmin},
+		&fakeCompanyRepo{err: context.DeadlineExceeded},
+	)
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", w.Code)
 	}

--- a/backend/internal/handler/admin_company_handler_test.go
+++ b/backend/internal/handler/admin_company_handler_test.go
@@ -31,9 +31,14 @@ type fakeCompanyRepo struct {
 	activeCalled bool
 	gotActiveID  uint64
 	gotActive    bool
+	// listAllCalls は「拒否時に DB を引いていないこと」を検証するための呼び出し回数。
+	listAllCalls int
 }
 
-func (f *fakeCompanyRepo) ListAll(context.Context) ([]domain.Company, error) { return f.rows, f.err }
+func (f *fakeCompanyRepo) ListAll(context.Context) ([]domain.Company, error) {
+	f.listAllCalls++
+	return f.rows, f.err
+}
 
 func (f *fakeCompanyRepo) FindByID(context.Context, uint64) (*domain.Company, error) {
 	return nil, f.err
@@ -77,7 +82,10 @@ func Test_会社管理ハンドラ_横断ビュー_super_admin以外は禁止(t 
 	}
 }
 
-// listCompaniesAs は指定 actor で会社一覧を叩く。actor が nil のときは未認証扱い。
+// listCompaniesAs は指定 actor で会社一覧を叩く。
+// handler を直接呼ぶため middleware.RequireAdmin は通らない点に注意。
+// actor が nil のケースは「currentUser 未設定」を表し、handler 単体では
+// isSuperAdmin(nil) により 403 になる（実運用では入口の middleware が先に 401 を返す）。
 func listCompaniesAs(t *testing.T, actor *domain.User, repo *fakeCompanyRepo) *httptest.ResponseRecorder {
 	t.Helper()
 	w := httptest.NewRecorder()
@@ -121,6 +129,53 @@ func Test_会社管理ハンドラ_一覧_super_admin以外は禁止(t *testing.
 				t.Fatalf("want %d, got %d", tc.want, w.Code)
 			}
 			if strings.Contains(w.Body.String(), "Secret Co") {
+				t.Fatalf("会社名が漏れている: %s", w.Body.String())
+			}
+		})
+	}
+}
+
+// 実ルートと同じ順序（RequireAdmin → List）で認可を検証する。
+// handler 単体テストでは middleware を通らないため、未認証が 401 になることや
+// 非管理者が入口で落ちて DB を引かないことは、この形でしか担保できない。
+func Test_会社一覧_実ルート順序での認可(t *testing.T) {
+	cases := []struct {
+		name      string
+		actor     *domain.User
+		want      int
+		wantCalls int
+	}{
+		{"super_admin は取得できる", &domain.User{ID: 1, Role: domain.RoleSuperAdmin}, http.StatusOK, 1},
+		{"company_admin は 403", &domain.User{ID: 2, Role: domain.RoleCompanyAdmin}, http.StatusForbidden, 0},
+		{"trainee は入口で 403", &domain.User{ID: 3, Role: domain.RoleTrainee}, http.StatusForbidden, 0},
+		{"未認証は入口で 401", nil, http.StatusUnauthorized, 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeCompanyRepo{rows: []domain.Company{{ID: 1, Name: "Secret Co"}}}
+
+			r := gin.New()
+			// CurrentUser middleware の代わりに actor を context へ積む。
+			r.Use(func(c *gin.Context) {
+				if tc.actor != nil {
+					c.Set(middleware.ContextKeyCurrentUser, tc.actor)
+				}
+				c.Next()
+			})
+			r.GET("/admin/companies", middleware.RequireAdmin(), newAdminCompanyHandler(repo).List)
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin/companies", nil))
+
+			if w.Code != tc.want {
+				t.Fatalf("status: want %d, got %d", tc.want, w.Code)
+			}
+			if repo.listAllCalls != tc.wantCalls {
+				t.Fatalf("ListAll 呼び出し回数: want %d, got %d（拒否時に DB を引いてはならない）",
+					tc.wantCalls, repo.listAllCalls)
+			}
+			if tc.want != http.StatusOK && strings.Contains(w.Body.String(), "Secret Co") {
 				t.Fatalf("会社名が漏れている: %s", w.Body.String())
 			}
 		})

--- a/backend/internal/handler/middleware/require_admin.go
+++ b/backend/internal/handler/middleware/require_admin.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+// RequireAdmin は super_admin / company_admin 以外を /admin/* 系から締め出す。
+//
+// 各 handler にも role 検査はあるが、それだけだと 1 箇所書き忘れただけで穴になる
+// （実際 GET /admin/companies で認可が抜けており、trainee が全顧客企業を列挙できた:
+// FRESTYLE-76。招待取消でも同種の漏れがあった: FRESTYLE-228）。
+// 入口で非管理者を落とす多層防御として置く。
+//
+// super_admin 限定か company_admin も可かの細かい判定は、引き続き各 handler / usecase
+// が行う（admin 配下には company_admin が使う会員管理・招待も含まれるため、
+// ここで super_admin 限定にはできない）。
+func RequireAdmin() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		user := CurrentUserFromContext(c)
+		if user == nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		if user.Role != domain.RoleSuperAdmin && user.Role != domain.RoleCompanyAdmin {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/handler/middleware/require_admin_test.go
+++ b/backend/internal/handler/middleware/require_admin_test.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+func TestRequireAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cases := []struct {
+		name       string
+		actor      *domain.User
+		wantStatus int
+		wantNext   bool
+	}{
+		{"super_admin は通す", &domain.User{ID: 1, Role: domain.RoleSuperAdmin}, http.StatusOK, true},
+		{"company_admin は通す", &domain.User{ID: 2, Role: domain.RoleCompanyAdmin}, http.StatusOK, true},
+		{"trainee は 403", &domain.User{ID: 3, Role: domain.RoleTrainee}, http.StatusForbidden, false},
+		{"role 空は 403", &domain.User{ID: 4}, http.StatusForbidden, false},
+		{"未認証は 401", nil, http.StatusUnauthorized, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nextCalled := false
+
+			r := gin.New()
+			// CurrentUser middleware の代わりに context へ actor を積む。
+			r.Use(func(c *gin.Context) {
+				if tc.actor != nil {
+					c.Set(ContextKeyCurrentUser, tc.actor)
+				}
+				c.Next()
+			})
+			r.GET("/admin/companies", RequireAdmin(), func(c *gin.Context) {
+				nextCalled = true
+				c.Status(http.StatusOK)
+			})
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/admin/companies", nil))
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status: want %d, got %d", tc.wantStatus, w.Code)
+			}
+			if nextCalled != tc.wantNext {
+				t.Fatalf("next 到達: want %v, got %v", tc.wantNext, nextCalled)
+			}
+		})
+	}
+}

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -30,7 +30,11 @@ func newAuditMiddleware(db *gorm.DB) gin.HandlerFunc {
 // registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
 // 認可（super_admin / company_admin のみ）は handler 層で実施する。
 // audit は変更操作を監査ログに記録する middleware（router で生成して共有する）。
-func registerAdminRoutes(g *gin.RouterGroup, deps *routeDeps, audit gin.HandlerFunc) {
+func registerAdminRoutes(parent *gin.RouterGroup, deps *routeDeps, audit gin.HandlerFunc) {
+	// 非管理者(trainee 等)は入口で落とす。個々の handler の role 検査は残すが、
+	// 1 箇所書き忘れただけで穴になるため多層防御を敷く（FRESTYLE-76 / FRESTYLE-228）。
+	g := parent.Group("", middleware.RequireAdmin())
+
 	companyRepo := persistence.NewCompanyRepository(deps.db)
 	companyHandler := NewAdminCompanyHandler(
 		usecase.NewListCompaniesUseCase(companyRepo),

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -27,8 +27,12 @@ func newAuditMiddleware(db *gorm.DB) gin.HandlerFunc {
 	})
 }
 
-// registerAdminRoutes は管理者向けの招待管理エンドポイントを登録する。
-// 認可（super_admin / company_admin のみ）は handler 層で実施する。
+// registerAdminRoutes は管理者向けエンドポイント（会社 / 会員 / 招待 / 監査ログ）を登録する。
+//
+// 認可は 2 段構え:
+//   - 入口: middleware.RequireAdmin が非管理者（trainee 等）を落とす
+//   - 詳細: super_admin 限定か company_admin も可かは各 handler / usecase が判定する
+//
 // audit は変更操作を監査ログに記録する middleware（router で生成して共有する）。
 func registerAdminRoutes(parent *gin.RouterGroup, deps *routeDeps, audit gin.HandlerFunc) {
 	// 非管理者(trainee 等)は入口で落とす。個々の handler の role 検査は残すが、

--- a/backend/internal/handler/routes_company_application.go
+++ b/backend/internal/handler/routes_company_application.go
@@ -24,7 +24,10 @@ func registerCompanyApplicationPublicRoutes(g *gin.RouterGroup, h *CompanyApplic
 	g.POST("/company-applications", middleware.RateLimitPerMinute(5, 5), h.Create)
 }
 
-// registerCompanyApplicationAdminRoutes は super_admin 用の一覧 / status 更新を登録する（認可は handler 層）。
+// registerCompanyApplicationAdminRoutes は super_admin 用の一覧 / status 更新を登録する。
+//
+// 認可は 2 段構え: 入口の middleware.RequireAdmin が非管理者を落とし、
+// super_admin 限定の判定は handler の requireSuperAdmin が行う。
 // audit は status 更新（承認/却下）を監査ログに記録する middleware。
 func registerCompanyApplicationAdminRoutes(parent *gin.RouterGroup, h *CompanyApplicationHandler, audit gin.HandlerFunc) {
 	// 他の /admin/* と同様、非管理者は入口で落とす（多層防御。細かい判定は handler 側）。

--- a/backend/internal/handler/routes_company_application.go
+++ b/backend/internal/handler/routes_company_application.go
@@ -26,7 +26,10 @@ func registerCompanyApplicationPublicRoutes(g *gin.RouterGroup, h *CompanyApplic
 
 // registerCompanyApplicationAdminRoutes は super_admin 用の一覧 / status 更新を登録する（認可は handler 層）。
 // audit は status 更新（承認/却下）を監査ログに記録する middleware。
-func registerCompanyApplicationAdminRoutes(g *gin.RouterGroup, h *CompanyApplicationHandler, audit gin.HandlerFunc) {
+func registerCompanyApplicationAdminRoutes(parent *gin.RouterGroup, h *CompanyApplicationHandler, audit gin.HandlerFunc) {
+	// 他の /admin/* と同様、非管理者は入口で落とす（多層防御。細かい判定は handler 側）。
+	g := parent.Group("", middleware.RequireAdmin())
+
 	g.GET("/admin/company-applications", h.List)
 	g.PATCH("/admin/company-applications/:id/status", audit, h.UpdateStatus)
 }


### PR DESCRIPTION
## 概要

`GET /admin/companies` に権限チェックが無く、**ログイン済みなら受講者(trainee)でも全顧客企業を列挙できる**状態でした。B2B SaaS で顧客リストが他社に露出するため優先度高です。

同じ handler の `Stats` / `SetActive` には `isSuperAdmin` ガードがあり、**一覧だけ実装漏れ**でした。swagger には「認可は middleware で別途担保」と書かれていましたが、admin ルートは認証のみの `authed` グループに登録されており、**その記述自体が誤り**でした。

## 変更内容

### 1. 直接の修正
- `List` に `isSuperAdmin` ガードを追加（兄弟メソッドと同じ形）
- 誤っていた swagger の `@Description` を実態に修正し、`@Failure 401/403` を追記 → `make openapi` 再生成

### 2. 多層防御（同種バグの構造的な予防）
- `middleware.RequireAdmin` を新設し、**`/admin/*` 全体で非管理者を入口で遮断**
- handler 側の細かい判定（super_admin 限定か company_admin も可か）は従来どおり残す。admin 配下には company_admin が使う会員管理・招待が含まれるため、一律 super_admin にはできないため
- 今回の件と FRESTYLE-228（招待取消の認可漏れ）は同じ構造の事故なので、handler の書き忘れが即座に穴になる状態を塞ぎます

### 3. 全 admin エンドポイントの監査（チケットの受け入れ条件）

| エンドポイント | 認可 |
|---|---|
| `/admin/companies` List | ❌ 漏れ → **本 PR で修正** |
| `/admin/companies` Stats / SetActive | ✅ isSuperAdmin |
| `/admin/members` 全 5 メソッド | ✅ isAdminActor |
| `/admin/invitations` List / Create | ✅ role 分岐 |
| `/admin/invitations` Cancel | ✅ FRESTYLE-228 で修正済(usecase 層) |
| `/admin/audit-events` | ✅ isSuperAdmin |
| `/admin/company-applications` | ✅ requireSuperAdmin |

**漏れは本件の 1 件のみ**でした。

## テスト

- handler: trainee / company_admin / 未認証 → **403 かつ会社名がレスポンスに含まれないこと**を検証、super_admin → 200
- middleware: super_admin/company_admin は通過、trainee・role 空 → 403、未認証 → 401（テーブル駆動）
- **修正を外すとテストが落ちることを実際に確認済み**（trainee で 200 が返り会社名が漏れる）
- `go test ./internal/...` 全 9 パッケージ ok / `golangci-lint` 0 issues / `archlint` OK

## 関連チケット

- FRESTYLE-76 https://frestyle.atlassian.net/browse/FRESTYLE-76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ**
  - 管理者向け機能へのアクセス制御を強化しました。
  - 未認証の場合は401、権限のない場合は403を返し、処理を拒否します。
  - 会社一覧はsuper_adminのみ利用可能となり、未許可ユーザーに会社情報を表示しません。
  - 企業申請の一覧取得・ステータス更新にも管理者認証を適用しました。

- **テスト**
  - 各権限レベルおよび未認証状態でのアクセス制御を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->