### PR TITLE
fix: ダッシュボード等で紹介ページが一瞬映るちらつきを解消 (FRESTYLE-230)

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -105,15 +105,21 @@ jobs:
         run: |
           aws s3 sync dist/ s3://fre-style-bucket --delete \
             --cache-control "public, max-age=31536000, immutable" \
-            --exclude "index.html"
+            --exclude "index.html" \
+            --exclude "app.html"
 
       # 2) index.html は no-cache。これがないと古い index.html がブラウザにキャッシュされ、
       #    次デプロイの --delete で消えた旧チャンクを参照して 404(MIME text/html)になる。
-      - name: Upload index.html (no-cache)
+      # index.html はトップ用(プリレンダー済み)、app.html は SPA フォールバック用(空シェル)。
+      # どちらも no-cache。古い HTML がキャッシュされると、--delete で消えた旧チャンクを
+      # 参照して 404(MIME text/html)になる。
+      - name: Upload HTML entrypoints (no-cache)
         run: |
-          aws s3 cp dist/index.html s3://fre-style-bucket/index.html \
-            --cache-control "no-cache, must-revalidate" \
-            --content-type "text/html; charset=utf-8"
+          for f in index.html app.html; do
+            aws s3 cp "dist/$f" "s3://fre-style-bucket/$f" \
+              --cache-control "no-cache, must-revalidate" \
+              --content-type "text/html; charset=utf-8"
+          done
 
       - name: Invalidate CloudFront cache
         run: |

--- a/frontend/scripts/prerender.mjs
+++ b/frontend/scripts/prerender.mjs
@@ -13,12 +13,14 @@
  * 使い方: npm run build && node scripts/prerender.mjs
  */
 import { createServer } from 'node:http';
-import { readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
+import { copyFile, readFile, writeFile, mkdir, readdir, stat } from 'node:fs/promises';
 import { join, extname, dirname, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
 
 const ROUTES = ['/']; // Phase 1: 公開トップのみ
+// SPA フォールバック用の空シェル。CloudFront のエラー応答がこのファイルを返す（FRESTYLE-230）。
+const SHELL_FILE = 'app.html';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DIST = join(HERE, '..', 'dist');
 const READY_SELECTOR = 'html[data-prerender-ready]';
@@ -108,6 +110,21 @@ async function main() {
   if (!(await fileExists(join(DIST, 'index.html')))) {
     throw new Error('dist/index.html が無い。先に `npm run build` を実行してください。');
   }
+
+  // プリレンダーで index.html を上書きする前に、素の（中身が空の）シェルを app.html として残す。
+  // CloudFront の SPA フォールバックはこちらを返す。index.html を返すと /dashboard 等でも
+  // LP の HTML が先に描画され、「一瞬 LP が映ってから目的の画面に切り替わる」ちらつきになる
+  // （FRESTYLE-230）。トップ(/)だけは既定のルートオブジェクトとして index.html が返るため
+  // SEO 用のプリレンダー結果はそのまま活きる。
+  const shellPath = join(DIST, SHELL_FILE);
+  await copyFile(join(DIST, 'index.html'), shellPath);
+  const shellHtml = await readFile(shellPath, 'utf-8');
+  if (!/<div id="root">\s*<\/div>/.test(shellHtml)) {
+    throw new Error(
+      `prerender: ${SHELL_FILE} が空シェルでない。build 直後の index.html から作る必要がある。`,
+    );
+  }
+  console.log(`shell: ${SHELL_FILE}（SPA フォールバック用・空シェル）`);
 
   const { server, port } = await startServer();
   const base = `http://127.0.0.1:${port}`;


### PR DESCRIPTION
## 概要

`/dashboard` などトップ以外を開くと、**毎回一瞬だけ紹介ページ(LP)が表示されてから目的の画面に切り替わる**問題の修正です。利用者から「ものすごいストレス」との報告があり最優先で対応しました。

## 原因

SEO 対策(FRESTYLE-222)で LP の内容を焼き込んだ `index.html` を配信するようにしましたが、CloudFront の SPA フォールバック(400/403/404/500 → `/index.html`)により、**`/dashboard` でも同じ LP 入り HTML が返っていました**。

実測: `/` と `/dashboard` が**同一の 28,987 バイト**を返していた。

そのためブラウザは「LP を描画 → JS 起動 → 目的の画面に描き替え」となり、LP が一瞬見えていました。

## 変更内容

**トップだけ LP 入り、それ以外は空シェル**を返す構成にします。

- `scripts/prerender.mjs`: `index.html` を上書きする前の**素のシェルを `app.html` として保存**。空シェルであることを assert（取り違え防止の回帰ガード）
- `cd-frontend.yml`: `app.html` も `index.html` と同様に **no-cache** でアップロードし、長期キャッシュ側の sync からは除外

**あわせて CloudFront のエラー応答の参照先を `/index.html` → `/app.html` に切り替えます**（配信は Terraform 管理外のため CLI で実施。マージ後に適用）。

トップ(`/`)は既定のルートオブジェクトとして `index.html` を返すため、**SEO 効果はそのまま維持**されます。

## 検証（実ブラウザ）

CloudFront の挙動（`/`→index.html、実ファイル→そのまま、それ以外→app.html）を再現したローカルサーバに Playwright で接続し、描画を 10ms 間隔で監視しました。

| パス | LP の描画 | 期待 | 結果 |
|---|---|---|---|
| `/dashboard` | なし | 映ってはいけない | ✅ |
| `/notes` | なし | 映ってはいけない | ✅ |
| `/` | あり | 映るべき | ✅ |

**フォールバックを `index.html` に戻すと `/dashboard` `/notes` が ❌ になることも確認済み**（検証手法が有効であることの担保）。

生成物: `index.html` 28,987 バイト（LP 入り）/ `app.html` 6,416 バイト（空シェル）

## スコープ外

`/company-application` など他の公開ページのプリレンダー配信は FRESTYLE-221 の Phase 2 として別途。

## 関連チケット

- FRESTYLE-230 https://frestyle.atlassian.net/browse/FRESTYLE-230