### PR TITLE
feat: 存在しない URL に 404 ページを表示する (FRESTYLE-86)

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -12,6 +12,9 @@ import { useBackendHealth } from '@/shared/lib/hooks/useBackendHealth';
 import ToastContainer from '@/app/providers/ToastContainer';
 import { lazyWithReload, clearLazyReloadFlags } from '@/shared/lib/lazyWithReload';
 
+/* v8 ignore start -- 以下はコード分割のためのルート表。各 `() => import(...)` は
+   中身を持たない読み込み用の関数で、埋めるには全ページを描画するしかなく指標として
+   意味を持たない。実ロジック（NavigationToast / AppRoutes）は計測対象のまま残す。 */
 // 認証不要ページ
 const LoginPage = lazyWithReload(() => import('@/pages/login').then((m) => ({ default: m.LoginPage })), 'LoginPage');
 const LoginCallback = lazyWithReload(() => import('@/pages/login-callback').then((m) => ({ default: m.LoginCallback })), 'LoginCallback');
@@ -49,6 +52,7 @@ const MarkdownSyntaxHelpPage = lazyWithReload(() => import('@/pages/markdown-syn
 // inkwell プリミティブの見た目確認用カタログ（認証不要・削除可）。
 const InkwellShowcasePage = lazyWithReload(() => import('@/pages/inkwell-showcase').then((m) => ({ default: m.InkwellShowcasePage })), 'InkwellShowcasePage');
 const NotFoundPage = lazyWithReload(() => import('@/pages/not-found').then((m) => ({ default: m.NotFoundPage })), 'NotFoundPage');
+/* v8 ignore stop */
 
 function NavigationToast() {
   const location = useLocation();

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -48,6 +48,7 @@ const CourseDetailPage = lazyWithReload(() => import('@/pages/course-detail').th
 const MarkdownSyntaxHelpPage = lazyWithReload(() => import('@/pages/markdown-syntax-help').then((m) => ({ default: m.MarkdownSyntaxHelpPage })), 'MarkdownSyntaxHelpPage');
 // inkwell プリミティブの見た目確認用カタログ（認証不要・削除可）。
 const InkwellShowcasePage = lazyWithReload(() => import('@/pages/inkwell-showcase').then((m) => ({ default: m.InkwellShowcasePage })), 'InkwellShowcasePage');
+const NotFoundPage = lazyWithReload(() => import('@/pages/not-found').then((m) => ({ default: m.NotFoundPage })), 'NotFoundPage');
 
 function NavigationToast() {
   const location = useLocation();
@@ -144,6 +145,11 @@ export default function App() {
         <Route path="/admin/audit" element={<AdminAuditLogPage />} />
         <Route path="/admin/invitations" element={<AdminInvitationsPage />} />
       </Route>
+
+      {/* どのルートにも一致しない URL の受け皿（FRESTYLE-86）。
+          認証ブロックの外に置く: 中に入れると未ログイン時に /login へ飛ばされ、
+          タイポや古いリンクで来た訪問者に 404 を見せられない（公開サイトとして不適切）。 */}
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
     </Suspense>
     <NavigationToast />

--- a/frontend/src/app/__tests__/notFoundRoute.test.tsx
+++ b/frontend/src/app/__tests__/notFoundRoute.test.tsx
@@ -4,12 +4,13 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
-import authReducer from '@/entities/user/model/authSlice';
+import { authReducer } from '@/entities/user';
 import { clearAuthHint } from '@/shared/lib/authHint';
 
-// バックエンド死活監視はこのテストの関心事ではない（未応答だとメンテ画面に切り替わる）。
+// バックエンド死活監視はこのテストの関心事ではない（unhealthy だとメンテ画面に切り替わる）。
+// 戻り値は実装と同じ形にする（App は status を読む。形がずれると偶然通るだけになる）。
 vi.mock('@/shared/lib/hooks/useBackendHealth', () => ({
-  useBackendHealth: () => ({ isHealthy: true }),
+  useBackendHealth: () => ({ status: 'healthy', recheck: vi.fn() }),
 }));
 
 function renderAt(path: string) {

--- a/frontend/src/app/__tests__/notFoundRoute.test.tsx
+++ b/frontend/src/app/__tests__/notFoundRoute.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+import authReducer from '@/entities/user/model/authSlice';
+import { clearAuthHint } from '@/shared/lib/authHint';
+
+// バックエンド死活監視はこのテストの関心事ではない（未応答だとメンテ画面に切り替わる）。
+vi.mock('@/shared/lib/hooks/useBackendHealth', () => ({
+  useBackendHealth: () => ({ isHealthy: true }),
+}));
+
+function renderAt(path: string) {
+  const store = configureStore({ reducer: { auth: authReducer } });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[path]}>
+        <App />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+/**
+ * catch-all（`path="*"`）の結線を App ごと描画して検証する（FRESTYLE-86）。
+ *
+ * NotFoundPage 単体のテストだけでは、ルートの配置換え・パス指定の誤り・遅延 import の
+ * 接続不良を検出できない。「未知の URL を開いたら 404 が出る」という利用者から見た
+ * 契約をここで固定する。
+ */
+describe('未知の URL のルーティング', () => {
+  beforeEach(() => {
+    clearAuthHint();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    '/this-page-does-not-exist',
+    '/courses/not-a-real-segment/deep/path',
+    '/admin/存在しない画面',
+  ])('%s は 404 ページを表示する', async (path) => {
+    renderAt(path);
+
+    expect(
+      await screen.findByRole('heading', { name: 'ページが見つかりません', level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  // 認証ブロックの中に置くと、未ログインでは /login へ飛ばされて 404 を見せられない。
+  it('未ログインでもログイン画面に飛ばさず 404 を表示する', async () => {
+    renderAt('/this-page-does-not-exist');
+
+    expect(
+      await screen.findByRole('heading', { name: 'ページが見つかりません', level: 1 }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'ログイン' })).not.toBeInTheDocument();
+  });
+
+  it('既知の公開ルートは 404 にしない', async () => {
+    renderAt('/login');
+
+    // ログイン画面の描画完了を待ってから、404 が出ていないことを確認する。
+    await screen.findByRole('form', { name: 'ログインフォーム' });
+    expect(
+      screen.queryByRole('heading', { name: 'ページが見つかりません' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/not-found/__tests__/NotFoundPage.test.tsx
+++ b/frontend/src/pages/not-found/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NotFoundPage from '../ui/NotFoundPage';
+import { AUTH_HINT_COOKIE, setAuthHint, clearAuthHint } from '@/shared/lib/authHint';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NotFoundPage />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * 存在しない URL の受け皿（FRESTYLE-86）。
+ * これが無いと、タイポや古いリンクで来た人が真っ白な画面のまま戻る手段を失う。
+ */
+describe('NotFoundPage', () => {
+  beforeEach(() => {
+    clearAuthHint();
+    document.head.querySelector('meta[name="robots"]')?.remove();
+  });
+
+  afterEach(() => {
+    clearAuthHint();
+  });
+
+  it('見つからないことを日本語で伝える', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: 'ページが見つかりません', level: 1 })).toBeInTheDocument();
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  it('ヘッダーからトップへ戻れる', () => {
+    renderPage();
+
+    expect(screen.getByRole('link', { name: 'FreStyle ホーム' })).toHaveAttribute('href', '/');
+  });
+
+  // SPA は HTTP 404 を返せないため、少なくとも検索エンジンには登録させない。
+  it('検索エンジンに登録させない', () => {
+    renderPage();
+
+    const robots = document.head.querySelector('meta[name="robots"]');
+    expect(robots).toHaveAttribute('content', 'noindex, nofollow');
+  });
+
+  it('タイトルを設定する', () => {
+    renderPage();
+
+    expect(document.title).toBe('ページが見つかりません | FreStyle');
+  });
+
+  describe('ログイン済みのとき', () => {
+    beforeEach(() => {
+      setAuthHint();
+    });
+
+    it('ダッシュボードへ戻る導線を出す', () => {
+      renderPage();
+
+      expect(screen.getByRole('link', { name: 'ホームへ戻る' })).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('ログイン導線は出さない', () => {
+      renderPage();
+
+      expect(screen.queryByRole('link', { name: 'ログイン' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('未ログインのとき', () => {
+    it('トップとログインの導線を出す', () => {
+      renderPage();
+
+      expect(screen.getByRole('link', { name: 'トップへ戻る' })).toHaveAttribute('href', '/');
+      expect(screen.getByRole('link', { name: 'ログイン' })).toHaveAttribute('href', '/login');
+    });
+
+    it('ダッシュボードへは案内しない', () => {
+      renderPage();
+
+      expect(screen.queryByRole('link', { name: 'ホームへ戻る' })).not.toBeInTheDocument();
+    });
+
+    // 目印の値が 1 以外なら未ログイン扱い（authHint の判定と契約を揃える）。
+    it('目印が 1 以外なら未ログイン扱いにする', () => {
+      document.cookie = `${AUTH_HINT_COOKIE}=10; path=/`;
+
+      renderPage();
+
+      expect(screen.getByRole('link', { name: 'ログイン' })).toBeInTheDocument();
+      document.cookie = `${AUTH_HINT_COOKIE}=; path=/; max-age=0`;
+    });
+  });
+});

--- a/frontend/src/pages/not-found/index.ts
+++ b/frontend/src/pages/not-found/index.ts
@@ -1,0 +1,1 @@
+export { default as NotFoundPage } from './ui/NotFoundPage';

--- a/frontend/src/pages/not-found/ui/NotFoundPage.tsx
+++ b/frontend/src/pages/not-found/ui/NotFoundPage.tsx
@@ -1,0 +1,76 @@
+import { Link } from 'react-router-dom';
+import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
+import { hasAuthHint } from '@/shared/lib/authHint';
+
+/**
+ * 存在しない URL の受け皿（FRESTYLE-86）。
+ *
+ * catch-all（`path="*"`）が無かったため、タイポ・古いリンク・削除済みリソースで
+ * 完全に真っ白な画面になり、戻る手段が無いまま離脱していた。
+ *
+ * ログイン状態は目印 Cookie で判断する（FRESTYLE-231）。認証必須ルートの外に置く
+ * ページなので `/auth/me` の結果を待つと表示が遅れ、待たずに Redux を読むと未確定の
+ * 既定値（未ログイン扱い）で描画してしまう。この画面は行き先の案内を出し分けるだけで
+ * 権限を判定しないため、目印で十分（実際の認証は遷移先で行われる）。
+ */
+export default function NotFoundPage() {
+  // 存在しない URL が検索結果に載らないようにする。SPA は HTTP 404 を返せないため、
+  // 少なくとも検索エンジンには「登録しないでほしい」と伝える。
+  useDocumentMeta({
+    title: 'ページが見つかりません | FreStyle',
+    robots: 'noindex, nofollow',
+  });
+
+  const signedIn = hasAuthHint();
+
+  return (
+    <div className="min-h-screen flex flex-col bg-surface-0">
+      <header className="flex-shrink-0 h-16 border-b border-surface-3 flex items-center px-4 sm:px-6">
+        <Link to="/" className="flex items-center gap-2" aria-label="FreStyle ホーム">
+          <img src="/brand-mark.svg" alt="" className="w-7 h-7 flex-shrink-0" />
+          <span className="text-sm font-semibold text-[var(--color-text-primary)]">FreStyle</span>
+        </Link>
+      </header>
+
+      <main className="flex-1 flex items-center justify-center px-4 py-16">
+        <div className="w-full max-w-md text-center">
+          <p className="text-sm font-semibold tracking-widest text-brand-500">404</p>
+          <h1 className="mt-2 text-2xl font-bold text-[var(--color-text-primary)]">
+            ページが見つかりません
+          </h1>
+          <p className="mt-4 text-sm leading-relaxed text-[var(--color-text-muted)]">
+            お探しのページは移動または削除された可能性があります。
+            <br />
+            URL に誤りがないかご確認ください。
+          </p>
+
+          <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
+            {signedIn ? (
+              <Link
+                to="/dashboard"
+                className="inline-flex items-center justify-center px-5 py-2.5 rounded-md bg-brand-500 text-white text-sm font-medium hover:bg-brand-600 transition-colors"
+              >
+                ホームへ戻る
+              </Link>
+            ) : (
+              <>
+                <Link
+                  to="/"
+                  className="inline-flex items-center justify-center px-5 py-2.5 rounded-md bg-brand-500 text-white text-sm font-medium hover:bg-brand-600 transition-colors"
+                >
+                  トップへ戻る
+                </Link>
+                <Link
+                  to="/login"
+                  className="inline-flex items-center justify-center px-5 py-2.5 rounded-md border border-surface-3 text-sm font-medium text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors"
+                >
+                  ログイン
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

catch-all（`path="*"`）が無く、**存在しない URL を開くと案内もヘッダーも無い真っ白な画面**になっていた。タイポ・古いリンク・削除済みリソースで来た人は何が起きたか分からず、戻る手段も無いまま離脱してしまう。

`path="*"` の 404 ページを追加する。

## 設計判断

### catch-all を認証ブロックの「外」に置いた

中（`Protected` の内側）に入れると、**未ログインの訪問者は `/login` へ飛ばされて 404 を見られません**。タイポや古いリンクで来た人にはログイン画面が出るだけで、何が起きたのか分からないままです。

公開サイト（SEO 対象）になったため、**存在しない URL に対してログイン画面を 200 で返す**状態（ソフト 404）も避けたいところです。

### ログイン判定は目印 Cookie を使う

認証必須ルートの外にあるページなので:

- `/auth/me` の結果を待つ → **表示が遅れる**
- 待たずに Redux を読む → **未確定の既定値（未ログイン扱い）で描画**してしまう（FRESTYLE-233 と同じ罠）

この画面は**行き先の案内を出し分けるだけで権限判定をしない**ため、FRESTYLE-231 で導入した目印 Cookie で十分です。仮に目印が古くても、遷移先で通常の認証チェックが走ります。

### noindex を設定

SPA はクライアント側から HTTP 404 を返せません。少なくとも検索エンジンには「登録しないでほしい」と伝えるため `noindex, nofollow` を設定しました。既存の `useDocumentMeta` を利用しています。

## 表示

| 状態 | 導線 |
| --- | --- |
| ログイン済み | 「ホームへ戻る」→ `/dashboard` |
| 未ログイン | 「トップへ戻る」→ `/` ／ 「ログイン」→ `/login` |

どちらもヘッダー（ロゴ → `/`）付きです。

## テスト

**単体テスト 9 件**: 見出しと 404 表記 / ヘッダーの導線 / noindex / タイトル / ログイン済みの導線とログイン導線を出さないこと / 未ログインの導線とダッシュボードへ案内しないこと / 目印が `1` 以外なら未ログイン扱い。

**実ブラウザ確認**（ビルド成果物を preview で配信し、`/this-page-does-not-exist` を開く）:

| 状態 | 404 表示 | 真っ白 | 導線 | robots |
| --- | --- | --- | --- | --- |
| 未ログイン | ✅ あり | ✅ ならない | FreStyle→`/` / トップへ戻る→`/` / ログイン→`/login` | noindex, nofollow |
| ログイン済み | ✅ あり | ✅ ならない | FreStyle→`/` / ホームへ戻る→`/dashboard` | noindex, nofollow |

| 検証 | 結果 |
| --- | --- |
| `tsc --noEmit` | OK |
| `eslint --max-warnings 0`（FSD 境界 lint 含む） | OK |
| `vitest run --coverage` | **1320 passed (161 files)** |
| `npm run build` | OK |
| `knip`（未使用検出） | 指摘なし |

カバレッジ: Statements 86.36% / Lines 88.19%

## セキュリティ影響

なし。表示のみの追加で、認証やデータの扱いには触れていません。目印 Cookie を偽装しても遷移先で通常の認証チェックが走るため権限は得られません。

## ロールバック方針

PR revert で戻せます。バックエンド・DB の変更はありません。

## 関連チケット

- FRESTYLE-86（本件）
- FRESTYLE-231（目印 Cookie の導入）/ FRESTYLE-233（認証状態が未確定のまま描画しない）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 存在しないURLにアクセスした際、404ページを表示するようになりました。
  * ホーム、ダッシュボード、トップページ、ログインへの導線を追加しました。
  * 404ページが検索エンジンに登録されないよう設定しました。

* **テスト**
  * 404表示、ページタイトル、メタ情報、認証状態ごとの遷移を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->