### PR TITLE
refactor: フロントエンドのデプロイを長寿命 AWS キーから OIDC へ移行 (FRESTYLE-89)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -27,14 +27,21 @@ AWS 認証はすべて GitHub OIDC で、ワークフローが実行のたびに
 | `cd-backend.yml` | `frestyle-prod-github-actions-role` | `terraform/github-oidc.tf` |
 | `cd-frontend.yml` | `frestyle-prod-github-actions-frontend-role` | `terraform/github-oidc-frontend.tf` |
 
-> **廃止済み Secrets**:
-> `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`（FRESTYLE-89 の cd-frontend OIDC 化で不要になった。
-> 最後まで残っていた長寿命キー）。
+> **失効待ち（ワークフローは参照しないが、認証情報としてはまだ有効）**:
+> ワークフローから参照されなくなっても、認証情報そのものは失効させるまで有効なままで、
+> 漏えいすれば悪用できる。次の 2 つは発行元で失効させるまで「廃止済み」とは扱わない。
 >
-> 以下は FRESTYLE-61 の cd-backend Terraform 前提化で不要になったもの:
-> `IAC_REPO` / `IAC_REPO_TOKEN`（IaC リポから CFn テンプレートを clone する PAT）、
-> `COGNITO_CLIENT_ID` 等の COGNITO_*（CFn の parameter-overrides 用。タスク定義の env / secrets は
-> infra リポの Terraform `ecs.tf` が持つ）。GitHub Secrets 側に残っていても参照されない。
+> | Secret | 失効手順 |
+> |---|---|
+> | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | OIDC デプロイの成功を確認 → IAM ユーザーのアクセスキーを無効化してから削除 → GitHub Secrets からも削除（FRESTYLE-89） |
+> | `IAC_REPO_TOKEN` | PAT を revoke → GitHub Secrets からも削除（FRESTYLE-61） |
+>
+> 失効まで終えたら、この表から下の「廃止済み」へ移す。
+>
+> **廃止済み Secrets**（認証情報ではない / 参照されない）:
+> `IAC_REPO`、`COGNITO_CLIENT_ID` 等の COGNITO_*（CFn の parameter-overrides 用。タスク定義の
+> env / secrets は infra リポの Terraform `ecs.tf` が持つ）。いずれも FRESTYLE-61 の cd-backend
+> Terraform 前提化で不要になった。GitHub Secrets 側に残っていても参照されない。
 
 ### Secrets 一覧確認
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,12 +15,23 @@ CI と CD を **完全に分離** しています。テスト・ビルド検証�
 
 | 種別 | Secret 名 | 用途 |
 |---|---|---|
-| AWS | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | `cd-frontend.yml` の S3 sync / CloudFront invalidation 用（backend は OIDC ロールに移行済） |
 | AWS | `AWS_ECR_API_SERVER_REPOSITORY` | ECR リポジトリ名（例: `fre-style`） |
 | AWS | `CLOUDFRONT_DISTRIBUTION_ID` | CloudFront キャッシュ無効化対象 |
 | Frontend | `VITE_API_BASE_URL` / `VITE_COGNITO_DOMAIN` / `VITE_CLIENT_ID` / `VITE_REDIRECT_URI` / `VITE_RESPONSE_TYPE` / `VITE_SCOPE` | フロントエンドビルド時に注入 |
 
-> **廃止済み Secrets**（FRESTYLE-61 の cd-backend Terraform 前提化で不要になったもの）:
+AWS 認証はすべて GitHub OIDC で、ワークフローが実行のたびに一時認証情報を引き受ける（長寿命の
+アクセスキーは使わない）。ロールは infra リポの Terraform が管理する。
+
+| ワークフロー | 引き受けるロール | 定義 |
+|---|---|---|
+| `cd-backend.yml` | `frestyle-prod-github-actions-role` | `terraform/github-oidc.tf` |
+| `cd-frontend.yml` | `frestyle-prod-github-actions-frontend-role` | `terraform/github-oidc-frontend.tf` |
+
+> **廃止済み Secrets**:
+> `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`（FRESTYLE-89 の cd-frontend OIDC 化で不要になった。
+> 最後まで残っていた長寿命キー）。
+>
+> 以下は FRESTYLE-61 の cd-backend Terraform 前提化で不要になったもの:
 > `IAC_REPO` / `IAC_REPO_TOKEN`（IaC リポから CFn テンプレートを clone する PAT）、
 > `COGNITO_CLIENT_ID` 等の COGNITO_*（CFn の parameter-overrides 用。タスク定義の env / secrets は
 > infra リポの Terraform `ecs.tf` が持つ）。GitHub Secrets 側に残っていても参照されない。

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -116,10 +116,11 @@ jobs:
     # 本番反映ジョブは production Environment に紐付け、required reviewers の承認待ちで止める。
     environment: production
     # OIDC トークンの発行に必要(FRESTYLE-89)。第三者コードを実行しないこの job にだけ与える。
-    # contents: read は checkout しないので実際には使わないが、既定の read 権限を明示して固定する。
+    # checkout しないので contents は付けない。同一 run の artifact 取得に GITHUB_TOKEN の
+    # 権限は要らない(別 run / 別リポから取るときだけ actions:read 付きの token が要る)。
+    # permissions を明示した時点で、ここに書いていない権限はすべて none になる。
     permissions:
       id-token: write
-      contents: read
 
     steps:
       - name: Download built assets

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -46,17 +46,17 @@ jobs:
             exit 1
           fi
 
-  deploy:
-    name: Build & Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 12
     needs: [guard]
     if: always() && (github.event_name == 'push' || needs.guard.result == 'success')
-    # 本番反映ジョブは production Environment に紐付け、required reviewers の承認待ちで止める。
-    environment: production
-    # OIDC トークンの発行に必要(FRESTYLE-89)。
+    # npm ci / build / prerender は第三者のコードを実行するため、この job には AWS を触れる
+    # 権限を与えない。id-token: write を持たせると、侵害された依存パッケージが
+    # ACTIONS_ID_TOKEN_REQUEST_* 経由でトークンを発行し本番ロールを assume できてしまう。
+    # contents: read は actions/checkout がソースを取得するためだけに必要(FRESTYLE-89)。
     permissions:
-      id-token: write
       contents: read
     defaults:
       run:
@@ -97,6 +97,36 @@ jobs:
         run: |
           npx playwright install --with-deps chromium
           npm run prerender
+
+      # deploy job へはビルド成果物だけを渡す。deploy 側は checkout しないため、
+      # 本番ロールを持つ job にリポジトリのソースやスクリプトが存在しない。
+      - name: Upload built assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy to S3 + CloudFront
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build]
+    # 本番反映ジョブは production Environment に紐付け、required reviewers の承認待ちで止める。
+    environment: production
+    # OIDC トークンの発行に必要(FRESTYLE-89)。第三者コードを実行しないこの job にだけ与える。
+    # contents: read は checkout しないので実際には使わないが、既定の read 権限を明示して固定する。
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download built assets
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-dist
+          path: dist
 
       # 静的キーではなく OIDC でその実行だけ有効な一時認証情報を得る(FRESTYLE-89)。
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -19,6 +19,10 @@ on:
 
 env:
   AWS_REGION: ap-northeast-1
+  # GitHub OIDC で引き受けるデプロイ用ロール(FRESTYLE-89)。長寿命の静的キーは廃止。
+  # 権限は配信バケットへのアップロードと CloudFront のキャッシュ無効化のみ。
+  # 定義: frestyle-infrastructure の terraform/github-oidc-frontend.tf
+  AWS_ROLE_ARN: arn:aws:iam::010928196665:role/frestyle-prod-github-actions-frontend-role
 
 permissions:
   contents: read
@@ -50,6 +54,10 @@ jobs:
     if: always() && (github.event_name == 'push' || needs.guard.result == 'success')
     # 本番反映ジョブは production Environment に紐付け、required reviewers の承認待ちで止める。
     environment: production
+    # OIDC トークンの発行に必要(FRESTYLE-89)。
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         working-directory: ./frontend
@@ -90,11 +98,11 @@ jobs:
           npx playwright install --with-deps chromium
           npm run prerender
 
-      - name: Configure AWS credentials
+      # 静的キーではなく OIDC でその実行だけ有効な一時認証情報を得る(FRESTYLE-89)。
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       # 1) ハッシュ付きアセットは内容不変なので immutable + 長期キャッシュで配信する。


### PR DESCRIPTION
## 概要

`cd-frontend.yml` だけが長寿命の静的 AWS キー（`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`）でデプロイしており、OIDC 化された backend から取り残されていました。静的キーは漏洩しても失効させるまで有効で、ローテーションも手作業になります。

実行のたびに一時認証情報を引き受ける形へ移行します。**これで本リポジトリから長寿命の AWS キーは無くなります。**

## 変更内容

### `.github/workflows/cd-frontend.yml`

- `Configure AWS credentials` を `role-to-assume` 方式に変更（`aws-access-key-id` / `aws-secret-access-key` を削除）
- deploy ジョブに `permissions: id-token: write` を追加（OIDC トークンの発行に必要）
- 引き受けるロール ARN をワークフローの `env` に記載

### `.github/workflows/README.md`

- 必要な Secrets の表から `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` を削除
- どのワークフローがどのロールを引き受けるかの対応表を追加
- 廃止済み Secrets の節に追記

### 前提（適用済み）

infra リポ https://github.com/norman6464/frestyle-infrastructure/pull/195 で `frestyle-prod-github-actions-frontend-role` を作成し、`terraform apply` 済みです（`Apply complete! Resources: 2 added, 0 changed, 0 destroyed.`）。`aws iam get-role` でロールの存在を確認しました。

権限は以下のみで、バケットの作成・削除・ポリシー変更は含みません。

- `s3:ListBucket`（`fre-style-bucket`）
- `s3:PutObject` / `s3:GetObject` / `s3:DeleteObject`（`fre-style-bucket/*`）
- `cloudfront:CreateInvalidation`（`EF0PL0IKWZYIW`）

信頼ポリシーは `cd-frontend.yml` のトリガー（main からの手動実行 / `release/v*` タグ / `environment: production`）に対応させています。

## テスト

- IAM ロールが本番に存在することを `aws iam get-role` で確認済み
- YAML として妥当であること、`deploy` ジョブに `id-token: write` が入っていることを確認済み
- ワークフローの動作確認は**マージ後に実際にフロントエンドデプロイを実行**して行います（成功を確認できてはじめて GitHub Secrets 側の静的キーを削除します）

## 関連チケット

FRESTYLE-89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **セキュリティ**
  - デプロイ時のAWS認証を長期的なアクセスキーから、より安全な一時認証情報へ変更しました。
  - 不要となった認証情報やシークレットの利用を廃止し、認証情報の管理リスクを軽減しました。

- **ドキュメント**
  - 利用中のシークレット一覧を更新し、廃止済みの項目を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->