### PR TITLE
fix: 旧ドメイン削除で表示不能になった画像を復旧しフォールバックを追加 (FRESTYLE-232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## デプロイURL
 
-[https://normanblog.com](https://normanblog.com)
+[https://frestyle.jp](https://frestyle.jp)
 
 
 ## システム構成（全体像）

--- a/backend/migrations/0019_migrate_stale_image_domain.sql
+++ b/backend/migrations/0019_migrate_stale_image_domain.sql
@@ -5,12 +5,19 @@
 -- 移行前に保存された URL は名前解決できず、アバターと教材の図が表示できなくなった。
 -- S3 のオブジェクトは無傷で新ドメインから配信できるため、文字列の差し替えで復旧する。
 --
--- 教材本文には図の URL のほかに auth. / api. / staging. の説明も含まれる。これらは
--- 実際に frestyle.jp 配下へ移設済みなので、同じ置換で正しい値になる。
+-- 教材本文には図の URL のほかに auth. / api. / staging. / 送信元メールの説明も含まれる。
+-- これらは実際に frestyle.jp 配下へ移設済みなので、同じ置換で正しい値になる。
 -- 教材の正本リポジトリ（frestyle-teaching-materials）にも同一の置換を適用済みで、
 -- 次回の教材同期で旧ドメインが復活しないようにしてある。
 --
+-- 置換はドメイン境界に限定する。単純な部分文字列置換だと、旧ドメインを含むだけの
+-- 別ドメイン（notnormanblog.com / normanblog.company.com 等）まで壊してしまう。
+-- 前後が英数字・ハイフンでないことを先読み / 後読みで確認し、境界の文字を消費しない
+-- ため連続出現も取りこぼさない。
+--
 -- 冪等: 置換対象が無ければ 0 行更新で正常終了する。何度実行しても結果は変わらない。
+-- トランザクション: 適用は psql -f で行い外部のトランザクション管理は無いため、
+-- この中で BEGIN / COMMIT して原子性を確保する（既存 migration と同じ方式）。
 
 BEGIN;
 
@@ -18,18 +25,33 @@ BEGIN;
 -- apex に直す。この行は後段の一括置換より先に実行する必要がある
 -- （先に一括置換すると cdn.frestyle.jp という実在しない値になってしまう）。
 UPDATE course_chapters
-SET content = replace(content, 'https://cdn.normanblog.com', 'https://frestyle.jp')
-WHERE content LIKE '%cdn.normanblog.com%';
+SET content = regexp_replace(
+  content,
+  'https://cdn\.normanblog\.com(?![A-Za-z0-9-])',
+  'https://frestyle.jp',
+  'g'
+)
+WHERE content ~ 'https://cdn\.normanblog\.com(?![A-Za-z0-9-])';
 
 -- プロフィールのアイコン。
 UPDATE profiles
-SET avatar_url = replace(avatar_url, 'normanblog.com', 'frestyle.jp')
-WHERE avatar_url LIKE '%normanblog.com%';
+SET avatar_url = regexp_replace(
+  avatar_url,
+  '(?<![A-Za-z0-9-])normanblog\.com(?![A-Za-z0-9-])',
+  'frestyle.jp',
+  'g'
+)
+WHERE avatar_url ~ '(?<![A-Za-z0-9-])normanblog\.com(?![A-Za-z0-9-])';
 
 -- 教材本文（図の参照とアプリ内 URL の説明）。
 UPDATE course_chapters
-SET content = replace(content, 'normanblog.com', 'frestyle.jp')
-WHERE content LIKE '%normanblog.com%';
+SET content = regexp_replace(
+  content,
+  '(?<![A-Za-z0-9-])normanblog\.com(?![A-Za-z0-9-])',
+  'frestyle.jp',
+  'g'
+)
+WHERE content ~ '(?<![A-Za-z0-9-])normanblog\.com(?![A-Za-z0-9-])';
 
 -- 検証: 旧ドメインが残っていたら適用を失敗させる（部分適用のまま完了しない）。
 DO $$
@@ -37,10 +59,16 @@ DECLARE
   stale_profiles bigint;
   stale_chapters bigint;
   bogus_cdn      bigint;
+  corrupted      bigint;
 BEGIN
-  SELECT count(*) INTO stale_profiles FROM profiles WHERE avatar_url LIKE '%normanblog.com%';
-  SELECT count(*) INTO stale_chapters FROM course_chapters WHERE content LIKE '%normanblog.com%';
-  SELECT count(*) INTO bogus_cdn      FROM course_chapters WHERE content LIKE '%cdn.frestyle.jp%';
+  SELECT count(*) INTO stale_profiles FROM profiles
+   WHERE avatar_url ~ '(?<![A-Za-z0-9-])normanblog\.com(?![A-Za-z0-9-])';
+  SELECT count(*) INTO stale_chapters FROM course_chapters
+   WHERE content ~ '(?<![A-Za-z0-9-])normanblog\.com(?![A-Za-z0-9-])';
+  SELECT count(*) INTO bogus_cdn FROM course_chapters WHERE content LIKE '%cdn.frestyle.jp%';
+
+  -- 境界を無視した置換が起きると英数字の直後に新ドメインが現れる（例: notfrestyle.jp）。
+  SELECT count(*) INTO corrupted FROM course_chapters WHERE content ~ '[A-Za-z0-9-]frestyle\.jp';
 
   IF stale_profiles > 0 OR stale_chapters > 0 THEN
     RAISE EXCEPTION
@@ -50,6 +78,10 @@ BEGIN
 
   IF bogus_cdn > 0 THEN
     RAISE EXCEPTION '実在しない cdn.frestyle.jp が生成された: % 件', bogus_cdn;
+  END IF;
+
+  IF corrupted > 0 THEN
+    RAISE EXCEPTION 'ドメイン境界を跨いだ置換が起きた疑い: % 件', corrupted;
   END IF;
 END $$;
 

--- a/backend/migrations/0019_migrate_stale_image_domain.sql
+++ b/backend/migrations/0019_migrate_stale_image_domain.sql
@@ -1,0 +1,56 @@
+-- FRESTYLE-232: 保存済み絶対 URL の旧ドメインを新ドメインへ移行する。
+--
+-- 画像の表示 URL は「アップロード時点の配信ドメイン + キー」の絶対 URL として
+-- DB に保存される。FRESTYLE-226 で旧ドメイン normanblog.com を削除したため、
+-- 移行前に保存された URL は名前解決できず、アバターと教材の図が表示できなくなった。
+-- S3 のオブジェクトは無傷で新ドメインから配信できるため、文字列の差し替えで復旧する。
+--
+-- 教材本文には図の URL のほかに auth. / api. / staging. の説明も含まれる。これらは
+-- 実際に frestyle.jp 配下へ移設済みなので、同じ置換で正しい値になる。
+-- 教材の正本リポジトリ（frestyle-teaching-materials）にも同一の置換を適用済みで、
+-- 次回の教材同期で旧ドメインが復活しないようにしてある。
+--
+-- 冪等: 置換対象が無ければ 0 行更新で正常終了する。何度実行しても結果は変わらない。
+
+BEGIN;
+
+-- cdn.normanblog.com は実在しないサブドメイン（教材内の例示）。実際の配信元である
+-- apex に直す。この行は後段の一括置換より先に実行する必要がある
+-- （先に一括置換すると cdn.frestyle.jp という実在しない値になってしまう）。
+UPDATE course_chapters
+SET content = replace(content, 'https://cdn.normanblog.com', 'https://frestyle.jp')
+WHERE content LIKE '%cdn.normanblog.com%';
+
+-- プロフィールのアイコン。
+UPDATE profiles
+SET avatar_url = replace(avatar_url, 'normanblog.com', 'frestyle.jp')
+WHERE avatar_url LIKE '%normanblog.com%';
+
+-- 教材本文（図の参照とアプリ内 URL の説明）。
+UPDATE course_chapters
+SET content = replace(content, 'normanblog.com', 'frestyle.jp')
+WHERE content LIKE '%normanblog.com%';
+
+-- 検証: 旧ドメインが残っていたら適用を失敗させる（部分適用のまま完了しない）。
+DO $$
+DECLARE
+  stale_profiles bigint;
+  stale_chapters bigint;
+  bogus_cdn      bigint;
+BEGIN
+  SELECT count(*) INTO stale_profiles FROM profiles WHERE avatar_url LIKE '%normanblog.com%';
+  SELECT count(*) INTO stale_chapters FROM course_chapters WHERE content LIKE '%normanblog.com%';
+  SELECT count(*) INTO bogus_cdn      FROM course_chapters WHERE content LIKE '%cdn.frestyle.jp%';
+
+  IF stale_profiles > 0 OR stale_chapters > 0 THEN
+    RAISE EXCEPTION
+      '旧ドメインが残存: profiles.avatar_url=% 件 / course_chapters.content=% 件',
+      stale_profiles, stale_chapters;
+  END IF;
+
+  IF bogus_cdn > 0 THEN
+    RAISE EXCEPTION '実在しない cdn.frestyle.jp が生成された: % 件', bogus_cdn;
+  END IF;
+END $$;
+
+COMMIT;

--- a/frontend/src/shared/ui/Avatar.tsx
+++ b/frontend/src/shared/ui/Avatar.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 type AvatarSize = 'sm' | 'md' | 'lg' | 'xl';
 
 interface AvatarProps {
@@ -14,13 +16,26 @@ const SIZE_STYLES: Record<AvatarSize, { container: string; text: string }> = {
 };
 
 export default function Avatar({ name, src, size = 'md' }: AvatarProps) {
+  // 画像が読めなかったときは頭文字表示に戻す。フォールバックが無いとブラウザ既定の
+  // 「壊れた画像」マークと代替テキストが出て崩れた見た目になる（FRESTYLE-232）。
+  const [failed, setFailed] = useState(false);
   const initial = name ? name.charAt(0).toUpperCase() : '?';
   const styles = SIZE_STYLES[size];
 
-  if (src) {
+  // src が差し替わったら再試行する（前の URL の失敗を引きずらない）。
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  if (src && !failed) {
     return (
       <div className={`${styles.container} rounded-full flex-shrink-0 overflow-hidden`}>
-        <img src={src} alt={name} className="w-full h-full object-cover rounded-full" />
+        <img
+          src={src}
+          alt={name}
+          onError={() => setFailed(true)}
+          className="w-full h-full object-cover rounded-full"
+        />
       </div>
     );
   }

--- a/frontend/src/shared/ui/__tests__/Avatar.test.tsx
+++ b/frontend/src/shared/ui/__tests__/Avatar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Avatar from '../Avatar';
 
 describe('Avatar', () => {
@@ -81,5 +81,34 @@ describe('Avatar', () => {
     const { container } = render(<Avatar name="A" src="https://example.com/photo.jpg" />);
     const avatar = container.firstChild as HTMLElement;
     expect(avatar.className).toContain('rounded-full');
+  });
+
+  // 画像が読めないとき（配信先の消滅・削除済みオブジェクト等）にブラウザ既定の
+  // 「壊れた画像」を出さず、頭文字に戻ることを保証する（FRESTYLE-232）。
+  describe('画像の読み込みに失敗したとき', () => {
+    it('頭文字のフォールバックに切り替わる', () => {
+      render(<Avatar name="河野 拓真" src="https://example.com/dead.jpg" />);
+      fireEvent.error(screen.getByRole('img'));
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(screen.getByText('河')).toBeInTheDocument();
+    });
+
+    it('src が差し替わると再試行する', () => {
+      const { rerender } = render(<Avatar name="河野" src="https://example.com/dead.jpg" />);
+      fireEvent.error(screen.getByRole('img'));
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+
+      rerender(<Avatar name="河野" src="https://example.com/alive.jpg" />);
+
+      const img = screen.getByRole('img');
+      expect(img).toHaveAttribute('src', 'https://example.com/alive.jpg');
+    });
+
+    it('読み込めている間は画像のまま', () => {
+      render(<Avatar name="河野" src="https://example.com/alive.jpg" />);
+      expect(screen.getByRole('img')).toBeInTheDocument();
+      expect(screen.queryByText('河')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/shared/ui/__tests__/Avatar.test.tsx
+++ b/frontend/src/shared/ui/__tests__/Avatar.test.tsx
@@ -103,6 +103,8 @@ describe('Avatar', () => {
 
       const img = screen.getByRole('img');
       expect(img).toHaveAttribute('src', 'https://example.com/alive.jpg');
+      // 画像とフォールバックが同時に出ないこと（排他の契約を固定する）。
+      expect(screen.queryByText('河')).not.toBeInTheDocument();
     });
 
     it('読み込めている間は画像のまま', () => {


### PR DESCRIPTION
## 概要

ヘッダーのユーザーアイコンが**壊れた画像**として表示されるという指摘から調査したところ、アイコンだけでなく**教材の図 200 点も表示できなくなっている**ことが判明した。

原因は FRESTYLE-226 での旧ドメイン normanblog.com の削除。画像の表示 URL は「**アップロード時点の配信ドメイン + キー**」の絶対 URL として DB に保存される設計のため、ドメインを削除した時点で保存済み URL が名前解決できなくなった。

## 調査結果（本番で実地確認）

### 影響範囲（本番 DB の全テキスト列を横断調査）

| 対象 | 件数 | 症状 |
| --- | --- | --- |
| `profiles.avatar_url` | **4 件**（アイコン設定者の全員） | ヘッダー・設定画面のアイコンが壊れた画像になる |
| `course_chapters.content` | **140 章**（URL 実数 200 超） | 教材本文の図が表示されない |

修正前、`profiles.avatar_url` のうち新ドメインを指すものは **0 件**だった。

### 画像データ自体は無事

| 確認内容 | 結果 |
| --- | --- |
| `https://normanblog.com/notes/diagrams/*.png` | 応答コード **000**（名前解決失敗） |
| `https://frestyle.jp/notes/diagrams/*.png` | **200 / image/png** |
| `https://frestyle.jp/profiles/1/*.jpg` | **200 / image/jpeg** |
| CloudFront の振り分け | `profiles/*` `notes/*` は画像バケットへ正しく振り分け済み |

**保存されている文字列を差し替えるだけで復旧する**ことが確認できた。

## 変更内容

### 1. `Avatar` に読み込み失敗のフォールバックを追加

従来は `src` があれば画像タグを描画するのみで**失敗時の処理が無く**、ブラウザ既定の「壊れた画像」マークと代替テキストがそのまま出て、頭文字と重なった崩れた見た目になっていた。読み込み失敗を検知して頭文字表示へ切り替える。`src` が差し替わったら失敗状態をリセットし、前の URL の失敗を引きずらない。

### 2. migration `0019` — 保存済み URL の移行

`profiles.avatar_url` と `course_chapters.content` の旧ドメインを新ドメインへ置換する。

- **冪等**（対象が無ければ 0 行更新で正常終了。何度実行しても結果は同じ）
- 適用後に残存を数え、**残っていれば例外で停止**する（部分適用のまま完了しない）
- 教材内の `cdn.normanblog.com` は**実在しない架空のサブドメイン**（例示用）だったため、実際の配信元である apex に直す。この置換を一括置換より先に実行しないと `cdn.frestyle.jp` という実在しない値が生まれるため順序に依存する。この点も検証に含めた

### 3. README のデプロイ URL を新ドメインへ

## テスト

- **Avatar 単体テスト 16 件合格**（うち今回追加 3 件）: 読み込み失敗で頭文字に切り替わる / `src` 差し替えで再試行する / 読み込めている間は画像のまま
- 全体: **vitest 1245 passed (158 files)** / tsc / eslint 0 / build 成功 / カバレッジ 86.23%

### 本番適用の結果（適用済み）

| 項目 | 適用前 | 適用後 |
| --- | --- | --- |
| `profiles`（旧ドメイン） | 4 | **0** |
| `course_chapters`（旧ドメイン） | 140 | **0** |
| `profiles`（新ドメイン） | 0 | **4** |
| `course_chapters`（新ドメイン） | — | **140** |
| 架空の `cdn.frestyle.jp` | — | **0** |

修正後のアバター URL 3 件が **200 で画像**（jpeg / webp / png）を返すことを確認済み。

## 関連チケット

- FRESTYLE-232（本件）/ FRESTYLE-226（旧ドメイン撤去・発生元）
- 教材の正本: norman6464/frestyle-teaching-materials#39（マージ済み。**正本を直さないと次回の教材同期で旧 URL が復活する**）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - サイトのURLを `https://frestyle.jp` に変更しました。
  - プロフィール画像の読み込みに失敗した場合、ユーザーのイニシャルを表示するようになりました。
  - 画像URLが更新されると、自動的に再読み込みを試みます。

- **改善**
  - 保存済みコンテンツ内の旧ドメインを新ドメインへ更新しました。

- **不具合修正**
  - 画像が表示できない場合でも、プロフィール表示が崩れないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->