### PR TITLE
docs: 規約 §3.3 のテスト方針を実態に合わせる (FRESTYLE-235)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,7 +127,9 @@ PR / チケット / コミット / コメント / docs に**他社プロダク�
 ### 3.3 テスト
 
 - **TDD を基本**とする。カバレッジ目標: 新規コード **80% 以上**
-- バックエンド: `testing` + `stretchr/testify`（`go test ./...`）— usecase は interface モック（testify/mock）、repository は sqlite メモリ、handler は `httptest` + `gin.New()`、infra は境界で fake / stub 注入
+- **バックエンド（単体）**: `testing` + `stretchr/testify`（`go test ./...`）— usecase は interface モック（testify/mock）、handler は `httptest` + `gin.New()`、infra は境界で fake / stub 注入。**DB を必要としないものだけ**をここに置く
+- **バックエンド（結合）**: repository は **本物の PostgreSQL** で検証する（sqlite は使わない。依存も入れていない）。ファイル先頭に `//go:build integration`、テスト関数名に `Integration` を含める。ローカルは `make test-integration`（docker で postgres 起動 → 実行 → 必ず破棄）、CI は専用ジョブ `integration tests (postgres)` が `-tags=integration` で実行する
+- 結合テストの接続は `internal/testsupport.OpenTestDB`。`TruncateAll` が TRUNCATE CASCADE するため、**DSN が Supabase / 本番 pooler を指す場合は接続前に落とす安全弁**が入っている（誤設定で本番データを消さないため）
 - フロントエンド: Vitest + React Testing Library（`npm test`）— `render` + `screen.getByRole` でアクセシビリティも検証、Hook は `renderHook`
 
 ### 3.4 コメント


### PR DESCRIPTION
## 概要

`.claude/CLAUDE.md` §3.3 に「**repository は sqlite メモリ**」と書かれていたが、**実態は本物の PostgreSQL を使った結合テスト**だった。記述を実装に合わせる。

## なぜ直すか（実害が出た）

FRESTYLE-77 のレビューで、CodeRabbit が**この記述を根拠に「sqlite メモリへ移行してください」と提案**してきた。実態に沿わない指摘だったため理由を説明して見送ったが、**規約が誤っている限り同じやり取りが繰り返される**。

新しく参画した人が §3.3 に従って sqlite でテストを書こうとしても、依存も基盤も無いため行き詰まる。

## 実地確認した事実

| 項目 | 実態 |
| --- | --- |
| `go.mod` の sqlite 依存 | **0 件**（そもそも使えない） |
| `internal/testsupport` | **PostgreSQL 専用**（`gorm.io/driver/postgres`） |
| persistence のテスト 18 ファイル | **17 が `//go:build integration`**（残り 1 は DB 不要の純ロジック） |
| 結合テストの DB | `docker-compose.integration.yml` の **postgres:17.6-alpine** |
| ローカル実行 | `make test-integration`（docker 起動 → 実行 → 必ず破棄） |
| CI | 専用ジョブ `integration tests (postgres)` |
| 安全弁 | DSN が Supabase / 本番 pooler なら**接続前に落とす** |

## 変更内容

「バックエンド」の 1 行を **単体 / 結合の 2 本立て + 接続の注意**に分けた。

- **単体**: DB を必要としないものだけを置く（usecase のモック・handler の httptest・infra の fake）
- **結合**: repository は本物の PostgreSQL。build tag `//go:build integration`、関数名に `Integration`、ローカルは `make test-integration`、CI は専用ジョブ
- **安全弁**: `TruncateAll` が TRUNCATE CASCADE するため、本番を指す DSN では接続前に落ちることを明記（誤設定で本番データを消さないため）

**テスト方式そのものは変えていません**（実装に記述を合わせるだけ）。

## テスト

ドキュメントのみのため自動テストなし。代わりに**記載内容がすべて実在することを確認**した。

| 確認 | 結果 |
| --- | --- |
| `go.mod` に sqlite が無い | ✅ |
| `testsupport` が postgres ドライバ | ✅ |
| `make test-integration` が存在 | ✅ |
| CI に `integration tests (postgres)` が存在 | ✅ |
| 安全弁 `looksLikeSupabase` が存在 | ✅ |
| `TruncateAll` が TRUNCATE を実行 | ✅ |

規約の行数は 268 → **270 行**（200〜300 行の制約内）。

## セキュリティ影響

なし。本リポジトリは PUBLIC のため接続情報は書いていない（結合テストの DSN は localhost のダミー資格情報で、既存の Makefile に記載済みのもの）。

## 関連チケット

- FRESTYLE-235（本件）/ FRESTYLE-77（この乖離が実害として現れた作業）