### PR TITLE
refactor: usecase テスト 3 ファイルの手書き fake を repofakes へ移行する (FRESTYLE-4)

### DIFF
--- a/backend/internal/usecase/audit_usecase_test.go
+++ b/backend/internal/usecase/audit_usecase_test.go
@@ -36,11 +36,14 @@ func Test_監査記録_入力をイベントに詰めて保存する(t *testing.
 }
 
 func Test_監査記録_保存失敗を伝播(t *testing.T) {
+	// 「何かエラーが出た」ではなく repository のエラーがそのまま伝わることを見る。
+	wantErr := errors.New("db")
 	repo := &repofakes.FakeAuditRepository{
-		RecordFunc: func(context.Context, *domain.AuditEvent) error { return errors.New("db") },
+		RecordFunc: func(context.Context, *domain.AuditEvent) error { return wantErr },
 	}
 	uc := usecase.NewRecordAuditEventUseCase(repo)
-	assert.Error(t, uc.Execute(context.Background(), usecase.RecordAuditEventInput{}))
+	err := uc.Execute(context.Background(), usecase.RecordAuditEventInput{})
+	require.ErrorIs(t, err, wantErr)
 }
 
 func Test_監査ログ一覧_新しい順で返す(t *testing.T) {

--- a/backend/internal/usecase/audit_usecase_test.go
+++ b/backend/internal/usecase/audit_usecase_test.go
@@ -7,32 +7,20 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeAuditRepo は AuditRepository の fake。
-type fakeAuditRepo struct {
-	recorded []domain.AuditEvent
-	listRows []domain.AuditEvent
-	recErr   error
-	listErr  error
-}
-
-func (f *fakeAuditRepo) Record(_ context.Context, e *domain.AuditEvent) error {
-	if f.recErr != nil {
-		return f.recErr
-	}
-	f.recorded = append(f.recorded, *e)
-	return nil
-}
-
-func (f *fakeAuditRepo) ListRecent(context.Context, int) ([]domain.AuditEvent, error) {
-	return f.listRows, f.listErr
-}
-
 func Test_監査記録_入力をイベントに詰めて保存する(t *testing.T) {
-	repo := &fakeAuditRepo{}
+	// 保存された内容を検証したいので、fake の中でクロージャに退避する。
+	var recorded []domain.AuditEvent
+	repo := &repofakes.FakeAuditRepository{
+		RecordFunc: func(_ context.Context, e *domain.AuditEvent) error {
+			recorded = append(recorded, *e)
+			return nil
+		},
+	}
 	uc := usecase.NewRecordAuditEventUseCase(repo)
 
 	err := uc.Execute(context.Background(), usecase.RecordAuditEventInput{
@@ -40,23 +28,31 @@ func Test_監査記録_入力をイベントに詰めて保存する(t *testing.
 		Action: "PATCH /admin/companies/:id/active", TargetID: 3,
 	})
 	require.NoError(t, err)
-	require.Len(t, repo.recorded, 1)
-	assert.Equal(t, uint64(9), repo.recorded[0].ActorID)
-	assert.Equal(t, "admin@x", repo.recorded[0].ActorEmail)
-	assert.Equal(t, "PATCH /admin/companies/:id/active", repo.recorded[0].Action)
-	assert.Equal(t, uint64(3), repo.recorded[0].TargetID)
+	require.Len(t, recorded, 1)
+	assert.Equal(t, uint64(9), recorded[0].ActorID)
+	assert.Equal(t, "admin@x", recorded[0].ActorEmail)
+	assert.Equal(t, "PATCH /admin/companies/:id/active", recorded[0].Action)
+	assert.Equal(t, uint64(3), recorded[0].TargetID)
 }
 
 func Test_監査記録_保存失敗を伝播(t *testing.T) {
-	uc := usecase.NewRecordAuditEventUseCase(&fakeAuditRepo{recErr: errors.New("db")})
+	repo := &repofakes.FakeAuditRepository{
+		RecordFunc: func(context.Context, *domain.AuditEvent) error { return errors.New("db") },
+	}
+	uc := usecase.NewRecordAuditEventUseCase(repo)
 	assert.Error(t, uc.Execute(context.Background(), usecase.RecordAuditEventInput{}))
 }
 
 func Test_監査ログ一覧_新しい順で返す(t *testing.T) {
-	repo := &fakeAuditRepo{listRows: []domain.AuditEvent{{ID: 2}, {ID: 1}}}
+	repo := &repofakes.FakeAuditRepository{
+		ListRecentFunc: func(context.Context, int) ([]domain.AuditEvent, error) {
+			return []domain.AuditEvent{{ID: 2}, {ID: 1}}, nil
+		},
+	}
 	uc := usecase.NewListAuditEventsUseCase(repo)
 	rows, err := uc.Execute(context.Background())
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	assert.Equal(t, uint64(2), rows[0].ID)
+	assert.Equal(t, int64(1), repo.ListRecentCalls.Load())
 }

--- a/backend/internal/usecase/get_company_learning_summary_usecase_test.go
+++ b/backend/internal/usecase/get_company_learning_summary_usecase_test.go
@@ -85,7 +85,7 @@ func Test_メンバー学習サマリー_直近リストは5名まで(t *testing
 }
 
 func Test_メンバー学習サマリー_会社未所属は空サマリー(t *testing.T) {
-	repo, got := learningActivityRepo(nil, nil)
+	repo, _ := learningActivityRepo(nil, nil)
 	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 
 	out, err := uc.Execute(context.Background(), &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
@@ -93,7 +93,9 @@ func Test_メンバー学習サマリー_会社未所属は空サマリー(t *te
 	assert.Equal(t, 0, out.TraineeCount)
 	assert.NotNil(t, out.RecentMembers)
 	assert.Empty(t, out.RecentMembers)
-	assert.Zero(t, got.companyID, "会社未所属では集計クエリを打たない")
+	// companyID は「呼ばれていない」ときも「0 で呼ばれた」ときも 0 になるため、
+	// 呼び出し回数で確かめる。
+	assert.Zero(t, repo.ListMemberActivitiesCalls.Load(), "会社未所属では集計クエリを打たない")
 }
 
 func Test_メンバー学習サマリー_集計ウィンドウは今日を含む7日間(t *testing.T) {
@@ -110,5 +112,5 @@ func Test_メンバー学習サマリー_集計エラーはそのまま返す(t 
 	repo, _ := learningActivityRepo(nil, context.DeadlineExceeded)
 	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 	_, err := uc.Execute(context.Background(), companyAdminActor(10))
-	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/backend/internal/usecase/get_company_learning_summary_usecase_test.go
+++ b/backend/internal/usecase/get_company_learning_summary_usecase_test.go
@@ -9,25 +9,31 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeCompanyLearningActivityRepo は CompanyLearningActivitySummarizer の fake。
-type fakeCompanyLearningActivityRepo struct {
-	rows        []repository.MemberLearningActivity
-	err         error
-	gotCompany  uint64
-	gotFromDate time.Time
+// summarizerArgs は fake が受け取った引数の控え。usecase が「何を渡したか」を検証するために使う。
+type summarizerArgs struct {
+	companyID uint64
+	fromDate  time.Time
 }
 
-func (f *fakeCompanyLearningActivityRepo) ListMemberActivities(_ context.Context, companyID uint64, fromDate time.Time) ([]repository.MemberLearningActivity, error) {
-	f.gotCompany = companyID
-	f.gotFromDate = fromDate
-	if f.err != nil {
-		return nil, f.err
+// learningActivityRepo は指定の結果を返す fake と、渡された引数の控えを返す。
+func learningActivityRepo(rows []repository.MemberLearningActivity, err error) (*repofakes.FakeCompanyLearningActivitySummarizer, *summarizerArgs) {
+	got := &summarizerArgs{}
+	repo := &repofakes.FakeCompanyLearningActivitySummarizer{
+		ListMemberActivitiesFunc: func(_ context.Context, companyID uint64, fromDate time.Time) ([]repository.MemberLearningActivity, error) {
+			got.companyID = companyID
+			got.fromDate = fromDate
+			if err != nil {
+				return nil, err
+			}
+			return rows, nil
+		},
 	}
-	return f.rows, nil
+	return repo, got
 }
 
 func companyAdminActor(companyID uint64) *domain.User {
@@ -40,17 +46,17 @@ func Test_メンバー学習サマリー_集計される(t *testing.T) {
 	today := time.Now().UTC()
 	yesterday := today.AddDate(0, 0, -1)
 	tenDaysAgo := today.AddDate(0, 0, -10)
-	repo := &fakeCompanyLearningActivityRepo{rows: []repository.MemberLearningActivity{
+	repo, got := learningActivityRepo([]repository.MemberLearningActivity{
 		{UserID: 11, Name: "今日学習した人", LastActiveDate: datePtr(today), RecentActivityCount: 3},
 		{UserID: 12, Name: "昨日学習した人", LastActiveDate: datePtr(yesterday), RecentActivityCount: 1},
 		{UserID: 13, Name: "先週以前の人", LastActiveDate: datePtr(tenDaysAgo), RecentActivityCount: 0},
 		{UserID: 14, Name: "未学習の人", LastActiveDate: nil, RecentActivityCount: 0},
-	}}
+	}, nil)
 	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 
 	out, err := uc.Execute(context.Background(), companyAdminActor(10))
 	require.NoError(t, err)
-	assert.Equal(t, uint64(10), repo.gotCompany)
+	assert.Equal(t, uint64(10), got.companyID)
 	assert.Equal(t, 4, out.TraineeCount)
 	assert.Equal(t, 1, out.ActiveToday)
 	assert.Equal(t, 2, out.ActiveThisWeek, "直近 7 日の活動回数 > 0 の 2 名")
@@ -69,7 +75,8 @@ func Test_メンバー学習サマリー_直近リストは5名まで(t *testing
 			LastActiveDate: datePtr(today.AddDate(0, 0, -i)), RecentActivityCount: 1,
 		})
 	}
-	uc := usecase.NewGetCompanyLearningSummaryUseCase(&fakeCompanyLearningActivityRepo{rows: rows})
+	repo, _ := learningActivityRepo(rows, nil)
+	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 
 	out, err := uc.Execute(context.Background(), companyAdminActor(10))
 	require.NoError(t, err)
@@ -78,7 +85,7 @@ func Test_メンバー学習サマリー_直近リストは5名まで(t *testing
 }
 
 func Test_メンバー学習サマリー_会社未所属は空サマリー(t *testing.T) {
-	repo := &fakeCompanyLearningActivityRepo{}
+	repo, got := learningActivityRepo(nil, nil)
 	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 
 	out, err := uc.Execute(context.Background(), &domain.User{ID: 1, Role: domain.RoleSuperAdmin})
@@ -86,21 +93,22 @@ func Test_メンバー学習サマリー_会社未所属は空サマリー(t *te
 	assert.Equal(t, 0, out.TraineeCount)
 	assert.NotNil(t, out.RecentMembers)
 	assert.Empty(t, out.RecentMembers)
-	assert.Zero(t, repo.gotCompany, "会社未所属では集計クエリを打たない")
+	assert.Zero(t, got.companyID, "会社未所属では集計クエリを打たない")
 }
 
 func Test_メンバー学習サマリー_集計ウィンドウは今日を含む7日間(t *testing.T) {
-	repo := &fakeCompanyLearningActivityRepo{}
+	repo, got := learningActivityRepo(nil, nil)
 	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 
 	_, err := uc.Execute(context.Background(), companyAdminActor(10))
 	require.NoError(t, err)
 	wantFrom := time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02")
-	assert.Equal(t, wantFrom, repo.gotFromDate.Format("2006-01-02"))
+	assert.Equal(t, wantFrom, got.fromDate.Format("2006-01-02"))
 }
 
 func Test_メンバー学習サマリー_集計エラーはそのまま返す(t *testing.T) {
-	uc := usecase.NewGetCompanyLearningSummaryUseCase(&fakeCompanyLearningActivityRepo{err: context.DeadlineExceeded})
+	repo, _ := learningActivityRepo(nil, context.DeadlineExceeded)
+	uc := usecase.NewGetCompanyLearningSummaryUseCase(repo)
 	_, err := uc.Execute(context.Background(), companyAdminActor(10))
 	require.Error(t, err)
 }

--- a/backend/internal/usecase/get_daily_streak_usecase_test.go
+++ b/backend/internal/usecase/get_daily_streak_usecase_test.go
@@ -65,7 +65,10 @@ func Test_連続学習統計_活動なしは全て0(t *testing.T) {
 }
 
 func Test_連続学習統計_userID必須(t *testing.T) {
-	uc := NewGetDailyStreakUseCase(dailyActivityRepo())
+	repo := dailyActivityRepo()
+	uc := NewGetDailyStreakUseCase(repo)
 	_, err := uc.Execute(context.Background(), 0)
 	assert.Error(t, err)
+	// 入口で弾いているので repository には到達しない（呼んだあとに失敗しても Error は立つため）。
+	assert.Zero(t, repo.ListByUserCalls.Load(), "userID 未指定なら集計クエリを打たない")
 }

--- a/backend/internal/usecase/get_daily_streak_usecase_test.go
+++ b/backend/internal/usecase/get_daily_streak_usecase_test.go
@@ -6,21 +6,17 @@ import (
 	"time"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
-	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 )
 
-// fakeDailyActivityRepo は UserDailyActivityRepository の in-memory fake。
-type fakeDailyActivityRepo struct {
-	activities []domain.UserDailyActivity
-}
-
-func (f *fakeDailyActivityRepo) Increment(_ context.Context, _ uint64, _ time.Time, _ repository.UserDailyActivityIncrement) error {
-	return nil
-}
-
-func (f *fakeDailyActivityRepo) ListByUser(_ context.Context, _ uint64, _, _ time.Time) ([]domain.UserDailyActivity, error) {
-	return f.activities, nil
+// dailyActivityRepo は指定の活動履歴を返す fake を組み立てる。
+func dailyActivityRepo(activities ...domain.UserDailyActivity) *repofakes.FakeUserDailyActivityRepository {
+	return &repofakes.FakeUserDailyActivityRepository{
+		ListByUserFunc: func(context.Context, uint64, time.Time, time.Time) ([]domain.UserDailyActivity, error) {
+			return activities, nil
+		},
+	}
 }
 
 func day(offset int) time.Time {
@@ -32,9 +28,7 @@ func act(offset, exercises int) domain.UserDailyActivity {
 }
 
 func Test_連続学習統計_今日まで連続していればcurrentStreakに数える(t *testing.T) {
-	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{activities: []domain.UserDailyActivity{
-		act(-2, 1), act(-1, 1), act(0, 1),
-	}})
+	uc := NewGetDailyStreakUseCase(dailyActivityRepo(act(-2, 1), act(-1, 1), act(0, 1)))
 	out, err := uc.Execute(context.Background(), 7)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, out.CurrentStreak)
@@ -44,9 +38,7 @@ func Test_連続学習統計_今日まで連続していればcurrentStreakに�
 
 func Test_連続学習統計_途切れた過去の連続はlongestStreakにだけ残る(t *testing.T) {
 	// 5 日前〜3 日前の 3 連続 + 今日のみ → current=1, longest=3, total=4
-	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{activities: []domain.UserDailyActivity{
-		act(-5, 1), act(-4, 1), act(-3, 1), act(0, 1),
-	}})
+	uc := NewGetDailyStreakUseCase(dailyActivityRepo(act(-5, 1), act(-4, 1), act(-3, 1), act(0, 1)))
 	out, err := uc.Execute(context.Background(), 7)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, out.CurrentStreak)
@@ -55,9 +47,7 @@ func Test_連続学習統計_途切れた過去の連続はlongestStreakにだ�
 }
 
 func Test_連続学習統計_全カウンタ0の行は学習日に数えない(t *testing.T) {
-	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{activities: []domain.UserDailyActivity{
-		act(-1, 0), act(0, 1),
-	}})
+	uc := NewGetDailyStreakUseCase(dailyActivityRepo(act(-1, 0), act(0, 1)))
 	out, err := uc.Execute(context.Background(), 7)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, out.CurrentStreak)
@@ -66,7 +56,7 @@ func Test_連続学習統計_全カウンタ0の行は学習日に数えない(t
 }
 
 func Test_連続学習統計_活動なしは全て0(t *testing.T) {
-	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{})
+	uc := NewGetDailyStreakUseCase(dailyActivityRepo())
 	out, err := uc.Execute(context.Background(), 7)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, out.CurrentStreak)
@@ -75,7 +65,7 @@ func Test_連続学習統計_活動なしは全て0(t *testing.T) {
 }
 
 func Test_連続学習統計_userID必須(t *testing.T) {
-	uc := NewGetDailyStreakUseCase(&fakeDailyActivityRepo{})
+	uc := NewGetDailyStreakUseCase(dailyActivityRepo())
 	_, err := uc.Execute(context.Background(), 0)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## 概要

Phase 1（PR #2214）で再上陸させた fakegen の生成物を実際に使い始める。手書き fake は port にメソッドが増えるたびに手で追従させる必要があるが、生成 fake なら `make fakegen` の再実行で済む。

チケットの注意事項「1 つの PR ですべてを置き換えず、テスト単位で小さく分割する」に従い、**自己完結している 3 ファイル**から始める。

| ファイル | 手書き fake | 移行先 |
|---|---|---|
| `audit_usecase_test.go` | `fakeAuditRepo` | `FakeAuditRepository` |
| `get_daily_streak_usecase_test.go` | `fakeDailyActivityRepo` | `FakeUserDailyActivityRepository` |
| `get_company_learning_summary_usecase_test.go` | `fakeCompanyLearningActivityRepo` | `FakeCompanyLearningActivitySummarizer` |

## 移行の方針

**保存内容の検証**はクロージャに退避して同じ検証を維持する。状態検証のスタイルは変えない。

```go
var recorded []domain.AuditEvent
repo := &repofakes.FakeAuditRepository{
    RecordFunc: func(_ context.Context, e *domain.AuditEvent) error {
        recorded = append(recorded, *e)
        return nil
    },
}
```

**引数の検証**が要る箇所は、生成 fake に小さな控え struct を添えるヘルパを用意した。控えは interface を実装しないので、port が変わっても追従が要らない。

```go
func learningActivityRepo(rows []repository.MemberLearningActivity, err error) (
    *repofakes.FakeCompanyLearningActivitySummarizer, *summarizerArgs,
)
```

**呼び出し回数**は生成 fake の `XxxCalls` が `atomic.Int64` なので `.Load()` で読む。

## 移行対象から除外したもの

`fakeCodeRunner` / `fakeExecutor` / `fakeDownloader` は `internal/usecase/repository` の port ではなく、**fakegen の生成対象外**のため移行しない。手書き fake 21 型のうち移行できるのはこれらを除いた分になる。

## 残りの作業

10 ファイル / 18 型が残る。うち `fakeCourseRepo` / `fakeTeachingMaterialRepo` / `fakeLessonProgressRepo` は **複数のテストファイルから参照されている**（`course_usecase_test.go` / `list_courses_with_progress_usecase_test.go` / `get_last_viewed_chapter_usecase_test.go`）。この 3 型は巻き込み範囲が広いので、まとめて 1 つの PR にする。

## テスト

- `go test -race ./internal/usecase/...` パス
- `go vet ./...` クリーン
- `gofumpt -l` 未整形なし
- `golangci-lint run ./internal/usecase/...` **0 issues**

既存のテストケースは 1 つも削っていない。アサーションの内容も同じで、fake の生成方法だけを変えている。

## 関連チケット

- FRESTYLE-4 https://frestyle.atlassian.net/browse/FRESTYLE-4
- Phase 1: PR #2214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * 監査記録の保存・取得処理に関するテストを共通のテスト用リポジトリへ統一しました。
  * 学習サマリーの集計条件、対象会社、エラー処理に関する検証を整理しました。
  * デイリー継続日数のテスト構成を簡素化し、既存の検証内容を維持しました。
  * これにより、テストの再利用性と保守性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->