### PR TITLE
refactor: 自己完結の usecase テスト 2 ファイルを repofakes へ移行する (FRESTYLE-4)

### DIFF
--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -6,60 +6,47 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeMemberUserRepo は UserRepository を満たすテスト用 fake。
-type fakeMemberUserRepo struct {
+// memberStore は fake が読み書きする in-memory の状態。
+type memberStore struct {
 	byCompany map[uint64][]domain.User
 	byID      map[uint64]*domain.User
 	updated   map[uint64]*bool
 }
 
-func newFakeMemberUserRepo() *fakeMemberUserRepo {
-	return &fakeMemberUserRepo{
+// memberUserRepo は UserRepository の fake を、このテストが使う 3 メソッドだけ差し込んで返す。
+// 残り 9 メソッドは生成 fake がゼロ値を返すので、no-op を手で書く必要がない。
+func memberUserRepo() (*repofakes.FakeUserRepository, *memberStore) {
+	s := &memberStore{
 		byCompany: map[uint64][]domain.User{},
 		byID:      map[uint64]*domain.User{},
 		updated:   map[uint64]*bool{},
 	}
-}
-
-func (f *fakeMemberUserRepo) FindByCognitoSub(context.Context, string) (*domain.User, error) {
-	return nil, nil
-}
-
-func (f *fakeMemberUserRepo) FindByID(_ context.Context, id uint64) (*domain.User, error) {
-	return f.byID[id], nil
-}
-
-func (f *fakeMemberUserRepo) ListByRole(context.Context, string) ([]domain.User, error) {
-	return nil, nil
-}
-
-func (f *fakeMemberUserRepo) ListByCompanyID(_ context.Context, companyID uint64) ([]domain.User, error) {
-	return f.byCompany[companyID], nil
-}
-func (f *fakeMemberUserRepo) Create(context.Context, *domain.User) error { return nil }
-func (f *fakeMemberUserRepo) UpdateName(context.Context, uint64, string) error {
-	return nil
-}
-func (f *fakeMemberUserRepo) UpdateRole(context.Context, uint64, string) error      { return nil }
-func (f *fakeMemberUserRepo) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
-func (f *fakeMemberUserRepo) UpdateActive(context.Context, uint64, bool) error      { return nil }
-func (f *fakeMemberUserRepo) SoftDelete(context.Context, uint64) error              { return nil }
-func (f *fakeMemberUserRepo) MarkOnboarded(context.Context, uint64) error           { return nil }
-func (f *fakeMemberUserRepo) UpdateAiChatEnabled(_ context.Context, userID uint64, enabled *bool) error {
-	f.updated[userID] = enabled
-	return nil
+	repo := &repofakes.FakeUserRepository{
+		FindByIDFunc: func(_ context.Context, id uint64) (*domain.User, error) {
+			return s.byID[id], nil
+		},
+		ListByCompanyIDFunc: func(_ context.Context, companyID uint64) ([]domain.User, error) {
+			return s.byCompany[companyID], nil
+		},
+		UpdateAiChatEnabledFunc: func(_ context.Context, userID uint64, enabled *bool) error {
+			s.updated[userID] = enabled
+			return nil
+		},
+	}
+	return repo, s
 }
 
 func ptrBool(b bool) *bool    { return &b }
 func u64ptr(v uint64) *uint64 { return &v }
 
 func Test_会社メンバー一覧ユースケース(t *testing.T) {
-	repo := newFakeMemberUserRepo()
-	repo.byCompany[10] = []domain.User{{ID: 1, CompanyID: u64ptr(10)}, {ID: 2, CompanyID: u64ptr(10)}}
+	repo, store := memberUserRepo()
+	store.byCompany[10] = []domain.User{{ID: 1, CompanyID: u64ptr(10)}, {ID: 2, CompanyID: u64ptr(10)}}
 	uc := usecase.NewListCompanyMembersUseCase(repo)
 
 	t.Run("自社の従業員一覧を返す", func(t *testing.T) {
@@ -75,22 +62,22 @@ func Test_会社メンバー一覧ユースケース(t *testing.T) {
 }
 
 func Test_メンバーAI利用可否更新ユースケース(t *testing.T) {
-	repo := newFakeMemberUserRepo()
-	repo.byID[1] = &domain.User{ID: 1, CompanyID: u64ptr(10), Role: domain.RoleTrainee}
-	repo.byID[2] = &domain.User{ID: 2, CompanyID: u64ptr(20), Role: domain.RoleTrainee} // 別会社
+	repo, store := memberUserRepo()
+	store.byID[1] = &domain.User{ID: 1, CompanyID: u64ptr(10), Role: domain.RoleTrainee}
+	store.byID[2] = &domain.User{ID: 2, CompanyID: u64ptr(20), Role: domain.RoleTrainee} // 別会社
 	uc := usecase.NewUpdateMemberAiAccessUseCase(repo)
 	actor := &domain.User{ID: 9, CompanyID: u64ptr(10), Role: domain.RoleCompanyAdmin}
 
 	t.Run("自社の従業員の AI を個別 OFF にできる", func(t *testing.T) {
 		err := uc.Execute(context.Background(), actor, 1, ptrBool(false))
 		require.NoError(t, err)
-		require.NotNil(t, repo.updated[1])
-		assert.False(t, *repo.updated[1])
+		require.NotNil(t, store.updated[1])
+		assert.False(t, *store.updated[1])
 	})
 	t.Run("nil で会社設定に従う状態へ戻せる", func(t *testing.T) {
 		err := uc.Execute(context.Background(), actor, 1, nil)
 		require.NoError(t, err)
-		assert.Nil(t, repo.updated[1])
+		assert.Nil(t, store.updated[1])
 	})
 	t.Run("別会社の従業員は更新できない(403相当)", func(t *testing.T) {
 		err := uc.Execute(context.Background(), actor, 2, ptrBool(true))

--- a/backend/internal/usecase/admin_member_usecase_test.go
+++ b/backend/internal/usecase/admin_member_usecase_test.go
@@ -77,7 +77,11 @@ func Test_メンバーAI利用可否更新ユースケース(t *testing.T) {
 	t.Run("nil で会社設定に従う状態へ戻せる", func(t *testing.T) {
 		err := uc.Execute(context.Background(), actor, 1, nil)
 		require.NoError(t, err)
-		assert.Nil(t, store.updated[1])
+		// updated[1] は「キーが無い」ときも nil になる。単独実行でも「呼ばれたうえで
+		// nil が渡った」ことを見たいので、キーの存在を先に確かめる。
+		got, ok := store.updated[1]
+		require.True(t, ok, "UpdateAiChatEnabled が呼ばれていること")
+		assert.Nil(t, got)
 	})
 	t.Run("別会社の従業員は更新できない(403相当)", func(t *testing.T) {
 		err := uc.Execute(context.Background(), actor, 2, ptrBool(true))

--- a/backend/internal/usecase/list_company_stats_usecase_test.go
+++ b/backend/internal/usecase/list_company_stats_usecase_test.go
@@ -8,49 +8,39 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeStatsCompanyRepo は CompanyRepository の最小 fake。
-type fakeStatsCompanyRepo struct {
-	rows []domain.Company
-	err  error
+// statsCompanyRepo は ListAll だけを差し込んだ CompanyRepository の fake を返す。
+// 他の 3 メソッドは生成 fake がゼロ値を返すため no-op を書かなくてよい。
+func statsCompanyRepo(rows []domain.Company, err error) *repofakes.FakeCompanyRepository {
+	return &repofakes.FakeCompanyRepository{
+		ListAllFunc: func(context.Context) ([]domain.Company, error) { return rows, err },
+	}
 }
 
-func (f *fakeStatsCompanyRepo) ListAll(context.Context) ([]domain.Company, error) {
-	return f.rows, f.err
-}
-
-func (f *fakeStatsCompanyRepo) FindByID(context.Context, uint64) (*domain.Company, error) {
-	return nil, nil
-}
-
-func (f *fakeStatsCompanyRepo) UpdateAiChatEnabled(context.Context, uint64, bool) error { return nil }
-
-func (f *fakeStatsCompanyRepo) UpdateActive(context.Context, uint64, bool) error { return nil }
-
-// fakeCounter は CompanyMemberCounter の fake。
-type fakeCounter struct {
-	rows []repository.CompanyMemberCount
-	err  error
-}
-
-func (f *fakeCounter) CountMembersByCompany(context.Context) ([]repository.CompanyMemberCount, error) {
-	return f.rows, f.err
+// memberCounter は CompanyMemberCounter の fake を返す。
+func memberCounter(rows []repository.CompanyMemberCount, err error) *repofakes.FakeCompanyMemberCounter {
+	return &repofakes.FakeCompanyMemberCounter{
+		CountMembersByCompanyFunc: func(context.Context) ([]repository.CompanyMemberCount, error) {
+			return rows, err
+		},
+	}
 }
 
 func Test_会社横断ビュー_会社にメンバー集計をマージして返す(t *testing.T) {
-	companies := &fakeStatsCompanyRepo{rows: []domain.Company{
+	companies := statsCompanyRepo([]domain.Company{
 		{ID: 1, Name: "アクメ社", IsActive: true},
 		{ID: 2, Name: "ベータ社", IsActive: false},
 		{ID: 3, Name: "メンバー無し社", IsActive: true},
-	}}
-	counter := &fakeCounter{rows: []repository.CompanyMemberCount{
+	}, nil)
+	counter := memberCounter([]repository.CompanyMemberCount{
 		{CompanyID: 1, Total: 5, Active: 4, Trainees: 3},
 		{CompanyID: 2, Total: 2, Active: 0, Trainees: 1},
 		// 会社 3 は集計に出てこない（メンバー 0）→ zero value で埋まることを検証
-	}}
+	}, nil)
 	uc := usecase.NewListCompanyStatsUseCase(companies, counter)
 
 	stats, err := uc.Execute(context.Background())
@@ -74,19 +64,21 @@ func Test_会社横断ビュー_会社にメンバー集計をマージして返
 }
 
 func Test_会社横断ビュー_会社一覧の取得失敗を伝播(t *testing.T) {
+	wantErr := errors.New("db down")
 	uc := usecase.NewListCompanyStatsUseCase(
-		&fakeStatsCompanyRepo{err: errors.New("db down")},
-		&fakeCounter{},
+		statsCompanyRepo(nil, wantErr),
+		memberCounter(nil, nil),
 	)
 	_, err := uc.Execute(context.Background())
-	assert.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
 }
 
 func Test_会社横断ビュー_集計の取得失敗を伝播(t *testing.T) {
+	wantErr := errors.New("count failed")
 	uc := usecase.NewListCompanyStatsUseCase(
-		&fakeStatsCompanyRepo{rows: []domain.Company{{ID: 1, Name: "X"}}},
-		&fakeCounter{err: errors.New("count failed")},
+		statsCompanyRepo([]domain.Company{{ID: 1, Name: "X"}}, nil),
+		memberCounter(nil, wantErr),
 	)
 	_, err := uc.Execute(context.Background())
-	assert.Error(t, err)
+	require.ErrorIs(t, err, wantErr)
 }


### PR DESCRIPTION
## 概要

Phase 2 の 2 バッチ目。他ファイルから参照されていない fake を移行する。

| ファイル | 手書き fake | 移行先 |
|---|---|---|
| `admin_member_usecase_test.go` | `fakeMemberUserRepo` | `FakeUserRepository` |
| `list_company_stats_usecase_test.go` | `fakeStatsCompanyRepo` | `FakeCompanyRepository` |
| 〃 | `fakeCounter` | `FakeCompanyMemberCounter` |

## fat interface で効果が大きい

`UserRepository` は 12 メソッドあるが、このテストが挙動を差し込むのは **FindByID / ListByCompanyID / UpdateAiChatEnabled の 3 つだけ**。手書き fake は残り 9 つを no-op で埋めていた。

```go
// 移行前: 使わないメソッドも全部書く必要があった
func (f *fakeMemberUserRepo) FindByCognitoSub(context.Context, string) (*domain.User, error) { return nil, nil }
func (f *fakeMemberUserRepo) ListByRole(context.Context, string) ([]domain.User, error)      { return nil, nil }
func (f *fakeMemberUserRepo) Create(context.Context, *domain.User) error                     { return nil }
func (f *fakeMemberUserRepo) UpdateRole(context.Context, uint64, string) error               { return nil }
// ...あと 5 つ
```

生成 fake は未設定のメソッドがゼロ値を返すので、この分がまるごと不要になる。**port にメソッドが増えても、このテストは何も直さなくてよくなった**のが実質的な効果。

## in-memory な状態の扱い

状態を持つ fake は、状態だけを別の struct に切り出してクロージャから参照する形にした。

```go
type memberStore struct {
	byCompany map[uint64][]domain.User
	byID      map[uint64]*domain.User
	updated   map[uint64]*bool
}

func memberUserRepo() (*repofakes.FakeUserRepository, *memberStore)
```

この struct は interface を実装していないため、**port が変わっても追従が要らない**。Phase 2-a で使った控え struct と同じ考え方。

## 先回りで直した点

PR #2219 で CodeRabbit から受けた指摘と同じパターンが `list_company_stats` にもあった。エラー伝播のテストが `assert.Error` のみで、別のエラーが返っても通ってしまう状態だったので、sentinel を用意して `require.ErrorIs` で確かめるようにした。

## テスト

- `go test -race ./internal/usecase/...` パス
- `gofumpt -l` 未整形なし
- `golangci-lint run ./internal/usecase/...` **0 issues**

テストケースの削除やアサーションの緩和はしていない。

## 残りの作業

6 ファイルが残る。内訳は次のとおり。

- **移行対象**: `manage_member` / `create_company_application` / `submit_master_exercise`（一部）
- **クラスタ**: `teaching_material` / `lesson_progress` / `get_last_viewed_chapter` ほか、`fakeCourseRepo` を 4 ファイルが共有しているため 1 PR にまとめる必要がある
- **対象外**: `fakeCodeRunner` / `fakeExecutor` / `fakeDownloader` は `internal/usecase/repository` の port ではなく fakegen の生成対象外

## 関連チケット

- FRESTYLE-4 https://frestyle.atlassian.net/browse/FRESTYLE-4
- Phase 1: PR #2214 / Phase 2-a: PR #2219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 管理機能および企業統計機能に関するテストの信頼性を向上しました。
  * データ取得や更新処理の検証を整理し、異常発生時のエラー情報が正しく引き継がれることを確認できるようにしました。
  * これにより、今後の変更に対する検証精度と保守性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->