### PR TITLE
fix: company_admin の招待画面で super_admin 専用の会社一覧 API を呼ばない (FRESTYLE-247)

### DIFF
--- a/frontend/src/pages/admin-invitations/__tests__/AdminInvitationsPage.test.tsx
+++ b/frontend/src/pages/admin-invitations/__tests__/AdminInvitationsPage.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+// Redux: 管理者としてページを表示できる状態にする。
+const mockState = { auth: { isAdmin: true, loading: false } };
+vi.mock('react-redux', () => ({
+  useSelector: (sel: (s: typeof mockState) => unknown) => sel(mockState),
+  useDispatch: () => vi.fn(),
+}));
+
+const getCurrentUser = vi.fn();
+vi.mock('@/entities/user', () => ({
+  AuthRepository: { getCurrentUser: () => getCurrentUser() },
+}));
+
+const listInvitations = vi.fn();
+vi.mock('@/entities/invitation', () => ({
+  AdminInvitationRepository: {
+    list: () => listInvitations(),
+    create: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+const listCompanies = vi.fn();
+vi.mock('@/entities/company', () => ({
+  CompanyRepository: { list: () => listCompanies() },
+}));
+
+import AdminInvitationsPage from '../ui/AdminInvitationsPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminInvitationsPage />
+    </MemoryRouter>,
+  );
+}
+
+const pendingInvitation = {
+  id: 10,
+  email: 'member@example.com',
+  role: 'trainee',
+  createdAt: '2026-08-05T00:00:00Z',
+  expiresAt: '2026-08-12T00:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AdminInvitationsPage のロール別データ取得', () => {
+  it('company_admin では会社一覧 API を呼ばず、画面がエラーにならない', async () => {
+    getCurrentUser.mockResolvedValue({ id: 2, role: 'company_admin', companyId: 1 });
+    listInvitations.mockResolvedValue([pendingInvitation]);
+
+    renderPage();
+
+    // 会社欄は自社固定の表示になり、招待一覧も表示される。
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('所属会社（自社に固定）')).toBeInTheDocument();
+    });
+    expect(screen.getByText('member@example.com')).toBeInTheDocument();
+
+    // super_admin 専用の会社一覧 API は呼ばない（403 で画面全体が落ちる原因だった）。
+    expect(listCompanies).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    // 役職は受講者に固定される。
+    expect(screen.getByDisplayValue('受講者（自社のメンバー）')).toBeInTheDocument();
+  });
+
+  it('super_admin では会社一覧を取得して選択肢に表示する', async () => {
+    getCurrentUser.mockResolvedValue({ id: 1, role: 'super_admin', companyId: null });
+    listInvitations.mockResolvedValue([]);
+    listCompanies.mockResolvedValue([{ id: 1, name: '株式会社FreStyle' }]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: '株式会社FreStyle' })).toBeInTheDocument();
+    });
+    expect(listCompanies).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    // 役職は会社管理者に固定される。
+    expect(screen.getByDisplayValue('会社管理者（招待先の会社の管理者）')).toBeInTheDocument();
+  });
+
+  it('招待一覧の取得に失敗したときはエラーを表示する', async () => {
+    getCurrentUser.mockResolvedValue({ id: 2, role: 'company_admin', companyId: 1 });
+    listInvitations.mockRejectedValue(new Error('network error'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('データの取得に失敗しました');
+    });
+  });
+});

--- a/frontend/src/pages/admin-invitations/ui/AdminInvitationsPage.tsx
+++ b/frontend/src/pages/admin-invitations/ui/AdminInvitationsPage.tsx
@@ -68,10 +68,13 @@ export default function AdminInvitationsPage() {
   const fetchAll = useCallback(async () => {
     setLoading(true);
     try {
-      const [user, data, cos] = await Promise.all([
-        AuthRepository.getCurrentUser(),
+      // 会社一覧 API は super_admin 専用。company_admin で呼ぶと 403 になり、
+      // Promise.all ごと reject して招待一覧まで巻き込むため、先に自分の role を
+      // 確認してから super_admin のときだけ取得する（company_admin は自社固定で不要）。
+      const user = await AuthRepository.getCurrentUser();
+      const [data, cos] = await Promise.all([
         AdminInvitationRepository.list(),
-        CompanyRepository.list(),
+        user.role === 'super_admin' ? CompanyRepository.list() : Promise.resolve<Company[]>([]),
       ]);
       setMe(user);
       setInvitations(data);
@@ -192,13 +195,12 @@ export default function AdminInvitationsPage() {
         <label className="block text-sm">
           <span className="block mb-1">会社 *</span>
           {isCompanyAdmin ? (
-            // CompanyAdmin は自社にしか招待を出せない仕様。会社名を表示するだけにする。
+            // CompanyAdmin は自社にしか招待を出せない仕様。会社一覧 API は呼ばない
+            // （super_admin 専用）ため、固定文言で自社宛であることを示す。
             <input
               type="text"
               readOnly
-              value={
-                companies.find((c) => c.id === form.companyId)?.name ?? '所属会社'
-              }
+              value="所属会社（自社に固定）"
               className="w-full border rounded px-2 py-1 bg-[var(--color-surface-2)] text-[var(--color-text-muted)]"
             />
           ) : (


### PR DESCRIPTION
## 概要
company_admin ロールで「管理: メンバー招待」を開くと「データの取得に失敗しました」となり招待一覧も表示されない不具合の修正。`fetchAll` が role を確認せず super_admin 専用の `GET /admin/companies` を `Promise.all` に含めて呼んでいたため、company_admin では必ず 403 → Promise.all ごと reject → 画面全体がエラーになっていた（staging の backend ログで 403 を実測確認）。

## 変更内容
- [AdminInvitationsPage.tsx](frontend/src/pages/admin-invitations/ui/AdminInvitationsPage.tsx): 先に自分の role を取得し、**super_admin のときだけ** `CompanyRepository.list()` を呼ぶ。company_admin の会社欄は「所属会社（自社に固定）」の固定文言に変更（会社一覧を持たないため）
- テスト新規: ロール別分岐（company_admin で会社一覧 API を呼ばない / super_admin で呼ぶ / 一覧取得失敗時のエラー表示）

## テスト
- vitest: 164 files / 1343 tests 全パス（新規 3 テスト含む）
- `tsc --noEmit` / `eslint --max-warnings 0` / `npm run build` すべて成功
- マージ後 staging へデプロイし、company_admin アカウントで画面表示を確認予定

## 関連チケット
- FRESTYLE-247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 会社管理者向けの招待フォームで、自社情報と受講者区分を自動設定するようになりました。
  - システム管理者向けの招待フォームで、会社一覧から対象会社を選択できるようになりました。

- **不具合修正**
  - 招待一覧の取得に失敗した場合、エラーメッセージが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->