### PR TITLE
refactor: 画面から直接の通信をやめ repository 層に寄せる (FRESTYLE-22)

### DIFF
--- a/frontend/src/entities/ai-chat/api/__tests__/aiChatRepository.test.ts
+++ b/frontend/src/entities/ai-chat/api/__tests__/aiChatRepository.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import aiChatRepository from '../aiChatRepository';
+import apiClient from '@/shared/api/axios';
+import axios from 'axios';
+
+vi.mock('@/shared/api/axios', () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+  },
+}));
+
+vi.mock('axios', () => ({
+  default: {
+    put: vi.fn(),
+  },
+}));
+
+/**
+ * 添付ファイルのアップロード（FRESTYLE-22）。
+ *
+ * 以前は画面（MessageInput）が直接 fetch していた。通信は repository 層に置く。
+ */
+describe('aiChatRepository の添付アップロード', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('presigned URL へファイル本体を PUT する', async () => {
+    vi.mocked(axios.put).mockResolvedValue({});
+    const file = new File(['dummy'], 'shot.png', { type: 'image/png' });
+
+    await aiChatRepository.uploadAttachment('https://s3.example.com/upload?sig=x', file);
+
+    expect(axios.put).toHaveBeenCalledWith('https://s3.example.com/upload?sig=x', file, {
+      headers: { 'Content-Type': 'image/png' },
+    });
+  });
+
+  // 送信先は S3 であって自分の API ではない。apiClient を使うと認証 Cookie が付き、
+  // 401 で /login へ飛ばす割り込みも動いてしまう。
+  it('自分の API 用クライアントは使わない', async () => {
+    vi.mocked(axios.put).mockResolvedValue({});
+    const file = new File(['dummy'], 'shot.png', { type: 'image/png' });
+
+    await aiChatRepository.uploadAttachment('https://s3.example.com/upload', file);
+
+    expect(apiClient.put).not.toHaveBeenCalled();
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('アップロードの失敗は呼び出し側へ伝える', async () => {
+    vi.mocked(axios.put).mockRejectedValue(new Error('network error'));
+    const file = new File(['dummy'], 'shot.png', { type: 'image/png' });
+
+    await expect(
+      aiChatRepository.uploadAttachment('https://s3.example.com/upload', file),
+    ).rejects.toThrow('network error');
+  });
+
+  it('presigned URL の発行は自分の API へ問い合わせる', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { uploadUrl: 'https://s3.example.com/u', key: 'ai-chat/1/x.png', expiresIn: 600 },
+    });
+
+    const res = await aiChatRepository.issueAttachmentUploadUrl({
+      filename: 'shot.png',
+      contentType: 'image/png',
+      sizeBytes: 123,
+    });
+
+    expect(apiClient.post).toHaveBeenCalled();
+    expect(res.key).toBe('ai-chat/1/x.png');
+  });
+});

--- a/frontend/src/entities/ai-chat/api/aiChatRepository.ts
+++ b/frontend/src/entities/ai-chat/api/aiChatRepository.ts
@@ -1,4 +1,5 @@
 import apiClient from '@/shared/api/axios';
+import axios from 'axios';
 import { toArray } from '@/shared/lib/toArray';
 import { AI_CHAT } from '@/shared/config/apiRoutes';
 import type { AiSession, AiMessage } from '../model/types';
@@ -66,6 +67,19 @@ class AiChatRepository {
   ): Promise<AttachmentUploadUrlResponse> {
     const response = await apiClient.post(AI_CHAT.attachmentUploadUrl, request);
     return response.data;
+  }
+
+  /**
+   * 発行済みの presigned URL へファイル本体を直接 PUT する。
+   *
+   * 送信先は S3 で自分の API ではないため、apiClient（認証 Cookie と 401 の
+   * リダイレクトを持つ）ではなく素の axios を使う。ProfileRepository.uploadToS3 と
+   * 同じ方針。通信そのものは画面ではなくこの層に置く（FRESTYLE-22）。
+   */
+  async uploadAttachment(uploadUrl: string, file: File): Promise<void> {
+    await axios.put(uploadUrl, file, {
+      headers: { 'Content-Type': file.type },
+    });
   }
 }
 

--- a/frontend/src/pages/ask-ai/model/useAiChatSse.ts
+++ b/frontend/src/pages/ask-ai/model/useAiChatSse.ts
@@ -80,6 +80,9 @@ export function useAiChatSse({ endpoint, onEvent, onClose }: UseAiChatSseOptions
       abortRef.current = controller;
 
       try {
+        // ここは意図的に素の fetch を使う（repository 層を経由しない / FRESTYLE-22）。
+        // 応答を最後まで待たず届いた分から順に読む必要があり、ブラウザの axios では
+        // 本文を逐次読み出せない。fetch の ReadableStream が要る。
         const res = await fetch(endpoint, {
           method: 'POST',
           credentials: 'include',

--- a/frontend/src/pages/ask-ai/ui/MessageInput.tsx
+++ b/frontend/src/pages/ask-ai/ui/MessageInput.tsx
@@ -149,14 +149,8 @@ export default function MessageInput({ onSend, isSending = false }: MessageInput
           contentType: file.type,
           sizeBytes: file.size,
         });
-        const putRes = await fetch(uploadUrl, {
-          method: 'PUT',
-          headers: { 'Content-Type': file.type },
-          body: file,
-        });
-        if (!putRes.ok) {
-          throw new Error(`upload failed: ${putRes.status}`);
-        }
+        // 通信は repository 層に置く（画面から直接 fetch しない / FRESTYLE-22）。
+        await aiChatRepository.uploadAttachment(uploadUrl, file);
         setPending((prev) =>
           prev.map((a) =>
             a.key === tempKey ? { ...a, key, uploading: false } : a

--- a/frontend/src/pages/ask-ai/ui/__tests__/MessageInput.test.tsx
+++ b/frontend/src/pages/ask-ai/ui/__tests__/MessageInput.test.tsx
@@ -5,6 +5,7 @@ import MessageInput from '../MessageInput';
 vi.mock('@/entities/ai-chat/api/aiChatRepository', () => ({
   default: {
     issueAttachmentUploadUrl: vi.fn(),
+    uploadAttachment: vi.fn(),
   },
 }));
 
@@ -16,6 +17,7 @@ describe('MessageInput', () => {
   beforeEach(() => {
     mockOnSend.mockClear();
     vi.mocked(aiChatRepository.issueAttachmentUploadUrl).mockReset();
+    vi.mocked(aiChatRepository.uploadAttachment).mockReset().mockResolvedValue(undefined);
     if (!('createObjectURL' in URL)) {
       // happy-dom fallback: 一部バージョンで未定義
       (URL as unknown as { createObjectURL?: (b: Blob) => string }).createObjectURL = vi.fn(
@@ -146,16 +148,13 @@ describe('MessageInput', () => {
     expect(mockOnSend).toHaveBeenCalledWith('ボタン送信', []);
   });
 
-  it('画像を選択すると presigned URL を取得して S3 へ PUT する', async () => {
+  // 通信は repository 層に置いた（画面から直接 fetch しない / FRESTYLE-22）。
+  it('画像を選択すると presigned URL を取得して repository 経由でアップロードする', async () => {
     vi.mocked(aiChatRepository.issueAttachmentUploadUrl).mockResolvedValue({
       uploadUrl: 'https://s3.example.com/put',
       key: 'ai-chat/7/abc.png',
       expiresIn: 600,
     });
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(null, { status: 200 })
-    );
-
     render(<MessageInput onSend={mockOnSend} />);
 
     const file = new File(['fake-bytes'], 'cat.png', { type: 'image/png' });
@@ -170,9 +169,9 @@ describe('MessageInput', () => {
       });
     });
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledWith(
+      expect(aiChatRepository.uploadAttachment).toHaveBeenCalledWith(
         'https://s3.example.com/put',
-        expect.objectContaining({ method: 'PUT' })
+        file,
       );
     });
 
@@ -187,7 +186,6 @@ describe('MessageInput', () => {
       );
     });
 
-    fetchSpy.mockRestore();
   });
 
   it('未対応の MIME はバリデーションエラーで弾かれ presigned URL を呼ばない', async () => {

--- a/frontend/src/shared/lib/hooks/useBackendHealth.ts
+++ b/frontend/src/shared/lib/hooks/useBackendHealth.ts
@@ -63,6 +63,10 @@ export function useBackendHealth(): UseBackendHealthResult {
     const controller = new AbortController();
     fetchControllerRef.current = controller;
     try {
+      // ここは意図的に素の fetch を使う（repository 層を経由しない / FRESTYLE-22）。
+      // apiClient には「401 ならトークンを更新し、失敗したら /login へ飛ばす」割り込みが
+      // 入っている。死活監視でそれが動くと、サーバーが落ちているだけでログイン画面へ
+      // 飛ばされてしまい監視が成立しない。credentials: 'omit' で認証も送らない。
       const res = await fetch(url, {
         method: 'GET',
         cache: 'no-store',


### PR DESCRIPTION
## 概要

UI コンポーネント（`MessageInput`）が S3 の presigned URL へ**直接 `fetch` していた**。通信の詳細が画面に混ざっており、層の責務違反になっている。

`ProfileRepository.uploadToS3` という**既存の前例**があるので、同じ形に揃えた。

## 変更内容

### 明確な層違反を修正

`aiChatRepository.uploadAttachment` を追加し、画面はそれを呼ぶだけにした。

```diff
- const putRes = await fetch(uploadUrl, {
-   method: 'PUT',
-   headers: { 'Content-Type': file.type },
-   body: file,
- });
- if (!putRes.ok) {
-   throw new Error(`upload failed: ${putRes.status}`);
- }
+ // 通信は repository 層に置く（画面から直接 fetch しない / FRESTYLE-22）。
+ await aiChatRepository.uploadAttachment(uploadUrl, file);
```

送信先は **S3 であって自分の API ではない**ため、`apiClient`（認証 Cookie と 401 のリダイレクト割り込みを持つ）ではなく素の `axios` を使う。これも前例と同じ方針。

### 残る 2 箇所は「消さずに理由を残す」

調査したところ、他の 2 箇所は**技術的に生 `fetch` が必要**だった。誤って `apiClient` に「修正」されると壊れるため、**理由をコードに明記**して残した。

| 箇所 | 生 fetch が必要な理由 |
| --- | --- |
| `useBackendHealth` | `apiClient` には「401 ならトークン更新 → 失敗したら `/login` へ」の割り込みがある。**死活監視でそれが動くと、サーバーが落ちているだけでログイン画面へ飛ばされ監視が成立しない**。`credentials: 'omit'` で認証も送っていない |
| `useAiChatSse` | 応答を最後まで待たず**届いた分から順に読む**必要があり、ブラウザの axios では本文を逐次読み出せない。`fetch` の `ReadableStream` が要る |

「層違反に見えるが実は必要」という状態を、**コメントで意図的な選択に変えた**。

## テスト

### 既存テストが「画面が直接 fetch する」ことを検証していた

```diff
- expect(fetchSpy).toHaveBeenCalledWith('https://s3.example.com/put', ...)
+ expect(aiChatRepository.uploadAttachment).toHaveBeenCalledWith('https://s3.example.com/put', file)
```

層を移したので実態に合わせた。

### repository のテストを新規追加

| 検証 | 意図 |
| --- | --- |
| presigned URL へ本体を PUT する | ヘッダ（Content-Type）まで確認 |
| **自分の API 用クライアントを使わない** | `apiClient` に流すと認証 Cookie が付き、401 の割り込みも動いてしまう |
| 失敗は呼び出し側へ伝える | 握りつぶさない |
| URL 発行は自分の API へ | 2 つの通信先を取り違えていない |

| 検証 | 結果 |
| --- | --- |
| `tsc` / `eslint --max-warnings 0` / `build` | OK |
| `vitest` | **1340 passed (163 files)** |
| **UI 層の生 fetch** | **0 件**（`pages/*/ui`・`entities/*/ui`・`widgets/*/ui` を確認） |

カバレッジ: 文 86.41% / 分岐 80.63%

## セキュリティ影響

なし。通信先と認証の扱いは変えていない（S3 へは従来どおり認証情報を送らない）。

## ロールバック方針

PR revert で戻せる。

## 関連チケット

- FRESTYLE-22