### PR TITLE
fix: 検証環境の FQDN を 1 階層(<sub>-staging.<base>)へ変更する (FRESTYLE-309)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,7 +1,12 @@
 name: Staging Deploy
 
 # 目的: メンバーが「ブランチを選び、サブドメイン名を入力するだけ」で
-#       <subdomain>.<STAGING_BASE_DOMAIN> に検証環境をデプロイする(FRESTYLE-245)。
+#       <subdomain>-staging.<STAGING_BASE_DOMAIN> に検証環境をデプロイする(FRESTYLE-245)。
+#
+# FQDN が 1 階層(<sub>-staging.example.net)なのは、Cloudflare の Universal SSL が
+# 持つ証明書が <base> と *.<base> だけで、TLS のワイルドカードが 1 階層しか一致しない
+# ため。2 階層(<sub>.staging.<base>)にすると Cloudflare 経由で TLS handshake が
+# 失敗する(FRESTYLE-309)。
 #
 # 仕組み(push 型ではなく pull 型):
 #   1) runner 上で backend / frontend の Docker image をビルドし ECR に push
@@ -24,7 +29,7 @@ on:
   workflow_dispatch:
     inputs:
       subdomain:
-        description: '例: kinoshita → kinoshita.<STAGING_BASE_DOMAIN>'
+        description: '例: kinoshita → kinoshita-staging.<STAGING_BASE_DOMAIN>'
         required: true
         type: string
 
@@ -41,8 +46,12 @@ env:
   # (run への ${{ }} 直埋めによる script injection を避ける)。
   SUBDOMAIN: ${{ inputs.subdomain }}
   # 検証環境のベースドメイン。box 側 scripts/staging/deploy-from-registry の
-  # BASE_DOMAIN と一致させること(不一致だと Caddy が別 FQDN の証明書を取りに行って失敗する)。
+  # BASE_DOMAIN と一致させること(不一致だと別ドメイン向けのイメージが配布される)。
   BASE_DOMAIN: ${{ vars.STAGING_BASE_DOMAIN }}
+  # 検証環境の FQDN。組み立てを 1 箇所に集約し、以降のシェルはこれだけを参照する
+  # (callback / VITE_REDIRECT_URI / 表示 URL がばらばらに組み立てられて
+  # ずれるのを防ぐ。3 点が一致していないと OIDC ログインが必ず失敗する)。
+  STAGING_FQDN: ${{ inputs.subdomain }}-staging.${{ vars.STAGING_BASE_DOMAIN }}
   BACKEND_ECR_REPO: ${{ vars.STAGING_BACKEND_ECR_REPO }}
   FRONTEND_ECR_REPO: ${{ vars.STAGING_FRONTEND_ECR_REPO }}
   COGNITO_USER_POOL_ID: ${{ vars.STAGING_COGNITO_USER_POOL_ID }}
@@ -73,7 +82,7 @@ jobs:
     # この sub のみを許可しているため、宣言を外すと assume が必ず失敗する。
     environment:
       name: staging
-      url: https://${{ inputs.subdomain }}.${{ vars.STAGING_BASE_DOMAIN }}
+      url: https://${{ inputs.subdomain }}-staging.${{ vars.STAGING_BASE_DOMAIN }}
     # id-token: write は OIDC トークン発行に、contents: read は checkout に必要。
     permissions:
       id-token: write
@@ -116,7 +125,7 @@ jobs:
               echo "ERROR: '$SUBDOMAIN' は予約済みサブドメインです。"
               exit 1 ;;
           esac
-          echo "deploy 先: https://$SUBDOMAIN.$BASE_DOMAIN"
+          echo "deploy 先: https://$STAGING_FQDN"
 
       # workflow_dispatch で選んだ ref(ブランチ)がそのまま checkout される。
       - uses: actions/checkout@v6
@@ -153,7 +162,7 @@ jobs:
             --build-arg VITE_API_BASE_URL="" \
             --build-arg VITE_COGNITO_DOMAIN="$COGNITO_DOMAIN" \
             --build-arg VITE_CLIENT_ID="$COGNITO_CLIENT_ID" \
-            --build-arg VITE_REDIRECT_URI="https://$SUBDOMAIN.$BASE_DOMAIN/login/callback" \
+            --build-arg VITE_REDIRECT_URI="https://$STAGING_FQDN/login/callback" \
             --label "frestyle.base-domain=$BASE_DOMAIN" \
             -t "$ECR_REGISTRY/$FRONTEND_ECR_REPO:$SUBDOMAIN"
           docker push "$ECR_REGISTRY/$FRONTEND_ECR_REPO:$SUBDOMAIN"
@@ -172,8 +181,8 @@ jobs:
       # 数秒だけなので 3 回で十分収束する)。
       - name: Register Cognito callback / logout URLs
         run: |
-          CALLBACK="https://$SUBDOMAIN.$BASE_DOMAIN/login/callback"
-          LOGOUT="https://$SUBDOMAIN.$BASE_DOMAIN"
+          CALLBACK="https://$STAGING_FQDN/login/callback"
+          LOGOUT="https://$STAGING_FQDN"
           register() {
             aws cognito-idp describe-user-pool-client \
               --user-pool-id "$COGNITO_USER_POOL_ID" \
@@ -256,7 +265,7 @@ jobs:
 
       - name: Show staging URL
         run: |
-          URL="https://$SUBDOMAIN.$BASE_DOMAIN"
+          URL="https://$STAGING_FQDN"
           echo "デプロイ完了: $URL"
           {
             echo "## Staging Deploy 完了"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -82,7 +82,7 @@ jobs:
     # この sub のみを許可しているため、宣言を外すと assume が必ず失敗する。
     environment:
       name: staging
-      url: https://${{ inputs.subdomain }}-staging.${{ vars.STAGING_BASE_DOMAIN }}
+      url: https://${{ env.STAGING_FQDN }}
     # id-token: write は OIDC トークン発行に、contents: read は checkout に必要。
     permissions:
       id-token: write


### PR DESCRIPTION
## 概要

Staging Deploy のデプロイ先 FQDN を `<sub>.staging.<base>`（2 階層）から **`<sub>-staging.<base>`（1 階層）** へ変更します。

## 背景

ステージングのアプリ本体を Cloudflare Access 配下に置くため DNS を Cloudflare 経由（proxied）へ切り替えたところ、**TLS handshake が失敗**して到達不可になりました（切り戻し済み）。

```
$ curl https://norman6464.staging.frestyle.net/
curl: (35) sslv3 alert handshake failure
```

原因は Cloudflare の Universal SSL の証明書範囲です。実測した SAN は次のとおりでした。

```
SAN: ['frestyle.net', '*.frestyle.net']
```

**TLS のワイルドカードは 1 階層しか一致しません。**

| ホスト | 階層 | 証明書 | 結果 |
|---|---|---|---|
| `staging-db.frestyle.net` | 1 階層 | `*.frestyle.net` に一致 | 動作する |
| `norman6464.staging.frestyle.net` | 2 階層 | 一致しない | handshake 失敗 |

Advanced Certificate Manager（$10/月）を購入すれば 2 階層のままでも解決しますが、FQDN を 1 階層にすれば無料で恒久的に解決するため後者を採ります。

## 変更内容

- FQDN の組み立てを **`STAGING_FQDN` へ集約**

  従来は callback / logout / `VITE_REDIRECT_URI` / 表示 URL が各所で個別に `$SUBDOMAIN.$BASE_DOMAIN` と組み立てられていました。片方だけ直すと **OIDC の 3 点一致（フロントに焼き込む値 / backend の設定 / Cognito 登録値）が崩れてログインが必ず失敗する**構造だったため、1 箇所に寄せます。
- `environment.url` / 入力の説明 / ヘッダコメントを新形式へ

`environment.url` も `${{ env.STAGING_FQDN }}` を参照します（当初「`env` を参照できない」と書いていましたが誤りで、context availability 表に `env` は含まれています）。

## 併せて実施済み（リポジトリ外）

- Actions Variable `STAGING_BASE_DOMAIN`: `staging.frestyle.net` → **`frestyle.net`**
- frestyle-staging 側の対応 PR: norman6464/frestyle-staging#16

box 側の `deploy-from-registry` は frontend イメージのラベル `frestyle.base-domain` を配布先と突き合わせる guard を持っており、両者を同時に `frestyle.net` へ揃えないと deploy が停止します。上記 PR と本 PR は同時にマージが必要です。

## テスト

- YAML が妥当であること、`STAGING_FQDN` / `environment.url` が新形式で展開されることを確認
- 2 階層の参照が残っていないことを全文検索で確認
- マージ後に `staging-deploy` を実行し、`<sub>-staging.frestyle.net` で TLS・Cognito ログインまで通ることを確認してチケットに記録します

## 影響範囲

- 全メンバーの検証環境 URL が `<sub>.staging.frestyle.net` → `<sub>-staging.frestyle.net` に変わります（**周知が必要**）
- frontend は `VITE_REDIRECT_URI` をビルド時に焼き込むため、**各自 `staging-deploy` の再実行が必要**です
- Cognito の callback / logout URL は workflow が自動追記します

## 関連チケット

FRESTYLE-309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * ステージング環境のURL形式を統一しました。
  * デプロイ先や完了画面へのリンクが、新しいステージングURL形式で表示されます。
  * ログイン後のリダイレクト、コールバック、ログアウト時の遷移先を新しいURLに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
