### PR TITLE
refactor: course クラスタ 5 ファイルのテストを repofakes へ移行する (FRESTYLE-4)

### DIFF
--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func Test_コース_取得_traineeは下書き不可(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Get(context.Background(), 5, 10, domain.RoleTrainee)
 	require.Error(t, err)
@@ -20,8 +20,8 @@ func Test_コース_取得_traineeは下書き不可(t *testing.T) {
 }
 
 func Test_コース_取得_traineeは自社の公開を読める(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Get(context.Background(), 5, 10, domain.RoleTrainee)
 	require.NoError(t, err)
@@ -29,16 +29,16 @@ func Test_コース_取得_traineeは自社の公開を読める(t *testing.T) {
 }
 
 func Test_コース_取得_別会社は禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Get(context.Background(), 5, 99, domain.RoleCompanyAdmin)
 	require.Error(t, err)
 }
 
 func Test_コース_作成_traineeは禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
@@ -48,24 +48,24 @@ func Test_コース_作成_traineeは禁止(t *testing.T) {
 }
 
 func Test_コース_作成_会社管理者は成功(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
 		Title: "Web 基礎", Description: "HTTP / REST", SortOrder: 10, IsPublished: true,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, crepo.created)
-	assert.Equal(t, uint64(7), crepo.created.CreatedByUserID)
-	assert.Equal(t, uint64(10), crepo.created.CompanyID)
+	require.NotNil(t, cstore.created)
+	assert.Equal(t, uint64(7), cstore.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), cstore.created.CompanyID)
 	assert.Equal(t, "Web 基礎", got.Title)
 	assert.Equal(t, 10, got.SortOrder)
 }
 
 func Test_コース_作成_会社未所属は禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
@@ -75,19 +75,19 @@ func Test_コース_作成_会社未所属は禁止(t *testing.T) {
 }
 
 func Test_コース_更新_別会社は禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
 		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
 	})
 	require.Error(t, err)
-	assert.Nil(t, crepo.updated)
+	assert.Nil(t, cstore.updated)
 }
 
 func Test_コース_更新_自社管理者は成功(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10, Title: "old"}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -95,30 +95,30 @@ func Test_コース_更新_自社管理者は成功(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "new", got.Title)
-	assert.NotNil(t, crepo.updated)
+	assert.NotNil(t, cstore.updated)
 }
 
 func Test_コース_削除_traineeは禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
 	require.Error(t, err)
 }
 
 func Test_コース_削除_自社管理者は教材も連鎖削除(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10}})
+	mrepo, mstore := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), crepo.deleted)
-	assert.Equal(t, uint64(1), mrepo.deletedByCo, "コース配下の教材も cascade で削除される")
+	assert.Equal(t, uint64(1), cstore.deleted)
+	assert.Equal(t, uint64(1), mstore.deletedByCourse, "コース配下の教材も cascade で削除される")
 }
 
 func Test_コース_作成_カテゴリ付きで成功(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -129,8 +129,8 @@ func Test_コース_作成_カテゴリ付きで成功(t *testing.T) {
 }
 
 func Test_コース_作成_不正なカテゴリは拒否(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -138,12 +138,12 @@ func Test_コース_作成_不正なカテゴリは拒否(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid course category")
-	assert.Nil(t, crepo.created)
+	assert.Nil(t, cstore.created)
 }
 
 func Test_コース_作成_カテゴリ未分類は許可(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -154,8 +154,8 @@ func Test_コース_作成_カテゴリ未分類は許可(t *testing.T) {
 }
 
 func Test_コース_更新_カテゴリを変更できる(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Category: domain.CourseCategoryDevBasics}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10, Category: domain.CourseCategoryDevBasics}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -166,8 +166,8 @@ func Test_コース_更新_カテゴリを変更できる(t *testing.T) {
 }
 
 func Test_コース_作成_言語付きで成功(t *testing.T) {
-	crepo := &fakeCourseRepo{}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Create(context.Background(), usecase.CreateCourseInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -175,12 +175,12 @@ func Test_コース_作成_言語付きで成功(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "go", got.Language)
-	assert.Equal(t, "go", crepo.created.Language)
+	assert.Equal(t, "go", cstore.created.Language)
 }
 
 func Test_コース_更新_言語を変更できる(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Language: "go"}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10, Language: "go"}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -191,8 +191,8 @@ func Test_コース_更新_言語を変更できる(t *testing.T) {
 }
 
 func Test_コース_更新_言語は空にもできる(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10, Language: "go"}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10, Language: "go"}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	got, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -203,8 +203,8 @@ func Test_コース_更新_言語は空にもできる(t *testing.T) {
 }
 
 func Test_コース_更新_不正なカテゴリは拒否(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 1, CompanyID: 10}}
-	mrepo := &fakeTeachingMaterialRepo{}
+	crepo, cstore := courseRepo(courseFakeConfig{get: &domain.Course{ID: 1, CompanyID: 10}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
 	uc := usecase.NewCourseUseCase(crepo, mrepo)
 	_, err := uc.Update(context.Background(), usecase.UpdateCourseInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -212,5 +212,5 @@ func Test_コース_更新_不正なカテゴリは拒否(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid course category")
-	assert.Nil(t, crepo.updated)
+	assert.Nil(t, cstore.updated)
 }

--- a/backend/internal/usecase/course_usecase_test.go
+++ b/backend/internal/usecase/course_usecase_test.go
@@ -59,6 +59,10 @@ func Test_コース_作成_会社管理者は成功(t *testing.T) {
 	require.NotNil(t, cstore.created)
 	assert.Equal(t, uint64(7), cstore.created.CreatedByUserID)
 	assert.Equal(t, uint64(10), cstore.created.CompanyID)
+	assert.Equal(t, "Web 基礎", cstore.created.Title)
+	assert.Equal(t, "HTTP / REST", cstore.created.Description)
+	assert.Equal(t, 10, cstore.created.SortOrder)
+	assert.True(t, cstore.created.IsPublished)
 	assert.Equal(t, "Web 基礎", got.Title)
 	assert.Equal(t, 10, got.SortOrder)
 }
@@ -95,7 +99,11 @@ func Test_コース_更新_自社管理者は成功(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "new", got.Title)
-	assert.NotNil(t, cstore.updated)
+	require.NotNil(t, cstore.updated)
+	assert.Equal(t, "new", cstore.updated.Title)
+	assert.Equal(t, "X", cstore.updated.Description)
+	assert.Equal(t, 200, cstore.updated.SortOrder)
+	assert.True(t, cstore.updated.IsPublished)
 }
 
 func Test_コース_削除_traineeは禁止(t *testing.T) {

--- a/backend/internal/usecase/get_last_viewed_chapter_usecase_test.go
+++ b/backend/internal/usecase/get_last_viewed_chapter_usecase_test.go
@@ -7,34 +7,29 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
 
-// fakeChapterViewRepo は UserChapterViewRepository の fake。
-type fakeChapterViewRepo struct {
-	lastViewed *domain.UserChapterView
-	getErr     error
-}
-
-func (f *fakeChapterViewRepo) UpsertView(context.Context, uint64, uint64, uint64) error { return nil }
-
-func (f *fakeChapterViewRepo) ListRecentByUser(context.Context, uint64, int) ([]domain.UserChapterView, error) {
-	return nil, nil
-}
-
-func (f *fakeChapterViewRepo) GetLastViewedByUserAndCourse(context.Context, uint64, uint64) (*domain.UserChapterView, error) {
-	if f.getErr != nil {
-		return nil, f.getErr
+// chapterViewRepo は UserChapterViewRepository の生成 fake に、このテストが使う
+// GetLastViewedByUserAndCourse だけを差し込んで返す。
+func chapterViewRepo(lastViewed *domain.UserChapterView, getErr error) *repofakes.FakeUserChapterViewRepository {
+	return &repofakes.FakeUserChapterViewRepository{
+		GetLastViewedByUserAndCourseFunc: func(context.Context, uint64, uint64) (*domain.UserChapterView, error) {
+			if getErr != nil {
+				return nil, getErr
+			}
+			return lastViewed, nil
+		},
 	}
-	return f.lastViewed, nil
 }
 
 func Test_最終閲覧章_履歴があれば返す(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
 	view := &domain.UserChapterView{UserID: 7, TeachingMaterialID: 42, CourseID: 5, LastViewedAt: time.Now()}
-	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{lastViewed: view})
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, chapterViewRepo(view, nil))
 
 	got, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
 		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
@@ -45,8 +40,8 @@ func Test_最終閲覧章_履歴があれば返す(t *testing.T) {
 }
 
 func Test_最終閲覧章_履歴なしはnilを返す(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
-	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{lastViewed: nil})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, chapterViewRepo(nil, nil))
 
 	got, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
 		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
@@ -56,8 +51,8 @@ func Test_最終閲覧章_履歴なしはnilを返す(t *testing.T) {
 }
 
 func Test_最終閲覧章_他社コースは禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
-	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, chapterViewRepo(nil, nil))
 
 	_, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
 		UserID: 7, ActorCompanyID: 99, ActorRole: domain.RoleTrainee, CourseID: 5,
@@ -67,8 +62,8 @@ func Test_最終閲覧章_他社コースは禁止(t *testing.T) {
 }
 
 func Test_最終閲覧章_traineeは未公開コース禁止(t *testing.T) {
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
-	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}})
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, chapterViewRepo(nil, nil))
 
 	_, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
 		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,
@@ -78,8 +73,8 @@ func Test_最終閲覧章_traineeは未公開コース禁止(t *testing.T) {
 }
 
 func Test_最終閲覧章_コースが無ければNotFound(t *testing.T) {
-	crepo := &fakeCourseRepo{getErr: gorm.ErrRecordNotFound}
-	uc := usecase.NewGetLastViewedChapterUseCase(crepo, &fakeChapterViewRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{getErr: gorm.ErrRecordNotFound})
+	uc := usecase.NewGetLastViewedChapterUseCase(crepo, chapterViewRepo(nil, nil))
 
 	_, err := uc.Execute(context.Background(), usecase.GetLastViewedChapterInput{
 		UserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, CourseID: 5,

--- a/backend/internal/usecase/lesson_progress_usecase_test.go
+++ b/backend/internal/usecase/lesson_progress_usecase_test.go
@@ -119,14 +119,15 @@ func Test_レッスン完了_存在しない教材は404相当(t *testing.T) {
 }
 
 func Test_レッスン完了_記録失敗を伝播(t *testing.T) {
-	progress, _ := progressRepo(progressFakeConfig{completeErr: errors.New("db")})
+	wantErr := errors.New("db")
+	progress, _ := progressRepo(progressFakeConfig{completeErr: wantErr})
 	mat, crs := publishedSetup(5, 10, 1)
 	uc := usecase.NewMarkLessonCompletedUseCase(progress, mat, crs, &nopActivityRepo{})
 
 	err := uc.Execute(context.Background(), usecase.MarkLessonCompletedInput{
 		UserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, TeachingMaterialID: 5,
 	})
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, wantErr, "repository のエラーを別のエラーに置き換えず伝播する")
 }
 
 func Test_レッスン完了取消_行を削除する(t *testing.T) {

--- a/backend/internal/usecase/lesson_progress_usecase_test.go
+++ b/backend/internal/usecase/lesson_progress_usecase_test.go
@@ -7,122 +7,70 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
 
-// fakeLessonProgressRepo は LessonProgressRepository の fake。
-type fakeLessonProgressRepo struct {
+// progressStore は進捗 fake が記録する状態(course クラスタのテストで共有)。
+type progressStore struct {
 	completed   map[uint64]uint64 // materialID -> courseID
+	countCalled bool
+}
+
+// progressFakeConfig は進捗 fake の応答設定。ゼロ値はすべて「空を返す」。
+type progressFakeConfig struct {
 	listRows    []domain.UserLessonProgress
 	completeErr error
-	// CountCompletedByUserGroupedByCourse 用
-	countsByCourse map[uint64]int
-	countErr       error
-	countCalled    bool
+	counts      map[uint64]int
+	countErr    error
 }
 
-func (f *fakeLessonProgressRepo) CountCompletedByUserGroupedByCourse(context.Context, uint64) (map[uint64]int, error) {
-	f.countCalled = true
-	if f.countErr != nil {
-		return nil, f.countErr
+// progressRepo は LessonProgressRepository の生成 fake に、このクラスタが使う
+// メソッドだけを差し込んで返す。
+func progressRepo(cfg progressFakeConfig) (*repofakes.FakeLessonProgressRepository, *progressStore) {
+	st := &progressStore{completed: map[uint64]uint64{}}
+	repo := &repofakes.FakeLessonProgressRepository{
+		MarkCompletedFunc: func(_ context.Context, _, materialID, courseID uint64) (bool, error) {
+			if cfg.completeErr != nil {
+				return false, cfg.completeErr
+			}
+			_, alreadyDone := st.completed[materialID]
+			st.completed[materialID] = courseID
+			return !alreadyDone, nil
+		},
+		MarkIncompleteFunc: func(_ context.Context, _, materialID uint64) error {
+			delete(st.completed, materialID)
+			return nil
+		},
+		ListByUserFunc: func(context.Context, uint64) ([]domain.UserLessonProgress, error) {
+			return cfg.listRows, nil
+		},
+		CountCompletedByUserGroupedByCourseFunc: func(context.Context, uint64) (map[uint64]int, error) {
+			st.countCalled = true
+			if cfg.countErr != nil {
+				return nil, cfg.countErr
+			}
+			return cfg.counts, nil
+		},
 	}
-	return f.countsByCourse, nil
+	return repo, st
 }
-
-func newFakeLessonProgressRepo() *fakeLessonProgressRepo {
-	return &fakeLessonProgressRepo{completed: map[uint64]uint64{}}
-}
-
-func (f *fakeLessonProgressRepo) MarkCompleted(_ context.Context, _, materialID, courseID uint64) (bool, error) {
-	if f.completeErr != nil {
-		return false, f.completeErr
-	}
-	_, alreadyDone := f.completed[materialID]
-	f.completed[materialID] = courseID
-	return !alreadyDone, nil
-}
-
-func (f *fakeLessonProgressRepo) MarkIncomplete(_ context.Context, _, materialID uint64) error {
-	delete(f.completed, materialID)
-	return nil
-}
-
-func (f *fakeLessonProgressRepo) ListByUser(context.Context, uint64) ([]domain.UserLessonProgress, error) {
-	return f.listRows, nil
-}
-
-// fakeMaterialRepoForProgress は TeachingMaterialRepository の最小 fake（GetByID のみ意味を持つ）。
-type fakeMaterialRepoForProgress struct {
-	material *domain.TeachingMaterial
-	getErr   error
-}
-
-func (f *fakeMaterialRepoForProgress) GetByID(context.Context, uint64) (*domain.TeachingMaterial, error) {
-	if f.getErr != nil {
-		return nil, f.getErr
-	}
-	return f.material, nil
-}
-
-func (f *fakeMaterialRepoForProgress) ListByCompany(context.Context, uint64, bool) ([]domain.TeachingMaterial, error) {
-	return nil, nil
-}
-
-func (f *fakeMaterialRepoForProgress) ListByCourse(context.Context, uint64, bool) ([]domain.TeachingMaterial, error) {
-	return nil, nil
-}
-
-func (f *fakeMaterialRepoForProgress) CountByCourseForCompany(context.Context, uint64, bool) (map[uint64]int, error) {
-	return nil, nil
-}
-
-func (f *fakeMaterialRepoForProgress) Create(context.Context, *domain.TeachingMaterial) error {
-	return nil
-}
-
-func (f *fakeMaterialRepoForProgress) Update(context.Context, *domain.TeachingMaterial) error {
-	return nil
-}
-
-func (f *fakeMaterialRepoForProgress) Delete(context.Context, uint64) error { return nil }
-
-func (f *fakeMaterialRepoForProgress) DeleteByCourse(context.Context, uint64) error { return nil }
-
-// fakeCourseRepoForProgress は CourseRepository の最小 fake（GetByID のみ意味を持つ）。
-type fakeCourseRepoForProgress struct {
-	course *domain.Course
-	getErr error
-}
-
-func (f *fakeCourseRepoForProgress) GetByID(context.Context, uint64) (*domain.Course, error) {
-	if f.getErr != nil {
-		return nil, f.getErr
-	}
-	return f.course, nil
-}
-
-func (f *fakeCourseRepoForProgress) ListByCompany(context.Context, uint64, bool) ([]domain.Course, error) {
-	return nil, nil
-}
-func (f *fakeCourseRepoForProgress) Create(context.Context, *domain.Course) error { return nil }
-func (f *fakeCourseRepoForProgress) Update(context.Context, *domain.Course) error { return nil }
-func (f *fakeCourseRepoForProgress) Delete(context.Context, uint64) error         { return nil }
 
 // publishedSetup は「自社・公開教材・公開コース」の正常に完了できる組み合わせを作る。
-func publishedSetup(materialID, companyID, courseID uint64) (*fakeMaterialRepoForProgress, *fakeCourseRepoForProgress) {
-	mat := &fakeMaterialRepoForProgress{material: &domain.TeachingMaterial{
+func publishedSetup(materialID, companyID, courseID uint64) (*repofakes.FakeTeachingMaterialRepository, *repofakes.FakeCourseRepository) {
+	mat, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: materialID, CompanyID: companyID, CourseID: courseID, IsPublished: true,
-	}}
-	crs := &fakeCourseRepoForProgress{course: &domain.Course{
+	}})
+	crs, _ := courseRepo(courseFakeConfig{get: &domain.Course{
 		ID: courseID, CompanyID: companyID, IsPublished: true,
-	}}
+	}})
 	return mat, crs
 }
 
 func Test_レッスン完了_自社の公開教材はcourse_idを解決して記録する(t *testing.T) {
-	progress := newFakeLessonProgressRepo()
+	progress, pstore := progressRepo(progressFakeConfig{})
 	mat, crs := publishedSetup(5, 10, 99)
 	uc := usecase.NewMarkLessonCompletedUseCase(progress, mat, crs, &nopActivityRepo{})
 
@@ -130,11 +78,11 @@ func Test_レッスン完了_自社の公開教材はcourse_idを解決して記
 		UserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, TeachingMaterialID: 5,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, uint64(99), progress.completed[5]) // 教材の course_id が使われる
+	assert.Equal(t, uint64(99), pstore.completed[5]) // 教材の course_id が使われる
 }
 
 func Test_レッスン完了_他社の教材は403相当で弾く(t *testing.T) {
-	progress := newFakeLessonProgressRepo()
+	progress, pstore := progressRepo(progressFakeConfig{})
 	mat, crs := publishedSetup(5, 10, 99) // company 10 の教材
 	uc := usecase.NewMarkLessonCompletedUseCase(progress, mat, crs, &nopActivityRepo{})
 
@@ -142,15 +90,15 @@ func Test_レッスン完了_他社の教材は403相当で弾く(t *testing.T) 
 		UserID: 1, ActorCompanyID: 20, ActorRole: domain.RoleTrainee, TeachingMaterialID: 5, // 別 company
 	})
 	assert.ErrorIs(t, err, usecase.ErrLessonForbidden)
-	assert.Empty(t, progress.completed)
+	assert.Empty(t, pstore.completed)
 }
 
 func Test_レッスン完了_trainee_に未公開の教材は403相当(t *testing.T) {
-	progress := newFakeLessonProgressRepo()
-	mat := &fakeMaterialRepoForProgress{material: &domain.TeachingMaterial{
+	progress, _ := progressRepo(progressFakeConfig{})
+	mat, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 5, CompanyID: 10, CourseID: 99, IsPublished: false, // 下書き
-	}}
-	crs := &fakeCourseRepoForProgress{course: &domain.Course{ID: 99, CompanyID: 10, IsPublished: true}}
+	}})
+	crs, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 99, CompanyID: 10, IsPublished: true}})
 	uc := usecase.NewMarkLessonCompletedUseCase(progress, mat, crs, &nopActivityRepo{})
 
 	err := uc.Execute(context.Background(), usecase.MarkLessonCompletedInput{
@@ -160,12 +108,10 @@ func Test_レッスン完了_trainee_に未公開の教材は403相当(t *testin
 }
 
 func Test_レッスン完了_存在しない教材は404相当(t *testing.T) {
-	uc := usecase.NewMarkLessonCompletedUseCase(
-		newFakeLessonProgressRepo(),
-		&fakeMaterialRepoForProgress{getErr: gorm.ErrRecordNotFound},
-		&fakeCourseRepoForProgress{},
-		&nopActivityRepo{},
-	)
+	progress, _ := progressRepo(progressFakeConfig{})
+	mat, _ := materialRepo(materialFakeConfig{getErr: gorm.ErrRecordNotFound})
+	crs, _ := courseRepo(courseFakeConfig{})
+	uc := usecase.NewMarkLessonCompletedUseCase(progress, mat, crs, &nopActivityRepo{})
 	err := uc.Execute(context.Background(), usecase.MarkLessonCompletedInput{
 		UserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee, TeachingMaterialID: 404,
 	})
@@ -173,8 +119,7 @@ func Test_レッスン完了_存在しない教材は404相当(t *testing.T) {
 }
 
 func Test_レッスン完了_記録失敗を伝播(t *testing.T) {
-	progress := newFakeLessonProgressRepo()
-	progress.completeErr = errors.New("db")
+	progress, _ := progressRepo(progressFakeConfig{completeErr: errors.New("db")})
 	mat, crs := publishedSetup(5, 10, 1)
 	uc := usecase.NewMarkLessonCompletedUseCase(progress, mat, crs, &nopActivityRepo{})
 
@@ -185,17 +130,18 @@ func Test_レッスン完了_記録失敗を伝播(t *testing.T) {
 }
 
 func Test_レッスン完了取消_行を削除する(t *testing.T) {
-	progress := newFakeLessonProgressRepo()
-	progress.completed[5] = 1
+	progress, pstore := progressRepo(progressFakeConfig{})
+	pstore.completed[5] = 1
 	uc := usecase.NewMarkLessonIncompleteUseCase(progress)
 	require.NoError(t, uc.Execute(context.Background(), 1, 5))
-	_, ok := progress.completed[5]
+	_, ok := pstore.completed[5]
 	assert.False(t, ok)
 }
 
 func Test_学習進捗一覧_完了記録を返す(t *testing.T) {
-	progress := newFakeLessonProgressRepo()
-	progress.listRows = []domain.UserLessonProgress{{TeachingMaterialID: 1, CourseID: 9}}
+	progress, _ := progressRepo(progressFakeConfig{
+		listRows: []domain.UserLessonProgress{{TeachingMaterialID: 1, CourseID: 9}},
+	})
 	uc := usecase.NewListLessonProgressUseCase(progress)
 	rows, err := uc.Execute(context.Background(), 1)
 	require.NoError(t, err)

--- a/backend/internal/usecase/list_courses_with_progress_usecase_test.go
+++ b/backend/internal/usecase/list_courses_with_progress_usecase_test.go
@@ -110,7 +110,7 @@ func Test_コース一覧進捗付き_章数集計エラーはそのまま返す
 	_, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
 	})
-	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func Test_コース一覧進捗付き_完了集計エラーはそのまま返す(t *testing.T) {
@@ -122,5 +122,5 @@ func Test_コース一覧進捗付き_完了集計エラーはそのまま返す
 	_, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
 	})
-	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }

--- a/backend/internal/usecase/list_courses_with_progress_usecase_test.go
+++ b/backend/internal/usecase/list_courses_with_progress_usecase_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func Test_コース一覧進捗付き_各コースに章数と完了章数が合成される(t *testing.T) {
-	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1, Title: "Git"}, {ID: 2, Title: "Docker"}}}
-	mrepo := &fakeTeachingMaterialRepo{countsByCourse: map[uint64]int{1: 3, 2: 12}}
-	prepo := &fakeLessonProgressRepo{countsByCourse: map[uint64]int{1: 2}}
+	crepo, _ := courseRepo(courseFakeConfig{rows: []domain.Course{{ID: 1, Title: "Git"}, {ID: 2, Title: "Docker"}}})
+	mrepo, _ := materialRepo(materialFakeConfig{counts: map[uint64]int{1: 3, 2: 12}})
+	prepo, _ := progressRepo(progressFakeConfig{counts: map[uint64]int{1: 2}})
 	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 
 	out, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
@@ -29,8 +29,10 @@ func Test_コース一覧進捗付き_各コースに章数と完了章数が合
 }
 
 func Test_コース一覧進捗付き_集計に無いコースは0章(t *testing.T) {
-	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 7, Title: "空のコース"}}}
-	uc := usecase.NewListCoursesWithProgressUseCase(crepo, &fakeTeachingMaterialRepo{}, &fakeLessonProgressRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{rows: []domain.Course{{ID: 7, Title: "空のコース"}}})
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	prepo, _ := progressRepo(progressFakeConfig{})
+	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 
 	out, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
@@ -42,7 +44,10 @@ func Test_コース一覧進捗付き_集計に無いコースは0章(t *testing
 }
 
 func Test_コース一覧進捗付き_会社未所属は空スライス(t *testing.T) {
-	uc := usecase.NewListCoursesWithProgressUseCase(&fakeCourseRepo{}, &fakeTeachingMaterialRepo{}, &fakeLessonProgressRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{})
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	prepo, _ := progressRepo(progressFakeConfig{})
+	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 	out, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 0, ActorRole: domain.RoleSuperAdmin,
 	})
@@ -53,8 +58,10 @@ func Test_コース一覧進捗付き_会社未所属は空スライス(t *testi
 
 func Test_コース一覧進捗付き_0件でもnilではなく空スライス(t *testing.T) {
 	// GORM の Find は 0 件時に nil スライスを返し JSON で null になるため正規化する(FRESTYLE-70)。
-	crepo := &fakeCourseRepo{rows: nil}
-	uc := usecase.NewListCoursesWithProgressUseCase(crepo, &fakeTeachingMaterialRepo{}, &fakeLessonProgressRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{rows: nil})
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	prepo, _ := progressRepo(progressFakeConfig{})
+	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 	out, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
 	})
@@ -64,40 +71,41 @@ func Test_コース一覧進捗付き_0件でもnilではなく空スライス(t
 }
 
 func Test_コース一覧進捗付き_traineeは公開のみで集計(t *testing.T) {
-	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
-	mrepo := &fakeTeachingMaterialRepo{countsByCourse: map[uint64]int{1: 5}}
-	prepo := &fakeLessonProgressRepo{countsByCourse: map[uint64]int{1: 1}}
+	crepo, _ := courseRepo(courseFakeConfig{rows: []domain.Course{{ID: 1}}})
+	mrepo, mstore := materialRepo(materialFakeConfig{counts: map[uint64]int{1: 5}})
+	prepo, pstore := progressRepo(progressFakeConfig{counts: map[uint64]int{1: 1}})
 	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 
 	_, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, mrepo.lastCountIncludeUnpublished)
-	assert.False(t, *mrepo.lastCountIncludeUnpublished, "trainee の分母は published のみ")
-	assert.True(t, prepo.countCalled, "trainee は完了章数も集計する")
+	require.NotNil(t, mstore.lastCountIncludeUnpublished)
+	assert.False(t, *mstore.lastCountIncludeUnpublished, "trainee の分母は published のみ")
+	assert.True(t, pstore.countCalled, "trainee は完了章数も集計する")
 }
 
 func Test_コース一覧進捗付き_管理ロールは完了集計をスキップ(t *testing.T) {
-	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
-	mrepo := &fakeTeachingMaterialRepo{countsByCourse: map[uint64]int{1: 5}}
-	prepo := &fakeLessonProgressRepo{countsByCourse: map[uint64]int{1: 3}}
+	crepo, _ := courseRepo(courseFakeConfig{rows: []domain.Course{{ID: 1}}})
+	mrepo, mstore := materialRepo(materialFakeConfig{counts: map[uint64]int{1: 5}})
+	prepo, pstore := progressRepo(progressFakeConfig{counts: map[uint64]int{1: 3}})
 	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 
 	out, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, mrepo.lastCountIncludeUnpublished)
-	assert.True(t, *mrepo.lastCountIncludeUnpublished, "admin は下書き章も分母に含む")
-	assert.False(t, prepo.countCalled, "管理ロールは完了記録を持たないため集計しない")
+	require.NotNil(t, mstore.lastCountIncludeUnpublished)
+	assert.True(t, *mstore.lastCountIncludeUnpublished, "admin は下書き章も分母に含む")
+	assert.False(t, pstore.countCalled, "管理ロールは完了記録を持たないため集計しない")
 	assert.Equal(t, 0, out[0].CompletedCount)
 }
 
 func Test_コース一覧進捗付き_章数集計エラーはそのまま返す(t *testing.T) {
-	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
-	mrepo := &fakeTeachingMaterialRepo{countErr: context.DeadlineExceeded}
-	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, &fakeLessonProgressRepo{})
+	crepo, _ := courseRepo(courseFakeConfig{rows: []domain.Course{{ID: 1}}})
+	mrepo, _ := materialRepo(materialFakeConfig{countErr: context.DeadlineExceeded})
+	prepo, _ := progressRepo(progressFakeConfig{})
+	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 
 	_, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{
 		ActorUserID: 5, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
@@ -106,9 +114,9 @@ func Test_コース一覧進捗付き_章数集計エラーはそのまま返す
 }
 
 func Test_コース一覧進捗付き_完了集計エラーはそのまま返す(t *testing.T) {
-	crepo := &fakeCourseRepo{rows: []domain.Course{{ID: 1}}}
-	mrepo := &fakeTeachingMaterialRepo{countsByCourse: map[uint64]int{1: 5}}
-	prepo := &fakeLessonProgressRepo{countErr: context.DeadlineExceeded}
+	crepo, _ := courseRepo(courseFakeConfig{rows: []domain.Course{{ID: 1}}})
+	mrepo, _ := materialRepo(materialFakeConfig{counts: map[uint64]int{1: 5}})
+	prepo, _ := progressRepo(progressFakeConfig{countErr: context.DeadlineExceeded})
 	uc := usecase.NewListCoursesWithProgressUseCase(crepo, mrepo, prepo)
 
 	_, err := uc.Execute(context.Background(), usecase.ListCoursesWithProgressInput{

--- a/backend/internal/usecase/teaching_material_usecase_test.go
+++ b/backend/internal/usecase/teaching_material_usecase_test.go
@@ -6,120 +6,131 @@ import (
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository/repofakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/gorm"
 )
 
-// fakeTeachingMaterialRepo は usecase テスト用フェイク。
-type fakeTeachingMaterialRepo struct {
-	rows           []domain.TeachingMaterial
-	getResp        *domain.TeachingMaterial
-	getErr         error
-	created        *domain.TeachingMaterial
-	updated        *domain.TeachingMaterial
-	deleted        uint64
-	deletedByCo    uint64
-	listCourseID   uint64
-	listIncludeAll bool
-	// CountByCourseForCompany 用
-	countsByCourse              map[uint64]int
-	countErr                    error
+// materialStore は教材 fake が記録する呼び出し内容(course クラスタのテストで共有)。
+type materialStore struct {
+	listCourseID                uint64
+	listIncludeAll              bool
+	created                     *domain.TeachingMaterial
+	updated                     *domain.TeachingMaterial
+	deleted                     uint64
+	deletedByCourse             uint64
 	lastCountIncludeUnpublished *bool
 }
 
-func (r *fakeTeachingMaterialRepo) CountByCourseForCompany(_ context.Context, _ uint64, includeUnpublished bool) (map[uint64]int, error) {
-	r.lastCountIncludeUnpublished = &includeUnpublished
-	if r.countErr != nil {
-		return nil, r.countErr
+// materialFakeConfig は教材 fake の応答設定。ゼロ値はすべて「空を返す」。
+type materialFakeConfig struct {
+	get      *domain.TeachingMaterial
+	getErr   error
+	counts   map[uint64]int
+	countErr error
+}
+
+// materialRepo は TeachingMaterialRepository の生成 fake に、このクラスタが使う
+// メソッドだけを差し込んで返す。残りは生成 fake がゼロ値を返すので no-op が要らない。
+func materialRepo(cfg materialFakeConfig) (*repofakes.FakeTeachingMaterialRepository, *materialStore) {
+	st := &materialStore{}
+	repo := &repofakes.FakeTeachingMaterialRepository{
+		GetByIDFunc: func(context.Context, uint64) (*domain.TeachingMaterial, error) {
+			if cfg.getErr != nil {
+				return nil, cfg.getErr
+			}
+			return cfg.get, nil
+		},
+		ListByCourseFunc: func(_ context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
+			st.listCourseID, st.listIncludeAll = courseID, includeUnpublished
+			return nil, nil
+		},
+		CountByCourseForCompanyFunc: func(_ context.Context, _ uint64, includeUnpublished bool) (map[uint64]int, error) {
+			st.lastCountIncludeUnpublished = &includeUnpublished
+			if cfg.countErr != nil {
+				return nil, cfg.countErr
+			}
+			return cfg.counts, nil
+		},
+		CreateFunc: func(_ context.Context, m *domain.TeachingMaterial) error {
+			m.ID = 99
+			st.created = m
+			return nil
+		},
+		UpdateFunc: func(_ context.Context, m *domain.TeachingMaterial) error {
+			st.updated = m
+			return nil
+		},
+		DeleteFunc: func(_ context.Context, id uint64) error {
+			st.deleted = id
+			return nil
+		},
+		DeleteByCourseFunc: func(_ context.Context, courseID uint64) error {
+			st.deletedByCourse = courseID
+			return nil
+		},
 	}
-	return r.countsByCourse, nil
+	return repo, st
 }
 
-func (r *fakeTeachingMaterialRepo) ListByCompany(_ context.Context, _ uint64, _ bool) ([]domain.TeachingMaterial, error) {
-	return r.rows, nil
-}
-
-func (r *fakeTeachingMaterialRepo) ListByCourse(_ context.Context, courseID uint64, includeUnpublished bool) ([]domain.TeachingMaterial, error) {
-	r.listCourseID, r.listIncludeAll = courseID, includeUnpublished
-	return r.rows, nil
-}
-
-func (r *fakeTeachingMaterialRepo) GetByID(_ context.Context, _ uint64) (*domain.TeachingMaterial, error) {
-	return r.getResp, r.getErr
-}
-
-func (r *fakeTeachingMaterialRepo) Create(_ context.Context, m *domain.TeachingMaterial) error {
-	m.ID = 99
-	r.created = m
-	return nil
-}
-
-func (r *fakeTeachingMaterialRepo) Update(_ context.Context, m *domain.TeachingMaterial) error {
-	r.updated = m
-	return nil
-}
-
-func (r *fakeTeachingMaterialRepo) Delete(_ context.Context, id uint64) error {
-	r.deleted = id
-	return nil
-}
-
-func (r *fakeTeachingMaterialRepo) DeleteByCourse(_ context.Context, courseID uint64) error {
-	r.deletedByCo = courseID
-	return nil
-}
-
-// fakeCourseRepo は course 依存をスタブ化する。
-type fakeCourseRepo struct {
-	rows    []domain.Course
-	getResp *domain.Course
-	getErr  error
+// courseStore はコース fake が記録する更新内容(course クラスタのテストで共有)。
+type courseStore struct {
 	created *domain.Course
 	updated *domain.Course
 	deleted uint64
 }
 
-func (r *fakeCourseRepo) ListByCompany(_ context.Context, _ uint64, _ bool) ([]domain.Course, error) {
-	return r.rows, nil
+// courseFakeConfig はコース fake の応答設定。ゼロ値はすべて「空を返す」。
+type courseFakeConfig struct {
+	rows   []domain.Course
+	get    *domain.Course
+	getErr error
 }
 
-func (r *fakeCourseRepo) GetByID(_ context.Context, _ uint64) (*domain.Course, error) {
-	if r.getErr != nil {
-		return nil, r.getErr
+// courseRepo は CourseRepository の生成 fake に、このクラスタが使うメソッドだけを
+// 差し込んで返す。
+func courseRepo(cfg courseFakeConfig) (*repofakes.FakeCourseRepository, *courseStore) {
+	st := &courseStore{}
+	repo := &repofakes.FakeCourseRepository{
+		ListByCompanyFunc: func(context.Context, uint64, bool) ([]domain.Course, error) {
+			return cfg.rows, nil
+		},
+		GetByIDFunc: func(context.Context, uint64) (*domain.Course, error) {
+			if cfg.getErr != nil {
+				return nil, cfg.getErr
+			}
+			return cfg.get, nil
+		},
+		CreateFunc: func(_ context.Context, c *domain.Course) error {
+			c.ID = 88
+			st.created = c
+			return nil
+		},
+		UpdateFunc: func(_ context.Context, c *domain.Course) error {
+			st.updated = c
+			return nil
+		},
+		DeleteFunc: func(_ context.Context, id uint64) error {
+			st.deleted = id
+			return nil
+		},
 	}
-	return r.getResp, nil
-}
-
-func (r *fakeCourseRepo) Create(_ context.Context, c *domain.Course) error {
-	c.ID = 88
-	r.created = c
-	return nil
-}
-
-func (r *fakeCourseRepo) Update(_ context.Context, c *domain.Course) error {
-	r.updated = c
-	return nil
-}
-
-func (r *fakeCourseRepo) Delete(_ context.Context, id uint64) error {
-	r.deleted = id
-	return nil
+	return repo, st
 }
 
 func Test_教材_コース別一覧_traineeは公開のみ(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	mrepo, mstore := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleTrainee)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(5), mrepo.listCourseID)
-	assert.False(t, mrepo.listIncludeAll, "trainee は draft を含まない")
+	assert.Equal(t, uint64(5), mstore.listCourseID)
+	assert.False(t, mstore.listIncludeAll, "trainee は draft を含まない")
 }
 
 func Test_教材_コース別一覧_traineeは非公開コースを見られない(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleTrainee)
 	require.Error(t, err)
@@ -127,19 +138,19 @@ func Test_教材_コース別一覧_traineeは非公開コースを見られな�
 }
 
 func Test_教材_コース別一覧_会社管理者は下書きも含む(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	mrepo, mstore := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.ListByCourse(context.Background(), 5, 10, domain.RoleCompanyAdmin)
 	require.NoError(t, err)
-	assert.True(t, mrepo.listIncludeAll)
+	assert.True(t, mstore.listIncludeAll)
 }
 
 func Test_教材_取得_traineeは下書き不可(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
 	require.Error(t, err)
@@ -147,10 +158,10 @@ func Test_教材_取得_traineeは下書き不可(t *testing.T) {
 }
 
 func Test_教材_取得_traineeは自社の公開を読める(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Get(context.Background(), 1, 10, domain.RoleTrainee)
 	require.NoError(t, err)
@@ -158,10 +169,10 @@ func Test_教材_取得_traineeは自社の公開を読める(t *testing.T) {
 }
 
 func Test_教材_取得_別会社は禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: true,
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: true}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Get(context.Background(), 1, 99, domain.RoleCompanyAdmin)
 	require.Error(t, err)
@@ -169,10 +180,10 @@ func Test_教材_取得_別会社は禁止(t *testing.T) {
 }
 
 func Test_教材_取得_運営は別会社も許可(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, IsPublished: false,
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10, IsPublished: false}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Get(context.Background(), 1, 99, domain.RoleSuperAdmin)
 	require.NoError(t, err)
@@ -180,8 +191,8 @@ func Test_教材_取得_運営は別会社も許可(t *testing.T) {
 }
 
 func Test_教材_作成_traineeは禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 1, ActorCompanyID: 10, ActorRole: domain.RoleTrainee,
@@ -191,24 +202,24 @@ func Test_教材_作成_traineeは禁止(t *testing.T) {
 }
 
 func Test_教材_作成_会社管理者は成功(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	mrepo, mstore := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
 		CourseID: 5, Title: "Spring 入門", Content: "# Spring", IsPublished: true,
 	})
 	require.NoError(t, err)
-	require.NotNil(t, mrepo.created)
-	assert.Equal(t, uint64(7), mrepo.created.CreatedByUserID)
-	assert.Equal(t, uint64(10), mrepo.created.CompanyID)
-	assert.Equal(t, uint64(5), mrepo.created.CourseID)
+	require.NotNil(t, mstore.created)
+	assert.Equal(t, uint64(7), mstore.created.CreatedByUserID)
+	assert.Equal(t, uint64(10), mstore.created.CompanyID)
+	assert.Equal(t, uint64(5), mstore.created.CourseID)
 	assert.Equal(t, "Spring 入門", got.Title)
 }
 
 func Test_教材_作成_コースID欠落は禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{}
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -219,8 +230,8 @@ func Test_教材_作成_コースID欠落は禁止(t *testing.T) {
 }
 
 func Test_教材_作成_別会社コースは禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 99}}
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 99}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 7, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -231,8 +242,8 @@ func Test_教材_作成_別会社コースは禁止(t *testing.T) {
 }
 
 func Test_教材_作成_会社未所属は禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{}
-	crepo := &fakeCourseRepo{}
+	mrepo, _ := materialRepo(materialFakeConfig{})
+	crepo, _ := courseRepo(courseFakeConfig{})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Create(context.Background(), usecase.CreateTeachingMaterialInput{
 		ActorUserID: 7, ActorCompanyID: 0, ActorRole: domain.RoleCompanyAdmin,
@@ -242,23 +253,23 @@ func Test_教材_作成_会社未所属は禁止(t *testing.T) {
 }
 
 func Test_教材_更新_別会社は禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, mstore := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	_, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
 		ID: 1, ActorCompanyID: 99, ActorRole: domain.RoleCompanyAdmin, Title: "new",
 	})
 	require.Error(t, err)
-	assert.Nil(t, mrepo.updated)
+	assert.Nil(t, mstore.updated)
 }
 
 func Test_教材_更新_自社管理者は成功(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, mstore := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5, Title: "old",
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	got, err := uc.Update(context.Background(), usecase.UpdateTeachingMaterialInput{
 		ID: 1, ActorCompanyID: 10, ActorRole: domain.RoleCompanyAdmin,
@@ -267,29 +278,26 @@ func Test_教材_更新_自社管理者は成功(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "new", got.Title)
 	assert.Equal(t, 200, got.OrderInCourse)
-	assert.NotNil(t, mrepo.updated)
+	assert.NotNil(t, mstore.updated)
 }
 
 func Test_教材_削除_traineeは禁止(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, _ := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5,
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
 	require.Error(t, err)
 }
 
 func Test_教材_削除_自社管理者は成功(t *testing.T) {
-	mrepo := &fakeTeachingMaterialRepo{getResp: &domain.TeachingMaterial{
+	mrepo, mstore := materialRepo(materialFakeConfig{get: &domain.TeachingMaterial{
 		ID: 1, CompanyID: 10, CourseID: 5,
-	}}
-	crepo := &fakeCourseRepo{getResp: &domain.Course{ID: 5, CompanyID: 10}}
+	}})
+	crepo, _ := courseRepo(courseFakeConfig{get: &domain.Course{ID: 5, CompanyID: 10}})
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleCompanyAdmin)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(1), mrepo.deleted)
+	assert.Equal(t, uint64(1), mstore.deleted)
 }
-
-// 念のため: gorm 依存を import で残すための no-op（一部 import path 揃え用）。
-var _ = gorm.ErrRecordNotFound

--- a/backend/internal/usecase/teaching_material_usecase_test.go
+++ b/backend/internal/usecase/teaching_material_usecase_test.go
@@ -199,6 +199,7 @@ func Test_教材_作成_traineeは禁止(t *testing.T) {
 		CourseID: 5, Title: "X", Content: "Y", IsPublished: true,
 	})
 	require.Error(t, err)
+	assert.Zero(t, mrepo.CreateCalls.Load(), "認可拒否時は書き込みを実行しない")
 }
 
 func Test_教材_作成_会社管理者は成功(t *testing.T) {
@@ -214,6 +215,9 @@ func Test_教材_作成_会社管理者は成功(t *testing.T) {
 	assert.Equal(t, uint64(7), mstore.created.CreatedByUserID)
 	assert.Equal(t, uint64(10), mstore.created.CompanyID)
 	assert.Equal(t, uint64(5), mstore.created.CourseID)
+	assert.Equal(t, "Spring 入門", mstore.created.Title)
+	assert.Equal(t, "# Spring", mstore.created.Content)
+	assert.True(t, mstore.created.IsPublished)
 	assert.Equal(t, "Spring 入門", got.Title)
 }
 
@@ -239,6 +243,7 @@ func Test_教材_作成_別会社コースは禁止(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forbidden")
+	assert.Zero(t, mrepo.CreateCalls.Load(), "別会社コースには書き込みを実行しない")
 }
 
 func Test_教材_作成_会社未所属は禁止(t *testing.T) {
@@ -278,7 +283,11 @@ func Test_教材_更新_自社管理者は成功(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "new", got.Title)
 	assert.Equal(t, 200, got.OrderInCourse)
-	assert.NotNil(t, mstore.updated)
+	require.NotNil(t, mstore.updated)
+	assert.Equal(t, "new", mstore.updated.Title)
+	assert.Equal(t, "X", mstore.updated.Content)
+	assert.Equal(t, 200, mstore.updated.OrderInCourse)
+	assert.True(t, mstore.updated.IsPublished)
 }
 
 func Test_教材_削除_traineeは禁止(t *testing.T) {
@@ -289,6 +298,7 @@ func Test_教材_削除_traineeは禁止(t *testing.T) {
 	uc := usecase.NewTeachingMaterialUseCase(mrepo, crepo)
 	err := uc.Delete(context.Background(), 1, 10, domain.RoleTrainee)
 	require.Error(t, err)
+	assert.Zero(t, mrepo.DeleteCalls.Load(), "認可拒否時は削除を実行しない")
 }
 
 func Test_教材_削除_自社管理者は成功(t *testing.T) {


### PR DESCRIPTION
## 概要
FRESTYLE-4（テスト用 fake の fakegen 生成 fake への移行）Phase 2-d。course クラスタ 5 ファイル（teaching_material / course / lesson_progress / get_last_viewed_chapter / list_courses_with_progress）の手書き fake 4 種（約 190 行）を撤去し、生成 fake（repofakes）+ closure で状態を記録する store 構造体に置き換える。

## 変更内容
- `fakeTeachingMaterialRepo` / `fakeCourseRepo` → [teaching_material_usecase_test.go](backend/internal/usecase/teaching_material_usecase_test.go) の `materialRepo` / `courseRepo` ヘルパ（設定 struct + store）に置換
- `fakeLessonProgressRepo` → [lesson_progress_usecase_test.go](backend/internal/usecase/lesson_progress_usecase_test.go) の `progressRepo` ヘルパに置換
- `fakeChapterViewRepo` → [get_last_viewed_chapter_usecase_test.go](backend/internal/usecase/get_last_viewed_chapter_usecase_test.go) の `chapterViewRepo` ヘルパに置換
- `fakeMaterialRepoForProgress` / `fakeCourseRepoForProgress`（lesson_progress 内の重複 fake）は上記ヘルパに統合して削除
- テストの検証内容・ケース数は不変

## テスト
- `go test ./internal/usecase/` 全パス（検証内容の変更なし）
- `go vet` / `gofumpt` 差分なし

## 関連チケット
- FRESTYLE-4（先行: PR #2219 / #2220 / #2221。残りは execute_code / send_ai_message_stream / submit_master_exercise の 3 ファイル）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * コース、教材、レッスン進捗、閲覧履歴に関する動作検証を強化しました。
  * 作成・更新・削除、公開範囲、権限、カテゴリ・言語変更、不正値への対応を継続的に確認できるよう改善しました。
  * 進捗集計やエラー処理、未公開・未存在データの扱いに関する検証範囲を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->