### PR TITLE
feat: 招待メールを SMTP でも送れるようにする（staging メールキャッチャー経路） (FRESTYLE-248)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,8 +45,10 @@ NOTE_IMAGES_CDN_URL=https://your-cloudfront-domain.cloudfront.net
 SES_REGION=ap-northeast-1
 SES_FROM_ADDRESS=
 
-# SES を使わない環境(staging)向けの SMTP 送信設定。
-# MAIL_SMTP_HOST を設定すると SES より優先して SMTP で送信する(メールキャッチャー宛・認証/TLS なし)
+# SES を使わない環境(staging / local)向けの SMTP 送信設定。
+# MAIL_SMTP_HOST を設定すると SES より優先して SMTP で送信する(メールキャッチャー宛・認証/TLS なし)。
+# local は backend/docker-compose.mail.yml でキャッチャーを起動し MAIL_SMTP_HOST=localhost を設定
+# (受信メールは http://localhost:8025 で閲覧)。staging は box の edge スタックが常駐させる。
 MAIL_SMTP_HOST=
 MAIL_SMTP_PORT=1025
 MAIL_FROM_ADDRESS=

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,12 @@ NOTE_IMAGES_CDN_URL=https://your-cloudfront-domain.cloudfront.net
 SES_REGION=ap-northeast-1
 SES_FROM_ADDRESS=
 
+# SES を使わない環境(staging)向けの SMTP 送信設定。
+# MAIL_SMTP_HOST を設定すると SES より優先して SMTP で送信する(メールキャッチャー宛・認証/TLS なし)
+MAIL_SMTP_HOST=
+MAIL_SMTP_PORT=1025
+MAIL_FROM_ADDRESS=
+
 # 招待マジックリンクの組み立てに使うフロントエンドの絶対 URL
 # 例: https://normanblog.com  /  http://localhost:5173
 APP_BASE_URL=http://localhost:5173

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -86,7 +86,7 @@ jobs:
           fi
           # 予約サブドメイン(エッジが使用)は box 側と同様にここでも拒否する。
           case "$SUBDOMAIN" in
-            db|www|api)
+            db|www|api|mail)
               echo "ERROR: '$SUBDOMAIN' は予約済みサブドメインです。"
               exit 1 ;;
           esac

--- a/backend/docker-compose.mail.yml
+++ b/backend/docker-compose.mail.yml
@@ -1,0 +1,20 @@
+# ローカル開発用メールキャッチャー。招待メールの SMTP 送信を手元で確認する。
+#
+# 起動:
+#   cd backend && docker compose -f docker-compose.mail.yml up -d
+# .env に設定:
+#   MAIL_SMTP_HOST=localhost
+#   MAIL_FROM_ADDRESS=noreply@localhost
+# 受信メールの閲覧: http://localhost:8025
+#
+# staging は同じイメージを box の edge スタック(frestyle-staging リポ)で常駐させ、
+# https://mail.staging.frestyle.jp (Basic 認証) で閲覧する。
+
+services:
+  mail:
+    image: axllent/mailpit:v1.30
+    container_name: frestyle-local-mail
+    restart: unless-stopped
+    ports:
+      - '1025:1025' # SMTP (backend からの送信先)
+      - '8025:8025' # Web UI (受信メールの閲覧)

--- a/backend/internal/handler/routes_admin.go
+++ b/backend/internal/handler/routes_admin.go
@@ -8,6 +8,7 @@ import (
 	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
 	"github.com/norman6464/FreStyle/backend/internal/handler/middleware"
 	"github.com/norman6464/FreStyle/backend/internal/infra/ses"
+	"github.com/norman6464/FreStyle/backend/internal/infra/smtp"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
 	"gorm.io/gorm"
 )
@@ -76,6 +77,15 @@ func registerAdminRoutes(parent *gin.RouterGroup, deps *routeDeps, audit gin.Han
 	var mailBuilder usecase.MailBuilder
 
 	switch {
+	case deps.cfg.SMTP.Host != "" && deps.cfg.SMTP.FromAddress != "" && deps.cfg.AppBaseURL != "":
+		// staging: SES は使わず、box 上のメールキャッチャーへ SMTP で送る。
+		// 実メールは外部へ飛ばず、受信分は mail サブドメインの Web UI で閲覧する。
+		sender = smtp.NewSender(deps.cfg.SMTP.Host, deps.cfg.SMTP.Port, deps.cfg.SMTP.FromAddress)
+		baseURL := deps.cfg.AppBaseURL
+		linkBuilder = func(token string) string {
+			return ses.MagicLinkURL(baseURL, token)
+		}
+		mailBuilder = ses.BuildInvitationMail
 	case deps.cfg.SES.FromAddress == "" || deps.cfg.AppBaseURL == "":
 		// ローカルでは送信をスキップしてフローだけ通す（usecase 側でリンクをログに残す）。
 		log.Printf("WARN: SES_FROM_ADDRESS or APP_BASE_URL not set — invitation emails will NOT be sent (token will be logged instead)")

--- a/backend/internal/infra/config/config.go
+++ b/backend/internal/infra/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Bedrock  BedrockConfig
 	DynamoDB DynamoDBConfig
 	SES      SESConfig
+	SMTP     SMTPConfig
 }
 
 // S3Config は profile / note 画像 upload の presign 発行に必要な設定。
@@ -60,6 +61,15 @@ type DynamoDBConfig struct {
 // 未設定（空文字）のときは送信スキップ → token をログに残してフォールバック。
 type SESConfig struct {
 	Region      string
+	FromAddress string
+}
+
+// SMTPConfig は SES を使わない環境（staging）向けのメール送信設定。
+// Host が設定されているときは SES より優先して SMTP で送信する
+// （staging の box 上メールキャッチャーが宛先。認証・TLS なしの内部ネットワーク前提）。
+type SMTPConfig struct {
+	Host        string
+	Port        string
 	FromAddress string
 }
 
@@ -115,6 +125,11 @@ func Load() (*Config, error) {
 		SES: SESConfig{
 			Region:      getEnvOrDefault("SES_REGION", getEnvOrDefault("AWS_REGION", "ap-northeast-1")),
 			FromAddress: os.Getenv("SES_FROM_ADDRESS"),
+		},
+		SMTP: SMTPConfig{
+			Host:        os.Getenv("MAIL_SMTP_HOST"),
+			Port:        getEnvOrDefault("MAIL_SMTP_PORT", "1025"),
+			FromAddress: os.Getenv("MAIL_FROM_ADDRESS"),
 		},
 	}
 	// DATABASE_URL か DB_HOST の少なくとも一方は必須。

--- a/backend/internal/infra/smtp/sender.go
+++ b/backend/internal/infra/smtp/sender.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"mime"
+	"net/mail"
 	netsmtp "net/smtp"
 	"strings"
 )
@@ -24,6 +25,16 @@ func NewSender(host, port, from string) *Sender {
 
 // SendInvitationEmail は multipart/alternative(text + html)の 1 通を SMTP で送信する。
 func (s *Sender) SendInvitationEmail(_ context.Context, to, subject, htmlBody, textBody string) error {
+	// ヘッダインジェクション対策: to はリクエスト由来のため、アドレスとして検証してから
+	// パース結果のアドレス部のみをヘッダとエンベロープに使う(改行や追加ヘッダを排除)。
+	parsed, err := mail.ParseAddress(to)
+	if err != nil {
+		return fmt.Errorf("smtp: invalid to address %q: %w", to, err)
+	}
+	to = parsed.Address
+	// 件名も改行を除去してからエンコードする(本文は DATA 部のヘッダ外なのでそのままでよい)。
+	subject = strings.NewReplacer("\r", " ", "\n", " ").Replace(subject)
+
 	const boundary = "frestyle-invitation-boundary"
 	var b strings.Builder
 	b.WriteString("From: " + s.from + "\r\n")

--- a/backend/internal/infra/smtp/sender.go
+++ b/backend/internal/infra/smtp/sender.go
@@ -1,0 +1,50 @@
+// Package smtp は SES を使わない環境(staging)向けのメール送信実装。
+// 宛先は box 上のメールキャッチャー(同一 Docker ネットワーク内の SMTP サーバー)で、
+// 認証・TLS なしの内部ネットワーク前提。実メールは外部へ送信されない。
+package smtp
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	netsmtp "net/smtp"
+	"strings"
+)
+
+// Sender は usecase.MagicLinkSender を SMTP で満たす送信実装。
+type Sender struct {
+	addr string // host:port
+	from string // 送信元アドレス(ベアアドレス。エンベロープと From ヘッダの両方に使う)
+}
+
+// NewSender は host:port のメールキャッチャーへ from 名義で送る Sender を返す。
+func NewSender(host, port, from string) *Sender {
+	return &Sender{addr: host + ":" + port, from: from}
+}
+
+// SendInvitationEmail は multipart/alternative(text + html)の 1 通を SMTP で送信する。
+func (s *Sender) SendInvitationEmail(_ context.Context, to, subject, htmlBody, textBody string) error {
+	const boundary = "frestyle-invitation-boundary"
+	var b strings.Builder
+	b.WriteString("From: " + s.from + "\r\n")
+	b.WriteString("To: " + to + "\r\n")
+	// 日本語件名は RFC 2047 の Q エンコードで包む。
+	b.WriteString("Subject: " + mime.QEncoding.Encode("utf-8", subject) + "\r\n")
+	b.WriteString("MIME-Version: 1.0\r\n")
+	b.WriteString("Content-Type: multipart/alternative; boundary=" + boundary + "\r\n")
+	b.WriteString("\r\n")
+	for _, part := range []struct{ contentType, body string }{
+		{"text/plain; charset=utf-8", textBody},
+		{"text/html; charset=utf-8", htmlBody},
+	} {
+		b.WriteString("--" + boundary + "\r\n")
+		b.WriteString("Content-Type: " + part.contentType + "\r\n\r\n")
+		b.WriteString(part.body + "\r\n")
+	}
+	b.WriteString("--" + boundary + "--\r\n")
+
+	if err := netsmtp.SendMail(s.addr, nil, s.from, []string{to}, []byte(b.String())); err != nil {
+		return fmt.Errorf("smtp send to %s via %s: %w", to, s.addr, err)
+	}
+	return nil
+}

--- a/backend/internal/infra/smtp/sender_test.go
+++ b/backend/internal/infra/smtp/sender_test.go
@@ -101,6 +101,48 @@ func Test_SMTP送信_宛先と件名と両形式の本文が届く(t *testing.T)
 	}
 }
 
+func Test_SMTP送信_宛先の改行注入は拒否する(t *testing.T) {
+	// ヘッダインジェクション(CRLF で Bcc 等を注入)はアドレス検証で弾く。
+	s := NewSender("127.0.0.1", "1", "noreply@staging.example.jp")
+	err := s.SendInvitationEmail(
+		context.Background(),
+		"a@example.com\r\nBcc: victim@example.com", "s", "h", "t",
+	)
+	if err == nil {
+		t.Fatal("改行入りの宛先が拒否されなかった")
+	}
+}
+
+func Test_SMTP送信_件名の改行は除去される(t *testing.T) {
+	addr, received := fakeSMTPServer(t)
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+
+	s := NewSender(host, port, "noreply@staging.example.jp")
+	if err := s.SendInvitationEmail(
+		context.Background(),
+		"invitee@example.com", "subject\r\nBcc: victim@example.com", "h", "t",
+	); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	var got string
+	select {
+	case got = <-received:
+	case <-time.After(3 * time.Second):
+		t.Fatal("fake サーバーに DATA が届かなかった")
+	}
+	// 改行が除去されていれば "Bcc:" は Subject 行の中の無害な文字列として残るだけで、
+	// 独立したヘッダ行(行頭の Bcc:)にはならない。
+	for _, line := range strings.Split(got, "\n") {
+		if strings.HasPrefix(strings.TrimRight(line, "\r"), "Bcc:") {
+			t.Errorf("件名経由でヘッダ行が注入された。got:\n%s", got)
+		}
+	}
+}
+
 func Test_SMTP送信_接続失敗はエラーを返す(t *testing.T) {
 	// 未使用ポートに向けて送ると接続エラーになる。
 	s := NewSender("127.0.0.1", "1", "noreply@staging.example.jp")

--- a/backend/internal/infra/smtp/sender_test.go
+++ b/backend/internal/infra/smtp/sender_test.go
@@ -1,0 +1,110 @@
+package smtp
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeSMTPServer は 1 接続だけ受けて DATA の中身を received へ流す最小 SMTP サーバー。
+func fakeSMTPServer(t *testing.T) (addr string, received <-chan string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ch := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		fmt.Fprintf(conn, "220 fake ready\r\n")
+		var data strings.Builder
+		inData := false
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if inData {
+				if strings.TrimRight(line, "\r\n") == "." {
+					inData = false
+					fmt.Fprintf(conn, "250 ok\r\n")
+					ch <- data.String()
+					continue
+				}
+				data.WriteString(line)
+				continue
+			}
+			switch cmd := strings.ToUpper(strings.TrimSpace(line)); {
+			case strings.HasPrefix(cmd, "DATA"):
+				inData = true
+				fmt.Fprintf(conn, "354 go ahead\r\n")
+			case strings.HasPrefix(cmd, "QUIT"):
+				fmt.Fprintf(conn, "221 bye\r\n")
+				return
+			default: // EHLO / HELO / MAIL FROM / RCPT TO
+				fmt.Fprintf(conn, "250 ok\r\n")
+			}
+		}
+	}()
+	return ln.Addr().String(), ch
+}
+
+func Test_SMTP送信_宛先と件名と両形式の本文が届く(t *testing.T) {
+	addr, received := fakeSMTPServer(t)
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+
+	s := NewSender(host, port, "noreply@staging.example.jp")
+	if err := s.SendInvitationEmail(
+		context.Background(),
+		"invitee@example.com", "FreStyle への招待", "<p>magic-link</p>", "magic-link-text",
+	); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	var got string
+	select {
+	case got = <-received:
+	case <-time.After(3 * time.Second):
+		t.Fatal("fake サーバーに DATA が届かなかった")
+	}
+
+	for _, want := range []string{
+		"From: noreply@staging.example.jp",
+		"To: invitee@example.com",
+		"multipart/alternative",
+		"text/plain; charset=utf-8",
+		"text/html; charset=utf-8",
+		"<p>magic-link</p>",
+		"magic-link-text",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("送信データに %q が含まれない。got:\n%s", want, got)
+		}
+	}
+	// 日本語件名は RFC 2047 でエンコードされる(生の UTF-8 が Subject 行に出ない)。
+	if !strings.Contains(got, "Subject: =?utf-8?q?") {
+		t.Errorf("Subject が Q エンコードされていない。got:\n%s", got)
+	}
+}
+
+func Test_SMTP送信_接続失敗はエラーを返す(t *testing.T) {
+	// 未使用ポートに向けて送ると接続エラーになる。
+	s := NewSender("127.0.0.1", "1", "noreply@staging.example.jp")
+	if err := s.SendInvitationEmail(context.Background(), "a@example.com", "s", "h", "t"); err == nil {
+		t.Fatal("接続できないのにエラーが返らなかった")
+	}
+}


### PR DESCRIPTION
## 概要
staging では SES が使えず招待メールが送信されない（FRESTYLE-71 コメント参照）。staging 用に「box 上のメールキャッチャーへ SMTP で送信し、Web UI で閲覧する」経路を追加する。クリーンアーキテクチャの送信 port（`usecase.MagicLinkSender`）はそのままに、infra 実装の追加と wiring の設定判定のみで実現する。

## 変更内容
- [internal/infra/smtp/sender.go](backend/internal/infra/smtp/sender.go)（新規）: `SendInvitationEmail` を SMTP で実装（multipart/alternative・日本語件名は RFC 2047 Q エンコード・認証/TLS なしの内部ネットワーク前提）
- [config.go](backend/internal/infra/config/config.go): `SMTPConfig`（`MAIL_SMTP_HOST` / `MAIL_SMTP_PORT` 既定 1025 / `MAIL_FROM_ADDRESS`）を追加
- [routes_admin.go](backend/internal/handler/routes_admin.go): `MAIL_SMTP_HOST` 設定時は SMTP sender を最優先で採用。リンク・本文の組み立て（`ses.MagicLinkURL` / `ses.BuildInvitationMail`）は共通利用
- [staging-deploy.yml](.github/workflows/staging-deploy.yml): 予約サブドメインに `mail` を追加（メール UI 用）
- `.env.example`: `MAIL_*` キーを追記

環境判定は env 名ではなく**設定の有無**で行うため、本番（SES）・ローカル（送信スキップ）の挙動は不変。

## テスト
- 新規: fake SMTP サーバー（net.Listener）で送信内容（From/To/件名エンコード/text+html 両パート）を検証・接続失敗時のエラーも検証
- `go build ./...` / 変更パッケージの `go test` 成功（sandbox の Java runner テストのみローカル環境依存で変更前から失敗・CI で検証）
- `gofumpt` 差分なし / workflow YAML 構文 OK

## 関連チケット
- FRESTYLE-248（staging 側の compose / Caddy は次の PR）