### PR TITLE
fix: FRESTYLE-14 ユーザー作成と招待更新を同一トランザクション化

### DIFF
--- a/backend/internal/adapter/persistence/admin_invitation_repository.go
+++ b/backend/internal/adapter/persistence/admin_invitation_repository.go
@@ -105,7 +105,7 @@ func (r *adminInvitationRepository) UpdateStatus(
 		return result.Error
 	}
 	if result.RowsAffected != 1 {
-		return gorm.ErrRecordNotFound
+		return repository.ErrInvitationAlreadyClaimed
 	}
 
 	return nil

--- a/backend/internal/adapter/persistence/admin_invitation_repository.go
+++ b/backend/internal/adapter/persistence/admin_invitation_repository.go
@@ -87,6 +87,26 @@ func (r *adminInvitationRepository) Create(ctx context.Context, inv *domain.Admi
 	return r.db.WithContext(ctx).Create(inv).Error
 }
 
-func (r *adminInvitationRepository) UpdateStatus(ctx context.Context, id uint64, status string) error {
-	return r.db.WithContext(ctx).Model(&domain.AdminInvitation{}).Where("id = ?", id).Update("status", status).Error
+func (r *adminInvitationRepository) UpdateStatus(
+	ctx context.Context,
+	id uint64,
+	status string,
+) error {
+	result := r.db.WithContext(ctx).
+		Model(&domain.AdminInvitation{}).
+		Where(
+			"id = ? AND status = ?",
+			id,
+			domain.InvitationStatusPending,
+		).
+		Update("status", status)
+
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected != 1 {
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
 }

--- a/backend/internal/adapter/persistence/user_invitation_transaction.go
+++ b/backend/internal/adapter/persistence/user_invitation_transaction.go
@@ -1,0 +1,35 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"gorm.io/gorm"
+)
+
+type userInvitationTransactionRunner struct {
+	db *gorm.DB
+}
+
+// NewUserInvitationTransactionRunner はユーザーと招待の
+// トランザクション実装を生成する。
+func NewUserInvitationTransactionRunner(
+	db *gorm.DB,
+) repository.UserInvitationTransactionRunner {
+	return &userInvitationTransactionRunner{db: db}
+}
+
+func (r *userInvitationTransactionRunner) WithinTransaction(
+	ctx context.Context,
+	fn func(
+		users repository.UserRepository,
+		invitations repository.AdminInvitationRepository,
+	) error,
+) error {
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(
+			NewUserRepository(tx),
+			NewAdminInvitationRepository(tx),
+		)
+	})
+}

--- a/backend/internal/handler/auth_handler_test.go
+++ b/backend/internal/handler/auth_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
 )
 
 // fakeUserRepo は AuthHandler.upsertUserFromIDToken のテスト用 stub。
@@ -133,14 +134,38 @@ func makeIDToken(t *testing.T, claims map[string]any) string {
 	return header + "." + body + "."
 }
 
+type authTestTransactionRunner struct {
+	users       repository.UserRepository
+	invitations repository.AdminInvitationRepository
+}
+
+func (r *authTestTransactionRunner) WithinTransaction(
+	ctx context.Context,
+	fn func(
+		users repository.UserRepository,
+		invitations repository.AdminInvitationRepository,
+	) error,
+) error {
+	return fn(r.users, r.invitations)
+}
+
 // newTestAuthHandler はテスト用 AuthHandler を組み立てる。tokens は使わない。
 func newTestAuthHandler(
 	users *fakeUserRepo,
 	invitations *fakeInvitationRepo,
 ) *AuthHandler {
+	transactionRunner := &authTestTransactionRunner{
+		users:       users,
+		invitations: invitations,
+	}
+
 	return &AuthHandler{
-		users:      users,
-		upsertUser: usecase.NewUpsertUserFromIDTokenUseCase(users, invitations),
+		users: users,
+		upsertUser: usecase.NewUpsertUserFromIDTokenUseCase(
+			users,
+			invitations,
+			transactionRunner,
+		),
 	}
 }
 

--- a/backend/internal/handler/routes_auth.go
+++ b/backend/internal/handler/routes_auth.go
@@ -18,8 +18,12 @@ func registerAuthPublicRoutes(g *gin.RouterGroup, deps *routeDeps) *AuthHandler 
 	getCurrentUser := usecase.NewGetCurrentUserUseCase(deps.userRepo)
 	invitations := persistence.NewAdminInvitationRepository(deps.db)
 	aiAccess := usecase.NewAiChatEnabledForUserUseCase(persistence.NewCompanyRepository(deps.db))
-	upsertUser := usecase.NewUpsertUserFromIDTokenUseCase(deps.userRepo, invitations)
-
+	transactionRunner := persistence.NewUserInvitationTransactionRunner(deps.db)
+	upsertUser := usecase.NewUpsertUserFromIDTokenUseCase(
+		deps.userRepo,
+		invitations,
+		transactionRunner,
+	)
 	// USER_PASSWORD_AUTH 用の authenticator。AWS 認証情報の解決に失敗しても起動は止めず、
 	// nil のまま渡して /auth/cognito/login だけ 500 にする（Hosted UI ログインには影響させない）。
 	var pwAuth passwordAuthenticator

--- a/backend/internal/usecase/repository/admin_invitation.go
+++ b/backend/internal/usecase/repository/admin_invitation.go
@@ -2,9 +2,14 @@ package repository
 
 import (
 	"context"
+	"errors"
 
 	"github.com/norman6464/FreStyle/backend/internal/domain"
 )
+
+// ErrInvitationAlreadyClaimed は、pending の招待の更新対象が
+// 1 件でなかったことを表す。
+var ErrInvitationAlreadyClaimed = errors.New("invitation already claimed")
 
 // AdminInvitationRepository は invitations テーブルへのアクセスを提供する。
 type AdminInvitationRepository interface {
@@ -19,7 +24,7 @@ type AdminInvitationRepository interface {
 	// FindByID は ID 一致の招待を返す（該当なしは nil, nil）。会社スコープの認可判定に使う。
 	FindByID(ctx context.Context, id uint64) (*domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
-	// UpdateStatus は pending の招待だけを指定statusへ更新する。
-	// 更新対象が1件でなければエラーを返す。
+	// UpdateStatus は pending の招待だけを指定 status へ更新する。
+	// 更新対象が 1 件でなければ ErrInvitationAlreadyClaimed を返す。
 	UpdateStatus(ctx context.Context, id uint64, status string) error
 }

--- a/backend/internal/usecase/repository/admin_invitation.go
+++ b/backend/internal/usecase/repository/admin_invitation.go
@@ -19,5 +19,7 @@ type AdminInvitationRepository interface {
 	// FindByID は ID 一致の招待を返す（該当なしは nil, nil）。会社スコープの認可判定に使う。
 	FindByID(ctx context.Context, id uint64) (*domain.AdminInvitation, error)
 	Create(ctx context.Context, inv *domain.AdminInvitation) error
+	// UpdateStatus は pending の招待だけを指定statusへ更新する。
+	// 更新対象が1件でなければエラーを返す。
 	UpdateStatus(ctx context.Context, id uint64, status string) error
 }

--- a/backend/internal/usecase/repository/user_invitation_transaction.go
+++ b/backend/internal/usecase/repository/user_invitation_transaction.go
@@ -1,0 +1,15 @@
+package repository
+
+import "context"
+
+// UserInvitationTransactionRunner はユーザーと招待の更新を
+// 単一トランザクション内で実行する。
+type UserInvitationTransactionRunner interface {
+	WithinTransaction(
+		ctx context.Context,
+		fn func(
+			users UserRepository,
+			invitations AdminInvitationRepository,
+		) error,
+	) error
+}

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase.go
@@ -21,18 +21,21 @@ type UpsertUserFromIDTokenInput struct {
 
 // UpsertUserFromIDTokenUseCase は認証済みユーザーの作成・更新を行う。
 type UpsertUserFromIDTokenUseCase struct {
-	users       repository.UserRepository
-	invitations repository.AdminInvitationRepository
+	users             repository.UserRepository
+	invitations       repository.AdminInvitationRepository
+	transactionRunner repository.UserInvitationTransactionRunner
 }
 
 // NewUpsertUserFromIDTokenUseCase はUpsertUserFromIDTokenUseCaseを生成する。
 func NewUpsertUserFromIDTokenUseCase(
 	users repository.UserRepository,
 	invitations repository.AdminInvitationRepository,
+	transactionRunner repository.UserInvitationTransactionRunner,
 ) *UpsertUserFromIDTokenUseCase {
 	return &UpsertUserFromIDTokenUseCase{
-		users:       users,
-		invitations: invitations,
+		users:             users,
+		invitations:       invitations,
+		transactionRunner: transactionRunner,
 	}
 }
 
@@ -235,18 +238,36 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 		CompanyID:  companyID,
 	}
 
-	if err := u.users.Create(ctx, user); err != nil {
-		return false, fmt.Errorf("create user: %w", err)
+	if u.transactionRunner == nil {
+		return false, errors.New(
+			"user invitation transaction runner not configured",
+		)
 	}
 
-	if inv != nil {
-		if err := u.invitations.UpdateStatus(
-			ctx,
-			inv.ID,
-			domain.InvitationStatusAccepted,
-		); err != nil {
-			return false, fmt.Errorf("accept invitation: %w", err)
-		}
+	if err := u.transactionRunner.WithinTransaction(
+		ctx,
+		func(
+			users repository.UserRepository,
+			invitations repository.AdminInvitationRepository,
+		) error {
+			if err := users.Create(ctx, user); err != nil {
+				return fmt.Errorf("create user: %w", err)
+			}
+
+			if inv != nil {
+				if err := invitations.UpdateStatus(
+					ctx,
+					inv.ID,
+					domain.InvitationStatusAccepted,
+				); err != nil {
+					return fmt.Errorf("accept invitation: %w", err)
+				}
+			}
+
+			return nil
+		},
+	); err != nil {
+		return false, err
 	}
 
 	return true, nil

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase.go
@@ -267,7 +267,10 @@ func (u *UpsertUserFromIDTokenUseCase) Execute(
 			return nil
 		},
 	); err != nil {
-		return false, err
+		return false, fmt.Errorf(
+			"create user and accept invitation transaction: %w",
+			err,
+		)
 	}
 
 	return true, nil

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_integration_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_integration_test.go
@@ -262,12 +262,12 @@ func TestUpsertUserFromIDToken_Transaction_Integration(t *testing.T) {
 		}
 
 		results := make(chan executeResult, 2)
-		execute := func(cognitoSub string) {
+		execute := func(cognitoSub string, email string) {
 			allowed, err := uc.Execute(
 				ctx,
 				usecase.UpsertUserFromIDTokenInput{
 					CognitoSub:      cognitoSub,
-					Email:           invitation.Email,
+					Email:           email,
 					InvitationToken: token,
 				},
 			)
@@ -277,8 +277,8 @@ func TestUpsertUserFromIDToken_Transaction_Integration(t *testing.T) {
 			}
 		}
 
-		go execute("concurrent-sub-1")
-		go execute("concurrent-sub-2")
+		go execute("concurrent-sub-1", "concurrent-1@example.com")
+		go execute("concurrent-sub-2", "concurrent-2@example.com")
 
 		for i := 0; i < 2; i++ {
 			select {
@@ -301,6 +301,17 @@ func TestUpsertUserFromIDToken_Transaction_Integration(t *testing.T) {
 				successCount++
 			case !result.allowed && result.err != nil:
 				failureCount++
+				require.ErrorIs(
+					t,
+					result.err,
+					repository.ErrInvitationAlreadyClaimed,
+				)
+			default:
+				t.Fatalf(
+					"想定外の戻り値: allowed=%t err=%v",
+					result.allowed,
+					result.err,
+				)
 			}
 		}
 

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_integration_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_integration_test.go
@@ -1,0 +1,165 @@
+//go:build integration
+
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/norman6464/FreStyle/backend/internal/adapter/persistence"
+	"github.com/norman6464/FreStyle/backend/internal/domain"
+	"github.com/norman6464/FreStyle/backend/internal/testsupport"
+	"github.com/norman6464/FreStyle/backend/internal/usecase"
+	"github.com/norman6464/FreStyle/backend/internal/usecase/repository"
+	"github.com/stretchr/testify/require"
+)
+
+type failingInvitationRepository struct {
+	repository.AdminInvitationRepository
+	err error
+}
+
+func (r *failingInvitationRepository) UpdateStatus(
+	_ context.Context,
+	_ uint64,
+	_ string,
+) error {
+	return r.err
+}
+
+type failingInvitationTransactionRunner struct {
+	inner repository.UserInvitationTransactionRunner
+	err   error
+}
+
+func (r *failingInvitationTransactionRunner) WithinTransaction(
+	ctx context.Context,
+	fn func(
+		users repository.UserRepository,
+		invitations repository.AdminInvitationRepository,
+	) error,
+) error {
+	return r.inner.WithinTransaction(
+		ctx,
+		func(
+			users repository.UserRepository,
+			invitations repository.AdminInvitationRepository,
+		) error {
+			return fn(
+				users,
+				&failingInvitationRepository{
+					AdminInvitationRepository: invitations,
+					err:                       r.err,
+				},
+			)
+		},
+	)
+}
+
+func TestUpsertUserFromIDToken_Transaction_Integration(t *testing.T) {
+	db := testsupport.OpenTestDB(t)
+	ctx := context.Background()
+
+	t.Run("ユーザー作成と招待受諾をまとめてコミットする", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "users", "invitations")
+
+		users := persistence.NewUserRepository(db)
+		invitations := persistence.NewAdminInvitationRepository(db)
+		runner := persistence.NewUserInvitationTransactionRunner(db)
+
+		invitation := &domain.AdminInvitation{
+			CompanyID: 42,
+			Email:     "commit@example.com",
+			Name:      "Commit User",
+			Role:      domain.RoleTrainee,
+			Status:    domain.InvitationStatusPending,
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		}
+		require.NoError(t, invitations.Create(ctx, invitation))
+
+		uc := usecase.NewUpsertUserFromIDTokenUseCase(
+			users,
+			invitations,
+			runner,
+		)
+
+		allowed, err := uc.Execute(
+			ctx,
+			usecase.UpsertUserFromIDTokenInput{
+				CognitoSub: "commit-sub",
+				Email:      invitation.Email,
+			},
+		)
+
+		require.NoError(t, err)
+		require.True(t, allowed)
+
+		created, err := users.FindByCognitoSub(ctx, "commit-sub")
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		accepted, err := invitations.FindByID(ctx, invitation.ID)
+		require.NoError(t, err)
+		require.NotNil(t, accepted)
+		require.Equal(
+			t,
+			domain.InvitationStatusAccepted,
+			accepted.Status,
+		)
+	})
+
+	t.Run("招待更新失敗時にユーザー作成もロールバックする", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "users", "invitations")
+
+		users := persistence.NewUserRepository(db)
+		invitations := persistence.NewAdminInvitationRepository(db)
+		updateErr := errors.New("forced invitation update failure")
+
+		runner := &failingInvitationTransactionRunner{
+			inner: persistence.NewUserInvitationTransactionRunner(db),
+			err:   updateErr,
+		}
+
+		invitation := &domain.AdminInvitation{
+			CompanyID: 42,
+			Email:     "rollback@example.com",
+			Name:      "Rollback User",
+			Role:      domain.RoleTrainee,
+			Status:    domain.InvitationStatusPending,
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		}
+		require.NoError(t, invitations.Create(ctx, invitation))
+
+		uc := usecase.NewUpsertUserFromIDTokenUseCase(
+			users,
+			invitations,
+			runner,
+		)
+
+		allowed, err := uc.Execute(
+			ctx,
+			usecase.UpsertUserFromIDTokenInput{
+				CognitoSub: "rollback-sub",
+				Email:      invitation.Email,
+			},
+		)
+
+		require.False(t, allowed)
+		require.ErrorIs(t, err, updateErr)
+
+		created, err := users.FindByCognitoSub(ctx, "rollback-sub")
+		require.NoError(t, err)
+		require.Nil(t, created)
+
+		pending, err := invitations.FindByID(ctx, invitation.ID)
+		require.NoError(t, err)
+		require.NotNil(t, pending)
+		require.Equal(
+			t,
+			domain.InvitationStatusPending,
+			pending.Status,
+		)
+	})
+}

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_integration_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_integration_test.go
@@ -34,6 +34,58 @@ type failingInvitationTransactionRunner struct {
 	err   error
 }
 
+type synchronizedInvitationRepository struct {
+	repository.AdminInvitationRepository
+	ready   chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r *synchronizedInvitationRepository) UpdateStatus(
+	ctx context.Context,
+	id uint64,
+	status string,
+) error {
+	r.ready <- struct{}{}
+	<-r.release
+
+	return r.AdminInvitationRepository.UpdateStatus(
+		ctx,
+		id,
+		status,
+	)
+}
+
+type synchronizedInvitationTransactionRunner struct {
+	inner   repository.UserInvitationTransactionRunner
+	ready   chan<- struct{}
+	release <-chan struct{}
+}
+
+func (r *synchronizedInvitationTransactionRunner) WithinTransaction(
+	ctx context.Context,
+	fn func(
+		users repository.UserRepository,
+		invitations repository.AdminInvitationRepository,
+	) error,
+) error {
+	return r.inner.WithinTransaction(
+		ctx,
+		func(
+			users repository.UserRepository,
+			invitations repository.AdminInvitationRepository,
+		) error {
+			return fn(
+				users,
+				&synchronizedInvitationRepository{
+					AdminInvitationRepository: invitations,
+					ready:                     r.ready,
+					release:                   r.release,
+				},
+			)
+		},
+	)
+}
+
 func (r *failingInvitationTransactionRunner) WithinTransaction(
 	ctx context.Context,
 	fn func(
@@ -160,6 +212,121 @@ func TestUpsertUserFromIDToken_Transaction_Integration(t *testing.T) {
 			t,
 			domain.InvitationStatusPending,
 			pending.Status,
+		)
+	})
+
+	t.Run("同じ招待tokenの並行利用ではユーザーを1件だけ作成する", func(t *testing.T) {
+		testsupport.TruncateAll(t, db, "users", "invitations")
+
+		users := persistence.NewUserRepository(db)
+		invitations := persistence.NewAdminInvitationRepository(db)
+
+		token := "concurrent-invitation-token"
+		invitation := &domain.AdminInvitation{
+			CompanyID: 42,
+			Email:     "concurrent@example.com",
+			Name:      "Concurrent User",
+			Role:      domain.RoleTrainee,
+			Status:    domain.InvitationStatusPending,
+			Token:     &token,
+			ExpiresAt: time.Now().UTC().Add(time.Hour),
+		}
+		require.NoError(t, invitations.Create(ctx, invitation))
+
+		ready := make(chan struct{}, 2)
+		release := make(chan struct{})
+
+		// 途中でテストが失敗しても、待機中のgoroutineを解放する。
+		defer func() {
+			select {
+			case <-release:
+			default:
+				close(release)
+			}
+		}()
+
+		runner := &synchronizedInvitationTransactionRunner{
+			inner:   persistence.NewUserInvitationTransactionRunner(db),
+			ready:   ready,
+			release: release,
+		}
+		uc := usecase.NewUpsertUserFromIDTokenUseCase(
+			users,
+			invitations,
+			runner,
+		)
+
+		type executeResult struct {
+			allowed bool
+			err     error
+		}
+
+		results := make(chan executeResult, 2)
+		execute := func(cognitoSub string) {
+			allowed, err := uc.Execute(
+				ctx,
+				usecase.UpsertUserFromIDTokenInput{
+					CognitoSub:      cognitoSub,
+					Email:           invitation.Email,
+					InvitationToken: token,
+				},
+			)
+			results <- executeResult{
+				allowed: allowed,
+				err:     err,
+			}
+		}
+
+		go execute("concurrent-sub-1")
+		go execute("concurrent-sub-2")
+
+		for i := 0; i < 2; i++ {
+			select {
+			case <-ready:
+			case <-time.After(5 * time.Second):
+				t.Fatal("2つの処理が招待更新直前まで到達しなかった")
+			}
+		}
+
+		close(release)
+
+		first := <-results
+		second := <-results
+
+		successCount := 0
+		failureCount := 0
+		for _, result := range []executeResult{first, second} {
+			switch {
+			case result.allowed && result.err == nil:
+				successCount++
+			case !result.allowed && result.err != nil:
+				failureCount++
+			}
+		}
+
+		require.Equal(t, 1, successCount)
+		require.Equal(t, 1, failureCount)
+
+		var userCount int64
+		require.NoError(
+			t,
+			db.Model(&domain.User{}).
+				Where(
+					"cognito_sub IN ?",
+					[]string{"concurrent-sub-1", "concurrent-sub-2"},
+				).
+				Count(&userCount).
+				Error,
+		)
+		require.Equal(t, int64(1), userCount)
+
+		accepted, err := invitations.FindByID(ctx, invitation.ID)
+		require.NoError(t, err)
+		require.NotNil(t, accepted)
+		require.Equal(
+			t,
+			domain.InvitationStatusAccepted,
+			accepted.Status,
 		)
 	})
 }

--- a/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
+++ b/backend/internal/usecase/upsert_user_from_id_token_usecase_test.go
@@ -105,11 +105,45 @@ func (s *upsertInvitationRepoSpy) UpdateStatus(
 	return s.updateErr
 }
 
+type passthroughUserInvitationTransactionRunner struct {
+	users       repository.UserRepository
+	invitations repository.AdminInvitationRepository
+	called      bool
+	committed   bool
+	rolledBack  bool
+}
+
+func (r *passthroughUserInvitationTransactionRunner) WithinTransaction(
+	ctx context.Context,
+	fn func(
+		users repository.UserRepository,
+		invitations repository.AdminInvitationRepository,
+	) error,
+) error {
+	r.called = true
+
+	err := fn(r.users, r.invitations)
+	if err != nil {
+		r.rolledBack = true
+		return err
+	}
+
+	r.committed = true
+	return nil
+}
+
 func newUpsertUserFromIDTokenUseCaseForTest(
 	users repository.UserRepository,
 	invitations repository.AdminInvitationRepository,
 ) *UpsertUserFromIDTokenUseCase {
-	return NewUpsertUserFromIDTokenUseCase(users, invitations)
+	return NewUpsertUserFromIDTokenUseCase(
+		users,
+		invitations,
+		&passthroughUserInvitationTransactionRunner{
+			users:       users,
+			invitations: invitations,
+		},
+	)
 }
 
 func Test_UpsertUserFromIDToken_招待のRoleとCompanyを適用してAcceptedにする(t *testing.T) {
@@ -123,7 +157,15 @@ func Test_UpsertUserFromIDToken_招待のRoleとCompanyを適用してAccepted�
 			Status:    domain.InvitationStatusPending,
 		},
 	}
-	uc := newUpsertUserFromIDTokenUseCaseForTest(users, invitations)
+	runner := &passthroughUserInvitationTransactionRunner{
+		users:       users,
+		invitations: invitations,
+	}
+	uc := NewUpsertUserFromIDTokenUseCase(
+		users,
+		invitations,
+		runner,
+	)
 
 	allowed, err := uc.Execute(
 		context.Background(),
@@ -964,9 +1006,14 @@ func Test_UpsertUserFromIDToken_新規ユーザーのトランザクションエ
 			}
 			tc.configure(users, invitations)
 
-			uc := newUpsertUserFromIDTokenUseCaseForTest(
+			runner := &passthroughUserInvitationTransactionRunner{
+				users:       users,
+				invitations: invitations,
+			}
+			uc := NewUpsertUserFromIDTokenUseCase(
 				users,
 				invitations,
+				runner,
 			)
 
 			allowed, err := uc.Execute(
@@ -1001,6 +1048,15 @@ func Test_UpsertUserFromIDToken_新規ユーザーのトランザクションエ
 					invitations.updateCalls,
 					tc.wantUpdateStatusCalls,
 				)
+			}
+			if !runner.called {
+				t.Fatal("トランザクションが開始されていない")
+			}
+			if !runner.rolledBack {
+				t.Fatal("エラー時にロールバックが選択されていない")
+			}
+			if runner.committed {
+				t.Fatal("エラー時にコミットしてはいけない")
 			}
 		})
 	}


### PR DESCRIPTION
## 概要

FreStyle-14に記述された問題に対応しました。
新規ユーザー作成と招待ステータス更新が別々に確定され、招待更新の失敗時にユーザーだけが残る可能性がありました。ので、両処理を同一トランザクション内で実行し、部分的な更新が残らないようにしました。

## 変更内容

- usecase層にユーザー作成・招待更新用のトランザクション境界を追加
- persistence層にGORMを使用したトランザクション実装を追加
- 新規ユーザー作成と招待ステータス更新を同一トランザクション内で実行
- 招待更新失敗時にユーザー作成もロールバックされる単体テストを追加
- PostgreSQLを使用した正常系・ロールバック確認の結合テストを追加
- handlerの依存関係組み立てと関連テストを更新

## テスト

- `go test ./internal/usecase`：PASS
- `go test ./internal/adapter/persistence`：PASS
- `go test ./internal/handler`：Windows環境では既存のPOSIX専用sandboxコードによりビルド不可
- `make test-integration`：Docker Desktopが停止していたためローカルでは未実行
- Linux環境での全テスト・PostgreSQL結合テストはGitHub Actionsで確認予定

## 関連 Issue

- [FRESTYLE-14](https://frestyle.atlassian.net/browse/FRESTYLE-14)

---

### セルフチェック

- [x] タイトルに Prefix（`feat` / `fix` / `refactor` / `docs` / `test` / `chore` 等）を付けた
- [x] 新規・変更コードに単体テストを追加した（backend: `go test` / frontend: Vitest）
- [ ] backend を変更した場合 `make verify`（gofmt / vet / build / test / 3 linter）が通る
- [x] handler / swaggo 注釈を変えた場合 `make openapi` を実行し `docs/` を commit した
- [x] 仕様・手順を変えた場合は `docs/`（または該当 README）を更新した
- [x] `main` への直接コミットではなく、PR 経由である


[FRESTYLE-14]: https://frestyle.atlassian.net/browse/FRESTYLE-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **不具合修正**
  - 新規登録時のユーザー作成と招待承認を一括処理するよう改善しました。
  - 招待承認に失敗した場合、ユーザー作成も取り消され、招待は保留状態に戻ります。
  - 登録処理の途中でデータだけが反映される不整合を防止しました。
  - 保留中の招待のみを承認できるようになりました。

- **テスト**
  - 正常完了時の反映、失敗時のロールバック、同一招待の同時利用を確認するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->