### PR TITLE
fix: 通知の取得失敗を握りつぶさず伝え、通知作成の N+1 を解消する (FRESTYLE-94, FRESTYLE-17)

### DIFF
--- a/backend/internal/adapter/persistence/notification_repository.go
+++ b/backend/internal/adapter/persistence/notification_repository.go
@@ -21,6 +21,17 @@ func (r *notificationRepository) Create(ctx context.Context, n *domain.Notificat
 	return r.db.WithContext(ctx).Create(n).Error
 }
 
+// CreateMany は複数件を 1 回の INSERT でまとめて作成する（FRESTYLE-17）。
+// 宛先が 1 人増えるごとに DB との往復が 1 回増える形だったため、件数に比例して
+// 申請処理が遅くなっていた。
+func (r *notificationRepository) CreateMany(ctx context.Context, ns []domain.Notification) error {
+	if len(ns) == 0 {
+		// GORM は空スライスに対して "empty slice found" を返すため、ここで打ち切る。
+		return nil
+	}
+	return r.db.WithContext(ctx).Create(&ns).Error
+}
+
 func (r *notificationRepository) ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error) {
 	uid, ok := toInt64ID(userID)
 	if !ok {

--- a/backend/internal/adapter/persistence/notification_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/notification_repository_integration_test.go
@@ -4,8 +4,13 @@ package persistence_test
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
 
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -87,4 +92,50 @@ func TestNotificationRepository_CreateMany_Integration(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, rows)
 	})
+}
+
+// countingLogger は実行された SQL のうち INSERT の回数を数える GORM ロガー。
+// 「まとめて 1 回で書き込む」ことを、保存結果ではなく実際に発行された SQL で確かめる。
+type countingLogger struct {
+	gormlogger.Interface
+	mu     sync.Mutex
+	insert int
+}
+
+func (l *countingLogger) Trace(
+	ctx context.Context,
+	begin time.Time,
+	fc func() (string, int64),
+	err error,
+) {
+	sql, _ := fc()
+	if strings.Contains(strings.ToUpper(sql), "INSERT INTO") {
+		l.mu.Lock()
+		l.insert++
+		l.mu.Unlock()
+	}
+	l.Interface.Trace(ctx, begin, fc, err)
+}
+
+// TestNotificationRepository_CreateManyIssuesSingleInsert_Integration は、宛先が増えても
+// 発行される INSERT が 1 回であることを実 Postgres で検証する（FRESTYLE-17）。
+//
+// 保存結果の件数だけを見ていると、GORM の CreateBatchSize が有効な環境で複数回に
+// 分割されても気づけない。実際に流れた SQL を数えて契約を固定する。
+func TestNotificationRepository_CreateManyIssuesSingleInsert_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	testsupport.TruncateAll(t, db, "notifications")
+
+	counter := &countingLogger{Interface: db.Logger}
+	repo := persistence.NewNotificationRepository(db.Session(&gorm.Session{Logger: counter}))
+
+	ns := make([]domain.Notification, 0, 10)
+	for i := uint64(1); i <= 10; i++ {
+		ns = append(ns, domain.Notification{
+			UserID: i, Type: "company_application", Title: "申請", Body: "A 社から申請",
+		})
+	}
+	require.NoError(t, repo.CreateMany(context.Background(), ns))
+
+	require.Equal(t, 1, counter.insert, "宛先 10 件でも INSERT は 1 回であること")
 }

--- a/backend/internal/adapter/persistence/notification_repository_integration_test.go
+++ b/backend/internal/adapter/persistence/notification_repository_integration_test.go
@@ -45,3 +45,46 @@ func TestNotificationRepository_Integration(t *testing.T) {
 		require.Equal(t, int64(1), unread)
 	})
 }
+
+// TestNotificationRepository_CreateMany_Integration は一括作成を実 Postgres で検証する。
+// 宛先が増えるたびに DB との往復が増えないよう 1 回の INSERT にまとめている（FRESTYLE-17）。
+func TestNotificationRepository_CreateMany_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	repo := persistence.NewNotificationRepository(db)
+	ctx := context.Background()
+
+	t.Run("複数件をまとめて作成できる", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "notifications")
+
+		ns := []domain.Notification{
+			{UserID: 1, Type: "company_application", Title: "申請", Body: "A 社から申請"},
+			{UserID: 2, Type: "company_application", Title: "申請", Body: "A 社から申請"},
+			{UserID: 3, Type: "company_application", Title: "申請", Body: "A 社から申請"},
+		}
+		require.NoError(t, repo.CreateMany(ctx, ns))
+
+		// 宛先ごとに 1 件ずつ、本文まで保存されていること。
+		for _, want := range ns {
+			rows, err := repo.ListByUserID(ctx, want.UserID)
+			require.NoError(t, err)
+			require.Len(t, rows, 1)
+			require.Equal(t, want.Title, rows[0].Title)
+			require.Equal(t, want.Body, rows[0].Body)
+			require.Equal(t, want.Type, rows[0].Type)
+			require.False(t, rows[0].IsRead)
+			require.NotZero(t, rows[0].ID, "ID が採番されること")
+		}
+	})
+
+	t.Run("空スライスは何もせず成功する", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "notifications")
+
+		// 宛先が 0 人のときに呼び出し側で分岐しなくて済むようにする。
+		require.NoError(t, repo.CreateMany(ctx, nil))
+		require.NoError(t, repo.CreateMany(ctx, []domain.Notification{}))
+
+		rows, err := repo.ListByUserID(ctx, 1)
+		require.NoError(t, err)
+		require.Empty(t, rows)
+	})
+}

--- a/backend/internal/handler/notification_handler_test.go
+++ b/backend/internal/handler/notification_handler_test.go
@@ -20,7 +20,8 @@ type fakeNotifRepo struct {
 	err   error
 }
 
-func (f *fakeNotifRepo) Create(context.Context, *domain.Notification) error { return f.err }
+func (f *fakeNotifRepo) Create(context.Context, *domain.Notification) error      { return f.err }
+func (f *fakeNotifRepo) CreateMany(context.Context, []domain.Notification) error { return f.err }
 func (f *fakeNotifRepo) ListByUserID(context.Context, uint64) ([]domain.Notification, error) {
 	return f.rows, f.err
 }

--- a/backend/internal/usecase/create_company_application_usecase.go
+++ b/backend/internal/usecase/create_company_application_usecase.go
@@ -89,15 +89,20 @@ func (u *CreateCompanyApplicationUseCase) notifySuperAdmins(ctx context.Context,
 	}
 	title := "新しい企業申請が届きました"
 	body := fmt.Sprintf("%s（%s / %s）から利用申請がありました。", app.CompanyName, app.ApplicantName, app.Email)
+
+	// 宛先ごとに 1 件ずつ書き込むと、管理者が増えるほど DB との往復が比例して増える。
+	// まとめて 1 回で書き込む（FRESTYLE-17）。
+	notifications := make([]domain.Notification, 0, len(admins))
 	for _, admin := range admins {
-		n := &domain.Notification{
+		notifications = append(notifications, domain.Notification{
 			UserID: admin.ID,
 			Type:   domain.NotificationTypeCompanyApplication,
 			Title:  title,
 			Body:   body,
-		}
-		if err := u.notifications.Create(ctx, n); err != nil {
-			log.Printf("company-application: notify super_admin %d failed: %v", admin.ID, err)
-		}
+		})
+	}
+	if err := u.notifications.CreateMany(ctx, notifications); err != nil {
+		// 通知は申請受付の付随処理。失敗しても申請自体は成立させる（従来と同じ方針）。
+		log.Printf("company-application: notify %d super_admins failed: %v", len(notifications), err)
 	}
 }

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -57,9 +57,12 @@ type recordingNotifRepo struct {
 	created []domain.Notification
 	// createManyCalls は「宛先の人数によらず 1 回で書き込む」ことを検証するための回数。
 	createManyCalls int
+	// createCalls は 1 件ずつ書き込む旧経路に戻っていないことの検証用。
+	createCalls int
 }
 
 func (r *recordingNotifRepo) Create(_ context.Context, n *domain.Notification) error {
+	r.createCalls++
 	r.created = append(r.created, *n)
 	return nil
 }
@@ -147,57 +150,66 @@ func (r *failingNotifRepo) CreateMany(context.Context, []domain.Notification) er
 
 // 宛先が増えても DB への書き込みは 1 回に保つ（FRESTYLE-17）。
 // 1 件ずつ書き込む実装だと管理者の人数に比例して往復が増え、申請処理が遅くなる。
-func Test_会社申請作成_管理者が何人でも通知の書き込みは1回(t *testing.T) {
-	admins := make([]domain.User, 0, 5)
-	for i := uint64(1); i <= 5; i++ {
-		admins = append(admins, domain.User{ID: i})
-	}
-	notifs := &recordingNotifRepo{}
-	uc := usecase.NewCreateCompanyApplicationUseCase(
-		&fakeAppRepo{}, &fakeUsersForApp{admins: admins}, notifs,
-	)
-
-	if _, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
-		CompanyName:   "Example Corp",
-		ApplicantName: "山田太郎",
-		Email:         "yamada@example.com",
-	}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if notifs.createManyCalls != 1 {
-		t.Fatalf("書き込みは 1 回であること（人数分の往復にしない）: got %d", notifs.createManyCalls)
-	}
-	if len(notifs.created) != len(admins) {
-		t.Fatalf("管理者の人数ぶん作られること: want %d, got %d", len(admins), len(notifs.created))
-	}
-	// 宛先が取り違えられていないこと。
-	for i, n := range notifs.created {
-		if n.UserID != admins[i].ID {
-			t.Fatalf("宛先が一致しない: index=%d want=%d got=%d", i, admins[i].ID, n.UserID)
+func Test_会社申請作成_通知はまとめて1回で書き込む(t *testing.T) {
+	makeAdmins := func(n int) []domain.User {
+		out := make([]domain.User, 0, n)
+		for i := 1; i <= n; i++ {
+			out = append(out, domain.User{ID: uint64(i)})
 		}
+		return out
 	}
-}
 
-// 管理者が 0 人のときに空で呼び出して DB 側でエラーにならないこと。
-func Test_会社申請作成_管理者が0人でも申請は成立する(t *testing.T) {
-	notifs := &recordingNotifRepo{}
-	uc := usecase.NewCreateCompanyApplicationUseCase(
-		&fakeAppRepo{}, &fakeUsersForApp{admins: nil}, notifs,
-	)
+	tests := []struct {
+		name            string
+		admins          []domain.User
+		wantCreateMany  int // まとめ書き込みの回数
+		wantNotifations int // 作られる通知の件数
+	}{
+		{name: "管理者が0人", admins: nil, wantCreateMany: 1, wantNotifations: 0},
+		{name: "管理者が1人", admins: makeAdmins(1), wantCreateMany: 1, wantNotifations: 1},
+		{name: "管理者が5人", admins: makeAdmins(5), wantCreateMany: 1, wantNotifations: 5},
+		{name: "管理者が20人", admins: makeAdmins(20), wantCreateMany: 1, wantNotifations: 20},
+	}
 
-	app, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
-		CompanyName:   "Example Corp",
-		ApplicantName: "山田太郎",
-		Email:         "yamada@example.com",
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if app.Status != domain.CompanyApplicationStatusPending {
-		t.Fatalf("status should be pending, got %q", app.Status)
-	}
-	if len(notifs.created) != 0 {
-		t.Fatalf("通知は作られないこと: got %d", len(notifs.created))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifs := &recordingNotifRepo{}
+			uc := usecase.NewCreateCompanyApplicationUseCase(
+				&fakeAppRepo{}, &fakeUsersForApp{admins: tt.admins}, notifs,
+			)
+
+			app, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
+				CompanyName:   "Example Corp",
+				ApplicantName: "山田太郎",
+				Email:         "yamada@example.com",
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if app.Status != domain.CompanyApplicationStatusPending {
+				t.Fatalf("status should be pending, got %q", app.Status)
+			}
+
+			// 人数によらず書き込みは 1 回。
+			if notifs.createManyCalls != tt.wantCreateMany {
+				t.Fatalf("まとめ書き込みの回数: want %d, got %d", tt.wantCreateMany, notifs.createManyCalls)
+			}
+			// 1 件ずつ書き込む旧経路に戻っていないこと。
+			if notifs.createCalls != 0 {
+				t.Fatalf("1 件ずつの Create は呼ばないこと: got %d", notifs.createCalls)
+			}
+			if len(notifs.created) != tt.wantNotifations {
+				t.Fatalf("通知の件数: want %d, got %d", tt.wantNotifations, len(notifs.created))
+			}
+			// 宛先が取り違えられていないこと。
+			for i, n := range notifs.created {
+				if n.UserID != tt.admins[i].ID {
+					t.Fatalf("宛先が一致しない: index=%d want=%d got=%d", i, tt.admins[i].ID, n.UserID)
+				}
+				if n.Type != domain.NotificationTypeCompanyApplication {
+					t.Fatalf("種別が一致しない: %q", n.Type)
+				}
+			}
+		})
 	}
 }

--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -53,10 +53,20 @@ func (f *fakeUsersForApp) ListByCompanyID(context.Context, uint64) ([]domain.Use
 }
 func (f *fakeUsersForApp) UpdateAiChatEnabled(context.Context, uint64, *bool) error { return nil }
 
-type recordingNotifRepo struct{ created []domain.Notification }
+type recordingNotifRepo struct {
+	created []domain.Notification
+	// createManyCalls は「宛先の人数によらず 1 回で書き込む」ことを検証するための回数。
+	createManyCalls int
+}
 
 func (r *recordingNotifRepo) Create(_ context.Context, n *domain.Notification) error {
 	r.created = append(r.created, *n)
+	return nil
+}
+
+func (r *recordingNotifRepo) CreateMany(_ context.Context, ns []domain.Notification) error {
+	r.created = append(r.created, ns...)
+	r.createManyCalls++
 	return nil
 }
 
@@ -129,4 +139,65 @@ type failingNotifRepo struct{ recordingNotifRepo }
 
 func (r *failingNotifRepo) Create(context.Context, *domain.Notification) error {
 	return errors.New("boom")
+}
+
+func (r *failingNotifRepo) CreateMany(context.Context, []domain.Notification) error {
+	return errors.New("boom")
+}
+
+// 宛先が増えても DB への書き込みは 1 回に保つ（FRESTYLE-17）。
+// 1 件ずつ書き込む実装だと管理者の人数に比例して往復が増え、申請処理が遅くなる。
+func Test_会社申請作成_管理者が何人でも通知の書き込みは1回(t *testing.T) {
+	admins := make([]domain.User, 0, 5)
+	for i := uint64(1); i <= 5; i++ {
+		admins = append(admins, domain.User{ID: i})
+	}
+	notifs := &recordingNotifRepo{}
+	uc := usecase.NewCreateCompanyApplicationUseCase(
+		&fakeAppRepo{}, &fakeUsersForApp{admins: admins}, notifs,
+	)
+
+	if _, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
+		CompanyName:   "Example Corp",
+		ApplicantName: "山田太郎",
+		Email:         "yamada@example.com",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if notifs.createManyCalls != 1 {
+		t.Fatalf("書き込みは 1 回であること（人数分の往復にしない）: got %d", notifs.createManyCalls)
+	}
+	if len(notifs.created) != len(admins) {
+		t.Fatalf("管理者の人数ぶん作られること: want %d, got %d", len(admins), len(notifs.created))
+	}
+	// 宛先が取り違えられていないこと。
+	for i, n := range notifs.created {
+		if n.UserID != admins[i].ID {
+			t.Fatalf("宛先が一致しない: index=%d want=%d got=%d", i, admins[i].ID, n.UserID)
+		}
+	}
+}
+
+// 管理者が 0 人のときに空で呼び出して DB 側でエラーにならないこと。
+func Test_会社申請作成_管理者が0人でも申請は成立する(t *testing.T) {
+	notifs := &recordingNotifRepo{}
+	uc := usecase.NewCreateCompanyApplicationUseCase(
+		&fakeAppRepo{}, &fakeUsersForApp{admins: nil}, notifs,
+	)
+
+	app, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
+		CompanyName:   "Example Corp",
+		ApplicantName: "山田太郎",
+		Email:         "yamada@example.com",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if app.Status != domain.CompanyApplicationStatusPending {
+		t.Fatalf("status should be pending, got %q", app.Status)
+	}
+	if len(notifs.created) != 0 {
+		t.Fatalf("通知は作られないこと: got %d", len(notifs.created))
+	}
 }

--- a/backend/internal/usecase/notification_usecase_test.go
+++ b/backend/internal/usecase/notification_usecase_test.go
@@ -16,6 +16,10 @@ func (s *stubNotificationRepo) Create(_ context.Context, _ *domain.Notification)
 	return s.err
 }
 
+func (s *stubNotificationRepo) CreateMany(_ context.Context, _ []domain.Notification) error {
+	return s.err
+}
+
 func (s *stubNotificationRepo) ListByUserID(_ context.Context, _ uint64) ([]domain.Notification, error) {
 	return s.rows, s.err
 }

--- a/backend/internal/usecase/repository/notification.go
+++ b/backend/internal/usecase/repository/notification.go
@@ -10,6 +10,9 @@ import (
 type NotificationRepository interface {
 	// Create は通知を 1 件作成する（システムが super_admin 等に通知を出す用途）。
 	Create(ctx context.Context, n *domain.Notification) error
+	// CreateMany は通知をまとめて作成する。宛先が増えるほど往復が比例して増えるのを避ける。
+	// 空スライスは何もせず nil を返す（呼び出し側で件数を気にしなくてよいように）。
+	CreateMany(ctx context.Context, ns []domain.Notification) error
 	ListByUserID(ctx context.Context, userID uint64) ([]domain.Notification, error)
 	// MarkRead は WHERE で user_id を絞り、自分以外の通知を既読化できないようにする。
 	MarkRead(ctx context.Context, userID, id uint64) error

--- a/frontend/src/pages/notifications/__tests__/NotificationPage.test.tsx
+++ b/frontend/src/pages/notifications/__tests__/NotificationPage.test.tsx
@@ -50,8 +50,8 @@ describe('NotificationPage', () => {
   it('通知一覧が表示される', () => {
     mockedUseNotification.mockReturnValue({
       notifications: [
-        { id: 1, type: 'GOAL_ACHIEVED', title: '月間目標を達成しました', message: 'おめでとう', isRead: false, createdAt: '2024-06-15T10:00:00Z' },
-        { id: 2, type: 'SYSTEM', title: 'システム通知', message: 'メンテナンス', isRead: true, createdAt: '2024-06-14T10:00:00Z' },
+        { id: 1, type: 'company_application', title: '新しい利用申請が届きました', body: '株式会社サンプルから利用申請がありました。', isRead: false, createdAt: '2026-08-02T10:00:00Z' },
+        { id: 2, type: 'company_application', title: '新しい利用申請が届きました', body: '株式会社テストから利用申請がありました。', isRead: true, createdAt: '2026-08-01T10:00:00Z' },
       ],
       unreadCount: 1,
       loading: false,
@@ -62,15 +62,16 @@ describe('NotificationPage', () => {
     });
 
     render(<NotificationPage />);
-    expect(screen.getByText('月間目標を達成しました')).toBeInTheDocument();
-    expect(screen.getByText('システム通知')).toBeInTheDocument();
+    // 同じタイトルが 2 件並ぶため、区別のつく本文で検証する。
+    expect(screen.getByText('株式会社サンプルから利用申請がありました。')).toBeInTheDocument();
+    expect(screen.getByText('株式会社テストから利用申請がありました。')).toBeInTheDocument();
     expect(screen.getByText('1件の未読')).toBeInTheDocument();
   });
 
   it('未読がある場合「すべて既読にする」ボタンが表示される', () => {
     mockedUseNotification.mockReturnValue({
       notifications: [
-        { id: 1, type: 'GOAL_ACHIEVED', title: '目標達成', message: 'テスト', isRead: false, createdAt: '2024-06-15T10:00:00Z' },
+        { id: 1, type: 'company_application', title: '新しい利用申請が届きました', body: 'テスト', isRead: false, createdAt: '2026-08-02T10:00:00Z' },
       ],
       unreadCount: 1,
       loading: false,
@@ -89,7 +90,7 @@ describe('NotificationPage', () => {
   it('未読が0件の場合「すべて既読にする」ボタンが非表示', () => {
     mockedUseNotification.mockReturnValue({
       notifications: [
-        { id: 1, type: 'SYSTEM', title: '通知', message: 'テスト', isRead: true, createdAt: '2024-06-15T10:00:00Z' },
+        { id: 1, type: 'company_application', title: '新しい利用申請が届きました', body: 'テスト', isRead: true, createdAt: '2026-08-02T10:00:00Z' },
       ],
       unreadCount: 0,
       loading: false,
@@ -164,7 +165,10 @@ describe('NotificationPage', () => {
 
       render(<NotificationPage />);
 
+      // エラーの帯と一緒に、取得済みの通知も見えていること。
       expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('新しい利用申請が届きました')).toBeInTheDocument();
+      expect(screen.getByText('株式会社サンプルから利用申請がありました。')).toBeInTheDocument();
       expect(screen.queryByText('通知はありません')).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/pages/notifications/__tests__/NotificationPage.test.tsx
+++ b/frontend/src/pages/notifications/__tests__/NotificationPage.test.tsx
@@ -22,6 +22,7 @@ describe('NotificationPage', () => {
       notifications: [],
       unreadCount: 0,
       loading: true,
+      error: null,
       markAsRead: mockMarkAsRead,
       markAllAsRead: mockMarkAllAsRead,
       refresh: vi.fn(),
@@ -36,6 +37,7 @@ describe('NotificationPage', () => {
       notifications: [],
       unreadCount: 0,
       loading: false,
+      error: null,
       markAsRead: mockMarkAsRead,
       markAllAsRead: mockMarkAllAsRead,
       refresh: vi.fn(),
@@ -53,6 +55,7 @@ describe('NotificationPage', () => {
       ],
       unreadCount: 1,
       loading: false,
+      error: null,
       markAsRead: mockMarkAsRead,
       markAllAsRead: mockMarkAllAsRead,
       refresh: vi.fn(),
@@ -71,6 +74,7 @@ describe('NotificationPage', () => {
       ],
       unreadCount: 1,
       loading: false,
+      error: null,
       markAsRead: mockMarkAsRead,
       markAllAsRead: mockMarkAllAsRead,
       refresh: vi.fn(),
@@ -89,6 +93,7 @@ describe('NotificationPage', () => {
       ],
       unreadCount: 0,
       loading: false,
+      error: null,
       markAsRead: mockMarkAsRead,
       markAllAsRead: mockMarkAllAsRead,
       refresh: vi.fn(),
@@ -96,5 +101,71 @@ describe('NotificationPage', () => {
 
     render(<NotificationPage />);
     expect(screen.queryByText('すべて既読にする')).not.toBeInTheDocument();
+  });
+
+  // 取得に失敗したときに「通知はありません」と嘘を見せないことを固定する（FRESTYLE-94）。
+  describe('取得に失敗したとき', () => {
+    const failing = (overrides = {}) => ({
+      notifications: [],
+      unreadCount: 0,
+      loading: false,
+      error: '通知の取得に失敗しました。',
+      markAsRead: mockMarkAsRead,
+      markAllAsRead: mockMarkAllAsRead,
+      refresh: vi.fn(),
+      ...overrides,
+    });
+
+    it('エラーを知らせ、空状態を出さない', () => {
+      mockedUseNotification.mockReturnValue(failing());
+
+      render(<NotificationPage />);
+
+      expect(screen.getByRole('alert')).toHaveTextContent('通知の取得に失敗しました。');
+      expect(screen.queryByText('通知はありません')).not.toBeInTheDocument();
+    });
+
+    it('0 件ではなく読み込めていないことを明示する', () => {
+      mockedUseNotification.mockReturnValue(failing());
+
+      render(<NotificationPage />);
+
+      expect(
+        screen.getByText('通知が無いのではなく、読み込めていない状態です。'),
+      ).toBeInTheDocument();
+    });
+
+    it('再試行ボタンから再取得できる', () => {
+      const refresh = vi.fn();
+      mockedUseNotification.mockReturnValue(failing({ refresh }));
+
+      render(<NotificationPage />);
+      fireEvent.click(screen.getByRole('button', { name: '再試行' }));
+
+      expect(refresh).toHaveBeenCalled();
+    });
+
+    // 直前まで表示していた通知は残す（消すと「消えた」と誤解される）。
+    it('取得済みの通知がある場合はそれを表示したままにする', () => {
+      mockedUseNotification.mockReturnValue(
+        failing({
+          notifications: [
+            {
+              id: 1,
+              type: 'company_application',
+              title: '新しい利用申請が届きました',
+              body: '株式会社サンプルから利用申請がありました。',
+              isRead: false,
+              createdAt: '2026-08-02T10:00:00Z',
+            },
+          ],
+        }),
+      );
+
+      render(<NotificationPage />);
+
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.queryByText('通知はありません')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/pages/notifications/model/__tests__/useNotification.test.ts
+++ b/frontend/src/pages/notifications/model/__tests__/useNotification.test.ts
@@ -157,4 +157,41 @@ describe('useNotification', () => {
       expect(result.current.notifications).toHaveLength(2);
     });
   });
+
+  // 既読化に失敗しても finally で再取得しており、画面はサーバーの実状態に合う。
+  // この再取得が消えると「押したのに変わらない」状態に戻るため契約として固定する。
+  describe('既読化に失敗したとき', () => {
+    it('markAsRead が失敗しても再取得してサーバー状態に合わせる', async () => {
+      const { result } = renderHook(() => useNotification());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      mockMarkAsRead.mockRejectedValue(new Error('API Error'));
+      // 再取得では既読済み・未読 0 が返る（他の経路で既読になった状況）。
+      mockGetAll.mockResolvedValue(mockNotifications.map((n) => ({ ...n, isRead: true })));
+      mockGetUnreadCount.mockResolvedValue(0);
+
+      await act(async () => {
+        await result.current.markAsRead(1);
+      });
+
+      expect(mockGetAll).toHaveBeenCalledTimes(2);
+      expect(result.current.unreadCount).toBe(0);
+      expect(result.current.notifications.every((n) => n.isRead)).toBe(true);
+    });
+
+    it('markAllAsRead が失敗しても再取得する', async () => {
+      const { result } = renderHook(() => useNotification());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      mockMarkAllAsRead.mockRejectedValue(new Error('API Error'));
+      mockGetUnreadCount.mockResolvedValue(0);
+
+      await act(async () => {
+        await result.current.markAllAsRead();
+      });
+
+      expect(mockGetAll).toHaveBeenCalledTimes(2);
+      expect(result.current.unreadCount).toBe(0);
+    });
+  });
 });

--- a/frontend/src/pages/notifications/model/__tests__/useNotification.test.ts
+++ b/frontend/src/pages/notifications/model/__tests__/useNotification.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useNotification } from '../useNotification';
+import type { Notification } from '@/entities/notification';
 
 const mockGetAll = vi.fn();
 const mockMarkAsRead = vi.fn();
@@ -16,9 +17,24 @@ vi.mock('@/entities/notification/api/notificationRepository', () => ({
   },
 }));
 
-const mockNotifications = [
-  { id: 1, type: 'NEW_MESSAGE', title: '新しいメッセージ', message: '田中さんから', isRead: false, relatedId: 5, createdAt: '2026-01-15T10:30:00' },
-  { id: 2, type: 'GOAL_ACHIEVED', title: '目標達成', message: '日次目標を達成しました', isRead: true, createdAt: '2026-01-15T09:00:00' },
+// backend が実際に作る形に合わせる（type=company_application / 本文は body）。
+const mockNotifications: Notification[] = [
+  {
+    id: 1,
+    type: 'company_application',
+    title: '新しい利用申請が届きました',
+    body: '株式会社サンプル（山田 太郎 / taro@example.com）から利用申請がありました。',
+    isRead: false,
+    createdAt: '2026-08-02T10:30:00Z',
+  },
+  {
+    id: 2,
+    type: 'company_application',
+    title: '新しい利用申請が届きました',
+    body: '株式会社テスト（鈴木 花子 / hanako@example.com）から利用申請がありました。',
+    isRead: true,
+    createdAt: '2026-08-02T09:00:00Z',
+  },
 ];
 
 describe('useNotification', () => {
@@ -91,17 +107,54 @@ describe('useNotification', () => {
     expect(mockMarkAllAsRead).toHaveBeenCalled();
   });
 
-  it('API失敗時はエラーなく空リストを返す', async () => {
-    mockGetAll.mockRejectedValue(new Error('API Error'));
-    mockGetUnreadCount.mockRejectedValue(new Error('API Error'));
-
-    const { result } = renderHook(() => useNotification());
-
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
+  // 取得できなかったことを空配列で表すと「通知は 0 件」と区別がつかず、
+  // 障害中に「通知はありません」という嘘を見せてしまう（FRESTYLE-94）。
+  describe('取得に失敗したとき', () => {
+    beforeEach(() => {
+      mockGetAll.mockRejectedValue(new Error('API Error'));
+      mockGetUnreadCount.mockRejectedValue(new Error('API Error'));
     });
 
-    expect(result.current.notifications).toEqual([]);
-    expect(result.current.unreadCount).toBe(0);
+    it('エラーを立てる（握りつぶさない）', async () => {
+      const { result } = renderHook(() => useNotification());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+      expect(result.current.error).toBeTruthy();
+    });
+
+    it('直前に表示していた通知を空にしない', async () => {
+      mockGetAll.mockReset().mockResolvedValueOnce(mockNotifications);
+      mockGetUnreadCount.mockReset().mockResolvedValueOnce(1);
+
+      const { result } = renderHook(() => useNotification());
+      await waitFor(() => expect(result.current.notifications).toHaveLength(2));
+
+      // 2 回目の取得だけ失敗させる
+      mockGetAll.mockRejectedValue(new Error('API Error'));
+      mockGetUnreadCount.mockRejectedValue(new Error('API Error'));
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      expect(result.current.error).toBeTruthy();
+      expect(result.current.notifications).toHaveLength(2);
+      expect(result.current.unreadCount).toBe(1);
+    });
+
+    it('再取得に成功したらエラーが消える', async () => {
+      const { result } = renderHook(() => useNotification());
+      await waitFor(() => expect(result.current.error).toBeTruthy());
+
+      mockGetAll.mockResolvedValue(mockNotifications);
+      mockGetUnreadCount.mockResolvedValue(1);
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.notifications).toHaveLength(2);
+    });
   });
 });

--- a/frontend/src/pages/notifications/model/useNotification.ts
+++ b/frontend/src/pages/notifications/model/useNotification.ts
@@ -1,13 +1,16 @@
 import { useState, useCallback, useEffect } from 'react';
 import { NotificationRepository } from '@/entities/notification';
 import type { Notification } from '@/entities/notification';
+import { classifyApiError } from '@/shared/lib/classifyApiError';
 
 export function useNotification() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchData = useCallback(async () => {
+    setLoading(true);
     try {
       const [notifs, count] = await Promise.all([
         NotificationRepository.getAll(),
@@ -15,9 +18,12 @@ export function useNotification() {
       ]);
       setNotifications(notifs);
       setUnreadCount(count);
-    } catch {
-      setNotifications([]);
-      setUnreadCount(0);
+      setError(null);
+    } catch (err) {
+      // 取得できなかったことを空配列で表すと「通知は 0 件」と区別がつかず、
+      // 障害中に「通知はありません」という嘘を見せてしまう（FRESTYLE-94）。
+      // 直前まで表示していた内容は消さずに残し、失敗した事実だけを伝える。
+      setError(classifyApiError(err, '通知の取得に失敗しました。'));
     } finally {
       setLoading(false);
     }
@@ -27,25 +33,36 @@ export function useNotification() {
     fetchData();
   }, [fetchData]);
 
-  const markAsRead = useCallback(async (notificationId: number) => {
-    try {
-      await NotificationRepository.markAsRead(notificationId);
-    } catch {
-      // エラー時もUIを最新状態に更新
-    } finally {
-      await fetchData();
-    }
-  }, [fetchData]);
+  const markAsRead = useCallback(
+    async (notificationId: number) => {
+      try {
+        await NotificationRepository.markAsRead(notificationId);
+      } catch {
+        // 既読化に失敗しても再取得で実際の状態に合わせる（楽観更新はしない）。
+      } finally {
+        await fetchData();
+      }
+    },
+    [fetchData],
+  );
 
   const markAllAsRead = useCallback(async () => {
     try {
       await NotificationRepository.markAllAsRead();
     } catch {
-      // エラー時もUIを最新状態に更新
+      // 同上。
     } finally {
       await fetchData();
     }
   }, [fetchData]);
 
-  return { notifications, unreadCount, loading, markAsRead, markAllAsRead, refresh: fetchData };
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    error,
+    markAsRead,
+    markAllAsRead,
+    refresh: fetchData,
+  };
 }

--- a/frontend/src/pages/notifications/ui/NotificationPage.tsx
+++ b/frontend/src/pages/notifications/ui/NotificationPage.tsx
@@ -35,32 +35,30 @@ export default function NotificationPage() {
         )}
       </div>
 
-      {/* 取得に失敗したときは「0 件」と誤解させない。空状態より先に判定する（FRESTYLE-94）。 */}
-      {error ? (
+      {/* 取得に失敗したことは独立した帯で伝える。取得済みの通知は隠さない（FRESTYLE-94）。 */}
+      {error && (
         <div
           role="alert"
-          className="rounded-lg border border-surface-3 bg-surface-1 px-4 py-6 text-center"
+          className="rounded-lg border border-surface-3 bg-surface-1 px-4 py-4 flex items-start gap-3"
         >
-          <ExclamationTriangleIcon className="mx-auto w-8 h-8 text-[var(--color-text-muted)]" />
-          <p className="mt-3 text-sm font-medium text-[var(--color-text-primary)]">{error}</p>
-          <p className="mt-1 text-xs text-[var(--color-text-muted)]">
-            通知が無いのではなく、読み込めていない状態です。
-          </p>
+          <ExclamationTriangleIcon className="w-5 h-5 flex-shrink-0 text-[var(--color-text-muted)] mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-[var(--color-text-primary)]">{error}</p>
+            <p className="mt-1 text-xs text-[var(--color-text-muted)]">
+              通知が無いのではなく、読み込めていない状態です。
+            </p>
+          </div>
           <button
             type="button"
             onClick={refresh}
-            className="mt-4 inline-flex items-center justify-center px-4 py-2 rounded-md border border-surface-3 text-xs font-medium text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors"
+            className="flex-shrink-0 inline-flex items-center justify-center px-3 py-1.5 rounded-md border border-surface-3 text-xs font-medium text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors"
           >
             再試行
           </button>
         </div>
-      ) : notifications.length === 0 ? (
-        <EmptyState
-          icon={BellIcon}
-          title="通知はありません"
-          description="お知らせが届くとここに表示されます"
-        />
-      ) : (
+      )}
+
+      {notifications.length > 0 ? (
         <div className="space-y-2">
           {notifications.map((notification) => (
             <NotificationItem
@@ -70,6 +68,15 @@ export default function NotificationPage() {
             />
           ))}
         </div>
+      ) : (
+        // 取得に失敗しているときは「0 件」と断定できないので空状態を出さない。
+        !error && (
+          <EmptyState
+            icon={BellIcon}
+            title="通知はありません"
+            description="お知らせが届くとここに表示されます"
+          />
+        )
       )}
     </div>
   );

--- a/frontend/src/pages/notifications/ui/NotificationPage.tsx
+++ b/frontend/src/pages/notifications/ui/NotificationPage.tsx
@@ -2,10 +2,11 @@ import { useNotification } from '../model/useNotification';
 import EmptyState from '@/shared/ui/EmptyState';
 import Loading from '@/shared/ui/Loading';
 import { NotificationItem } from '@/entities/notification';
-import { BellIcon } from '@heroicons/react/24/outline';
+import { BellIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 
 export default function NotificationPage() {
-  const { notifications, unreadCount, loading, markAsRead, markAllAsRead } = useNotification();
+  const { notifications, unreadCount, loading, error, markAsRead, markAllAsRead, refresh } =
+    useNotification();
 
   if (loading) {
     return (
@@ -34,11 +35,30 @@ export default function NotificationPage() {
         )}
       </div>
 
-      {notifications.length === 0 ? (
+      {/* 取得に失敗したときは「0 件」と誤解させない。空状態より先に判定する（FRESTYLE-94）。 */}
+      {error ? (
+        <div
+          role="alert"
+          className="rounded-lg border border-surface-3 bg-surface-1 px-4 py-6 text-center"
+        >
+          <ExclamationTriangleIcon className="mx-auto w-8 h-8 text-[var(--color-text-muted)]" />
+          <p className="mt-3 text-sm font-medium text-[var(--color-text-primary)]">{error}</p>
+          <p className="mt-1 text-xs text-[var(--color-text-muted)]">
+            通知が無いのではなく、読み込めていない状態です。
+          </p>
+          <button
+            type="button"
+            onClick={refresh}
+            className="mt-4 inline-flex items-center justify-center px-4 py-2 rounded-md border border-surface-3 text-xs font-medium text-[var(--color-text-primary)] hover:bg-[var(--color-nav-hover)] transition-colors"
+          >
+            再試行
+          </button>
+        </div>
+      ) : notifications.length === 0 ? (
         <EmptyState
           icon={BellIcon}
           title="通知はありません"
-          description="新しいメッセージや目標達成時に通知が届きます"
+          description="お知らせが届くとここに表示されます"
         />
       ) : (
         <div className="space-y-2">


### PR DESCRIPTION
## 概要

通知まわりの 2 件をまとめて対応する。どちらも同じ画面・同じ層に閉じており、分けるとテストの重複が大きいため 1 PR にした。

| チケット | 内容 |
| --- | --- |
| **FRESTYLE-94** | 障害中に「通知はありません」と**嘘を表示**していた |
| **FRESTYLE-17** | 通知作成が宛先の人数だけ **DB と往復**していた |

---

## FRESTYLE-94 — 障害時の偽の空状態

`useNotification` が取得失敗を `catch` して空配列に置き換えていた。

```ts
} catch {
  setNotifications([]);   // ← 失敗を「0 件」に化かしていた
  setUnreadCount(0);
}
```

結果、API 障害中でも画面には **「通知はありません」**「新しいメッセージや目標達成時に通知が届きます」と表示される。**利用者は通知が本当に無いと誤認し、障害に気づけない。**

### 変更内容

- **失敗時はエラーを立てる**。直前まで表示していた通知は**消さない**（消すと「通知が消えた」と誤解される）
- 画面は**空状態より先にエラーを判定**し、「通知が無いのではなく、読み込めていない状態です」と明示して**再試行**を出す
- 成功したらエラーを消す

### 既存テストがこの不具合を仕様として固定していた

```ts
it('API失敗時はエラーなく空リストを返す', ...)   // ← まさにこの不具合
```

テスト名からして「エラーなく空リストを返す」が期待値になっていたため、**壊れているのにテストは通り続けていた**。実際の期待に書き直した。

fixture も存在しない種別・項目（`GOAL_ACHIEVED` / `message`）で書かれていたので、実際の契約（`company_application` / `body`）に合わせた（FRESTYLE-87 と同種の食い違い）。

**あわせて空状態の説明文も修正**。「新しいメッセージや目標達成時に通知が届きます」は **backend に存在しない通知種別**を案内していた。

---

## FRESTYLE-17 — 通知作成の N+1

`super_admin` 全員への通知を 1 件ずつ INSERT していた。管理者が増えるほど DB との往復が比例して増える。

```go
for _, admin := range admins {
    u.notifications.Create(ctx, n)   // ← 人数ぶん往復
}
```

### 変更内容

- `CreateMany` を追加し、**1 回の INSERT にまとめた**
- **既存の `Create` は残す**（他の呼び出し元を壊さないため。チケットの指示どおり）
- **空スライスは何もせず成功**させる。GORM は空スライスに `empty slice found` を返すため、呼び出し側が「宛先 0 人」を気にしなくて済むようにする

## テスト

**追加テストが修正前のコードで失敗することを確認済み**（frontend 7 件）。

### FRESTYLE-94（frontend）

| 検証 | 内容 |
| --- | --- |
| エラーを立てる | 握りつぶさない |
| 直前の通知を空にしない | 2 回目の取得だけ失敗させ、表示が保持されることを確認 |
| 再取得で回復 | 成功したらエラーが消える |
| 空状態を出さない | エラー時に「通知はありません」が出ないこと |
| 再試行 | ボタンから再取得が呼ばれること |

### FRESTYLE-17（backend）

| 検証 | 内容 |
| --- | --- |
| **書き込みは 1 回** | 管理者 5 人でも `CreateMany` の呼び出しは 1 回（人数分の往復にしない） |
| 宛先の正しさ | 人数ぶん作られ、宛先が取り違えられていない |
| 管理者 0 人 | 申請は成立し、通知は作られない |
| **結合テスト（実 Postgres）** | 複数件がまとめて保存され、本文・種別・ID 採番まで正しいこと / 空スライスが安全なこと |

### 検証結果

| 対象 | 結果 |
| --- | --- |
| backend `build` / `vet` / `gofumpt` / **golangci-lint 0 issues** | OK |
| archlint / naminglint / apispec-lint / slicelint | すべて OK |
| `go test ./...` | 全パッケージ ok |
| frontend `tsc` / `eslint` / `build` | OK |
| frontend `vitest` | **1334 passed (162 files)** |

カバレッジ: 文 86.34% / 関数 83.01% / 行 88.15%

## スコープ外

ヘッダーの未読バッジ（`Header.tsx`）は取得失敗時にバッジを隠す。バッジには誤りを伝える余地が無く、既存コードにも意図がコメントされているため今回は触っていない。

## セキュリティ影響

なし。表示とデータ書き込み方法の変更のみ。

## ロールバック方針

PR revert で戻せる。DB スキーマの変更なし。

## 関連チケット

- FRESTYLE-94 / FRESTYLE-17
- FRESTYLE-87（通知の項目名の食い違い。fixture の誤りはここと同根）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数の管理者へ通知をまとめて作成できるようになり、通知処理を効率化しました。
  * 通知を既読にする操作に対応しました。

* **バグ修正**
  * 通知取得に失敗した場合も、既存の通知を保持するよう改善しました。
  * 取得エラー時に警告と再試行ボタンを表示します。
  * 再試行が成功すると、エラー表示が解除され最新の通知に更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->