### PR TITLE
chore: 使われなくなった配信 CDN URL の設定を削除 (FRESTYLE-234)

### DIFF
--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -39,9 +39,8 @@ type Config struct {
 
 // S3Config は profile / note 画像 upload の presign 発行に必要な設定。
 type S3Config struct {
-	Region            string
-	NoteImagesBucket  string
-	NoteImagesCDNBase string // 配信用 CDN URL (CloudFront / virtual-hosted)
+	Region           string
+	NoteImagesBucket string
 }
 
 // BedrockConfig は AWS Bedrock Converse API 呼び出しに必要な設定。
@@ -101,8 +100,6 @@ func Load() (*Config, error) {
 		S3: S3Config{
 			Region:           getEnvOrDefault("AWS_REGION", "ap-northeast-1"),
 			NoteImagesBucket: os.Getenv("NOTE_IMAGES_BUCKET"),
-			// ecs.yml が渡す環境変数名は NOTE_IMAGES_CDN_URL。
-			NoteImagesCDNBase: getEnvOrDefault("NOTE_IMAGES_CDN_URL", ""),
 		},
 		Bedrock: BedrockConfig{
 			Region: getEnvOrDefault("AWS_REGION", "ap-northeast-1"),


### PR DESCRIPTION
## 概要

FRESTYLE-234 で画像の参照をルート相対パスにしたことで、**配信ドメインを組み立てる処理が無くなった**。`config` に定義だけが残り、値はどこからも読まれていない状態だったので削除する。

## 変更内容

`S3Config` から `NoteImagesCDNBase`（環境変数 `NOTE_IMAGES_CDN_URL`）を削除。

削除前に、**値を消費している箇所が無いこと**を確認した。

```
$ rg "NoteImagesCDNBase|NOTE_IMAGES_CDN_URL" backend/ --glob '!**/docs/**'
（config.go の定義と読み込みのみ。利用箇所ゼロ）
```

削除後は参照が完全に消えている。

## なぜ消すか

設定が残っていても動作に害は無い（誰も読まないため）。ただし「**読まれない設定**」はコードを次に触る人に「これは何に効くのか」と考えさせる。実態と揃えておく。

## テスト

| 検証 | 結果 |
| --- | --- |
| `go build` / `go vet` / `gofumpt` | OK |
| **golangci-lint** | **0 issues** |
| archlint / naminglint / apispec-lint / slicelint | すべて OK |
| `go test ./...` | 全パッケージ ok |

## 残作業

環境変数そのもの（ECS タスク定義の `NOTE_IMAGES_CDN_URL`）の撤去は **infra リポの PR** で行う。順序はどちらが先でも安全（読まない設定が渡されるだけ / 定義の無い設定を読まないだけ）。

## セキュリティ影響

なし。

## ロールバック方針

PR revert で戻せる。DB 変更なし。

## 関連チケット

- FRESTYLE-234 Phase 4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **変更**
  - 画像配信URLに関する不要な設定項目を削除しました。
  - `NOTE_IMAGES_CDN_URL` 環境変数の読み込みを廃止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->