### PR TITLE
fix: 管理者の初回ログインで学習者向け画面が一瞬映るのを解消 (FRESTYLE-233)

### DIFF
--- a/frontend/src/features/auth/model/useAuth.ts
+++ b/frontend/src/features/auth/model/useAuth.ts
@@ -44,7 +44,15 @@ export const useAuth = () => {
       try {
         const userInfo = await AuthRepository.login(request);
         setUser(userInfo);
-        dispatch(setAuthData({ isAdmin: !!userInfo.isAdmin }));
+        dispatch(
+          setAuthData({
+            isAdmin: !!userInfo.isAdmin,
+            // role を渡さないと未確定(null)のまま「読み込み完了」になり、ダッシュボードが
+            // 既定として学習者向けを描画してしまう（FRESTYLE-233）。
+            role: userInfo.role ?? null,
+            aiChatEnabledForTrainees: userInfo.aiChatEnabledForTrainees ?? true,
+          }),
+        );
         return true;
       } catch (err) {
         setError(classifyApiError(err, 'ログインに失敗しました。'));
@@ -124,7 +132,13 @@ export const useAuth = () => {
     try {
       const userInfo = await AuthRepository.getCurrentUser();
       setUser(userInfo);
-      dispatch(setAuthData({ isAdmin: !!userInfo.isAdmin }));
+      dispatch(
+        setAuthData({
+          isAdmin: !!userInfo.isAdmin,
+          role: userInfo.role ?? null,
+          aiChatEnabledForTrainees: userInfo.aiChatEnabledForTrainees ?? true,
+        }),
+      );
       return userInfo;
     } catch (err) {
       setError(classifyApiError(err, 'ユーザー情報の取得に失敗しました。'));

--- a/frontend/src/features/auth/model/useAuth.ts
+++ b/frontend/src/features/auth/model/useAuth.ts
@@ -47,10 +47,11 @@ export const useAuth = () => {
         dispatch(
           setAuthData({
             isAdmin: !!userInfo.isAdmin,
-            // role を渡さないと未確定(null)のまま「読み込み完了」になり、ダッシュボードが
-            // 既定として学習者向けを描画してしまう（FRESTYLE-233）。
-            role: userInfo.role ?? null,
-            aiChatEnabledForTrainees: userInfo.aiChatEnabledForTrainees ?? true,
+            // 値が無いときは undefined のまま渡し、setAuthData に現在値を維持させる
+            // （FRESTYLE-233）。?? で null / true を入れると、ユーザー情報を返さない
+            // 応答（/auth/cognito/login は message のみ）で確定済みのロールを消してしまう。
+            role: userInfo.role,
+            aiChatEnabledForTrainees: userInfo.aiChatEnabledForTrainees,
           }),
         );
         return true;
@@ -135,8 +136,8 @@ export const useAuth = () => {
       dispatch(
         setAuthData({
           isAdmin: !!userInfo.isAdmin,
-          role: userInfo.role ?? null,
-          aiChatEnabledForTrainees: userInfo.aiChatEnabledForTrainees ?? true,
+          role: userInfo.role,
+          aiChatEnabledForTrainees: userInfo.aiChatEnabledForTrainees,
         }),
       );
       return userInfo;

--- a/frontend/src/pages/home/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/home/__tests__/MenuPage.test.tsx
@@ -35,7 +35,7 @@ const sampleSummary: CompanyLearningSummary = {
   ],
 };
 
-function renderMenu(role: string, aiChatEnabledForTrainees = true) {
+function renderMenu(role: string | null, aiChatEnabledForTrainees = true) {
   const store = configureStore({
     reducer: { auth: authReducer },
     preloadedState: {
@@ -151,5 +151,44 @@ describe('MenuPage', () => {
 
     expect(screen.getByText('コース')).toBeInTheDocument();
     expect(screen.queryByText('連続学習')).not.toBeInTheDocument();
+  });
+
+  // role が null のときは「未認証」と「未確定」を区別できない。確定前に描画すると
+  // すべてのロール判定が false になり、既定として学習者向けが出てしまう。
+  // 管理者のログイン直後に学習者画面が一瞬映る原因だった（FRESTYLE-233）。
+  describe('ロールが未確定のとき', () => {
+    it('学習者向けのカードを一切描画しない', () => {
+      renderMenu(null);
+
+      expect(screen.queryByText('コース')).not.toBeInTheDocument();
+      expect(screen.queryByText('コード演習')).not.toBeInTheDocument();
+      expect(screen.queryByText('ノート')).not.toBeInTheDocument();
+      expect(screen.queryByText('学習レポート')).not.toBeInTheDocument();
+    });
+
+    it('管理者向けのカードも見出しも描画しない', () => {
+      renderMenu(null);
+
+      expect(screen.queryByText('会社一覧')).not.toBeInTheDocument();
+      expect(screen.queryByText('招待管理')).not.toBeInTheDocument();
+      expect(screen.queryByText('管理メニュー')).not.toBeInTheDocument();
+      expect(screen.queryByText('FreStyle へようこそ')).not.toBeInTheDocument();
+    });
+
+    it('読み込み中であることを伝える', () => {
+      const { container } = renderMenu(null);
+
+      expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+    });
+
+    it('ロールが確定したら本来の画面に切り替わる', () => {
+      const { unmount } = renderMenu(null);
+      expect(screen.queryByText('管理メニュー')).not.toBeInTheDocument();
+      unmount();
+
+      renderMenu('super_admin');
+      expect(screen.getByText('管理メニュー')).toBeInTheDocument();
+      expect(screen.queryByText('コース')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/home/__tests__/MenuPage.test.tsx
+++ b/frontend/src/pages/home/__tests__/MenuPage.test.tsx
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
 import MenuPage from '../ui/MenuPage';
-import authReducer from '@/entities/user/model/authSlice';
+import authReducer, { setAuthData } from '@/entities/user/model/authSlice';
 import { useUserDashboard } from '../model/useUserDashboard';
 import { useCompanyLearningSummary } from '../model/useCompanyLearningSummary';
 import type { UserDashboard } from '@/entities/user';
@@ -42,13 +42,14 @@ function renderMenu(role: string | null, aiChatEnabledForTrainees = true) {
       auth: { role, aiChatEnabledForTrainees } as never,
     },
   });
-  return render(
+  const view = render(
     <Provider store={store}>
       <MemoryRouter>
         <MenuPage />
       </MemoryRouter>
     </Provider>,
   );
+  return { ...view, store };
 }
 
 describe('MenuPage', () => {
@@ -175,18 +176,24 @@ describe('MenuPage', () => {
       expect(screen.queryByText('FreStyle へようこそ')).not.toBeInTheDocument();
     });
 
-    it('読み込み中であることを伝える', () => {
-      const { container } = renderMenu(null);
+    it('読み込み中であることを支援技術に伝える', () => {
+      renderMenu(null);
 
-      expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveTextContent('読み込み中');
     });
 
+    // 同じ store を保ったままロールを流し込み、実際の遷移として検証する
+    // （別マウントで比較すると「起動時の状態」を 2 通り見ているだけになる）。
     it('ロールが確定したら本来の画面に切り替わる', () => {
-      const { unmount } = renderMenu(null);
+      const { store } = renderMenu(null);
+      expect(screen.getByRole('status')).toBeInTheDocument();
       expect(screen.queryByText('管理メニュー')).not.toBeInTheDocument();
-      unmount();
 
-      renderMenu('super_admin');
+      act(() => {
+        store.dispatch(setAuthData({ role: 'super_admin', isAdmin: true }));
+      });
+
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
       expect(screen.getByText('管理メニュー')).toBeInTheDocument();
       expect(screen.queryByText('コース')).not.toBeInTheDocument();
     });

--- a/frontend/src/pages/home/ui/MenuPage.tsx
+++ b/frontend/src/pages/home/ui/MenuPage.tsx
@@ -32,6 +32,10 @@ import StatsSkeleton from './StatsSkeleton';
  *   統計 API のロード中はメニューを先出しせずスケルトンで待ち、レイアウトシフトと
  *   「メニューだけ先に出てサイドバーが後から差し込まれる」ちらつきを防ぐ。
  *   super_admin は統計を持たないので即時表示。
+ *
+ *   role が null の間はどのロールとしても描画しない（FRESTYLE-233）。null は「未認証」と
+ *   「未確定」の両方を表すため、確定前に描画すると全ての判定が false になり、既定として
+ *   学習者向けが出てしまう。管理者のログイン直後に学習者画面が一瞬映る原因だった。
  */
 export default function MenuPage() {
   const role = useAppSelector((state) => state.auth.role);
@@ -39,6 +43,7 @@ export default function MenuPage() {
   const isSuperAdmin = role === 'super_admin';
   const isTrainee = role === 'trainee';
   const isCompanyAdmin = role === 'company_admin';
+  const roleUnresolved = role === null;
   const showAi = !isTrainee || aiEnabled;
 
   // サイドバーの中身はロールで出し分ける(FRESTYLE-103):
@@ -49,6 +54,16 @@ export default function MenuPage() {
 
   // 学習者/管理者向けはサイドバーのロード完了まで本体を出さず、両カラムを同時に出す。
   const waitingForStats = (isTrainee && dashboardLoading) || (isCompanyAdmin && summaryLoading);
+
+  // ロール未確定のうちは見出しもサイドバーもロールに依存するため、ページ全体を
+  // 読み込み表示にする。ここで役割別の要素を出すと、確定後に差し替わってちらつく。
+  if (roleUnresolved) {
+    return (
+      <div className="px-4 sm:px-6 pt-8 pb-24 max-w-6xl mx-auto" aria-busy="true">
+        <MenuSkeleton />
+      </div>
+    );
+  }
 
   return (
     <div className="px-4 sm:px-6 pt-8 pb-24 max-w-6xl mx-auto">

--- a/frontend/src/pages/home/ui/MenuPage.tsx
+++ b/frontend/src/pages/home/ui/MenuPage.tsx
@@ -60,6 +60,10 @@ export default function MenuPage() {
   if (roleUnresolved) {
     return (
       <div className="px-4 sm:px-6 pt-8 pb-24 max-w-6xl mx-auto" aria-busy="true">
+        {/* スケルトンは装飾（aria-hidden）なので、待機中であることは live region で伝える。 */}
+        <span role="status" className="sr-only">
+          読み込み中
+        </span>
         <MenuSkeleton />
       </div>
     );

--- a/frontend/src/pages/login-callback/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/login-callback/__tests__/LoginCallback.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@/entities/user/api/authRepository');
 
 function renderWithRoute(search: string) {
   const store = configureStore({ reducer: { auth: authReducer } });
-  return render(
+  const view = render(
     <Provider store={store}>
       <MemoryRouter initialEntries={[`/callback${search}`]}>
         <ToastProvider>
@@ -31,12 +31,20 @@ function renderWithRoute(search: string) {
       </MemoryRouter>
     </Provider>,
   );
+  return { ...view, store };
 }
 
 describe('LoginCallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('alert', vi.fn());
+    // 既定は「認可コード交換に成功し、/auth/me も引ける」状態。
+    vi.mocked(authRepository.probeCurrentUser).mockResolvedValue({
+      id: 1,
+      isAdmin: true,
+      role: 'super_admin',
+      aiChatEnabledForTrainees: true,
+    });
   });
 
   it('ローディング表示がされる', () => {
@@ -83,6 +91,71 @@ describe('LoginCallback', () => {
 
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { toast: '認証に失敗しました' } });
+    });
+  });
+
+  // 遷移前にロールを確定させないと、ダッシュボードが「管理者ではない」と誤判定して
+  // 学習者向け画面を一瞬描画してしまう（FRESTYLE-233）。
+  describe('ロールの確定', () => {
+    it('遷移前に /auth/me を引いてロールを反映する', async () => {
+      vi.mocked(authRepository.callback).mockResolvedValue({});
+
+      const { store } = renderWithRoute('?code=valid-code');
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+      });
+      expect(authRepository.probeCurrentUser).toHaveBeenCalled();
+      expect(store.getState().auth.role).toBe('super_admin');
+      expect(store.getState().auth.isAdmin).toBe(true);
+    });
+
+    it('ロールが反映されてから遷移する（順序）', async () => {
+      vi.mocked(authRepository.callback).mockResolvedValue({});
+      let roleAtNavigate: string | null = 'まだ呼ばれていない';
+      const { store } = renderWithRoute('?code=valid-code');
+      mockNavigate.mockImplementation(() => {
+        roleAtNavigate = store.getState().auth.role;
+      });
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+      });
+      expect(roleAtNavigate).toBe('super_admin');
+    });
+
+    it('trainee のロールもそのまま反映される', async () => {
+      vi.mocked(authRepository.callback).mockResolvedValue({});
+      vi.mocked(authRepository.probeCurrentUser).mockResolvedValue({
+        id: 2,
+        isAdmin: false,
+        role: 'trainee',
+        aiChatEnabledForTrainees: false,
+      });
+
+      const { store } = renderWithRoute('?code=valid-code');
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+      });
+      expect(store.getState().auth.role).toBe('trainee');
+      expect(store.getState().auth.aiChatEnabledForTrainees).toBe(false);
+    });
+
+    // 認可コードの交換は成功しているので認証は成立している。ここでログイン画面へ
+    // 戻すと「ログインできたのに戻される」挙動になるため、フル読み込みで復帰する。
+    it('ロールの取得だけ失敗したときはログイン画面へ戻さずフル読み込みする', async () => {
+      const assign = vi.fn();
+      vi.stubGlobal('location', { ...window.location, assign });
+      vi.mocked(authRepository.callback).mockResolvedValue({});
+      vi.mocked(authRepository.probeCurrentUser).mockRejectedValue(new Error('一時的な通信エラー'));
+
+      renderWithRoute('?code=valid-code');
+
+      await waitFor(() => {
+        expect(assign).toHaveBeenCalledWith('/dashboard');
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith('/login', expect.anything());
     });
   });
 });

--- a/frontend/src/pages/login-callback/__tests__/LoginCallback.test.tsx
+++ b/frontend/src/pages/login-callback/__tests__/LoginCallback.test.tsx
@@ -145,15 +145,16 @@ describe('LoginCallback', () => {
     // 認可コードの交換は成功しているので認証は成立している。ここでログイン画面へ
     // 戻すと「ログインできたのに戻される」挙動になるため、フル読み込みで復帰する。
     it('ロールの取得だけ失敗したときはログイン画面へ戻さずフル読み込みする', async () => {
-      const assign = vi.fn();
-      vi.stubGlobal('location', { ...window.location, assign });
+      // 使用済みの認可コードを含む URL を履歴に残さないため replace で遷移する。
+      const replace = vi.fn();
+      vi.stubGlobal('location', { ...window.location, replace });
       vi.mocked(authRepository.callback).mockResolvedValue({});
       vi.mocked(authRepository.probeCurrentUser).mockRejectedValue(new Error('一時的な通信エラー'));
 
       renderWithRoute('?code=valid-code');
 
       await waitFor(() => {
-        expect(assign).toHaveBeenCalledWith('/dashboard');
+        expect(replace).toHaveBeenCalledWith('/dashboard');
       });
       expect(mockNavigate).not.toHaveBeenCalledWith('/login', expect.anything());
     });

--- a/frontend/src/pages/login-callback/model/__tests__/useLoginCallback.test.ts
+++ b/frontend/src/pages/login-callback/model/__tests__/useLoginCallback.test.ts
@@ -17,6 +17,8 @@ vi.mock('@/shared/lib/store', () => ({
 vi.mock('@/entities/user/api/authRepository', () => ({
   default: {
     callback: vi.fn(),
+    // 遷移前にロールを確定させるため callback 成功後に呼ばれる（FRESTYLE-233）。
+    probeCurrentUser: vi.fn(),
   },
 }));
 
@@ -32,6 +34,11 @@ describe('useLoginCallback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSearchParams = '';
+    vi.mocked(authRepository.probeCurrentUser).mockResolvedValue({
+      id: 1,
+      isAdmin: false,
+      role: 'trainee',
+    } as any);
   });
 
   it('codeがある場合にauthRepository.callbackを呼び出す', async () => {

--- a/frontend/src/pages/login-callback/model/useLoginCallback.ts
+++ b/frontend/src/pages/login-callback/model/useLoginCallback.ts
@@ -42,8 +42,8 @@ export function useLoginCallback() {
           dispatch(
             setAuthData({
               isAdmin: !!me.isAdmin,
-              role: me.role ?? null,
-              aiChatEnabledForTrainees: me.aiChatEnabledForTrainees ?? true,
+              role: me.role,
+              aiChatEnabledForTrainees: me.aiChatEnabledForTrainees,
             }),
           );
           setAuthHint();
@@ -53,8 +53,9 @@ export function useLoginCallback() {
           if (exchanged) {
             // ロールを引けなかっただけ。フル読み込みで AuthInitializer に確定させる
             // （SPA 内 navigate では再取得されず、ロール未確定のまま留まるため）。
+            // replace で遷移し、使用済みの認可コードを含む URL を履歴に残さない。
             setAuthHint();
-            window.location.assign('/dashboard');
+            window.location.replace('/dashboard');
             return;
           }
           // backend が PR-OIDC-Gate で返す 403 invitation_required を識別して

--- a/frontend/src/pages/login-callback/model/useLoginCallback.ts
+++ b/frontend/src/pages/login-callback/model/useLoginCallback.ts
@@ -25,14 +25,38 @@ export function useLoginCallback() {
       // 招待マジックリンク経由でログインしてきた場合、AcceptInvitationPage が保存した
       // sessionStorage の token を取り出して callback に渡す（使い切りで自動削除）。
       const invitationToken = consumeInvitationToken();
+      // 認可コードの交換が済んだか。済んでいれば認証は成立しているので、以降の失敗で
+      // ログイン画面へ戻してはいけない（ログインできたのに戻される、という挙動になる）。
+      let exchanged = false;
+
       authRepository
         .callback(code, invitationToken)
         .then(() => {
-          dispatch(setAuthData());
+          exchanged = true;
+          // callback の応答は { success } のみでロールを含まない。ロールを確定させずに
+          // 遷移すると、ダッシュボードが「管理者ではない」と誤判定して学習者向け画面を
+          // 一瞬描画してしまう（FRESTYLE-233）。遷移前に /auth/me で確定させる。
+          return authRepository.probeCurrentUser();
+        })
+        .then((me) => {
+          dispatch(
+            setAuthData({
+              isAdmin: !!me.isAdmin,
+              role: me.role ?? null,
+              aiChatEnabledForTrainees: me.aiChatEnabledForTrainees ?? true,
+            }),
+          );
           setAuthHint();
           navigate('/dashboard');
         })
         .catch((err) => {
+          if (exchanged) {
+            // ロールを引けなかっただけ。フル読み込みで AuthInitializer に確定させる
+            // （SPA 内 navigate では再取得されず、ロール未確定のまま留まるため）。
+            setAuthHint();
+            window.location.assign('/dashboard');
+            return;
+          }
           // backend が PR-OIDC-Gate で返す 403 invitation_required を識別して
           // 専用メッセージを表示する。それ以外は従来どおり「認証に失敗しました」。
           const { status, serverCode, serverMessage } = getApiError(err);


### PR DESCRIPTION
## 概要

管理者が初回ログインすると、ホーム画面で**一瞬だけ学習者向けの表示（コース・コード演習・ノート等のカードと右サイドバー）が出てから**管理者向けの表示に切り替わる、という指摘への対応。

## 原因

ロールが**まだ分からない状態**と、**分かった上で管理者ではない状態**が、どちらも `role = null` で表現されているため、前者が後者として扱われていた。

`MenuPage` は `role` からロールを判定している。

```
const isSuperAdmin   = role === 'super_admin';
const isTrainee      = role === 'trainee';
const isCompanyAdmin = role === 'company_admin';
```

`role` が `null`（未確定）だと**この 3 つがすべて false** になり:

- 待機判定 `waitingForStats` も false になるため、スケルトンで待たない
- 分岐が末尾の `else` に落ちて**学習者向けカード一式が描画される**
- 右サイドバーの条件も `!isSuperAdmin` なので**表示されてしまう**

そこへ後からロールが確定して差し替わる。これがちらつきとして見える。

### なぜ OAuth の初回ログインで起きるか

| 経路 | 実装 | 結果 |
| --- | --- | --- |
| メール / パスワード | `window.location.assign('/dashboard')` で**フル再読み込み** | `AuthInitializer` が `/auth/me` を引いてロールを確定させてから描画するため**問題なし** |
| **OAuth コールバック** | `dispatch(setAuthData())` を**引数なし**で呼び、直後に SPA 内 `navigate('/dashboard')` | `loading` は false になるが **`role` は `null` のまま**遷移 → ちらつく |

`callback` の応答は `{ success }` のみでロールを含まず、`setAuthData` は「payload に無いフィールドは現在値を維持する」実装のため、`null` が残っていた。

## 変更内容

**2 層で修正した。**

### 1. 根本 — 遷移前にロールを確定させる

コールバック成功後に `/auth/me` を引き、`isAdmin` / `role` / AI 設定まで反映してから遷移する。

**ロール取得だけ失敗した場合の扱い**: 認可コードの交換は成功していて**認証自体は成立している**ため、ログイン画面へ戻すと「ログインできたのに戻される」挙動になる。この場合はフル読み込みで `AuthInitializer` に確定を委ねる（SPA 内 `navigate` では再取得されず、ロール未確定のまま留まるため）。

`useAuth` の 2 箇所も `role` を渡すよう揃えた。

### 2. 防御 — ロール未確定なら役割別の表示を出さない

`MenuPage` はロールが未確定の間、**ページ全体を読み込み表示**にする。見出し（「運営管理者ダッシュボード」「FreStyle へようこそ」）もサイドバーの有無もロールに依存するため、一部だけ出すと確定後に差し替わってちらつく。

これにより、将来ロールを渡し忘れる呼び出しが増えても**ちらつきが復活しない**。

## テスト

**追加した 7 件が修正前のコードで失敗することを確認済み**（回帰検知の実証）。

```
× 学習者向けのカードを一切描画しない
× 管理者向けのカードも見出しも描画しない
× 読み込み中であることを伝える
× 遷移前に /auth/me を引いてロールを反映する
× ロールが反映されてから遷移する（順序）
× trainee のロールもそのまま反映される
× ロールの取得だけ失敗したときはログイン画面へ戻さずフル読み込みする
```

修正後は全て合格。既存テスト 2 件（`probeCurrentUser` 未モックで落ちていたもの）も実態に合わせて更新した。

- **vitest 1253 passed (158 files)** / tsc / eslint 0 / build 成功
- カバレッジ: Statements 86.27% / Branches 80.56% / Lines 88.09%

## セキュリティ影響

なし。表示の出し分けタイミングの修正のみで、権限判定はサーバー側で行われる。ロールを詐称しても API 側で拒否される。

## 関連チケット

- FRESTYLE-233（本件）
- FRESTYLE-230 / FRESTYLE-231（同種の「確定前に既定の表示が出てしまう」ちらつき）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ログイン後にユーザーの権限とAIチャット設定を正しく反映するようになりました。
  * ユーザー情報の読み込み中は、権限に応じたメニューを表示せず、読み込み中の画面を表示します。
  * ユーザー情報の取得完了後、適切なダッシュボードへ遷移します。
  * ユーザー情報の取得に失敗した場合も、ログイン状態を再初期化して処理を継続できるようになりました。

* **テスト**
  * 権限の反映、画面遷移、読み込み中表示に関する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->