### PR TITLE
revert: 検証環境の FQDN を 2 階層(<sub>.staging.<base>)に戻す (FRESTYLE-309)

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,12 +1,13 @@
 name: Staging Deploy
 
 # 目的: メンバーが「ブランチを選び、サブドメイン名を入力するだけ」で
-#       <subdomain>-staging.<STAGING_BASE_DOMAIN> に検証環境をデプロイする(FRESTYLE-245)。
+#       <subdomain>.<STAGING_BASE_DOMAIN> に検証環境をデプロイする(FRESTYLE-245)。
 #
-# FQDN が 1 階層(<sub>-staging.example.net)なのは、Cloudflare の Universal SSL が
-# 持つ証明書が <base> と *.<base> だけで、TLS のワイルドカードが 1 階層しか一致しない
-# ため。2 階層(<sub>.staging.<base>)にすると Cloudflare 経由で TLS handshake が
-# 失敗する(FRESTYLE-309)。
+# この FQDN は 2 階層(<sub>.staging.<base>)で、Lightsail へ直接公開し Caddy が
+# Let's Encrypt で証明書を取得する。Cloudflare を経由させていないのは、Universal SSL
+# の証明書が <base> と *.<base> だけで TLS のワイルドカードが 1 階層しか一致せず、
+# 2 階層のままでは proxied にすると handshake が失敗するため(FRESTYLE-309)。
+# 管理 UI(staging-db / staging-mail)は 1 階層なので Cloudflare Access 配下にある。
 #
 # 仕組み(push 型ではなく pull 型):
 #   1) runner 上で backend / frontend の Docker image をビルドし ECR に push
@@ -29,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       subdomain:
-        description: '例: kinoshita → kinoshita-staging.<STAGING_BASE_DOMAIN>'
+        description: '例: kinoshita → kinoshita.<STAGING_BASE_DOMAIN>'
         required: true
         type: string
 
@@ -51,7 +52,7 @@ env:
   # 検証環境の FQDN。組み立てを 1 箇所に集約し、以降のシェルはこれだけを参照する
   # (callback / VITE_REDIRECT_URI / 表示 URL がばらばらに組み立てられて
   # ずれるのを防ぐ。3 点が一致していないと OIDC ログインが必ず失敗する)。
-  STAGING_FQDN: ${{ inputs.subdomain }}-staging.${{ vars.STAGING_BASE_DOMAIN }}
+  STAGING_FQDN: ${{ inputs.subdomain }}.${{ vars.STAGING_BASE_DOMAIN }}
   BACKEND_ECR_REPO: ${{ vars.STAGING_BACKEND_ECR_REPO }}
   FRONTEND_ECR_REPO: ${{ vars.STAGING_FRONTEND_ECR_REPO }}
   COGNITO_USER_POOL_ID: ${{ vars.STAGING_COGNITO_USER_POOL_ID }}


### PR DESCRIPTION
## 概要

#2233 で導入した FQDN の 1 階層化を戻し、検証環境の URL を従来の `<sub>.staging.frestyle.net` に戻します。

## 背景

**アプリ本体を Cloudflare Access 配下に置く方針を取り下げました。**

Access を効かせるには DNS を Cloudflare 経由（proxied）にする必要がありますが、Cloudflare の Universal SSL が持つ証明書は `frestyle.net` と `*.frestyle.net` だけで、**TLS のワイルドカードは 1 階層しか一致しません**（実測済み）。

2 階層の FQDN を保護するには次の二択でした。

| 案 | URL | 費用 |
|---|---|---|
| A | `<sub>.staging.frestyle.net` のまま + Advanced Certificate Manager | $10/月 |
| B | `<sub>-staging.frestyle.net` へ 1 階層化 | 無料 |

**URL は従来のまま維持し、費用も掛けない**という判断になったため、アプリ本体は Lightsail へ直接公開し Caddy が Let's Encrypt で証明書を取得する従来構成に戻します。

## 変更内容

- `STAGING_FQDN` の組み立てを `${{ inputs.subdomain }}.${{ vars.STAGING_BASE_DOMAIN }}` へ
- ヘッダコメントと入力の説明を 2 階層の実態に合わせて修正

### `STAGING_FQDN` への集約は残します

単純な revert にはしていません。この集約は**命名の問題とは独立した改善**だからです。

これが無いと callback / logout / `VITE_REDIRECT_URI` / 表示 URL が各所で個別に `$SUBDOMAIN.$BASE_DOMAIN` と組み立てられ、**片方だけ直したときに OIDC の 3 点一致が崩れてログインが必ず失敗する**構造に戻ってしまいます。

## 併せて実施（リポジトリ外）

- Actions Variable `STAGING_BASE_DOMAIN` を `staging.frestyle.net` へ戻し済み
- frestyle-staging 側の revert PR: norman6464/frestyle-staging#17
- Access アプリ `staging-app`（`*.frestyle.net`）と Tunnel の ingress を削除予定
- DNS の `*` CNAME（proxied）を削除予定

## 維持するもの

**管理 UI（pgAdmin / mailpit）の Cloudflare Access 保護は維持します。** `staging-db.frestyle.net` / `staging-mail.frestyle.net` は 1 階層のため Universal SSL の対象で、今回の制約を受けません。

Zero Trust のチームドメインを `normandesign.cloudflareaccess.com` から `frestyle.cloudflareaccess.com` へ変更した件もそのまま維持します。

## テスト

- YAML が妥当で `STAGING_FQDN` / `environment.url` が 2 階層で展開されることを確認
- 1 階層形式の参照が残っていないことを確認
- box へ反映後、`https://<sub>.staging.frestyle.net` が 200 を返すことを確認します

## 関連チケット

FRESTYLE-309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * ステージング環境のドメイン形式を `<サブドメイン>.<ベースドメイン>` に変更しました。
  * 関連する説明や入力例を新しい形式に更新しました。
  * ステージング環境をCloudflare経由ではなく、Lightsailへ直接公開する構成を明記しました。
  * Caddyによる証明書取得の説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->