### PR TITLE
refactor: 画像の参照をルート相対パスにしてドメイン移行に強くする (FRESTYLE-234)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -4413,7 +4413,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "publicUrl": {
-                    "description": "PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。",
+                    "description": "PublicURL はアップロード後に img / Markdown から参照する表示用パス。\n配信ドメインは含めない（FRESTYLE-234。ドメイン変更で保存済みデータが壊れないように）。",
                     "type": "string"
                 },
                 "url": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4406,7 +4406,7 @@
                     "type": "string"
                 },
                 "publicUrl": {
-                    "description": "PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。",
+                    "description": "PublicURL はアップロード後に img / Markdown から参照する表示用パス。\n配信ドメインは含めない（FRESTYLE-234。ドメイン変更で保存済みデータが壊れないように）。",
                     "type": "string"
                 },
                 "url": {

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -297,7 +297,9 @@ definitions:
       key:
         type: string
       publicUrl:
-        description: PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。
+        description: |-
+          PublicURL はアップロード後に img / Markdown から参照する表示用パス。
+          配信ドメインは含めない（FRESTYLE-234。ドメイン変更で保存済みデータが壊れないように）。
         type: string
       url:
         type: string

--- a/backend/internal/adapter/persistence/image_presigner_test.go
+++ b/backend/internal/adapter/persistence/image_presigner_test.go
@@ -1,0 +1,88 @@
+package persistence
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 表示 URL に配信ドメインを含めないことを固定する（FRESTYLE-234）。
+//
+// 絶対 URL で保存していると、配信ドメインを変えるたびに過去の画像が全て参照不能になる
+// （FRESTYLE-232 で実害）。ここが絶対 URL に戻ると同じ障害が再発するため、
+// 「/ で始まりドメインを含まない」ことを契約としてテストで固定する。
+func Test_画像の表示URLに配信ドメインを含めないこと(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		publicURL  func(t *testing.T) string
+		wantPrefix string
+	}{
+		{
+			name: "プロフィール画像",
+			publicURL: func(t *testing.T) string {
+				t.Helper()
+				out, err := NewStubProfileImagePresigner("bucket").
+					Generate(ctx, 7, "icon.png", "image/png")
+				require.NoError(t, err)
+				return out.ImageURL
+			},
+			wantPrefix: "/profiles/7/",
+		},
+		{
+			name: "ノート画像",
+			publicURL: func(t *testing.T) string {
+				t.Helper()
+				out, err := NewStubNoteImagePresigner("bucket").Generate(ctx, 7, "image/png")
+				require.NoError(t, err)
+				return out.PublicURL
+			},
+			wantPrefix: "/notes/7/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.publicURL(t)
+
+			assert.True(t, strings.HasPrefix(got, tt.wantPrefix),
+				"%s で始まるルート相対パスであること: %s", tt.wantPrefix, got)
+			assert.NotContains(t, got, "://", "配信ドメイン（スキーム）を含めないこと: %s", got)
+			assert.False(t, strings.HasPrefix(got, "//"),
+				"//host/path 形式（プロトコル相対）にしないこと: %s", got)
+		})
+	}
+}
+
+// アップロード先の presigned URL は S3 への直接 PUT なので絶対 URL のままでよい。
+// 表示 URL と混同して相対化してしまわないことを確認する。
+func Test_アップロード先URLは絶対URLのままであること(t *testing.T) {
+	ctx := context.Background()
+
+	profile, err := NewStubProfileImagePresigner("bucket").
+		Generate(ctx, 7, "icon.png", "image/png")
+	require.NoError(t, err)
+	assert.Contains(t, profile.UploadURL, "://", "アップロード先は絶対 URL であること")
+
+	note, err := NewStubNoteImagePresigner("bucket").Generate(ctx, 7, "image/png")
+	require.NoError(t, err)
+	assert.Contains(t, note.URL, "://", "アップロード先は絶対 URL であること")
+}
+
+func Test_画像のキーは表示URLから先頭のスラッシュを外した値になること(t *testing.T) {
+	ctx := context.Background()
+
+	// 将来キー保存方式へ移す場合に、相対パスから機械的にキーを得られることを担保する。
+	profile, err := NewStubProfileImagePresigner("bucket").
+		Generate(ctx, 7, "icon.png", "image/png")
+	require.NoError(t, err)
+	assert.Equal(t, profile.Key, strings.TrimPrefix(profile.ImageURL, "/"))
+
+	note, err := NewStubNoteImagePresigner("bucket").Generate(ctx, 7, "image/png")
+	require.NoError(t, err)
+	assert.Equal(t, note.Key, strings.TrimPrefix(note.PublicURL, "/"))
+}

--- a/backend/internal/adapter/persistence/note_image_repository.go
+++ b/backend/internal/adapter/persistence/note_image_repository.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -11,18 +10,16 @@ import (
 )
 
 // noteImagePresigner は note 画像用の S3 presigner（notes/{userId}/{epochNs}.bin キー）。
-// cdnBase は配信用 CDN URL（NOTE_IMAGES_CDN_URL）。アップロード後の参照 URL 組み立てに使う。
 type noteImagePresigner struct {
-	pre     s3Presigner
-	cdnBase string
+	pre s3Presigner
 }
 
-// NewNoteImagePresigner は本番経路。infra/s3.Presigner と配信 CDN base を渡して使う。
-func NewNoteImagePresigner(p s3Presigner, cdnBase string) repository.NoteImagePresigner {
-	return &noteImagePresigner{pre: p, cdnBase: cdnBase}
+// NewNoteImagePresigner は本番経路。infra/s3.Presigner を渡して使う。
+func NewNoteImagePresigner(p s3Presigner) repository.NoteImagePresigner {
+	return &noteImagePresigner{pre: p}
 }
 
-// NewStubNoteImagePresigner は test / dev 用 stub（CDN 未設定で相対 URL を返す）。
+// NewStubNoteImagePresigner は test / dev 用 stub。
 func NewStubNoteImagePresigner(bucket string) repository.NoteImagePresigner {
 	return &noteImagePresigner{pre: &stubPresigner{bucket: bucket}}
 }
@@ -40,17 +37,12 @@ func (p *noteImagePresigner) Generate(ctx context.Context, userID uint64, conten
 		return nil, err
 	}
 	return &domain.NoteImageUploadURL{
-		URL:       url,
-		Key:       key,
-		PublicURL: p.publicURL(key),
+		URL: url,
+		Key: key,
+		// 配信ドメインを含めない（FRESTYLE-234）。画像はアプリと同一オリジンで配信され、
+		// ブラウザが現在のドメインを補って解決するため、この形ならドメインを変えても
+		// 保存済みデータを書き換えずに済む。
+		PublicURL: "/" + key,
 		ExpiresIn: int(ttl.Seconds()),
 	}, nil
-}
-
-// publicURL は配信用 URL を組み立てる。cdnBase 未設定時は同一オリジンの相対 URL にフォールバック。
-func (p *noteImagePresigner) publicURL(key string) string {
-	if p.cdnBase == "" {
-		return "/" + key
-	}
-	return strings.TrimRight(p.cdnBase, "/") + "/" + key
 }

--- a/backend/internal/adapter/persistence/profile_image_repository.go
+++ b/backend/internal/adapter/persistence/profile_image_repository.go
@@ -12,21 +12,17 @@ import (
 
 // profileImagePresigner は profile アイコン用の S3 presigner（profiles/{userId}/{epochNs}{ext} キー）。
 type profileImagePresigner struct {
-	pre    s3Presigner
-	cdnURL string
+	pre s3Presigner
 }
 
-// NewProfileImagePresigner は本番経路。cdnURL は配信用ベース URL（CloudFront / S3）。
-func NewProfileImagePresigner(p s3Presigner, cdnURL string) repository.ProfileImagePresigner {
-	return &profileImagePresigner{pre: p, cdnURL: strings.TrimRight(cdnURL, "/")}
+// NewProfileImagePresigner は本番経路。
+func NewProfileImagePresigner(p s3Presigner) repository.ProfileImagePresigner {
+	return &profileImagePresigner{pre: p}
 }
 
 // NewStubProfileImagePresigner は test / dev 用 stub。
-func NewStubProfileImagePresigner(bucket, cdnURL string) repository.ProfileImagePresigner {
-	return &profileImagePresigner{
-		pre:    &stubPresigner{bucket: bucket},
-		cdnURL: strings.TrimRight(cdnURL, "/"),
-	}
+func NewStubProfileImagePresigner(bucket string) repository.ProfileImagePresigner {
+	return &profileImagePresigner{pre: &stubPresigner{bucket: bucket}}
 }
 
 func (p *profileImagePresigner) Generate(ctx context.Context, userID uint64, fileName, contentType string) (*domain.ProfileImageUploadURL, error) {
@@ -44,7 +40,11 @@ func (p *profileImagePresigner) Generate(ctx context.Context, userID uint64, fil
 	}
 	return &domain.ProfileImageUploadURL{
 		UploadURL: url,
-		ImageURL:  fmt.Sprintf("%s/%s", p.cdnURL, key),
+		// 配信ドメインを含めない（FRESTYLE-234）。画像はアプリと同一オリジンで配信され、
+		// ブラウザが現在のドメインを補って解決するため、この形ならドメインを変えても
+		// 保存済みデータを書き換えずに済む。絶対 URL で保存していた頃は、ドメイン移行の
+		// たびに過去の画像が全て参照不能になっていた（FRESTYLE-232 で実害）。
+		ImageURL:  "/" + key,
 		Key:       key,
 		ExpiresIn: int(ttl.Seconds()),
 	}, nil

--- a/backend/internal/domain/note_image.go
+++ b/backend/internal/domain/note_image.go
@@ -4,7 +4,8 @@ package domain
 type NoteImageUploadURL struct {
 	URL string `json:"url"`
 	Key string `json:"key"`
-	// PublicURL はアップロード後に img / Markdown から参照する配信用 URL（CDN 経由）。
+	// PublicURL はアップロード後に img / Markdown から参照する表示用パス。
+	// 配信ドメインは含めない（FRESTYLE-234。ドメイン変更で保存済みデータが壊れないように）。
 	PublicURL string `json:"publicUrl"`
 	ExpiresIn int    `json:"expiresIn"`
 }

--- a/backend/internal/domain/profile_image.go
+++ b/backend/internal/domain/profile_image.go
@@ -1,7 +1,8 @@
 package domain
 
 // ProfileImageUploadURL は profile アイコン用の S3 直接アップロード URL を表す。
-// UploadURL は PUT 対象、ImageURL はアップロード後に表示する URL。
+// UploadURL は PUT 対象、ImageURL はアップロード後に表示するパス。
+// ImageURL に配信ドメインは含めない（FRESTYLE-234。ドメイン変更で保存済みデータが壊れないように）。
 type ProfileImageUploadURL struct {
 	UploadURL string `json:"uploadUrl"`
 	ImageURL  string `json:"imageUrl"`

--- a/backend/internal/handler/routes_note.go
+++ b/backend/internal/handler/routes_note.go
@@ -55,5 +55,5 @@ func newNoteImagePresignerOrFallback(deps *routeDeps) repository.NoteImagePresig
 		log.Printf("[note-image] failed to init S3 presigner (%v) — falling back to stub", err)
 		return persistence.NewStubNoteImagePresigner(bucket)
 	}
-	return persistence.NewNoteImagePresigner(pre, deps.cfg.S3.NoteImagesCDNBase)
+	return persistence.NewNoteImagePresigner(pre)
 }

--- a/backend/internal/handler/routes_profile.go
+++ b/backend/internal/handler/routes_profile.go
@@ -45,21 +45,18 @@ func registerProfileRoutes(g *gin.RouterGroup, deps *routeDeps) {
 }
 
 // newProfileImagePresignerOrFallback は本番では real な presigner、NOTE_IMAGES_BUCKET 未設定や
-// 初期化失敗時は stub にフォールバックする。CDN ベースは未指定時 virtual-hosted-style で組み立てる。
+// 初期化失敗時は stub にフォールバックする。
+// 表示 URL は配信ドメインを含めないルート相対パスなので CDN ベースは渡さない（FRESTYLE-234）。
 func newProfileImagePresignerOrFallback(deps *routeDeps) repository.ProfileImagePresigner {
 	bucket := deps.cfg.S3.NoteImagesBucket
 	if bucket == "" {
 		log.Printf("[profile] NOTE_IMAGES_BUCKET unset — using stub presigner (DEV)")
-		return persistence.NewStubProfileImagePresigner("stub-bucket", deps.cfg.S3.NoteImagesCDNBase)
+		return persistence.NewStubProfileImagePresigner("stub-bucket")
 	}
 	pre, err := infraS3.NewPresigner(context.Background(), deps.cfg.S3.Region, bucket)
 	if err != nil {
 		log.Printf("[profile] failed to init S3 presigner (%v) — falling back to stub", err)
-		return persistence.NewStubProfileImagePresigner(bucket, deps.cfg.S3.NoteImagesCDNBase)
+		return persistence.NewStubProfileImagePresigner(bucket)
 	}
-	cdnBase := deps.cfg.S3.NoteImagesCDNBase
-	if cdnBase == "" {
-		cdnBase = "https://" + bucket + ".s3." + deps.cfg.S3.Region + ".amazonaws.com"
-	}
-	return persistence.NewProfileImagePresigner(pre, cdnBase)
+	return persistence.NewProfileImagePresigner(pre)
 }

--- a/backend/migrations/0020_image_urls_to_relative_paths.sql
+++ b/backend/migrations/0020_image_urls_to_relative_paths.sql
@@ -1,0 +1,55 @@
+-- FRESTYLE-234: 画像の参照を配信ドメイン込みの絶対 URL からルート相対パスへ移行する。
+--
+-- 絶対 URL で保存していると、配信ドメインを変えるたびに過去の画像が全て参照不能になる
+-- （FRESTYLE-232 で実害。アバター 4 件と教材 140 章の図が本番で表示できなくなった）。
+-- 画像はアプリと同一オリジンで配信されるため、ドメインを含めない「/notes/...」形式なら
+-- ブラウザが現在のドメインを補って解決し、以後ドメインが変わってもデータは無傷で済む。
+--
+-- 変換対象は画像のパスだけに限定する。教材本文には「このアドレスでアクセスします」と
+-- 説明するためのアプリ URL（/invitations/ /login/ /auth/ /courses/ 等）も含まれており、
+-- これらを相対化すると説明文として意味が壊れる。CloudFront が画像バケットへ振り分けて
+-- いる /notes/ と /profiles/ のみを対象にする。
+--
+-- 冪等: 変換済みなら 0 行更新で正常終了する。何度実行しても結果は変わらない。
+-- トランザクション: 適用は psql -f で行い外部のトランザクション管理は無いため、
+-- この中で BEGIN / COMMIT して原子性を確保する（既存 migration と同じ方式）。
+
+BEGIN;
+
+-- プロフィールのアイコン（列の値そのものが画像 URL）。
+UPDATE profiles
+SET avatar_url = regexp_replace(avatar_url, '^https?://[^/]+(/profiles/)', '\1')
+WHERE avatar_url ~ '^https?://[^/]+/profiles/';
+
+-- 教材本文（Markdown に埋め込まれた画像）。
+UPDATE course_chapters
+SET content = regexp_replace(content, 'https?://[^/\s)"'']+(/(?:notes|profiles)/)', '\1', 'g')
+WHERE content ~ 'https?://[^/\s)"'']+/(?:notes|profiles)/';
+
+-- ノート本文（現時点で該当 0 件だが、後から増えても取りこぼさないよう同じ処理を入れる）。
+UPDATE notes
+SET content = regexp_replace(content, 'https?://[^/\s)"'']+(/(?:notes|profiles)/)', '\1', 'g')
+WHERE content ~ 'https?://[^/\s)"'']+/(?:notes|profiles)/';
+
+-- 検証: 画像の絶対 URL が残っていたら適用を失敗させる（部分適用のまま完了しない）。
+DO $$
+DECLARE
+  stale_profiles bigint;
+  stale_chapters bigint;
+  stale_notes    bigint;
+BEGIN
+  SELECT count(*) INTO stale_profiles FROM profiles
+   WHERE avatar_url ~ '^https?://[^/]+/profiles/';
+  SELECT count(*) INTO stale_chapters FROM course_chapters
+   WHERE content ~ 'https?://[^/\s)"'']+/(?:notes|profiles)/';
+  SELECT count(*) INTO stale_notes FROM notes
+   WHERE content ~ 'https?://[^/\s)"'']+/(?:notes|profiles)/';
+
+  IF stale_profiles > 0 OR stale_chapters > 0 OR stale_notes > 0 THEN
+    RAISE EXCEPTION
+      '画像の絶対 URL が残存: profiles=% 件 / course_chapters=% 件 / notes=% 件',
+      stale_profiles, stale_chapters, stale_notes;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## 概要

画像 URL に**配信ドメインを含めて保存**していたため、ドメインを変えるたびに過去の画像が全て参照不能になっていた。FRESTYLE-232 で実害が出ている（旧ドメイン削除でアバター 4 件と教材 140 章の図が本番から消えた）。

ドメインを含めない `/notes/diagrams/xxx.png` の形にすることで、**以後ドメインを変えてもデータは無傷**になる。

Design Doc は FRESTYLE-234 で**案 D（ルート相対パス）として承認済み**。

## 着手前調査 — 承認時の計画より小さく済んだ

### Phase 1（表示側の両対応）は不要だった

ルート相対パスは**ブラウザが標準で解決する**。本番の frestyle.jp 上で実際に読み込んで確認した。

| 指定した値 | 解決先 | 結果 |
| --- | --- | --- |
| `/profiles/1/*.jpg` | `https://frestyle.jp/profiles/1/...` | ✅ 幅 756px |
| `/notes/diagrams/*.png` | `https://frestyle.jp/notes/diagrams/...` | ✅ 幅 2317px |

あわせて**絶対 URL を前提にした文字列処理がフロントに無い**ことも確認（`startsWith('http')` 等の分岐なし）。

### ブラウザ以外の利用者もいなかった

相対パスが危険なのは「ブラウザ以外が解決する」場合。該当が無いことを確認した。

| 懸念 | 実態 |
| --- | --- |
| メールへの画像埋め込み | 無し |
| OGP（`og:image`） | **静的な絶対 URL**。利用者データ由来ではない |
| backend での消費 | `avatar_url` は素通しのみ |
| AI チャット添付 | **URL を保存していない**（キーのみ。Bedrock へはバイト列） |

### ノート画像は元から正しい方向だった

`note_image_repository.go` は**設定が空なら既に `/` + key を返す**実装だった。設定が入っていたために絶対 URL になっていただけ。

## 変更内容

### 1. 保存する値から配信ドメインを外す

`profile` / `note` の presigner が表示用パスにドメインを含めないようにした。**アップロード先の presigned URL は S3 への直接 PUT なので絶対 URL のまま**（ここを相対化すると壊れる）。

### 2. migration `0020` — 既存データの変換

**変換は画像パス（`/notes/` `/profiles/`）だけに限定した。** 教材本文には「このアドレスでアクセスします」と説明するアプリ URL も含まれており、相対化すると説明文として意味が壊れる。

本番 DB で変換規則を実測して確認:

| 入力 | 変換後 |
| --- | --- |
| `![図](https://frestyle.jp/notes/diagrams/18-sqs.png)` | `![図](/notes/diagrams/18-sqs.png)` ✅ |
| `https://frestyle.jp/profiles/123/avatar.png` | `/profiles/123/avatar.png` ✅ |
| `URL = https://frestyle.jp/invitations/accept?token=<UUID>` | **不変** ✅ |
| `本番: https://frestyle.jp/login` | **不変** ✅ |
| `https://frestyle.jp/courses/5/chapters` | **不変** ✅ |

CloudFront が画像バケットへ振り分けているのが `/notes/` と `/profiles/` のみで、この境界と一致している。

冪等で、変換後に画像の絶対 URL が残っていれば `RAISE EXCEPTION` で停止する。

### 3. テスト

表示パスが相対であることを契約として固定した。ここが絶対 URL に戻ると同じ障害が再発する。

- 表示パスが `/profiles/7/` `/notes/7/` で始まり、`://` を含まないこと
- プロトコル相対（`//host/path`）にもしないこと
- **アップロード先は絶対 URL のまま**であること（表示用と混同しない）
- **キー = 表示パスから先頭の `/` を外した値**であること（将来キー保存方式へ移す場合の退路）

## テスト結果

| 対象 | 結果 |
| --- | --- |
| `go build` / `go vet` / `gofumpt` | OK |
| **golangci-lint** | **0 issues** |
| archlint / naminglint / apispec-lint / slicelint | すべて OK |
| `go test ./...` | 全パッケージ ok |
| `make openapi` | 実行済み（差分は説明文の反映のみ） |

## 適用手順

1. 本 PR をマージ・**backend をデプロイ**（以後の新規アップロードが相対パスになる）
2. 教材の正本 PR（norman6464/frestyle-teaching-materials#40）をマージ
3. migration `0020` を本番へ適用（既存データの変換）

**表示側は絶対 URL と相対パスの両方を解決できる**ため、変換の途中で混在しても壊れない。

## 残作業（別 PR）

`NOTE_IMAGES_CDN_URL` が不要になるので ECS タスク定義から撤去する（Phase 4）。設定が残っていても害は無いため急がない。

## セキュリティ影響

なし。参照の書き方を変えるだけで、公開範囲や権限は変わらない。

## ロールバック方針

PR revert で保存形式は戻る。DB は逆向きの変換で戻せるが、**戻す意味は無い**（絶対 URL に戻すと次のドメイン変更で再び壊れる）。

## 関連チケット

- FRESTYLE-234（設計・承認済み）/ FRESTYLE-232（ドメイン削除で画像が消えた障害）
- 教材の正本: norman6464/frestyle-teaching-materials#40