### PR TITLE
FRESTYLE-15 auth handler にユーザー upsert のビジネスロジックが集中している問題を修正(refactor)

### DIFF
--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -376,7 +376,7 @@ func (h *AuthHandler) upsertUserFromIDToken(
 ) (allowed bool, err error) {
 	claims, decodeErr := middleware.DecodeClaims(idToken)
 	if decodeErr != nil {
-		return false, fmt.Errorf("decode id_token: %w", decodeErr)
+		return false, fmt.Errorf("failed to decode id_token: %w", decodeErr)
 	}
 
 	if h.upsertUser == nil {

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -186,25 +186,23 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
-	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
-
 	// Callback と同じ招待ゲート。内部エラー(DB/decode)は 500、招待拒否は 403 に切り分ける。
 	allowed, upErr := h.upsertUserFromIDToken(c, tok.IDToken, "")
 	if upErr != nil {
 		log.Printf("cognito password login: upsert failed: %v", upErr)
-		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		return
 	}
 	if !allowed {
-		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "invitation_required",
 			"message": "FreStyle のご利用には管理者からの招待が必要です。招待メールに記載されたリンクからログインしてください。",
 		})
 		return
 	}
+
+	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
+	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
 	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
 }
@@ -246,26 +244,24 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
-	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
-
 	// 初回ログインで users 行が無いと /auth/me が 404 になるため upsert する。
-	// 内部エラー(DB/decode)は 500、招待拒否は 403。拒否時は Cookie をクリアしてセッションを残さない。
+	// 内部エラー(DB/decode)は 500、招待拒否は 403 に切り分ける。
 	allowed, upErr := h.upsertUserFromIDToken(c, tok.IDToken, req.InvitationToken)
 	if upErr != nil {
 		log.Printf("cognito callback: upsert failed: %v", upErr)
-		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal_error"})
 		return
 	}
 	if !allowed {
-		middleware.ClearAuthCookies(c)
 		c.JSON(http.StatusForbidden, gin.H{
 			"error":   "invitation_required",
 			"message": "FreStyle のご利用には管理者からの招待が必要です。招待メールに記載されたリンクからログインしてください。",
 		})
 		return
 	}
+
+	middleware.SetAccessTokenCookie(c, tok.AccessToken, tok.ExpiresIn)
+	middleware.SetRefreshTokenCookie(c, tok.RefreshToken)
 
 	c.JSON(http.StatusOK, gin.H{"message": "ログインしました。"})
 }

--- a/backend/internal/handler/auth_handler.go
+++ b/backend/internal/handler/auth_handler.go
@@ -26,8 +26,8 @@ type passwordAuthenticator interface {
 // OAuth2 通信は infra/cognito.TokenExchanger に切り出し、ここは HTTP 境界と user upsert だけを持つ。
 type AuthHandler struct {
 	getCurrentUser *usecase.GetCurrentUserUseCase
+	upsertUser     *usecase.UpsertUserFromIDTokenUseCase
 	users          repository.UserRepository
-	invitations    repository.AdminInvitationRepository
 	cognitoCfg     *config.CognitoConfig
 	tokens         *cognito.TokenExchanger
 	passwordAuth   passwordAuthenticator
@@ -35,20 +35,19 @@ type AuthHandler struct {
 }
 
 // NewAuthHandler は本番用に http.Client + 10s timeout の TokenExchanger を組み立てて DI する。
-// invitations は招待受諾フロー（初回ログイン時に invitations から role/companyId を反映）に使う。nil 可。
 // aiChatAccess は /auth/me で aiChatEnabledForTrainees を算出するのに使う。nil 可（その場合は既定 true）。
 func NewAuthHandler(
 	getCurrentUser *usecase.GetCurrentUserUseCase,
+	upsertUser *usecase.UpsertUserFromIDTokenUseCase,
 	users repository.UserRepository,
-	invitations repository.AdminInvitationRepository,
 	cognitoCfg *config.CognitoConfig,
 	passwordAuth passwordAuthenticator,
 	aiChatAccess *usecase.AiChatEnabledForUserUseCase,
 ) *AuthHandler {
 	return &AuthHandler{
 		getCurrentUser: getCurrentUser,
+		upsertUser:     upsertUser,
 		users:          users,
-		invitations:    invitations,
 		cognitoCfg:     cognitoCfg,
 		passwordAuth:   passwordAuth,
 		aiChatAccess:   aiChatAccess,
@@ -369,119 +368,35 @@ func (h *AuthHandler) handleTokenError(c *gin.Context, op string, err error) (in
 	}
 }
 
-// upsertUserFromIDToken は id_token の claim から users 行を新規作成 / role 更新する。
-// 戻り値は (allowed, err)。allowed=false かつ err=nil は「招待なし & Cognito admin でもない」新規
-// ユーザーの **ログイン拒否（403）** を表す。err!=nil は decode 失敗 / DB 失敗等の **内部エラー（500）**で、
-// 招待拒否と切り分けて呼び元がレスポンスを出し分けられるようにする。
-// invitationToken 指定時は email より優先して照合する（同 email 複数 pending での誤一致防止）。
-// 招待ゲートを handler 層に置くのは、Cookie 発行 / 401-403 を返す認可境界が HTTP 層だから。
-func (h *AuthHandler) upsertUserFromIDToken(c *gin.Context, idToken, invitationToken string) (allowed bool, err error) {
-	claims, derr := middleware.DecodeClaims(idToken)
-	if derr != nil {
-		return false, fmt.Errorf("decode id_token: %w", derr)
+// upsertUserFromIDToken はIDトークンから認証情報を取得し、ユーザー更新をusecaseへ委譲する。
+func (h *AuthHandler) upsertUserFromIDToken(
+	c *gin.Context,
+	idToken string,
+	invitationToken string,
+) (allowed bool, err error) {
+	claims, decodeErr := middleware.DecodeClaims(idToken)
+	if decodeErr != nil {
+		return false, fmt.Errorf("decode id_token: %w", decodeErr)
 	}
-	if h.users == nil {
-		return false, errors.New("user repository not configured")
+
+	if h.upsertUser == nil {
+		return false, errors.New("upsert user usecase not configured")
 	}
+
 	sub, _ := claims["sub"].(string)
-	if sub == "" {
-		return false, errors.New("id_token missing sub")
-	}
 	email, _ := claims["email"].(string)
-	// OIDC 経由は id_token に name を含む（Cognito SRP では無いこともあるので空許容）。
-	oidcName, _ := claims["name"].(string)
+	name, _ := claims["name"].(string)
 	groups := middleware.ToStringSliceFromClaim(claims["cognito:groups"])
 	isCognitoAdmin := middleware.IsAdminFromGroups(groups)
 
-	// 招待検索: invitationToken 優先、無ければ email でフォールバック。
-	var inv *domain.AdminInvitation
-	if h.invitations != nil {
-		if invitationToken != "" {
-			inv, _ = h.invitations.FindPendingByToken(c.Request.Context(), invitationToken)
-		}
-		if inv == nil && email != "" {
-			inv, _ = h.invitations.FindPendingByEmail(c.Request.Context(), email)
-		}
-	}
-
-	existing, _ := h.users.FindByCognitoSub(c.Request.Context(), sub)
-	if existing != nil {
-		// Name が email のまま（旧フローの仮値）なら OIDC name で自動補正する。
-		// ユーザーが明示的に書き換えている場合は触らない。
-		if oidcName != "" && existing.Email != "" && existing.Name == existing.Email {
-			if err := h.users.UpdateName(c.Request.Context(), existing.ID, oidcName); err != nil {
-				log.Printf("upsertUserFromIDToken: backfill name failed userID=%d: %v", existing.ID, err)
-			}
-		}
-		// role 更新の制約: super_admin は降格しない / 招待昇格は trainee → company_admin のみ /
-		// Cognito group admin は super_admin に昇格する。
-		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
-			_ = h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleSuperAdmin)
-		}
-		if inv != nil && existing.Role != domain.RoleSuperAdmin {
-			// 昇格は trainee → company_admin だけ反映する。
-			if existing.Role == domain.RoleTrainee && inv.Role == domain.RoleCompanyAdmin {
-				if err := h.users.UpdateRole(c.Request.Context(), existing.ID, domain.RoleCompanyAdmin); err != nil {
-					log.Printf("upsertUserFromIDToken: existing user role upgrade failed userID=%d: %v", existing.ID, err)
-				} else {
-					log.Printf("upsertUserFromIDToken: existing user upgraded trainee→company_admin userID=%d email=%s", existing.ID, email)
-				}
-			}
-			// company 紐付け: 招待の company_id と異なる / 未設定なら更新する。
-			if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
-				if err := h.users.UpdateCompanyID(c.Request.Context(), existing.ID, inv.CompanyID); err != nil {
-					log.Printf("upsertUserFromIDToken: existing user company update failed userID=%d: %v", existing.ID, err)
-				}
-			}
-			// 招待を accepted にマーク（再利用防止 + 監査）。
-			_ = h.invitations.UpdateStatus(c.Request.Context(), inv.ID, domain.InvitationStatusAccepted)
-		}
-		return true, nil
-	}
-
-	// 新規ユーザー: 招待 OR Cognito group "admin" のいずれかが必要。両方無ければ拒否（403、内部エラーではない）。
-	if !isCognitoAdmin && inv == nil {
-		log.Printf("upsertUserFromIDToken: signup blocked — no invitation and not Cognito admin sub=%s email=%s token_provided=%t", sub, email, invitationToken != "")
-		return false, nil
-	}
-
-	role := domain.RoleTrainee
-	var companyID *uint64
-	var acceptedInvID uint64
-	// name の優先順位: 招待 name > OIDC name > email（フォールバック）。
-	name := email
-	if oidcName != "" {
-		name = oidcName
-	}
-
-	if isCognitoAdmin {
-		role = domain.RoleSuperAdmin
-	}
-	if inv != nil {
-		if inv.Role == domain.RoleCompanyAdmin || inv.Role == domain.RoleTrainee {
-			role = inv.Role
-		}
-		cid := inv.CompanyID
-		companyID = &cid
-		acceptedInvID = inv.ID
-		if inv.Name != "" {
-			name = inv.Name
-		}
-	}
-
-	if err := h.users.Create(c.Request.Context(), &domain.User{
-		CognitoSub: sub,
-		Email:      email,
-		Name:       name,
-		Role:       role,
-		CompanyID:  companyID,
-	}); err != nil {
-		log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
-		return false, fmt.Errorf("create user: %w", err)
-	}
-	// 招待を accepted にマーク（履歴・監査）。
-	if h.invitations != nil && acceptedInvID != 0 {
-		_ = h.invitations.UpdateStatus(c.Request.Context(), acceptedInvID, domain.InvitationStatusAccepted)
-	}
-	return true, nil
+	return h.upsertUser.Execute(
+		c.Request.Context(),
+		usecase.UpsertUserFromIDTokenInput{
+			CognitoSub:      sub,
+			Email:           email,
+			Name:            name,
+			IsCognitoAdmin:  isCognitoAdmin,
+			InvitationToken: invitationToken,
+		},
+	)
 }

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -130,7 +130,10 @@ func makeIDToken(t *testing.T, claims map[string]any) string {
 }
 
 // newTestAuthHandler はテスト用 AuthHandler を組み立てる。tokens は使わない。
-func newTestAuthHandler(users *fakeUserRepo, invitations *fakeInvitationRepo) *AuthHandler {
+func newTestAuthHandler(
+	users *fakeUserRepo,
+	invitations *fakeInvitationRepo,
+) *AuthHandler {
 	return &AuthHandler{
 		users:      users,
 		upsertUser: usecase.NewUpsertUserFromIDTokenUseCase(users, invitations),
@@ -272,9 +275,6 @@ func Test_IDトークンからユーザー登録_既存運営管理者は招待�
 	}
 }
 
-// dummy: 使用していないが strings import のリンタを満たすために残す（今後 assert で使う）
-var _ = strings.Contains
-
 // 新規ユーザ作成時に id_token の `name` claim が Name に使われる（email にフォールバックしない）。
 func Test_IDトークンからユーザー登録_新規はOIDC名をメールより優先(t *testing.T) {
 	users := &fakeUserRepo{}
@@ -391,5 +391,25 @@ func Test_IDトークンからユーザー登録_表示名カスタム済みは�
 	}
 	if users.updateNameVal != "" {
 		t.Errorf("expected no backfill, but UpdateName called with %q", users.updateNameVal)
+	}
+}
+
+func Test_IDトークンからユーザー登録_デコード失敗を明示する(t *testing.T) {
+	h := &AuthHandler{}
+
+	allowed, err := h.upsertUserFromIDToken(
+		newGinCtx(),
+		"invalid-id-token",
+		"",
+	)
+
+	if allowed {
+		t.Fatal("不正なIDトークンを許可してはいけない")
+	}
+	if err == nil {
+		t.Fatal("デコードエラーが返されていない")
+	}
+	if !strings.Contains(err.Error(), "failed to decode id_token") {
+		t.Fatalf("error = %q", err.Error())
 	}
 }

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
 )
 
 // fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
@@ -130,7 +131,10 @@ func makeIDToken(t *testing.T, claims map[string]any) string {
 
 // newTestAuthHandler はテスト用 AuthHandler を組み立てる。tokens は使わない。
 func newTestAuthHandler(users *fakeUserRepo, invitations *fakeInvitationRepo) *AuthHandler {
-	return &AuthHandler{users: users, invitations: invitations}
+	return &AuthHandler{
+		users:      users,
+		upsertUser: usecase.NewUpsertUserFromIDTokenUseCase(users, invitations),
+	}
 }
 
 func init() {
@@ -142,86 +146,6 @@ func newGinCtx() *gin.Context {
 	c, _ := gin.CreateTestContext(nil)
 	c.Request = mustNewRequest()
 	return c
-}
-
-func Test_IDトークンからユーザー登録_招待もadminもない新規を拒否(t *testing.T) {
-	users := &fakeUserRepo{}
-	invs := &fakeInvitationRepo{}
-	h := newTestAuthHandler(users, invs)
-
-	idToken := makeIDToken(t, map[string]any{
-		"sub":   "new-google-user",
-		"email": "stranger@example.com",
-		// cognito:groups なし、招待もなし → 拒否されるべき
-	})
-
-	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
-	if allowed {
-		t.Fatalf("expected allowed=false for non-invited non-admin signup")
-	}
-	if users.created != nil {
-		t.Fatalf("user must NOT be created when no invitation/admin")
-	}
-}
-
-func Test_IDトークンからユーザー登録_Cognito_adminは招待なしでも許可(t *testing.T) {
-	users := &fakeUserRepo{}
-	invs := &fakeInvitationRepo{}
-	h := newTestAuthHandler(users, invs)
-
-	idToken := makeIDToken(t, map[string]any{
-		"sub":            "first-super-admin",
-		"email":          "ops@example.com",
-		"cognito:groups": []string{"admin"},
-	})
-
-	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
-	if !allowed {
-		t.Fatalf("Cognito group admin must be allowed even without invitation")
-	}
-	if users.created == nil || users.created.Role != domain.RoleSuperAdmin {
-		t.Fatalf("expected super_admin to be created, got %+v", users.created)
-	}
-}
-
-func Test_IDトークンからユーザー登録_招待済みはroleと会社を適用(t *testing.T) {
-	users := &fakeUserRepo{}
-	cid := uint64(42)
-	invs := &fakeInvitationRepo{
-		pendingByEmail: map[string]*domain.AdminInvitation{
-			"trainee@example.com": {
-				ID: 99, CompanyID: cid, Email: "trainee@example.com",
-				Role: domain.RoleTrainee, Name: "佐藤", Status: domain.InvitationStatusPending,
-			},
-		},
-	}
-	h := newTestAuthHandler(users, invs)
-
-	idToken := makeIDToken(t, map[string]any{
-		"sub":   "google-trainee-1",
-		"email": "trainee@example.com",
-	})
-
-	allowed := upsertAllowed(h, newGinCtx(), idToken, "")
-	if !allowed {
-		t.Fatalf("invited user must be allowed")
-	}
-	if users.created == nil {
-		t.Fatalf("expected user to be created")
-	}
-	if users.created.Role != domain.RoleTrainee {
-		t.Errorf("expected role=trainee, got %q", users.created.Role)
-	}
-	if users.created.CompanyID == nil || *users.created.CompanyID != cid {
-		t.Errorf("expected company_id=%d, got %+v", cid, users.created.CompanyID)
-	}
-	if users.created.Name != "佐藤" {
-		t.Errorf("expected displayName=佐藤, got %q", users.created.Name)
-	}
-	// 招待は accepted にマークされる
-	if invs.updatedID != 99 || invs.updatedStatus != domain.InvitationStatusAccepted {
-		t.Errorf("invitation must be marked accepted, got id=%d status=%q", invs.updatedID, invs.updatedStatus)
-	}
 }
 
 func Test_IDトークンからユーザー登録_既存ユーザーは常に許可(t *testing.T) {
@@ -325,33 +249,6 @@ func Test_IDトークンからユーザー登録_無効なtokenはメールに�
 	}
 	if users.created == nil || users.created.Role != domain.RoleTrainee {
 		t.Errorf("expected trainee from email-based invitation, got %+v", users.created)
-	}
-}
-
-// 既存の trainee ユーザーが company_admin 招待を受けた場合、role を昇格 + company を反映する。
-// 過去に signup した既存ユーザーが後から CompanyAdmin として招待されたケースの救済。
-func Test_IDトークンからユーザー登録_既存traineeは会社管理者招待で昇格(t *testing.T) {
-	existing := &domain.User{ID: 5, CognitoSub: "existing-trainee", Email: "u@example.com", Role: domain.RoleTrainee}
-	users := &fakeUserRepo{existingBySub: map[string]*domain.User{"existing-trainee": existing}}
-	invs := &fakeInvitationRepo{
-		pendingByToken: map[string]*domain.AdminInvitation{
-			"magic-xyz": {ID: 9, CompanyID: 42, Email: "u@example.com", Role: domain.RoleCompanyAdmin},
-		},
-	}
-	h := newTestAuthHandler(users, invs)
-	idToken := makeIDToken(t, map[string]any{"sub": "existing-trainee", "email": "u@example.com"})
-
-	if !upsertAllowed(h, newGinCtx(), idToken, "magic-xyz") {
-		t.Fatal("must be allowed for existing user with token")
-	}
-	if users.updateRoleVal != domain.RoleCompanyAdmin || users.updateRoleID != 5 {
-		t.Errorf("role must be upgraded to company_admin, got id=%d role=%q", users.updateRoleID, users.updateRoleVal)
-	}
-	if users.updateCompanyID != 5 || users.updateCompanyVal != 42 {
-		t.Errorf("company_id must be updated to 42, got id=%d company=%d", users.updateCompanyID, users.updateCompanyVal)
-	}
-	if invs.updatedID != 9 || invs.updatedStatus != domain.InvitationStatusAccepted {
-		t.Errorf("invitation must be marked accepted, got id=%d status=%q", invs.updatedID, invs.updatedStatus)
 	}
 }
 

--- a/backend/internal/handler/password_login_test.go
+++ b/backend/internal/handler/password_login_test.go
@@ -41,7 +41,8 @@ func Test_ログイン_成功_既存ユーザー(t *testing.T) {
 	}}
 	idTok := makeIDToken(t, map[string]any{"sub": "sub-1", "email": "u@example.com"})
 	pw := &fakePasswordAuth{token: &cognito.Token{AccessToken: "AT", IDToken: idTok, RefreshToken: "RT", ExpiresIn: 3600}}
-	h := &AuthHandler{users: users, invitations: &fakeInvitationRepo{}, passwordAuth: pw}
+	h := newTestAuthHandler(users, &fakeInvitationRepo{})
+	h.passwordAuth = pw
 
 	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
 	h.Login(c)
@@ -58,10 +59,12 @@ func Test_ログイン_成功_既存ユーザー(t *testing.T) {
 }
 
 func Test_ログイン_認証情報不正_401(t *testing.T) {
-	h := &AuthHandler{
-		users:        &fakeUserRepo{},
-		invitations:  &fakeInvitationRepo{},
-		passwordAuth: &fakePasswordAuth{err: cognito.ErrInvalidCredentials},
+	h := newTestAuthHandler(
+		&fakeUserRepo{},
+		&fakeInvitationRepo{},
+	)
+	h.passwordAuth = &fakePasswordAuth{
+		err: cognito.ErrInvalidCredentials,
 	}
 	c, rec := postLoginCtx(`{"email":"u@example.com","password":"wrong"}`)
 	h.Login(c)
@@ -73,10 +76,16 @@ func Test_ログイン_認証情報不正_401(t *testing.T) {
 
 func Test_ログイン_招待なし新規ユーザー_403(t *testing.T) {
 	idTok := makeIDToken(t, map[string]any{"sub": "new-sub", "email": "new@example.com"})
-	h := &AuthHandler{
-		users:        &fakeUserRepo{},       // 既存ユーザーなし
-		invitations:  &fakeInvitationRepo{}, // pending 招待なし
-		passwordAuth: &fakePasswordAuth{token: &cognito.Token{AccessToken: "AT", IDToken: idTok, RefreshToken: "RT"}},
+	h := newTestAuthHandler(
+		&fakeUserRepo{},
+		&fakeInvitationRepo{},
+	)
+	h.passwordAuth = &fakePasswordAuth{
+		token: &cognito.Token{
+			AccessToken:  "AT",
+			IDToken:      idTok,
+			RefreshToken: "RT",
+		},
 	}
 	c, rec := postLoginCtx(`{"email":"new@example.com","password":"secret123"}`)
 	h.Login(c)
@@ -113,10 +122,13 @@ func Test_ログイン_upsert内部エラー_500(t *testing.T) {
 	inv := &fakeInvitationRepo{pendingByEmail: map[string]*domain.AdminInvitation{
 		"u@example.com": {ID: 1, Role: domain.RoleTrainee, CompanyID: 1},
 	}}
-	h := &AuthHandler{
-		users:        users,
-		invitations:  inv,
-		passwordAuth: &fakePasswordAuth{token: &cognito.Token{AccessToken: "AT", IDToken: idTok, RefreshToken: "RT"}},
+	h := newTestAuthHandler(users, inv)
+	h.passwordAuth = &fakePasswordAuth{
+		token: &cognito.Token{
+			AccessToken:  "AT",
+			IDToken:      idTok,
+			RefreshToken: "RT",
+		},
 	}
 	c, rec := postLoginCtx(`{"email":"u@example.com","password":"secret123"}`)
 	h.Login(c)

--- a/backend/internal/handler/password_login_test.go
+++ b/backend/internal/handler/password_login_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/cognito"
 )
 
@@ -33,6 +35,22 @@ func postLoginCtx(body string) (*gin.Context, *httptest.ResponseRecorder) {
 	req.Header.Set("Content-Type", "application/json")
 	c.Request = req
 	return c, rec
+}
+
+func assertAuthCookiesUnchanged(
+	t *testing.T,
+	rec *httptest.ResponseRecorder,
+) {
+	t.Helper()
+	for _, cookie := range rec.Result().Cookies() {
+		if cookie.Name == middleware.CookieAccessToken ||
+			cookie.Name == middleware.CookieRefreshToken {
+			t.Fatalf(
+				"authentication cookie %q must not be changed on invitation denial",
+				cookie.Name,
+			)
+		}
+	}
 }
 
 func Test_ログイン_成功_既存ユーザー(t *testing.T) {
@@ -87,12 +105,94 @@ func Test_ログイン_招待なし新規ユーザー_403(t *testing.T) {
 			RefreshToken: "RT",
 		},
 	}
-	c, rec := postLoginCtx(`{"email":"new@example.com","password":"secret123"}`)
-	h.Login(c)
+	router := gin.New()
+	router.POST("/api/v2/auth/cognito/login", h.Login)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v2/auth/cognito/login",
+		strings.NewReader(`{"email":"new@example.com","password":"secret123"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{
+		Name:  middleware.CookieAccessToken,
+		Value: "existing-access-token",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  middleware.CookieRefreshToken,
+		Value: "existing-refresh-token",
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("want 403, got %d body=%s", rec.Code, rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), `"error":"invitation_required"`) {
+		t.Fatalf("body = %s, want invitation_required", rec.Body.String())
+	}
+	assertAuthCookiesUnchanged(t, rec)
+}
+
+func Test_コールバック_招待なし新規ユーザー_403(t *testing.T) {
+	idToken := makeIDToken(t, map[string]any{
+		"sub":   "new-callback-sub",
+		"email": "new-callback@example.com",
+	})
+	tokenServer := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(cognito.Token{
+				AccessToken:  "new-access-token",
+				IDToken:      idToken,
+				RefreshToken: "new-refresh-token",
+				ExpiresIn:    3600,
+				TokenType:    "Bearer",
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		},
+	))
+	defer tokenServer.Close()
+
+	h := newTestAuthHandler(
+		&fakeUserRepo{},
+		&fakeInvitationRepo{},
+	)
+	h.tokens = cognito.NewTokenExchangerWithClient(
+		cognito.Config{
+			ClientID:    "test-client",
+			RedirectURI: "https://example.com/callback",
+			TokenURI:    tokenServer.URL,
+		},
+		tokenServer.Client(),
+	)
+
+	router := gin.New()
+	router.POST("/api/v2/auth/login", h.Callback)
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v2/auth/login",
+		strings.NewReader(`{"code":"authorization-code"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{
+		Name:  middleware.CookieAccessToken,
+		Value: "existing-access-token",
+	})
+	req.AddCookie(&http.Cookie{
+		Name:  middleware.CookieRefreshToken,
+		Value: "existing-refresh-token",
+	})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"error":"invitation_required"`) {
+		t.Fatalf("body = %s, want invitation_required", rec.Body.String())
+	}
+	assertAuthCookiesUnchanged(t, rec)
 }
 
 func Test_ログイン_パスワード欠落_400(t *testing.T) {

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -18,6 +18,7 @@ func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler 
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
 	invitations := persistence.NewAdminInvitationRepository(deps.db)
 	aiAccess := usecase.NewAiChatEnabledForUserUseCase(persistence.NewCompanyRepository(deps.db))
+	upsertUser := usecase.NewUpsertUserFromIDTokenUseCase(deps.userRepo, invitations)
 
 	// USER_PASSWORD_AUTH 用の authenticator。AWS 認証情報の解決に失敗しても起動は止めず、
 	// nil のまま渡して /auth/cognito/login だけ 500 にする（Hosted UI ログインには影響させない）。
@@ -28,7 +29,7 @@ func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler 
 		pwAuth = pa
 	}
 
-	authHandler := NewAuthHandler(getCurrentUser, deps.userRepo, invitations, &deps.cfg.Cognito, pwAuth, aiAccess)
+	authHandler := NewAuthHandler(getCurrentUser, upsertUser, deps.userRepo, &deps.cfg.Cognito, pwAuth, aiAccess)
 
 	g.POST("/auth/logout", authHandler.Logout)
 	// login（認可コード→token 交換）は認証不要のため、総当たり緩和に per-IP 制限を掛ける。

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase.go
@@ -36,6 +36,92 @@ func NewUpsertUserFromIDTokenUseCase(
 	}
 }
 
+func (u *UpsertUserFromIDTokenUseCase) shouldBackfillName(
+	oidcName string,
+	existing *domain.User,
+) bool {
+	return oidcName != "" &&
+		existing != nil &&
+		existing.Email != "" &&
+		existing.Name == existing.Email
+}
+
+func (u *UpsertUserFromIDTokenUseCase) shouldUpdateRoleFromInvitation(
+	isCognitoAdmin bool,
+	existing *domain.User,
+	inv *domain.AdminInvitation,
+) bool {
+	return !isCognitoAdmin &&
+		existing != nil &&
+		inv != nil &&
+		existing.Role == domain.RoleTrainee &&
+		inv.Role == domain.RoleCompanyAdmin
+}
+
+func (u *UpsertUserFromIDTokenUseCase) updateExistingUser(
+	ctx context.Context,
+	existing *domain.User,
+	inv *domain.AdminInvitation,
+	oidcName string,
+	isCognitoAdmin bool,
+) error {
+	if u.shouldBackfillName(oidcName, existing) {
+		if err := u.users.UpdateName(ctx, existing.ID, oidcName); err != nil {
+			return fmt.Errorf("update existing user name: %w", err)
+		}
+	}
+
+	if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
+		if err := u.users.UpdateRole(
+			ctx,
+			existing.ID,
+			domain.RoleSuperAdmin,
+		); err != nil {
+			return fmt.Errorf("update existing user admin role: %w", err)
+		}
+	}
+
+	if inv == nil || existing.Role == domain.RoleSuperAdmin {
+		return nil
+	}
+
+	if u.shouldUpdateRoleFromInvitation(
+		isCognitoAdmin,
+		existing,
+		inv,
+	) {
+		if err := u.users.UpdateRole(
+			ctx,
+			existing.ID,
+			domain.RoleCompanyAdmin,
+		); err != nil {
+			return fmt.Errorf("update existing user invitation role: %w", err)
+		}
+	}
+
+	if inv.CompanyID != 0 &&
+		(existing.CompanyID == nil ||
+			*existing.CompanyID != inv.CompanyID) {
+		if err := u.users.UpdateCompanyID(
+			ctx,
+			existing.ID,
+			inv.CompanyID,
+		); err != nil {
+			return fmt.Errorf("update existing user company: %w", err)
+		}
+	}
+
+	if err := u.invitations.UpdateStatus(
+		ctx,
+		inv.ID,
+		domain.InvitationStatusAccepted,
+	); err != nil {
+		return fmt.Errorf("accept invitation: %w", err)
+	}
+
+	return nil
+}
+
 // Execute はユーザー情報と招待情報を基にユーザーを作成・更新する。
 func (u *UpsertUserFromIDTokenUseCase) Execute(
 	ctx context.Context,
@@ -89,43 +175,14 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 	}
 
 	if existing != nil {
-		if oidcName != "" && existing.Email != "" && existing.Name == existing.Email {
-			if err := u.users.UpdateName(ctx, existing.ID, oidcName); err != nil {
-				log.Printf("upsertUserFromIDToken: backfill name failed userID=%d: %v", existing.ID, err)
-			}
-		}
-
-		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
-			_ = u.users.UpdateRole(ctx, existing.ID, domain.RoleSuperAdmin)
-		}
-		if inv != nil && existing.Role != domain.RoleSuperAdmin {
-			if !isCognitoAdmin &&
-				existing.Role == domain.RoleTrainee &&
-				inv.Role == domain.RoleCompanyAdmin {
-				if err := u.users.UpdateRole(
-					ctx,
-					existing.ID,
-					domain.RoleCompanyAdmin,
-				); err != nil {
-					log.Printf(
-						"upsertUserFromIDToken: existing user role update failed userID=%d: %v",
-						existing.ID,
-						err,
-					)
-				} else {
-					log.Printf(
-						"upsertUserFromIDToken: existing user updated trainee→company_admin userID=%d email=%s",
-						existing.ID,
-						email,
-					)
-				}
-			}
-			if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
-				if err := u.users.UpdateCompanyID(ctx, existing.ID, inv.CompanyID); err != nil {
-					log.Printf("upsertUserFromIDToken: existing user company update failed userID=%d: %v", existing.ID, err)
-				}
-			}
-			_ = u.invitations.UpdateStatus(ctx, inv.ID, domain.InvitationStatusAccepted)
+		if err := u.updateExistingUser(
+			ctx,
+			existing,
+			inv,
+			oidcName,
+			isCognitoAdmin,
+		); err != nil {
+			return false, fmt.Errorf("update existing user: %w", err)
 		}
 		return true, nil
 	}
@@ -142,7 +199,6 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 
 	role := domain.RoleTrainee
 	var companyID *uint64
-	var acceptedInvID uint64
 
 	name := email
 	if oidcName != "" {
@@ -159,26 +215,36 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 			role = inv.Role
 		}
 
-		cid := inv.CompanyID
-		companyID = &cid
-		acceptedInvID = inv.ID
+		if inv.CompanyID != 0 {
+			cid := inv.CompanyID
+			companyID = &cid
+		}
 		if inv.Name != "" {
 			name = inv.Name
 		}
 	}
 
-	if err := u.users.Create(ctx, &domain.User{
+	user := &domain.User{
 		CognitoSub: sub,
 		Email:      email,
 		Name:       name,
 		Role:       role,
 		CompanyID:  companyID,
-	}); err != nil {
-		log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
+	}
+
+	if err := u.users.Create(ctx, user); err != nil {
 		return false, fmt.Errorf("create user: %w", err)
 	}
-	if u.invitations != nil && acceptedInvID != 0 {
-		_ = u.invitations.UpdateStatus(ctx, acceptedInvID, domain.InvitationStatusAccepted)
+
+	if inv != nil {
+		if err := u.invitations.UpdateStatus(
+			ctx,
+			inv.ID,
+			domain.InvitationStatusAccepted,
+		); err != nil {
+			return false, fmt.Errorf("accept invitation: %w", err)
+		}
 	}
+
 	return true, nil
 }

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase.go
@@ -1,0 +1,145 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+)
+
+// UpsertUserFromIDTokenInput はIDトークンから取得したユーザー情報を表す。
+type UpsertUserFromIDTokenInput struct {
+	CognitoSub      string
+	Email           string
+	Name            string
+	IsCognitoAdmin  bool
+	InvitationToken string
+}
+
+// UpsertUserFromIDTokenUseCase は認証済みユーザーの作成・更新を行う。
+type UpsertUserFromIDTokenUseCase struct {
+	users       repository.UserRepository
+	invitations repository.AdminInvitationRepository
+}
+
+// NewUpsertUserFromIDTokenUseCase はUpsertUserFromIDTokenUseCaseを生成する。
+func NewUpsertUserFromIDTokenUseCase(
+	users repository.UserRepository,
+	invitations repository.AdminInvitationRepository,
+) *UpsertUserFromIDTokenUseCase {
+	return &UpsertUserFromIDTokenUseCase{
+		users:       users,
+		invitations: invitations,
+	}
+}
+
+// Execute はユーザー情報と招待情報を基にユーザーを作成・更新する。
+func (u *UpsertUserFromIDTokenUseCase) Execute(
+	ctx context.Context,
+	in UpsertUserFromIDTokenInput,
+) (allowed bool, err error) {
+	if u.users == nil {
+		return false, errors.New("user repository not configured")
+	}
+
+	sub := in.CognitoSub
+	if sub == "" {
+		return false, errors.New("id_token missing sub")
+	}
+
+	email := in.Email
+	oidcName := in.Name
+	isCognitoAdmin := in.IsCognitoAdmin
+	invitationToken := in.InvitationToken
+
+	var inv *domain.AdminInvitation
+	if u.invitations != nil {
+		if invitationToken != "" {
+			inv, _ = u.invitations.FindPendingByToken(ctx, invitationToken)
+		}
+		if inv == nil && email != "" {
+			inv, _ = u.invitations.FindPendingByEmail(ctx, email)
+		}
+	}
+
+	existing, _ := u.users.FindByCognitoSub(ctx, sub)
+	if existing != nil {
+		if oidcName != "" && existing.Email != "" && existing.Name == existing.Email {
+			if err := u.users.UpdateName(ctx, existing.ID, oidcName); err != nil {
+				log.Printf("upsertUserFromIDToken: backfill name failed userID=%d: %v", existing.ID, err)
+			}
+		}
+
+		if isCognitoAdmin && existing.Role != domain.RoleSuperAdmin {
+			_ = u.users.UpdateRole(ctx, existing.ID, domain.RoleSuperAdmin)
+		}
+		if inv != nil && existing.Role != domain.RoleSuperAdmin {
+			if existing.Role == domain.RoleTrainee && inv.Role == domain.RoleCompanyAdmin {
+				if err := u.users.UpdateRole(ctx, existing.ID, domain.RoleCompanyAdmin); err != nil {
+					log.Printf("upsertUserFromIDToken: existing user role upgrade failed userID=%d: %v", existing.ID, err)
+				} else {
+					log.Printf("upsertUserFromIDToken: existing user upgraded trainee→company_admin userID=%d email=%s", existing.ID, email)
+				}
+			}
+			if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
+				if err := u.users.UpdateCompanyID(ctx, existing.ID, inv.CompanyID); err != nil {
+					log.Printf("upsertUserFromIDToken: existing user company update failed userID=%d: %v", existing.ID, err)
+				}
+			}
+			_ = u.invitations.UpdateStatus(ctx, inv.ID, domain.InvitationStatusAccepted)
+		}
+		return true, nil
+	}
+
+	if !isCognitoAdmin && inv == nil {
+		log.Printf(
+			"upsertUserFromIDToken: signup blocked - no invitation and not Cognito admin sub=%s email=%s token_provided=%t",
+			sub,
+			email,
+			invitationToken != "",
+		)
+		return false, nil
+	}
+
+	role := domain.RoleTrainee
+	var companyID *uint64
+	var acceptedInvID uint64
+
+	name := email
+	if oidcName != "" {
+		name = oidcName
+	}
+
+	if isCognitoAdmin {
+		role = domain.RoleSuperAdmin
+	}
+	if inv != nil {
+		if inv.Role == domain.RoleCompanyAdmin || inv.Role == domain.RoleTrainee {
+			role = inv.Role
+		}
+		cid := inv.CompanyID
+		companyID = &cid
+		acceptedInvID = inv.ID
+		if inv.Name != "" {
+			name = inv.Name
+		}
+	}
+
+	if err := u.users.Create(ctx, &domain.User{
+		CognitoSub: sub,
+		Email:      email,
+		Name:       name,
+		Role:       role,
+		CompanyID:  companyID,
+	}); err != nil {
+		log.Printf("upsertUserFromIDToken: create user failed sub=%s email=%s err=%v", sub, email, err)
+		return false, fmt.Errorf("create user: %w", err)
+	}
+	if u.invitations != nil && acceptedInvID != 0 {
+		_ = u.invitations.UpdateStatus(ctx, acceptedInvID, domain.InvitationStatusAccepted)
+	}
+	return true, nil
+}

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase.go
@@ -65,6 +65,8 @@ func (u *UpsertUserFromIDTokenUseCase) updateExistingUser(
 	oidcName string,
 	isCognitoAdmin bool,
 ) error {
+	role := existing.Role
+
 	if u.shouldBackfillName(oidcName, existing) {
 		if err := u.users.UpdateName(ctx, existing.ID, oidcName); err != nil {
 			return fmt.Errorf("update existing user name: %w", err)
@@ -79,9 +81,10 @@ func (u *UpsertUserFromIDTokenUseCase) updateExistingUser(
 		); err != nil {
 			return fmt.Errorf("update existing user admin role: %w", err)
 		}
+		role = domain.RoleSuperAdmin
 	}
 
-	if inv == nil || existing.Role == domain.RoleSuperAdmin {
+	if inv == nil || role == domain.RoleSuperAdmin {
 		return nil
 	}
 

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase.go
@@ -58,14 +58,36 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 	var inv *domain.AdminInvitation
 	if u.invitations != nil {
 		if invitationToken != "" {
-			inv, _ = u.invitations.FindPendingByToken(ctx, invitationToken)
+			var findErr error
+			inv, findErr = u.invitations.FindPendingByToken(ctx, invitationToken)
+			if findErr != nil {
+				return false, fmt.Errorf(
+					"find pending invitation by token: %w",
+					findErr,
+				)
+			}
 		}
+
 		if inv == nil && email != "" {
-			inv, _ = u.invitations.FindPendingByEmail(ctx, email)
+			var findErr error
+			inv, findErr = u.invitations.FindPendingByEmail(ctx, email)
+			if findErr != nil {
+				return false, fmt.Errorf(
+					"find pending invitation by email: %w",
+					findErr,
+				)
+			}
 		}
 	}
 
-	existing, _ := u.users.FindByCognitoSub(ctx, sub)
+	existing, findErr := u.users.FindByCognitoSub(ctx, sub)
+	if findErr != nil {
+		return false, fmt.Errorf(
+			"find user by cognito sub: %w",
+			findErr,
+		)
+	}
+
 	if existing != nil {
 		if oidcName != "" && existing.Email != "" && existing.Name == existing.Email {
 			if err := u.users.UpdateName(ctx, existing.ID, oidcName); err != nil {
@@ -77,11 +99,25 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 			_ = u.users.UpdateRole(ctx, existing.ID, domain.RoleSuperAdmin)
 		}
 		if inv != nil && existing.Role != domain.RoleSuperAdmin {
-			if existing.Role == domain.RoleTrainee && inv.Role == domain.RoleCompanyAdmin {
-				if err := u.users.UpdateRole(ctx, existing.ID, domain.RoleCompanyAdmin); err != nil {
-					log.Printf("upsertUserFromIDToken: existing user role upgrade failed userID=%d: %v", existing.ID, err)
+			if !isCognitoAdmin &&
+				existing.Role == domain.RoleTrainee &&
+				inv.Role == domain.RoleCompanyAdmin {
+				if err := u.users.UpdateRole(
+					ctx,
+					existing.ID,
+					domain.RoleCompanyAdmin,
+				); err != nil {
+					log.Printf(
+						"upsertUserFromIDToken: existing user role update failed userID=%d: %v",
+						existing.ID,
+						err,
+					)
 				} else {
-					log.Printf("upsertUserFromIDToken: existing user upgraded trainee→company_admin userID=%d email=%s", existing.ID, email)
+					log.Printf(
+						"upsertUserFromIDToken: existing user updated trainee→company_admin userID=%d email=%s",
+						existing.ID,
+						email,
+					)
 				}
 			}
 			if inv.CompanyID != 0 && (existing.CompanyID == nil || *existing.CompanyID != inv.CompanyID) {
@@ -117,9 +153,12 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 		role = domain.RoleSuperAdmin
 	}
 	if inv != nil {
-		if inv.Role == domain.RoleCompanyAdmin || inv.Role == domain.RoleTrainee {
+		if !isCognitoAdmin &&
+			(inv.Role == domain.RoleCompanyAdmin ||
+				inv.Role == domain.RoleTrainee) {
 			role = inv.Role
 		}
+
 		cid := inv.CompanyID
 		companyID = &cid
 		acceptedInvID = inv.ID

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -2,6 +2,8 @@ package usecase
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
@@ -18,9 +20,14 @@ type upsertUserRepoSpy struct {
 }
 
 type upsertInvitationRepoSpy struct {
-	pending       *domain.AdminInvitation
-	updatedID     uint64
-	updatedStatus string
+	pending         *domain.AdminInvitation
+	pendingByToken  *domain.AdminInvitation
+	tokenFindErr    error
+	emailFindErr    error
+	tokenFindCalled bool
+	emailFindCalled bool
+	updatedID       uint64
+	updatedStatus   string
 }
 
 func (s *upsertInvitationRepoSpy) ListAll(
@@ -40,12 +47,21 @@ func (s *upsertInvitationRepoSpy) FindPendingByEmail(
 	_ context.Context,
 	_ string,
 ) (*domain.AdminInvitation, error) {
-	return s.pending, nil
+	s.emailFindCalled = true
+	return s.pending, s.emailFindErr
 }
 
 func (s *upsertInvitationRepoSpy) FindPendingByToken(
 	_ context.Context,
 	_ string,
+) (*domain.AdminInvitation, error) {
+	s.tokenFindCalled = true
+	return s.pendingByToken, s.tokenFindErr
+}
+
+func (s *upsertInvitationRepoSpy) FindByID(
+	_ context.Context,
+	_ uint64,
 ) (*domain.AdminInvitation, error) {
 	return nil, nil
 }
@@ -257,5 +273,147 @@ func Test_UpsertUserFromIDToken_CognitoAdminは招待なしでもSuperAdminと�
 	}
 	if users.created.Role != domain.RoleSuperAdmin {
 		t.Fatalf("role = %q, want %q", users.created.Role, domain.RoleSuperAdmin)
+	}
+}
+
+func Test_UpsertUserFromIDToken_検索エラーを返す(t *testing.T) {
+	tokenFindErr := errors.New("token lookup failed")
+	emailFindErr := errors.New("email lookup failed")
+	userFindErr := errors.New("user lookup failed")
+
+	tests := []struct {
+		name        string
+		users       *stubUserRepo
+		invitations *upsertInvitationRepoSpy
+		input       UpsertUserFromIDTokenInput
+		wantErr     error
+		wantMessage string
+	}{
+		{
+			name:  "トークンによる招待検索が失敗する",
+			users: &stubUserRepo{},
+			invitations: &upsertInvitationRepoSpy{
+				tokenFindErr: tokenFindErr,
+			},
+			input: UpsertUserFromIDTokenInput{
+				CognitoSub:      "token-error-sub",
+				InvitationToken: "invitation-token",
+			},
+			wantErr:     tokenFindErr,
+			wantMessage: "find pending invitation by token",
+		},
+		{
+			name:  "メールによる招待検索が失敗する",
+			users: &stubUserRepo{},
+			invitations: &upsertInvitationRepoSpy{
+				emailFindErr: emailFindErr,
+			},
+			input: UpsertUserFromIDTokenInput{
+				CognitoSub: "email-error-sub",
+				Email:      "user@example.com",
+			},
+			wantErr:     emailFindErr,
+			wantMessage: "find pending invitation by email",
+		},
+		{
+			name: "ユーザー検索が失敗する",
+			users: &stubUserRepo{
+				err: userFindErr,
+			},
+			input: UpsertUserFromIDTokenInput{
+				CognitoSub: "user-error-sub",
+			},
+			wantErr:     userFindErr,
+			wantMessage: "find user by cognito sub",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			uc := NewUpsertUserFromIDTokenUseCase(
+				tc.users,
+				tc.invitations,
+			)
+
+			allowed, err := uc.Execute(
+				context.Background(),
+				tc.input,
+			)
+
+			if allowed {
+				t.Fatal("検索エラー時に許可してはいけない")
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want wrapped %v", err, tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantMessage) {
+				t.Fatalf(
+					"error = %q, want message containing %q",
+					err.Error(),
+					tc.wantMessage,
+				)
+			}
+		})
+	}
+}
+
+func Test_UpsertUserFromIDToken_招待トークンをメールより優先する(t *testing.T) {
+	users := &upsertUserRepoSpy{}
+	invitations := &upsertInvitationRepoSpy{
+		pendingByToken: &domain.AdminInvitation{
+			ID:        10,
+			Role:      domain.RoleTrainee,
+			CompanyID: 100,
+			Name:      "Token User",
+			Status:    domain.InvitationStatusPending,
+		},
+		pending: &domain.AdminInvitation{
+			ID:        20,
+			Role:      domain.RoleCompanyAdmin,
+			CompanyID: 200,
+			Name:      "Email User",
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := NewUpsertUserFromIDTokenUseCase(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub:      "invited-sub",
+			Email:           "invited@example.com",
+			InvitationToken: "invitation-token",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("有効なトークン招待があるユーザーは許可されるべき")
+	}
+	if !invitations.tokenFindCalled {
+		t.Fatal("トークン検索が呼ばれていない")
+	}
+	if invitations.emailFindCalled {
+		t.Fatal("トークンで招待が見つかった場合はメール検索を呼んではいけない")
+	}
+	if users.created == nil {
+		t.Fatal("ユーザーが作成されていない")
+	}
+	if users.created.Role != domain.RoleTrainee {
+		t.Fatalf(
+			"role = %q, want %q",
+			users.created.Role,
+			domain.RoleTrainee,
+		)
+	}
+	if users.created.CompanyID == nil || *users.created.CompanyID != 100 {
+		t.Fatalf("companyID = %v, want 100", users.created.CompanyID)
+	}
+	if users.created.Name != "Token User" {
+		t.Fatalf("name = %q, want %q", users.created.Name, "Token User")
+	}
+	if invitations.updatedID != 10 {
+		t.Fatalf("accepted invitation ID = %d, want 10", invitations.updatedID)
 	}
 }

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -542,7 +542,6 @@ func Test_UpsertUserFromIDToken_Cognito管理者は招待Roleで降格しない(
 					IsCognitoAdmin: true,
 				},
 			)
-
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -598,7 +597,6 @@ func Test_UpsertUserFromIDToken_未対応の招待Roleは適用しない(
 			Email:      "user@example.com",
 		},
 	)
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -645,7 +643,6 @@ func Test_UpsertUserFromIDToken_招待のCompanyIDが0なら未所属にする(
 			Email:      "no-company@example.com",
 		},
 	)
-
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -7,16 +7,33 @@ import (
 	"testing"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 type upsertUserRepoSpy struct {
 	stubUserRepo
 	created *domain.User
 
+	findByCognitoSubCalls int
+	createCalls           int
+	createErr             error
+	roleUpdateCalls       int
+	roleUpdateErr         error
+	companyUpdateCalls    int
+	companyUpdateErr      error
+
 	roleUpdateUserID    uint64
 	roleUpdateValue     string
 	companyUpdateUserID uint64
 	companyUpdateValue  uint64
+}
+
+func (s *upsertUserRepoSpy) FindByCognitoSub(
+	ctx context.Context,
+	sub string,
+) (*domain.User, error) {
+	s.findByCognitoSubCalls++
+	return s.stubUserRepo.FindByCognitoSub(ctx, sub)
 }
 
 type upsertInvitationRepoSpy struct {
@@ -26,6 +43,8 @@ type upsertInvitationRepoSpy struct {
 	emailFindErr    error
 	tokenFindCalled bool
 	emailFindCalled bool
+	updateCalls     int
+	updateErr       error
 	updatedID       uint64
 	updatedStatus   string
 }
@@ -78,9 +97,17 @@ func (s *upsertInvitationRepoSpy) UpdateStatus(
 	id uint64,
 	status string,
 ) error {
+	s.updateCalls++
 	s.updatedID = id
 	s.updatedStatus = status
-	return nil
+	return s.updateErr
+}
+
+func newUpsertUserFromIDTokenUseCaseForTest(
+	users repository.UserRepository,
+	invitations repository.AdminInvitationRepository,
+) *UpsertUserFromIDTokenUseCase {
+	return NewUpsertUserFromIDTokenUseCase(users, invitations)
 }
 
 func Test_UpsertUserFromIDToken_招待のRoleとCompanyを適用してAcceptedにする(t *testing.T) {
@@ -94,7 +121,7 @@ func Test_UpsertUserFromIDToken_招待のRoleとCompanyを適用してAccepted�
 			Status:    domain.InvitationStatusPending,
 		},
 	}
-	uc := NewUpsertUserFromIDTokenUseCase(users, invitations)
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
 
 	allowed, err := uc.Execute(
 		context.Background(),
@@ -138,7 +165,15 @@ func Test_UpsertUserFromIDToken_招待のRoleとCompanyを適用してAccepted�
 	}
 }
 
-func (s *upsertUserRepoSpy) Create(_ context.Context, user *domain.User) error {
+func (s *upsertUserRepoSpy) Create(
+	_ context.Context,
+	user *domain.User,
+) error {
+	s.createCalls++
+	if s.createErr != nil {
+		return s.createErr
+	}
+
 	copied := *user
 	s.created = &copied
 	return nil
@@ -149,6 +184,11 @@ func (s *upsertUserRepoSpy) UpdateRole(
 	userID uint64,
 	role string,
 ) error {
+	s.roleUpdateCalls++
+	if s.roleUpdateErr != nil {
+		return s.roleUpdateErr
+	}
+
 	s.roleUpdateUserID = userID
 	s.roleUpdateValue = role
 	return nil
@@ -159,6 +199,11 @@ func (s *upsertUserRepoSpy) UpdateCompanyID(
 	userID uint64,
 	companyID uint64,
 ) error {
+	s.companyUpdateCalls++
+	if s.companyUpdateErr != nil {
+		return s.companyUpdateErr
+	}
+
 	s.companyUpdateUserID = userID
 	s.companyUpdateValue = companyID
 	return nil
@@ -184,7 +229,7 @@ func Test_UpsertUserFromIDToken_既存TraineeをCompanyAdminへ昇格して会�
 			Status:    domain.InvitationStatusPending,
 		},
 	}
-	uc := NewUpsertUserFromIDTokenUseCase(users, invitations)
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
 
 	allowed, err := uc.Execute(
 		context.Background(),
@@ -232,7 +277,7 @@ func Test_UpsertUserFromIDToken_既存TraineeをCompanyAdminへ昇格して会�
 
 func Test_UpsertUserFromIDToken_招待も管理者権限もない新規ユーザーを拒否(t *testing.T) {
 	users := &stubUserRepo{}
-	uc := NewUpsertUserFromIDTokenUseCase(users, nil)
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, nil)
 
 	allowed, err := uc.Execute(
 		context.Background(),
@@ -251,7 +296,7 @@ func Test_UpsertUserFromIDToken_招待も管理者権限もない新規ユーザ
 
 func Test_UpsertUserFromIDToken_CognitoAdminは招待なしでもSuperAdminとして作成する(t *testing.T) {
 	users := &upsertUserRepoSpy{}
-	uc := NewUpsertUserFromIDTokenUseCase(users, nil)
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, nil)
 
 	allowed, err := uc.Execute(
 		context.Background(),
@@ -330,7 +375,7 @@ func Test_UpsertUserFromIDToken_検索エラーを返す(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			uc := NewUpsertUserFromIDTokenUseCase(
+			uc := newUpsertUserFromIDTokenUseCaseForTest(
 				tc.users,
 				tc.invitations,
 			)
@@ -375,7 +420,7 @@ func Test_UpsertUserFromIDToken_招待トークンをメールより優先する
 			Status:    domain.InvitationStatusPending,
 		},
 	}
-	uc := NewUpsertUserFromIDTokenUseCase(users, invitations)
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
 
 	allowed, err := uc.Execute(
 		context.Background(),
@@ -397,6 +442,13 @@ func Test_UpsertUserFromIDToken_招待トークンをメールより優先する
 	if invitations.emailFindCalled {
 		t.Fatal("トークンで招待が見つかった場合はメール検索を呼んではいけない")
 	}
+	if invitations.updatedStatus != domain.InvitationStatusAccepted {
+		t.Fatalf(
+			"invitation status = %q, want %q",
+			invitations.updatedStatus,
+			domain.InvitationStatusAccepted,
+		)
+	}
 	if users.created == nil {
 		t.Fatal("ユーザーが作成されていない")
 	}
@@ -415,5 +467,392 @@ func Test_UpsertUserFromIDToken_招待トークンをメールより優先する
 	}
 	if invitations.updatedID != 10 {
 		t.Fatalf("accepted invitation ID = %d, want 10", invitations.updatedID)
+	}
+}
+
+func Test_UpsertUserFromIDToken_CognitoSubが空なら処理しない(t *testing.T) {
+	users := &upsertUserRepoSpy{}
+	invitations := &upsertInvitationRepoSpy{}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "",
+			Email:      "user@example.com",
+		},
+	)
+
+	if allowed {
+		t.Fatal("CognitoSubが空のユーザーを許可してはいけない")
+	}
+	if err == nil {
+		t.Fatal("CognitoSubが空の場合はエラーを返すべき")
+	}
+	if !strings.Contains(err.Error(), "id_token missing sub") {
+		t.Fatalf(
+			"error = %q, want message containing %q",
+			err.Error(),
+			"id_token missing sub",
+		)
+	}
+	if users.findByCognitoSubCalls != 0 {
+		t.Fatalf(
+			"FindByCognitoSub calls = %d, want 0",
+			users.findByCognitoSubCalls,
+		)
+	}
+	if invitations.tokenFindCalled || invitations.emailFindCalled {
+		t.Fatal("CognitoSubが空の場合は招待を検索してはいけない")
+	}
+	if users.createCalls != 0 {
+		t.Fatalf("Create calls = %d, want 0", users.createCalls)
+	}
+}
+
+func Test_UpsertUserFromIDToken_Cognito管理者は招待Roleで降格しない(
+	t *testing.T,
+) {
+	invitationRoles := []string{
+		domain.RoleTrainee,
+		domain.RoleCompanyAdmin,
+	}
+
+	for _, invitationRole := range invitationRoles {
+		t.Run(invitationRole, func(t *testing.T) {
+			users := &upsertUserRepoSpy{}
+			invitations := &upsertInvitationRepoSpy{
+				pending: &domain.AdminInvitation{
+					ID:        30,
+					Role:      invitationRole,
+					CompanyID: 42,
+					Status:    domain.InvitationStatusPending,
+				},
+			}
+			uc := newUpsertUserFromIDTokenUseCaseForTest(
+				users,
+				invitations,
+			)
+
+			allowed, err := uc.Execute(
+				context.Background(),
+				UpsertUserFromIDTokenInput{
+					CognitoSub:     "admin-with-invitation",
+					Email:          "admin@example.com",
+					IsCognitoAdmin: true,
+				},
+			)
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !allowed {
+				t.Fatal("Cognito管理者は許可されるべき")
+			}
+			if users.created == nil {
+				t.Fatal("ユーザーが作成されていない")
+			}
+			if users.created.Role != domain.RoleSuperAdmin {
+				t.Fatalf(
+					"role = %q, want %q",
+					users.created.Role,
+					domain.RoleSuperAdmin,
+				)
+			}
+			if invitations.updateCalls != 1 {
+				t.Fatalf(
+					"UpdateStatus calls = %d, want 1",
+					invitations.updateCalls,
+				)
+			}
+			if invitations.updatedStatus !=
+				domain.InvitationStatusAccepted {
+				t.Fatalf(
+					"status = %q, want %q",
+					invitations.updatedStatus,
+					domain.InvitationStatusAccepted,
+				)
+			}
+		})
+	}
+}
+
+func Test_UpsertUserFromIDToken_未対応の招待Roleは適用しない(
+	t *testing.T,
+) {
+	users := &upsertUserRepoSpy{}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        40,
+			Role:      domain.RoleSuperAdmin,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "unsupported-role",
+			Email:      "user@example.com",
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("有効な招待があるユーザーは許可されるべき")
+	}
+	if users.created == nil {
+		t.Fatal("ユーザーが作成されていない")
+	}
+	if users.created.Role != domain.RoleTrainee {
+		t.Fatalf(
+			"role = %q, want safe default %q",
+			users.created.Role,
+			domain.RoleTrainee,
+		)
+	}
+	if invitations.updatedStatus != domain.InvitationStatusAccepted {
+		t.Fatalf(
+			"status = %q, want %q",
+			invitations.updatedStatus,
+			domain.InvitationStatusAccepted,
+		)
+	}
+}
+
+func Test_UpsertUserFromIDToken_招待のCompanyIDが0なら未所属にする(
+	t *testing.T,
+) {
+	users := &upsertUserRepoSpy{}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        50,
+			Role:      domain.RoleTrainee,
+			CompanyID: 0,
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "no-company",
+			Email:      "no-company@example.com",
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("有効な招待があるユーザーは許可されるべき")
+	}
+	if users.created == nil {
+		t.Fatal("ユーザーが作成されていない")
+	}
+	if users.created.CompanyID != nil {
+		t.Fatalf(
+			"companyID = %v, want nil",
+			users.created.CompanyID,
+		)
+	}
+}
+
+func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
+	t *testing.T,
+) {
+	mutationErr := errors.New("mutation failed")
+
+	tests := []struct {
+		name                  string
+		invitationRole        string
+		configure             func(*upsertUserRepoSpy, *upsertInvitationRepoSpy)
+		wantUpdateStatusCalls int
+	}{
+		{
+			name:           "Role更新に失敗する",
+			invitationRole: domain.RoleCompanyAdmin,
+			configure: func(
+				users *upsertUserRepoSpy,
+				_ *upsertInvitationRepoSpy,
+			) {
+				users.roleUpdateErr = mutationErr
+			},
+			wantUpdateStatusCalls: 0,
+		},
+		{
+			name:           "CompanyID更新に失敗する",
+			invitationRole: domain.RoleTrainee,
+			configure: func(
+				users *upsertUserRepoSpy,
+				_ *upsertInvitationRepoSpy,
+			) {
+				users.companyUpdateErr = mutationErr
+			},
+			wantUpdateStatusCalls: 0,
+		},
+		{
+			name:           "招待ステータス更新に失敗する",
+			invitationRole: domain.RoleTrainee,
+			configure: func(
+				_ *upsertUserRepoSpy,
+				invitations *upsertInvitationRepoSpy,
+			) {
+				invitations.updateErr = mutationErr
+			},
+			wantUpdateStatusCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			users := &upsertUserRepoSpy{
+				stubUserRepo: stubUserRepo{
+					user: &domain.User{
+						ID:         7,
+						CognitoSub: "existing-user",
+						Email:      "existing@example.com",
+						Name:       "Existing User",
+						Role:       domain.RoleTrainee,
+					},
+				},
+			}
+			invitations := &upsertInvitationRepoSpy{
+				pending: &domain.AdminInvitation{
+					ID:        60,
+					Role:      tc.invitationRole,
+					CompanyID: 42,
+					Status:    domain.InvitationStatusPending,
+				},
+			}
+			tc.configure(users, invitations)
+
+			uc := newUpsertUserFromIDTokenUseCaseForTest(
+				users,
+				invitations,
+			)
+
+			allowed, err := uc.Execute(
+				context.Background(),
+				UpsertUserFromIDTokenInput{
+					CognitoSub: "existing-user",
+					Email:      "existing@example.com",
+				},
+			)
+
+			if allowed {
+				t.Fatal("更新失敗時にユーザーを許可してはいけない")
+			}
+			if !errors.Is(err, mutationErr) {
+				t.Fatalf(
+					"error = %v, want wrapped %v",
+					err,
+					mutationErr,
+				)
+			}
+			if invitations.updateCalls !=
+				tc.wantUpdateStatusCalls {
+				t.Fatalf(
+					"UpdateStatus calls = %d, want %d",
+					invitations.updateCalls,
+					tc.wantUpdateStatusCalls,
+				)
+			}
+		})
+	}
+}
+
+func Test_UpsertUserFromIDToken_新規ユーザーのトランザクションエラーを返す(
+	t *testing.T,
+) {
+	mutationErr := errors.New("new user mutation failed")
+
+	tests := []struct {
+		name                  string
+		configure             func(*upsertUserRepoSpy, *upsertInvitationRepoSpy)
+		wantCreateCalls       int
+		wantUpdateStatusCalls int
+	}{
+		{
+			name: "ユーザー作成に失敗する",
+			configure: func(
+				users *upsertUserRepoSpy,
+				_ *upsertInvitationRepoSpy,
+			) {
+				users.createErr = mutationErr
+			},
+			wantCreateCalls:       1,
+			wantUpdateStatusCalls: 0,
+		},
+		{
+			name: "ユーザー作成後の招待更新に失敗する",
+			configure: func(
+				_ *upsertUserRepoSpy,
+				invitations *upsertInvitationRepoSpy,
+			) {
+				invitations.updateErr = mutationErr
+			},
+			wantCreateCalls:       1,
+			wantUpdateStatusCalls: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			users := &upsertUserRepoSpy{}
+			invitations := &upsertInvitationRepoSpy{
+				pending: &domain.AdminInvitation{
+					ID:        70,
+					Role:      domain.RoleTrainee,
+					CompanyID: 42,
+					Status:    domain.InvitationStatusPending,
+				},
+			}
+			tc.configure(users, invitations)
+
+			uc := newUpsertUserFromIDTokenUseCaseForTest(
+				users,
+				invitations,
+			)
+
+			allowed, err := uc.Execute(
+				context.Background(),
+				UpsertUserFromIDTokenInput{
+					CognitoSub: "new-user-error",
+					Email:      "new-user@example.com",
+				},
+			)
+
+			if allowed {
+				t.Fatal("トランザクション失敗時に許可してはいけない")
+			}
+			if !errors.Is(err, mutationErr) {
+				t.Fatalf(
+					"error = %v, want wrapped %v",
+					err,
+					mutationErr,
+				)
+			}
+			if users.createCalls != tc.wantCreateCalls {
+				t.Fatalf(
+					"Create calls = %d, want %d",
+					users.createCalls,
+					tc.wantCreateCalls,
+				)
+			}
+			if invitations.updateCalls !=
+				tc.wantUpdateStatusCalls {
+				t.Fatalf(
+					"UpdateStatus calls = %d, want %d",
+					invitations.updateCalls,
+					tc.wantUpdateStatusCalls,
+				)
+			}
+		})
 	}
 }

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -1,0 +1,261 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+)
+
+type upsertUserRepoSpy struct {
+	stubUserRepo
+	created *domain.User
+
+	roleUpdateUserID    uint64
+	roleUpdateValue     string
+	companyUpdateUserID uint64
+	companyUpdateValue  uint64
+}
+
+type upsertInvitationRepoSpy struct {
+	pending       *domain.AdminInvitation
+	updatedID     uint64
+	updatedStatus string
+}
+
+func (s *upsertInvitationRepoSpy) ListAll(
+	_ context.Context,
+) ([]domain.AdminInvitation, error) {
+	return nil, nil
+}
+
+func (s *upsertInvitationRepoSpy) ListByCompanyID(
+	_ context.Context,
+	_ uint64,
+) ([]domain.AdminInvitation, error) {
+	return nil, nil
+}
+
+func (s *upsertInvitationRepoSpy) FindPendingByEmail(
+	_ context.Context,
+	_ string,
+) (*domain.AdminInvitation, error) {
+	return s.pending, nil
+}
+
+func (s *upsertInvitationRepoSpy) FindPendingByToken(
+	_ context.Context,
+	_ string,
+) (*domain.AdminInvitation, error) {
+	return nil, nil
+}
+
+func (s *upsertInvitationRepoSpy) Create(
+	_ context.Context,
+	_ *domain.AdminInvitation,
+) error {
+	return nil
+}
+
+func (s *upsertInvitationRepoSpy) UpdateStatus(
+	_ context.Context,
+	id uint64,
+	status string,
+) error {
+	s.updatedID = id
+	s.updatedStatus = status
+	return nil
+}
+
+func Test_UpsertUserFromIDToken_招待のRoleとCompanyを適用してAcceptedにする(t *testing.T) {
+	users := &upsertUserRepoSpy{}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        10,
+			Role:      domain.RoleCompanyAdmin,
+			CompanyID: 42,
+			Name:      "Invited User",
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := NewUpsertUserFromIDTokenUseCase(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "invited-sub",
+			Email:      "invited@example.com",
+			Name:       "OIDC User",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("有効な招待があるユーザーは許可されるべき")
+	}
+	if users.created == nil {
+		t.Fatal("ユーザーが作成されていない")
+	}
+	if users.created.Role != domain.RoleCompanyAdmin {
+		t.Fatalf(
+			"role = %q, want %q",
+			users.created.Role,
+			domain.RoleCompanyAdmin,
+		)
+	}
+	if users.created.CompanyID == nil || *users.created.CompanyID != 42 {
+		t.Fatalf("companyID = %v, want 42", users.created.CompanyID)
+	}
+	if users.created.Name != "Invited User" {
+		t.Fatalf("name = %q, want %q", users.created.Name, "Invited User")
+	}
+	if invitations.updatedID != 10 {
+		t.Fatalf("updated invitation ID = %d, want 10", invitations.updatedID)
+	}
+	if invitations.updatedStatus != domain.InvitationStatusAccepted {
+		t.Fatalf(
+			"status = %q, want %q",
+			invitations.updatedStatus,
+			domain.InvitationStatusAccepted,
+		)
+	}
+}
+
+func (s *upsertUserRepoSpy) Create(_ context.Context, user *domain.User) error {
+	copied := *user
+	s.created = &copied
+	return nil
+}
+
+func (s *upsertUserRepoSpy) UpdateRole(
+	_ context.Context,
+	userID uint64,
+	role string,
+) error {
+	s.roleUpdateUserID = userID
+	s.roleUpdateValue = role
+	return nil
+}
+
+func (s *upsertUserRepoSpy) UpdateCompanyID(
+	_ context.Context,
+	userID uint64,
+	companyID uint64,
+) error {
+	s.companyUpdateUserID = userID
+	s.companyUpdateValue = companyID
+	return nil
+}
+
+func Test_UpsertUserFromIDToken_既存TraineeをCompanyAdminへ昇格して会社に紐付ける(t *testing.T) {
+	users := &upsertUserRepoSpy{
+		stubUserRepo: stubUserRepo{
+			user: &domain.User{
+				ID:         7,
+				CognitoSub: "existing-sub",
+				Email:      "existing@example.com",
+				Name:       "Existing User",
+				Role:       domain.RoleTrainee,
+			},
+		},
+	}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        20,
+			Role:      domain.RoleCompanyAdmin,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := NewUpsertUserFromIDTokenUseCase(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "existing-sub",
+			Email:      "existing@example.com",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("既存ユーザーは許可されるべき")
+	}
+	if users.created != nil {
+		t.Fatal("既存ユーザーを新規作成してはいけない")
+	}
+	if users.roleUpdateUserID != 7 {
+		t.Fatalf("role更新対象ID = %d, want 7", users.roleUpdateUserID)
+	}
+	if users.roleUpdateValue != domain.RoleCompanyAdmin {
+		t.Fatalf(
+			"更新role = %q, want %q",
+			users.roleUpdateValue,
+			domain.RoleCompanyAdmin,
+		)
+	}
+	if users.companyUpdateUserID != 7 {
+		t.Fatalf("company更新対象ID = %d, want 7", users.companyUpdateUserID)
+	}
+	if users.companyUpdateValue != 42 {
+		t.Fatalf("更新companyID = %d, want 42", users.companyUpdateValue)
+	}
+	if invitations.updatedID != 20 {
+		t.Fatalf("更新された招待ID = %d, want 20", invitations.updatedID)
+	}
+	if invitations.updatedStatus != domain.InvitationStatusAccepted {
+		t.Fatalf(
+			"招待status = %q, want %q",
+			invitations.updatedStatus,
+			domain.InvitationStatusAccepted,
+		)
+	}
+}
+
+func Test_UpsertUserFromIDToken_招待も管理者権限もない新規ユーザーを拒否(t *testing.T) {
+	users := &stubUserRepo{}
+	uc := NewUpsertUserFromIDTokenUseCase(users, nil)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "new-sub",
+			Email:      "new@example.com",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if allowed {
+		t.Fatal("招待も管理者権限もない新規ユーザーは拒否されるべき")
+	}
+}
+
+func Test_UpsertUserFromIDToken_CognitoAdminは招待なしでもSuperAdminとして作成する(t *testing.T) {
+	users := &upsertUserRepoSpy{}
+	uc := NewUpsertUserFromIDTokenUseCase(users, nil)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub:     "admin-sub",
+			Email:          "admin@example.com",
+			Name:           "Admin User",
+			IsCognitoAdmin: true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("Cognito adminは招待なしでも許可されるべき")
+	}
+	if users.created == nil {
+		t.Fatal("ユーザーが作成されていない")
+	}
+	if users.created.Role != domain.RoleSuperAdmin {
+		t.Fatalf("role = %q, want %q", users.created.Role, domain.RoleSuperAdmin)
+	}
+}

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -671,135 +671,188 @@ func Test_UpsertUserFromIDToken_招待のCompanyIDが0なら未所属にする(
 	}
 }
 
-func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
-	t *testing.T,
-) {
+func Test_UpsertUserFromIDToken_名前補完の更新に失敗する(t *testing.T) {
 	mutationErr := errors.New("mutation failed")
-
-	tests := []struct {
-		name                  string
-		invitationRole        string
-		existingName          string
-		inputName             string
-		configure             func(*upsertUserRepoSpy, *upsertInvitationRepoSpy)
-		wantUpdateNameCalls   int
-		wantUpdateStatusCalls int
-	}{
-		{
-			name:           "Name補完に失敗する",
-			invitationRole: domain.RoleTrainee,
-			existingName:   "existing@example.com",
-			inputName:      "OIDC User",
-			configure: func(
-				users *upsertUserRepoSpy,
-				_ *upsertInvitationRepoSpy,
-			) {
-				users.nameUpdateErr = mutationErr
+	users := &upsertUserRepoSpy{
+		stubUserRepo: stubUserRepo{
+			user: &domain.User{
+				ID:         7,
+				CognitoSub: "existing-user",
+				Email:      "existing@example.com",
+				Name:       "existing@example.com",
+				Role:       domain.RoleTrainee,
 			},
-			wantUpdateNameCalls:   1,
-			wantUpdateStatusCalls: 0,
 		},
-		{
-			name:           "Role更新に失敗する",
-			invitationRole: domain.RoleCompanyAdmin,
-			existingName:   "Existing User",
-			configure: func(
-				users *upsertUserRepoSpy,
-				_ *upsertInvitationRepoSpy,
-			) {
-				users.roleUpdateErr = mutationErr
-			},
-			wantUpdateStatusCalls: 0,
-		},
-		{
-			name:           "CompanyID更新に失敗する",
-			invitationRole: domain.RoleTrainee,
-			existingName:   "Existing User",
-			configure: func(
-				users *upsertUserRepoSpy,
-				_ *upsertInvitationRepoSpy,
-			) {
-				users.companyUpdateErr = mutationErr
-			},
-			wantUpdateStatusCalls: 0,
-		},
-		{
-			name:           "招待ステータス更新に失敗する",
-			invitationRole: domain.RoleTrainee,
-			existingName:   "Existing User",
-			configure: func(
-				_ *upsertUserRepoSpy,
-				invitations *upsertInvitationRepoSpy,
-			) {
-				invitations.updateErr = mutationErr
-			},
-			wantUpdateStatusCalls: 1,
+		nameUpdateErr: mutationErr,
+	}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        60,
+			Role:      domain.RoleTrainee,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
 		},
 	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			users := &upsertUserRepoSpy{
-				stubUserRepo: stubUserRepo{
-					user: &domain.User{
-						ID:         7,
-						CognitoSub: "existing-user",
-						Email:      "existing@example.com",
-						Name:       tc.existingName,
-						Role:       domain.RoleTrainee,
-					},
-				},
-			}
-			invitations := &upsertInvitationRepoSpy{
-				pending: &domain.AdminInvitation{
-					ID:        60,
-					Role:      tc.invitationRole,
-					CompanyID: 42,
-					Status:    domain.InvitationStatusPending,
-				},
-			}
-			tc.configure(users, invitations)
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "existing-user",
+			Email:      "existing@example.com",
+			Name:       "OIDC User",
+		},
+	)
 
-			uc := newUpsertUserFromIDTokenUseCaseForTest(
-				users,
-				invitations,
-			)
+	if allowed {
+		t.Fatal("名前補完の更新失敗時にユーザーを許可してはいけない")
+	}
+	if !errors.Is(err, mutationErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, mutationErr)
+	}
+	if users.nameUpdateCalls != 1 {
+		t.Fatalf("UpdateName calls = %d, want 1", users.nameUpdateCalls)
+	}
+	if invitations.updateCalls != 0 {
+		t.Fatalf("UpdateStatus calls = %d, want 0", invitations.updateCalls)
+	}
+}
 
-			allowed, err := uc.Execute(
-				context.Background(),
-				UpsertUserFromIDTokenInput{
-					CognitoSub: "existing-user",
-					Email:      "existing@example.com",
-					Name:       tc.inputName,
-				},
-			)
+func Test_UpsertUserFromIDToken_ロール更新に失敗する(t *testing.T) {
+	mutationErr := errors.New("mutation failed")
+	users := &upsertUserRepoSpy{
+		stubUserRepo: stubUserRepo{
+			user: &domain.User{
+				ID:         7,
+				CognitoSub: "existing-user",
+				Email:      "existing@example.com",
+				Name:       "Existing User",
+				Role:       domain.RoleTrainee,
+			},
+		},
+		roleUpdateErr: mutationErr,
+	}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        60,
+			Role:      domain.RoleCompanyAdmin,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
 
-			if allowed {
-				t.Fatal("更新失敗時にユーザーを許可してはいけない")
-			}
-			if !errors.Is(err, mutationErr) {
-				t.Fatalf(
-					"error = %v, want wrapped %v",
-					err,
-					mutationErr,
-				)
-			}
-			if users.nameUpdateCalls != tc.wantUpdateNameCalls {
-				t.Fatalf(
-					"UpdateName calls = %d, want %d",
-					users.nameUpdateCalls,
-					tc.wantUpdateNameCalls,
-				)
-			}
-			if invitations.updateCalls !=
-				tc.wantUpdateStatusCalls {
-				t.Fatalf(
-					"UpdateStatus calls = %d, want %d",
-					invitations.updateCalls,
-					tc.wantUpdateStatusCalls,
-				)
-			}
-		})
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "existing-user",
+			Email:      "existing@example.com",
+		},
+	)
+
+	if allowed {
+		t.Fatal("ロール更新失敗時にユーザーを許可してはいけない")
+	}
+	if !errors.Is(err, mutationErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, mutationErr)
+	}
+	if users.roleUpdateCalls != 1 {
+		t.Fatalf("UpdateRole calls = %d, want 1", users.roleUpdateCalls)
+	}
+	if invitations.updateCalls != 0 {
+		t.Fatalf("UpdateStatus calls = %d, want 0", invitations.updateCalls)
+	}
+}
+
+func Test_UpsertUserFromIDToken_会社更新に失敗する(t *testing.T) {
+	mutationErr := errors.New("mutation failed")
+	users := &upsertUserRepoSpy{
+		stubUserRepo: stubUserRepo{
+			user: &domain.User{
+				ID:         7,
+				CognitoSub: "existing-user",
+				Email:      "existing@example.com",
+				Name:       "Existing User",
+				Role:       domain.RoleTrainee,
+			},
+		},
+		companyUpdateErr: mutationErr,
+	}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        60,
+			Role:      domain.RoleTrainee,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "existing-user",
+			Email:      "existing@example.com",
+		},
+	)
+
+	if allowed {
+		t.Fatal("会社更新失敗時にユーザーを許可してはいけない")
+	}
+	if !errors.Is(err, mutationErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, mutationErr)
+	}
+	if users.companyUpdateCalls != 1 {
+		t.Fatalf(
+			"UpdateCompanyID calls = %d, want 1",
+			users.companyUpdateCalls,
+		)
+	}
+	if invitations.updateCalls != 0 {
+		t.Fatalf("UpdateStatus calls = %d, want 0", invitations.updateCalls)
+	}
+}
+
+func Test_UpsertUserFromIDToken_招待ステータス更新に失敗する(t *testing.T) {
+	mutationErr := errors.New("mutation failed")
+	users := &upsertUserRepoSpy{
+		stubUserRepo: stubUserRepo{
+			user: &domain.User{
+				ID:         7,
+				CognitoSub: "existing-user",
+				Email:      "existing@example.com",
+				Name:       "Existing User",
+				Role:       domain.RoleTrainee,
+			},
+		},
+	}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        60,
+			Role:      domain.RoleTrainee,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
+		},
+		updateErr: mutationErr,
+	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub: "existing-user",
+			Email:      "existing@example.com",
+		},
+	)
+
+	if allowed {
+		t.Fatal("招待ステータス更新失敗時にユーザーを許可してはいけない")
+	}
+	if !errors.Is(err, mutationErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, mutationErr)
+	}
+	if invitations.updateCalls != 1 {
+		t.Fatalf("UpdateStatus calls = %d, want 1", invitations.updateCalls)
 	}
 }
 

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -17,6 +17,8 @@ type upsertUserRepoSpy struct {
 	findByCognitoSubCalls int
 	createCalls           int
 	createErr             error
+	nameUpdateCalls       int
+	nameUpdateErr         error
 	roleUpdateCalls       int
 	roleUpdateErr         error
 	companyUpdateCalls    int
@@ -179,6 +181,15 @@ func (s *upsertUserRepoSpy) Create(
 	return nil
 }
 
+func (s *upsertUserRepoSpy) UpdateName(
+	_ context.Context,
+	_ uint64,
+	_ string,
+) error {
+	s.nameUpdateCalls++
+	return s.nameUpdateErr
+}
+
 func (s *upsertUserRepoSpy) UpdateRole(
 	_ context.Context,
 	userID uint64,
@@ -329,7 +340,7 @@ func Test_UpsertUserFromIDToken_検索エラーを返す(t *testing.T) {
 	tests := []struct {
 		name        string
 		users       *stubUserRepo
-		invitations *upsertInvitationRepoSpy
+		invitations repository.AdminInvitationRepository
 		input       UpsertUserFromIDTokenInput
 		wantErr     error
 		wantMessage string
@@ -668,12 +679,30 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 	tests := []struct {
 		name                  string
 		invitationRole        string
+		existingName          string
+		inputName             string
 		configure             func(*upsertUserRepoSpy, *upsertInvitationRepoSpy)
+		wantUpdateNameCalls   int
 		wantUpdateStatusCalls int
 	}{
 		{
+			name:           "Name補完に失敗する",
+			invitationRole: domain.RoleTrainee,
+			existingName:   "existing@example.com",
+			inputName:      "OIDC User",
+			configure: func(
+				users *upsertUserRepoSpy,
+				_ *upsertInvitationRepoSpy,
+			) {
+				users.nameUpdateErr = mutationErr
+			},
+			wantUpdateNameCalls:   1,
+			wantUpdateStatusCalls: 0,
+		},
+		{
 			name:           "Role更新に失敗する",
 			invitationRole: domain.RoleCompanyAdmin,
+			existingName:   "Existing User",
 			configure: func(
 				users *upsertUserRepoSpy,
 				_ *upsertInvitationRepoSpy,
@@ -685,6 +714,7 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 		{
 			name:           "CompanyID更新に失敗する",
 			invitationRole: domain.RoleTrainee,
+			existingName:   "Existing User",
 			configure: func(
 				users *upsertUserRepoSpy,
 				_ *upsertInvitationRepoSpy,
@@ -696,6 +726,7 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 		{
 			name:           "招待ステータス更新に失敗する",
 			invitationRole: domain.RoleTrainee,
+			existingName:   "Existing User",
 			configure: func(
 				_ *upsertUserRepoSpy,
 				invitations *upsertInvitationRepoSpy,
@@ -714,7 +745,7 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 						ID:         7,
 						CognitoSub: "existing-user",
 						Email:      "existing@example.com",
-						Name:       "Existing User",
+						Name:       tc.existingName,
 						Role:       domain.RoleTrainee,
 					},
 				},
@@ -739,6 +770,7 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 				UpsertUserFromIDTokenInput{
 					CognitoSub: "existing-user",
 					Email:      "existing@example.com",
+					Name:       tc.inputName,
 				},
 			)
 
@@ -752,6 +784,13 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 					mutationErr,
 				)
 			}
+			if users.nameUpdateCalls != tc.wantUpdateNameCalls {
+				t.Fatalf(
+					"UpdateName calls = %d, want %d",
+					users.nameUpdateCalls,
+					tc.wantUpdateNameCalls,
+				)
+			}
 			if invitations.updateCalls !=
 				tc.wantUpdateStatusCalls {
 				t.Fatalf(
@@ -761,6 +800,66 @@ func Test_UpsertUserFromIDToken_既存ユーザー更新エラーを返す(
 				)
 			}
 		})
+	}
+}
+
+func Test_UpsertUserFromIDToken_既存Cognito管理者は招待を適用しない(
+	t *testing.T,
+) {
+	users := &upsertUserRepoSpy{
+		stubUserRepo: stubUserRepo{
+			user: &domain.User{
+				ID:         70,
+				CognitoSub: "existing-admin",
+				Email:      "admin@example.com",
+				Name:       "Existing Admin",
+				Role:       domain.RoleTrainee,
+			},
+		},
+	}
+	invitations := &upsertInvitationRepoSpy{
+		pending: &domain.AdminInvitation{
+			ID:        70,
+			Role:      domain.RoleCompanyAdmin,
+			CompanyID: 42,
+			Status:    domain.InvitationStatusPending,
+		},
+	}
+	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+
+	allowed, err := uc.Execute(
+		context.Background(),
+		UpsertUserFromIDTokenInput{
+			CognitoSub:     "existing-admin",
+			Email:          "admin@example.com",
+			IsCognitoAdmin: true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !allowed {
+		t.Fatal("Cognito管理者は許可されるべき")
+	}
+	if users.roleUpdateCalls != 1 ||
+		users.roleUpdateValue != domain.RoleSuperAdmin {
+		t.Fatalf(
+			"UpdateRole calls = %d, role = %q",
+			users.roleUpdateCalls,
+			users.roleUpdateValue,
+		)
+	}
+	if users.companyUpdateCalls != 0 {
+		t.Fatalf(
+			"UpdateCompanyID calls = %d, want 0",
+			users.companyUpdateCalls,
+		)
+	}
+	if invitations.updateCalls != 0 {
+		t.Fatalf(
+			"UpdateStatus calls = %d, want 0",
+			invitations.updateCalls,
+		)
 	}
 }
 


### PR DESCRIPTION
<!--
PR タイトル・本文は日本語で。タイトルは Prefix を付ける（feat / fix / refactor / docs / test / chore / perf / style）。
詳細な規約は CONTRIBUTING.md を参照。
-->

## 概要

UpsertUserFromIDToken 相当の usecase を新設し、ビジネスルールをそこへ移す

handler は認証情報の取り出しと usecase 呼び出しだけに徹し、判断ロジックを持たない

抽出した usecase に単体テスト（部品単位の自動テスト）を追加する。role 昇格・company 紐付け・招待マークの分岐をそれぞれ検証する

## 変更内容

auth_handler.goから新設したupsert_user_from_id_token_usecase.goへupsertUserFromIDTokenを移植

auth_handler.goからupsertUserFromIDTokenの範囲を削除

上記二つが正しく動くようにコードを改変

## テスト

## テスト

<!-- どう検証したか（コマンド・結果）。新規コードには単体テストを付ける -->

- `go test -count=1 ./internal/usecase -run UpsertUserFromIDToken`
  - 結果: PASS
  - 
## 関連 Issue

[FREESTYLE-15](https://frestyle.atlassian.net/browse/FRESTYLE-15)

---

### セルフチェック

- [ ] タイトルに Prefix（`feat` / `fix` / `refactor` / `docs` / `test` / `chore` 等）を付けた
- [ ] 新規・変更コードに単体テストを追加した（backend: `go test` / frontend: Vitest）
- [ ] backend を変更した場合 `make verify`（gofmt / vet / build / test / 3 linter）が通る
- [ ] handler / swaggo 注釈を変えた場合 `make openapi` を実行し `docs/` を commit した
- [ ] 仕様・手順を変えた場合は `docs/`（または該当 README）を更新した
- [ ] `main` への直接コミットではなく、PR 経由である


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 招待情報や管理者権限に基づくユーザーの作成・更新に対応しました。
  * 招待されたユーザーのロールや会社情報を自動設定し、招待を承認済みに更新します。
  * 管理者権限を持つユーザーを、招待なしでも適切な権限で登録できるようにしました。

* **バグ修正**
  * 既存ユーザーの昇格や会社情報の紐付けが正しく反映されるよう改善しました。
  * 招待も管理者権限もない新規ユーザーの登録を拒否します。
  * 招待トークンを優先して、正しい招待情報を適用します。
  * ユーザー処理に失敗した場合、認証 Cookie を発行しないよう改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->