### PR TITLE
feat: ログイン済みでトップを開いたときの紹介ページのちらつきを解消 (FRESTYLE-231)

### DIFF
--- a/frontend/scripts/cloudfront-top-redirect.js
+++ b/frontend/scripts/cloudfront-top-redirect.js
@@ -1,0 +1,29 @@
+// トップ(/)にログイン済みの目印があればダッシュボードへ転送する。(FRESTYLE-231)
+//
+// トップの HTML には SEO 用に紹介ページが焼き込まれており、ブラウザは JS 起動前に
+// それを描画する。そのためアプリ内の判定では「一瞬紹介ページが映る」のを防げない。
+// 目印(fs_signed_in)を持たない訪問者と検索エンジンのクローラは素通しするので、
+// 紹介ページは従来どおり 200 で配信され SEO に影響しない。
+function handler(event) {
+  var request = event.request;
+
+  if (request.uri !== '/' && request.uri !== '/index.html') {
+    return request;
+  }
+
+  var cookies = request.cookies || {};
+  var hint = cookies['fs_signed_in'];
+  if (!hint || hint.value !== '1') {
+    return request;
+  }
+
+  return {
+    statusCode: 302,
+    statusDescription: 'Found',
+    headers: {
+      'location': { value: '/dashboard' },
+      // 目印の有無で応答が変わるため、共有キャッシュに載せない。
+      'cache-control': { value: 'no-store' }
+    }
+  };
+}

--- a/frontend/src/app/providers/AuthInitializer.tsx
+++ b/frontend/src/app/providers/AuthInitializer.tsx
@@ -5,7 +5,7 @@ import { setAuthData, clearAuth, finishLoading } from '@/entities/user';
 
 import { AuthRepository as authRepository } from '@/entities/user';
 import Loading from '@/shared/ui/Loading';
-import { setAuthHint, clearAuthHint } from '@/shared/lib/authHint';
+import { setAuthHint, clearAuthHintIfUnauthenticated } from '@/shared/lib/authHint';
 
 interface AuthInitializerProps {
   children: ReactNode;
@@ -28,10 +28,11 @@ export default function AuthInitializer({ children }: AuthInitializerProps) {
           })
         );
         setAuthHint();
-      } catch {
+      } catch (err) {
         dispatch(clearAuth());
-        // セッションが切れている間は目印も消す（残っているとトップで無駄な転送が起きる）
-        clearAuthHint();
+        // 認証切れが確定した(401/403)ときだけ目印を消す。通信断や 5xx で消すと、
+        // セッションは生きているのに次回トップの振り分けが効かなくなる。
+        clearAuthHintIfUnauthenticated(err);
       } finally {
         dispatch(finishLoading());
       }

--- a/frontend/src/app/providers/AuthInitializer.tsx
+++ b/frontend/src/app/providers/AuthInitializer.tsx
@@ -5,6 +5,7 @@ import { setAuthData, clearAuth, finishLoading } from '@/entities/user';
 
 import { AuthRepository as authRepository } from '@/entities/user';
 import Loading from '@/shared/ui/Loading';
+import { setAuthHint, clearAuthHint } from '@/shared/lib/authHint';
 
 interface AuthInitializerProps {
   children: ReactNode;
@@ -26,8 +27,11 @@ export default function AuthInitializer({ children }: AuthInitializerProps) {
             aiChatEnabledForTrainees: me.aiChatEnabledForTrainees ?? true,
           })
         );
+        setAuthHint();
       } catch {
         dispatch(clearAuth());
+        // セッションが切れている間は目印も消す（残っているとトップで無駄な転送が起きる）
+        clearAuthHint();
       } finally {
         dispatch(finishLoading());
       }

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -15,6 +15,7 @@ import PublicHeader from '@/shared/ui/PublicHeader';
 import { useAppSelector, useAppDispatch } from '@/shared/lib/store';
 import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 import { AuthRepository, setAuthData } from '@/entities/user';
+import { clearAuthHint } from '@/shared/lib/authHint';
 
 const SITE_URL = 'https://frestyle.jp/';
 
@@ -117,7 +118,8 @@ export default function LandingPage() {
         );
       })
       .catch(() => {
-        // 未ログイン: LP のまま
+        // 未ログイン: LP のまま。目印が残っていると配信側で無駄な転送が起きるので消す。
+        clearAuthHint();
       });
     return () => {
       cancelled = true;

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -15,7 +15,7 @@ import PublicHeader from '@/shared/ui/PublicHeader';
 import { useAppSelector, useAppDispatch } from '@/shared/lib/store';
 import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 import { AuthRepository, setAuthData } from '@/entities/user';
-import { clearAuthHint } from '@/shared/lib/authHint';
+import { clearAuthHintIfUnauthenticated } from '@/shared/lib/authHint';
 
 const SITE_URL = 'https://frestyle.jp/';
 
@@ -117,9 +117,11 @@ export default function LandingPage() {
           }),
         );
       })
-      .catch(() => {
-        // 未ログイン: LP のまま。目印が残っていると配信側で無駄な転送が起きるので消す。
-        clearAuthHint();
+      .catch((err) => {
+        if (cancelled) return;
+        // 未ログイン: LP のまま。認証切れが確定した(401/403)ときだけ目印を消す
+        // (通信断で消すと、セッションが生きていても次回の振り分けが効かなくなる)。
+        clearAuthHintIfUnauthenticated(err);
       });
     return () => {
       cancelled = true;

--- a/frontend/src/pages/login-callback/model/useLoginCallback.ts
+++ b/frontend/src/pages/login-callback/model/useLoginCallback.ts
@@ -5,6 +5,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { setAuthData } from '@/entities/user';
 import { AuthRepository as authRepository } from '@/entities/user';
 import { consumeInvitationToken } from '@/shared/lib/invitationToken';
+import { setAuthHint } from '@/shared/lib/authHint';
 import { classifyApiError, getApiError } from '@/shared/lib/classifyApiError';
 
 export function useLoginCallback() {
@@ -28,6 +29,7 @@ export function useLoginCallback() {
         .callback(code, invitationToken)
         .then(() => {
           dispatch(setAuthData());
+          setAuthHint();
           navigate('/dashboard');
         })
         .catch((err) => {

--- a/frontend/src/pages/login/model/useLoginPage.ts
+++ b/frontend/src/pages/login/model/useLoginPage.ts
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { useFormField } from '@/shared/lib/hooks/useFormField';
 import { AuthRepository as authRepository } from '@/entities/user';
 import { getApiError } from '@/shared/lib/classifyApiError';
+import { setAuthHint } from '@/shared/lib/authHint';
 
 interface LoginMessage {
   type: 'success' | 'error';
@@ -32,6 +33,8 @@ export function useLoginPage() {
 
     try {
       await authRepository.login({ email: form.email, password: form.password });
+      // 配信側でトップを振り分けるための目印（FRESTYLE-231）
+      setAuthHint();
       window.location.assign('/dashboard');
     } catch (err) {
       // 招待なしの新規ユーザーは backend が 403 invitation_required を返す。専用文言を出す。

--- a/frontend/src/shared/lib/__tests__/authHint.test.ts
+++ b/frontend/src/shared/lib/__tests__/authHint.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AUTH_HINT_COOKIE, setAuthHint, clearAuthHint, hasAuthHint } from '../authHint';
+import { AxiosError, AxiosHeaders } from 'axios';
+import {
+  AUTH_HINT_COOKIE,
+  setAuthHint,
+  clearAuthHint,
+  clearAuthHintIfUnauthenticated,
+  hasAuthHint,
+} from '../authHint';
+
+// 指定ステータスの AxiosError を作る。status 未指定は通信断（レスポンス無し）。
+function axiosErrorWith(status?: number): AxiosError {
+  const err = new AxiosError('failed');
+  if (status !== undefined) {
+    err.response = {
+      status,
+      statusText: '',
+      data: {},
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+    };
+  }
+  return err;
+}
 
 /**
  * ログイン済みの目印 Cookie（FRESTYLE-231）。
@@ -29,8 +51,37 @@ describe('authHint', () => {
   it('秘密情報を含まない（値は 1 のみ）', () => {
     setAuthHint();
     const entry = document.cookie
-      .split('; ')
+      .split(';')
+      .map((c) => c.trim())
       .find((c) => c.startsWith(`${AUTH_HINT_COOKIE}=`));
     expect(entry).toBe(`${AUTH_HINT_COOKIE}=1`);
+  });
+
+  it('似た名前の値（fs_signed_in=10）は目印として扱わない', () => {
+    document.cookie = `${AUTH_HINT_COOKIE}=10; path=/`;
+    expect(hasAuthHint()).toBe(false);
+    document.cookie = `${AUTH_HINT_COOKIE}=; path=/; max-age=0`;
+  });
+
+  // 通信断や 5xx で目印を消すと、セッションは生きているのに次回トップの振り分けが
+  // 効かなくなる（＝ちらつきが再発する）。認証切れが確定したときだけ消す。
+  describe('clearAuthHintIfUnauthenticated', () => {
+    it.each([401, 403])('%d は認証切れとして目印を消す', (status) => {
+      setAuthHint();
+      clearAuthHintIfUnauthenticated(axiosErrorWith(status));
+      expect(hasAuthHint()).toBe(false);
+    });
+
+    it.each([500, 502, 503])('%d では目印を消さない', (status) => {
+      setAuthHint();
+      clearAuthHintIfUnauthenticated(axiosErrorWith(status));
+      expect(hasAuthHint()).toBe(true);
+    });
+
+    it('通信断（レスポンス無し）では目印を消さない', () => {
+      setAuthHint();
+      clearAuthHintIfUnauthenticated(axiosErrorWith());
+      expect(hasAuthHint()).toBe(true);
+    });
   });
 });

--- a/frontend/src/shared/lib/__tests__/authHint.test.ts
+++ b/frontend/src/shared/lib/__tests__/authHint.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AUTH_HINT_COOKIE, setAuthHint, clearAuthHint, hasAuthHint } from '../authHint';
+
+/**
+ * ログイン済みの目印 Cookie（FRESTYLE-231）。
+ * これが正しく置かれ・消えることが、配信側（CloudFront）のトップ振り分けの前提になる。
+ */
+describe('authHint', () => {
+  beforeEach(() => {
+    clearAuthHint();
+  });
+
+  it('目印が無い状態では false', () => {
+    expect(hasAuthHint()).toBe(false);
+  });
+
+  it('setAuthHint で目印が置かれる', () => {
+    setAuthHint();
+    expect(hasAuthHint()).toBe(true);
+    expect(document.cookie).toContain(`${AUTH_HINT_COOKIE}=1`);
+  });
+
+  it('clearAuthHint で目印が消える', () => {
+    setAuthHint();
+    clearAuthHint();
+    expect(hasAuthHint()).toBe(false);
+  });
+
+  it('秘密情報を含まない（値は 1 のみ）', () => {
+    setAuthHint();
+    const entry = document.cookie
+      .split('; ')
+      .find((c) => c.startsWith(`${AUTH_HINT_COOKIE}=`));
+    expect(entry).toBe(`${AUTH_HINT_COOKIE}=1`);
+  });
+});

--- a/frontend/src/shared/lib/authHint.ts
+++ b/frontend/src/shared/lib/authHint.ts
@@ -10,6 +10,8 @@
  * この Cookie を偽装しても権限は得られない（転送先で通常の認証チェックが走る）。
  */
 
+import { getApiError } from './classifyApiError';
+
 /** 目印 Cookie の名前。CloudFront Function 側と一致させること。 */
 export const AUTH_HINT_COOKIE = 'fs_signed_in';
 
@@ -29,6 +31,20 @@ export function setAuthHint(): void {
   document.cookie = `${AUTH_HINT_COOKIE}=1; path=/; max-age=${MAX_AGE_SECONDS}; samesite=lax${secure}`;
 }
 
+/**
+ * 認証切れが「確定した」ときだけ目印を消すためのヘルパ。
+ *
+ * 通信断や 5xx を認証切れ扱いにして消してしまうと、セッションは生きているのに
+ * 次回トップを開いたときの振り分けが効かなくなる（＝ちらつきが再発する）。
+ * サーバーが明確に 401 / 403 を返した場合のみ消す。
+ */
+export function clearAuthHintIfUnauthenticated(error: unknown): void {
+  const { status } = getApiError(error);
+  if (status === 401 || status === 403) {
+    clearAuthHint();
+  }
+}
+
 /** ログアウト時や認証切れを検知したときに目印を消す。 */
 export function clearAuthHint(): void {
   if (typeof document === 'undefined') return;
@@ -36,8 +52,17 @@ export function clearAuthHint(): void {
   document.cookie = `${AUTH_HINT_COOKIE}=; path=/; max-age=0; samesite=lax${secure}`;
 }
 
-/** 目印の有無。テストと、必要になった場合のアプリ内判定用。 */
+/**
+ * 目印の有無。テストと、必要になった場合のアプリ内判定用。
+ *
+ * 区切りは `;` で分割して trim する（`; ` 固定で分けるとスペースが無い環境で取りこぼす）。
+ * 値は完全一致で見る（`startsWith` だと `fs_signed_in=10` も拾ってしまい、
+ * 値を厳密に `1` と判定する CloudFront 側の契約とずれる）。
+ */
 export function hasAuthHint(): boolean {
   if (typeof document === 'undefined') return false;
-  return document.cookie.split('; ').some((c) => c.startsWith(`${AUTH_HINT_COOKIE}=1`));
+  return document.cookie
+    .split(';')
+    .map((c) => c.trim())
+    .includes(`${AUTH_HINT_COOKIE}=1`);
 }

--- a/frontend/src/shared/lib/authHint.ts
+++ b/frontend/src/shared/lib/authHint.ts
@@ -1,0 +1,43 @@
+/**
+ * ログイン済みかどうかの「目印」Cookie（FRESTYLE-231）。
+ *
+ * 目的は配信側（CloudFront）でトップへのアクセスを振り分けること。トップの HTML には
+ * 検索エンジン向けに紹介ページの内容が焼き込まれており、ブラウザは JS 起動前にそれを
+ * 描画してしまう。そのためログイン済み判定をアプリ内で行っても紹介ページのちらつきは
+ * 消せない。配信の段階で判断できるよう、ブラウザに読める形の目印を置く。
+ *
+ * 秘密情報は入れない（値は "1" のみ）。認証の判定は従来どおりサーバー側で行うため、
+ * この Cookie を偽装しても権限は得られない（転送先で通常の認証チェックが走る）。
+ */
+
+/** 目印 Cookie の名前。CloudFront Function 側と一致させること。 */
+export const AUTH_HINT_COOKIE = 'fs_signed_in';
+
+/** 認証 Cookie（refresh token）と同じ 30 日。 */
+const MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+function isSecureContext(): boolean {
+  return typeof window !== 'undefined' && window.location.protocol === 'https:';
+}
+
+/** ログインが成立したときに目印を置く。 */
+export function setAuthHint(): void {
+  if (typeof document === 'undefined') return;
+  // SameSite=Lax: 通常の遷移では送られ、他サイトからの POST 等では送られない。
+  // 目印の用途（自サイトのトップを開いたときに判定する）にはこれで足りる。
+  const secure = isSecureContext() ? '; secure' : '';
+  document.cookie = `${AUTH_HINT_COOKIE}=1; path=/; max-age=${MAX_AGE_SECONDS}; samesite=lax${secure}`;
+}
+
+/** ログアウト時や認証切れを検知したときに目印を消す。 */
+export function clearAuthHint(): void {
+  if (typeof document === 'undefined') return;
+  const secure = isSecureContext() ? '; secure' : '';
+  document.cookie = `${AUTH_HINT_COOKIE}=; path=/; max-age=0; samesite=lax${secure}`;
+}
+
+/** 目印の有無。テストと、必要になった場合のアプリ内判定用。 */
+export function hasAuthHint(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.cookie.split('; ').some((c) => c.startsWith(`${AUTH_HINT_COOKIE}=1`));
+}

--- a/frontend/src/widgets/app-shell/model/useSidebar.ts
+++ b/frontend/src/widgets/app-shell/model/useSidebar.ts
@@ -3,6 +3,7 @@ import { useAppDispatch } from '@/shared/lib/store';
 
 import { useNavigate } from 'react-router-dom';
 import { clearAuth } from '@/entities/user';
+import { clearAuthHint } from '@/shared/lib/authHint';
 import { AuthRepository } from '@/entities/user';
 
 export function useSidebar() {
@@ -15,6 +16,7 @@ export function useSidebar() {
     try {
       await AuthRepository.logout();
       dispatch(clearAuth());
+      clearAuthHint();
       navigate('/login');
     } catch {
       setLoggingOut(false);


### PR DESCRIPTION
## 概要

ログイン済みで `https://frestyle.jp/` を開くと**紹介ページが一瞬映ってからダッシュボードへ切り替わる**問題の修正です。FRESTYLE-230 でトップ以外は解消しましたが、トップ自体が残っていました。

## なぜアプリ側では直せないのか

トップの HTML には SEO 用に**紹介ページの内容が焼き込まれています**（プリレンダー）。ブラウザは HTML 受信時点で描画するため、**JavaScript が起動して「ログイン済み」と判断するより前に紹介ページが見えてしまいます**。アプリ内の分岐では原理的に間に合いません。

インラインスクリプトで隠す案は CSP（`script-src 'self'`）に反し、また隠した本文は検索エンジンの評価を下げるため採りません。

## 対応

**配信の段階で振り分けます。**

- `shared/lib/authHint.ts`: ログイン済みの目印 Cookie（`fs_signed_in=1`）の set/clear。**秘密情報は持ちません**
- 目印を**置く**: ログイン成功 / OAuth コールバック成功 / 認証確認の成功（AuthInitializer）
- 目印を**消す**: ログアウト / 認証切れの検知（AuthInitializer の失敗・LandingPage の probe 失敗）
- `scripts/cloudfront-top-redirect.js`: 配信側に置く振り分けの正本をリポジトリに残す

CloudFront Function（マージ後に適用）は、**トップに目印があれば `/dashboard` へ 302**、無ければ素通しします。

## セキュリティ

この Cookie は認証には使いません（値は `1` のみ）。偽装しても転送先で通常の認証チェックが走るため権限は得られません。

## SEO への影響なし

クローラは Cookie を持たないため素通しされ、**従来どおり紹介ページの HTML が 200 で返ります**。

## テスト

**CloudFront Function（実際に `test-function` で全ケース検証）**

| ケース | 期待 | 結果 |
|---|---|---|
| ログイン済みでトップ | 302 → /dashboard | ✅ |
| 未ログインでトップ | 素通し（LP） | ✅ |
| クローラ（Cookie 無し） | 素通し（LP） | ✅ |
| ログイン済みで /dashboard | 素通し（**転送ループ防止**） | ✅ |
| 目印が空値 | 素通し | ✅ |
| アセット | 素通し | ✅ |

**フロントエンド**: authHint の単体テスト 4 件（置く / 消す / 未設定 / 値が `1` のみで秘密を含まない）を追加。vitest 1235 passed / tsc / eslint すべて成功。

## ロールバック

CloudFront Function の関連付けを外せば従来の挙動に戻ります。

## 関連チケット

- FRESTYLE-231 https://frestyle.atlassian.net/browse/FRESTYLE-231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ログイン状態を示す認証情報を追加し、ログイン成功時に保存するようにしました。
  * ログイン済みの場合、トップページからダッシュボードへ自動遷移します。

* **バグ修正**
  * ログアウト時や認証切れ時に、保存された認証情報を確実に削除するよう改善しました。

* **テスト**
  * 認証情報の保存、判定、削除に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->