### PR TITLE
refactor: manage_member と create_company_application を repofakes へ移行する (FRESTYLE-4)

### DIFF
--- a/backend/internal/usecase/create_company_application_usecase_test.go
+++ b/backend/internal/usecase/create_company_application_usecase_test.go
@@ -7,51 +7,40 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 )
 
-type fakeAppRepo struct {
-	created *domain.CompanyApplication
-	err     error
-}
+// appStore は fake が記録した申請。
+type appStore struct{ created *domain.CompanyApplication }
 
-func (r *fakeAppRepo) Create(_ context.Context, app *domain.CompanyApplication) error {
-	if r.err != nil {
-		return r.err
+// appRepo は Create だけを差し込んだ CompanyApplicationRepository の fake を返す。
+func appRepo(err error) (*repofakes.FakeCompanyApplicationRepository, *appStore) {
+	st := &appStore{}
+	repo := &repofakes.FakeCompanyApplicationRepository{
+		CreateFunc: func(_ context.Context, app *domain.CompanyApplication) error {
+			if err != nil {
+				return err
+			}
+			app.ID = 1
+			st.created = app
+			return nil
+		},
 	}
-	app.ID = 1
-	r.created = app
-	return nil
+	return repo, st
 }
 
-func (r *fakeAppRepo) ListAll(context.Context) ([]domain.CompanyApplication, error) { return nil, nil }
-func (r *fakeAppRepo) UpdateStatus(context.Context, uint64, string) error           { return nil }
-
-// fakeUsersForApp は ListByRole で super_admin を返す最小 UserRepository。
-type fakeUsersForApp struct{ admins []domain.User }
-
-func (f *fakeUsersForApp) FindByCognitoSub(context.Context, string) (*domain.User, error) {
-	return nil, nil
-}
-
-func (f *fakeUsersForApp) FindByID(context.Context, uint64) (*domain.User, error) { return nil, nil }
-
-func (f *fakeUsersForApp) ListByRole(_ context.Context, role string) ([]domain.User, error) {
-	if role == domain.RoleSuperAdmin {
-		return f.admins, nil
+// usersForApp は ListByRole で super_admin だけを返す UserRepository の fake。
+// 残り 11 メソッドは生成 fake がゼロ値を返すので no-op を書かなくてよい。
+func usersForApp(admins []domain.User) *repofakes.FakeUserRepository {
+	return &repofakes.FakeUserRepository{
+		ListByRoleFunc: func(_ context.Context, role string) ([]domain.User, error) {
+			if role == domain.RoleSuperAdmin {
+				return admins, nil
+			}
+			return nil, nil
+		},
 	}
-	return nil, nil
 }
-func (f *fakeUsersForApp) Create(context.Context, *domain.User) error            { return nil }
-func (f *fakeUsersForApp) UpdateName(context.Context, uint64, string) error      { return nil }
-func (f *fakeUsersForApp) UpdateRole(context.Context, uint64, string) error      { return nil }
-func (f *fakeUsersForApp) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
-func (f *fakeUsersForApp) UpdateActive(context.Context, uint64, bool) error      { return nil }
-func (f *fakeUsersForApp) SoftDelete(context.Context, uint64) error              { return nil }
-func (f *fakeUsersForApp) MarkOnboarded(context.Context, uint64) error           { return nil }
-func (f *fakeUsersForApp) ListByCompanyID(context.Context, uint64) ([]domain.User, error) {
-	return nil, nil
-}
-func (f *fakeUsersForApp) UpdateAiChatEnabled(context.Context, uint64, *bool) error { return nil }
 
 type recordingNotifRepo struct {
 	created []domain.Notification
@@ -83,8 +72,8 @@ func (r *recordingNotifRepo) CountUnread(context.Context, uint64) (int64, error)
 }
 
 func Test_会社申請作成_運営管理者へ通知(t *testing.T) {
-	apps := &fakeAppRepo{}
-	users := &fakeUsersForApp{admins: []domain.User{{ID: 10}, {ID: 11}}}
+	apps, _ := appRepo(nil)
+	users := usersForApp([]domain.User{{ID: 10}, {ID: 11}})
 	notifs := &recordingNotifRepo{}
 	uc := usecase.NewCreateCompanyApplicationUseCase(apps, users, notifs)
 
@@ -109,7 +98,7 @@ func Test_会社申請作成_運営管理者へ通知(t *testing.T) {
 }
 
 func Test_会社申請作成_バリデーション(t *testing.T) {
-	uc := usecase.NewCreateCompanyApplicationUseCase(&fakeAppRepo{}, &fakeUsersForApp{}, &recordingNotifRepo{})
+	uc := usecase.NewCreateCompanyApplicationUseCase(mustAppRepo(), usersForApp(nil), &recordingNotifRepo{})
 	cases := []usecase.CreateCompanyApplicationInput{
 		{CompanyName: "", ApplicantName: "a", Email: "a@b.com"},     // company 欠落
 		{CompanyName: "c", ApplicantName: "", Email: "a@b.com"},     // name 欠落
@@ -125,15 +114,15 @@ func Test_会社申請作成_バリデーション(t *testing.T) {
 
 func Test_会社申請作成_通知失敗でも保存(t *testing.T) {
 	// 通知作成に失敗しても申請保存は成功扱い（best-effort）。
-	apps := &fakeAppRepo{}
-	users := &fakeUsersForApp{admins: []domain.User{{ID: 10}}}
+	apps, appsStore := appRepo(nil)
+	users := usersForApp([]domain.User{{ID: 10}})
 	uc := usecase.NewCreateCompanyApplicationUseCase(apps, users, &failingNotifRepo{})
 	if _, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
 		CompanyName: "c", ApplicantName: "a", Email: "a@b.com",
 	}); err != nil {
 		t.Fatalf("application should be created despite notify failure, got %v", err)
 	}
-	if apps.created == nil {
+	if appsStore.created == nil {
 		t.Fatal("application was not saved")
 	}
 }
@@ -175,7 +164,7 @@ func Test_会社申請作成_通知はまとめて1回で書き込む(t *testing
 		t.Run(tt.name, func(t *testing.T) {
 			notifs := &recordingNotifRepo{}
 			uc := usecase.NewCreateCompanyApplicationUseCase(
-				&fakeAppRepo{}, &fakeUsersForApp{admins: tt.admins}, notifs,
+				mustAppRepo(), usersForApp(tt.admins), notifs,
 			)
 
 			app, err := uc.Execute(context.Background(), usecase.CreateCompanyApplicationInput{
@@ -212,4 +201,10 @@ func Test_会社申請作成_通知はまとめて1回で書き込む(t *testing
 			}
 		})
 	}
+}
+
+// mustAppRepo は記録を使わない場面向けに fake だけを返す。
+func mustAppRepo() *repofakes.FakeCompanyApplicationRepository {
+	repo, _ := appRepo(nil)
+	return repo
 }

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -11,10 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// manageStore は fake が記録する更新内容。
+// manageStore は fake が記録する更新内容。対象 ID も控え、別のユーザーに
+// 操作が飛んでいないことまで検証できるようにする。
 type manageStore struct {
-	updateActiveGot *bool
-	softDeleted     bool
+	updateActiveGot    *bool
+	updateActiveUserID uint64
+	softDeleted        bool
+	softDeletedUserID  uint64
 }
 
 // manageMemberRepo は UserRepository の fake を、このテストが使う 3 メソッドだけ
@@ -23,12 +26,14 @@ func manageMemberRepo(target *domain.User) (*repofakes.FakeUserRepository, *mana
 	st := &manageStore{}
 	repo := &repofakes.FakeUserRepository{
 		FindByIDFunc: func(context.Context, uint64) (*domain.User, error) { return target, nil },
-		UpdateActiveFunc: func(_ context.Context, _ uint64, active bool) error {
+		UpdateActiveFunc: func(_ context.Context, userID uint64, active bool) error {
 			st.updateActiveGot = &active
+			st.updateActiveUserID = userID
 			return nil
 		},
-		SoftDeleteFunc: func(context.Context, uint64) error {
+		SoftDeleteFunc: func(_ context.Context, userID uint64) error {
 			st.softDeleted = true
+			st.softDeletedUserID = userID
 			return nil
 		},
 	}
@@ -45,6 +50,7 @@ func Test_メンバー有効化_会社管理者_自社_OK(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, store.updateActiveGot)
 	assert.False(t, *store.updateActiveGot)
+	assert.Equal(t, uint64(2), store.updateActiveUserID, "指定した対象に対して更新すること")
 }
 
 func Test_メンバー有効化_会社管理者_別会社_禁止(t *testing.T) {
@@ -67,6 +73,8 @@ func Test_メンバー有効化_運営管理者_任意の会社_OK(t *testing.T)
 
 	require.NoError(t, err)
 	require.NotNil(t, store.updateActiveGot)
+	assert.False(t, *store.updateActiveGot, "実装が true を渡す回帰を検出する")
+	assert.Equal(t, uint64(2), store.updateActiveUserID)
 }
 
 func Test_メンバー有効化_自分自身_禁止(t *testing.T) {
@@ -100,6 +108,7 @@ func Test_メンバー論理削除_会社管理者_自社_OK(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, store.softDeleted)
+	assert.Equal(t, uint64(2), store.softDeletedUserID, "指定した対象を削除すること")
 }
 
 func Test_メンバー論理削除_自分自身_禁止(t *testing.T) {
@@ -122,4 +131,15 @@ func Test_メンバー論理削除_会社管理者_別会社_禁止(t *testing.T
 
 	require.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
 	assert.False(t, store.softDeleted)
+}
+
+func Test_メンバー論理削除_見つからない(t *testing.T) {
+	repo, _ := manageMemberRepo(nil)
+	uc := usecase.NewSoftDeleteMemberUseCase(repo)
+	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
+
+	err := uc.Execute(context.Background(), actor, 999)
+
+	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
+	assert.Zero(t, repo.SoftDeleteCalls.Load(), "対象が居なければ削除は走らない")
 }

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -14,6 +14,7 @@ import (
 // manageStore は fake が記録する更新内容。対象 ID も控え、別のユーザーに
 // 操作が飛んでいないことまで検証できるようにする。
 type manageStore struct {
+	findByIDUserID     uint64
 	updateActiveGot    *bool
 	updateActiveUserID uint64
 	softDeleted        bool
@@ -25,7 +26,10 @@ type manageStore struct {
 func manageMemberRepo(target *domain.User) (*repofakes.FakeUserRepository, *manageStore) {
 	st := &manageStore{}
 	repo := &repofakes.FakeUserRepository{
-		FindByIDFunc: func(context.Context, uint64) (*domain.User, error) { return target, nil },
+		FindByIDFunc: func(_ context.Context, userID uint64) (*domain.User, error) {
+			st.findByIDUserID = userID
+			return target, nil
+		},
 		UpdateActiveFunc: func(_ context.Context, userID uint64, active bool) error {
 			st.updateActiveGot = &active
 			st.updateActiveUserID = userID
@@ -50,6 +54,7 @@ func Test_メンバー有効化_会社管理者_自社_OK(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, store.updateActiveGot)
 	assert.False(t, *store.updateActiveGot)
+	assert.Equal(t, uint64(2), store.findByIDUserID, "対象の取得は指定した ID で行うこと")
 	assert.Equal(t, uint64(2), store.updateActiveUserID, "指定した対象に対して更新すること")
 }
 
@@ -108,6 +113,7 @@ func Test_メンバー論理削除_会社管理者_自社_OK(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, store.softDeleted)
+	assert.Equal(t, uint64(2), store.findByIDUserID, "対象の取得は指定した ID で行うこと")
 	assert.Equal(t, uint64(2), store.softDeletedUserID, "指定した対象を削除すること")
 }
 

--- a/backend/internal/usecase/manage_member_usecase_test.go
+++ b/backend/internal/usecase/manage_member_usecase_test.go
@@ -6,137 +6,120 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// fakeManageRepo は SetMemberActive / SoftDeleteMember の認可検証用 fake。
-type fakeManageRepo struct {
-	target          *domain.User // FindByID が返す対象
+// manageStore は fake が記録する更新内容。
+type manageStore struct {
 	updateActiveGot *bool
 	softDeleted     bool
 }
 
-func (f *fakeManageRepo) FindByID(context.Context, uint64) (*domain.User, error) {
-	return f.target, nil
+// manageMemberRepo は UserRepository の fake を、このテストが使う 3 メソッドだけ
+// 差し込んで返す。残り 8 メソッドは生成 fake がゼロ値を返すので no-op が要らない。
+func manageMemberRepo(target *domain.User) (*repofakes.FakeUserRepository, *manageStore) {
+	st := &manageStore{}
+	repo := &repofakes.FakeUserRepository{
+		FindByIDFunc: func(context.Context, uint64) (*domain.User, error) { return target, nil },
+		UpdateActiveFunc: func(_ context.Context, _ uint64, active bool) error {
+			st.updateActiveGot = &active
+			return nil
+		},
+		SoftDeleteFunc: func(context.Context, uint64) error {
+			st.softDeleted = true
+			return nil
+		},
+	}
+	return repo, st
 }
-
-func (f *fakeManageRepo) UpdateActive(_ context.Context, _ uint64, active bool) error {
-	f.updateActiveGot = &active
-	return nil
-}
-
-func (f *fakeManageRepo) SoftDelete(context.Context, uint64) error {
-	f.softDeleted = true
-	return nil
-}
-
-func (f *fakeManageRepo) FindByCognitoSub(context.Context, string) (*domain.User, error) {
-	return nil, nil
-}
-
-func (f *fakeManageRepo) ListByRole(context.Context, string) ([]domain.User, error) { return nil, nil }
-
-func (f *fakeManageRepo) ListByCompanyID(context.Context, uint64) ([]domain.User, error) {
-	return nil, nil
-}
-
-func (f *fakeManageRepo) Create(context.Context, *domain.User) error { return nil }
-
-func (f *fakeManageRepo) UpdateAiChatEnabled(context.Context, uint64, *bool) error { return nil }
-
-func (f *fakeManageRepo) UpdateName(context.Context, uint64, string) error { return nil }
-
-func (f *fakeManageRepo) UpdateRole(context.Context, uint64, string) error { return nil }
-
-func (f *fakeManageRepo) UpdateCompanyID(context.Context, uint64, uint64) error { return nil }
-
-func (f *fakeManageRepo) MarkOnboarded(context.Context, uint64) error { return nil }
 
 func Test_メンバー有効化_会社管理者_自社_OK(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)})
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
 
 	err := uc.Execute(context.Background(), actor, 2, false)
 
 	require.NoError(t, err)
-	require.NotNil(t, repo.updateActiveGot)
-	assert.False(t, *repo.updateActiveGot)
+	require.NotNil(t, store.updateActiveGot)
+	assert.False(t, *store.updateActiveGot)
 }
 
 func Test_メンバー有効化_会社管理者_別会社_禁止(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)})
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
 
 	err := uc.Execute(context.Background(), actor, 2, false)
 
 	require.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
-	assert.Nil(t, repo.updateActiveGot, "別会社では更新してはならない")
+	assert.Nil(t, store.updateActiveGot, "別会社では更新してはならない")
 }
 
 func Test_メンバー有効化_運営管理者_任意の会社_OK(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)})
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin, CompanyID: nil}
 
 	err := uc.Execute(context.Background(), actor, 2, false)
 
 	require.NoError(t, err)
-	require.NotNil(t, repo.updateActiveGot)
+	require.NotNil(t, store.updateActiveGot)
 }
 
 func Test_メンバー有効化_自分自身_禁止(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)})
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
 
 	err := uc.Execute(context.Background(), actor, 1, false)
 
 	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
-	assert.Nil(t, repo.updateActiveGot, "自分自身は無効化できない")
+	assert.Nil(t, store.updateActiveGot, "自分自身は無効化できない")
 }
 
 func Test_メンバー有効化_見つからない(t *testing.T) {
-	repo := &fakeManageRepo{target: nil}
+	repo, _ := manageMemberRepo(nil)
 	uc := usecase.NewSetMemberActiveUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleSuperAdmin}
 
 	err := uc.Execute(context.Background(), actor, 999, false)
 
 	require.ErrorIs(t, err, usecase.ErrMemberNotFound)
+	assert.Zero(t, repo.UpdateActiveCalls.Load(), "対象が居なければ更新は走らない")
 }
 
 func Test_メンバー論理削除_会社管理者_自社_OK(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(10)})
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
 
 	err := uc.Execute(context.Background(), actor, 2)
 
 	require.NoError(t, err)
-	assert.True(t, repo.softDeleted)
+	assert.True(t, store.softDeleted)
 }
 
 func Test_メンバー論理削除_自分自身_禁止(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)})
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
 
 	err := uc.Execute(context.Background(), actor, 1)
 
 	require.ErrorIs(t, err, usecase.ErrCannotManageSelf)
-	assert.False(t, repo.softDeleted, "自分自身は削除できない")
+	assert.False(t, store.softDeleted, "自分自身は削除できない")
 }
 
 func Test_メンバー論理削除_会社管理者_別会社_禁止(t *testing.T) {
-	repo := &fakeManageRepo{target: &domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)}}
+	repo, store := manageMemberRepo(&domain.User{ID: 2, Role: domain.RoleTrainee, CompanyID: u64ptr(99)})
 	uc := usecase.NewSoftDeleteMemberUseCase(repo)
 	actor := &domain.User{ID: 1, Role: domain.RoleCompanyAdmin, CompanyID: u64ptr(10)}
 
 	err := uc.Execute(context.Background(), actor, 2)
 
 	require.ErrorIs(t, err, usecase.ErrMemberNotInActorCompany)
-	assert.False(t, repo.softDeleted)
+	assert.False(t, store.softDeleted)
 }


### PR DESCRIPTION
## 概要

Phase 2 の 3 バッチ目。他ファイルから参照されていない fake を移行する。

| ファイル | 手書き fake | 移行先 | 差し込むメソッド |
|---|---|---|---|
| `manage_member_usecase_test.go` | `fakeManageRepo` | `FakeUserRepository` | 3 / 11 |
| `create_company_application_usecase_test.go` | `fakeAppRepo` | `FakeCompanyApplicationRepository` | 1 / 3 |
| 〃 | `fakeUsersForApp` | `FakeUserRepository` | **1 / 12** |

`fakeUsersForApp` は `ListByRole` しか使っていないのに、手書きでは残り 11 メソッドを no-op で埋めていた。

## 検証を 1 つ足した

「対象が見つからないときは更新しない」ことを `UpdateActiveCalls` で確かめるようにした。`ErrMemberNotFound` が返ることだけを見ていると、**repository を呼んだあとに失敗する実装でも通ってしまう**ため。

```go
require.ErrorIs(t, err, usecase.ErrMemberNotFound)
assert.Zero(t, repo.UpdateActiveCalls.Load(), "対象が居なければ更新は走らない")
```

## テスト

- `go test -race ./internal/usecase/` パス
- `gofumpt -l` 未整形なし
- `golangci-lint run ./internal/usecase/...` **0 issues**

## 調査で分かった移行範囲のずれ（重要）

チケットは「約 11 ファイル」「`fakeXxxRepo` という名前」としているが、**実際の手書きテストダブルは `fake` 命名だけではなかった**。

```
fake*       21 型（当初の集計）
stub*       12 型（stubHealthRepo / stubUserRepo / stubNoteRepo など）
その他       recordingNotifRepo / failingNotifRepo / nopActivityRepo
            / settingsCompanyRepo / statusRepo など
```

合計すると **33 型前後**で、当初把握していた 21 型より大幅に多い。

さらに `send_ai_message_stream_usecase_test.go` は**すでに `testify/mock` を使っている**（`mockSessionRepo struct{ mock.Mock }`）。つまり現状のコードベースには **手書き fake / 手書き stub / testify mock の 3 つの流儀が混在**している。

この事実は、PR #2220 で CodeRabbit が指摘した `.claude/CLAUDE.md` §3.3（「usecase は testify/mock」）との不整合とも関係する。移行範囲をどこまで広げるかは、規約側の方針決定とセットで判断したい。**本 PR は当初スコープどおり `fake` 命名のものだけを対象にしている。**

## 関連チケット

- FRESTYLE-4 https://frestyle.atlassian.net/browse/FRESTYLE-4
- Phase 1: PR #2214 / Phase 2-a: PR #2219 / Phase 2-b: PR #2220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **テスト**
  * 申請処理とメンバー管理に関するテストの信頼性を向上しました。
  * メンバーの有効化・論理削除について、権限がない場合に更新されないことを検証するよう改善しました。
  * 通知失敗時の申請保存や通知の一括作成に関する検証を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->