### PR TITLE
test/frestyle 23 member authz tests

### DIFF
--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -76,4 +76,18 @@ func Test_メンバーAI利用可否更新ユースケース(t *testing.T) {
 		err := uc.Execute(context.Background(), &domain.User{ID: 9, Role: domain.RoleSuperAdmin}, 1, ptrBool(true))
 		assert.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
 	})
+
+	t.Run("自分自身のAI利用可否も更新できる(自己編集の禁止は無い)", func(t *testing.T) {
+		selfActor := &domain.User{ID: 1, CompanyID: u64ptr(10), Role: domain.RoleCompanyAdmin}
+		err := uc.Execute(context.Background(), selfActor, 1, ptrBool(false))
+		require.NoError(t, err, "UpdateMemberAiAccessUseCase には自己編集を禁止するチェックが無い")
+		require.NotNil(t, repo.updated[1])
+		assert.False(t, *repo.updated[1])
+	})
+	t.Run("super_admin(会社未所属)はこのusecaseを実行できない", func(t *testing.T) {
+		superActor := &domain.User{ID: 9, Role: domain.RoleSuperAdmin, CompanyID: nil}
+		err := uc.Execute(context.Background(), superActor, 1, ptrBool(true))
+		assert.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany,
+			"super_admin は CompanyID=nil のため actor.CompanyID==nil チェックで弾かれる(現状の既知の問題)")
+	})
 }

--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -76,18 +76,19 @@ func Test_メンバーAI利用可否更新ユースケース(t *testing.T) {
 		err := uc.Execute(context.Background(), &domain.User{ID: 9, Role: domain.RoleSuperAdmin}, 1, ptrBool(true))
 		assert.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
 	})
-
 	t.Run("自分自身のAI利用可否も更新できる(自己編集の禁止は無い)", func(t *testing.T) {
+		updateCalled, lastEnabled = false, nil
 		selfActor := &domain.User{ID: 1, CompanyID: u64ptr(10), Role: domain.RoleCompanyAdmin}
 		err := uc.Execute(context.Background(), selfActor, 1, ptrBool(false))
 		require.NoError(t, err, "UpdateMemberAiAccessUseCase には自己編集を禁止するチェックが無い")
-		require.NotNil(t, repo.updated[1])
-		assert.False(t, *repo.updated[1])
+		require.True(t, updateCalled)
+		require.NotNil(t, lastEnabled)
+		assert.False(t, *lastEnabled)
 	})
 	t.Run("super_admin(会社未所属)はこのusecaseを実行できない", func(t *testing.T) {
 		superActor := &domain.User{ID: 9, Role: domain.RoleSuperAdmin, CompanyID: nil}
 		err := uc.Execute(context.Background(), superActor, 1, ptrBool(true))
 		assert.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany,
-			"super_admin は CompanyID=nil のため actor.CompanyID==nil チェックで弾かれる(現状の既知の問題)")
+			"super_admin は CompanyID=nil のため actor.CompanyID==nil チェックで弾かれる(現状の既知の制約)")
 	})
 }

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -133,3 +133,35 @@ func Test_メンバー論理削除_見つからない(t *testing.T) {
 	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
 	repo.AssertNotCalled(t, "SoftDelete", mock.Anything, mock.Anything)
 }
+
+func Test_メンバー論理削除_運営管理者_任意の会社_OK(t *testing.T) {
+      repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
+      uc := usecase.NewSoftDeleteMemberUseCase(repo)
+      actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+
+      err := uc.Execute(context.Background(), actor, 2)
+
+      require.NoError(t, err)
+      assert.True(t, repo.softDeleted, "super_admin は会社を問わず削除できる")
+}
+
+func Test_メンバー論理削除_運営管理者_自分自身_禁止(t *testing.T) {
+      repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
+      uc := usecase.NewSoftDeleteMemberUseCase(repo)
+      actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+
+      err := uc.Execute(context.Background(), actor, 1)
+
+      require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
+      assert.False(t, repo.softDeleted, "super_admin でも自分自身は削除できない")
+}
+
+func Test_メンバー論理削除_見つからない(t *testing.T) {
+      repo := &fakeManageRepo{target: nil}
+      uc := usecase.NewSoftDeleteMemberUseCase(repo)
+      actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+
+      err := uc.Execute(context.Background(), actor, 999)
+
+      require.ErrorIs(t, err, usecase.ErrMemberNotFound)
+}

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -66,6 +66,17 @@ func Test_メンバー有効化_自分自身_禁止(t *testing.T) {
 	repo.AssertNotCalled(t, "UpdateActive", mock.Anything, mock.Anything, mock.Anything)
 }
 
+func Test_メンバー有効化_運営管理者_自分自身_禁止(t *testing.T){
+	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
+	uc := usecase.NewSetMemberActiveUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+	
+	err := uc.Execute(context.Background(), actor, 1, false)
+
+	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
+	assert.Nil(t, repo.updateActiveGot, "super_admin でも自分自身は無効かできない")
+}
+
 func Test_メンバー有効化_見つからない(t *testing.T) {
 	repo := manageMemberRepo(nil)
 	uc := usecase.NewSetMemberActiveUseCase(repo)

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -67,14 +67,14 @@ func Test_メンバー有効化_自分自身_禁止(t *testing.T) {
 }
 
 func Test_メンバー有効化_運営管理者_自分自身_禁止(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
+	repo := manageMemberRepo(&domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil})
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
 
 	err := uc.Execute(context.Background(), actor, 1, false)
 
 	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
-	assert.Nil(t, repo.updateActiveGot, "super_admin でも自分自身は無効かできない")
+	repo.AssertNotCalled(t, "UpdateActive", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func Test_メンバー有効化_見つからない(t *testing.T) {
@@ -123,6 +123,29 @@ func Test_メンバー論理削除_会社管理者_別会社_禁止(t *testing.T
 	repo.AssertNotCalled(t, "SoftDelete", mock.Anything, mock.Anything)
 }
 
+func Test_メンバー論理削除_運営管理者_任意の会社_OK(t *testing.T) {
+	repo := manageMemberRepo(&domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)})
+	repo.On("SoftDelete", mock.Anything, uint64(2)).Return(nil)
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+
+	err := uc.Execute(context.Background(), actor, 2)
+
+	require.NoError(t, err)
+	repo.AssertExpectations(t) // super_admin は会社を問わず削除できる
+}
+
+func Test_メンバー論理削除_運営管理者_自分自身_禁止(t *testing.T) {
+	repo := manageMemberRepo(&domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil})
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+
+	err := uc.Execute(context.Background(), actor, 1)
+
+	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
+	repo.AssertNotCalled(t, "SoftDelete", mock.Anything, mock.Anything) // super_admin でも自分自身は削除できない
+}
+
 func Test_メンバー論理削除_見つからない(t *testing.T) {
 	repo := manageMemberRepo(nil)
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
@@ -132,36 +155,4 @@ func Test_メンバー論理削除_見つからない(t *testing.T) {
 
 	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
 	repo.AssertNotCalled(t, "SoftDelete", mock.Anything, mock.Anything)
-}
-
-func Test_メンバー論理削除_運営管理者_任意の会社_OK(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
-	uc := usecase.NewSoftDeleteMemberUseCase(repo)
-	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
-
-	err := uc.Execute(context.Background(), actor, 2)
-
-	require.NoError(t, err)
-	assert.True(t, repo.softDeleted, "super_admin は会社を問わず削除できる")
-}
-
-func Test_メンバー論理削除_運営管理者_自分自身_禁止(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
-	uc := usecase.NewSoftDeleteMemberUseCase(repo)
-	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
-
-	err := uc.Execute(context.Background(), actor, 1)
-
-	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
-	assert.False(t, repo.softDeleted, "super_admin でも自分自身は削除できない")
-}
-
-func Test_メンバー論理削除_見つからない(t *testing.T) {
-	repo := &fakeManageRepo{target: nil}
-	uc := usecase.NewSoftDeleteMemberUseCase(repo)
-	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
-
-	err := uc.Execute(context.Background(), actor, 999)
-
-	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
 }

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -66,11 +66,11 @@ func Test_メンバー有効化_自分自身_禁止(t *testing.T) {
 	repo.AssertNotCalled(t, "UpdateActive", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func Test_メンバー有効化_運営管理者_自分自身_禁止(t *testing.T){
+func Test_メンバー有効化_運営管理者_自分自身_禁止(t *testing.T) {
 	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
-	
+
 	err := uc.Execute(context.Background(), actor, 1, false)
 
 	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
@@ -135,33 +135,33 @@ func Test_メンバー論理削除_見つからない(t *testing.T) {
 }
 
 func Test_メンバー論理削除_運営管理者_任意の会社_OK(t *testing.T) {
-      repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
-      uc := usecase.NewSoftDeleteMemberUseCase(repo)
-      actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
 
-      err := uc.Execute(context.Background(), actor, 2)
+	err := uc.Execute(context.Background(), actor, 2)
 
-      require.NoError(t, err)
-      assert.True(t, repo.softDeleted, "super_admin は会社を問わず削除できる")
+	require.NoError(t, err)
+	assert.True(t, repo.softDeleted, "super_admin は会社を問わず削除できる")
 }
 
 func Test_メンバー論理削除_運営管理者_自分自身_禁止(t *testing.T) {
-      repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
-      uc := usecase.NewSoftDeleteMemberUseCase(repo)
-      actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
+	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}}
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
 
-      err := uc.Execute(context.Background(), actor, 1)
+	err := uc.Execute(context.Background(), actor, 1)
 
-      require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
-      assert.False(t, repo.softDeleted, "super_admin でも自分自身は削除できない")
+	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
+	assert.False(t, repo.softDeleted, "super_admin でも自分自身は削除できない")
 }
 
 func Test_メンバー論理削除_見つからない(t *testing.T) {
-      repo := &fakeManageRepo{target: nil}
-      uc := usecase.NewSoftDeleteMemberUseCase(repo)
-      actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+	repo := &fakeManageRepo{target: nil}
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
 
-      err := uc.Execute(context.Background(), actor, 999)
+	err := uc.Execute(context.Background(), actor, 999)
 
-      require.ErrorIs(t, err, usecase.ErrMemberNotFound)
+	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
 }


### PR DESCRIPTION
<!--
PR タイトル・本文は日本語で。タイトルは Prefix を付ける（feat / fix / refactor / docs / test / chore / perf / style）。
詳細な規約は CONTRIBUTING.md を参照。
-->
## Jira
https://frestyle.atlassian.net/browse/FRESTYLE-23

## 概要

<!-- この PR で何を・なぜやったかを 1〜3 行で -->
会員管理に関する3つのusecase(`SetMemberActiveUseCase` / `SoftDeleteMemberUseCase` / `UpdateMemberAiAccessUseCase`)について、認可分岐を検証する単体テストのうち既存のテストから欠けていたケースを追加した。認可ロジック自体は変更していない。

## 変更内容

<!-- 主な変更点を箇条書きで -->
- `manage_member_usecase_test.go`
  - `SetMemberActiveUseCase`: 「super_admin×自分自身は禁止」の1ケースを追加
  - `SoftDeleteMemberUseCase`: 「super_admin×任意の会社=OK」「super_admin×自分自身=禁止」「対象が見つからない」の3ケースを追加(既存はcompany_adminのケースのみで、super_admin関連が丸ごと欠けていた)
- `admin_member_usecase_test.go`
  - `UpdateMemberAiAccessUseCase`に2ケース追加。**このusecaseは他の2つと異なり、共通の認可ヘルパ`authorizeMemberManagement`を使わない独自ロジックになっており、roleチェック・自己編集禁止チェックが無い**。そのため現状は super_admin がこのusecaseを実行できず、自分自身への操作も許可されてしまう。今回はこの現状の挙動をそのままテストとして固定した(スコープ外のためロジックは変更していない)

## テスト

<!-- どう検証したか（コマンド・結果）。新規コードには単体テストを付ける -->
- 追加した6ケースを含め `go test ./internal/usecase/... -run Test_メンバー -v` で全PASSを確認
- `make verify`(gofumpt整形 / go vet / go build / go test / archlint / apispec-lint / naminglint)すべて成功
- usecaseパッケージのカバレッジ: `authorizeMemberManagement` 88.9%、対象3 usecaseの`Execute`はいずれも87.5%(未カバー分はリポジトリエラー等、認可分岐そのものではない防御的コード)

## 関連 Issue

<!-- 例: Closes #123 / Refs #456 -->

---

### セルフチェック

- [〇 ] タイトルに Prefix（`feat` / `fix` / `refactor` / `docs` / `test` / `chore` 等）を付けた
- [〇 ] 新規・変更コードに単体テストを追加した（backend: `go test` / frontend: Vitest）
- [〇 ] backend を変更した場合 `make verify`（gofmt / vet / build / test / 3 linter）が通る
- [ ] handler / swaggo 注釈を変えた場合 `make openapi` を実行し `docs/` を commit した
- [ ] 仕様・手順を変えた場合は `docs/`（または該当 README）を更新した
- [〇 ] `main` への直接コミットではなく、PR 経由である


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **権限管理の改善**
  - 管理者が自身のAI利用可否を更新できるようになりました。
  - 所属していない会社のメンバー操作を適切に拒否します。
  - 運営管理者による自身の有効化・論理削除を禁止します。
  - 運営管理者が任意の会社のメンバーを削除できるようになりました。
  - メンバー削除時に、対象の存在や所属関係を確認します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->