### PR TITLE
feat: LP を Figma デザインに合わせて再構成する (FRESTYLE-251)

### DIFF
--- a/frontend/e2e/local/public-pages.spec.ts
+++ b/frontend/e2e/local/public-pages.spec.ts
@@ -30,14 +30,14 @@ test.describe('公開トップ（未ログイン）', () => {
 
     // ヒーロー見出しが出ていること（LP が描画されている）。
     await expect(
-      page.getByRole('heading', { level: 1, name: /新卒ITエンジニア向け研修プラットフォーム/ })
+      page.getByRole('heading', { level: 1, name: /「わかる」で終わらせない/ })
     ).toBeVisible();
 
     // リダイレクトは非同期に起きるため、猶予を置いてから URL を確認する。
     await page.waitForTimeout(2000);
     await expect(page).not.toHaveURL(/\/login/);
     await expect(
-      page.getByRole('heading', { level: 1, name: /新卒ITエンジニア向け研修プラットフォーム/ })
+      page.getByRole('heading', { level: 1, name: /「わかる」で終わらせない/ })
     ).toBeVisible();
   });
 

--- a/frontend/src/pages/landing/ui/CtaStrip.tsx
+++ b/frontend/src/pages/landing/ui/CtaStrip.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+/** セクション間で繰り返す小型 CTA(白ピル + 申請ボタン)。反復導線で申請への距離を縮める。 */
+export default function CtaStrip({ text }: { text: string }) {
+  return (
+    <div className="flex justify-center bg-white pb-14">
+      <span className="inline-flex items-center gap-4 rounded-full border border-slate-200 bg-white py-2.5 pl-6 pr-3 text-[13.5px] font-bold text-slate-600 shadow-[0_10px_30px_-18px_rgba(23,36,92,0.35)]">
+        {text}
+        <Link
+          to="/company-application"
+          className="rounded-full bg-brand-600 px-5 py-2 text-[13px] font-bold text-white transition hover:bg-brand-700"
+        >
+          導入・利用申請
+        </Link>
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -2,15 +2,21 @@ import { useEffect } from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import {
   ArrowRightIcon,
+  BellIcon,
   BookOpenIcon,
   ChartBarIcon,
   ChatBubbleLeftRightIcon,
   CheckCircleIcon,
-  CheckIcon,
+  ClipboardDocumentListIcon,
   CodeBracketIcon,
+  EnvelopeIcon,
+  LockClosedIcon,
   MapIcon,
-  PlusIcon,
+  PencilSquareIcon,
+  ShieldCheckIcon,
   UserGroupIcon,
+  UserIcon,
+  UserPlusIcon,
 } from '@heroicons/react/24/outline';
 import PublicHeader from '@/shared/ui/PublicHeader';
 import { useAppSelector, useAppDispatch } from '@/shared/lib/store';
@@ -22,66 +28,222 @@ const SITE_URL = 'https://frestyle.jp/';
 
 const LANGUAGES = ['PHP', 'Java', 'JavaScript', 'TypeScript', 'Go', 'Ruby', 'C', 'C++', 'SQL'];
 
-const FEATURES: { icon: typeof BookOpenIcon; title: string; body: string }[] = [
+// 機能カードのアイコン地色。5 色を循環させ、単色の羅列になるのを避ける。
+const TINTS = {
+  blue: 'bg-brand-50 text-brand-700',
+  green: 'bg-emerald-50 text-emerald-600',
+  violet: 'bg-violet-50 text-violet-600',
+  amber: 'bg-amber-50 text-amber-600',
+  teal: 'bg-teal-50 text-teal-600',
+} as const;
+
+const FEATURES: {
+  icon: typeof BookOpenIcon;
+  tint: keyof typeof TINTS;
+  title: string;
+  body: string;
+}[] = [
+  {
+    icon: BookOpenIcon,
+    tint: 'blue',
+    title: 'コース学習',
+    body: 'Git・Docker・Go・PostgreSQL などを章立てで学ぶ。続きから再開できる。',
+  },
+  {
+    icon: CodeBracketIcon,
+    tint: 'green',
+    title: 'コーディング演習',
+    body: 'ブラウザのエディタで書いて即採点。多言語に対応。',
+  },
   {
     icon: ChatBubbleLeftRightIcon,
-    title: 'AI チャットで質問',
-    body: '詰まったところを AI にその場で相談。学習の流れを止めずに、疑問を解消しながら進められる。',
+    tint: 'violet',
+    title: 'AI チャット',
+    body: '詰まったらその場で質問。学習の流れを止めない。',
   },
   {
     icon: ChartBarIcon,
+    tint: 'amber',
     title: '学習レポート',
-    body: '取り組んだ量や進み具合をレポートで可視化。受講者は自分の伸びを、研修担当はチームの状況を把握できる。',
+    body: '取り組んだ量と進み具合を可視化。伸びが見える。',
+  },
+  {
+    icon: PencilSquareIcon,
+    tint: 'teal',
+    title: '学習ノート',
+    body: '学びを自分の言葉で記録。画像も貼れる。',
   },
   {
     icon: UserGroupIcon,
-    title: 'メンバーの学習状況（管理者）',
-    body: '企業の研修担当は、メンバーごとの進捗・つまずきを一覧で確認。招待もマジックリンクで簡単に行える。',
+    tint: 'blue',
+    title: 'メンバーの学習状況',
+    body: '研修担当は進捗・つまずきを一覧で確認できる。',
+  },
+  {
+    icon: EnvelopeIcon,
+    tint: 'green',
+    title: 'メンバー招待',
+    body: 'マジックリンクで招待。届いたリンクから参加するだけ。',
+  },
+  {
+    icon: BellIcon,
+    tint: 'violet',
+    title: '通知',
+    body: '申請や招待の動きを見逃さない。',
   },
   {
     icon: MapIcon,
+    tint: 'amber',
     title: '迷わない導線',
-    body: '「何を学ぶか」で迷わないよう、学習領域→コース→章の順に整理。初学者がひとりでも進められる設計。',
+    body: '学習領域→コース→章の順に整理。ひとりでも進められる。',
   },
 ];
 
-const STRENGTHS: string[] = [
-  '読むだけで終わらない — 書いて即採点する演習までが研修',
-  '受講者の伸びと研修担当の把握を、同じ場所で',
-  '初学者がひとりでも迷わず進める学習導線',
-];
-
-const STEPS: { title: string; body: string }[] = [
-  { title: '利用申請', body: '企業の研修担当が利用申請を送信。折り返しご案内します。' },
-  { title: 'メンバー招待', body: '受講者をマジックリンクで招待。受け取ったリンクから参加できます。' },
-  { title: '学習開始', body: 'コース学習とコーディング演習で、手を動かしながら研修を進めます。' },
-  { title: '進捗の確認', body: '学習レポートで、受講者・研修担当の双方が伸びを確認できます。' },
-];
-
-const FAQS: { q: string; a: string }[] = [
+const WALK_STEPS: { title: string; body: string }[] = [
   {
-    q: 'FreStyle とは何ですか？',
-    a: 'FreStyle は、新卒 IT エンジニア向けの統合研修プラットフォームです。コース学習・多言語のコーディング演習・AI チャット・学習レポートを1つにまとめ、研修の実施と進捗管理を支援します。',
+    title: '章を読んで理解する',
+    body: '実務直結のコースを章立てで。読んだところまで自動で記録されます。',
   },
   {
-    q: '誰が使うサービスですか？',
-    a: '新卒・若手エンジニアの受講者と、その研修を運営する企業の研修担当者が対象です。受講者は学習を、担当者はメンバーの学習状況の把握を行えます。',
+    title: '演習を解いて、即採点',
+    body: 'ブラウザのエディタで書いて提出。その場で採点され、「できた」が確かめられます。',
   },
   {
-    q: 'どんな言語の演習ができますか？',
-    a: 'PHP・Java・JavaScript・TypeScript・Go・Ruby・C・C++・SQL などに対応しています。ブラウザ上で書いてそのまま採点できます。',
+    title: '詰まったら AI に質問',
+    body: '調べ物で学習が止まらない。文脈を踏まえた回答がその場で返ります。',
   },
   {
-    q: '利用を始めるには？',
-    a: '企業の研修担当者が利用申請を送るところから始まります。受講者は担当者からの招待リンクで参加します。',
+    title: 'レポートで振り返る',
+    body: '取り組んだ量と伸びが自動で集計。研修担当も同じ画面でチームを見守れます。',
   },
 ];
 
-// ヒーローとフッターで共有する「方眼紙」モチーフ(エンジニアの学習ノート)。
-const GRID_PATTERN_LIGHT =
-  'bg-[linear-gradient(to_right,rgba(15,23,42,0.045)_1px,transparent_1px),linear-gradient(to_bottom,rgba(15,23,42,0.045)_1px,transparent_1px)] bg-[size:36px_36px]';
+const REPORT_ROWS: { name: string; pct: number }[] = [
+  { name: 'Git 入門', pct: 100 },
+  { name: 'Docker 入門', pct: 68 },
+  { name: 'Go 基礎', pct: 24 },
+  { name: 'SQL 演習', pct: 52 },
+];
+
+// Before/After 比較表。列 = 研修の観点、行 = 従来の研修 / FreStyle。
+const BA_COLUMNS = ['教材と学び方', '質問対応', '進捗の把握'];
+const BA_BEFORE: { t: string; body: string }[] = [
+  { t: '読んで終わり', body: '座学とスライド中心。理解した「つもり」のまま配属日を迎えてしまう。' },
+  {
+    t: '先輩の手が空くまで待つ',
+    body: '質問のたびに先輩の作業が止まる。聞きづらくて詰まったまま進むことも。',
+  },
+  { t: '日報と口頭で確認', body: '誰がどこで詰まっているかが見えず、フォローが後手に回る。' },
+];
+const BA_AFTER: { t: string; body: string }[] = [
+  { t: '書いて、即採点', body: '章を読んだらすぐ演習。ブラウザで書いて採点され、「できる」まで届く。' },
+  { t: 'AI にその場で質問', body: '学習の流れを止めずに疑問を解消。先輩の時間を奪わない。' },
+  {
+    t: 'レポートと一覧で見える',
+    body: '受講者の伸びとつまずきを研修担当が同じ場所で把握。フォローが先手になる。',
+  },
+];
+
+const ROLES: {
+  icon: typeof UserIcon;
+  tint: keyof typeof TINTS;
+  label: string;
+  title: string;
+  items: string[];
+}[] = [
+  {
+    icon: UserIcon,
+    tint: 'blue',
+    label: 'TRAINEE',
+    title: '受講者',
+    items: [
+      'コースを読み、演習を解いて即採点',
+      '詰まったら AI チャットに質問',
+      'ノートに学びを記録、レポートで自分の伸びを確認',
+    ],
+  },
+  {
+    icon: UserGroupIcon,
+    tint: 'green',
+    label: 'COMPANY ADMIN',
+    title: '企業の研修担当',
+    items: [
+      'メンバーをマジックリンクで招待',
+      '進捗・つまずきを一覧で把握して先回りでフォロー',
+      'AI 利用の可否などをメンバーごとに管理',
+    ],
+  },
+  {
+    icon: ShieldCheckIcon,
+    tint: 'violet',
+    label: 'OPERATOR',
+    title: '運営',
+    items: [
+      '企業の利用申請を受け付けて開設',
+      '会社・メンバーを横断で管理',
+      '操作の監査ログで運用を透明に',
+    ],
+  },
+];
+
+const SECURITY: { icon: typeof ShieldCheckIcon; title: string; body: string }[] = [
+  {
+    icon: ShieldCheckIcon,
+    title: '企業ごとのデータ分離',
+    body: 'コース・演習・進捗は会社単位で分離して管理。',
+  },
+  {
+    icon: UserPlusIcon,
+    title: '招待制ログイン',
+    body: '参加はマジックリンクの招待から。野良登録はできない。',
+  },
+  {
+    icon: LockClosedIcon,
+    title: 'ロール別の権限管理',
+    body: '受講者・研修担当・運営で見える範囲と操作を分ける。',
+  },
+  {
+    icon: ClipboardDocumentListIcon,
+    title: '操作の監査ログ',
+    body: '管理操作の記録を残し、運用を追跡できる。',
+  },
+];
+
+// 濃紺ヒーロー・最終 CTA で共有する「方眼紙」モチーフ(エンジニアの学習ノート)。
 const GRID_PATTERN_DARK =
-  'bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:36px_36px]';
+  'bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:38px_38px]';
+
+/** セクション見出し(eyebrow + タイトル + リード)。on dark は配色だけ差し替える。 */
+function SectionHead({ eyebrow, title, lede, dark }: { eyebrow: string; title: string; lede?: string; dark?: boolean }) {
+  return (
+    <div className="text-center">
+      <p className={`text-xs font-bold tracking-[0.16em] ${dark ? 'text-[#9db8f5]' : 'text-brand-700'}`}>{eyebrow}</p>
+      <h2
+        className={`mt-3 text-[1.75rem] font-extrabold leading-snug tracking-tight sm:text-[2rem] ${dark ? 'text-white' : ''}`}
+      >
+        {title}
+      </h2>
+      {lede && <p className={`mt-3 ${dark ? 'text-[#c7d5f7]' : 'text-slate-600'}`}>{lede}</p>}
+    </div>
+  );
+}
+
+/** セクション間で繰り返す小型 CTA(白ピル + 申請ボタン)。反復導線で申請への距離を縮める。 */
+function CtaStrip({ text }: { text: string }) {
+  return (
+    <div className="flex justify-center bg-white pb-14">
+      <span className="inline-flex items-center gap-4 rounded-full border border-slate-200 bg-white py-2.5 pl-6 pr-3 text-[13.5px] font-bold text-slate-600 shadow-[0_10px_30px_-18px_rgba(23,36,92,0.35)]">
+        {text}
+        <Link
+          to="/company-application"
+          className="rounded-full bg-brand-600 px-5 py-2 text-[13px] font-bold text-white transition hover:bg-brand-700"
+        >
+          導入・利用申請
+        </Link>
+      </span>
+    </div>
+  );
+}
 
 /**
  * LandingPage は未ログイン/検索ボット向けの公開トップ。SEO のインデックス対象。
@@ -89,7 +251,9 @@ const GRID_PATTERN_DARK =
  * ログイン済みで来た場合はダッシュボードへ送る（クライアント遷移時のみ。初回ロードは
  * 認証状態未確定なので LP を表示する = プリレンダーも LP になる）。
  *
- * 配色は Tailwind パレット（brand + 青バイアスの slate、正解表示のみ既存画面と同じ emerald）。
+ * 構成は濃紺ヒーロー + 機能グリッド + 学習の進み方(ダーク) + Before/After 比較 +
+ * ロール別 + セキュリティ + 反復 CTA。実数値・顧客ロゴ・事例は載せない方針。
+ * 配色は Tailwind パレット（brand + slate、正解表示のみ既存画面と同じ emerald）。
  * テーマ CSS 変数のうち accent 系は未定義で、参照すると透明背景になる事故が起きた（FRESTYLE-223）。
  * ヒーローの「タイプ → 採点 → 合格」演出は CSS アニメーションのみ（JS タイマー不使用）で、
  * prefers-reduced-motion では motion-reduce:* で静止画にフォールバックする。
@@ -155,50 +319,54 @@ export default function LandingPage() {
       </div>
 
       <main>
-        {/* ヒーロー: 「書いて即採点」がその場で動く */}
-        <section className="relative overflow-hidden bg-[radial-gradient(52rem_30rem_at_82%_-12%,rgba(37,99,235,0.10),transparent_60%)]">
+        {/* ヒーロー(濃紺): コピー + 「書いて即採点」がその場で動く UI コラージュ */}
+        <section className="relative overflow-hidden bg-[linear-gradient(165deg,#0e1c47_0%,#16295f_60%,#1d3a8f_100%)] text-white">
           <div
             aria-hidden="true"
-            className={`pointer-events-none absolute inset-0 ${GRID_PATTERN_LIGHT} [mask-image:linear-gradient(to_bottom,black,transparent_78%)]`}
+            className={`pointer-events-none absolute inset-0 ${GRID_PATTERN_DARK} [mask-image:radial-gradient(60rem_40rem_at_30%_0%,black,transparent_75%)]`}
           />
-          <div className="relative mx-auto max-w-6xl px-6 pt-20 pb-24 sm:pt-24">
+          <div className="relative mx-auto max-w-6xl px-6 pb-24 pt-20 sm:pt-24">
             <div className="grid items-center gap-14 lg:grid-cols-2">
               <div className="text-center lg:text-left">
-                <p className="inline-flex items-center gap-2 rounded-full border border-brand-200 bg-brand-50 px-3.5 py-1.5 text-xs font-bold text-brand-800">
-                  <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-brand-600" />
+                <p className="inline-flex items-center gap-2 rounded-full border border-white/25 bg-white/10 px-3.5 py-1.5 text-xs font-bold text-[#dbe6ff]">
+                  <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-[#8fb3ff]" />
                   企業向け・新卒エンジニア研修 SaaS
                 </p>
-                <h1 className="mt-6 text-[2.1rem] font-extrabold leading-[1.28] tracking-tight sm:text-[2.7rem] lg:text-[3rem]">
+                <h1 className="mt-6 text-[1.95rem] font-extrabold leading-[1.34] tracking-tight sm:text-[2.35rem] lg:text-[2.45rem]">
                   「わかる」で終わらせない、
                   <br />
-                  <span className="text-brand-600">新卒ITエンジニア向け研修プラットフォーム</span>
+                  <span className="text-[#8fb3ff]">
+                    書いて、動かして、
+                    <br />
+                    「できる」に届く研修へ。
+                  </span>
                 </h1>
-                <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-slate-600 sm:text-lg lg:mx-0">
+                <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-[#c7d5f7] sm:text-lg lg:mx-0">
                   コース学習・多言語のコーディング演習・AI チャット・学習レポートを1つに。
                   手を動かして学び、研修の進捗をまとめて管理できます。
                 </p>
                 <div className="mt-9 flex flex-col justify-center gap-3 sm:flex-row lg:justify-start">
                   <Link
                     to="/company-application"
-                    className="inline-flex items-center justify-center gap-2 rounded-[10px] bg-brand-600 px-6 py-3 font-bold text-white shadow-[0_1px_2px_rgba(29,78,216,0.3),0_8px_24px_-8px_rgba(37,99,235,0.5)] transition hover:-translate-y-px hover:bg-brand-700"
+                    className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-7 py-3 font-bold text-brand-700 shadow-[0_12px_32px_-12px_rgba(0,0,0,0.5)] transition hover:-translate-y-px hover:bg-brand-50"
                   >
                     企業の方：導入・利用申請
                     <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
                   </Link>
                   <Link
                     to="/login"
-                    className="inline-flex items-center justify-center rounded-[10px] border border-slate-300 bg-white px-6 py-3 font-bold text-slate-800 transition hover:border-brand-200 hover:bg-brand-50"
+                    className="inline-flex items-center justify-center rounded-full border border-white/40 px-7 py-3 font-bold text-white transition hover:border-white/60 hover:bg-white/10"
                   >
                     受講者の方：ログイン
                   </Link>
                 </div>
                 <div className="mt-11">
-                  <p className="text-[11.5px] font-bold tracking-[0.12em] text-slate-500">演習対応言語</p>
+                  <p className="text-[11.5px] font-bold tracking-[0.12em] text-[#8fa3d6]">演習対応言語</p>
                   <ul className="mt-2.5 flex flex-wrap justify-center gap-1.5 lg:justify-start" aria-label="演習対応言語">
                     {LANGUAGES.map((lang) => (
                       <li
                         key={lang}
-                        className="rounded-md border border-slate-200 bg-white px-2.5 py-0.5 font-mono text-xs text-slate-600"
+                        className="rounded-md border border-white/20 bg-white/[.06] px-2.5 py-0.5 font-mono text-xs text-[#dbe6ff]"
                       >
                         {lang}
                       </li>
@@ -209,17 +377,14 @@ export default function LandingPage() {
 
               {/* エディタ・ヴィネット: タイプ → 採点 → 合格の一連をモーションで見せる(装飾・CSS のみ) */}
               <div aria-hidden="true" className="relative hidden lg:block">
-                <div className="rounded-2xl border border-slate-200 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.06),0_24px_60px_-24px_rgba(23,36,92,0.28)]">
+                <div className="rounded-2xl border border-white/20 bg-white text-slate-900 shadow-[0_30px_80px_-30px_rgba(0,0,0,0.6)]">
                   <div className="flex items-center gap-1.5 border-b border-slate-200 px-5 py-3">
                     <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
                     <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
                     <span className="h-2.5 w-2.5 rounded-full bg-slate-200" />
                     <span className="ml-2.5 font-mono text-xs text-slate-500">コーディング演習 — greet.js</span>
-                    <span className="ml-auto rounded-md border border-brand-200 bg-brand-50 px-2.5 py-0.5 text-[11.5px] font-bold text-brand-700">
-                      ▶ 実行して採点
-                    </span>
                   </div>
-                  <pre className="overflow-hidden px-5 pt-5 pb-2 font-mono text-[13.5px] leading-[1.9] text-slate-700">
+                  <pre className="overflow-hidden px-5 pb-2 pt-5 font-mono text-[13.5px] leading-[1.9] text-slate-700">
                     <code>
                       <span className="block opacity-0 animate-lp-type [animation-delay:0.5s] motion-reduce:animate-none motion-reduce:opacity-100">
                         <span className="mr-3 select-none text-slate-300">1</span>
@@ -235,7 +400,7 @@ export default function LandingPage() {
                       <span className="block opacity-0 animate-lp-type [animation-delay:1.6s] motion-reduce:animate-none motion-reduce:opacity-100">
                         <span className="mr-3 select-none text-slate-300">3</span>
                         {'}'}
-                        <span className="ml-0.5 inline-block h-[15px] w-[7px] -mb-0.5 bg-brand-600 animate-lp-blink motion-reduce:animate-none" />
+                        <span className="ml-0.5 -mb-0.5 inline-block h-[15px] w-[7px] bg-brand-600 animate-lp-blink motion-reduce:animate-none" />
                       </span>
                     </code>
                   </pre>
@@ -248,13 +413,13 @@ export default function LandingPage() {
                   </div>
                 </div>
                 {/* 浮遊チップ: AI 質問と進捗の体験を添える */}
-                <div className="absolute -right-3 -top-4 flex items-center gap-2.5 rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-[12.5px] font-bold shadow-[0_12px_32px_-12px_rgba(23,36,92,0.25)] animate-lp-drift motion-reduce:animate-none">
+                <div className="absolute -right-3 -top-4 flex items-center gap-2.5 rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-[12.5px] font-bold text-slate-900 shadow-[0_16px_40px_-16px_rgba(0,0,0,0.5)] animate-lp-drift motion-reduce:animate-none">
                   <span className="grid h-7 w-7 place-items-center rounded-lg bg-brand-50 text-brand-700">
                     <ChatBubbleLeftRightIcon className="h-4 w-4" aria-hidden="true" />
                   </span>
                   詰まったら AI にその場で質問
                 </div>
-                <div className="absolute -bottom-5 -left-4 flex items-center gap-2.5 rounded-xl border border-slate-200 bg-white px-3.5 py-3 shadow-[0_12px_32px_-12px_rgba(23,36,92,0.25)] animate-lp-drift [animation-delay:1.2s] motion-reduce:animate-none">
+                <div className="absolute -bottom-5 -left-4 flex items-center gap-2.5 rounded-xl border border-slate-200 bg-white px-3.5 py-3 shadow-[0_16px_40px_-16px_rgba(0,0,0,0.5)] animate-lp-drift [animation-delay:1.2s] motion-reduce:animate-none">
                   <span className="block h-1.5 w-24 overflow-hidden rounded-full bg-slate-200">
                     <span className="block h-full w-[68%] rounded-full bg-brand-600" />
                   </span>
@@ -263,186 +428,223 @@ export default function LandingPage() {
               </div>
             </div>
           </div>
-
         </section>
 
-        {/* FreStyle とは */}
-        <section className="mx-auto grid max-w-6xl gap-10 px-6 py-24 lg:grid-cols-2 lg:gap-16">
-          <div>
-            <p className="flex items-center gap-2 text-xs font-bold tracking-[0.14em] text-brand-700">
-              <span aria-hidden="true" className="h-0.5 w-5 bg-brand-600" />
-              ABOUT
-            </p>
-            <h2 className="mt-3.5 text-[1.9rem] font-extrabold leading-snug tracking-tight">FreStyle とは</h2>
-            <p className="mt-4 leading-relaxed text-slate-600">
-              FreStyle は、新卒・若手 IT エンジニアの研修を一気通貫で支える統合プラットフォームです。
-              読むだけの座学で終わらせず、ブラウザ上のエディタで書いて即採点する演習まで含めることで、
-              「わかる」だけでなく「できる」に届く研修を実現します。受講者は自分の伸びを、
-              企業の研修担当はメンバーの学習状況を、それぞれ同じ場所で把握できます。
-            </p>
-          </div>
-          <ul className="space-y-3.5 self-center">
-            {STRENGTHS.map((strength) => (
-              <li
-                key={strength}
-                className="flex items-start gap-3.5 rounded-2xl border border-slate-200 bg-white px-5 py-5 font-semibold"
+        {/* 機能群グリッド: 小カード 9 枚で「必要な道具が揃っている」ことを見せる */}
+        <section id="features" className="mx-auto max-w-6xl px-6 py-24">
+          <SectionHead
+            eyebrow="FEATURES"
+            title="研修をつなぎ、学びの完了まで届ける機能群"
+            lede="学ぶ・試す・振り返る・見守る。研修に必要な道具を、1つのプラットフォームに。"
+          />
+          <div className="mt-11 grid gap-3.5 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((feature) => (
+              <div
+                key={feature.title}
+                className="flex items-start gap-3.5 rounded-2xl border border-slate-200 bg-white px-[18px] py-[18px] transition hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-[0_14px_36px_-20px_rgba(23,36,92,0.25)]"
               >
-                <span className="mt-0.5 grid h-7 w-7 flex-none place-items-center rounded-lg bg-emerald-50 text-emerald-600">
-                  <CheckIcon className="h-4 w-4 [stroke-width:3]" aria-hidden="true" />
+                <span
+                  className={`grid h-[38px] w-[38px] flex-none place-items-center rounded-[10px] ${TINTS[feature.tint]}`}
+                >
+                  <feature.icon className="h-5 w-5" aria-hidden="true" />
                 </span>
-                <span className="text-[15px] text-slate-800">{strength}</span>
-              </li>
+                <div>
+                  <h3 className="text-[15px] font-bold">{feature.title}</h3>
+                  <p className="mt-1 text-[12.8px] leading-[1.65] text-slate-600">{feature.body}</p>
+                </div>
+              </div>
             ))}
-          </ul>
+          </div>
         </section>
 
-        {/* 主な機能(ベント配置: 学ぶ体験の 2 枚を主役に) */}
-        <section className="border-y border-slate-200 bg-slate-50">
-          <div className="mx-auto max-w-6xl px-6 py-24">
-            <p className="flex items-center justify-center gap-2 text-xs font-bold tracking-[0.14em] text-brand-700">
-              <span aria-hidden="true" className="h-0.5 w-5 bg-brand-600" />
-              FEATURES
-            </p>
-            <h2 className="mt-3.5 text-center text-[1.9rem] font-extrabold tracking-tight sm:text-3xl">主な機能</h2>
-            <p className="mt-3 text-center text-slate-600">研修の実施から進捗管理まで、必要なものを1つに。</p>
+        <CtaStrip text="研修の立ち上げは 4 ステップで完了" />
 
-            <div className="mt-12 grid gap-4 sm:grid-cols-2 lg:grid-cols-12">
-              {/* 主役カード: コース学習(進捗のミニビジュアル付き) */}
-              <div className="flex flex-col rounded-2xl border border-slate-200 bg-white p-7 transition hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-[0_16px_40px_-20px_rgba(23,36,92,0.22)] lg:col-span-6">
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-brand-50">
-                  <BookOpenIcon className="h-6 w-6 text-brand-700" aria-hidden="true" />
-                </span>
-                <h3 className="mt-4 text-lg font-bold">コース学習</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600">
-                  Git・Docker・Linux・Go・PostgreSQL からクリーンアーキテクチャまで、実務直結のコースを章立てで学べる。進捗はコースごとに記録され、続きから再開できる。
-                </p>
-                <div aria-hidden="true" className="mt-auto grid gap-2.5 pt-6">
-                  {[
-                    { name: 'Git 入門', pct: 100 },
-                    { name: 'Docker 入門', pct: 68 },
-                    { name: 'Go 基礎', pct: 24 },
-                  ].map((row) => (
+        {/* 学習の進み方(ダーク): 4 ステップ + 学習レポートのモック */}
+        <section id="flow" className="bg-[linear-gradient(180deg,#0e1c47_0%,#16295f_100%)]">
+          <div className="mx-auto max-w-6xl px-6 py-24">
+            <SectionHead
+              dark
+              eyebrow="HOW IT WORKS"
+              title="学びっぱなしにさせない。進捗はすべて FreStyle が記録する"
+              lede="受講者は学ぶことに集中するだけ。記録と可視化はプラットフォームの仕事です。"
+            />
+            <div className="mt-12 grid items-center gap-12 lg:grid-cols-2">
+              <ol className="border-t border-white/[.14]">
+                {WALK_STEPS.map((step, index) => (
+                  <li key={step.title} className="flex gap-4 border-b border-white/[.14] px-1 py-5">
+                    <span className="mt-0.5 grid h-[30px] w-[30px] flex-none place-items-center rounded-full border border-white/25 bg-white/10 font-mono text-[13px] font-extrabold text-[#9db8f5]">
+                      {index + 1}
+                    </span>
+                    <div>
+                      <h3 className="text-base font-bold text-white">{step.title}</h3>
+                      <p className="mt-1 text-[13.5px] leading-relaxed text-[#c7d5f7]">{step.body}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+              <div
+                aria-hidden="true"
+                className="overflow-hidden rounded-2xl border border-white/20 bg-white text-slate-900 shadow-[0_30px_80px_-30px_rgba(0,0,0,0.6)]"
+              >
+                <div className="flex items-center justify-between border-b border-slate-200 px-[18px] py-3.5">
+                  <span className="text-[13px] font-bold">学習レポート</span>
+                  <span className="rounded-md bg-brand-50 px-2.5 py-0.5 text-[11px] font-bold text-brand-700">
+                    今週の進捗
+                  </span>
+                </div>
+                <div className="grid gap-2.5 p-[18px]">
+                  {REPORT_ROWS.map((row) => (
                     <div
                       key={row.name}
-                      className="grid grid-cols-[7.5em_1fr_3em] items-center gap-2.5 text-[11.5px] font-semibold text-slate-500"
+                      className="grid grid-cols-[7.5em_1fr_3.2em] items-center gap-2.5 text-xs font-semibold text-slate-500"
                     >
                       <span>{row.name}</span>
-                      <span className="block h-[7px] overflow-hidden rounded bg-slate-100">
+                      <span className="block h-[7px] overflow-hidden rounded bg-slate-50">
                         <span className="block h-full rounded bg-brand-600" style={{ width: `${row.pct}%` }} />
                       </span>
                       <span className="text-right font-mono [font-variant-numeric:tabular-nums]">{row.pct}%</span>
                     </div>
                   ))}
                 </div>
+                <div className="mx-[18px] mb-[18px] rounded-[10px] border border-emerald-200 bg-emerald-50 px-3.5 py-2.5 text-[12.5px] font-bold text-emerald-700">
+                  ✓ 今日も学習を継続中 — 演習 3 問に合格
+                </div>
               </div>
+            </div>
+          </div>
+        </section>
 
-              {/* 主役カード: コーディング演習(ターミナルのミニビジュアル付き) */}
-              <div className="flex flex-col rounded-2xl border border-slate-200 bg-white p-7 transition hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-[0_16px_40px_-20px_rgba(23,36,92,0.22)] lg:col-span-6">
-                <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-brand-50">
-                  <CodeBracketIcon className="h-6 w-6 text-brand-700" aria-hidden="true" />
-                </span>
-                <h3 className="mt-4 text-lg font-bold">コーディング演習</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600">
-                  ブラウザ上のエディタで書いて即採点。PHP・Java・JavaScript・TypeScript・Go・Ruby・C・C++・SQL など多言語に対応し、手を動かして身につける。
-                </p>
-                <div aria-hidden="true" className="mt-auto pt-6">
-                  <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-xs leading-[1.9] text-slate-700">
-                    $ 提出しました…
-                    <br />
-                    <span className="font-bold text-emerald-600">✓ 正解</span> — 3 / 3 のテストに合格(0.12s)
+        {/* Before / After 比較: 従来の研修との違いを観点別に見せる */}
+        <section id="compare" className="mx-auto max-w-6xl px-6 py-24">
+          <SectionHead
+            eyebrow="BEFORE / AFTER"
+            title="FreStyle で変わる新人研修"
+            lede="「教える・答える・把握する」の手間を、プラットフォームに任せる。"
+          />
+          <div className="mt-11 overflow-x-auto rounded-[18px] border border-slate-200">
+            <table className="w-full min-w-[640px] border-collapse text-sm">
+              <thead>
+                <tr className="bg-slate-50 text-left text-[13px] text-slate-500">
+                  <th scope="col" className="w-[9em] border-b border-slate-200 px-5 py-3.5" />
+                  {BA_COLUMNS.map((col) => (
+                    <th
+                      key={col}
+                      scope="col"
+                      className="border-b border-l border-slate-200 px-5 py-3.5 font-bold"
+                    >
+                      {col}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="align-top">
+                  <th
+                    scope="row"
+                    className="border-b border-slate-200 bg-slate-50 px-5 py-5 text-left text-[13.5px] font-bold text-slate-500"
+                  >
+                    従来の研修
+                  </th>
+                  {BA_BEFORE.map((cell) => (
+                    <td key={cell.t} className="border-b border-l border-slate-200 px-5 py-5">
+                      <span className="block text-[15px] font-extrabold text-slate-500">{cell.t}</span>
+                      <p className="mt-1 text-[13px] leading-relaxed text-slate-600">{cell.body}</p>
+                    </td>
+                  ))}
+                </tr>
+                <tr className="align-top">
+                  <th
+                    scope="row"
+                    className="bg-slate-50 px-5 py-5 text-left text-[13.5px] font-bold text-slate-500"
+                  >
+                    FreStyle
+                  </th>
+                  {BA_AFTER.map((cell) => (
+                    <td key={cell.t} className="border-l border-slate-200 bg-brand-50 px-5 py-5">
+                      <span className="block text-[15px] font-extrabold text-emerald-600">✓ {cell.t}</span>
+                      <p className="mt-1 text-[13px] leading-relaxed text-slate-600">{cell.body}</p>
+                    </td>
+                  ))}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <CtaStrip text="受講者は招待リンクから参加するだけ" />
+
+        {/* ロール別の使い方: 立場ごとの体験を並べる */}
+        <section className="mx-auto max-w-6xl px-6 pb-24 pt-10">
+          <SectionHead eyebrow="FOR EACH ROLE" title="立場ごとに、見える景色を用意" />
+          <div className="mt-11 grid gap-4 lg:grid-cols-3">
+            {ROLES.map((role) => (
+              <div key={role.title} className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+                <div className="flex items-center gap-3 border-b border-slate-200 bg-slate-50 px-5 py-4">
+                  <span
+                    className={`grid h-9 w-9 flex-none place-items-center rounded-[10px] ${TINTS[role.tint]}`}
+                  >
+                    <role.icon className="h-5 w-5" aria-hidden="true" />
+                  </span>
+                  <div>
+                    <p className="text-[11px] font-bold tracking-[0.06em] text-slate-500">{role.label}</p>
+                    <h3 className="text-[15.5px] font-extrabold">{role.title}</h3>
                   </div>
                 </div>
+                <ul className="grid gap-2.5 px-5 pb-5 pt-4">
+                  {role.items.map((item) => (
+                    <li key={item} className="relative pl-[22px] text-[13.5px] text-slate-600">
+                      <span
+                        aria-hidden="true"
+                        className="absolute left-0 top-[7px] h-3 w-3 rounded border-[1.5px] border-brand-200 bg-brand-50"
+                      />
+                      {item}
+                    </li>
+                  ))}
+                </ul>
               </div>
+            ))}
+          </div>
+        </section>
 
-              {FEATURES.map((feature) => (
-                <div
-                  key={feature.title}
-                  className="rounded-2xl border border-slate-200 bg-white p-6 transition hover:-translate-y-0.5 hover:border-brand-200 hover:shadow-[0_16px_40px_-20px_rgba(23,36,92,0.22)] lg:col-span-3"
-                >
-                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-brand-50">
-                    <feature.icon className="h-6 w-6 text-brand-700" aria-hidden="true" />
+        {/* セキュリティと運用: 企業導入の不安に先回りで答える */}
+        <section className="border-y border-slate-200 bg-slate-50">
+          <div className="mx-auto max-w-6xl px-6 py-20">
+            <SectionHead eyebrow="SECURITY" title="企業利用を前提にした設計" />
+            <div className="mt-11 grid gap-3.5 sm:grid-cols-2 lg:grid-cols-4">
+              {SECURITY.map((item) => (
+                <div key={item.title} className="rounded-2xl border border-slate-200 bg-white p-5 text-center">
+                  <span className="mx-auto grid h-11 w-11 place-items-center rounded-xl bg-brand-50 text-brand-700">
+                    <item.icon className="h-[22px] w-[22px]" aria-hidden="true" />
                   </span>
-                  <h3 className="mt-4 text-base font-bold">{feature.title}</h3>
-                  <p className="mt-2 text-[13.5px] leading-relaxed text-slate-600">{feature.body}</p>
+                  <h3 className="mt-3 text-[14.5px] font-bold">{item.title}</h3>
+                  <p className="mt-1.5 text-[12.5px] leading-relaxed text-slate-600">{item.body}</p>
                 </div>
               ))}
             </div>
           </div>
         </section>
 
-        {/* 導入の流れ(接続レール) */}
-        <section className="mx-auto max-w-6xl px-6 py-24">
-          <p className="flex items-center justify-center gap-2 text-xs font-bold tracking-[0.14em] text-brand-700">
-            <span aria-hidden="true" className="h-0.5 w-5 bg-brand-600" />
-            FLOW
-          </p>
-          <h2 className="mt-3.5 text-center text-[1.9rem] font-extrabold tracking-tight sm:text-3xl">導入の流れ</h2>
-          <p className="mt-3 text-center text-slate-600">申請から研修開始まで、4 ステップで始められます。</p>
-          <ol className="relative mt-14 grid gap-9 sm:grid-cols-2 lg:grid-cols-4">
-            <span
-              aria-hidden="true"
-              className="absolute left-[12.5%] right-[12.5%] top-[19px] hidden h-0.5 bg-brand-100 lg:block"
-            />
-            {STEPS.map((step, index) => (
-              <li key={step.title} className="relative px-2 text-center">
-                <span className="relative z-[1] mx-auto grid h-10 w-10 place-items-center rounded-full bg-brand-600 font-mono text-[15px] font-extrabold text-white ring-[6px] ring-white">
-                  {index + 1}
-                </span>
-                <h3 className="mt-4 text-base font-bold">{step.title}</h3>
-                <p className="mt-2 text-[13.5px] leading-relaxed text-slate-600">{step.body}</p>
-              </li>
-            ))}
-          </ol>
-        </section>
-
-        {/* FAQ(罫線リスト型) */}
-        <section className="border-y border-slate-200 bg-slate-50">
-          <div className="mx-auto max-w-6xl px-6 py-24">
-            <p className="flex items-center justify-center gap-2 text-xs font-bold tracking-[0.14em] text-brand-700">
-              <span aria-hidden="true" className="h-0.5 w-5 bg-brand-600" />
-              FAQ
-            </p>
-            <h2 className="mt-3.5 text-center text-[1.9rem] font-extrabold tracking-tight sm:text-3xl">よくある質問</h2>
-            <div className="mx-auto mt-11 max-w-3xl border-t border-slate-200">
-              {FAQS.map((faq) => (
-                <details key={faq.q} className="group border-b border-slate-200">
-                  <summary className="flex cursor-pointer list-none items-center justify-between gap-5 px-1.5 py-6 font-bold [&::-webkit-details-marker]:hidden">
-                    {faq.q}
-                    <span
-                      aria-hidden="true"
-                      className="grid h-7 w-7 flex-none place-items-center rounded-lg bg-white text-brand-700 transition-transform group-open:rotate-45 group-open:bg-brand-50"
-                    >
-                      <PlusIcon className="h-4 w-4 [stroke-width:2.5]" />
-                    </span>
-                  </summary>
-                  <p className="px-1.5 pb-6 pr-12 text-[14.5px] leading-relaxed text-slate-600">{faq.a}</p>
-                </details>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* CTA バンド(濃紺グラデーション + 方眼モチーフ) */}
-        <section className="relative overflow-hidden bg-gradient-to-br from-[#17245c] via-[#1d3a8f] to-brand-700">
+        {/* 最終 CTA(濃紺 + 方眼モチーフ) */}
+        <section className="relative overflow-hidden bg-[linear-gradient(160deg,#0e1c47_0%,#1d3a8f_70%,#1d4ed8_100%)]">
           <div aria-hidden="true" className={`pointer-events-none absolute inset-0 ${GRID_PATTERN_DARK}`} />
           <div className="relative mx-auto max-w-4xl px-6 py-20 text-center">
             <h2 className="text-[1.9rem] font-extrabold tracking-tight text-white sm:text-3xl">
               研修の実施と管理を、FreStyle で。
             </h2>
-            <p className="mt-4 text-brand-100">
+            <p className="mt-4 text-[#c7d5f7]">
               まずは企業の利用申請から。受講者の方は招待リンクからログインできます。
             </p>
             <div className="mt-9 flex flex-col justify-center gap-3 sm:flex-row">
               <Link
                 to="/company-application"
-                className="inline-flex items-center justify-center gap-2 rounded-[10px] bg-white px-6 py-3 font-bold text-brand-700 shadow-[0_10px_30px_-10px_rgba(0,0,0,0.4)] transition hover:-translate-y-px hover:bg-brand-50"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-white px-7 py-3 font-bold text-brand-700 shadow-[0_12px_32px_-12px_rgba(0,0,0,0.5)] transition hover:-translate-y-px hover:bg-brand-50"
               >
                 企業の方：導入・利用申請
                 <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
               </Link>
               <Link
                 to="/login"
-                className="inline-flex items-center justify-center rounded-[10px] border border-white/35 px-6 py-3 font-bold text-white transition hover:border-white/60 hover:bg-white/10"
+                className="inline-flex items-center justify-center rounded-full border border-white/40 px-7 py-3 font-bold text-white transition hover:border-white/60 hover:bg-white/10"
               >
                 受講者の方：ログイン
               </Link>
@@ -452,7 +654,7 @@ export default function LandingPage() {
       </main>
 
       {/* フッター */}
-      <footer className="bg-slate-900">
+      <footer className="bg-[#0a1330]">
         <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-6 px-6 py-10 sm:flex-row">
           <div className="flex items-center gap-2">
             <img src="/favicon.svg" alt="" aria-hidden="true" className="h-6 w-6" />
@@ -460,7 +662,7 @@ export default function LandingPage() {
               FreStyle — 新卒ITエンジニア向け研修プラットフォーム
             </span>
           </div>
-          <nav className="flex items-center gap-6 text-sm text-slate-400" aria-label="フッター">
+          <nav className="flex items-center gap-6 text-sm text-[#9aa5c4]" aria-label="フッター">
             <Link to="/login" className="transition hover:text-white">
               ログイン
             </Link>

--- a/frontend/src/pages/landing/ui/LandingPage.tsx
+++ b/frontend/src/pages/landing/ui/LandingPage.tsx
@@ -19,6 +19,8 @@ import {
   UserPlusIcon,
 } from '@heroicons/react/24/outline';
 import PublicHeader from '@/shared/ui/PublicHeader';
+import SectionHead from './SectionHead';
+import CtaStrip from './CtaStrip';
 import { useAppSelector, useAppDispatch } from '@/shared/lib/store';
 import { useDocumentMeta } from '@/shared/lib/hooks/useDocumentMeta';
 import { AuthRepository, setAuthData } from '@/entities/user';
@@ -126,20 +128,23 @@ const REPORT_ROWS: { name: string; pct: number }[] = [
 ];
 
 // Before/After 比較表。列 = 研修の観点、行 = 従来の研修 / FreStyle。
-const BA_COLUMNS = ['教材と学び方', '質問対応', '進捗の把握'];
-const BA_BEFORE: { t: string; body: string }[] = [
-  { t: '読んで終わり', body: '座学とスライド中心。理解した「つもり」のまま配属日を迎えてしまう。' },
+const COMPARISON_COLUMNS = ['教材と学び方', '質問対応', '進捗の把握'];
+const COMPARISON_BEFORE: { heading: string; body: string }[] = [
+  { heading: '読んで終わり', body: '座学とスライド中心。理解した「つもり」のまま配属日を迎えてしまう。' },
   {
-    t: '先輩の手が空くまで待つ',
+    heading: '先輩の手が空くまで待つ',
     body: '質問のたびに先輩の作業が止まる。聞きづらくて詰まったまま進むことも。',
   },
-  { t: '日報と口頭で確認', body: '誰がどこで詰まっているかが見えず、フォローが後手に回る。' },
+  { heading: '日報と口頭で確認', body: '誰がどこで詰まっているかが見えず、フォローが後手に回る。' },
 ];
-const BA_AFTER: { t: string; body: string }[] = [
-  { t: '書いて、即採点', body: '章を読んだらすぐ演習。ブラウザで書いて採点され、「できる」まで届く。' },
-  { t: 'AI にその場で質問', body: '学習の流れを止めずに疑問を解消。先輩の時間を奪わない。' },
+const COMPARISON_AFTER: { heading: string; body: string }[] = [
   {
-    t: 'レポートと一覧で見える',
+    heading: '書いて、即採点',
+    body: '章を読んだらすぐ演習。ブラウザで書いて採点され、「できる」まで届く。',
+  },
+  { heading: 'AI にその場で質問', body: '学習の流れを止めずに疑問を解消。先輩の時間を奪わない。' },
+  {
+    heading: 'レポートと一覧で見える',
     body: '受講者の伸びとつまずきを研修担当が同じ場所で把握。フォローが先手になる。',
   },
 ];
@@ -212,38 +217,6 @@ const SECURITY: { icon: typeof ShieldCheckIcon; title: string; body: string }[] 
 // 濃紺ヒーロー・最終 CTA で共有する「方眼紙」モチーフ(エンジニアの学習ノート)。
 const GRID_PATTERN_DARK =
   'bg-[linear-gradient(to_right,rgba(255,255,255,0.05)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.05)_1px,transparent_1px)] bg-[size:38px_38px]';
-
-/** セクション見出し(eyebrow + タイトル + リード)。on dark は配色だけ差し替える。 */
-function SectionHead({ eyebrow, title, lede, dark }: { eyebrow: string; title: string; lede?: string; dark?: boolean }) {
-  return (
-    <div className="text-center">
-      <p className={`text-xs font-bold tracking-[0.16em] ${dark ? 'text-[#9db8f5]' : 'text-brand-700'}`}>{eyebrow}</p>
-      <h2
-        className={`mt-3 text-[1.75rem] font-extrabold leading-snug tracking-tight sm:text-[2rem] ${dark ? 'text-white' : ''}`}
-      >
-        {title}
-      </h2>
-      {lede && <p className={`mt-3 ${dark ? 'text-[#c7d5f7]' : 'text-slate-600'}`}>{lede}</p>}
-    </div>
-  );
-}
-
-/** セクション間で繰り返す小型 CTA(白ピル + 申請ボタン)。反復導線で申請への距離を縮める。 */
-function CtaStrip({ text }: { text: string }) {
-  return (
-    <div className="flex justify-center bg-white pb-14">
-      <span className="inline-flex items-center gap-4 rounded-full border border-slate-200 bg-white py-2.5 pl-6 pr-3 text-[13.5px] font-bold text-slate-600 shadow-[0_10px_30px_-18px_rgba(23,36,92,0.35)]">
-        {text}
-        <Link
-          to="/company-application"
-          className="rounded-full bg-brand-600 px-5 py-2 text-[13px] font-bold text-white transition hover:bg-brand-700"
-        >
-          導入・利用申請
-        </Link>
-      </span>
-    </div>
-  );
-}
 
 /**
  * LandingPage は未ログイン/検索ボット向けの公開トップ。SEO のインデックス対象。
@@ -457,7 +430,7 @@ export default function LandingPage() {
           </div>
         </section>
 
-        <CtaStrip text="研修の立ち上げは 4 ステップで完了" />
+        <CtaStrip text="受講者の学習は 4 ステップで進む" />
 
         {/* 学習の進み方(ダーク): 4 ステップ + 学習レポートのモック */}
         <section id="flow" className="bg-[linear-gradient(180deg,#0e1c47_0%,#16295f_100%)]">
@@ -521,12 +494,18 @@ export default function LandingPage() {
             title="FreStyle で変わる新人研修"
             lede="「教える・答える・把握する」の手間を、プラットフォームに任せる。"
           />
-          <div className="mt-11 overflow-x-auto rounded-[18px] border border-slate-200">
+          {/* 表は狭い画面で横スクロールするため、キーボードでも操作できるようフォーカス可能にする */}
+          <div
+            role="region"
+            aria-label="従来の研修と FreStyle の比較"
+            tabIndex={0}
+            className="mt-11 overflow-x-auto rounded-[18px] border border-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600"
+          >
             <table className="w-full min-w-[640px] border-collapse text-sm">
               <thead>
                 <tr className="bg-slate-50 text-left text-[13px] text-slate-500">
                   <th scope="col" className="w-[9em] border-b border-slate-200 px-5 py-3.5" />
-                  {BA_COLUMNS.map((col) => (
+                  {COMPARISON_COLUMNS.map((col) => (
                     <th
                       key={col}
                       scope="col"
@@ -545,9 +524,9 @@ export default function LandingPage() {
                   >
                     従来の研修
                   </th>
-                  {BA_BEFORE.map((cell) => (
-                    <td key={cell.t} className="border-b border-l border-slate-200 px-5 py-5">
-                      <span className="block text-[15px] font-extrabold text-slate-500">{cell.t}</span>
+                  {COMPARISON_BEFORE.map((cell) => (
+                    <td key={cell.heading} className="border-b border-l border-slate-200 px-5 py-5">
+                      <span className="block text-[15px] font-extrabold text-slate-500">{cell.heading}</span>
                       <p className="mt-1 text-[13px] leading-relaxed text-slate-600">{cell.body}</p>
                     </td>
                   ))}
@@ -559,9 +538,11 @@ export default function LandingPage() {
                   >
                     FreStyle
                   </th>
-                  {BA_AFTER.map((cell) => (
-                    <td key={cell.t} className="border-l border-slate-200 bg-brand-50 px-5 py-5">
-                      <span className="block text-[15px] font-extrabold text-emerald-600">✓ {cell.t}</span>
+                  {COMPARISON_AFTER.map((cell) => (
+                    <td key={cell.heading} className="border-l border-slate-200 bg-brand-50 px-5 py-5">
+                      <span className="block text-[15px] font-extrabold text-emerald-600">
+                        ✓ {cell.heading}
+                      </span>
                       <p className="mt-1 text-[13px] leading-relaxed text-slate-600">{cell.body}</p>
                     </td>
                   ))}

--- a/frontend/src/pages/landing/ui/SectionHead.tsx
+++ b/frontend/src/pages/landing/ui/SectionHead.tsx
@@ -1,0 +1,26 @@
+/** セクション見出し(eyebrow + タイトル + リード)。dark は濃紺セクション用に配色だけ差し替える。 */
+export default function SectionHead({
+  eyebrow,
+  title,
+  lede,
+  dark,
+}: {
+  eyebrow: string;
+  title: string;
+  lede?: string;
+  dark?: boolean;
+}) {
+  return (
+    <div className="text-center">
+      <p className={`text-xs font-bold tracking-[0.16em] ${dark ? 'text-[#9db8f5]' : 'text-brand-700'}`}>
+        {eyebrow}
+      </p>
+      <h2
+        className={`mt-3 text-[1.75rem] font-extrabold leading-snug tracking-tight sm:text-[2rem] ${dark ? 'text-white' : ''}`}
+      >
+        {title}
+      </h2>
+      {lede && <p className={`mt-3 ${dark ? 'text-[#c7d5f7]' : 'text-slate-600'}`}>{lede}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -64,8 +64,13 @@ describe('LandingPage', () => {
 
   it('Before/After 比較表を行見出し付きの table で表示する', () => {
     renderLanding(false);
-    const table = screen.getByRole('table');
-    expect(table).toBeInTheDocument();
+    // getByRole は未検出時に例外を投げるため、取得自体が存在検証になる
+    screen.getByRole('table');
+    // 横スクロールする表はキーボードでも操作できる必要がある(WCAG 2.1.1)
+    expect(screen.getByRole('region', { name: '従来の研修と FreStyle の比較' })).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
     expect(screen.getByRole('rowheader', { name: '従来の研修' })).toBeInTheDocument();
     expect(screen.getByRole('rowheader', { name: 'FreStyle' })).toBeInTheDocument();
     for (const col of ['教材と学び方', '質問対応', '進捗の把握']) {

--- a/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
+++ b/frontend/src/pages/landing/ui/__tests__/LandingPage.test.tsx
@@ -39,12 +39,16 @@ describe('LandingPage', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: /新卒ITエンジニア向け研修プラットフォーム/,
+        name: /「わかる」で終わらせない/,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'FreStyle とは' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '主な機能' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'よくある質問' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /研修をつなぎ、学びの完了まで届ける機能群/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /学びっぱなしにさせない/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'FreStyle で変わる新人研修' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '立場ごとに、見える景色を用意' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: '企業利用を前提にした設計' })).toBeInTheDocument();
     // CTA は遷移先まで検証する（存在確認だけでは誤配線を検知できない）
     const applyLinks = screen.getAllByRole('link', { name: /利用申請/ });
     expect(applyLinks.length).toBeGreaterThan(0);
@@ -55,6 +59,17 @@ describe('LandingPage', () => {
     expect(loginLinks.length).toBeGreaterThan(0);
     for (const link of loginLinks) {
       expect(link).toHaveAttribute('href', '/login');
+    }
+  });
+
+  it('Before/After 比較表を行見出し付きの table で表示する', () => {
+    renderLanding(false);
+    const table = screen.getByRole('table');
+    expect(table).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: '従来の研修' })).toBeInTheDocument();
+    expect(screen.getByRole('rowheader', { name: 'FreStyle' })).toBeInTheDocument();
+    for (const col of ['教材と学び方', '質問対応', '進捗の把握']) {
+      expect(screen.getByRole('columnheader', { name: col })).toBeInTheDocument();
     }
   });
 
@@ -75,7 +90,7 @@ describe('LandingPage', () => {
     renderLanding(false);
     // 認証確認が reject された後も LP のまま
     expect(
-      await screen.findByRole('heading', { level: 1, name: /新卒ITエンジニア向け研修プラットフォーム/ }),
+      await screen.findByRole('heading', { level: 1, name: /「わかる」で終わらせない/ }),
     ).toBeInTheDocument();
     expect(screen.queryByText('ダッシュボード')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## 概要

Figma で作成した LP デザイン（ファイル: FreStyle LP）を実装に反映する。BtoB SaaS の LP でよく使われる「濃紺ヒーロー → 機能グリッド → 進み方 → Before/After → ロール別 → セキュリティ → 反復 CTA」の構成に組み替えた。実在しない数値・顧客ロゴ・事例は載せない方針を維持している。

## 変更内容

- **ヒーロー**: 濃紺グラデーション + 方眼モチーフ。見出しを 3 行構成に変更し、白/アウトラインの CTA と演習対応言語チップを配置。右側は「書いて即採点」のエディタ演出（CSS アニメーションのみ・`motion-reduce` で静止）
- **機能グリッド**: 9 枚の小カード（コース学習 / 演習 / AI チャット / レポート / ノート / 学習状況 / 招待 / 通知 / 導線）。アイコン地色を 5 色で循環
- **学習の進み方（ダーク）**: 4 ステップ + 学習レポートのモック
- **Before/After**: 従来の研修と FreStyle を「教材と学び方 / 質問対応 / 進捗の把握」の 3 観点で比較する table（行見出し付き）
- **ロール別**: 受講者 / 企業の研修担当 / 運営
- **セキュリティ**: データ分離 / 招待制ログイン / ロール別権限 / 監査ログ
- **反復 CTA**: セクション間に「導入・利用申請」への小型ピルを 2 か所挿入
- 旧構成の「FreStyle とは」「導入の流れ」「よくある質問」は上記に統合して撤去

## テスト

- `npx vitest run`: 164 files / 1344 tests 全通過（LP は 6 tests、Before/After 表の行・列見出しを検証するケースを追加）
- `npx tsc --noEmit` / `npx eslint src/pages/landing --max-warnings 0`: エラーなし
- `npm run build` → `npm run prerender`: 成功（本文入り HTML 43KB を生成）。ローカルで dist を配信し、全セクションのスクリーンショットで描画を目視確認

## 関連チケット

FRESTYLE-251

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ランディングページを刷新し、機能一覧、学習フロー、Before/After比較、ロール別説明、セキュリティ情報を追加しました。
  * 濃紺のヒーロー、進捗表示、複数のCTAを追加しました。
  * 各セクションをカードやグリッドで整理し、情報を見つけやすくしました。

* **スタイル**
  * ヒーロー、CTA、カード、ボタン、フッターなどのデザインを更新しました。

* **テスト**
  * 新しい見出し、比較表、未ログイン時の表示に関する検証を更新・追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->